### PR TITLE
[sqlite3] update to 3.39.1

### DIFF
--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -1,10 +1,10 @@
 # Be sure to update both of these versions together.
-set(SQLITE_VERSION 3370100)
-set(PKGCONFIG_VERSION 3.37.1)
-set(SQLITE_HASH b59343772dc4c6bb8e05fff6206eeb44861efa52c120c789ce6b733e974cf950657b6ab369aa405d75f45ed9cf1cb8128a76447bc63e9ce9822578d71581a7a3)
+set(SQLITE_VERSION 3390100)
+set(PKGCONFIG_VERSION 3.39.1)
+set(SQLITE_HASH e36f30839e0884d021f05f1220a6cf8956156bb00f1f661dcdbe1771ddeb7836e8348034c5e993194a5f28167affda2add6922b6aff4921854bbe566b2254a84)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://sqlite.org/2021/sqlite-amalgamation-${SQLITE_VERSION}.zip"
+    URLS "https://sqlite.org/2022/sqlite-amalgamation-${SQLITE_VERSION}.zip"
     FILENAME "sqlite-amalgamation-${SQLITE_VERSION}.zip"
     SHA512 ${SQLITE_HASH}
 )

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.37.2",
-  "port-version": 2,
+  "version": "3.39.1",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://github.com/sqlite/sqlite",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6833,8 +6833,8 @@
       "port-version": 0
     },
     "sqlite3": {
-      "baseline": "3.37.2",
-      "port-version": 2
+      "baseline": "3.39.1",
+      "port-version": 0
     },
     "sqlitecpp": {
       "baseline": "3.1.1",

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ccab102efea1120dc2140b4c0519676a65c055b6",
+      "version": "3.39.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8b96d4235bae7daf0cf3f65f66f9c28f9290628a",
       "version": "3.37.2",
       "port-version": 2


### PR DESCRIPTION
Fix #25777 

Update sqlite3 to the latest version 3.39.1

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static