### PR TITLE
[openal-soft] Add ALSA dependency on Linux

### DIFF
--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -9,7 +9,6 @@
   "dependencies": [
     {
       "name": "alsa",
-      "host": true,
       "platform": "linux"
     },
     {

--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -1,11 +1,17 @@
 {
   "name": "openal-soft",
   "version-semver": "1.22.2",
+  "port-version": 1,
   "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
   "homepage": "https://github.com/kcat/openal-soft",
   "license": "GPL-2.0-or-later",
   "supports": "!uwp",
   "dependencies": [
+    {
+      "name": "alsa",
+      "host": true,
+      "platform": "linux"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5114,7 +5114,7 @@
     },
     "openal-soft": {
       "baseline": "1.22.2",
-      "port-version": 0
+      "port-version": 1
     },
     "openblas": {
       "baseline": "0.3.20",

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc8b237222cf385c0d32c3cb077143b4788a05dd",
+      "git-tree": "2a5b37e3c3d9cd16ebbcdaddcce6cb7249aa21ec",
       "version-semver": "1.22.2",
       "port-version": 1
     },

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc8b237222cf385c0d32c3cb077143b4788a05dd",
+      "version-semver": "1.22.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "49395645807a6b8d7948d03474fbfa6c467be314",
       "version-semver": "1.22.2",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?

  openal-soft on Linux requires ALSA and doesn't work without it. I'm not sure what the "host" field is and I couldn't find it in the documentation so I just set it to true just like for the other dependencies.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
