### PR TITLE
[ableton] Fixed ASIO vs. ASIOSDK confusion

### DIFF
--- a/ports/ableton/portfile.cmake
+++ b/ports/ableton/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_from_github(
 )
 # Note that the dependencies ASIO and ASIOSDK are completely different things:
 # -ASIO (ASyncronous IO) is a cross-platform C++ library for network and low-level I/O programming
-# -ASIOSDK is the SDK for the Steinberg ASIO (Audio Stream Input/Output) driver, for proffesional Windows audio applications
+# -ASIOSDK is the SDK for the Steinberg ASIO (Audio Stream Input/Output) driver, for profesional Windows audio applications
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 FEATURES
@@ -36,16 +36,19 @@ if ("discoverytest" IN_LIST FEATURES)
     set(NEED_CATCH2 ON)
 endif()
 
-set(LINK_BUILD_ASIO OFF)
+set(NEED_ASIOSDK OFF)
 if ("hut" IN_LIST FEATURES)
-  set(LINK_BUILD_ASIO ON)
+  if(WIN32)
+    # Need Steinberg ASIO audio driver SDK (only this low-latency audio driver makes the developer tool 'hut' useful on Windows)
+    set(NEED_ASIOSDK ON)
+  endif()
 endif()
     
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS    
         -DNEED_CATCH2=${NEED_CATCH2}
-        -DLINK_BUILD_ASIO=${LINK_BUILD_ASIO}
+        -DLINK_BUILD_ASIO=${NEED_ASIOSDK}
 )
 
 if ("coretest" IN_LIST FEATURES)

--- a/ports/ableton/portfile.cmake
+++ b/ports/ableton/portfile.cmake
@@ -9,8 +9,12 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         replace_local_asiostandalone_by_vcpkg_asio.patch
+        replace_asiosdk_download_by_vcpkg_asiosdk.patch
         replace_local_catch_by_vcpkg_catch2.patch
 )
+# Note that the dependencies ASIO and ASIOSDK are completely different things:
+# -ASIO (ASyncronous IO) is a cross-platform C++ library for network and low-level I/O programming
+# -ASIOSDK is the SDK for the Steinberg ASIO (Audio Stream Input/Output) driver, for proffesional Windows audio applications
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 FEATURES
@@ -31,11 +35,17 @@ endif()
 if ("discoverytest" IN_LIST FEATURES)
     set(NEED_CATCH2 ON)
 endif()
+
+set(LINK_BUILD_ASIO OFF)
+if ("hut" IN_LIST FEATURES)
+  set(LINK_BUILD_ASIO ON)
+endif()
     
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS    
         -DNEED_CATCH2=${NEED_CATCH2}
+        -DLINK_BUILD_ASIO=${LINK_BUILD_ASIO}
 )
 
 if ("coretest" IN_LIST FEATURES)

--- a/ports/ableton/replace_asiosdk_download_by_vcpkg_asiosdk.patch
+++ b/ports/ableton/replace_asiosdk_download_by_vcpkg_asiosdk.patch
@@ -1,0 +1,48 @@
+diff --git "a/examples/CMakeLists.txt" "b/examples/CMakeLists.txt"
+
+--- "a/examples/CMakeLists.txt"
++++ "b/examples/CMakeLists.txt"
+@@ -9,28 +9,22 @@ project(LinkExamples)
+ #
+ 
+ if(WIN32)
+-  function(configure_asio asio_sdk_path_OUT)
+-    # ASIO-related path/file variables
+-    set(asio_download_root "https:/download.steinberg.net/sdk_downloads")
+-    set(asio_file_name "asiosdk_2.3.3_2019-06-14.zip")
+-    set(asio_dir_name "asiosdk_2.3.3_2019-06-14")
+-    set(asio_working_dir "${CMAKE_BINARY_DIR}/modules")
+-    set(asio_output_path "${asio_working_dir}/${asio_file_name}")
+-
+-    message(STATUS "Downloading ASIO SDK")
+-    file(DOWNLOAD "${asio_download_root}/${asio_file_name}" ${asio_output_path})
+-    file(SHA1 ${asio_output_path} asio_zip_hash)
+-    message("   ASIO SDK SHA1: ${asio_zip_hash}")
+-
+-    message("   Extracting ASIO SDK")
+-    execute_process(COMMAND ${CMAKE_COMMAND} -E tar "xf" ${asio_output_path} --format=zip
+-      WORKING_DIRECTORY ${asio_working_dir}
+-      INPUT_FILE ${asio_output_path}
+-    )
++  if(LINK_BUILD_ASIO)
++    function(configure_asio asio_sdk_path_OUT)
++      # ASIO-related path/file variables
++      find_package(ASIOSDK)
++      if(NOT ASIOSDK_FOUND)
++        message(FATAL_ERROR "Steinberg ASIO audio driver SDK not found")
++      else()
++        message(STATUS "Steinberg ASIO audio driver SDK root dir: ${ASIOSDK_ROOT_DIR}")
++      endif()
++      set(asio_working_dir "${ASIOSDK_ROOT_DIR}")
++      set(asio_output_path "${CMAKE_BINARY_DIR}/modules/asiosdk")
+ 
+-    # Set the ASIO SDK path for the caller
+-    set(${asio_sdk_path_OUT} "${asio_working_dir}/${asio_dir_name}" PARENT_SCOPE)
+-  endfunction()
++      # Set the ASIO SDK path for the caller
++      set(${asio_sdk_path_OUT} "${asio_working_dir}" PARENT_SCOPE)
++    endfunction()
++  endif()
+ endif()
+ 
+ #     _             _ _

--- a/ports/ableton/replace_local_asiostandalone_by_vcpkg_asio.patch
+++ b/ports/ableton/replace_local_asiostandalone_by_vcpkg_asio.patch
@@ -2,20 +2,18 @@ diff  a/cmake_include/AsioStandaloneConfig.cmake b/AsioStandaloneConfig.cmake
 
 --- a/cmake_include/AsioStandaloneConfig.cmake
 +++ b/cmake_include/AsioStandaloneConfig.cmake
-@@ -1,6 +1,12 @@
+@@ -1,6 +1,10 @@
  add_library(AsioStandalone::AsioStandalone IMPORTED INTERFACE)
-+if (LINK_BUILD_ASIO MATCHES "ON") 
  
 -set_property(TARGET AsioStandalone::AsioStandalone APPEND PROPERTY
 -  INTERFACE_INCLUDE_DIRECTORIES
 -  ${CMAKE_CURRENT_LIST_DIR}/../modules/asio-standalone/asio/include
 -)
-+  find_package(asio REQUIRED)
-+  if(asio_FOUND)
-+    message(STATUS "Dependency asio found in ${asio_DIR}")   
-+    set_property(TARGET AsioStandalone::AsioStandalone APPEND PROPERTY
-+      INTERFACE_INCLUDE_DIRECTORIES
-+      ${asio_DIR}/../../include
-+    )
-+  endif()
++find_package(asio REQUIRED)
++if(asio_FOUND)
++  message(STATUS "Dependency asio found in ${asio_DIR}")   
++  set_property(TARGET AsioStandalone::AsioStandalone APPEND PROPERTY
++    INTERFACE_INCLUDE_DIRECTORIES
++    ${asio_DIR}/../../include
++  )
 +endif()

--- a/ports/ableton/vcpkg.json
+++ b/ports/ableton/vcpkg.json
@@ -1,15 +1,13 @@
 {
   "name": "ableton",
   "version": "3.0.5",
+  "port-version": 1,
   "description": "Ableton Link, a technology that synchronizes musical beat, tempo, and phase across multiple applications running on one or more devices.",
   "homepage": "https://www.ableton.com/en/link/",
   "documentation": "http://ableton.github.io/link/",
   "license": "GPL-2.0-or-later",
   "dependencies": [
-    {
-      "name": "asio",
-      "platform": "windows"
-    },
+    "asio",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -33,7 +31,13 @@
       ]
     },
     "hut": {
-      "description": "Build LinkHut command line tool"
+      "description": "Build LinkHut command line tool",
+      "dependencies": [
+        {
+          "name": "asiosdk",
+          "platform": "windows"
+        }
+      ]
     },
     "hutsilent": {
       "description": "Build LinkHutSilent command line tool"

--- a/versions/a-/ableton.json
+++ b/versions/a-/ableton.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "783ec0dfdbd45f32f3fb083786d1ab33070804b7",
+      "git-tree": "70d81e7e966f983af654d779a02817d89eacea3b",
       "version": "3.0.5",
       "port-version": 1
     },

--- a/versions/a-/ableton.json
+++ b/versions/a-/ableton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "783ec0dfdbd45f32f3fb083786d1ab33070804b7",
+      "version": "3.0.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "bac28c4912d6fd4e32ad716ec8bf4e197c9a4cb8",
       "version": "3.0.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10,7 +10,7 @@
     },
     "ableton": {
       "baseline": "3.0.5",
-      "port-version": 0
+      "port-version": 1
     },
     "abseil": {
       "baseline": "20211102.1",


### PR DESCRIPTION
**Describe the pull request**

#### What does your PR fix?
  This fixes a failure I did in #25438
  I didn't realized, that Ableton Link has two dependencies with similar name ASIO and ASIOSDK, which are completely unrealated:
-  ASIO (ASyncronous IO) is a cross-platform C++ library for network and low-level I/O programming
-  ASIOSDK is the SDK for the Steinberg ASIO (Audio Stream Input/Output) drivers. Used for proffesional Windows audio applications.

Therefore I mangled these in the first version of the port.
 Correct is the new behaviour:
- ASIO is always needed accross all platforms
- ASIOSDK is only needed, if the feature "hut" is built on Windows platform

 #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  <all >

#### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

#### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes>
