### PR TITLE
[stb] Add stb_perlin.h

### DIFF
--- a/ports/stb/portfile.cmake
+++ b/ports/stb/portfile.cmake
@@ -6,8 +6,17 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# originally deleted due to patent US6867776, but it has expired and it has yet to be restored
+# see https://github.com/nothings/stb/commit/59e7dec3e8bb0a8d4050d03c2dc32cf71ffa87c6
+vcpkg_download_distfile(
+    STB_PERLIN_H
+    URLS "https://raw.githubusercontent.com/nothings/stb/2bb4a0accd4003c1db4c24533981e01b1adfd656/stb_perlin.h"
+    FILENAME stb_perlin.h
+    SHA512 9dbc77a530ea368a47988393c7228ffaa8622ce5ffd83770306eaa6282bf289f7f6e55f4a4a5c746798e8c8a49e180344fd8837983ec734664abf9077e37d39f
+)
+
 file(GLOB HEADER_FILES "${SOURCE_PATH}/*.h")
-file(COPY ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY ${HEADER_FILES} "${STB_PERLIN_H}" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/FindStb.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/stb/vcpkg.json
+++ b/ports/stb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "stb",
   "version-date": "2021-09-10",
+  "port-version": 1,
   "description": "public domain header-only libraries",
   "homepage": "https://github.com/nothings/stb",
   "license": "MIT OR CC-PDDC"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6882,7 +6882,7 @@
     },
     "stb": {
       "baseline": "2021-09-10",
-      "port-version": 0
+      "port-version": 1
     },
     "stduuid": {
       "baseline": "1.2.2",

--- a/versions/s-/stb.json
+++ b/versions/s-/stb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9ebadca0be90431f35a8d20b44f40b07285eb33d",
+      "version-date": "2021-09-10",
+      "port-version": 1
+    },
+    {
       "git-tree": "2da639ecba7048e0f722dc01fae6cef32d671991",
       "version-date": "2021-09-10",
       "port-version": 0


### PR DESCRIPTION
This PR adds stb_perlin.h, which was originally deleted due to a patent. The patent expired, but it was never added back. Details in the code.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
