### PR TITLE
[vcpkg-get-python-packages] Add support of the WindowsStore CMake.

### DIFF
--- a/ports/vcpkg-get-python-packages/vcpkg.json
+++ b/ports/vcpkg-get-python-packages/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "vcpkg-get-python-packages",
   "version-date": "2022-04-11",
-  "port-version": 1,
+  "port-version": 2,
   "documentation": "https://vcpkg.io/en/docs/README.html",
   "license": "MIT",
-  "supports": "native"
+  "supports": "native | windows"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7422,7 +7422,7 @@
     },
     "vcpkg-get-python-packages": {
       "baseline": "2022-04-11",
-      "port-version": 1
+      "port-version": 2
     },
     "vcpkg-gfortran": {
       "baseline": "3",

--- a/versions/v-/vcpkg-get-python-packages.json
+++ b/versions/v-/vcpkg-get-python-packages.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d9e2bc48e7b052f09e6fd9739506fc7f3d3d7de",
+      "version-date": "2022-04-11",
+      "port-version": 2
+    },
+    {
       "git-tree": "ffe13ab59e3e2f4f003498035bc1fbc06b64e164",
       "version-date": "2022-04-11",
       "port-version": 1


### PR DESCRIPTION
* vcpkg-get-python-packages Add support of the WindowsStore CMake.

* Update versions.

**Describe the pull request**

- #### What does your PR fix?
  Fixes installation compatibility for vcpkg-get-python-packages in the MinGW environment during the OpenCV dependencies installation process.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  MinGW, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
