### PR TITLE
Update VMs for July 2022 Patch Tuesday, and to Ubuntu 22.04.

### DIFF
--- a/ports/cuda/vcpkg.json
+++ b/ports/cuda/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cuda",
   "version": "10.1",
-  "port-version": 10,
+  "port-version": 11,
   "description": "A parallel computing platform and programming model",
   "homepage": "https://developer.nvidia.com/cuda-toolkit",
   "license": null,

--- a/ports/cuda/vcpkg_find_cuda.cmake
+++ b/ports/cuda/vcpkg_find_cuda.cmake
@@ -42,6 +42,8 @@ function(vcpkg_find_cuda)
             endif()
         endforeach()
 
+        vcpkg_list(APPEND CUDA_PATHS /usr/bin)
+
         find_program(NVCC
             NAMES nvcc
             PATHS

--- a/ports/cudnn/FindCUDNN.cmake
+++ b/ports/cudnn/FindCUDNN.cmake
@@ -25,7 +25,7 @@
 include(FindPackageHandleStandardArgs)
 
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
+  HINTS $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include /usr/include/x86_64-linux-gnu/
   PATH_SUFFIXES cuda/include include)
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
   HINTS $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/ /usr/

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT OUT_CUDA_VERSION CUDA_VE
 
 # Try to find CUDNN if it exists; only download if it doesn't exist
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include /usr/include/x86_64-linux-gnu/
   PATH_SUFFIXES cuda/include include)
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7

--- a/ports/cudnn/vcpkg.json
+++ b/ports/cudnn/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cudnn",
   "version": "7.6.5",
-  "port-version": 7,
+  "port-version": 8,
   "description": "NVIDIA's cuDNN deep neural network acceleration library.",
   "homepage": "https://developer.nvidia.com/cudnn",
   "license": null,

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 #
 variables:
-  windows-pool: 'PrWin-2022-06-15'
-  linux-pool: 'PrLin-2022-06-15'
+  windows-pool: 'PrWin-2022-07-14'
+  linux-pool: 'PrLin-2022-07-14'
   osx-pool: 'PrOsx-2022-02-04'
 
 parameters:

