### PR TITLE
[gdal] compatibility with 32bit devices android_api<24

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -59,6 +59,11 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS_RELEASE
         tools           BUILD_APPS
 )
 
+# Compatibility with older Android versions https://github.com/OSGeo/gdal/pull/5941
+if(VCPKG_TARGET_IS_ANDROID AND ANRDOID_PLATFORM VERSION_LESS 24 AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm"))
+    list(APPEND FEATURE_OPTIONS -DBUILD_WITHOUT_64BIT_OFFSET=ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.5.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2466,7 +2466,7 @@
     },
     "gdal": {
       "baseline": "3.5.1",
-      "port-version": 1
+      "port-version": 2
     },
     "gdcm": {
       "baseline": "3.0.12",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d114225017db64685132cde062afde8ec8cbc9b",
+      "version-semver": "3.5.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "dd8ff4159201d96aecb0cc2de325b56a522ae0e1",
       "version-semver": "3.5.1",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes building gdal for android 32bit with android_api<24, see https://github.com/OSGeo/gdal/pull/5941

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
