### PR TITLE
[ffmpeg] Fix failure of cross-compiling for ffmpeg due to use inappropriate strip.

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -461,7 +461,7 @@ endif()
 set(OPTIONS_CROSS " --enable-cross-compile")
 
 # ffmpeg needs --cross-prefix option to use appropriate tools for cross-compiling.
-if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "(/.+)gcc$" AND CMAKE_MATCH_1)
+if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "(/.+)gcc$")
     string(APPEND OPTIONS_CROSS " --cross-prefix=${CMAKE_MATCH_1}")
 endif()
 

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -96,6 +96,8 @@ if(VCPKG_TARGET_IS_MINGW)
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
         string(APPEND OPTIONS " --target-os=mingw64")
     endif()
+elseif(VCPKG_TARGET_IS_LINUX)
+    string(APPEND OPTIONS " --target-os=linux")
 elseif(VCPKG_TARGET_IS_WINDOWS)
     string(APPEND OPTIONS " --target-os=win32")
 elseif(VCPKG_TARGET_IS_OSX)
@@ -457,6 +459,11 @@ if (VCPKG_TARGET_IS_OSX)
 endif()
 
 set(OPTIONS_CROSS " --enable-cross-compile")
+
+# ffmpeg needs --cross-prefix option to use appropriate tools for cross-compiling.
+if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "(/.+)gcc$" AND CMAKE_MATCH_1)
+    string(APPEND OPTIONS_CROSS " --cross-prefix=${CMAKE_MATCH_1}")
+endif()
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     string(APPEND OPTIONS_CROSS " --arch=x86_64")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.1",
-  "port-version": 13,
+  "port-version": 14,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2230,7 +2230,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.1",
-      "port-version": 13
+      "port-version": 14
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0c833450003a7e139c33f09353f3e6fe1856763f",
+      "git-tree": "bd232549fb2bcffed0dcfac1e7e6a54f5a91b5cc",
       "version": "4.4.1",
       "port-version": 14
     },

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c833450003a7e139c33f09353f3e6fe1856763f",
+      "version": "4.4.1",
+      "port-version": 14
+    },
+    {
       "git-tree": "ad64f5ffe64b5fcd97e2e6d98273b70d498d6af0",
       "version": "4.4.1",
       "port-version": 13


### PR DESCRIPTION
Fix build failure of cross-compiling for ffmpeg.

- #### What does your PR fix?
[ffmpeg] Fix failure of cross-compiling for ffmpeg due to use inappropriate strip.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Basically.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  I am still working on this PR.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
