### PR TITLE
[libavif] update to v0.10.1

### DIFF
--- a/ports/libavif/fix-compiler-warnings.patch
+++ b/ports/libavif/fix-compiler-warnings.patch
@@ -1,0 +1,22 @@
+diff --git a/src/read.c b/src/read.c
+index 8d39b07..6289fa4 100644
+--- a/src/read.c
++++ b/src/read.c
+@@ -940,7 +940,7 @@ static avifResult avifDecoderItemMaxExtent(const avifDecoderItem * item, const a
+                     return AVIF_RESULT_BMFF_PARSE_FAILED;
+                 }
+                 startOffset += remainingOffset;
+-                extentSize -= remainingOffset;
++                extentSize -= (size_t)remainingOffset;
+                 remainingOffset = 0;
+             }
+         }
+@@ -3085,7 +3085,7 @@ static avifResult avifDecoderPrepareSample(avifDecoder * decoder, avifDecodeSamp
+ 
+             avifDecoderItem * item = avifMetaFindItem(decoder->data->meta, sample->itemID);
+             avifROData itemContents;
+-            avifResult readResult = avifDecoderItemRead(item, decoder->io, &itemContents, sample->offset, bytesToRead, &decoder->diag);
++            avifResult readResult = avifDecoderItemRead(item, decoder->io, &itemContents, (size_t)sample->offset, bytesToRead, &decoder->diag);
+             if (readResult != AVIF_RESULT_OK) {
+                 return readResult;
+             }

--- a/ports/libavif/portfile.cmake
+++ b/ports/libavif/portfile.cmake
@@ -1,15 +1,16 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AOMediaCodec/libavif
-    REF v0.9.2
-    SHA512 04400ae76214d2f0361a14897d6ee97be675375865bb96c8d237e9a4a1152ac1a966db903c11df82da71b0bc68599a5857e038cc90d63c5d3bc77b13169a3e75
+    REF f938f6b7dd412ffcbdab1808a265b6375dc7b037 #v0.10.1
+    SHA512 d4e01edb9891df0b0abc4a1d621287bce6ba38248a7ae458abd73c268b000557a52a5aa6be1fc715b694c8e48166aee458a371d806d5f28160c50ff653420e79
     HEAD_REF master
     PATCHES
         disable-source-utf8.patch
+        fix-compiler-warnings.patch
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DAVIF_CODEC_AOM=ON
         -DAVIF_BUILD_APPS=OFF
@@ -26,8 +27,8 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 
 # Remove duplicate files
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
-                    ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libavif/vcpkg.json
+++ b/ports/libavif/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "libavif",
-  "version-semver": "0.9.2",
-  "port-version": 1,
+  "version-semver": "0.10.1",
   "description": "Library for encoding and decoding AVIF files",
   "homepage": "https://github.com/AOMediaCodec/libavif",
+  "license": "BSD-2-Clause AND Apache-2.0",
   "dependencies": [
     "aom",
     "libyuv",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3453,8 +3453,8 @@
       "port-version": 1
     },
     "libavif": {
-      "baseline": "0.9.2",
-      "port-version": 1
+      "baseline": "0.10.1",
+      "port-version": 0
     },
     "libb2": {
       "baseline": "0.98.1",

--- a/versions/l-/libavif.json
+++ b/versions/l-/libavif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2789410c80d4668a070e8eba96873a221615f3b",
+      "version-semver": "0.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a160f6cf67dc99a095c98a9a7260b7a5fd110b7b",
       "version-semver": "0.9.2",
       "port-version": 1


### PR DESCRIPTION
Fix #25504

Update libavif to the latest version 0.10.1
Fix compiler warnings: warning C4242: '=': conversion from 'uint64_t' to 'size_t', possible loss of data

Note : no features need to test