### PR TITLE
[libspatialindex] mingw support

### DIFF
--- a/ports/libspatialindex/mingw.patch
+++ b/ports/libspatialindex/mingw.patch
@@ -1,0 +1,12 @@
+diff --color -ur a/src/CMakeLists.txt b/src/CMakeLists.txt
+--- a/src/CMakeLists.txt	2022-07-19 15:21:35.950966519 +0200
++++ b/src/CMakeLists.txt	2022-07-19 15:21:50.251002371 +0200
+@@ -208,7 +208,7 @@
+     PROPERTIES VERSION "${SIDX_LIB_VERSION}"
+                SOVERSION "${SIDX_LIB_SOVERSION}" )
+ 
+-if(WIN32)
++if(MSVC)
+     target_compile_options(${SIDX_LIB_NAME} PRIVATE "/wd4068")
+     target_compile_options(${SIDX_C_LIB_NAME} PRIVATE "/wd4068")
+ 

--- a/ports/libspatialindex/portfile.cmake
+++ b/ports/libspatialindex/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         static.patch
+        mingw.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/libspatialindex/vcpkg.json
+++ b/ports/libspatialindex/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libspatialindex",
   "version": "1.9.3",
+  "port-version": 1,
   "description": "C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API.",
   "homepage": "http://libspatialindex.github.com",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4090,7 +4090,7 @@
     },
     "libspatialindex": {
       "baseline": "1.9.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libspatialite": {
       "baseline": "5.0.1",

--- a/versions/l-/libspatialindex.json
+++ b/versions/l-/libspatialindex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48179f2e21bb0918129f0f2d02cacb39f88ab347",
+      "version": "1.9.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "2e1fceafc0be5ea8fd1b2961104f46a5e29c9a6c",
       "version": "1.9.3",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes MinGW for libspatialite, see https://github.com/libspatialindex/libspatialindex/pull/185

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
