### PR TITLE
[jsonnet] Update to 0.18.0

### DIFF
--- a/ports/jsonnet/0003-use-upstream-nlohmann-json.patch
+++ b/ports/jsonnet/0003-use-upstream-nlohmann-json.patch
@@ -1,5 +1,5 @@
 diff --git a/core/vm.cpp b/core/vm.cpp
-index 0cf06fa..d65a6d7 100644
+index 4617363..e328df5 100644
 --- a/core/vm.cpp
 +++ b/core/vm.cpp
 @@ -23,7 +23,7 @@ limitations under the License.
@@ -10,4 +10,4 @@ index 0cf06fa..d65a6d7 100644
 +#include "nlohmann/json.hpp"
  #include "md5.h"
  #include "parser.h"
- #include "state.h"
+ #include "ryml_std.hpp" // include this before any other ryml header

--- a/ports/jsonnet/0004-incorporate-md5.patch
+++ b/ports/jsonnet/0004-incorporate-md5.patch
@@ -1,4 +1,5 @@
 diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
+index a152fa9..e8a0efa 100644
 --- a/core/CMakeLists.txt
 +++ b/core/CMakeLists.txt
 @@ -15,7 +15,8 @@ set(LIBJSONNET_HEADERS
@@ -22,20 +23,20 @@ diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
  if (BUILD_SHARED_BINARIES)
  add_library(libjsonnet ${LIBJSONNET_HEADERS} ${LIBJSONNET_SOURCE})
 -add_dependencies(libjsonnet md5 stdlib)
--target_link_libraries(libjsonnet md5 nlohmann_json::nlohmann_json)
+-target_link_libraries(libjsonnet md5 nlohmann_json::nlohmann_json ryml)
 +add_dependencies(libjsonnet stdlib)
-+target_link_libraries(libjsonnet nlohmann_json::nlohmann_json)
++target_link_libraries(libjsonnet nlohmann_json::nlohmann_json ryml)
  
  file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/../include/libjsonnet.h JSONNET_VERSION_DEF
       REGEX "[#]define[ \t]+LIB_JSONNET_VERSION[ \t]+")
-@@ -54,8 +56,8 @@ endif()
+@@ -56,8 +58,8 @@ endif()
  if (BUILD_STATIC_LIBS)
      # Static library for jsonnet command-line tool.
      add_library(libjsonnet_static STATIC ${LIBJSONNET_SOURCE})
 -    add_dependencies(libjsonnet_static md5 stdlib)
--    target_link_libraries(libjsonnet_static md5 nlohmann_json::nlohmann_json)
+-    target_link_libraries(libjsonnet_static md5 nlohmann_json::nlohmann_json ryml)
 +    add_dependencies(libjsonnet_static stdlib)
-+    target_link_libraries(libjsonnet_static nlohmann_json::nlohmann_json)
++    target_link_libraries(libjsonnet_static nlohmann_json::nlohmann_json ryml)
      set_target_properties(libjsonnet_static PROPERTIES OUTPUT_NAME jsonnet)
      install(TARGETS libjsonnet_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
      target_include_directories(libjsonnet_static INTERFACE

--- a/ports/jsonnet/0005-use-upstream-rapidyaml.patch
+++ b/ports/jsonnet/0005-use-upstream-rapidyaml.patch
@@ -1,0 +1,47 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 23a8114..f430146 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,6 +15,7 @@ option(BUILD_STATIC_LIBS "Build a static libjsonnet." ON)
+ option(BUILD_SHARED_BINARIES "Link binaries to the shared libjsonnet instead of the static one." OFF)
+ option(USE_SYSTEM_GTEST "Use system-provided gtest library" OFF)
+ option(USE_SYSTEM_JSON "Use the system-provided json library" OFF)
++option(USE_SYSTEM_RYML "Use the system-provided rapidyaml library" OFF)
+ set(GLOBAL_OUTPUT_PATH_SUFFIX "" CACHE STRING
+     "Output artifacts directory.")
+ 
+@@ -104,6 +105,11 @@ if(USE_SYSTEM_JSON)
+ else()
+     add_subdirectory(third_party/json)
+ endif()
++if(USE_SYSTEM_RYML)
++    find_package(ryml CONFIG REQUIRED)
++else()
++    add_subdirectory(third_party/rapidyaml/rapidyaml ryml)
++endif()
+ 
+ # Look for libraries in global output path.
+ link_directories(${GLOBAL_OUTPUT_PATH})
+@@ -124,7 +130,6 @@ endif()
+ add_subdirectory(include)
+ add_subdirectory(stdlib)
+ add_subdirectory(third_party/md5)
+-add_subdirectory(third_party/rapidyaml/rapidyaml ryml)
+ add_subdirectory(core)
+ add_subdirectory(cpp)
+ add_subdirectory(cmd)
+diff --git a/core/vm.cpp b/core/vm.cpp
+index e328df5..2cafbb7 100644
+--- a/core/vm.cpp
++++ b/core/vm.cpp
+@@ -26,8 +26,8 @@ limitations under the License.
+ #include "nlohmann/json.hpp"
+ #include "md5.h"
+ #include "parser.h"
+-#include "ryml_std.hpp" // include this before any other ryml header
+-#include "ryml.hpp"
++#include "ryml/ryml_std.hpp" // include this before any other ryml header
++#include "ryml/ryml.hpp"
+ #include "state.h"
+ #include "static_analysis.h"
+ #include "string_utils.h"

--- a/ports/jsonnet/001-enable-msvc.patch
+++ b/ports/jsonnet/001-enable-msvc.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 385ea82..ebd12b6 100644
+index 5df20ca..23a8114 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -2,6 +2,8 @@
@@ -40,6 +40,7 @@ index c032f02..d80d2a0 100644
 +	install(TARGETS jsonnetfmt DESTINATION tools/jsonnet)
  endif()
 diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
+index e62a858..3b7afda 100644
 --- a/core/CMakeLists.txt
 +++ b/core/CMakeLists.txt
 @@ -28,7 +28,7 @@ set(LIBJSONNET_SOURCE
@@ -49,7 +50,7 @@ diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
 -add_library(libjsonnet SHARED ${LIBJSONNET_HEADERS} ${LIBJSONNET_SOURCE})
 +add_library(libjsonnet ${LIBJSONNET_HEADERS} ${LIBJSONNET_SOURCE})
  add_dependencies(libjsonnet md5 stdlib)
- target_link_libraries(libjsonnet md5 nlohmann_json::nlohmann_json)
+ target_link_libraries(libjsonnet md5 nlohmann_json::nlohmann_json ryml)
  
 @@ -46,7 +46,7 @@ set_target_properties(libjsonnet PROPERTIES OUTPUT_NAME jsonnet
  	PUBLIC_HEADER "${LIB_HEADER}")

--- a/ports/jsonnet/002-fix-dependency-and-install.patch
+++ b/ports/jsonnet/002-fix-dependency-and-install.patch
@@ -1,4 +1,5 @@
 diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
+index 3b7afda..a152fa9 100644
 --- a/core/CMakeLists.txt
 +++ b/core/CMakeLists.txt
 @@ -28,6 +28,7 @@ set(LIBJSONNET_SOURCE
@@ -8,8 +9,8 @@ diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
 +if (BUILD_SHARED_BINARIES)
  add_library(libjsonnet ${LIBJSONNET_HEADERS} ${LIBJSONNET_SOURCE})
  add_dependencies(libjsonnet md5 stdlib)
- target_link_libraries(libjsonnet md5 nlohmann_json::nlohmann_json)
-@@ -48,6 +49,7 @@ install(TARGETS libjsonnet
+ target_link_libraries(libjsonnet md5 nlohmann_json::nlohmann_json ryml)
+@@ -50,6 +51,7 @@ install(TARGETS libjsonnet
  	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
  target_include_directories(libjsonnet INTERFACE
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
@@ -17,13 +18,14 @@ diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
  
  if (BUILD_STATIC_LIBS)
      # Static library for jsonnet command-line tool.
-@@ -102,3 +104,5 @@ if (BUILD_TESTS)
+@@ -106,3 +108,5 @@ if (BUILD_TESTS)
      add_test(jsonnet_test_snippet
          ${GLOBAL_OUTPUT_PATH}/jsonnet -e ${TEST_SNIPPET})
  endif()
 +
 +install(FILES ${LIB_HEADER} DESTINATION include)
 diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
+index eb7686c..326125c 100644
 --- a/cpp/CMakeLists.txt
 +++ b/cpp/CMakeLists.txt
 @@ -8,9 +8,9 @@ set(LIBJSONNETPP_SOURCE
@@ -46,7 +48,7 @@ diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
  
  if (BUILD_STATIC_LIBS)
      # Static library for jsonnet command-line tool.
-@@ -38,6 +39,7 @@ else()
+@@ -42,6 +43,7 @@ else()
      add_library(libjsonnet++_for_binaries ALIAS libjsonnet++_static)
  endif()
  

--- a/ports/jsonnet/portfile.cmake
+++ b/ports/jsonnet/portfile.cmake
@@ -5,17 +5,18 @@ endif()
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO google/jsonnet
-  REF v0.17.0
-  SHA512 D3EE6947163D8ABCED504FF37ECF365C0311164CBF243D4C635D34944F0831CA9FCE2470ACF00EB9A218F82A2E553B3F885DB9BD21BB9DCEFBD707FA0202925D
+  REF v0.18.0
+  SHA512 08a64a4b132df1519292378cef93deb3c60d21636b2a71bce6c13e29cfd93cab465cad77e11f000fb984c5c75a4ca1c92504654fd2e5201343df767ea0e610d1
   HEAD_REF master
   PATCHES
     001-enable-msvc.patch
     002-fix-dependency-and-install.patch
     0003-use-upstream-nlohmann-json.patch
     0004-incorporate-md5.patch
+    0005-use-upstream-rapidyaml.patch
 )
 
-# see https://github.com/google/jsonnet/blob/v0.17.0/Makefile#L214
+# see https://github.com/google/jsonnet/blob/v0.18.0/Makefile#L220
 if(VCPKG_TARGET_IS_WINDOWS)
   find_program(PWSH_PATH pwsh)
   vcpkg_execute_required_process(
@@ -48,6 +49,7 @@ vcpkg_cmake_configure(
     -DBUILD_JSONNETFMT=OFF
     -DBUILD_TESTS=OFF
     -DUSE_SYSTEM_JSON=ON
+    -DUSE_SYSTEM_RYML=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/jsonnet/vcpkg.json
+++ b/ports/jsonnet/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "jsonnet",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Jsonnet - The data templating language",
   "homepage": "https://github.com/google/jsonnet",
   "supports": "!(windows & !static)",
   "dependencies": [
     "nlohmann-json",
+    "ryml",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/jsonnet/vcpkg.json
+++ b/ports/jsonnet/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "0.18.0",
   "description": "Jsonnet - The data templating language",
   "homepage": "https://github.com/google/jsonnet",
+  "license": "Apache-2.0",
   "supports": "!(windows & !static)",
   "dependencies": [
     "nlohmann-json",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3137,7 +3137,7 @@
       "port-version": 0
     },
     "jsonnet": {
-      "baseline": "0.17.0",
+      "baseline": "0.18.0",
       "port-version": 0
     },
     "jwt-cpp": {

--- a/versions/j-/jsonnet.json
+++ b/versions/j-/jsonnet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ac55d2bf1f121bd14e748bbf55569a49a9015d9",
+      "version": "0.18.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "24a514c5bcece6b71ac13744ec40f92f285fc689",
       "version": "0.17.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

Update jsonnet to 0.18.0.
jsonnet added YAML support starting with 0.18.0.
The original jsonnet uses its own third_party/rapidyaml, but vcpkg already has ports/ryml, so I have added a patch to make it use vcpkg's rapidyaml.

- #### What does your PR fix?
  Update jsonnet to 0.18.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  As before, Yes
 However, since ports/ryml is ONLY_STATIC_LIBRARY, what to do with jsonnet needs to be discussed.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
