### PR TITLE
[cairo] Fix mingw-dynamic builds

### DIFF
--- a/ports/cairo/mingw-dllexport.patch
+++ b/ports/cairo/mingw-dllexport.patch
@@ -1,0 +1,13 @@
+diff --git a/src/cairoint.h b/src/cairoint.h
+index cfa77dd..fbc0776 100644
+--- a/src/cairoint.h
++++ b/src/cairoint.h
+@@ -48,7 +48,7 @@
+ 
+ #include "config.h"
+ 
+-#ifdef _MSC_VER
++#ifdef _WIN32
+ #define cairo_public __declspec(dllexport)
+ #endif
+ 

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -1,5 +1,3 @@
-set(CAIRO_VERSION 1.17.4)
-
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
@@ -26,9 +24,6 @@ else()
 endif()
 
 if ("x11" IN_LIST FEATURES)
-    if (VCPKG_TARGET_IS_WINDOWS)
-        message(FATAL_ERROR "Feature x11 only support UNIX.")
-    endif()
     message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
     list(APPEND OPTIONS -Dxlib=enabled)
 else()
@@ -38,9 +33,6 @@ list(APPEND OPTIONS -Dxcb=disabled)
 list(APPEND OPTIONS -Dxlib-xcb=disabled)
 
 if("gobject" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        message(FATAL_ERROR "Feature gobject currently only supports dynamic build.")
-    endif()
     list(APPEND OPTIONS -Dglib=enabled)
 else()
     list(APPEND OPTIONS -Dglib=disabled)

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_gitlab(
     PATCHES
         cairo_static_fix.patch
         disable-atomic-ops-check.patch # See https://gitlab.freedesktop.org/cairo/cairo/-/issues/554
+        mingw-dllexport.patch
 )
 
 if("fontconfig" IN_LIST FEATURES)

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -42,7 +42,8 @@
       ]
     },
     "x11": {
-      "description": "build with x11 support"
+      "description": "build with x11 support",
+      "supports": "!windows"
     }
   }
 }

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairo",
   "version": "1.17.6",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1243,7 +1243,7 @@
     },
     "cairo": {
       "baseline": "1.17.6",
-      "port-version": 2
+      "port-version": 3
     },
     "cairomm": {
       "baseline": "1.16.1",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c339d543f41d311c7d4282ca1efa4e400eb30b73",
+      "version": "1.17.6",
+      "port-version": 3
+    },
+    {
       "git-tree": "63bc79e8f9980f2b780bb296d96bfc3221dba137",
       "version": "1.17.6",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes building cairo for mingw-dynamic (missing dllexport).
  Removes obsolete portfile code, now relying on `supports` expressions.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes