### PR TITLE
[brpc] Update to 1.2.0 and fix build error with gcc 11

### DIFF
--- a/ports/brpc/brpc-1783.diff
+++ b/ports/brpc/brpc-1783.diff
@@ -1,0 +1,592 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 11db84d02..7592a1862 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -56,7 +56,7 @@ config_setting(
+ 
+ COPTS = [
+     "-DBTHREAD_USE_FAST_PTHREAD_MUTEX",
+-    "-D__const__=",
++    "-D__const__=__unused__",
+     "-D_GNU_SOURCE",
+     "-DUSE_SYMBOLIZE",
+     "-DNO_TCMALLOC",
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 057695afc..bfc9fe4f0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -108,7 +108,7 @@ set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG
+ if(WITH_MESALINK)
+     set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DUSE_MESALINK")
+ endif()
+-set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DBRPC_REVISION=\\\"${BRPC_REVISION}\\\" -D__STRICT_ANSI__")
++set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__=__unused__ -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DBRPC_REVISION=\\\"${BRPC_REVISION}\\\" -D__STRICT_ANSI__")
+ set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEBUG_SYMBOL} ${THRIFT_CPP_FLAG}")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer")
+ set(CMAKE_C_FLAGS "${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-unused-parameter -fno-omit-frame-pointer")
+diff --git a/Makefile b/Makefile
+index e2e1a6b2e..da506f7c5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -20,10 +20,9 @@ include config.mk
+ 
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-# 3. Removed -Werror: Not block compilation for non-vital warnings, especially when the
++# 2. Removed -Werror: Not block compilation for non-vital warnings, especially when the
+ #    code is tested on newer systems. If the code is used in production, add -Werror back
+-CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DNDEBUG -DBRPC_REVISION=\"$(shell ./tools/get_brpc_revision.sh .)\"
++CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DNDEBUG -DBRPC_REVISION=\"$(shell ./tools/get_brpc_revision.sh .)\"
+ CXXFLAGS=$(CPPFLAGS) -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -std=c++0x
+ CFLAGS=$(CPPFLAGS) -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-unused-parameter -fno-omit-frame-pointer
+ DEBUG_CXXFLAGS = $(filter-out -DNDEBUG,$(CXXFLAGS)) -DUNIT_TEST -DBVAR_NOT_LINK_DEFAULT_VARIABLES
+diff --git a/config_brpc.sh b/config_brpc.sh
+index 842f100f9..cf04b7260 100755
+--- a/config_brpc.sh
++++ b/config_brpc.sh
+@@ -320,6 +320,10 @@ append_to_output "STATIC_LINKINGS=$STATIC_LINKINGS"
+ append_to_output "DYNAMIC_LINKINGS=$DYNAMIC_LINKINGS"
+ CPPFLAGS="-DBRPC_WITH_GLOG=$WITH_GLOG -DGFLAGS_NS=$GFLAGS_NS"
+ 
++# Avoid over-optimizations of TLS variables by GCC>=4.8
++# See: https://github.com/apache/incubator-brpc/issues/1693
++CPPFLAGS="${CPPFLAGS} -D__const__=__unused__"
++
+ if [ ! -z "$DEBUGSYMBOLS" ]; then
+     CPPFLAGS="${CPPFLAGS} $DEBUGSYMBOLS"
+ fi
+diff --git a/docs/cn/getting_started.md b/docs/cn/getting_started.md
+index 2602f5b41..56f80db3b 100644
+--- a/docs/cn/getting_started.md
++++ b/docs/cn/getting_started.md
+@@ -290,7 +290,7 @@ GCC7中over-aligned的问题暂时被禁止。
+ 
+ 使用其他版本的gcc可能会产生编译警告，请联系我们予以修复。
+ 
+-请在makefile中给cxxflags增加`-D__const__=`选项以避免[gcc4+中的errno问题](thread_local.md).
++请在makefile中给cxxflags增加`-D__const__=__unused__`选项以避免[gcc4+中的errno问题](thread_local.md).
+ 
+ ## Clang: 3.5-4.0
+ 
+diff --git a/docs/cn/thread_local.md b/docs/cn/thread_local.md
+index f8e1a491e..41e024749 100644
+--- a/docs/cn/thread_local.md
++++ b/docs/cn/thread_local.md
+@@ -57,9 +57,8 @@ Use *p ...                   -  still the errno of original pthread, undefined b
+ 
+ 严格地说这个问题不是gcc4导致的，而是glibc给__errno_location的签名不够准确，一个返回thread-local指针的函数依赖于段寄存器（TLS的一般实现方式），这怎么能算const呢？由于我们还未找到覆盖__errno_location的方法，所以这个问题目前实际的解决方法是：
+ 
+-**务必在直接或间接使用bthread的项目的gcc编译选项中添加`-D__const__=`，即把`__const__`定义为空，避免gcc4做相关优化。**
++**务必在直接或间接使用bthread的项目的gcc编译选项中添加`-D__const__=__unused__`，即把`__const__`定义为一个无副作用的属性，避免gcc4做相关优化。**
+ 
+-把`__const__`定义为空对程序其他部分的影响几乎为0。另外如果你没有**直接**使用errno（即你的项目中没有出现errno），或使用的是gcc
+-3.4，即使没有定义`-D__const__=`，程序的正确性也不会受影响，但为了防止未来可能的问题，我们强烈建议加上。
++把`__const__`定义为`__unused__`对程序其他部分的影响几乎为0。另外如果你没有**直接**使用errno（即你的项目中没有出现errno），或使用的是gcc 3.4，即使没有定义`-D__const__=__unused__`，程序的正确性也不会受影响，但为了防止未来可能的问题，我们强烈建议加上。
+ 
+-需要说明的是，和errno类似，pthread_self也有类似的问题，不过一般pthread_self除了打日志没有其他用途，影响面较小，在`-D__const__=`后pthread_self也会正常。
++需要说明的是，和errno类似，pthread_self也有类似的问题，不过一般pthread_self除了打日志没有其他用途，影响面较小，在`-D__const__=__unused__`后pthread_self也会正常。
+diff --git a/docs/en/getting_started.md b/docs/en/getting_started.md
+index c500f5807..4242f82a0 100644
+--- a/docs/en/getting_started.md
++++ b/docs/en/getting_started.md
+@@ -297,7 +297,7 @@ The over-aligned issues in GCC7 is suppressed temporarily now.
+ 
+ Using other versions of gcc may generate warnings, contact us to fix.
+ 
+-Adding `-D__const__=` to cxxflags in your makefiles is a must to avoid [errno issue in gcc4+](thread_local.md).
++Adding `-D__const__=__unused__` to cxxflags in your makefiles is a must to avoid [errno issue in gcc4+](thread_local.md).
+ 
+ ## Clang: 3.5-4.0
+ 
+diff --git a/example/BUILD b/example/BUILD
+index ee2c6ffd0..d688749d8 100644
+--- a/example/BUILD
++++ b/example/BUILD
+@@ -16,7 +16,7 @@
+ COPTS = [
+     "-D__STDC_FORMAT_MACROS",
+     "-DBTHREAD_USE_FAST_PTHREAD_MUTEX",
+-    "-D__const__=",
++    "-D__const__=__unused__",
+     "-D_GNU_SOURCE",
+     "-DUSE_SYMBOLIZE",
+     "-DNO_TCMALLOC",
+diff --git a/example/asynchronous_echo_c++/CMakeLists.txt b/example/asynchronous_echo_c++/CMakeLists.txt
+index 18fec20ee..4a118b19a 100644
+--- a/example/asynchronous_echo_c++/CMakeLists.txt
++++ b/example/asynchronous_echo_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/auto_concurrency_limiter/CMakeLists.txt b/example/auto_concurrency_limiter/CMakeLists.txt
+index ef20bf0a7..88b784277 100644
+--- a/example/auto_concurrency_limiter/CMakeLists.txt
++++ b/example/auto_concurrency_limiter/CMakeLists.txt
+@@ -70,7 +70,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/backup_request_c++/CMakeLists.txt b/example/backup_request_c++/CMakeLists.txt
+index d247bc150..fc39ba3cd 100644
+--- a/example/backup_request_c++/CMakeLists.txt
++++ b/example/backup_request_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/cancel_c++/CMakeLists.txt b/example/cancel_c++/CMakeLists.txt
+index 26f2581ba..ea611e03f 100644
+--- a/example/cancel_c++/CMakeLists.txt
++++ b/example/cancel_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/cascade_echo_c++/CMakeLists.txt b/example/cascade_echo_c++/CMakeLists.txt
+index 24d9249ae..6ca2e25dc 100644
+--- a/example/cascade_echo_c++/CMakeLists.txt
++++ b/example/cascade_echo_c++/CMakeLists.txt
+@@ -80,7 +80,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/dynamic_partition_echo_c++/CMakeLists.txt b/example/dynamic_partition_echo_c++/CMakeLists.txt
+index 5a268a6c9..8df3ad62e 100644
+--- a/example/dynamic_partition_echo_c++/CMakeLists.txt
++++ b/example/dynamic_partition_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/echo_c++/CMakeLists.txt b/example/echo_c++/CMakeLists.txt
+index 4e6f5231d..d7babd7f7 100644
+--- a/example/echo_c++/CMakeLists.txt
++++ b/example/echo_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/echo_c++/Makefile b/example/echo_c++/Makefile
+index 710cc7eda..fddde8cbc 100644
+--- a/example/echo_c++/Makefile
++++ b/example/echo_c++/Makefile
+@@ -20,8 +20,7 @@ BRPC_PATH=../..
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ ifeq ($(NEED_GPERFTOOLS), 1)
+ 	CXXFLAGS+=-DBRPC_ENABLE_CPU_PROFILER
+ endif
+diff --git a/example/grpc_c++/CMakeLists.txt b/example/grpc_c++/CMakeLists.txt
+index 5f9032e1c..49010e963 100644
+--- a/example/grpc_c++/CMakeLists.txt
++++ b/example/grpc_c++/CMakeLists.txt
+@@ -75,7 +75,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/http_c++/CMakeLists.txt b/example/http_c++/CMakeLists.txt
+index 388b58c2e..34f3050fa 100644
+--- a/example/http_c++/CMakeLists.txt
++++ b/example/http_c++/CMakeLists.txt
+@@ -86,7 +86,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/http_c++/Makefile b/example/http_c++/Makefile
+index dc9d430f6..515456559 100644
+--- a/example/http_c++/Makefile
++++ b/example/http_c++/Makefile
+@@ -20,8 +20,7 @@ BRPC_PATH=../../
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ ifeq ($(NEED_GPERFTOOLS), 1)
+ 	CXXFLAGS+=-DBRPC_ENABLE_CPU_PROFILER
+ endif
+diff --git a/example/memcache_c++/CMakeLists.txt b/example/memcache_c++/CMakeLists.txt
+index 2554b8295..85b4affcb 100644
+--- a/example/memcache_c++/CMakeLists.txt
++++ b/example/memcache_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/memcache_c++/Makefile b/example/memcache_c++/Makefile
+index 2579f68f4..03b3d4cd7 100644
+--- a/example/memcache_c++/Makefile
++++ b/example/memcache_c++/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer
+ HDRS+=$(BRPC_PATH)/output/include
+ LIBS+=$(BRPC_PATH)/output/lib
+ HDRPATHS = $(addprefix -I, $(HDRS))
+diff --git a/example/multi_threaded_echo_c++/CMakeLists.txt b/example/multi_threaded_echo_c++/CMakeLists.txt
+index c68010dc1..4a7291c47 100644
+--- a/example/multi_threaded_echo_c++/CMakeLists.txt
++++ b/example/multi_threaded_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/multi_threaded_echo_c++/Makefile b/example/multi_threaded_echo_c++/Makefile
+index 558b77c36..cd344f98d 100644
+--- a/example/multi_threaded_echo_c++/Makefile
++++ b/example/multi_threaded_echo_c++/Makefile
+@@ -20,8 +20,7 @@ BRPC_PATH=../..
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ ifeq ($(NEED_GPERFTOOLS), 1)
+ 	CXXFLAGS+=-DBRPC_ENABLE_CPU_PROFILER
+ endif
+diff --git a/example/multi_threaded_echo_fns_c++/CMakeLists.txt b/example/multi_threaded_echo_fns_c++/CMakeLists.txt
+index 148490a05..8345076eb 100644
+--- a/example/multi_threaded_echo_fns_c++/CMakeLists.txt
++++ b/example/multi_threaded_echo_fns_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/nshead_extension_c++/CMakeLists.txt b/example/nshead_extension_c++/CMakeLists.txt
+index 72c9b4183..b0b93a23d 100644
+--- a/example/nshead_extension_c++/CMakeLists.txt
++++ b/example/nshead_extension_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/nshead_pb_extension_c++/CMakeLists.txt b/example/nshead_pb_extension_c++/CMakeLists.txt
+index 82c055bab..448c7070f 100644
+--- a/example/nshead_pb_extension_c++/CMakeLists.txt
++++ b/example/nshead_pb_extension_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/parallel_echo_c++/CMakeLists.txt b/example/parallel_echo_c++/CMakeLists.txt
+index 65b251530..b24bb41f9 100644
+--- a/example/parallel_echo_c++/CMakeLists.txt
++++ b/example/parallel_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/partition_echo_c++/CMakeLists.txt b/example/partition_echo_c++/CMakeLists.txt
+index fecdfa0c3..25d98dbe5 100644
+--- a/example/partition_echo_c++/CMakeLists.txt
++++ b/example/partition_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/redis_c++/CMakeLists.txt b/example/redis_c++/CMakeLists.txt
+index f1bafece8..a7b008b5a 100644
+--- a/example/redis_c++/CMakeLists.txt
++++ b/example/redis_c++/CMakeLists.txt
+@@ -90,7 +90,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/redis_c++/Makefile b/example/redis_c++/Makefile
+index 4ba9505f0..7c94e195d 100644
+--- a/example/redis_c++/Makefile
++++ b/example/redis_c++/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer
++CXXFLAGS+=$(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer
+ HDRS+=$(BRPC_PATH)/output/include
+ LIBS+=$(BRPC_PATH)/output/lib
+ HDRPATHS = $(addprefix -I, $(HDRS))
+diff --git a/example/selective_echo_c++/CMakeLists.txt b/example/selective_echo_c++/CMakeLists.txt
+index 74135282e..7d65c7759 100644
+--- a/example/selective_echo_c++/CMakeLists.txt
++++ b/example/selective_echo_c++/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/session_data_and_thread_local/CMakeLists.txt b/example/session_data_and_thread_local/CMakeLists.txt
+index 120f92e22..28ba03565 100644
+--- a/example/session_data_and_thread_local/CMakeLists.txt
++++ b/example/session_data_and_thread_local/CMakeLists.txt
+@@ -85,7 +85,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/streaming_echo_c++/CMakeLists.txt b/example/streaming_echo_c++/CMakeLists.txt
+index 57fe261e7..34e041d77 100644
+--- a/example/streaming_echo_c++/CMakeLists.txt
++++ b/example/streaming_echo_c++/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/thrift_extension_c++/Makefile b/example/thrift_extension_c++/Makefile
+index 980b2085b..47b381fdb 100644
+--- a/example/thrift_extension_c++/Makefile
++++ b/example/thrift_extension_c++/Makefile
+@@ -20,8 +20,7 @@ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -g -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -g -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ ifeq ($(NEED_GPERFTOOLS), 1)
+ 	CXXFLAGS+=-DBRPC_ENABLE_CPU_PROFILER
+ endif
+diff --git a/src/butil/errno.h b/src/butil/errno.h
+index 0390a840b..14856eeb6 100644
+--- a/src/butil/errno.h
++++ b/src/butil/errno.h
+@@ -22,7 +22,12 @@
+ #ifndef BUTIL_BAIDU_ERRNO_H
+ #define BUTIL_BAIDU_ERRNO_H
+ 
+-#define __const__
++#ifndef __const__
++// Avoid over-optimizations of TLS variables by GCC>=4.8
++// See: https://github.com/apache/incubator-brpc/issues/1693
++#define __const__ __unused__
++#endif
++
+ #include <errno.h>                           // errno
+ #include "butil/macros.h"                     // BAIDU_CONCAT
+ 
+diff --git a/test/BUILD.bazel b/test/BUILD.bazel
+index c4649ab12..a170eaf8c 100644
+--- a/test/BUILD.bazel
++++ b/test/BUILD.bazel
+@@ -24,7 +24,7 @@ config_setting(
+ COPTS = [
+     "-D__STDC_FORMAT_MACROS",
+     "-DBTHREAD_USE_FAST_PTHREAD_MUTEX",
+-    "-D__const__=",
++    "-D__const__=__unused__",
+     "-D_GNU_SOURCE",
+     "-DUSE_SYMBOLIZE",
+     "-DNO_TCMALLOC",
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index f3e0c9bb3..980794f5f 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -52,7 +52,7 @@ else()
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES -D__STRICT_ANSI__ -include ${PROJECT_SOURCE_DIR}/test/sstream_workaround.h")
++set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__=__unused__ -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES -D__STRICT_ANSI__ -include ${PROJECT_SOURCE_DIR}/test/sstream_workaround.h")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -g -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer")
+ use_cxx11()
+ 
+diff --git a/test/Makefile b/test/Makefile
+index 99f7b4f74..5aa90e8be 100644
+--- a/test/Makefile
++++ b/test/Makefile
+@@ -18,7 +18,7 @@
+ NEED_GPERFTOOLS=1
+ NEED_GTEST=1
+ include ../config.mk
+-CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES --include sstream_workaround.h
++CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES --include sstream_workaround.h
+ CXXFLAGS=$(CPPFLAGS) -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -std=c++0x
+ 
+ #required by butil/crc32.cc to boost performance for 10x
+diff --git a/tools/BUILD b/tools/BUILD
+index 99f472fda..04b3abbf9 100644
+--- a/tools/BUILD
++++ b/tools/BUILD
+@@ -16,7 +16,7 @@
+ COPTS = [
+     "-D__STDC_FORMAT_MACROS",
+     "-DBTHREAD_USE_FAST_PTHREAD_MUTEX",
+-    "-D__const__=",
++    "-D__const__=__unused__",
+     "-D_GNU_SOURCE",
+     "-DUSE_SYMBOLIZE",
+     "-DNO_TCMALLOC",
+diff --git a/tools/parallel_http/Makefile b/tools/parallel_http/Makefile
+index 5b8664708..a57c5d5f5 100644
+--- a/tools/parallel_http/Makefile
++++ b/tools/parallel_http/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a
+diff --git a/tools/rpc_press/Makefile b/tools/rpc_press/Makefile
+index c1d866d05..8cae3033c 100644
+--- a/tools/rpc_press/Makefile
++++ b/tools/rpc_press/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a
+diff --git a/tools/rpc_replay/Makefile b/tools/rpc_replay/Makefile
+index fcd5eb6f9..8f4eadde8 100644
+--- a/tools/rpc_replay/Makefile
++++ b/tools/rpc_replay/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer -Wno-unused-parameter
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a
+diff --git a/tools/rpc_view/Makefile b/tools/rpc_view/Makefile
+index c654cfd5a..13f026cbe 100644
+--- a/tools/rpc_view/Makefile
++++ b/tools/rpc_view/Makefile
+@@ -19,8 +19,7 @@ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+ # Notes on the flags:
+ # 1. Added -fno-omit-frame-pointer: perf/tcmalloc-profiler use frame pointers by default
+-# 2. Added -D__const__= : Avoid over-optimizations of TLS variables by GCC>=4.8
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a
+diff --git a/tools/trackme_server/Makefile b/tools/trackme_server/Makefile
+index 79e8536d0..5bdd53f86 100644
+--- a/tools/trackme_server/Makefile
++++ b/tools/trackme_server/Makefile
+@@ -17,7 +17,7 @@
+ 
+ BRPC_PATH = ../../
+ include $(BRPC_PATH)/config.mk
+-CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -D__const__= -pipe -W -Wall -fPIC -fno-omit-frame-pointer
++CXXFLAGS = $(CPPFLAGS) -std=c++0x -DNDEBUG -O2 -pipe -W -Wall -fPIC -fno-omit-frame-pointer
+ HDRPATHS = -I$(BRPC_PATH)/output/include $(addprefix -I, $(HDRS))
+ LIBPATHS = -L$(BRPC_PATH)/output/lib $(addprefix -L, $(LIBS))
+ STATIC_LINKINGS += $(BRPC_PATH)/output/lib/libbrpc.a

--- a/ports/brpc/fix-boost-ptr.patch
+++ b/ports/brpc/fix-boost-ptr.patch
@@ -1,5 +1,5 @@
 diff --git a/src/brpc/policy/thrift_protocol.cpp b/src/brpc/policy/thrift_protocol.cpp
-index 634f8f37..21b118b1 100755
+index 9871c01..269cfe1 100644
 --- a/src/brpc/policy/thrift_protocol.cpp
 +++ b/src/brpc/policy/thrift_protocol.cpp
 @@ -45,8 +45,7 @@

--- a/ports/brpc/fix-build.patch
+++ b/ports/brpc/fix-build.patch
@@ -1,8 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 057695af..ed4979f6 100644
+index 5f46dc0..fe12819 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -63,7 +63,8 @@ endif()
+@@ -25,7 +25,7 @@ option(WITH_DEBUG_SYMBOLS "With debug symbols" ON)
+ option(WITH_THRIFT "With thrift framed protocol supported" OFF)
+ option(WITH_SNAPPY "With snappy" OFF)
+ option(BUILD_UNIT_TESTS "Whether to build unit tests" OFF)
+-option(BUILD_BRPC_TOOLS "Whether to build brpc tools" ON)
++option(BUILD_BRPC_TOOLS "Whether to build brpc tools" OFF)
+ option(DOWNLOAD_GTEST "Download and build a fresh copy of googletest. Requires Internet access." ON)
+ 
+ # Enable MACOSX_RPATH. Run "cmake --help-policy CMP0042" for policy details.
+@@ -65,7 +65,8 @@ endif()
  
  if(WITH_THRIFT)
      set(THRIFT_CPP_FLAG "-DENABLE_THRIFT_FRAMED_PROTOCOL")
@@ -12,7 +21,7 @@ index 057695af..ed4979f6 100644
  endif()
  
  include(GNUInstallDirs)
-@@ -142,18 +143,21 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+@@ -144,11 +145,14 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
      endif()
  endif()
  
@@ -21,7 +30,7 @@ index 057695af..ed4979f6 100644
 +get_target_property(PROTOBUF_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
 +set(PROTOBUF_LIBRARIES protobuf::libprotobuf)
  find_package(Threads REQUIRED)
--
+ 
 -find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
 -find_library(LEVELDB_LIB NAMES leveldb)
 +find_package(leveldb CONFIG REQUIRED)
@@ -29,6 +38,8 @@ index 057695af..ed4979f6 100644
 +set(LEVELDB_LIB leveldb::leveldb)
  if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
      message(FATAL_ERROR "Fail to find leveldb")
+ endif()
+@@ -163,8 +167,9 @@ if(WITH_SNAPPY)
  endif()
  
  if(WITH_GLOG)
@@ -40,7 +51,7 @@ index 057695af..ed4979f6 100644
      if((NOT GLOG_INCLUDE_PATH) OR (NOT GLOG_LIB))
          message(FATAL_ERROR "Fail to find glog")
      endif()
-@@ -171,7 +175,7 @@ if(WITH_MESALINK)
+@@ -182,7 +187,7 @@ if(WITH_MESALINK)
      include_directories(${MESALINK_INCLUDE_PATH})
  endif()
  
@@ -49,7 +60,7 @@ index 057695af..ed4979f6 100644
  if(NOT PROTOC_LIB)
      message(FATAL_ERROR "Fail to find protoc lib")
  endif()
-@@ -182,7 +186,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+@@ -193,7 +198,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
          )
  endif()
  
@@ -58,7 +69,7 @@ index 057695af..ed4979f6 100644
  
  include_directories(
          ${GFLAGS_INCLUDE_PATH}
-@@ -197,9 +201,9 @@ set(DYNAMIC_LIB
+@@ -208,9 +213,9 @@ set(DYNAMIC_LIB
      ${LEVELDB_LIB}
      ${PROTOC_LIB}
      ${CMAKE_THREAD_LIBS_INIT}
@@ -70,18 +81,8 @@ index 057695af..ed4979f6 100644
      dl
      z)
  
-@@ -434,7 +438,9 @@ if(BUILD_UNIT_TESTS)
-     enable_testing()
-     add_subdirectory(test)
- endif()
-+if(BUILD_TOOLS)
- add_subdirectory(tools)
-+endif()
- 
- file(COPY ${CMAKE_CURRENT_BINARY_DIR}/brpc/
-         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/output/include/brpc/
 diff --git a/cmake/FindGFLAGS.cmake b/cmake/FindGFLAGS.cmake
-index dfad5fd8..83a167f0 100644
+index dfad5fd..83a167f 100644
 --- a/cmake/FindGFLAGS.cmake
 +++ b/cmake/FindGFLAGS.cmake
 @@ -15,7 +15,8 @@
@@ -104,82 +105,79 @@ index dfad5fd8..83a167f0 100644
    set(GFLAGS_FOUND TRUE)
  endif(GFLAGS_INCLUDE_PATH AND GFLAGS_LIBRARY)
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index ee616eb1..35a5b48e 100644
+index 209c0e2..b9434ee 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -31,45 +31,77 @@ add_dependencies(SOURCES_LIB PROTO_LIB)
+@@ -30,17 +30,22 @@ add_dependencies(SOURCES_LIB PROTO_LIB)
+ # shared library needs POSITION_INDEPENDENT_CODE
  set_property(TARGET ${SOURCES_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
  set_property(TARGET ${BUTIL_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
- 
--add_library(brpc-shared SHARED $<TARGET_OBJECTS:BUTIL_LIB> 
-+if (BUILD_SHARED_LIBS)
-+add_library(brpc-shared SHARED $<TARGET_OBJECTS:BUTIL_LIB>
-                                $<TARGET_OBJECTS:SOURCES_LIB>
-                                $<TARGET_OBJECTS:PROTO_LIB>)
-+else()
+-
++if(NOT BUILD_SHARED_LIBS)
  add_library(brpc-static STATIC $<TARGET_OBJECTS:BUTIL_LIB>
                                 $<TARGET_OBJECTS:SOURCES_LIB>
                                 $<TARGET_OBJECTS:PROTO_LIB>)
+ 
+-if(BRPC_WITH_THRIFT)
++if(WITH_THRIFT)
+    target_link_libraries(brpc-static thrift)
+ endif()
 -
--target_link_libraries(brpc-shared ${DYNAMIC_LIB})
-+endif()
-+if (BUILD_SHARED_LIBS)
-+target_include_directories(brpc-shared PUBLIC $<INSTALL_INTERFACE:include>)
-+target_link_libraries(brpc-shared PUBLIC ${DYNAMIC_LIB})
-+else()
-+target_include_directories(brpc-static PUBLIC $<INSTALL_INTERFACE:include>)
 +target_link_libraries(brpc-static PUBLIC ${DYNAMIC_LIB})
-+endif()
- 
- if(BRPC_WITH_GLOG)
-+    if (BUILD_SHARED_LIBS)
-     target_link_libraries(brpc-shared ${GLOG_LIB})
-+    else()
++if(BRPC_WITH_GLOG)
 +    target_link_libraries(brpc-static ${GLOG_LIB})
-+    endif()
- endif()
- 
- if(BRPC_WITH_THRIFT)
-+    if (BUILD_SHARED_LIBS)
-     target_link_libraries(brpc-shared thrift)
-+    else()
-     target_link_libraries(brpc-static thrift)
-+    endif()
- endif()
- 
-+if (NOT BUILD_SHARED_LIBS)
- SET_TARGET_PROPERTIES(brpc-static PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
-+else()
- SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
 +endif()
++target_include_directories(brpc-static PUBLIC $<INSTALL_INTERFACE:include>)
+ SET_TARGET_PROPERTIES(brpc-static PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
+-
++endif()
++if(0)
+ # for protoc-gen-mcpack
+ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/output/bin)
+     
+@@ -49,35 +54,56 @@ set(protoc_gen_mcpack_SOURCES
+  )
+     
+ add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
+-
++endif()
+ if(BUILD_SHARED_LIBS)
+     add_library(brpc-shared SHARED $<TARGET_OBJECTS:BUTIL_LIB> 
+                                    $<TARGET_OBJECTS:SOURCES_LIB>
+                                    $<TARGET_OBJECTS:PROTO_LIB>)
+     target_link_libraries(brpc-shared ${DYNAMIC_LIB})
++    target_include_directories(brpc-shared PUBLIC $<INSTALL_INTERFACE:include>)
+     if(BRPC_WITH_GLOG)
+         target_link_libraries(brpc-shared ${GLOG_LIB})
+     endif()
+-    if(BRPC_WITH_THRIFT)
++    if(WITH_THRIFT)
+         target_link_libraries(brpc-shared thrift)
+     endif()
+     SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
  
--# for protoc-gen-mcpack
--set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/output/bin)
--    
--set(protoc_gen_mcpack_SOURCES
--    ${PROJECT_SOURCE_DIR}/src/mcpack2pb/generator.cpp
-- )
--add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
--target_link_libraries(protoc-gen-mcpack brpc-shared)
--    
- #install directory
--install(TARGETS brpc-shared
-+if (BUILD_SHARED_LIBS)
-+install(TARGETS brpc-shared EXPORT unofficial-brpcTargets
-         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-         )
+     target_link_libraries(protoc-gen-mcpack brpc-shared ${DYNAMIC_LIB} pthread)
+ 
+-    install(TARGETS brpc-shared
++    install(TARGETS brpc-shared EXPORT unofficial-brpcTargets
+             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             )
+ else()
+-    target_link_libraries(protoc-gen-mcpack brpc-static ${BRPC_PRIVATE_LIBS} pthread)
+ endif()
+ 
+ 
 -
 -install(TARGETS brpc-static
-+else()
++if(NOT BUILD_SHARED_LIBS)
 +install(TARGETS brpc-static EXPORT unofficial-brpcTargets
          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
          )
 +endif()
-+
 +file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-brpc-config.cmake"
 +[[include(CMakeFindDependencyMacro)
 +find_dependency(OpenSSL)

--- a/ports/brpc/portfile.cmake
+++ b/ports/brpc/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-build.patch
         fix-boost-ptr.patch
-        brpc-1783.diff
+        brpc-1783.diff #https://github.com/apache/incubator-brpc/pull/1783
 )
 
 vcpkg_cmake_configure(

--- a/ports/brpc/portfile.cmake
+++ b/ports/brpc/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 bd4c67967796592030903041ddb9205e24c9f196e63ebc153e08fbce723d93d27cd4f30f3c2cf904a93cda66ffa9db7d465d6e5fdac27a045ae84afad3dd1dc3
     HEAD_REF master
     PATCHES
-        #fix-build.patch
+        fix-build.patch
         fix-boost-ptr.patch
         brpc-1783.diff
 )

--- a/ports/brpc/portfile.cmake
+++ b/ports/brpc/portfile.cmake
@@ -1,12 +1,13 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/incubator-brpc
-    REF 06247c18ed6307613f04c0d2357cb91d0c14131b
-    SHA512 f31b1ce3bd99dd585686ec540c9713d5d5936b2d58aadfb3f0ef48faeaab1797f2373e14b73578c2f9f8355d1e9d03661e2ed9ed8c4349b4e43e510d2214b5ae
+    REF 29491107cbf405a494aaf80ee32344ba34e1d7e4 #1.2.0
+    SHA512 bd4c67967796592030903041ddb9205e24c9f196e63ebc153e08fbce723d93d27cd4f30f3c2cf904a93cda66ffa9db7d465d6e5fdac27a045ae84afad3dd1dc3
     HEAD_REF master
     PATCHES
-        fix-build.patch
+        #fix-build.patch
         fix-boost-ptr.patch
+        brpc-1783.diff
 )
 
 vcpkg_cmake_configure(

--- a/ports/brpc/vcpkg.json
+++ b/ports/brpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "brpc",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Industrial-grade RPC framework used throughout Baidu, with 1,000,000+ instances and thousands kinds of services, called \"baidu-rpc\" inside Baidu.",
   "homepage": "https://github.com/apache/incubator-brpc",
   "license": "Apache-2.0",

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9d792f86ea59e9347602d6a454b9f3b434b66926",
+      "git-tree": "d75b4f1f3f1bf6072c3095fe34f29e86c19ec4d5",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3637bde5f95f0fd9722caa254f086580012db7d1",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c88bb19658430803981fbfa4ec45432bed88310b",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3637bde5f95f0fd9722caa254f086580012db7d1",
+      "git-tree": "9d792f86ea59e9347602d6a454b9f3b434b66926",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1165,7 +1165,7 @@
       "port-version": 2
     },
     "brpc": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "brunocodutra-metal": {


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #23907, update `brpc` to 1.2.0. There is build error with gcc 11, fixed by upstream PR https://github.com/apache/incubator-brpc/pull/1783, sync up this fix to vcpkg.

