### PR TITLE
[date] add patch for MSVC 2019/2022 compatibility

### DIFF
--- a/ports/date/0001-call-from_stream-explicitly-from-date-namespace-677.patch
+++ b/ports/date/0001-call-from_stream-explicitly-from-date-namespace-677.patch
@@ -1,15 +1,5 @@
-From 8c126525cca26fe16c1280e3d6d315583fd29cfb Mon Sep 17 00:00:00 2001
-From: JulZimmermann <JulZimmermann@gmail.com>
-Date: Mon, 31 May 2021 18:54:11 +0200
-Subject: [PATCH] call from_stream explicitly from date namespace (#677)
-
-Co-authored-by: Julian Zimmermann <Julian.Zimmermann@gti.de>
----
- include/date/date.h | 46 ++++++++++++++++++++++-----------------------
- 1 file changed, 23 insertions(+), 23 deletions(-)
-
 diff --git a/include/date/date.h b/include/date/date.h
-index 153f801..d6545ac 100644
+index 7b6b4e4..cddd635 100644
 --- a/include/date/date.h
 +++ b/include/date/date.h
 @@ -7891,7 +7891,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, year& y,
@@ -102,7 +92,7 @@ index 153f801..d6545ac 100644
      if (!fds.has_tod)
          is.setstate(std::ios::failbit);
      if (!is.fail())
-@@ -8096,14 +8096,14 @@ std::basic_istream<CharT, Traits>&
+@@ -8077,14 +8077,14 @@ std::basic_istream<CharT, Traits>&
  operator>>(std::basic_istream<CharT, Traits>& is,
             const parse_manip<Parsable, CharT, Traits, Alloc>& x)
  {
@@ -119,7 +109,7 @@ index 153f801..d6545ac 100644
                              format.c_str(), tp),
                  parse_manip<Parsable, CharT, Traits, Alloc>{format, tp})
  {
-@@ -8115,7 +8115,7 @@ inline
+@@ -8096,7 +8096,7 @@ inline
  auto
  parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
        std::basic_string<CharT, Traits, Alloc>& abbrev)
@@ -128,7 +118,7 @@ index 153f801..d6545ac 100644
                              format.c_str(), tp, &abbrev),
                  parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev})
  {
-@@ -8127,7 +8127,7 @@ inline
+@@ -8108,7 +8108,7 @@ inline
  auto
  parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
        std::chrono::minutes& offset)
@@ -137,7 +127,7 @@ index 153f801..d6545ac 100644
                              format.c_str(), tp,
                              std::declval<std::basic_string<CharT, Traits, Alloc>*>(),
                              &offset),
-@@ -8141,7 +8141,7 @@ inline
+@@ -8122,7 +8122,7 @@ inline
  auto
  parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
        std::basic_string<CharT, Traits, Alloc>& abbrev, std::chrono::minutes& offset)
