### PR TITLE
[osg libraw openexr jasper] Dont block arm64-osx

### DIFF
--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "jasper",
   "version": "2.0.33",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/mdadams/jasper",
   "dependencies": [
@@ -28,7 +28,7 @@
           "features": [
             "opengl"
           ],
-          "platform": "!(windows & arm)"
+          "platform": "!(windows & arm) & !uwp"
         }
       ]
     },
@@ -37,11 +37,11 @@
       "dependencies": [
         {
           "name": "freeglut",
-          "platform": "!osx & !(windows & arm)"
+          "platform": "!osx & !(windows & arm) & !uwp"
         },
         {
           "name": "opengl",
-          "platform": "!(windows & arm)"
+          "platform": "!(windows & arm) & !uwp"
         }
       ]
     }

--- a/ports/libraw/vcpkg.json
+++ b/ports/libraw/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 9,
   "description": "raw image decoder library",
   "homepage": "https://www.libraw.org",
-  "supports": "!(arm & uwp)",
+  "supports": "!uwp",
   "dependencies": [
     "jasper",
     "lcms",

--- a/ports/libraw/vcpkg.json
+++ b/ports/libraw/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 8,
   "description": "raw image decoder library",
   "homepage": "https://www.libraw.org",
-  "supports": "!arm & !uwp",
+  "supports": "!(arm & uwp)",
   "dependencies": [
     "jasper",
     "lcms",

--- a/ports/libraw/vcpkg.json
+++ b/ports/libraw/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libraw",
   "version-string": "201903",
-  "port-version": 8,
+  "port-version": 9,
   "description": "raw image decoder library",
   "homepage": "https://www.libraw.org",
   "supports": "!(arm & uwp)",

--- a/ports/openexr/vcpkg.json
+++ b/ports/openexr/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "openexr",
   "version-string": "2.5.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications",
   "homepage": "https://www.openexr.com/",
-  "supports": "!uwp",
+  "supports": "!uwp & !(arm & windows)",
   "dependencies": [
     "zlib"
   ]

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 14,
   "description": "The OpenSceneGraph is an open source high performance 3D graphics toolkit.",
   "homepage": "https://github.com/openscenegraph/OpenSceneGraph",
-  "supports": "!arm & !uwp",
+  "supports": "!(arm & uwp)",
   "dependencies": [
     {
       "name": "expat",

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 15,
   "description": "The OpenSceneGraph is an open source high performance 3D graphics toolkit.",
   "homepage": "https://github.com/openscenegraph/OpenSceneGraph",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "expat",

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -4,7 +4,6 @@
   "port-version": 15,
   "description": "The OpenSceneGraph is an open source high performance 3D graphics toolkit.",
   "homepage": "https://github.com/openscenegraph/OpenSceneGraph",
-  "supports": "!(arm & uwp)",
   "dependencies": [
     {
       "name": "expat",

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osg",
   "version": "3.6.5",
-  "port-version": 14,
+  "port-version": 15,
   "description": "The OpenSceneGraph is an open source high performance 3D graphics toolkit.",
   "homepage": "https://github.com/openscenegraph/OpenSceneGraph",
   "supports": "!(arm & uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3978,7 +3978,7 @@
     },
     "libraw": {
       "baseline": "201903",
-      "port-version": 8
+      "port-version": 9
     },
     "librdkafka": {
       "baseline": "1.9.0",
@@ -5294,7 +5294,7 @@
     },
     "osg": {
       "baseline": "3.6.5",
-      "port-version": 14
+      "port-version": 15
     },
     "osg-qt": {
       "baseline": "Qt5",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3058,7 +3058,7 @@
     },
     "jasper": {
       "baseline": "2.0.33",
-      "port-version": 4
+      "port-version": 5
     },
     "jbig2dec": {
       "baseline": "0.19",
@@ -5166,7 +5166,7 @@
     },
     "openexr": {
       "baseline": "2.5.0",
-      "port-version": 3
+      "port-version": 4
     },
     "opengl": {
       "baseline": "2022-03-14",

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5220ea6a54e25d777f853a2c77196be67da02f3",
+      "version": "2.0.33",
+      "port-version": 5
+    },
+    {
       "git-tree": "5cc65b3d32490a3fd1bd1768188b905a873af2ef",
       "version": "2.0.33",
       "port-version": 4

--- a/versions/l-/libraw.json
+++ b/versions/l-/libraw.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "29f0c844c7ce540d4a4541ad145e17fb4264326e",
+      "git-tree": "13ab93771f3879d0f68e0418b028df14cb260dd3",
       "version-string": "201903",
       "port-version": 9
     },

--- a/versions/l-/libraw.json
+++ b/versions/l-/libraw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29f0c844c7ce540d4a4541ad145e17fb4264326e",
+      "version-string": "201903",
+      "port-version": 9
+    },
+    {
       "git-tree": "e07b6b8ed70ad198a64027d0e44eab43d116039d",
       "version-string": "201903",
       "port-version": 8

--- a/versions/o-/openexr.json
+++ b/versions/o-/openexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40df682add8b267e718dac8ea78a2bcb47006048",
+      "version-string": "2.5.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "7589d3f1641e6e63450303e424d966221375109f",
       "version-string": "2.5.0",
       "port-version": 3

--- a/versions/o-/osg.json
+++ b/versions/o-/osg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2443dfe66203d27d9314f08234413acf16cf525e",
+      "git-tree": "eae6fe2e3afc6d1609ec2ee7cd37b3b9d19c7da1",
       "version": "3.6.5",
       "port-version": 15
     },

--- a/versions/o-/osg.json
+++ b/versions/o-/osg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eae6fe2e3afc6d1609ec2ee7cd37b3b9d19c7da1",
+      "git-tree": "219045e2b75fc651860c70dbf97557d543269842",
       "version": "3.6.5",
       "port-version": 15
     },

--- a/versions/o-/osg.json
+++ b/versions/o-/osg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2443dfe66203d27d9314f08234413acf16cf525e",
+      "version": "3.6.5",
+      "port-version": 15
+    },
+    {
       "git-tree": "0a38fb280615f72738ab9ec48d92d8bee28017c9",
       "version": "3.6.5",
       "port-version": 14


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes arm64-osx targets for osg, libraw, openexr and jasper. In a [recent QT PR](https://github.com/microsoft/vcpkg/pull/25418) I blocked some of these targets accidently. This PR correctly represents what each port supports.  
>  - libraw does support compiling for arm64 but not uwp because of a dependency on CreateFile and other API's
>  - openexr does not support arm because of some intel intrinsic used
>  - osg does not support compiling for uwp but does support arm on other platforms like osx
>  - jasper does not support compiling for uwp

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
various

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
