### PR TITLE
[vcpkg baseline][isal, spdk-isal] Fix conflict

### DIFF
--- a/ports/isal/portfile.cmake
+++ b/ports/isal/portfile.cmake
@@ -1,4 +1,4 @@
-if(EXISTS ${CURRENT_INSTALLED_DIR}/share/spdk-isal/copyright)
+if(EXISTS "${CURRENT_INSTALLED_DIR}/share/spdk-isal/copyright")
     message(FATAL_ERROR "'${PORT}' conflicts with 'spdk-isal'. Please remove spdk-isal:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
 endif()
 

--- a/ports/isal/portfile.cmake
+++ b/ports/isal/portfile.cmake
@@ -1,3 +1,7 @@
+if(EXISTS ${CURRENT_INSTALLED_DIR}/share/spdk-isal/copyright)
+    message(FATAL_ERROR "'${PORT}' conflicts with 'spdk-isal'. Please remove spdk-isal:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO 01org/isa-l

--- a/ports/isal/vcpkg.json
+++ b/ports/isal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "isal",
   "version": "2.25.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Intel(R) Intelligent Storage Acceleration Library",
   "license": "BSD-3-Clause",
   "supports": "!(x86 | arm | uwp | osx)"

--- a/ports/isal/vcpkg.json
+++ b/ports/isal/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "2.25.0",
   "port-version": 3,
   "description": "Intel(R) Intelligent Storage Acceleration Library",
+  "homepage": "https://github.com/intel/isa-l",
   "license": "BSD-3-Clause",
   "supports": "!(x86 | arm | uwp | osx)"
 }

--- a/ports/spdk-isal/portfile.cmake
+++ b/ports/spdk-isal/portfile.cmake
@@ -1,3 +1,6 @@
+if(EXISTS ${CURRENT_INSTALLED_DIR}/share/isal/copyright)
+    message(FATAL_ERROR "'${PORT}' conflicts with 'isal'. Please remove isal:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
+endif()
 
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/spdk-isal/portfile.cmake
+++ b/ports/spdk-isal/portfile.cmake
@@ -1,4 +1,4 @@
-if(EXISTS ${CURRENT_INSTALLED_DIR}/share/isal/copyright)
+if(EXISTS "${CURRENT_INSTALLED_DIR}/share/isal/copyright")
     message(FATAL_ERROR "'${PORT}' conflicts with 'isal'. Please remove isal:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
 endif()
 

--- a/ports/spdk-isal/vcpkg.json
+++ b/ports/spdk-isal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "spdk-isal",
   "version-string": "20181006",
-  "port-version": 2,
+  "port-version": 3,
   "description": "SPDK mirror of isa-l. Intel(R) Intelligent Storage Acceleration Library",
   "license": "BSD-3-Clause",
   "supports": "!windows & !(osx & x64)"

--- a/ports/spdk-isal/vcpkg.json
+++ b/ports/spdk-isal/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "spdk-isal",
-  "version-string": "20181006",
+  "version-date": "2018-10-06",
   "port-version": 3,
   "description": "SPDK mirror of isa-l. Intel(R) Intelligent Storage Acceleration Library",
+  "homepage": "https://github.com/spdk/isa-l",
   "license": "BSD-3-Clause",
   "supports": "!windows & !(osx & x64)"
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -369,6 +369,7 @@ intel-mkl:x86-windows=fail
 irrlicht:arm64-windows=fail
 irrlicht:arm-uwp=fail
 irrlicht:x64-uwp=fail
+isal:x64-linux=skip
 jemalloc:arm64-windows=fail
 jemalloc:arm-uwp=fail
 jemalloc:x64-linux=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -369,6 +369,7 @@ intel-mkl:x86-windows=fail
 irrlicht:arm64-windows=fail
 irrlicht:arm-uwp=fail
 irrlicht:x64-uwp=fail
+# Conflict with spdk-isal
 isal:x64-linux=skip
 jemalloc:arm64-windows=fail
 jemalloc:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3030,7 +3030,7 @@
     },
     "isal": {
       "baseline": "2.25.0",
-      "port-version": 2
+      "port-version": 3
     },
     "ismrmrd": {
       "baseline": "1.5.0",
@@ -6745,8 +6745,8 @@
       "port-version": 1
     },
     "spdk-isal": {
-      "baseline": "20181006",
-      "port-version": 2
+      "baseline": "2018-10-06",
+      "port-version": 3
     },
     "spdlog": {
       "baseline": "1.10.0",

--- a/versions/i-/isal.json
+++ b/versions/i-/isal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "59b3a5b83b5a17b13ddebd8087711c572177c2ad",
+      "git-tree": "7fa8499c557c19920d80318d9a1999922cd28663",
       "version": "2.25.0",
       "port-version": 3
     },

--- a/versions/i-/isal.json
+++ b/versions/i-/isal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59b3a5b83b5a17b13ddebd8087711c572177c2ad",
+      "version": "2.25.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "121b0c9241ea1f704bf6cb9ad5f010f6ae732dd0",
       "version": "2.25.0",
       "port-version": 2

--- a/versions/s-/spdk-isal.json
+++ b/versions/s-/spdk-isal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e4bdd7cdc2680118f782b491350174ce51f922b",
+      "version-date": "2018-10-06",
+      "port-version": 3
+    },
+    {
       "git-tree": "de270891534b1e4332e4cfbd67437653a9217823",
       "version-string": "20181006",
       "port-version": 2

--- a/versions/s-/spdk-isal.json
+++ b/versions/s-/spdk-isal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e4bdd7cdc2680118f782b491350174ce51f922b",
+      "git-tree": "41bee637d2dbd80179b39bb1c5b84ec1afce7304",
       "version-date": "2018-10-06",
       "port-version": 3
     },


### PR DESCRIPTION
PR #24777 cause `spdk-isal` build failed on CI pipeline, due to `isal` is conflict with `spdk-isal`. Fix this conflict.
The error message:
```
-- Performing post-build validation
-- Performing post-build validation done
Uploaded binaries to 1 HTTP remotes.
The following files are already installed in /mnt/vcpkg-ci/installed/x64-linux and are in conflict with spdk-isal:x64-linux

Installed by isal:x64-linux
    debug/lib/libisal.a
    include/isa-l.h
    include/isa-l/crc.h
    include/isa-l/crc64.h
    include/isa-l/erasure_code.h
    include/isa-l/gf_vect_mul.h
    include/isa-l/igzip_lib.h
    include/isa-l/mem_routines.h
    include/isa-l/raid.h
    include/isa-l/test.h
    include/isa-l/types.h
    lib/libisal.a

Elapsed time to handle spdk-isal:x64-linux: 15.5 s
```
