### PR TITLE
[pybind11] Fix using pybind11 from CMake

### DIFF
--- a/ports/pybind11/0001-fix-cmake-support-release-and-debug-at-the-same-time.patch
+++ b/ports/pybind11/0001-fix-cmake-support-release-and-debug-at-the-same-time.patch
@@ -1,0 +1,87 @@
+From 9bd640b62bf3293b53500811922068fe356294df Mon Sep 17 00:00:00 2001
+From: Henry Schreiner <HenrySchreinerIII@gmail.com>
+Date: Wed, 18 May 2022 23:19:33 -0400
+Subject: [PATCH] fix(cmake): support release and debug at the same time
+ (#3948)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Jan: try to preserve Python v2 functionality.
+
+Backported-by: Jan Kundrát <jan.kundrat@telecominfraproject.com>
+---
+ tools/pybind11Tools.cmake | 50 ++++++++++++++++++++++++++++++---------
+ 1 file changed, 39 insertions(+), 11 deletions(-)
+
+diff --git a/tools/pybind11Tools.cmake b/tools/pybind11Tools.cmake
+index c255e5cf..d378a9ed 100644
+--- a/tools/pybind11Tools.cmake
++++ b/tools/pybind11Tools.cmake
+@@ -115,24 +115,52 @@ if(PYTHON_IS_DEBUG)
+     PROPERTY INTERFACE_COMPILE_DEFINITIONS Py_DEBUG)
+ endif()
+ 
+-set_property(
+-  TARGET pybind11::module
+-  APPEND
+-  PROPERTY
+-    INTERFACE_LINK_LIBRARIES pybind11::python_link_helper
+-    "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:$<BUILD_INTERFACE:${PYTHON_LIBRARIES}>>")
+-
+ if(PYTHON_VERSION VERSION_LESS 3)
+   set_property(
+     TARGET pybind11::pybind11
+     APPEND
+     PROPERTY INTERFACE_LINK_LIBRARIES pybind11::python2_no_register)
++
++  # FIXME: this is toally untested, but it's also unchanged from v2.9.2
++  set_property(
++    TARGET pybind11::module
++    APPEND
++    PROPERTY
++      INTERFACE_LINK_LIBRARIES pybind11::python_link_helper
++      "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:$<BUILD_INTERFACE:${PYTHON_LIBRARIES}>>")
++  set_property(
++   TARGET pybind11::embed
++   APPEND
++   PROPERTY INTERFACE_LINK_LIBRARIES pybind11::pybind11 $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
++
++else()
++  if(CMAKE_VERSION VERSION_LESS 3.11)
++    set_property(
++      TARGET pybind11::module
++      APPEND
++      PROPERTY
++        INTERFACE_LINK_LIBRARIES
++        pybind11::python_link_helper
++        "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:$<BUILD_INTERFACE:${PYTHON_LIBRARIES}>>"
++    )
++    set_property(
++      TARGET pybind11::embed
++      APPEND
++      PROPERTY INTERFACE_LINK_LIBRARIES pybind11::pybind11 $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
++  else()
++    target_link_libraries(
++      pybind11::module
++      INTERFACE
++        pybind11::python_link_helper
++        "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:$<BUILD_INTERFACE:${PYTHON_LIBRARIES}>>"
++    )
++
++    target_link_libraries(pybind11::embed INTERFACE pybind11::pybind11
++                                                    $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
++
++  endif()
+ endif()
+ 
+-set_property(
+-  TARGET pybind11::embed
+-  APPEND
+-  PROPERTY INTERFACE_LINK_LIBRARIES pybind11::pybind11 $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
+ 
+ function(pybind11_extension name)
+   # The prefix and extension are provided by FindPythonLibsNew.cmake
+-- 
+2.36.0
+

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v2.9.2
     SHA512 c6c18e5f59873adb3692640ade26472abd257607e7bb9fd48cfd1949878811e83d6ac6eb8c8dd926622d52ca4f13e5e6a58e0abaaaa1fa814ee831ea2b515272
     HEAD_REF master
+    PATCHES 0001-fix-cmake-support-release-and-debug-at-the-same-time.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pybind11",
   "version": "2.9.2",
+  "port-version": 1,
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5678,7 +5678,7 @@
     },
     "pybind11": {
       "baseline": "2.9.2",
-      "port-version": 0
+      "port-version": 1
     },
     "pystring": {
       "baseline": "1.1.3",

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0d7069ebce506d7512ca198d79c0545124fd833",
+      "version": "2.9.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "0723f5ac350935e5d68d8087c82883dffa706812",
       "version": "2.9.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #25163. Patch is adapted from upstream commit pybind/pybind11@1e4bd22bdca5068188d2d46136b79d18a1d1f647. In the meanwhile, however, upstream removed support for Python 2, so this patch tries to only touch the Python 3 codepath.

This is a different fix than #25377 as suggested in https://github.com/microsoft/vcpkg/pull/25377#issuecomment-1162670875; I tried to introduce the smallest possible change. Note that in the next upstream release they [will be removing support for Python 2.7](https://pybind11.readthedocs.io/en/stable/changelog.html#in-development) (and 3.5, but I guess that the 2.x version is a bigger piece of news).