### PR TITLE
[vcpkg baseline][ngspice] update to rev 37

### DIFF
--- a/ports/ngspice/portfile.cmake
+++ b/ports/ngspice/portfile.cmake
@@ -6,9 +6,9 @@ set(VCPKG_CRT_LINKAGE static)
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ngspice/ng-spice-rework
-    REF 35
-    FILENAME "ngspice-35.tar.gz"
-    SHA512 2f9b0f951e3ca8d52692beadb895b352311f67b8760f99d0e2f4718fce4b497dd68e2b933029eeacb4ed57551e959bc6e3747e64feb4722a4f841e734f5a664b
+    REF 37
+    FILENAME "ngspice-37.tar.gz"
+    SHA512 d49f7e78d3dd17ac8ea03d79dfbe8a9cf57c012395285cc0c0cf379e0c0c81f11cad68d5366dc2d2478959ed197e4d43380fbc15baf44f987f20ad00f1ee04ca
     PATCHES
         use-winbison-sharedspice.patch
         use-winbison-vngspice.patch

--- a/ports/ngspice/vcpkg.json
+++ b/ports/ngspice/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ngspice",
-  "version": "35",
-  "port-version": 2,
+  "version": "37",
   "description": "Ngspice is a mixed-level/mixed-signal electronic circuit simulator. It is a successor of the latest stable release of Berkeley SPICE",
   "homepage": "http://ngspice.sourceforge.net/",
   "license": "CC-BY-SA-4.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4889,8 +4889,8 @@
       "port-version": 0
     },
     "ngspice": {
-      "baseline": "35",
-      "port-version": 2
+      "baseline": "37",
+      "port-version": 0
     },
     "nifly": {
       "baseline": "1.0.0",

--- a/versions/n-/ngspice.json
+++ b/versions/n-/ngspice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a20625f4656372060074ee98cf95ef002b16178",
+      "version": "37",
+      "port-version": 0
+    },
+    {
       "git-tree": "ec514c4b9a568123369d7d081d004a2d92f6d592",
       "version": "35",
       "port-version": 2


### PR DESCRIPTION
Updated to vev 37

Error message:
```
Error: Failed to download from mirror set:
https://sourceforge.net/projects/ngspice/files/ng-spice-rework/35/ngspice-35.tar.gz/download: failed: status code 404
```
The download path is wrong, rev 35 was moved to the `old-releases\` directory, so update the latest version

Tested feature in the following triplets:

- x86-windows
- x64-windows