### PR TITLE
[sdl2-ttf] update to 2.20.0

### DIFF
--- a/ports/sdl2-ttf/fix-find_dependencies.patch
+++ b/ports/sdl2-ttf/fix-find_dependencies.patch
@@ -1,0 +1,41 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a097d5c..ca278d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -164,6 +164,7 @@ set(PC_REQUIRES)
+ set(BUILD_SHARED_LIBS OFF)
+ 
+ if(SDL2TTF_HARFBUZZ)
++    if(0)
+     if(SDL2TTF_HARFBUZZ_VENDORED)
+         message(STATUS "${PROJECT_NAME}: Using vendored harfbuzz library")
+         # HB_BUILD_UTILS variable is used by harfbuzz
+@@ -192,9 +193,16 @@ if(SDL2TTF_HARFBUZZ)
+     endif()
+     target_compile_definitions(SDL2_ttf PRIVATE TTF_USE_HARFBUZZ=1)
+     target_link_libraries(SDL2_ttf PRIVATE harfbuzz::harfbuzz)
++    endif()
++
++    find_package(harfbuzz REQUIRED)
++    target_compile_definitions(SDL2_ttf PRIVATE TTF_USE_HARFBUZZ=1)
++    target_link_libraries(SDL2_ttf PRIVATE harfbuzz::harfbuzz)
++
+ endif()
+ 
+ if(SDL2TTF_FREETYPE)
++    if(0)
+     if(SDL2TTF_FREETYPE_VENDORED)
+         message(STATUS "${PROJECT_NAME}: Using vendored freetype library")
+         # FT_DISABLE_ZLIB variable is used by freetype
+@@ -232,7 +240,11 @@ if(SDL2TTF_FREETYPE)
+         find_package(Freetype REQUIRED)
+         list(APPEND PC_REQUIRES freetype2)
+     endif()
++    endif()
++
++    find_package(Freetype REQUIRED)
+     target_link_libraries(SDL2_ttf PRIVATE Freetype::Freetype)
++
+ endif()
+ 
+ # Restore BUILD_SHARED_LIBS variable

--- a/ports/sdl2-ttf/portfile.cmake
+++ b/ports/sdl2-ttf/portfile.cmake
@@ -19,8 +19,7 @@ vcpkg_cmake_configure(
         -DBUILD_SHARED_LIBS=${BUILD_SHARED}
 )
 
-vcpkg_install_cmake()
-vcpkg_copy_pdbs()
+vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
 #Clean

--- a/ports/sdl2-ttf/portfile.cmake
+++ b/ports/sdl2-ttf/portfile.cmake
@@ -1,31 +1,31 @@
-set(VERSION 2.0.15)
+set(VERSION 2.20.0)
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-${VERSION}.tar.gz"
-    FILENAME "SDL2_ttf-${VERSION}.tar.gz"
-    SHA512 30d685932c3dd6f2c94e2778357a5c502f0421374293d7102a64d92f9c7861229bf36bedf51c1a698b296a58c858ca442d97afb908b7df1592fc8d4f8ae8ddfd
-)
-
-vcpkg_extract_source_archive_ex(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    REF ${VERSION}
+    REPO  libsdl-org/SDL_ttf
+    REF f5e4828ffc9d3a84f00011fede4446aecb4a685f #v2.20.0
+    SHA512 c0d2d6107e5427d9c1353e14cb4b0c3957d28391cfc772f1f972fe3aa8ba9e9dfdfcb64acd317a7836d46b3a50da9597b19a832f0baf5198654acb7b31ab1e6b
+    HEAD_REF main
+    PATCHES
+        fix-find_dependencies.patch
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS_DEBUG
-        -DSDL_TTF_SKIP_HEADERS=ON)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSDL2TTF_SAMPLES=OFF
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED}
+)
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets()
-vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+#Clean
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")   
 
-file(COPY ${SOURCE_PATH}/COPYING.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdl2-ttf)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/sdl2-ttf/COPYING.txt ${CURRENT_PACKAGES_DIR}/share/sdl2-ttf/copyright)
+#Copyright
+file(COPY "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/sdl2-ttf/copyright")

--- a/ports/sdl2-ttf/vcpkg.json
+++ b/ports/sdl2-ttf/vcpkg.json
@@ -1,11 +1,18 @@
 {
   "name": "sdl2-ttf",
-  "version-string": "2.0.15",
-  "port-version": 5,
+  "version": "2.20.0",
   "description": "A library for rendering TrueType fonts with SDL",
   "homepage": "https://www.libsdl.org/projects/SDL_ttf/",
   "dependencies": [
     "freetype",
-    "sdl2"
+    "sdl2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/sdl2-ttf/vcpkg.json
+++ b/ports/sdl2-ttf/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "2.20.0",
   "description": "A library for rendering TrueType fonts with SDL",
   "homepage": "https://www.libsdl.org/projects/SDL_ttf/",
+  "license": "Zlib",
   "dependencies": [
     "freetype",
     "sdl2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -12,7 +12,6 @@
       "baseline": "3.0.5",
       "port-version": 0
     },
-
     "abseil": {
       "baseline": "20211102.1",
       "port-version": 0
@@ -6478,8 +6477,8 @@
       "port-version": 9
     },
     "sdl2-ttf": {
-      "baseline": "2.0.15",
-      "port-version": 5
+      "baseline": "2.20.0",
+      "port-version": 0
     },
     "sdl2pp": {
       "baseline": "0.16.1",

--- a/versions/s-/sdl2-ttf.json
+++ b/versions/s-/sdl2-ttf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d17197737d374b67e81ebb534c7864f0daa4fa3d",
+      "git-tree": "b45d86e1fd3d35e2a331474f3d337ac84d125f08",
       "version": "2.20.0",
       "port-version": 0
     },

--- a/versions/s-/sdl2-ttf.json
+++ b/versions/s-/sdl2-ttf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7e2300b78862012095240fd5dd47f25290432ebc",
+      "git-tree": "d17197737d374b67e81ebb534c7864f0daa4fa3d",
       "version": "2.20.0",
       "port-version": 0
     },

--- a/versions/s-/sdl2-ttf.json
+++ b/versions/s-/sdl2-ttf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e2300b78862012095240fd5dd47f25290432ebc",
+      "version": "2.20.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cefc95479a9fa2c8a8c4f5539952978f77e3de99",
       "version-string": "2.0.15",
       "port-version": 5


### PR DESCRIPTION
Fix #25661
Update [sdl2-ttf] version to 2.20.0

Note: Port `sdl2-ttf` switched to github source https://github.com/libsdl-org/SDL_ttf after version 2.0.15.
No feature need to test.