### PR TITLE
[apsi] update version to 0.8.2

### DIFF
--- a/ports/apsi/portfile.cmake
+++ b/ports/apsi/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/APSI
-    REF 6365cb774b81a2a731334c656db21e5fdfb92870
-    SHA512 f21d710a345663aeb35035565c55fd900076589d087a03a1ad7df8b8004ae0e059196f3c94ee63b5ad815a858e5404eea34ae203f7778d4190fd323fd08b7084
+    REF ba71aeb28a9f21e4ad59c45aa88232b099ce0b87
+    SHA512 810bcbe0afa3d1c9d299a85bc4266135bdf9adc33bfc754c59731f6cfa6a89d449fb134cef34c4614742bd50e9f8f3916e5b64998dcea69883ca27b7da3c5f04
     HEAD_REF main
 )
 
@@ -14,6 +14,13 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         zeromq APSI_USE_ZMQ
 )
 
+set(CROSSCOMP_OPTIONS "")
+if (NOT HOST_TRIPLET STREQUAL TARGET_TRIPLET)
+    if (TARGET_TRIPLET MATCHES "^arm64.*")
+        set(CROSSCOMP_OPTIONS -DAPSI_FOURQ_ARM64_EXITCODE=0 -DAPSI_FOURQ_ARM64_EXITCODE__TRYRUN_OUTPUT="")
+    endif()
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     DISABLE_PARALLEL_CONFIGURE
@@ -21,11 +28,12 @@ vcpkg_cmake_configure(
         "-DAPSI_BUILD_TESTS=OFF"
         "-DAPSI_BUILD_CLI=OFF"
         ${FEATURE_OPTIONS}
+        ${CROSSCOMP_OPTIONS}
 )
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "APSI" CONFIG_PATH "lib/cmake/APSI-0.7")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "APSI" CONFIG_PATH "lib/cmake/APSI-0.8")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/apsi/vcpkg.json
+++ b/ports/apsi/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "apsi",
-  "version-semver": "0.7.0",
-  "port-version": 2,
+  "version-semver": "0.8.2",
   "description": "APSI is a research library for asymmetric private set intersection.",
   "homepage": "https://github.com/microsoft/APSI",
-  "supports": "static & !(arm & osx)",
+  "supports": "static",
   "dependencies": [
     "flatbuffers",
     "jsoncpp",

--- a/versions/a-/apsi.json
+++ b/versions/a-/apsi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "082ea46b68bf12b80951ce990950937511282e84",
+      "version-semver": "0.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "08bc0f650b7fa0ef77541eb74b90d0b9fe7fec03",
       "version-semver": "0.7.0",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -125,8 +125,8 @@
       "port-version": 7
     },
     "apsi": {
-      "baseline": "0.7.0",
-      "port-version": 2
+      "baseline": "0.8.2",
+      "port-version": 0
     },
     "arb": {
       "baseline": "2.21.1",


### PR DESCRIPTION
Update APSI library (https://github.com/microsoft/APSI) to version 0.8.2

- #### What does your PR fix?
  Fixes several issues reported in GitHub for APSI library:
  - Compiling for arm64 triplets
  - Cross-compiling for ARM from x86/x64
  - Cross compiling for x64 from Mac M1

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
x86-windows-static, x64-windows-static, arm64-windows-static, x64-linux, arm64-linux, arm64-osx, x64-osx

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
