### PR TITLE
[yasm] Fix supports expression value

### DIFF
--- a/ports/yasm/fix-arm-cross-build.patch
+++ b/ports/yasm/fix-arm-cross-build.patch
@@ -1,0 +1,94 @@
+diff --git a/cmake/modules/YasmMacros.cmake b/cmake/modules/YasmMacros.cmake
+index ab1be00..918f51b 100644
+--- a/cmake/modules/YasmMacros.cmake
++++ b/cmake/modules/YasmMacros.cmake
+@@ -58,7 +58,9 @@ macro (YASM_ADD_MODULE _module_NAME)
+ endmacro (YASM_ADD_MODULE)
+ 
+ macro (YASM_GENPERF _in_NAME _out_NAME)
++    if (NOT _tmp_GENPERF_EXE)
+     get_target_property(_tmp_GENPERF_EXE genperf LOCATION)
++    endif()
+     add_custom_command(
+         OUTPUT ${_out_NAME}
+         COMMAND ${_tmp_GENPERF_EXE} ${_in_NAME} ${_out_NAME}
+@@ -68,7 +70,9 @@ macro (YASM_GENPERF _in_NAME _out_NAME)
+ endmacro (YASM_GENPERF)
+ 
+ macro (YASM_RE2C _in_NAME _out_NAME)
++    if (NOT _tmp_RE2C_EXE)
+     get_target_property(_tmp_RE2C_EXE re2c LOCATION)
++    endif()
+     add_custom_command(
+         OUTPUT ${_out_NAME}
+         COMMAND ${_tmp_RE2C_EXE} ${ARGN} -o ${_out_NAME} ${_in_NAME}
+@@ -78,7 +82,9 @@ macro (YASM_RE2C _in_NAME _out_NAME)
+ endmacro (YASM_RE2C)
+ 
+ macro (YASM_GENMACRO _in_NAME _out_NAME _var_NAME)
++    if (NOT _tmp_GENMACRO_EXE)
+     get_target_property(_tmp_GENMACRO_EXE genmacro LOCATION)
++    endif()
+     add_custom_command(
+         OUTPUT ${_out_NAME}
+         COMMAND ${_tmp_GENMACRO_EXE} ${_out_NAME} ${_var_NAME} ${_in_NAME}
+diff --git a/modules/preprocs/nasm/CMakeLists.txt b/modules/preprocs/nasm/CMakeLists.txt
+index e10a9dd..e28ffbb 100644
+--- a/modules/preprocs/nasm/CMakeLists.txt
++++ b/modules/preprocs/nasm/CMakeLists.txt
+@@ -1,5 +1,8 @@
++if (NOT _tmp_GENVERSION_EXE)
+ add_executable(genversion preprocs/nasm/genversion.c)
++install(TARGETS genversion RUNTIME DESTINATION bin)
+ get_target_property(_tmp_GENVERSION_EXE genversion LOCATION)
++endif()
+ add_custom_command(
+     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version.mac
+     COMMAND ${_tmp_GENVERSION_EXE} ${CMAKE_CURRENT_BINARY_DIR}/version.mac
+diff --git a/tools/genmacro/CMakeLists.txt b/tools/genmacro/CMakeLists.txt
+index 27ba599..0168494 100644
+--- a/tools/genmacro/CMakeLists.txt
++++ b/tools/genmacro/CMakeLists.txt
+@@ -1,3 +1,7 @@
++if (NOT _tmp_GENMACRO_EXE)
+ add_executable(genmacro
+     genmacro.c
+     )
++
++install(TARGETS genmacro RUNTIME DESTINATION bin)
++endif()
+\ No newline at end of file
+diff --git a/tools/genperf/CMakeLists.txt b/tools/genperf/CMakeLists.txt
+index 6f50989..87d19bc 100644
+--- a/tools/genperf/CMakeLists.txt
++++ b/tools/genperf/CMakeLists.txt
+@@ -1,3 +1,4 @@
++if (NOT _tmp_GENPERF_EXE)
+ add_executable(genperf
+     genperf.c
+     perfect.c
+@@ -6,3 +7,6 @@ add_executable(genperf
+     ../../libyasm/xstrdup.c
+     )
+ set_target_properties(genperf PROPERTIES COMPILE_FLAGS -DYASM_LIB_DECL=)
++
++install(TARGETS genperf RUNTIME DESTINATION bin)
++endif()
+\ No newline at end of file
+diff --git a/tools/re2c/CMakeLists.txt b/tools/re2c/CMakeLists.txt
+index 7125d49..f2f1a40 100644
+--- a/tools/re2c/CMakeLists.txt
++++ b/tools/re2c/CMakeLists.txt
+@@ -1,3 +1,4 @@
++if (NOT _tmp_RE2C_EXE)
+ add_executable(re2c
+     main.c
+     code.c
+@@ -9,3 +10,6 @@ add_executable(re2c
+     substr.c
+     translate.c
+     )
++
++install(TARGETS re2c RUNTIME DESTINATION bin)
++endif()
+\ No newline at end of file

--- a/ports/yasm/portfile.cmake
+++ b/ports/yasm/portfile.cmake
@@ -42,7 +42,11 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 if (BUILD_TOOLS)
-    vcpkg_copy_tools(TOOL_NAMES vsyasm yasm ytasm re2c genmacro genperf genversion AUTO_CLEAN)
+    set(EXTRA_BUILD_TOOLS "")
+    if (NOT VCPKG_CROSSCOMPILING)
+        list(APPEND EXTRA_BUILD_TOOLS re2c genmacro genperf genversion)
+    endif()
+    vcpkg_copy_tools(TOOL_NAMES vsyasm yasm ytasm ${EXTRA_BUILD_TOOLS} AUTO_CLEAN)
     if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         file(COPY "${CURRENT_PACKAGES_DIR}/bin/yasmstd${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
             DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")

--- a/ports/yasm/portfile.cmake
+++ b/ports/yasm/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF 009450c7ad4d425fa5a10ac4bd6efbd25248d823 # 1.3.0 plus bugfixes for https://github.com/yasm/yasm/issues/153
     SHA512 a542577558676d11b52981925ea6219bffe699faa1682c033b33b7534f5a0dfe9f29c56b32076b68c48f65e0aef7c451be3a3af804c52caa4d4357de4caad83c
     HEAD_REF master
-    PATCHES add-feature-tools.patch
+    PATCHES
+        add-feature-tools.patch
+        fix-arm-cross-build.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -16,10 +18,21 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
 vcpkg_add_to_path("${PYTHON3_DIR}")
 
+set(HOST_TOOLS_OPTIONS "")
+if (VCPKG_CROSSCOMPILING)
+    list(APPEND HOST_TOOLS_OPTIONS
+        "-D_tmp_RE2C_EXE=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}/re2c${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+        "-D_tmp_GENPERF_EXE=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}/genperf${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+        "-D_tmp_GENMACRO_EXE=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}/genmacro${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+        "-D_tmp_GENVERSION_EXE=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}/genversion${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+    )
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        ${HOST_TOOLS_OPTIONS}
         -DENABLE_NLS=OFF
         -DYASM_BUILD_TESTS=OFF
 )
@@ -29,7 +42,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 if (BUILD_TOOLS)
-    vcpkg_copy_tools(TOOL_NAMES vsyasm yasm ytasm AUTO_CLEAN)
+    vcpkg_copy_tools(TOOL_NAMES vsyasm yasm ytasm re2c genmacro genperf genversion AUTO_CLEAN)
     if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         file(COPY "${CURRENT_PACKAGES_DIR}/bin/yasmstd${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
             DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")

--- a/ports/yasm/vcpkg.json
+++ b/ports/yasm/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "yasm",
   "version": "1.3.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Yasm is a complete rewrite of the NASM assembler under the new BSD License.",
   "homepage": "https://github.com/yasm/yasm",
-  "supports": "windows & !uwp & !arm",
+  "supports": "!uwp"
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/yasm/vcpkg.json
+++ b/ports/yasm/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 4,
   "description": "Yasm is a complete rewrite of the NASM assembler under the new BSD License.",
   "homepage": "https://github.com/yasm/yasm",
-  "supports": "!uwp"
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/yasm/vcpkg.json
+++ b/ports/yasm/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 4,
   "description": "Yasm is a complete rewrite of the NASM assembler under the new BSD License.",
   "homepage": "https://github.com/yasm/yasm",
+  "license": "BSD-2-Clause OR BSD-3-Clause OR Artistic-1.0 OR GPL-2.0-only OR LGPL-2.0-only",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/ports/yasm/vcpkg.json
+++ b/ports/yasm/vcpkg.json
@@ -17,7 +17,11 @@
     },
     {
       "name": "yasm",
-      "host": true
+      "host": true,
+      "default-features": false,
+      "features": [
+        "tools"
+      ]
     }
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7754,7 +7754,7 @@
     },
     "yasm": {
       "baseline": "1.3.0",
-      "port-version": 3
+      "port-version": 4
     },
     "yasm-tool": {
       "baseline": "2021-12-14",

--- a/versions/y-/yasm.json
+++ b/versions/y-/yasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f70e8525454924e729b729e47b69bc496b67a93",
+      "version": "1.3.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "4368509dc3dfe6cab848b8713b22c9c0ef408527",
       "version": "1.3.0",
       "port-version": 3

--- a/versions/y-/yasm.json
+++ b/versions/y-/yasm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d3db3efe177edd0d7f0230a61e48a6819c8c01ae",
+      "git-tree": "21a3c4abe70d58157b35508a1f1ee6c99ed8c912",
       "version": "1.3.0",
       "port-version": 4
     },

--- a/versions/y-/yasm.json
+++ b/versions/y-/yasm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f70e8525454924e729b729e47b69bc496b67a93",
+      "git-tree": "d3db3efe177edd0d7f0230a61e48a6819c8c01ae",
       "version": "1.3.0",
       "port-version": 4
     },

--- a/versions/y-/yasm.json
+++ b/versions/y-/yasm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "21a3c4abe70d58157b35508a1f1ee6c99ed8c912",
+      "git-tree": "796bb1f691c8ef8b04eb6577e95ab04167470dac",
       "version": "1.3.0",
       "port-version": 4
     },


### PR DESCRIPTION
The `supports` expression was wrongly changed by [merge to master](https://github.com/microsoft/vcpkg/pull/19162/commits/2fd21d1af6258a3688d7e4e203263099393ff7e2)。

Fix this.

Related: #19162.