### PR TITLE
[cppcodec] Windows compatibility fix

### DIFF
--- a/ports/cppcodec/0001-Fix-62.patch
+++ b/ports/cppcodec/0001-Fix-62.patch
@@ -1,0 +1,28 @@
+From 9f67d7026d3dee8fc6a0af614d97f9365cee2872 Mon Sep 17 00:00:00 2001
+From: Gabriele_Frau <gabriele.frau@sipalinformatica.it>
+Date: Wed, 17 Oct 2018 14:35:54 +0200
+Subject: [PATCH] Fix #62
+
+<Windows.h> includes macro definitions named max and min, wrap the call to max and min with parentheses, which prevent the macro expansion
+---
+ cppcodec/detail/stream_codec.hpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cppcodec/detail/stream_codec.hpp b/cppcodec/detail/stream_codec.hpp
+index d4204bc..4d8d054 100644
+--- a/cppcodec/detail/stream_codec.hpp
++++ b/cppcodec/detail/stream_codec.hpp
+@@ -187,8 +187,8 @@ template <typename T>
+ static CPPCODEC_ALWAYS_INLINE constexpr size_t num_possible_values()
+ {
+     return static_cast<size_t>(
+-            static_cast<intmax_t>(std::numeric_limits<T>::max())
+-                    - static_cast<intmax_t>(std::numeric_limits<T>::min()) + 1);
++            static_cast<intmax_t>((std::numeric_limits<T>::max)())
++                    - static_cast<intmax_t>((std::numeric_limits<T>::min)()) + 1);
+ }
+ 
+ template <typename CodecVariant, alphabet_index_t InvalidIdx, size_t I>
+-- 
+2.32.0.windows.1
+

--- a/ports/cppcodec/portfile.cmake
+++ b/ports/cppcodec/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v0.2
     SHA512 50c9c81cdb12560c87e513e1fd22c1ad24ea37b7d20a0e3044d43fb887f4c6494c69468e4d0811cd2fc1ae8fdb01b01cfb9f3cfdd8611d4bb0221cbd38cbead3
     HEAD_REF master
+	PATCHES 0001-Fix-62.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/cppcodec/vcpkg.json
+++ b/ports/cppcodec/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppcodec",
-  "version-string": "0.2",
+  "version": "0.2",
   "port-version": 3,
   "description": "Header-only C++11 library to encode/decode base64, base64url, base32, base32hex and hex (a.k.a. base16) as specified in RFC 4648, plus Crockford's base32."
 }

--- a/ports/cppcodec/vcpkg.json
+++ b/ports/cppcodec/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppcodec",
   "version-string": "0.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Header-only C++11 library to encode/decode base64, base64url, base32, base32hex and hex (a.k.a. base16) as specified in RFC 4648, plus Crockford's base32."
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1618,7 +1618,7 @@
     },
     "cppcodec": {
       "baseline": "0.2",
-      "port-version": 2
+      "port-version": 3
     },
     "cppcoro": {
       "baseline": "2020-02-28",

--- a/versions/c-/cppcodec.json
+++ b/versions/c-/cppcodec.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "89370bf2213b4bd2a116f2870c05a7f2920ea08d",
-      "version-string": "0.2",
+      "git-tree": "c2b218c7d3aef05b777ea2537d59b6d1aa2bbf4e",
+      "version": "0.2",
       "port-version": 3
     },
     {

--- a/versions/c-/cppcodec.json
+++ b/versions/c-/cppcodec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89370bf2213b4bd2a116f2870c05a7f2920ea08d",
+      "version-string": "0.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "cb6b230ec592ba7bc54d85013007f501971f03fa",
       "version-string": "0.2",
       "port-version": 2


### PR DESCRIPTION
Applying patch to fix a Windows compatibility issue which caused the redefinition of max()

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes