### PR TITLE
[gtest] update to 1.12.1 

### DIFF
--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
-    REF release-1.12.0
-    SHA512 6216e76a8c988b6b3739f3988c85f369eef2a8036c4412621a0d3d04ceeada00d35e487363be0a265035ac78f1a5065e1fe054a285c43df23b6abcc69f8bfe3d
+    REF release-1.12.1
+    SHA512 a9104dc6c53747e36e7dd7bb93dfce51a558bd31b487a9ef08def095518e1296da140e0db263e0644d9055dbd903c0cb69380cb2322941dbfb04780ef247df9c
     HEAD_REF main
     PATCHES
         clang-tidy-no-lint.patch

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtest",
-  "version-semver": "1.12.0",
+  "version-semver": "1.12.1",
   "description": "GoogleTest and GoogleMock testing frameworks",
   "homepage": "https://github.com/google/googletest",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2709,7 +2709,7 @@
       "port-version": 5
     },
     "gtest": {
-      "baseline": "1.12.0",
+      "baseline": "1.12.1",
       "port-version": 0
     },
     "gtk": {

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "",
+      "version-semver": "1.12.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "da295db55242fd454a3b42486c3f9043356ca40f",
       "version-semver": "1.12.0",
       "port-version": 0

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "",
+      "git-tree": "8f4ae2732d1a648bdfe56b16ae5d68df63ecf344",
       "version-semver": "1.12.1",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
update gtest to 1.12.1 - https://github.com/google/googletest/releases/tag/release-1.12.1

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
no changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes
