### PR TITLE
[triton] Fix build, add feature boost

### DIFF
--- a/ports/triton/portfile.cmake
+++ b/ports/triton/portfile.cmake
@@ -15,14 +15,15 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATICCRT)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         "python" PYTHON_BINDINGS
+        "boost"  BOOST_INTERFACE
 )
 
-set(ADDITIONAL_OPTIONS )
+set(ADDITIONAL_OPTIONS "")
 if(PYTHON_BINDINGS)
     vcpkg_find_acquire_program(PYTHON3)
     list(APPEND ADDITIONAL_OPTIONS
-        -DPYTHON_EXECUTABLE=${PYTHON3}
-        )
+        "-DPYTHON_EXECUTABLE=${PYTHON3}"
+    )
 endif()
 
 vcpkg_cmake_configure(
@@ -46,8 +47,7 @@ vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 # Remove duplicate files
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
-                    "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/triton/vcpkg.json
+++ b/ports/triton/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "triton",
   "version": "0.9",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Triton is a Dynamic Binary Analysis (DBA) framework. It provides internal components like a Dynamic Symbolic Execution (DSE) engine, a dynamic taint engine, AST representations of the x86, x86-64, ARM32 and AArch64 Instructions Set Architecture (ISA), SMT simplification passes, an SMT solver interface and, the last but not least, Python bindings.",
   "homepage": "https://github.com/JonathanSalwan/Triton",
   "license": "Apache-2.0",
@@ -27,6 +27,13 @@
     "z3"
   ],
   "features": {
+    "boost": {
+      "description": "Use Boost as multiprecision library",
+      "dependencies": [
+        "boost-multiprecision",
+        "boost-numeric-conversion"
+      ]
+    },
     "python": {
       "description": "Build Triton with Python bindings",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7238,7 +7238,7 @@
     },
     "triton": {
       "baseline": "0.9",
-      "port-version": 3
+      "port-version": 4
     },
     "trompeloeil": {
       "baseline": "41",

--- a/versions/t-/triton.json
+++ b/versions/t-/triton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b86390804efe4afb7989e40a4cf84ad7877e85a",
+      "version": "0.9",
+      "port-version": 4
+    },
+    {
       "git-tree": "dd0d283c09ee98abf32a81d0833e81a9e5222028",
       "version": "0.9",
       "port-version": 3


### PR DESCRIPTION
`BOOST_INTERFACE` is set to `ON` by default, so if any boost components (except the required components) were installed, it will be enabled, which caused this issue.

Add feature to fix this.

Fix #25902.

Already tested this feature on x86-windows and x64-windows-static.