### PR TITLE
[libspatialite] Fix mingw crossbuilds

### DIFF
--- a/ports/libspatialite/fix-mingw.patch
+++ b/ports/libspatialite/fix-mingw.patch
@@ -1,0 +1,13 @@
+diff --git a/src/gaiageo/gg_shape.c b/src/gaiageo/gg_shape.c
+index ee2f1cf..01f2571 100644
+--- a/src/gaiageo/gg_shape.c
++++ b/src/gaiageo/gg_shape.c
+@@ -58,7 +58,7 @@ the terms of any one of the MPL, the GPL or the LGPL.
+ #endif
+ 
+ #ifdef _WIN32
+-#include <Windows.h>
++#include <windows.h>
+ #endif
+ 
+ #if OMIT_ICONV == 0		/* if ICONV is disabled no SHP support is available */

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive_ex(
         fix-makefiles.patch
         fix-linux-configure.patch
         gaiaconfig-msvc.patch
+        fix-mingw.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS unused

--- a/ports/libspatialite/vcpkg.json
+++ b/ports/libspatialite/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 6,
   "description": "SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.",
   "homepage": "https://www.gaia-gis.it/gaia-sins/libspatialite-sources",
-  "license": "MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later",
+  "license": null,
   "dependencies": [
     "geos",
     "libiconv",

--- a/ports/libspatialite/vcpkg.json
+++ b/ports/libspatialite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libspatialite",
   "version": "5.0.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.",
   "homepage": "https://www.gaia-gis.it/gaia-sins/libspatialite-sources",
   "license": "MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4066,7 +4066,7 @@
     },
     "libspatialite": {
       "baseline": "5.0.1",
-      "port-version": 5
+      "port-version": 6
     },
     "libspnav": {
       "baseline": "0.2.3",

--- a/versions/l-/libspatialite.json
+++ b/versions/l-/libspatialite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17b2434a466cabf41bd653845871d5b4ec6bfdeb",
+      "version": "5.0.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "27ff74dc3c1f0d6c5e11dbcc110f34e46dae862a",
       "version": "5.0.1",
       "port-version": 5


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes mingw crossbuilds (i.e. case-sensitive file system).
  Update `license` field: Some feature set are GPL-only.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes