### PR TITLE
[poppler] update to version 22.8.0 and Add glib support

### DIFF
--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO poppler/poppler
-    REF poppler-22.03.0
-    SHA512 0229e50bbf21154f398480730649fd15ca37c7edae5abd63ed41ab722852d09e4dc2b9df66b13b1cfe3e7a0da945916e1bd39c75c4879ded2759eb465f69424a
+    REF 12853d22e9d0527c10ada02666aef629db3e5e7c #poppler-22.08.0
+    SHA512 d181bc8a521e216f163096e8baad7e73c898c24b18a5a4ab3b687bff4c29333c8c19961adaef54e684c1bdf26dab90183c3553fadb963b7a664e063bd3abcfcf
     HEAD_REF master
     PATCHES
         export-unofficial-poppler.patch
@@ -51,7 +51,6 @@ vcpkg_cmake_configure(
         -DBUILD_CPP_TESTS=OFF
         -DBUILD_MANUAL_TESTS=OFF
         -DENABLE_UTILS=OFF
-        -DENABLE_GLIB=OFF
         -DENABLE_GOBJECT_INTROSPECTION=OFF
         -DENABLE_QT5=OFF
         -DENABLE_QT6=OFF

--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         curl        ENABLE_LIBCURL
         private-api ENABLE_UNSTABLE_API_ABI_HEADERS
         zlib        ENABLE_ZLIB
+        glib        ENABLE_GLIB 
 )
 if("fontconfig" IN_LIST FEATURES)
     list(APPEND FEATURE_OPTIONS "-DFONT_CONFIGURATION=fontconfig")

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "poppler",
-  "version": "22.3.0",
-  "port-version": 2,
+  "version": "22.8.0",
   "description": "A PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "license": "GPL-2.0-or-later",
@@ -34,6 +33,10 @@
       "dependencies": [
         {
           "name": "cairo",
+          "default-features": false
+        },
+        {
+          "name": "glib",
           "default-features": false
         }
       ]

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -70,12 +70,15 @@
       "description": "glib for poppler",
       "dependencies": [
         {
-          "name": "cairo",
+          "name": "glib",
           "default-features": false
         },
         {
-          "name": "glib",
-          "default-features": false
+          "name": "poppler",
+          "default-features": false,
+          "features": [
+            "cairo"
+          ]
         }
       ]
     },

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -34,10 +34,6 @@
         {
           "name": "cairo",
           "default-features": false
-        },
-        {
-          "name": "glib",
-          "default-features": false
         }
       ]
     },
@@ -73,6 +69,10 @@
     "glib": {
       "description": "glib for poppler",
       "dependencies": [
+        {
+          "name": "cairo",
+          "default-features": false
+        },
         {
           "name": "glib",
           "default-features": false

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -67,6 +67,15 @@
         "fontconfig"
       ]
     },
+    "glib": {
+      "description": "glib for poppler",
+      "dependencies": [
+        {
+          "name": "glib",
+          "default-features": false
+        }
+      ]
+    },
     "private-api": {
       "description": "Install headers for private API (aka unstable API/ABI headers)"
     },
@@ -78,15 +87,6 @@
       "dependencies": [
         "zlib"
       ]
-    },
-    "glib": {
-       "description" : "glib for poppler",
-       "dependencies": [
-        {
-          "name": "glib",
-          "default-features": false
-        }       
-       ]
     }
   }
 }

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "poppler",
   "version": "22.3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "license": "GPL-2.0-or-later",
@@ -78,6 +78,15 @@
       "dependencies": [
         "zlib"
       ]
+    },
+    "glib": {
+       "description" : "glib for poppler",
+       "dependencies": [
+        {
+          "name": "glib",
+          "default-features": false
+        }       
+       ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5573,8 +5573,8 @@
       "port-version": 4
     },
     "poppler": {
-      "baseline": "22.3.0",
-      "port-version": 2
+      "baseline": "22.8.0",
+      "port-version": 0
     },
     "popsift": {
       "baseline": "0.9",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5574,7 +5574,7 @@
     },
     "poppler": {
       "baseline": "22.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "popsift": {
       "baseline": "0.9",

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e3aa5d9968dae0b468f3872d2d14193a75f26e8",
+      "version": "22.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2d14bc508abd0861bda1a16290ad65b061a82b7c",
       "version": "22.3.0",
       "port-version": 1

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7dc2b9bd918320a64cec6ab924e1e298d71c893",
+      "git-tree": "8551fcec6635c82fba6fc51d817e788dfae0a387",
       "version": "22.8.0",
       "port-version": 0
     },

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "0693a59587cbdfe94eb2da4e2f319d467d349c8c",
-      "version": "22.3.0",
-      "port-version": 2
-    },
-    {
       "git-tree": "2d14bc508abd0861bda1a16290ad65b061a82b7c",
       "version": "22.3.0",
       "port-version": 1

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3e3aa5d9968dae0b468f3872d2d14193a75f26e8",
+      "git-tree": "a7dc2b9bd918320a64cec6ab924e1e298d71c893",
       "version": "22.8.0",
       "port-version": 0
     },

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0693a59587cbdfe94eb2da4e2f319d467d349c8c",
+      "version": "22.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "2d14bc508abd0861bda1a16290ad65b061a82b7c",
       "version": "22.3.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #25266 

 Update poppler to version 22.8.0
 The poppler port lacks the glib bindings. Adding poppler[glib]

Feature 'glib' tested successfully in the following triplet:

- x86-windows
-  x64-windows
- x64-linux