### PR TITLE
[fastrtps] Update to 2.7.0, fix tool path and x64-linux-dynamic build

### DIFF
--- a/ports/fastrtps/disable-symlink.patch
+++ b/ports/fastrtps/disable-symlink.patch
@@ -5,12 +5,12 @@ we force the build script to create a batch file in any case.
 diff --git a/tools/fds/CMakeLists.txt b/tools/fds/CMakeLists.txt
 --- a/tools/fds/CMakeLists.txt
 +++ b/tools/fds/CMakeLists.txt
-@@ -124,7 +124,7 @@ if(NOT BUILD_SHARED_LIBS)
-     if( WIN32 )
-         # Use powershell to generate the link
-         install(
--          CODE "execute_process( COMMAND PowerShell -Command \"if( test-path ${PROJECT_NAME}.exe -PathType Leaf ) { rm ${PROJECT_NAME}.exe } ; New-Item -ItemType SymbolicLink -Target $<TARGET_FILE_NAME:${PROJECT_NAME}> -Path ${PROJECT_NAME}.exe \" ERROR_QUIET RESULTS_VARIABLE SYMLINK_FAILED WORKING_DIRECTORY \"${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}\") \n if( SYMLINK_FAILED ) \n message(STATUS \"Windows requires admin installation rights to create symlinks. A bat script will be provided instead.\") \n set(FAST_SERVER_BINARY_NAME $<TARGET_FILE_NAME:${PROJECT_NAME}>) \n configure_file(${CMAKE_CURRENT_LIST_DIR}/fast-discovery-server.bat.in ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}/${PROJECT_NAME}.bat @ONLY) \n endif()"
-+          CODE "set(FAST_SERVER_BINARY_NAME $<TARGET_FILE_NAME:${PROJECT_NAME}>) \n configure_file(${CMAKE_CURRENT_LIST_DIR}/fast-discovery-server.bat.in ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}/${PROJECT_NAME}.bat @ONLY) \n"
-           COMPONENT discovery)
-     else()
-         # Use ln to create the symbolic link. We remove the version from the file name but keep the debug suffix
+@@ -116,7 +116,7 @@ #   - on windows privileges to create symlinks (a .bat file is provided on unprivileged installations)
+ if( WIN32 )
+     # Use powershell to generate the link
+     install(
+-      CODE "execute_process( COMMAND PowerShell -Command \"if( test-path ${PROJECT_NAME}.exe -PathType Leaf ) { rm ${PROJECT_NAME}.exe } ; New-Item -ItemType SymbolicLink -Target $<TARGET_FILE_NAME:${PROJECT_NAME}> -Path ${PROJECT_NAME}.exe \" ERROR_QUIET RESULTS_VARIABLE SYMLINK_FAILED WORKING_DIRECTORY \"${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}\") \n if( SYMLINK_FAILED ) \n message(STATUS \"Windows requires admin installation rights to create symlinks. A bat script will be provided instead.\") \n set(FAST_SERVER_BINARY_NAME $<TARGET_FILE_NAME:${PROJECT_NAME}>) \n configure_file(${CMAKE_CURRENT_LIST_DIR}/fast-discovery-server.bat.in ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}/${PROJECT_NAME}.bat @ONLY) \n endif()"
++      CODE "set(FAST_SERVER_BINARY_NAME $<TARGET_FILE_NAME:${PROJECT_NAME}>) \n configure_file(${CMAKE_CURRENT_LIST_DIR}/fast-discovery-server.bat.in ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}/${PROJECT_NAME}.bat @ONLY) \n"
+       COMPONENT discovery)
+ else()
+     # Use ln to create the symbolic link. We remove the version from the file name but keep the debug suffix

--- a/ports/fastrtps/portfile.cmake
+++ b/ports/fastrtps/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-DDS
-    REF v2.4.0
-    SHA512 2E9C0378AF86DD657391D577F6951096DD45970A2C4D9C384EE5A452A1DD129E6E0AED91E0B908A35A04CAF979253700560561D34082DA81FE737FE104C149AF
+    REF v2.7.0
+    SHA512 289c94fb177209ffc80e93ae61822c83e7cb74ba7682f05a921c50ce048498bd811c19825d1fdb8af39b29a64904e96d87c5c59468139f0d8bb528549b80c94a
     HEAD_REF master
     PATCHES
         fix-find-package-asio.patch
@@ -58,12 +58,15 @@ elseif(VCPKG_TARGET_IS_LINUX)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/ros-discovery" "$dir/../tools/fastdds/fastdds.py" "$dir/../fastdds/fastdds.py")
 endif()
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/fastdds/discovery/parser.py" "tool_path / '../../../bin'" "tool_path / '../../${PORT}'")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/tools")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/fastrtps/vcpkg.json
+++ b/ports/fastrtps/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "fastrtps",
-  "version": "2.4.0",
+  "version": "2.7.0",
   "description": "Eprosima Fast RTPS is a C++ implementation of the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
+  "license": "Apache-2.0",
   "dependencies": [
     "asio",
     "fastcdr",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2205,7 +2205,7 @@
       "port-version": 1
     },
     "fastrtps": {
-      "baseline": "2.4.0",
+      "baseline": "2.7.0",
       "port-version": 0
     },
     "fawdlstty-libfv": {

--- a/versions/f-/fastrtps.json
+++ b/versions/f-/fastrtps.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a1b9df69d8a4219b390a65056d837dc6c0f385c",
+      "version": "2.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "54873b953029cdd41ffee26b13af0c661de41462",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
Summary of changes:
1) Update fastrtps to 2.7.0
2) Fix x64-linux-dynamic build (for https://github.com/microsoft/vcpkg/issues/25668)
3) Fix tools path in installed python script
