### PR TITLE
[libmicrodns] Add new port

### DIFF
--- a/ports/libmicrodns/portfile.cmake
+++ b/ports/libmicrodns/portfile.cmake
@@ -1,0 +1,16 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO videolabs/libmicrodns
+    REF 0.2.0
+    SHA512 6389ad9edaf1af7c831e8c05e4800964b13cf0eed2063fa3675e7b87c49428ae7b68ac4ed1e742ed5d46ea3ded190e3de076e73ebf167422505257d7b1a03e25
+    HEAD_REF master
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_install_meson()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+configure_file("${SOURCE_PATH}/COPYING" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/libmicrodns/vcpkg.json
+++ b/ports/libmicrodns/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libmicrodns",
+  "version": "0.2.0",
+  "description": "Minimal mDNS resolver (and announcer) library",
+  "homepage": "https://github.com/videolabs/libmicrodns",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -452,6 +452,9 @@ libmesh:x64-windows-static-md=skip
 libmesh:x86-windows=skip
 libmesh:x64-osx=skip
 libmesh:x64-linux=skip
+# Build fails since PIC is not enabled and some configuration tests do not work properly on UWP
+libmicrodns:arm-uwp=fail
+libmicrodns:x64-uwp=fail
 libmikmod:x64-osx=fail
 libmodman:arm-uwp=fail
 libmodman:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3808,6 +3808,10 @@
       "baseline": "1.5.0",
       "port-version": 4
     },
+    "libmicrodns": {
+      "baseline": "0.2.0",
+      "port-version": 0
+    },
     "libmicrohttpd": {
       "baseline": "0.9.75",
       "port-version": 0

--- a/versions/l-/libmicrodns.json
+++ b/versions/l-/libmicrodns.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "479151454954c9fe2e5ddce7f1b358f3c8688ce8",
+      "version": "0.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a port for libmicrodns
(dependency for gst-plugins-bad)

- #### What does your PR fix?
  None (new port)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All: supported
  Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
