### PR TITLE
[vcpkg baseline][gpgmm] Don't use bundled vulkan-headers

### DIFF
--- a/ports/gpgmm/no-bundled-vulkan.patch
+++ b/ports/gpgmm/no-bundled-vulkan.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
+index 5ad7cf6e..c9974d15 100644
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -50,7 +50,7 @@ if (GPGMM_ENABLE_TESTS)
+ 
+ endif() # GPGMM_ENABLE_TESTS
+ 
+-if (GPGMM_ENABLE_VK)
++if (0)
+   FetchContent_Declare(
+     vulkan-headers
+     GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Headers.git

--- a/ports/gpgmm/portfile.cmake
+++ b/ports/gpgmm/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
   REF v0.0.4
   SHA512 2ffc3c8299f2d10cb1c0013cd306ba45781a644fa0aa426ef1dfa616e4b53671461a376f65b7068b1ff8a4a2d1a6f9539664174eb5830ea6a760ef5e5d0fc6b0
   HEAD_REF main
+  PATCHES
+    no-bundled-vulkan.patch
 )
 
 # gpgmm\third_party config requires Git. Make the tool visible.
@@ -12,11 +14,11 @@ get_filename_component(GIT_DIR "${GIT}" DIRECTORY)
 vcpkg_add_to_path("${GIT_DIR}")
 
 vcpkg_cmake_configure(
-  SOURCE_PATH ${SOURCE_PATH}
+  SOURCE_PATH "${SOURCE_PATH}"
   DISABLE_PARALLEL_CONFIGURE
   OPTIONS
-  -DGPGMM_STANDALONE=OFF
-  -DGPGMM_ENABLE_TESTS=OFF
+    -DGPGMM_STANDALONE=OFF
+    -DGPGMM_ENABLE_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/gpgmm/vcpkg.json
+++ b/ports/gpgmm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gpgmm",
   "version": "0.0.4",
+  "port-version": 1,
   "description": "GPGMM is a General-Purpose GPU Memory Management library. It provides a common set of GPU memory routines optimized for GPUs. The library helps developers manage video memory by implementing the necessary functionality across components based on Vulkan or D3D12",
   "homepage": "https://github.com/intel/GPGMM/",
   "license": "Apache-2.0",
@@ -10,9 +11,7 @@
       "name": "vcpkg-cmake",
       "host": true
     },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    }
+    "vulkan",
+    "vulkan-headers"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2662,7 +2662,7 @@
     },
     "gpgmm": {
       "baseline": "0.0.4",
-      "port-version": 0
+      "port-version": 1
     },
     "gppanel": {
       "baseline": "2020-05-20",

--- a/versions/g-/gpgmm.json
+++ b/versions/g-/gpgmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "187df19bfb0b34fd604b0f0511663877e90fbfa3",
+      "version": "0.0.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "08e07fe17d9d990b3d2579b33c6851b60faa6c2c",
       "version": "0.0.4",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  gpgmm has file conflicts with vulkan-headers.

Note that CI didn't test this port and I didn't test it because neither CI nor myself have installed Vulkan SDK. Maybe @bbernhar can help to test this.