### PR TITLE
[libcuckoo] Update port @0.3.1

### DIFF
--- a/ports/libcuckoo/portfile.cmake
+++ b/ports/libcuckoo/portfile.cmake
@@ -1,16 +1,16 @@
-# Header-only library
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO efficient/libcuckoo
-    REF 8785773896d74f72b6224e59d37f5f8c3c1e022a
-    SHA512 e47f8fd132ee2acf347ee375759f96235cd090fdb825792f994ff5eb4d8fed55b8e8bea8d293ec96c1a5f1b46d19c6648eaf2482e482b7b9c0d6dc734bc2121d
+    REF ea8c36c65bf9cf83aaf6b0db971248c6ae3686cf
+    SHA512 5c36ebf6047afb3fa980049dc2e38b8e34443d40cff7ba9b7ee1fa8b78ff3dd92b2d0a346667a71eec6d0bfc917b3080c883146f97681f20f71ce618eac3f37f
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+# header-only library
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TESTS=OFF
@@ -19,11 +19,8 @@ vcpkg_configure_cmake(
         -DBUILD_UNIVERSAL_BENCHMARK=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/${PORT})
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
-
-# Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libcuckoo/vcpkg.json
+++ b/ports/libcuckoo/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "libcuckoo",
-  "version-string": "0.3",
-  "port-version": 1,
+  "version": "0.3.1",
   "description": "A high-performance, concurrent hash table",
-  "homepage": "https://github.com/efficient/libcuckoo"
+  "homepage": "https://github.com/efficient/libcuckoo",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3517,8 +3517,8 @@
       "port-version": 3
     },
     "libcuckoo": {
-      "baseline": "0.3",
-      "port-version": 1
+      "baseline": "0.3.1",
+      "port-version": 0
     },
     "libcurl-simple-https": {
       "baseline": "2022-02-14",

--- a/versions/l-/libcuckoo.json
+++ b/versions/l-/libcuckoo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c8390f186a348872f4f8caf773c6ce376cf4365",
+      "version": "0.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "47bda50b4e599d0dc81a015e175d1510de0ca62d",
       "version-string": "0.3",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Updates the `libcuckoo` port to the latest version (= 0.3.1)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes, I refactored the deprecated stuff away.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
