### PR TITLE
[dpdk] Only allow static library build

### DIFF
--- a/ports/dpdk/enable-only-static-build.patch
+++ b/ports/dpdk/enable-only-static-build.patch
@@ -1,5 +1,5 @@
 diff --git a/drivers/meson.build b/drivers/meson.build
-index 1d8123b00c..2de654692d 100644
+index 1d8123b00c..7ccf9187b2 100644
 --- a/drivers/meson.build
 +++ b/drivers/meson.build
 @@ -126,14 +126,15 @@ foreach subpath:subdirs
@@ -22,17 +22,17 @@ index 1d8123b00c..2de654692d 100644
                  endif
              endforeach
          endif
-@@ -158,6 +159,7 @@ foreach subpath:subdirs
- 
-         install_headers(headers)
+@@ -173,6 +174,7 @@ foreach subpath:subdirs
+                 output: out_filename,
+                 depends: [tmp_lib])
  
 +        if get_option('default_library') == 'static'
-         # generate pmdinfo sources by building a temporary
-         # lib and then running pmdinfogen on the contents of
-         # that lib. The final lib reuses the object files and
-@@ -220,6 +222,13 @@ foreach subpath:subdirs
-             endif
-         endif
+         # now build the static driver
+         static_lib = static_library(lib_name,
+                 sources,
+@@ -182,6 +184,14 @@ foreach subpath:subdirs
+                 c_args: cflags,
+                 install: true)
  
 +        static_dep = declare_dependency(
 +                include_directories: includes,
@@ -41,10 +41,11 @@ index 1d8123b00c..2de654692d 100644
 +        set_variable('static_@0@'.format(lib_name), static_dep)
 +
 +        else
-         shared_lib = shared_library(lib_name, sources,
-                 objects: objs,
-                 include_directories: includes,
-@@ -237,14 +246,10 @@ foreach subpath:subdirs
++
+         # now build the shared driver
+         version_map = '@0@/@1@/version.map'.format(meson.current_source_dir(), drv_path)
+         implib = 'lib' + lib_name + '.dll.a'
+@@ -237,14 +247,10 @@ foreach subpath:subdirs
          shared_dep = declare_dependency(link_with: shared_lib,
                  include_directories: includes,
                  dependencies: shared_deps)
@@ -62,7 +63,7 @@ index 1d8123b00c..2de654692d 100644
          if developer_mode
              message('drivers/@0@: Defining dependency "@1@"'.format(
 diff --git a/drivers/net/octeontx/base/meson.build b/drivers/net/octeontx/base/meson.build
-index 8e5e8c1b55..39593cd8a6 100644
+index 8e5e8c1b55..a793c193c3 100644
 --- a/drivers/net/octeontx/base/meson.build
 +++ b/drivers/net/octeontx/base/meson.build
 @@ -10,7 +10,7 @@ sources = [
@@ -70,12 +71,12 @@ index 8e5e8c1b55..39593cd8a6 100644
  static_objs = []
  foreach d: depends
 -    if not is_variable('shared_rte_' + d)
-+    if get_option('default_library') == 'shared' and not is_variable('shared_rte_' + d)
++    if not is_variable('static_rte_' + d)
          subdir_done()
      endif
      static_objs += get_variable('static_rte_' + d)
 diff --git a/lib/meson.build b/lib/meson.build
-index 24adbe44c9..e614ec57af 100644
+index 24adbe44c9..f8e0788d36 100644
 --- a/lib/meson.build
 +++ b/lib/meson.build
 @@ -146,14 +146,15 @@ foreach l:libraries
@@ -106,18 +107,22 @@ index 24adbe44c9..e614ec57af 100644
      # first build static lib
      static_lib = static_library(libname,
              sources,
-@@ -246,6 +248,10 @@ foreach l:libraries
-                 output: name + '.sym_chk')
-     endif
- 
+@@ -201,7 +203,14 @@ foreach l:libraries
+         # use pre-build objects to build shared lib
+         sources = []
+         objs += static_lib.extract_all_objects(recursive: false)
++    endif
++
 +    dpdk_static_libraries = [static_lib] + dpdk_static_libraries
 +    set_variable('static_rte_' + name, static_dep)
 +
-+    else
-     shared_lib = shared_library(libname,
-             sources,
-             objects: objs,
-@@ -262,10 +268,10 @@ foreach l:libraries
+     else
++
++    if use_function_versioning and not is_windows
+         # for compat we need to rebuild with
+         # RTE_BUILD_SHARED_LIB defined
+         cflags += '-DRTE_BUILD_SHARED_LIB'
+@@ -262,10 +271,10 @@ foreach l:libraries
              dependencies: shared_deps)
  
      dpdk_libraries = [shared_lib] + dpdk_libraries

--- a/ports/dpdk/portfile.cmake
+++ b/ports/dpdk/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 if(VCPKG_TARGET_IS_LINUX)
   execute_process(
     COMMAND uname --kernel-release
@@ -32,7 +34,7 @@ vcpkg_from_github(
   SHA512 ff80a9f87e71cd743ea5e62f515849bc6746fe7496a0d4b63ecf2bfe0d88da74f0e6c0257c07838c1f9ff41abd81827932b97731fb0fce60d56a8bab7e32347c
   HEAD_REF main
   PATCHES
-      enable-either-static-or-shared-build.patch
+      enable-only-static-build.patch
       remove-examples-src-from-datadir.patch
       stop-building-apps.patch)
 

--- a/ports/dpdk/unofficial-dpdk-config.cmake.in
+++ b/ports/dpdk/unofficial-dpdk-config.cmake.in
@@ -22,8 +22,7 @@ if(NOT VCPKG_PREFER_SYSTEM_LIBS)
 
   # libdpdk.pc and libdpdk-libs.pc are installed to this path
   set(ENV{PKG_CONFIG_PATH}
-      "${_IMPORT_PREFIX}${path_suffix}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}"
-  )
+      "${_IMPORT_PREFIX}${path_suffix}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 else()
   unset(backup_env_pkg_config_path)
 endif()
@@ -33,7 +32,16 @@ if(DEFINED ENV{PKG_CONFIG})
 else()
   set(PKG_CONFIG_EXECUTABLE "@PKGCONFIG@")
 endif()
+
 find_package(PkgConfig REQUIRED)
+if(${PKG_CONFIG_VERSION_STRING} VERSION_LESS "0.28")
+  message(
+    FATAL_ERROR
+      "  pkg-config version 0.28 or greater is required for DPDK.\n"
+      "  Upgrade pkg-config or use the PKG_CONFIG environment variable to set the path to a newer version of pkg-config. See\n"
+      "    https://doc.dpdk.org/guides/linux_gsg/sys_reqs.html#compilation-of-the-dpdk"
+  )
+endif()
 pkg_check_modules(LIBDPDK REQUIRED libdpdk>=@PORT_VERSION@)
 
 if(DEFINED backup_env_pkg_config_path)
@@ -65,7 +73,9 @@ else()
   target_link_libraries(unofficial::@PORT@::dpdk INTERFACE ${LIBDPDK_LDFLAGS})
 endif()
 
-target_include_directories(unofficial::@PORT@::dpdk INTERFACE ${INCLUDE_DIRS})
+set_target_properties(
+  unofficial::@PORT@::dpdk PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                      "${INCLUDE_DIRS}")
 
 find_package_handle_standard_args(
   unofficial-@PORT@

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dpdk",
   "version-string": "22.03",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1970,7 +1970,7 @@
     },
     "dpdk": {
       "baseline": "22.03",
-      "port-version": 1
+      "port-version": 2
     },
     "draco": {
       "baseline": "1.5.2",

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7dbca6d58c776150a421347821c56420573f2535",
+      "version-string": "22.03",
+      "port-version": 2
+    },
+    {
       "git-tree": "215be1cdd87b890d105bc8c5cb3e2e5d9a054038",
       "version-string": "22.03",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Restrict the port to allow static build only, because building the shared library depends on the static library.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
  `No`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `Yes`