### PR TITLE
[google-cloud-cpp] update to latest release (v2.0.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.42.0
-    SHA512 a4220aa4388bc3a1f3e24268c65193b6b01632fe661e952e8eaf898933e2bdc6e4f2254c5d1cc23b0853d8fbeb6de0510aa14f63b39d70d28b6430432430e468
+    REF v2.0.0
+    SHA512 9843c6b739c556be27e5e355b915ffdfa946a9e0a139da8b3a03a8c0abe6beb9088cfc0ba5c6fce1e32acbbce8384ffe59a752213c4bcec4c65a5b3ca8a9baf1
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/support_absl_cxx17.patch
+++ b/ports/google-cloud-cpp/support_absl_cxx17.patch
@@ -1,9 +1,9 @@
-diff --git a//CMakeLists.txt b/CMakeLists.txt
-index 4d03fee..42bb13c 100644
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a0d07d1..18320b6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -43,6 +43,14 @@ if (APPLE AND NOT DEFINED CMAKE_CXX_STANDARD)
-     set(CMAKE_CXX_STANDARD 11)
+     set(CMAKE_CXX_STANDARD 14)
  endif ()
  
 +find_package(absl CONFIG REQUIRED)
@@ -15,18 +15,18 @@ index 4d03fee..42bb13c 100644
 +endif ()
 +
  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.3)
          message(
 diff --git a/google/cloud/internal/port_platform.h b/google/cloud/internal/port_platform.h
-index f02cb7a..0ea8c9c 100644
+index b61eb48..327278f 100644
 --- a/google/cloud/internal/port_platform.h
 +++ b/google/cloud/internal/port_platform.h
 @@ -49,6 +49,8 @@
- // Abort compilation if the compiler does not support C++11.
- #if GOOGLE_CLOUD_CPP_CPP_VERSION < 201103L
- #  error "C++11 or newer is required"
+ // Abort compilation if the compiler does not support C++14.
+ #if GOOGLE_CLOUD_CPP_CPP_VERSION < 201402L
+ #  error "C++14 or newer is required"
 +#elif defined(ABSL_USE_CXX17) && GOOGLE_CLOUD_CPP_CPP_VERSION < 201703L
 +#  error "Compiled to use Abseil with C++17 support, but using with C++ < C++17"
- #endif  // GOOGLE_CLOUD_CPP_CPP_VERSION < 201103L
+ #endif  // GOOGLE_CLOUD_CPP_CPP_VERSION < 201402L
  
- // Abort the build if the version of the compiler is too old. With CMake we
+ // Abort the build if the version of the compiler is too old. This simplifies

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -107,7 +107,8 @@
             "grpc-common"
           ]
         }
-      ]
+      ],
+      "supports": "!windows"
     },
     "assuredworkloads": {
       "description": "Assured Workloads API C++ Client Library",
@@ -191,7 +192,8 @@
             "grpc-common"
           ]
         }
-      ]
+      ],
+      "supports": "!windows"
     },
     "cloudbuild": {
       "description": "Cloud Build API C++ Client Library",

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.42.0",
+  "version": "2.0.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -99,6 +99,7 @@
     },
     "asset": {
       "description": "Cloud Asset API C++ Client Library",
+      "supports": "!windows",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -107,8 +108,7 @@
             "grpc-common"
           ]
         }
-      ],
-      "supports": "!windows"
+      ]
     },
     "assuredworkloads": {
       "description": "Assured Workloads API C++ Client Library",
@@ -184,6 +184,7 @@
     },
     "channel": {
       "description": "Cloud Channel API C++ Client Library",
+      "supports": "!windows",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -192,8 +193,7 @@
             "grpc-common"
           ]
         }
-      ],
-      "supports": "!windows"
+      ]
     },
     "cloudbuild": {
       "description": "Cloud Build API C++ Client Library",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2625,7 +2625,7 @@
       "port-version": 0
     },
     "google-cloud-cpp": {
-      "baseline": "1.42.0",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3ba89c66f66ee89018f5a7890ee34404c49489c",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "95315156a8c6fefdde56b6c4718062975ff7e0ce",
       "version": "1.42.0",
       "port-version": 0

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a3ba89c66f66ee89018f5a7890ee34404c49489c",
+      "git-tree": "71a72e78da707ee567b96bc835cf25cd8e8eb975",
       "version": "2.0.0",
       "port-version": 0
     },


### PR DESCRIPTION
Updates the `google-cloud-cpp` to the latest release (v2.0.0).  This is a major release, as the package requires at least C++14.


- #### What does your PR fix?

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes.
