### PR TITLE
[gazebo] Fix Plugin failed with status code 3221225785

### DIFF
--- a/ports/gazebo/portfile.cmake
+++ b/ports/gazebo/portfile.cmake
@@ -26,7 +26,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DUSE_EXTERNAL_TINY_PROCESS_LIBRARY=ON
-        -DPKG_CONFIG_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf.exe
+        -DPKG_CONFIG_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf${VCPKG_HOST_EXECUTABLE_SUFFIX}
         ${FEATURE_OPTIONS}
         -DBUILD_TESTING=OFF  # Not enabled by default, but to be sure
 )

--- a/ports/gazebo/portfile.cmake
+++ b/ports/gazebo/portfile.cmake
@@ -22,18 +22,15 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         graphviz  NO_GRAPHVIZ_FEATURE
 )
 
-vcpkg_add_to_path(PREPEND "${CURRENT_INSTALLED_DIR}/debug/bin")
-vcpkg_add_to_path(PREPEND "${CURRENT_INSTALLED_DIR}/bin")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DUSE_EXTERNAL_TINY_PROCESS_LIBRARY=ON
-        -DPKG_CONFIG_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf.exe
         ${FEATURE_OPTIONS}
         -DBUILD_TESTING=OFF  # Not enabled by default, but to be sure
 )
 
-vcpkg_cmake_install()
+vcpkg_cmake_install(ADD_BIN_TO_PATH)
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/gazebo")
 vcpkg_copy_pdbs()
 

--- a/ports/gazebo/portfile.cmake
+++ b/ports/gazebo/portfile.cmake
@@ -22,8 +22,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         graphviz  NO_GRAPHVIZ_FEATURE
 )
 
-vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/debug/bin")
-vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/bin")
+vcpkg_add_to_path(PREPEND "${CURRENT_INSTALLED_DIR}/debug/bin")
+vcpkg_add_to_path(PREPEND "${CURRENT_INSTALLED_DIR}/bin")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/gazebo/portfile.cmake
+++ b/ports/gazebo/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DUSE_EXTERNAL_TINY_PROCESS_LIBRARY=ON
+        -DPKG_CONFIG_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf.exe
         ${FEATURE_OPTIONS}
         -DBUILD_TESTING=OFF  # Not enabled by default, but to be sure
 )

--- a/ports/gazebo/vcpkg.json
+++ b/ports/gazebo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gazebo",
   "version-date": "2022-01-20",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Open source robotics simulator.",
   "homepage": "http://gazebosim.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2454,7 +2454,7 @@
     },
     "gazebo": {
       "baseline": "2022-01-20",
-      "port-version": 1
+      "port-version": 2
     },
     "gcem": {
       "baseline": "1.14.1",

--- a/versions/g-/gazebo.json
+++ b/versions/g-/gazebo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "59f747fe3f0daa04d76908d8bcb21cc6b1949ae4",
+      "git-tree": "324403bb31aad7705e0f444e9c49f2b11417b9b0",
       "version-date": "2022-01-20",
       "port-version": 2
     },

--- a/versions/g-/gazebo.json
+++ b/versions/g-/gazebo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c167a499ea1a0fd2d05000cf0533e68b3f4f916b",
+      "git-tree": "59f747fe3f0daa04d76908d8bcb21cc6b1949ae4",
       "version-date": "2022-01-20",
       "port-version": 2
     },

--- a/versions/g-/gazebo.json
+++ b/versions/g-/gazebo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "241b111c1661a61a1b186ada6713c9d00ed1ca77",
+      "version-date": "2022-01-20",
+      "port-version": 2
+    },
+    {
       "git-tree": "702a7de5c38ff156813a73a32eac6c7ca73248e4",
       "version-date": "2022-01-20",
       "port-version": 1

--- a/versions/g-/gazebo.json
+++ b/versions/g-/gazebo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "241b111c1661a61a1b186ada6713c9d00ed1ca77",
+      "git-tree": "c167a499ea1a0fd2d05000cf0533e68b3f4f916b",
       "version-date": "2022-01-20",
       "port-version": 2
     },


### PR DESCRIPTION
- #### What does your PR fix?
  In our internal CI test, gazebo install failed with Plugin failed with status code 3221225785.
  
  I submitted this PR to fix this for the following reasons:
  1. 3221225785 indicates that the issue is not that the dll cannot be found.
  2. The exe and dll generated during the build process match. After local testing, the exe and the corresponding dll generated under debug and release work normally when they exist in the same folder.
  3. This issue should be caused by accidentally finding other dlls in the process of looking for dlls. So adding the path where the correct dll is stored to the top of the environment variable PATH can solve this issue.
  
  After applying the modification of this pr, this issue no longer occurs.
  
