### PR TITLE
[python3] Fix wrapper, mark mingw unsupported

### DIFF
--- a/ports/python3/vcpkg-cmake-wrapper.cmake
+++ b/ports/python3/vcpkg-cmake-wrapper.cmake
@@ -89,6 +89,9 @@ if(_PythonFinder_WantLibs)
             find_dependency(Intl)
             if(TARGET @PythonFinder_PREFIX@::Python)
                 get_target_property(_PYTHON_INTERFACE_LIBS @PythonFinder_PREFIX@::Python INTERFACE_LINK_LIBRARIES)
+                if(NOT _PYTHON_INTERFACE_LIBS)
+                    set(_PYTHON_INTERFACE_LIBS "")
+                endif()
                 list(REMOVE_ITEM _PYTHON_INTERFACE_LIBS "-liconv" "-lintl")
                 list(APPEND _PYTHON_INTERFACE_LIBS
                     Iconv::Iconv
@@ -99,6 +102,9 @@ if(_PythonFinder_WantLibs)
             endif()
             if(TARGET @PythonFinder_PREFIX@::Module)
                 get_target_property(_PYTHON_INTERFACE_LIBS @PythonFinder_PREFIX@::Module INTERFACE_LINK_LIBRARIES)
+                if(NOT _PYTHON_INTERFACE_LIBS)
+                    set(_PYTHON_INTERFACE_LIBS "")
+                endif()
                 list(REMOVE_ITEM _PYTHON_INTERFACE_LIBS "-liconv" "-lintl")
                 list(APPEND _PYTHON_INTERFACE_LIBS
                     Iconv::Iconv

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",
-  "supports": "!uwp",
+  "supports": "!uwp & !mingw",
   "dependencies": [
     {
       "name": "bzip2",

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "python3",
   "version": "3.10.5",
+  "port-version": 1,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5702,7 +5702,7 @@
     },
     "python3": {
       "baseline": "3.10.5",
-      "port-version": 0
+      "port-version": 1
     },
     "qca": {
       "baseline": "2.3.4",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c345c4a8ad91847522188517c68e8f83637f4440",
+      "version": "3.10.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "d7c43b7217707bb35a86859d9285496fc2bce8e2",
       "version": "3.10.5",
       "port-version": 0


### PR DESCRIPTION
Pulled out of #23918.

- #### What does your PR fix?
  Fixes reading of a possibly unset property in the wrapper. Cf. #23918, https://dev.azure.com/vcpkg/public/_build/results?buildId=74746&view=logs&j=7b75bd19-17d3-53d4-00fd-23f1a49a8ba4.
  Marks mingw as unsupported. Closes #25659.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  uwp and mingw unsupported, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes