### PR TITLE
[msbuild] don't fail on error messages

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -154,7 +154,9 @@
     <Message Text="%22$(_ZVcpkgExecutable)%22 install $(_ZVcpkgHostTripletParameter) --x-wait-for-lock --triplet %22$(VcpkgTriplet)%22 --vcpkg-root %22$(_ZVcpkgRoot)\%22 %22--x-manifest-root=$(_ZVcpkgManifestRoot)\%22 %22--x-install-root=$(_ZVcpkgInstalledDir)\%22 $(VcpkgAdditionalInstallOptions)"
           Importance="High" />
     <Exec Command="%22$(_ZVcpkgExecutable)%22 install $(_ZVcpkgHostTripletParameter) --x-wait-for-lock --triplet %22$(VcpkgTriplet)%22 --vcpkg-root %22$(_ZVcpkgRoot)\%22 %22--x-manifest-root=$(_ZVcpkgManifestRoot)\%22 %22--x-install-root=$(_ZVcpkgInstalledDir)\%22 $(VcpkgAdditionalInstallOptions)"
-          StandardOutputImportance="High" />
+          StandardOutputImportance="High"
+          IgnoreStandardErrorWarningFormat="true"
+          CustomWarningRegularExpression="([Ee]rror|[Ww]arning):" />
     <WriteLinesToFile File="$(_ZVcpkgTLogFileLocation)"
                       Lines="@(_ZVcpkgInstallManifestDependenciesInputs -> '^%(Identity)')"
                       Encoding="Unicode"


### PR DESCRIPTION
Currently the vcpkg msbuild integration "fails" when vcpkg print an `error` to stdout. For example 
```
EXEC : error : curl failed to put file to file:///G:/Entwicklung/vcpkg/assetcache/648d894940bcc29951752d7a8fd18c770ee8d4fd944e17f1a52588e51ca8f58375ba48514538f2e1387786fd812bb86f75fd6bdd0892685cdcafb2989942c848 with exit code '23' and http code '0' [C:\JenkinsSlave\workspace\develop-Cpp-Debug\lib\caqlib\caqlib.vcxproj]
```
and then 
```
    11>C:\JenkinsSlave\workspace\develop-Cpp-Debug\vcpkg\scripts\buildsystems\msbuild\vcpkg.targets(156,5): error MSB3073: Der Befehl ""C:\JenkinsSlave\workspace\GitLab-Cpp\vcpkg\vcpkg.exe" install "--host-triplet=x86-windows-v140-static" --x-wait-for-lock --triplet "x86-windows-v140-static" --vcpkg-root "C:\JenkinsSlave\workspace\GitLab-Cpp\vcpkg\\" "--x-manifest-root=C:\JenkinsSlave\workspace\develop-Cpp-Debug\\" "--x-install-root=C:\JenkinsSlave\workspace\develop-Cpp-Debug\vcpkg_installed\x86-windows-v140-static\\" --binarysource=files,G:/Entwicklung/vcpkg/binarycache,readwrite --overlay-triplets=C:\JenkinsSlave\workspace\develop-Cpp-Debug\all\\..\custom-triplets --overlay-ports=C:\JenkinsSlave\workspace\develop-Cpp-Debug\all\\..\vcpkg-overlay-ports --x-asset-sources=x-azurl,file:///G:/Entwicklung/vcpkg/assetcache,,readwrite" wurde mit dem Code -1 beendet. [C:\JenkinsSlave\workspace\develop-Cpp-Debug\lib\caqlib\caqlib.vcxproj]
```