### PR TITLE
[vcpkg baseline][opencv4] Fix hash check

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
     REPO opencv/opencv
     REF ${OPENCV_VERSION}
     SHA512 4d1783fd78425cc43bb2153446dd634cedd366a49592bccc0c538a40aa161fcf67db8f1b6b68f1ce0b4a93504b3f06f65931709277afb1a1ee9fe963094bca02
+    FILE_DISAMBIGUATOR 1
     HEAD_REF master
     PATCHES
       0001-disable-downloading.patch

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.5.5",
-  "port-version": 6,
+  "port-version": 7,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5186,7 +5186,7 @@
     },
     "opencv4": {
       "baseline": "4.5.5",
-      "port-version": 6
+      "port-version": 7
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e165720af85f0da853cf0a4ac9eb5cb20804d13",
+      "version": "4.5.5",
+      "port-version": 7
+    },
+    {
       "git-tree": "c929f4a1c447240d07e17d0f105b4a36e3d6b5ce",
       "version": "4.5.5",
       "port-version": 6


### PR DESCRIPTION
It looks like our staging `opencv-opencv-4.5.5.tar.gz` is out of date, add `FILE_DISAMBIGUATOR` to refresh the download.

Related: https://dev.azure.com/vcpkg/public/_build/results?buildId=75500&view=logs&j=df43fc99-7657-5523-d794-0e6eb30d1c3c&t=15d86973-cb1c-5895-c5a0-691c6e7936be&l=6721