### PR TITLE
[libproxy] Add support !static

### DIFF
--- a/ports/libproxy/portfile.cmake
+++ b/ports/libproxy/portfile.cmake
@@ -1,8 +1,3 @@
-# Enable static build in UNIX
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libproxy/libproxy

--- a/ports/libproxy/vcpkg.json
+++ b/ports/libproxy/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "libproxy",
   "version": "0.4.17",
-  "port-version": 3,
+  "port-version": 4,
   "description": "libproxy is a library that provides automatic proxy configuration management.",
   "homepage": "https://github.com/libproxy/libproxy",
   "license": "LGPL-2.1-only",
-  "supports": "!uwp",
+  "supports": "!uwp & !static",
   "dependencies": [
     "libmodman",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3954,7 +3954,7 @@
     },
     "libproxy": {
       "baseline": "0.4.17",
-      "port-version": 3
+      "port-version": 4
     },
     "libqcow": {
       "baseline": "20210419",

--- a/versions/l-/libproxy.json
+++ b/versions/l-/libproxy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7aa3e3fbb2539fe4adaaff6056effdc2a97ff14b",
+      "version": "0.4.17",
+      "port-version": 4
+    },
+    {
       "git-tree": "ff241fdc3665ad4d1dce051fcdd8ee8dc8617c86",
       "version": "0.4.17",
       "port-version": 3


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/25465
  
  According to the reply of issue https://github.com/libproxy/libproxy/issues/83 on upstream, this port does not support static compilation, so add `!static` into the support field.

  Note: no other port depends on this port.