### PR TITLE
[libsquish] Fix unexpected OpenMP dependency

### DIFF
--- a/ports/libsquish/portfile.cmake
+++ b/ports/libsquish/portfile.cmake
@@ -17,7 +17,9 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    OPTIONS ${FEATURE_OPTIONS}
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DBUILD_SQUISH_WITH_OPENMP=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/libsquish/vcpkg.json
+++ b/ports/libsquish/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsquish",
   "version": "1.15",
-  "port-version": 10,
+  "port-version": 11,
   "description": "Open source DXT compression library.",
   "homepage": "https://sourceforge.net/projects/libsquish",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4082,7 +4082,7 @@
     },
     "libsquish": {
       "baseline": "1.15",
-      "port-version": 10
+      "port-version": 11
     },
     "libsrt": {
       "baseline": "1.4.4",

--- a/versions/l-/libsquish.json
+++ b/versions/l-/libsquish.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c259e069413fc51d82423f6c9842ad285e210e9",
+      "version": "1.15",
+      "port-version": 11
+    },
+    {
       "git-tree": "9a7ae325bacc78d07dc92de654a877584cff0cca",
       "version": "1.15",
       "port-version": 10


### PR DESCRIPTION
- #### What does your PR fix?
  Quick fix for libsquish picking OpenMP in an uncontrolled way, breaking reuse of cached artifacts.
  Pulled out of https://github.com/microsoft/vcpkg/pull/23918 where the problem became visible:
  ~~~
  /usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libsquishd.a(squish.cpp.o): in function `squish::CompressImage(unsigned char const*, int, int, int, void*, int, float*)':
  /mnt/vcpkg-ci/buildtrees/libsquish/src/5b569b7023-6f73172d60.clean/squish.cpp:182: undefined reference to `GOMP_parallel'
  /usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libsquishd.a(squish.cpp.o): in function `squish::DecompressImage(unsigned char*, int, int, int, void const*, int)':
  /mnt/vcpkg-ci/buildtrees/libsquish/src/5b569b7023-6f73172d60.clean/squish.cpp:241: undefined reference to `GOMP_parallel'
  /usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libsquishd.a(squish.cpp.o): in function `squish::CompressImage(unsigned char const*, int, int, int, void*, int, float*) [clone ._omp_fn.0]':
  /mnt/vcpkg-ci/buildtrees/libsquish/src/5b569b7023-6f73172d60.clean/squish.cpp:184: undefined reference to `omp_get_num_threads'
  /usr/bin/ld: /mnt/vcpkg-ci/buildtrees/libsquish/src/5b569b7023-6f73172d60.clean/squish.cpp:184: undefined reference to `omp_get_thread_num'
  /usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libsquishd.a(squish.cpp.o): in function `squish::DecompressImage(unsigned char*, int, int, int, void const*, int) [clone ._omp_fn.0]':
  /mnt/vcpkg-ci/buildtrees/libsquish/src/5b569b7023-6f73172d60.clean/squish.cpp:243: undefined reference to `omp_get_num_threads'
  /usr/bin/ld: /mnt/vcpkg-ci/buildtrees/libsquish/src/5b569b7023-6f73172d60.clean/squish.cpp:243: undefined reference to `omp_get_thread_num'
  ~~~
  (Not adding a feature now because it needs more work to validate exported pc

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes