### PR TITLE
[basisu] Fix x64-linux-dynamic build, switch to vcpkg_cmake_configure

### DIFF
--- a/ports/basisu/portfile.cmake
+++ b/ports/basisu/portfile.cmake
@@ -7,34 +7,19 @@ vcpkg_from_github(
     PATCHES fix-addostream.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTS=OFF
 )
 
-vcpkg_install_cmake()
-
-#vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/basisu)
-if (WIN32)
-    set(TOOL_NAME basisu_tool.exe)
-else()
-    set(TOOL_NAME basisu_tool)
-endif()
-
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(COPY ${CURRENT_PACKAGES_DIR}/bin/${TOOL_NAME} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/basisu)
-
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/basisu)
-
-# Remove unnecessary files
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL_NAME})
-file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/${TOOL_NAME})
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-endif()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
+
+vcpkg_copy_tools(TOOL_NAMES "basisu_tool" AUTO_CLEAN)
+
+# Remove unnecessary files
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/basisu/vcpkg.json
+++ b/ports/basisu/vcpkg.json
@@ -1,10 +1,15 @@
 {
   "name": "basisu",
-  "version-string": "1.11",
-  "port-version": 5,
+  "version": "1.11",
+  "port-version": 6,
   "description": "Basis Universal is a supercompressed GPU texture and video compression format that outputs a highly compressed intermediate file format (.basis) that can be quickly transcoded to a wide variety of GPU texture compression formats.",
   "homepage": "https://github.com/BinomialLLC/basis_universal",
+  "license": "Apache-2.0",
   "dependencies": [
-    "lodepng"
+    "lodepng",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
   ]
 }

--- a/versions/b-/basisu.json
+++ b/versions/b-/basisu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8552deb382fab18170488ffdf05fdd50dd3e2d99",
+      "version": "1.11",
+      "port-version": 6
+    },
+    {
       "git-tree": "70d762c5a7350879f47429ea6275ba34f1c0f449",
       "version-string": "1.11",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -402,7 +402,7 @@
     },
     "basisu": {
       "baseline": "1.11",
-      "port-version": 5
+      "port-version": 6
     },
     "bcg729": {
       "baseline": "1.1.1",


### PR DESCRIPTION
This PR fixes build failure with `x64-linux-dynamic` triplet and also removes usage of deprecated `vcpkg_cmake_configure`.
For https://github.com/microsoft/vcpkg/issues/25668