### PR TITLE
[blake3] Add assembly implementations

### DIFF
--- a/ports/blake3/CMakeLists.txt
+++ b/ports/blake3/CMakeLists.txt
@@ -10,10 +10,8 @@ target_sources(blake3 PRIVATE
     c/blake3_portable.c
 )
 
-# This is a bit too exotic to be worth supporting right now
-target_compile_definitions(blake3 PRIVATE BLAKE3_NO_AVX512=1)
-
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    target_compile_definitions(blake3 PRIVATE BLAKE3_NO_AVX512=1)
     target_sources(blake3 PRIVATE
         c/blake3_avx2.c
         c/blake3_sse2.c
@@ -31,6 +29,7 @@ elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
             c/blake3_avx2_x86-64_windows_msvc.asm
             c/blake3_sse2_x86-64_windows_msvc.asm
             c/blake3_sse41_x86-64_windows_msvc.asm
+            c/blake3_avx512_x86-64_windows_msvc.asm
         )
     elseif(WIN32 AND NOT MSVC)
         enable_language(ASM)
@@ -38,6 +37,7 @@ elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
             c/blake3_avx2_x86-64_windows_gnu.S
             c/blake3_sse2_x86-64_windows_gnu.S
             c/blake3_sse41_x86-64_windows_gnu.S
+            c/blake3_avx512_x86-64_windows_gnu.S
         )
     else()
         enable_language(ASM)
@@ -45,10 +45,11 @@ elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
             c/blake3_avx2_x86-64_unix.S
             c/blake3_sse2_x86-64_unix.S
             c/blake3_sse41_x86-64_unix.S
+            c/blake3_avx512_x86-64_unix.S
         )        
     endif()
 else()
-    target_compile_definitions(blake3 PRIVATE BLAKE3_NO_SSE2=1 BLAKE3_NO_SSE41=1 BLAKE3_NO_AVX2=1)
+    target_compile_definitions(blake3 PRIVATE BLAKE3_NO_SSE2=1 BLAKE3_NO_SSE41=1 BLAKE3_NO_AVX2=1 BLAKE3_NO_AVX512=1)
 endif()
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")

--- a/ports/blake3/CMakeLists.txt
+++ b/ports/blake3/CMakeLists.txt
@@ -13,16 +13,39 @@ target_sources(blake3 PRIVATE
 # This is a bit too exotic to be worth supporting right now
 target_compile_definitions(blake3 PRIVATE BLAKE3_NO_AVX512=1)
 
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     target_sources(blake3 PRIVATE
         c/blake3_avx2.c
         c/blake3_sse2.c
         c/blake3_sse41.c
     )
-    if (NOT MSVC)
+    if(NOT MSVC)
         set_source_files_properties(c/blake3_avx2.c COMPILE_FLAGS -mavx2)
         set_source_files_properties(c/blake3_sse2.c COMPILE_FLAGS -msse2)
         set_source_files_properties(c/blake3_sse41.c COMPILE_FLAGS -msse4.1)
+    endif()
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    if(WIN32 AND MSVC)
+        enable_language(ASM_MASM)
+        target_sources(blake3 PRIVATE
+            c/blake3_avx2_x86-64_windows_msvc.asm
+            c/blake3_sse2_x86-64_windows_msvc.asm
+            c/blake3_sse41_x86-64_windows_msvc.asm
+        )
+    elseif(WIN32 AND NOT MSVC)
+        enable_language(ASM)
+        target_sources(blake3 PRIVATE
+            c/blake3_avx2_x86-64_windows_gnu.S
+            c/blake3_sse2_x86-64_windows_gnu.S
+            c/blake3_sse41_x86-64_windows_gnu.S
+        )
+    else()
+        enable_language(ASM)
+        target_sources(blake3 PRIVATE
+            c/blake3_avx2_x86-64_unix.S
+            c/blake3_sse2_x86-64_unix.S
+            c/blake3_sse41_x86-64_unix.S
+        )        
     endif()
 else()
     target_compile_definitions(blake3 PRIVATE BLAKE3_NO_SSE2=1 BLAKE3_NO_SSE41=1 BLAKE3_NO_AVX2=1)

--- a/ports/blake3/vcpkg.json
+++ b/ports/blake3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "blake3",
   "version": "1.3.1",
+  "port-version": 1,
   "description": "BLAKE3 cryptographic hash function.",
   "homepage": "https://github.com/BLAKE3-team/BLAKE3",
   "license": "CC0-1.0 OR Apache-2.0",

--- a/versions/b-/blake3.json
+++ b/versions/b-/blake3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dc5486cf347c0eedf7416735c5c0545cbdb4ac9d",
+      "git-tree": "78cffdc59cdb9f1c75dffa671578203d0a79fa42",
       "version": "1.3.1",
       "port-version": 1
     },

--- a/versions/b-/blake3.json
+++ b/versions/b-/blake3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc5486cf347c0eedf7416735c5c0545cbdb4ac9d",
+      "version": "1.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "62a5201ca424389c823b9b4be3d588e1cbb88a58",
       "version": "1.3.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -502,7 +502,7 @@
     },
     "blake3": {
       "baseline": "1.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "blas": {
       "baseline": "1",


### PR DESCRIPTION
- #### What does your PR fix?
  Adds assembly implementations of the library, which are significantly faster compared to intrinsics.
  Measured single-threaded performance increase from ~2.7GB/s to ~3.6GB/s on AMD 3995WX, Windows, MSVC.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes