### PR TITLE
[libdc1394] Fix dependencies, fix osx

### DIFF
--- a/ports/libdc1394/fix-macosx.patch
+++ b/ports/libdc1394/fix-macosx.patch
@@ -1,0 +1,11 @@
+--- a/dc1394/macosx/Makefile.in
++++ b/dc1394/macosx/Makefile.in
+@@ -119,7 +119,7 @@ AM_V_at = $(am__v_at_@AM_V@)
+ am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
+ am__v_at_0 = @
+ am__v_at_1 = 
+-DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)
++DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir) -I.@am__isrc@/.. -I.@am__isrc@/../..
+ depcomp = $(SHELL) $(top_srcdir)/depcomp
+ am__depfiles_maybe = depfiles
+ am__mv = mv -f

--- a/ports/libdc1394/portfile.cmake
+++ b/ports/libdc1394/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_sourceforge(
     REF "${LIBDC1394_VER}"
     FILENAME "libdc1394-${LIBDC1394_VER}.tar.gz"
     SHA512 2d60ed1054da67d8518e870193b60c1d79778858f48cc6487e252de00cc57a08548515d41914a37d0227d29e158d68892c290f83930ffd95f4a483dce5aa3d25
+    PATCHES
+        fix-macosx.patch
 )
 
 vcpkg_configure_make(

--- a/ports/libdc1394/portfile.cmake
+++ b/ports/libdc1394/portfile.cmake
@@ -10,13 +10,20 @@ vcpkg_from_sourceforge(
 
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS "--disable-examples"
+    OPTIONS
+        "--disable-examples"
+        ac_cv_lib_raw1394_raw1394_channel_modify=no
+        ac_cv_path_SDL_CONFIG=no
 )
 vcpkg_install_make()
+
+file(APPEND "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libdc1394-2.pc" "\nRequires.private: libusb-1.0\n")
+if(NOT VCPKG_BUILD_TYPE)
+    file(APPEND "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libdc1394-2.pc" "\nRequires.private: libusb-1.0\n")
+endif()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libdc1394/vcpkg.json
+++ b/ports/libdc1394/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "libdc1394",
   "version": "2.2.6",
+  "port-version": 1,
   "description": "libdc1394 is a library that provides a complete high level application programming interface (API) for developers who wish to control IEEE 1394 based cameras that conform to the 1394-based Digital Camera Specifications (also known as the IIDC or DCAM Specifications).",
   "homepage": "https://damien.douxchamps.net/ieee1394/libdc1394",
   "supports": "!windows",
   "dependencies": [
-    "sdl1"
+    "libusb"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3546,7 +3546,7 @@
     },
     "libdc1394": {
       "baseline": "2.2.6",
-      "port-version": 0
+      "port-version": 1
     },
     "libde265": {
       "baseline": "1.0.8",

--- a/versions/l-/libdc1394.json
+++ b/versions/l-/libdc1394.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "836d621852118c9ba8ce3e7ec8f3d8a2b9d9ea2b",
+      "version": "2.2.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "709fb395bf34f777acced25c12d6fd76d90f0100",
       "version": "2.2.6",
       "port-version": 0


### PR DESCRIPTION
Pulled out of  #23918.

- #### What does your PR fix?
  - sdl isn't needed: The port doesn't build examples. (This dependency blocked osx.)
  - libusb is needed. The port used to pick the system lib.
  - libraw1394 doesn't have a port. It must not be picked from the system.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  linux and osx, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes