### PR TITLE
[geos] Bump version to 3.11.0.

### DIFF
--- a/ports/geos/disable-warning-4996.patch
+++ b/ports/geos/disable-warning-4996.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index accc1a2..34d2055 100644
+index e758b5dc8..074986f38 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -174,7 +174,7 @@ target_compile_features(geos_cxx_flags INTERFACE cxx_std_11)
+@@ -187,7 +187,7 @@ target_compile_features(geos_cxx_flags INTERFACE cxx_std_11)
  target_compile_options(geos_cxx_flags INTERFACE
  	"$<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-ffp-contract=off>"
  	"$<$<CXX_COMPILER_ID:GNU>:-ffp-contract=off>"

--- a/ports/geos/fix-exported-config.patch
+++ b/ports/geos/fix-exported-config.patch
@@ -1,10 +1,10 @@
 diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
-index bc0e774..e3ca0bd 100644
+index a8c034fb2..a5cd14c13 100644
 --- a/tools/CMakeLists.txt
 +++ b/tools/CMakeLists.txt
-@@ -45,11 +45,18 @@ function(configure_install_geos_pc)
-   set(includedir "$\{prefix\}/${CMAKE_INSTALL_INCLUDEDIR}")
-   set(libdir "$\{exec_prefix\}/${CMAKE_INSTALL_LIBDIR}")
+@@ -61,11 +61,18 @@ function(configure_install_geos_pc)
+     set(libdir "$\{exec_prefix\}/${CMAKE_INSTALL_LIBDIR}")
+   endif()
    set(VERSION ${GEOS_VERSION})
 -  set(EXTRA_LIBS "-lstdc++")
 +  if(APPLE OR CMAKE_ANDROID_STL_TYPE MATCHES "^c\\+\\+")
@@ -22,7 +22,7 @@ index bc0e774..e3ca0bd 100644
  
    configure_file(
      ${CMAKE_CURRENT_SOURCE_DIR}/geos.pc.in
-@@ -61,9 +68,9 @@ function(configure_install_geos_pc)
+@@ -77,9 +84,9 @@ function(configure_install_geos_pc)
      DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
  endfunction()
  
@@ -34,7 +34,7 @@ index bc0e774..e3ca0bd 100644
  
  option(BUILD_ASTYLE "Build astyle (Artistic Style) tool" OFF)
 diff --git a/tools/geos-config.in b/tools/geos-config.in
-index 6eff1eb..8827f6a 100644
+index 6eff1eb14..8827f6ac6 100644
 --- a/tools/geos-config.in
 +++ b/tools/geos-config.in
 @@ -1,9 +1,11 @@

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,9 +1,9 @@
-set(GEOS_VERSION 3.10.2)
+set(GEOS_VERSION 3.11.0)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2"
     FILENAME "geos-${GEOS_VERSION}.tar.bz2"
-    SHA512 390381711ccf56b862c2736cf6329200822f121de1c49df52b8b85cabea8c7787b199df2196acacc2e5c677ff3ebe042d93d70e89deadbc19d754499edb65126
+    SHA512 40c7553bbb93673c231ddd0131b73bf43b3f50524bc5bd9e6934c068d2c09632f388b7429254ae15d9641da2d15e3a626b430438854e98d9e7419ad04e535189
 )
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/geos/vcpkg.json
+++ b/ports/geos/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "geos",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "description": "Geometry Engine Open Source",
   "homepage": "https://libgeos.org/",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2501,7 +2501,7 @@
       "port-version": 0
     },
     "geos": {
-      "baseline": "3.10.2",
+      "baseline": "3.11.0",
       "port-version": 0
     },
     "geotrans": {

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "65d05922979febad3d20696832347333c24f1c16",
+      "version": "3.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "aa45b04832db59c6f6c4e92cf0f67b21afe41a48",
       "version": "3.10.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Updates GEOS version from 3.10.2 to 3.11.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All. Yes,  I updated the CI baseline. 

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
