### PR TITLE
Extend triplet detection in CMake toolchain

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -227,6 +227,9 @@ if(NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO)
     endif()
 endif()
 
+if(NOT DEFINED VCPKG_TARGET_TRIPLET AND NOT "$ENV{VCPKG_DEFAULT_TRIPLET}" STREQUAL "")
+    set(VCPKG_TARGET_TRIPLET "$ENV{VCPKG_DEFAULT_TRIPLET}")
+endif()
 if(VCPKG_TARGET_TRIPLET)
     # This is required since a user might do: 'set(VCPKG_TARGET_TRIPLET somevalue)' [no CACHE] before the first project() call
     # Latter within the toolchain file we do: 'set(VCPKG_TARGET_TRIPLET somevalue CACHE STRING "")' which


### PR DESCRIPTION
- #### What does your PR fix?
  - In manifest mode: If the host triplet is initially undefined , let the vcpkg tool determine it.
    - This changes the setup of `CMAKE_PROGRAM_PATH`, selecting host `tools` instead of target `tools` (subject to `VCPKG_USE_HOST_TOOLS`).
    - In turn, this makes tools like `pkgconf` (for `find_package(PkgConfig)`) etc. readily available for manifest mode.
    - However, it also breaks access to scripts like `curl-config`.
      (This could be resolved by install such scripts to a different location than regular tools. They also need to reflect the build type.)
  - In general: Use environment variable `VCPKG_DEFAULT_TRIPLET` to initialize the target triplet if unset. 
    This merely complements the new behaviour for the default host triplet.
  - Related issues: 
    https://github.com/microsoft/vcpkg/issues/23607

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  not needed.

#### Remarks
Submitting this as draft, but for immediate feedback.
This might be complemented by passing `VCPKG_HOST_TRIPLET` in `vcpkg_cmake_configure`.
Background: https://github.com/microsoft/vcpkg/pull/22392#issuecomment-1162724678 ff. (CC @Neumann-A)