--- a/scripts/azure-pipelines/linux/create-image.ps1
+++ b/scripts/azure-pipelines/linux/create-image.ps1
@@ -88,8 +88,8 @@ $VM = Add-AzVMNetworkInterface -VM $VM -Id $Nic.Id
 $VM = Set-AzVMSourceImage `
   -VM $VM `
   -PublisherName 'Canonical' `
-  -Offer '0001-com-ubuntu-server-focal' `
-  -Skus '20_04-lts' `
+  -Offer '0001-com-ubuntu-server-jammy' `
+  -Skus '22_04-lts' `
   -Version latest
 
 $VM = Set-AzVMBootDiagnostic -VM $VM -Disable

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -15,7 +15,7 @@ APT_PACKAGES="git curl zip unzip tar"
 APT_PACKAGES="$APT_PACKAGES at libxt-dev gperf libxaw7-dev cifs-utils \
   build-essential g++ gfortran libx11-dev libxkbcommon-x11-dev libxi-dev \
   libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxinerama-dev libxxf86vm-dev \
-  libxcursor-dev yasm libnuma1 libnuma-dev python-six python3-six python-yaml \
+  libxcursor-dev yasm libnuma1 libnuma-dev \
   flex libbison-dev autoconf libudev-dev libncurses5-dev libtool libxrandr-dev \
   xutils-dev dh-autoreconf autoconf-archive libgles2-mesa-dev ruby-full \
   pkg-config meson nasm cmake ninja-build"
@@ -29,7 +29,7 @@ APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \
 
 # Additionally required by qt5-base for qt5-x11extras
 APT_PACKAGES="$APT_PACKAGES libxkbcommon-dev libxcb-keysyms1-dev \
-  libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync0-dev \
+  libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev \
   libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev \
   libxcb-render-util0-dev libxcb-xinerama0-dev libxcb-xkb-dev libxcb-xinput-dev"
 
@@ -67,7 +67,7 @@ APT_PACKAGES="$APT_PACKAGES libdbus-1-dev"
 APT_PACKAGES="$APT_PACKAGES libxtst-dev"
 
 # Additionally required/installed by Azure DevOps Scale Set Agents
-APT_PACKAGES="$APT_PACKAGES liblttng-ust0 libkrb5-3 zlib1g libicu66"
+APT_PACKAGES="$APT_PACKAGES libkrb5-3 zlib1g libicu70"
 
 apt-get -y install $APT_PACKAGES
 

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -16,6 +16,9 @@ APT_PACKAGES="at curl unzip tar libxt-dev gperf libxaw7-dev cifs-utils \
   xutils-dev dh-autoreconf autoconf-archive libgles2-mesa-dev ruby-full \
   pkg-config meson nasm cmake ninja-build"
 
+# CUDA tooling
+APT_PACKAGES="$APT_PACKAGES nvidia-cudnn nvidia-cuda-toolkit"
+
 # Additionally required by qt5-base
 APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \
   libxcb1-dev libx11-xcb-dev libxcb-glx0-dev libxcb-util0-dev"
@@ -63,15 +66,6 @@ apt-get -y install $APT_PACKAGES
 
 # Install the latest Haskell stack for bond
 curl -sSL https://get.haskellstack.org/ | sh
-
-# Install CUDA
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
-apt-get -y update
-apt-get install -y --no-install-recommends cuda-compiler-11-6 cuda-libraries-dev-11-6 cuda-driver-dev-11-6 \
-  cuda-cudart-dev-11-6 libcublas-11-6 libcurand-dev-11-6 cuda-nvml-dev-11-6 libcudnn8-dev libnccl2 libnccl-dev
 
 # Install PowerShell
 wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -78,6 +78,14 @@ curl -sSL https://get.haskellstack.org/ | sh
 update-nvidia-cudnn -d
 update-nvidia-cudnn -u
 
+# Install nccl
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
+mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
+apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
+apt-get -y update
+apt-get install --no-install-recommends libnccl2 libnccl-dev
+
 # Install PowerShell
 wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -74,6 +74,10 @@ apt-get -y install $APT_PACKAGES
 # Install the latest Haskell stack for bond
 curl -sSL https://get.haskellstack.org/ | sh
 
+# Start up cudnn
+update-nvidia-cudnn -d
+update-nvidia-cudnn -u
+
 # Install PowerShell
 wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -7,9 +7,13 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get -y update
 apt-get -y dist-upgrade
+
+# Install vcpkg prerequisites
+APT_PACKAGES="git curl zip unzip tar"
+
 # Install common build dependencies
-APT_PACKAGES="at curl unzip tar libxt-dev gperf libxaw7-dev cifs-utils \
-  build-essential g++ gfortran zip libx11-dev libxkbcommon-x11-dev libxi-dev \
+APT_PACKAGES="$APT_PACKAGES at libxt-dev gperf libxaw7-dev cifs-utils \
+  build-essential g++ gfortran libx11-dev libxkbcommon-x11-dev libxi-dev \
   libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxinerama-dev libxxf86vm-dev \
   libxcursor-dev yasm libnuma1 libnuma-dev python-six python3-six python-yaml \
   flex libbison-dev autoconf libudev-dev libncurses5-dev libtool libxrandr-dev \

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -59,6 +59,9 @@ APT_PACKAGES="$APT_PACKAGES libxdamage-dev"
 # Additionally required by gtk3 and at-spi2-atk
 APT_PACKAGES="$APT_PACKAGES libdbus-1-dev"
 
+# Additionally required by at-spi2-atk
+APT_PACKAGES="$APT_PACKAGES libxtst-dev"
+
 # Additionally required/installed by Azure DevOps Scale Set Agents
 APT_PACKAGES="$APT_PACKAGES liblttng-ust0 libkrb5-3 zlib1g libicu66"
 

--- a/scripts/azure-pipelines/windows/deploy-pwsh.ps1
+++ b/scripts/azure-pipelines/windows/deploy-pwsh.ps1
@@ -5,5 +5,5 @@
 
 # REPLACE WITH UTILITY-PREFIX.ps1
 
-$PwshUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.4/PowerShell-7.2.4-win-x64.msi'
+$PwshUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/PowerShell-7.2.5-win-x64.msi'
 InstallMSI -Url $PwshUrl -Name 'PowerShell Core'

--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -194,11 +194,11 @@
         <archiveName>ninja-freebsd-1.8.2.zip</archiveName>
     </tool>
     <tool name="powershell-core" os="windows">
-        <version>7.2.4</version>
+        <version>7.2.5</version>
         <exeRelativePath>pwsh.exe</exeRelativePath>
-        <url>https://github.com/PowerShell/PowerShell/releases/download/v7.2.4/PowerShell-7.2.4-win-x86.zip</url>
-        <sha512>4f337c66e03124cfc1e96a56a943ccd24f9a22f588fa461bea9e14733acf06acddd873860b10843c92251257a64fbfac967ae77c084960aaf6b14522435b7769</sha512>
-        <archiveName>PowerShell-7.2.4-win-x86.zip</archiveName>
+        <url>https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/PowerShell-7.2.5-win-x86.zip</url>
+        <sha512>75b549db2500a5510eae3ec595540b42726c1b049f382c7683b6f0ed26dddd219e2ac67e9902358615f96c7884eda63ec3d0ca558b7b92f4604fdc61322ca4dd</sha512>
+        <archiveName>PowerShell-7.2.5-win-x86.zip</archiveName>
     </tool>
     <tool name="node" os="windows">
         <version>16.15.1</version>

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1754,7 +1754,7 @@
     },
     "cudnn": {
       "baseline": "7.6.5",
-      "port-version": 7
+      "port-version": 8
     },
     "cunit": {
       "baseline": "2.1.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1750,7 +1750,7 @@
     },
     "cuda": {
       "baseline": "10.1",
-      "port-version": 10
+      "port-version": 11
     },
     "cudnn": {
       "baseline": "7.6.5",

--- a/versions/c-/cuda.json
+++ b/versions/c-/cuda.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d190177076c48287897d233ae2fa8c241f28f40",
+      "version": "10.1",
+      "port-version": 11
+    },
+    {
       "git-tree": "4e8939c3547a570a73098c091da7b9e28f71015c",
       "version": "10.1",
       "port-version": 10

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b29eb71b5187d6f0991ede2a56e2fda57e6cb520",
+      "version": "7.6.5",
+      "port-version": 8
+    },
+    {
       "git-tree": "cfd70db6f58e45dc96c44a61833d821d987c1588",
       "version": "7.6.5",
       "port-version": 7


### PR DESCRIPTION
* Changes the source from NVidia official for most CUDA things to Ubuntu's built in bits. Note that Ubuntu has no nccl so we're still getting that from them directly.
* Updates PowerShell to 7.2.5.
