### PR TITLE
[ccd] add double-precision option

### DIFF
--- a/ports/ccd/portfile.cmake
+++ b/ports/ccd/portfile.cmake
@@ -14,11 +14,17 @@ vcpkg_from_github(
         ${STATIC_PATCH}
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        double-precision     ENABLE_DOUBLE_PRECISION
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         -DBUILD_TESTING=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()

--- a/ports/ccd/portfile.cmake
+++ b/ports/ccd/portfile.cmake
@@ -19,23 +19,22 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         double-precision     ENABLE_DOUBLE_PRECISION
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/ccd)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/ccd)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/doc)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
 
-file(INSTALL ${SOURCE_PATH}/BSD-LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/BSD-LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_fixup_pkgconfig()

--- a/ports/ccd/vcpkg.json
+++ b/ports/ccd/vcpkg.json
@@ -4,6 +4,16 @@
   "port-version": 4,
   "description": "Library for collision detection between two convex shapes",
   "homepage": "https://github.com/danfis/libccd",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "double-precision": {
       "description": "Use float64 doubles for ccd"

--- a/ports/ccd/vcpkg.json
+++ b/ports/ccd/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ccd",
   "version-string": "2.1-4",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Library for collision detection between two convex shapes",
   "homepage": "https://github.com/danfis/libccd",
   "features": {

--- a/ports/ccd/vcpkg.json
+++ b/ports/ccd/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 4,
   "description": "Library for collision detection between two convex shapes",
   "homepage": "https://github.com/danfis/libccd",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/ccd/vcpkg.json
+++ b/ports/ccd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ccd",
-  "version-string": "2.1-4",
+  "version": "2.1",
   "port-version": 4,
   "description": "Library for collision detection between two convex shapes",
   "homepage": "https://github.com/danfis/libccd",

--- a/ports/ccd/vcpkg.json
+++ b/ports/ccd/vcpkg.json
@@ -3,5 +3,10 @@
   "version-string": "2.1-4",
   "port-version": 3,
   "description": "Library for collision detection between two convex shapes",
-  "homepage": "https://github.com/danfis/libccd"
+  "homepage": "https://github.com/danfis/libccd",
+  "features": {
+    "double-precision": {
+      "description": "Use float64 doubles for ccd"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1301,7 +1301,7 @@
       "port-version": 2
     },
     "ccd": {
-      "baseline": "2.1-4",
+      "baseline": "2.1",
       "port-version": 4
     },
     "ccfits": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1302,7 +1302,7 @@
     },
     "ccd": {
       "baseline": "2.1-4",
-      "port-version": 3
+      "port-version": 4
     },
     "ccfits": {
       "baseline": "2.5",

--- a/versions/c-/ccd.json
+++ b/versions/c-/ccd.json
@@ -6,11 +6,6 @@
       "port-version": 4
     },
     {
-      "git-tree": "fdd9f39b10a88357c83c56035c4b002a1107ddcd",
-      "version-string": "2.1-4",
-      "port-version": 4
-    },
-    {
       "git-tree": "8e6fc55567d05873ba6f78c3c33363a0fd9a1549",
       "version-string": "2.1-4",
       "port-version": 3

--- a/versions/c-/ccd.json
+++ b/versions/c-/ccd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fdd9f39b10a88357c83c56035c4b002a1107ddcd",
+      "version-string": "2.1-4",
+      "port-version": 4
+    },
+    {
       "git-tree": "8e6fc55567d05873ba6f78c3c33363a0fd9a1549",
       "version-string": "2.1-4",
       "port-version": 3

--- a/versions/c-/ccd.json
+++ b/versions/c-/ccd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f03d69c52a18594c673613991b9f55bc9d335434",
+      "git-tree": "a6cd46396151b69680100934c824c290c7057379",
       "version": "2.1",
       "port-version": 4
     },

--- a/versions/c-/ccd.json
+++ b/versions/c-/ccd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f03d69c52a18594c673613991b9f55bc9d335434",
+      "version": "2.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "fdd9f39b10a88357c83c56035c4b002a1107ddcd",
       "version-string": "2.1-4",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**

Add `double-precision` option to ccd. This will set the `ENABLE_DOUBLE_PRECISION` cmake option.

- #### What does your PR fix?
  Allows for ccd to be built with double precision float64 support.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
 Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
