### PR TITLE
[vcpkg baseline][yasm/vcpkg-tool-ninja] Fix build

### DIFF
--- a/ports/vcpkg-tool-ninja/portfile.cmake
+++ b/ports/vcpkg-tool-ninja/portfile.cmake
@@ -13,7 +13,9 @@ vcpkg_from_github(
     REF 170c387a7461d476523ae29c115a58f16e4d3430
     SHA512 75c0f263ad325d14c99c9a1d85e571832407b481271a2733e78183a478f7ecd22d84451fc8d7ce16ab20d641ce040761d7ab266695d66bbac5b2b9a3a29aa521
     HEAD_REF master
-    PATCHES "${LONG_PATH_PATCH}" # Long path support windows
+    PATCHES
+        "${LONG_PATH_PATCH}" # Long path support windows
+        use-internal-re2c.patch
 )
 set(VCPKG_BUILD_TYPE release) #we only need release here!
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")

--- a/ports/vcpkg-tool-ninja/use-internal-re2c.patch
+++ b/ports/vcpkg-tool-ninja/use-internal-re2c.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 42094d2..d4eda66 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -43,7 +43,7 @@ endif()
+ 
+ # --- optional re2c
+ find_program(RE2C re2c)
+-if(RE2C)
++if(0)
+ 	# the depfile parser and ninja lexers are generated using re2c.
+ 	function(re2c IN OUT)
+ 		add_custom_command(DEPENDS ${IN} OUTPUT ${OUT}

--- a/ports/vcpkg-tool-ninja/vcpkg.json
+++ b/ports/vcpkg-tool-ninja/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vcpkg-tool-ninja",
   "version-date": "2022-03-31",
+  "port-version": 1,
   "description": "Ninja is a small build system with a focus on speed.",
   "homepage": "https://ninja-build.org/",
   "license": "Apache-2.0",

--- a/ports/yasm/portfile.cmake
+++ b/ports/yasm/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         ${HOST_TOOLS_OPTIONS}
+        "-DPYTHON_EXECUTABLE=${PYTHON3}"
         -DENABLE_NLS=OFF
         -DYASM_BUILD_TESTS=OFF
 )

--- a/ports/yasm/vcpkg.json
+++ b/ports/yasm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "yasm",
   "version": "1.3.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Yasm is a complete rewrite of the NASM assembler under the new BSD License.",
   "homepage": "https://github.com/yasm/yasm",
   "license": "BSD-2-Clause OR BSD-3-Clause OR Artistic-1.0 OR GPL-2.0-only OR LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7450,7 +7450,7 @@
     },
     "vcpkg-tool-ninja": {
       "baseline": "2022-03-31",
-      "port-version": 0
+      "port-version": 1
     },
     "vcpkg-tool-nodejs": {
       "baseline": "14.17.4",
@@ -7758,7 +7758,7 @@
     },
     "yasm": {
       "baseline": "1.3.0",
-      "port-version": 4
+      "port-version": 5
     },
     "yasm-tool": {
       "baseline": "2021-12-14",

--- a/versions/v-/vcpkg-tool-ninja.json
+++ b/versions/v-/vcpkg-tool-ninja.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4dafd8bf3868653e8e4fa81340dfeaea288a43c",
+      "version-date": "2022-03-31",
+      "port-version": 1
+    },
+    {
       "git-tree": "0d55ba6e9ede00479127566b8f39fce7034e1b05",
       "version-date": "2022-03-31",
       "port-version": 0

--- a/versions/y-/yasm.json
+++ b/versions/y-/yasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9ad958de17f5b7661720dc322cff96b2dff8355",
+      "version": "1.3.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "796bb1f691c8ef8b04eb6577e95ab04167470dac",
       "version": "1.3.0",
       "port-version": 4


### PR DESCRIPTION
When building `yasm[tool]:arm64-windows` after buiding `python3:arm64-windows`:
```
cmd.exe /C "cd /D D:\buildtrees\yasm\arm64-windows-dbg\frontends\yasm && D:\installed\arm64-windows\tools\python3\python.exe D:/buildtrees/yasm/src/d25248d823-c7caeb1623.clean/frontends/yasm/genstring.py license_msg D:/buildtrees/yasm/arm64-windows-dbg/frontends/yasm/license.c D:/buildtrees/yasm/src/d25248d823-c7caeb1623.clean/COPYING"
This version of D:\installed\arm64-windows\tools\python3\python.exe is not compatible with the version of Windows you're running. Check your computer's system information and then contact the software publisher.
```
The `python3` used by `yasm[tool]` should be host.

When building `vcpkg-tool-ninja:arm64-windows` after buiding`yasm[tool]:arm64-windows`:
```
FAILED: depfile_parser.cc D:/buildtrees/vcpkg-tool-ninja/x64-windows-rel/depfile_parser.cc 
cmd.exe /C "cd /D D:\buildtrees\vcpkg-tool-ninja\x64-windows-rel && D:\installed\x64-windows\tools\yasm\re2c.exe -b -i --no-generation-date --no-version -o D:/buildtrees/vcpkg-tool-ninja/x64-windows-rel/depfile_parser.cc D:/buildtrees/vcpkg-tool-ninja/src/f16e4d3430-af0aa931e8.clean/src/depfile_parser.in.cc"
usage: re2c [-esbvhd] file
```
It looks like the `re2c` provided by yasm is inconsistent with the `re2c` used by ninja, making ninja use the built-in re2c forever.

Related: https://dev.azure.com/vcpkg/public/_build/results?buildId=74730&view=results