### PR TITLE
[readline-win32] export target

### DIFF
--- a/ports/readline-win32/CMakeLists.txt
+++ b/ports/readline-win32/CMakeLists.txt
@@ -56,11 +56,11 @@ install(FILES ${headers} DESTINATION include/readline)
 target_include_directories(readline PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
 
 install(TARGETS readline
-    EXPORT unofficial-readline-win32Config
+    EXPORT unofficial-readline-win32-config
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(EXPORT unofficial-readline-win32Config
-    NAMESPACE unofficial::readline::
+install(EXPORT unofficial-readline-win32-config
+    NAMESPACE unofficial::readline-win32::
     DESTINATION share/unofficial-readline-win32)

--- a/ports/readline-win32/CMakeLists.txt
+++ b/ports/readline-win32/CMakeLists.txt
@@ -50,7 +50,17 @@ add_library(readline
 	mbutil.c
     support/wcwidth.c)
 
+file(GLOB headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+install(FILES ${headers} DESTINATION include/readline)
+
+target_include_directories(readline PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+
 install(TARGETS readline
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
+    EXPORT unofficial-readline-win32Config
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(EXPORT unofficial-readline-win32Config
+    NAMESPACE unofficial::readline::
+    DESTINATION share/unofficial-readline-win32)

--- a/ports/readline-win32/portfile.cmake
+++ b/ports/readline-win32/portfile.cmake
@@ -6,21 +6,19 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH}/src/readline/5.0/readline-5.0-src)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/config.h DESTINATION ${SOURCE_PATH}/src/readline/5.0/readline-5.0-src)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}/src/readline/5.0/readline-5.0-src")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/config.h" DESTINATION "${SOURCE_PATH}/src/readline/5.0/readline-5.0-src")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}/src/readline/5.0/readline-5.0-src
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/src/readline/5.0/readline-5.0-src"
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-# Copy headers
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/include/readline)
-file(GLOB headers "${SOURCE_PATH}/src/readline/5.0/readline-5.0-src/*.h")
-file(COPY ${headers} DESTINATION ${CURRENT_PACKAGES_DIR}/include/readline)
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-readline-win32)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/src/readline/5.0/readline-5.0-src/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/src/readline/5.0/readline-5.0-src/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/readline-win32/vcpkg.json
+++ b/ports/readline-win32/vcpkg.json
@@ -1,8 +1,19 @@
 {
   "name": "readline-win32",
   "version": "5.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Implementation of readline for Windows Desktop",
   "homepage": "https://github.com/lltcggie",
-  "supports": "windows & !uwp"
+  "license": null,
+  "supports": "windows & !uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/readline-win32/vcpkg.json
+++ b/ports/readline-win32/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "5.0",
   "port-version": 5,
   "description": "Implementation of readline for Windows Desktop",
-  "homepage": "https://github.com/lltcggie",
+  "homepage": "https://github.com/lltcggie/readline",
   "license": null,
   "supports": "windows & !uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6198,7 +6198,7 @@
     },
     "readline-win32": {
       "baseline": "5.0",
-      "port-version": 4
+      "port-version": 5
     },
     "readosm": {
       "baseline": "1.1.0a",

--- a/versions/r-/readline-win32.json
+++ b/versions/r-/readline-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2507f88f520d5472ec37644c97aa860d471eaff6",
+      "version": "5.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "b1ed33b8ec37a1cf44926c9954b6943bce302b70",
       "version": "5.0",
       "port-version": 4

--- a/versions/r-/readline-win32.json
+++ b/versions/r-/readline-win32.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2507f88f520d5472ec37644c97aa860d471eaff6",
+      "git-tree": "19f9684f55a9aa01b5612a5ebec47960f51bacdd",
       "version": "5.0",
       "port-version": 5
     },


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/25589

Export target.

Tested usage on x64-windows.