### PR TITLE
[gdal] Fix hdf5 dependency

### DIFF
--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.5.1",
+  "port-version": 1,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,
@@ -115,7 +116,10 @@
       "dependencies": [
         {
           "name": "hdf5",
-          "default-features": false
+          "default-features": false,
+          "features": [
+            "cpp"
+          ]
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2466,7 +2466,7 @@
     },
     "gdal": {
       "baseline": "3.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "gdcm": {
       "baseline": "3.0.12",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd8ff4159201d96aecb0cc2de325b56a522ae0e1",
+      "version-semver": "3.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "f623db2a0771ad4df6c248b046cd8f369ecbdcca",
       "version-semver": "3.5.1",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  GDAL requests CXX support from HDF5 so we must depend on this feature.
  Fixes #25645.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
