### PR TITLE
[eastl] Fix error C2039 with Visual Studio 2022

### DIFF
--- a/ports/eastl/fix-error-C2039.diff
+++ b/ports/eastl/fix-error-C2039.diff
@@ -1,0 +1,88 @@
+diff --git a/include/EASTL/numeric_limits.h b/include/EASTL/numeric_limits.h
+index e991e7e9..e933c845 100644
+--- a/include/EASTL/numeric_limits.h
++++ b/include/EASTL/numeric_limits.h
+@@ -1435,6 +1435,19 @@ namespace eastl
+ 			static value_type round_error() 
+ 				{ return 0.5f; }
+ 
++			#if defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE >= 202206L // If using a recent version of MSVC's STL...
++			static value_type infinity()
++				{ return __builtin_huge_valf(); }
++
++			static value_type quiet_NaN()
++				{ return __builtin_nanf("0"); }
++
++			static value_type signaling_NaN()
++				{ return __builtin_nansf("1"); }
++
++			static value_type denorm_min()
++				{ return FLT_TRUE_MIN; }
++			#else
+ 			static value_type infinity() 
+ 				{ return _CSTD _FInf._Float; }
+ 
+@@ -1446,6 +1459,7 @@ namespace eastl
+ 
+ 			static value_type denorm_min() 
+ 				{ return _CSTD _FDenorm._Float; }
++			#endif
+ 
+ 		#endif
+ 	};
+@@ -1553,6 +1567,19 @@ namespace eastl
+ 			static value_type round_error() 
+ 				{ return 0.5f; }
+ 
++			#if defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE >= 202206L // If using a recent version of MSVC's STL...
++			static value_type infinity()
++				{ return __builtin_huge_val(); }
++
++			static value_type quiet_NaN()
++				{ return __builtin_nan("0"); }
++
++			static value_type signaling_NaN()
++				{ return __builtin_nans("1"); }
++
++			static value_type denorm_min()
++				{ return DBL_TRUE_MIN; }
++			#else
+ 			static value_type infinity() 
+ 				{ return _CSTD _Inf._Double; }
+ 
+@@ -1564,6 +1591,7 @@ namespace eastl
+ 
+ 			static value_type denorm_min() 
+ 				{ return _CSTD _Denorm._Double; }
++			#endif
+ 
+ 		#endif
+ 	};
+@@ -1671,6 +1699,19 @@ namespace eastl
+ 			static value_type round_error() 
+ 				{ return 0.5f; }
+ 
++			#if defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE >= 202206L // If using a recent version of MSVC's STL...
++			static value_type infinity()
++				{ return __builtin_huge_val(); }
++
++			static value_type quiet_NaN()
++				{ return __builtin_nan("0"); }
++
++			static value_type signaling_NaN()
++				{ return __builtin_nans("1"); }
++
++			static value_type denorm_min()
++				{ return LDBL_TRUE_MIN; }
++			#else
+ 			static value_type infinity() 
+ 				{ return _CSTD _LInf._Long_double; }
+ 
+@@ -1682,6 +1723,7 @@ namespace eastl
+ 
+ 			static value_type denorm_min() 
+ 				{ return _CSTD _LDenorm._Long_double; }
++			#endif
+ 
+ 		#endif
+ 	};

--- a/ports/eastl/portfile.cmake
+++ b/ports/eastl/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES 
         fix_cmake_install.patch
         Fix-error-C2338.patch
+        fix-error-C2039.diff
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/EASTLConfig.cmake.in" DESTINATION "${SOURCE_PATH}")

--- a/ports/eastl/vcpkg.json
+++ b/ports/eastl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "eastl",
   "version-string": "3.18.00",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Electronic Arts Standard Template Library. It is a C++ template library of containers, algorithms, and iterators useful for runtime and tool development across multiple platforms. It is a fairly extensive and robust implementation of such a library and has an emphasis on high performance above all other considerations.",
   "homepage": "https://github.com/electronicarts/EASTL",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -12,7 +12,6 @@
       "baseline": "3.0.5",
       "port-version": 0
     },
-
     "abseil": {
       "baseline": "20211102.1",
       "port-version": 0
@@ -2023,7 +2022,7 @@
     },
     "eastl": {
       "baseline": "3.18.00",
-      "port-version": 2
+      "port-version": 3
     },
     "easycl": {
       "baseline": "0.3",

--- a/versions/e-/eastl.json
+++ b/versions/e-/eastl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e7b533fac097c3aa75f7b46630ea62f10980f87",
+      "version-string": "3.18.00",
+      "port-version": 3
+    },
+    {
       "git-tree": "aa2de2990c3b1e6e008e1cafea8ad82c765278fb",
       "version-string": "3.18.00",
       "port-version": 2


### PR DESCRIPTION
In an internal version of Visual Studio, `eastl` install failed with following error:
```
D:\buildtrees\eastl\src\5ab9f1222a-55681b7249.clean\include\EASTL/numeric_limits.h(1439): error C2039: '_FInf': is not a member of '`global namespace''
D:\buildtrees\eastl\src\5ab9f1222a-55681b7249.clean\include\EASTL/numeric_limits.h(1439): error C2065: '_FInf': undeclared identifier
D:\buildtrees\eastl\src\5ab9f1222a-55681b7249.clean\include\EASTL/numeric_limits.h(1442): error C2039: '_FNan': is not a member of '`global namespace''
D:\buildtrees\eastl\src\5ab9f1222a-55681b7249.clean\include\EASTL/numeric_limits.h(1442): error C2065: '_FNan': undeclared identifier
D:\buildtrees\eastl\src\5ab9f1222a-55681b7249.clean\include\EASTL/numeric_limits.h(1445): error C2039: '_FSnan': is not a member of '`global namespace''
D:\buildtrees\eastl\src\5ab9f1222a-55681b7249.clean\include\EASTL/numeric_limits.h(1445): error C2065: '_FSnan': undeclared identifier
D:\buildtrees\eastl\src\5ab9f1222a-55681b7249.clean\include\EASTL/numeric_limits.h(1448): error C2039: '_FDenorm': is not a member of '`global namespace''
D:\buildtrees\eastl\src\5ab9f1222a-55681b7249.clean\include\EASTL/numeric_limits.h(1448): error C2065: '_FDenorm': undeclared identifier
```
This error fixed by upstream PR https://github.com/electronicarts/EASTL/pull/474, this PR is syncing up the fix to vcpkg.