### PR TITLE
[simdjson] Update to 2.2.0

### DIFF
--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO simdjson/simdjson
-    REF v1.1.0
+    REF v2.0.0
     HEAD_REF master
-    SHA512 f8718bd039e1a25f0b95880b957c43e6eba6eada6bb7f58cedde37669a46b15b3ff9f4c4ea775e1cf949657642ef0472fa8bac5bdc98882df63e7f292fb5a723
+    SHA512 2cf20799189171fa3bcac5b51a660635e4e3c8688c6cbfc527a17860b24abe534085b4918e916bcb23d0bc26f949301141b6bbf8bee6d4199c2c93cba2156b05
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO simdjson/simdjson
-    REF v2.0.0
+    REF 1075e8609c4afa253162d441437af929c29e31bb # v2.2.0
     HEAD_REF master
-    SHA512 2cf20799189171fa3bcac5b51a660635e4e3c8688c6cbfc527a17860b24abe534085b4918e916bcb23d0bc26f949301141b6bbf8bee6d4199c2c93cba2156b05
+    SHA512 c479a1a5f63686b3852a8407d3cb3f6ebf418dde40000c96bf973ebb2d31095ecd3e6a5353b8bdffd57f26179b6668d8ac39bfdb012d8b04ec6115cc39495b66
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version-semver": "2.0.0",
+  "version-semver": "2.2.0",
   "description": "A extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0",

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version-semver": "1.1.0",
+  "version-semver": "2.0.0",
   "description": "A extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6581,7 +6581,7 @@
       "port-version": 0
     },
     "simdjson": {
-      "baseline": "1.1.0",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6581,7 +6581,7 @@
       "port-version": 0
     },
     "simdjson": {
-      "baseline": "2.0.0",
+      "baseline": "2.2.0",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "4fad91e3589f242dbdd1e698b87f78eba9e6338b",
-      "version-semver": "2.0.0",
-      "port-version": 0
-    },
-    {
       "git-tree": "18a23d4f86c9f4d0db8feb5bb7eeb32ebcc3a3f2",
       "version-semver": "1.1.0",
       "port-version": 0

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2bc3bd74a2cb0719ba123f23538e9e974f88c320",
+      "version-semver": "2.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4fad91e3589f242dbdd1e698b87f78eba9e6338b",
       "version-semver": "2.0.0",
       "port-version": 0

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4fad91e3589f242dbdd1e698b87f78eba9e6338b",
+      "version-semver": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "18a23d4f86c9f4d0db8feb5bb7eeb32ebcc3a3f2",
       "version-semver": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Update simdjson to v2.0.0.

  Currently, the newest release in upstream is 2.2.0. I am planning to catch up upstream with several PRs:
  - 1.1.0 -> 2.0.0 -> 2.0.1 -> 2.0.2 -> 2.0.3 -> 2.0.4 -> 2.1.0 -> 2.2.0.

  (or maybe within one PR).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, Yes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