@@ -146,7 +136,7 @@ index 153f801..d6545ac 100644
                              format.c_str(), tp, &abbrev, &offset),
                  parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev, &offset})
  {
-@@ -8154,7 +8154,7 @@ template <class Parsable, class CharT>
+@@ -8135,7 +8135,7 @@ template <class Parsable, class CharT>
  inline
  auto
  parse(const CharT* format, Parsable& tp)
@@ -155,7 +145,7 @@ index 153f801..d6545ac 100644
                  parse_manip<Parsable, CharT>{format, tp})
  {
      return {format, tp};
-@@ -8164,7 +8164,7 @@ template <class Parsable, class CharT, class Traits, class Alloc>
+@@ -8145,7 +8145,7 @@ template <class Parsable, class CharT, class Traits, class Alloc>
  inline
  auto
  parse(const CharT* format, Parsable& tp, std::basic_string<CharT, Traits, Alloc>& abbrev)
@@ -164,7 +154,7 @@ index 153f801..d6545ac 100644
                              tp, &abbrev),
                  parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev})
  {
-@@ -8175,7 +8175,7 @@ template <class Parsable, class CharT>
+@@ -8156,7 +8156,7 @@ template <class Parsable, class CharT>
  inline
  auto
  parse(const CharT* format, Parsable& tp, std::chrono::minutes& offset)
@@ -173,7 +163,7 @@ index 153f801..d6545ac 100644
                              tp, std::declval<std::basic_string<CharT>*>(), &offset),
                  parse_manip<Parsable, CharT>{format, tp, nullptr, &offset})
  {
-@@ -8187,7 +8187,7 @@ inline
+@@ -8168,7 +8168,7 @@ inline
  auto
  parse(const CharT* format, Parsable& tp,
        std::basic_string<CharT, Traits, Alloc>& abbrev, std::chrono::minutes& offset)
@@ -182,42 +172,3 @@ index 153f801..d6545ac 100644
                              tp, &abbrev, &offset),
                  parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev, &offset})
  {
-@@ -8202,7 +8202,7 @@ template <class Parsable, class CharT, class Traits>
- inline
- auto
- parse(std::basic_string_view<CharT, Traits> format, Parsable& tp)
--    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(), tp),
-+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(), tp),
-                 parse_manip<Parsable, CharT, Traits>{format, tp})
- {
-     return {format, tp};
-@@ -8213,7 +8213,7 @@ inline
- auto
- parse(std::basic_string_view<CharT, Traits> format,
-       Parsable& tp, std::basic_string<CharT, Traits, Alloc>& abbrev)
--    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
-+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
-                             tp, &abbrev),
-                 parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev})
- {
-@@ -8224,7 +8224,7 @@ template <class Parsable, class CharT, class Traits>
- inline
- auto
- parse(std::basic_string_view<CharT, Traits> format, Parsable& tp, std::chrono::minutes& offset)
--    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
-+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
-                             tp, std::declval<std::basic_string<CharT, Traits>*>(), &offset),
-                 parse_manip<Parsable, CharT, Traits>{format, tp, nullptr, &offset})
- {
-@@ -8236,7 +8236,7 @@ inline
- auto
- parse(std::basic_string_view<CharT, Traits> format, Parsable& tp,
-       std::basic_string<CharT, Traits, Alloc>& abbrev, std::chrono::minutes& offset)
--    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
-+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
-                             tp, &abbrev, &offset),
-                 parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev, &offset})
- {
--- 
-2.36.1
-

--- a/ports/date/0001-call-from_stream-explicitly-from-date-namespace-677.patch
+++ b/ports/date/0001-call-from_stream-explicitly-from-date-namespace-677.patch
@@ -1,0 +1,223 @@
+From 8c126525cca26fe16c1280e3d6d315583fd29cfb Mon Sep 17 00:00:00 2001
+From: JulZimmermann <JulZimmermann@gmail.com>
+Date: Mon, 31 May 2021 18:54:11 +0200
+Subject: [PATCH] call from_stream explicitly from date namespace (#677)
+
+Co-authored-by: Julian Zimmermann <Julian.Zimmermann@gti.de>
+---
+ include/date/date.h | 46 ++++++++++++++++++++++-----------------------
+ 1 file changed, 23 insertions(+), 23 deletions(-)
+
+diff --git a/include/date/date.h b/include/date/date.h
+index 153f801..d6545ac 100644
+--- a/include/date/date.h
++++ b/include/date/date.h
+@@ -7891,7 +7891,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, year& y,
+ {
+     using CT = std::chrono::seconds;
+     fields<CT> fds{};
+-    from_stream(is, fmt, fds, abbrev, offset);
++    date::from_stream(is, fmt, fds, abbrev, offset);
+     if (!fds.ymd.year().ok())
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -7907,7 +7907,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, month& m,
+ {
+     using CT = std::chrono::seconds;
+     fields<CT> fds{};
+-    from_stream(is, fmt, fds, abbrev, offset);
++    date::from_stream(is, fmt, fds, abbrev, offset);
+     if (!fds.ymd.month().ok())
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -7923,7 +7923,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, day& d,
+ {
+     using CT = std::chrono::seconds;
+     fields<CT> fds{};
+-    from_stream(is, fmt, fds, abbrev, offset);
++    date::from_stream(is, fmt, fds, abbrev, offset);
+     if (!fds.ymd.day().ok())
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -7939,7 +7939,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, weekday& wd
+ {
+     using CT = std::chrono::seconds;
+     fields<CT> fds{};
+-    from_stream(is, fmt, fds, abbrev, offset);
++    date::from_stream(is, fmt, fds, abbrev, offset);
+     if (!fds.wd.ok())
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -7955,7 +7955,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, year_month&
+ {
+     using CT = std::chrono::seconds;
+     fields<CT> fds{};
+-    from_stream(is, fmt, fds, abbrev, offset);
++    date::from_stream(is, fmt, fds, abbrev, offset);
+     if (!fds.ymd.month().ok())
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -7971,7 +7971,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, month_day&
+ {
+     using CT = std::chrono::seconds;
+     fields<CT> fds{};
+-    from_stream(is, fmt, fds, abbrev, offset);
++    date::from_stream(is, fmt, fds, abbrev, offset);
+     if (!fds.ymd.month().ok() || !fds.ymd.day().ok())
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -7987,7 +7987,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+ {
+     using CT = std::chrono::seconds;
+     fields<CT> fds{};
+-    from_stream(is, fmt, fds, abbrev, offset);
++    date::from_stream(is, fmt, fds, abbrev, offset);
+     if (!fds.ymd.ok())
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -8007,7 +8007,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+     auto offptr = offset ? offset : &offset_local;
+     fields<CT> fds{};
+     fds.has_tod = true;
+-    from_stream(is, fmt, fds, abbrev, offptr);
++    date::from_stream(is, fmt, fds, abbrev, offptr);
+     if (!fds.ymd.ok() || !fds.tod.in_conventional_range())
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -8025,7 +8025,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+     using detail::round_i;
+     fields<CT> fds{};
+     fds.has_tod = true;
+-    from_stream(is, fmt, fds, abbrev, offset);
++    date::from_stream(is, fmt, fds, abbrev, offset);
+     if (!fds.ymd.ok() || !fds.tod.in_conventional_range())
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -8043,7 +8043,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+     using Duration = std::chrono::duration<Rep, Period>;
+     using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
+     fields<CT> fds{};
+-    from_stream(is, fmt, fds, abbrev, offset);
++    date::from_stream(is, fmt, fds, abbrev, offset);
+     if (!fds.has_tod)
+         is.setstate(std::ios::failbit);
+     if (!is.fail())
+@@ -8096,14 +8096,14 @@ std::basic_istream<CharT, Traits>&
+ operator>>(std::basic_istream<CharT, Traits>& is,
+            const parse_manip<Parsable, CharT, Traits, Alloc>& x)
+ {
+-    return from_stream(is, x.format_.c_str(), x.tp_, x.abbrev_, x.offset_);
++    return date::from_stream(is, x.format_.c_str(), x.tp_, x.abbrev_, x.offset_);
+ }
+ 
+ template <class Parsable, class CharT, class Traits, class Alloc>
+ inline
+ auto
+ parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
+                             format.c_str(), tp),
+                 parse_manip<Parsable, CharT, Traits, Alloc>{format, tp})
+ {
+@@ -8115,7 +8115,7 @@ inline
+ auto
+ parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
+       std::basic_string<CharT, Traits, Alloc>& abbrev)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
+                             format.c_str(), tp, &abbrev),
+                 parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev})
+ {
+@@ -8127,7 +8127,7 @@ inline
+ auto
+ parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
+       std::chrono::minutes& offset)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
+                             format.c_str(), tp,
+                             std::declval<std::basic_string<CharT, Traits, Alloc>*>(),
+                             &offset),
+@@ -8141,7 +8141,7 @@ inline
+ auto
+ parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
+       std::basic_string<CharT, Traits, Alloc>& abbrev, std::chrono::minutes& offset)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
+                             format.c_str(), tp, &abbrev, &offset),
+                 parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev, &offset})
+ {
+@@ -8154,7 +8154,7 @@ template <class Parsable, class CharT>
+ inline
+ auto
+ parse(const CharT* format, Parsable& tp)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT>&>(), format, tp),
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT>&>(), format, tp),
+                 parse_manip<Parsable, CharT>{format, tp})
+ {
+     return {format, tp};
+@@ -8164,7 +8164,7 @@ template <class Parsable, class CharT, class Traits, class Alloc>
+ inline
+ auto
+ parse(const CharT* format, Parsable& tp, std::basic_string<CharT, Traits, Alloc>& abbrev)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format,
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format,
+                             tp, &abbrev),
+                 parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev})
+ {
+@@ -8175,7 +8175,7 @@ template <class Parsable, class CharT>
+ inline
+ auto
+ parse(const CharT* format, Parsable& tp, std::chrono::minutes& offset)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT>&>(), format,
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT>&>(), format,
+                             tp, std::declval<std::basic_string<CharT>*>(), &offset),
+                 parse_manip<Parsable, CharT>{format, tp, nullptr, &offset})
+ {
+@@ -8187,7 +8187,7 @@ inline
+ auto
+ parse(const CharT* format, Parsable& tp,
+       std::basic_string<CharT, Traits, Alloc>& abbrev, std::chrono::minutes& offset)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format,
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format,
+                             tp, &abbrev, &offset),
+                 parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev, &offset})
+ {
+@@ -8202,7 +8202,7 @@ template <class Parsable, class CharT, class Traits>
+ inline
+ auto
+ parse(std::basic_string_view<CharT, Traits> format, Parsable& tp)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(), tp),
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(), tp),
+                 parse_manip<Parsable, CharT, Traits>{format, tp})
+ {
+     return {format, tp};
+@@ -8213,7 +8213,7 @@ inline
+ auto
+ parse(std::basic_string_view<CharT, Traits> format,
+       Parsable& tp, std::basic_string<CharT, Traits, Alloc>& abbrev)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
+                             tp, &abbrev),
+                 parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev})
+ {
+@@ -8224,7 +8224,7 @@ template <class Parsable, class CharT, class Traits>
+ inline
+ auto
+ parse(std::basic_string_view<CharT, Traits> format, Parsable& tp, std::chrono::minutes& offset)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
+                             tp, std::declval<std::basic_string<CharT, Traits>*>(), &offset),
+                 parse_manip<Parsable, CharT, Traits>{format, tp, nullptr, &offset})
+ {
+@@ -8236,7 +8236,7 @@ inline
+ auto
+ parse(std::basic_string_view<CharT, Traits> format, Parsable& tp,
+       std::basic_string<CharT, Traits, Alloc>& abbrev, std::chrono::minutes& offset)
+-    -> decltype(from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
++    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format.data(),
+                             tp, &abbrev, &offset),
+                 parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev, &offset})
+ {
+-- 
+2.36.1
+

--- a/ports/date/portfile.cmake
+++ b/ports/date/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
     0001-fix-uwp.patch
     0002-fix-cmake-3.14.patch
     fix-uninitialized-values.patch  #Update the new version please remove this patch
+    0001-call-from_stream-explicitly-from-date-namespace-677.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1814,7 +1814,7 @@
     },
     "date": {
       "baseline": "3.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "dav1d": {
       "baseline": "1.0.0",

--- a/versions/d-/date.json
+++ b/versions/d-/date.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48c25f72bcc98f5d8e753c8bc1def63e86672fd2",
+      "version": "3.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "14d5c6822908ad2fd1d700cca2067ae4b8ef4404",
       "version": "3.0.1",
       "port-version": 2

--- a/versions/d-/date.json
+++ b/versions/d-/date.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "48c25f72bcc98f5d8e753c8bc1def63e86672fd2",
+      "git-tree": "f775f27a3553ab95cf2ed2d6cbe1a40e46a64502",
       "version": "3.0.1",
       "port-version": 3
     },


### PR DESCRIPTION
**Describe the pull request**

This PR adds a new patch to the date library

- #### What does your PR fix?
  Fixes https://github.com/HowardHinnant/date/issues/676 and https://github.com/HowardHinnant/date/issues/717
  Backport of https://github.com/HowardHinnant/date/pull/677

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
no changes,No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  No, did changes manually

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
