### PR TITLE
[readline-unix] Fix x64-linux-dynamic build

### DIFF
--- a/ports/readline-unix/portfile.cmake
+++ b/ports/readline-unix/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_configure_make(
 vcpkg_install_make()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/readline-unix/bin" "${CURRENT_PACKAGES_DIR}/tools/readline-unix/debug/bin")
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/readline-unix/vcpkg.json
+++ b/ports/readline-unix/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "readline-unix",
   "version": "8.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Implementation of readline for unix",
+  "license": "GPL-3.0-or-later",
   "supports": "!windows",
   "dependencies": [
     "ncurses"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6222,7 +6222,7 @@
     },
     "readline-unix": {
       "baseline": "8.1",
-      "port-version": 1
+      "port-version": 2
     },
     "readline-win32": {
       "baseline": "5.0",

--- a/versions/r-/readline-unix.json
+++ b/versions/r-/readline-unix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e81a9fe4baa7c437b6e6d9636ae7c291e2ed81e9",
+      "version": "8.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "cc7ba8176a2492af17dc561bcb82c36f7c89e540",
       "version": "8.1",
       "port-version": 1


### PR DESCRIPTION
This PR fixes build failure with x64-linux-dynamic triplet.
For https://github.com/microsoft/vcpkg/issues/25668