### PR TITLE
Add cross-compiling support on linux for libsass port.

### DIFF
--- a/ports/libsass/portfile.cmake
+++ b/ports/libsass/portfile.cmake
@@ -7,9 +7,38 @@ vcpkg_from_github(
     PATCHES remove_compiler_flags.patch
 )
 
+# `--host` option is needed for cross-compiling on linux, to select the correct toolchains,
+# instead of using the detected native toolchains, which would cause failure. To avoid this,
+# we can specify the corresponding toolset to `VCPKG_TOOLSET_PREFIX` in the target triplet.
+# For example, while cross-compiling for arm64, we can specify `aarch64-linux-gnu` to 
+# `VCPKG_TOOLSET_PREFIX` variable in a target triplet file.
+if(VCPKG_HOST_IS_LINUX)
+    execute_process(COMMAND "uname" "-m" OUTPUT_VARIABLE HOST_SYSTEM_PROCESSOR OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(BUILD_OPTION --build=${HOST_SYSTEM_PROCESSOR}-linux-gnu)
+    if(DEFINED VCPKG_TOOLSET_PREFIX)
+        # Give a change to select an alternative toolset by user.
+        set(--host=${VCPKG_TOOLSET_PREFIX})
+    else()
+        message(NOTICE
+            "\nAutomatically select building toolset for ${VCPKG_TARGET_ARCHITECTURE}. "
+            "VCPKG_TOOLSET_PREFIX can be set in the triplet file to use specific toolset."
+            " Like for arm64:\n    set(VCPKG_TOOLSET_PREFIX aarch64-linux-gnu)\n"
+        )
+        # Select propriate toolset according to VCPKG_TARGET_ARCHITECTURE
+        if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+            set(HOST_OPTION --host=arm-linux-gnueabihf)
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+            set(HOST_OPTION --host=aarch64-linux-gnu)
+        endif()
+    endif()
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
+    OPTIONS
+        ${HOST_OPTION}
+        ${BUILD_OPTION}
 )
 vcpkg_install_make(MAKEFILE GNUmakefile)
 vcpkg_fixup_pkgconfig()

--- a/ports/libsass/vcpkg.json
+++ b/ports/libsass/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsass",
   "version": "3.6.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "LibSass - Sass compiler written in C++",
   "homepage": "https://github.com/sass/libsass",
   "supports": "!uwp"

--- a/ports/sassc/vcpkg.json
+++ b/ports/sassc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sassc",
   "version": "3.6.2",
+  "port-version": 1,
   "description": "SassC is a wrapper around libsass (http://github.com/sass/libsass) used to generate a useful command-line application that can be installed and packaged for several operating systems.",
   "homepage": "https://github.com/sass/sassc",
   "dependencies": [


### PR DESCRIPTION
Add cross-compiling support on linux for libsass port.

- #### What does your PR fix?
  Add configuration of `--host` and `--build` options in the profile of libsass port, to support cross-compiling on Linux.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Basically.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
I am still working on this PR.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
