### PR TITLE
[speex] update to 1.2.1

### DIFF
--- a/ports/speex/portfile.cmake
+++ b/ports/speex/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO xiph/speex
-  REF Speex-1.2.0
-  SHA512  612dfd67a9089f929b7f2a613ed3a1d2fda3d3ec0a4adafe27e2c1f4542de1870b42b8042f0dcb16d52e08313d686cc35b76940776419c775417f5bad18b448f
+  REF 5dceaaf3e23ee7fd17c80cb5f02a838fd6c18e01 #Speex-1.2.1
+  SHA512  d03da906ec26ddcea2e1dc4157ac6dd056e1407381b0f37edd350552a02a7372e9108b4e39ae522f1b165be04b813ee11db0b47d17607e4dad18118b9041636b
   HEAD_REF master
   PATCHES ${PATCHES}
 )
@@ -15,7 +15,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
   file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
   
   vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
   )
   vcpkg_cmake_install()
@@ -33,7 +33,7 @@ else()
       message("${PORT} currently requires the following libraries from the system package manager:\n    autoconf\n    automake\n    libtool\n\nIt can be installed with apt-get install autoconf automake libtool")
   endif()
   vcpkg_configure_make(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     OPTIONS --disable-binaries # no example programs (require libogg)
   )

--- a/ports/speex/vcpkg.json
+++ b/ports/speex/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "speex",
-  "version": "1.2.0",
-  "port-version": 11,
+  "version": "1.2.1",
   "description": "Speex is an Open Source/Free Software patent-free audio compression format designed for speech.",
   "homepage": "https://github.com/xiph/speex",
-  "license": null,
+  "license": "LGPL-2.0-or-later",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6761,8 +6761,8 @@
       "port-version": 0
     },
     "speex": {
-      "baseline": "1.2.0",
-      "port-version": 11
+      "baseline": "1.2.1",
+      "port-version": 0
     },
     "speexdsp": {
       "baseline": "1.2.0",

--- a/versions/s-/speex.json
+++ b/versions/s-/speex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0520509fd60e20c5362959a7549dd29f7d04d54b",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7cbe163c0a5fabd08cb6665c092d6b13dfa51d69",
       "version": "1.2.0",
       "port-version": 11


### PR DESCRIPTION
Fixes #25709, update `speex` to 1.2.1. No features need to test.
