### PR TITLE
[pcre] Fix build failure for loongarch64 cpu

### DIFF
--- a/ports/pcre/portfile.cmake
+++ b/ports/pcre/portfile.cmake
@@ -19,6 +19,11 @@ vcpkg_from_sourceforge(
     PATCHES ${PATCHES}
 )
 
+set(IS_PCRE_SUPPORT_JIT YES)
+if(VCPKG_TARGET_ARCHITECTURE MATCHES "loongarch")
+    set(IS_PCRE_SUPPORT_JIT NO)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
@@ -27,7 +32,7 @@ vcpkg_cmake_configure(
         -DPCRE_BUILD_PCRE32=YES
         -DPCRE_BUILD_PCRE16=YES
         -DPCRE_BUILD_PCRE8=YES
-        -DPCRE_SUPPORT_JIT=YES
+        -DPCRE_SUPPORT_JIT=${IS_PCRE_SUPPORT_JIT}
         -DPCRE_SUPPORT_UTF=YES
         -DPCRE_SUPPORT_UNICODE_PROPERTIES=YES
         # optional dependencies for PCREGREP

--- a/ports/pcre/vcpkg.json
+++ b/ports/pcre/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pcre",
   "version": "8.45",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Perl Compatible Regular Expressions",
   "homepage": "https://www.pcre.org/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -12,7 +12,6 @@
       "baseline": "3.0.5",
       "port-version": 0
     },
-
     "abseil": {
       "baseline": "20211102.1",
       "port-version": 0
@@ -5399,7 +5398,7 @@
     },
     "pcre": {
       "baseline": "8.45",
-      "port-version": 3
+      "port-version": 4
     },
     "pcre2": {
       "baseline": "10.40",

--- a/versions/p-/pcre.json
+++ b/versions/p-/pcre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50ec11ace2145fac2b0b01dae365a6764f716c6e",
+      "version": "8.45",
+      "port-version": 4
+    },
+    {
       "git-tree": "e8f61fdc5d1286667a8e14eb9521500b882394ad",
       "version": "8.45",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fix build failure for loongarch64 of pcre.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  linux,No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Basically.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
