### PR TITLE
[libspatialite] mingw support

### DIFF
--- a/ports/libspatialite/fix-mingw.patch
+++ b/ports/libspatialite/fix-mingw.patch
@@ -11,3 +11,14 @@ index ee2f1cf..01f2571 100644
  #endif
  
  #if OMIT_ICONV == 0		/* if ICONV is disabled no SHP support is available */
+diff --color -ur a/configure.ac b/configure.ac
+--- a/configure.ac	2022-07-21 17:23:50.490298108 +0200
++++ b/configure.ac	2022-07-21 17:25:45.671489524 +0200
+@@ -116,7 +116,6 @@
+ 
+ # Checks for installed libraries
+ AC_CHECK_LIB(sqlite3,sqlite3_prepare_v2,,AC_MSG_ERROR(['libsqlite3' is required but it doesn't seem to be installed on this system.]),-lm)
+-AC_CHECK_LIB(z,inflateInit_,,AC_MSG_ERROR(['libz' is required but it doesn't seem to be installed on this system.]),-lm)
+ 
+ AC_CONFIG_FILES([Makefile \
+ 		src/Makefile \

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -178,6 +178,7 @@ else()
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"
         AUTOCONFIG
+        DETERMINE_BUILD_TRIPLET
         OPTIONS
             ${TARGET_ALIAS}
             ${FREEXL_OPTION}

--- a/ports/libspatialite/vcpkg.json
+++ b/ports/libspatialite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libspatialite",
   "version": "5.0.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.",
   "homepage": "https://www.gaia-gis.it/gaia-sins/libspatialite-sources",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4094,7 +4094,7 @@
     },
     "libspatialite": {
       "baseline": "5.0.1",
-      "port-version": 6
+      "port-version": 7
     },
     "libspnav": {
       "baseline": "0.2.3",

--- a/versions/l-/libspatialite.json
+++ b/versions/l-/libspatialite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e92008bb08f680c156f894b77774f76b5ff89f21",
+      "version": "5.0.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "17b2434a466cabf41bd653845871d5b4ec6bfdeb",
       "version": "5.0.1",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes building libspatialite with MinGW. In MinGW the name of zlib is `libzlib`, configure hardcodes it as `z`, switch to whatever pkgconfig communicates.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes