### PR TITLE
[libtorrent] update to 2.0.7

### DIFF
--- a/ports/libtorrent/portfile.cmake
+++ b/ports/libtorrent/portfile.cmake
@@ -30,8 +30,8 @@ endif()
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO arvidn/libtorrent
-        REF e9bbf16bdd899f42aef0f0c2b1f214de2c15ac92 # v2.0.6
-        SHA512 5bc93be6b1bf5208f1bfc10ffe515e20face41ebf0f9cf7afc8f1c03addc42a88f92ec79a2c2a1d1a4fd0a3014b752d68e7e62cd86349694636b79da31ed8e08
+        REF 722d78250a30c89c92970a78be970269a395be36 # v2.0.7
+        SHA512 69c7e6c02db6ff6b10d94b52470eda38839b4121960f7d19c3829eb453a84a62f017e1607bbb8dd63528c1461686fa6f30af605a046faae2c9c916aa688b555f
         HEAD_REF RC_2_0
 )
 

--- a/ports/libtorrent/vcpkg.json
+++ b/ports/libtorrent/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtorrent",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "maintainers": "Arvid Norberg <arvid.norberg@gmail.com>",
   "description": "An efficient feature complete C++ BitTorrent implementation",
   "homepage": "https://libtorrent.org",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4161,7 +4161,7 @@
       "port-version": 2
     },
     "libtorrent": {
-      "baseline": "2.0.6",
+      "baseline": "2.0.7",
       "port-version": 0
     },
     "libu2f-server": {

--- a/versions/l-/libtorrent.json
+++ b/versions/l-/libtorrent.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1c101af3351c28c84e89394e1fb6826352bec76",
+      "version": "2.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ca0a5e5498fe7a999d78650e6ae935cebf1d764",
       "version": "2.0.6",
       "port-version": 0


### PR DESCRIPTION
Fix #25825

Update [libtorrent] version to v2.0.7

All features are tested successfully in the following triplet(except python):

- x86-windows
- x64-windows
- x64-windows-stataic