### PR TITLE
[xlnt] Add missing include

### DIFF
--- a/ports/xlnt/fix-missing-include.patch
+++ b/ports/xlnt/fix-missing-include.patch
@@ -1,0 +1,12 @@
+diff --git a/source/detail/number_format/number_formatter.cpp b/source/detail/number_format/number_formatter.cpp
+index b116fd0..653da0e 100644
+--- a/source/detail/number_format/number_formatter.cpp
++++ b/source/detail/number_format/number_formatter.cpp
+@@ -24,6 +24,7 @@
+ #include <algorithm>
+ #include <cctype>
+ #include <cmath>
++#include <limits>
+ 
+ #include <xlnt/utils/exceptions.hpp>
+ #include <detail/default_case.hpp>

--- a/ports/xlnt/portfile.cmake
+++ b/ports/xlnt/portfile.cmake
@@ -11,8 +11,9 @@ vcpkg_from_github(
     SHA512 414d691b372934326dc0da134eb7752c27c3223b6e92b433494d0758ca657f43b66894ad54ac97a8410387a2531a573c81572daa6a0434fa023e8e29ca74331c
     HEAD_REF master
     PATCHES
-        "fix-not-found-include.patch"
+        fix-not-found-include.patch
         ${win_patch}
+        fix-missing-include.patch
 )
 file(REMOVE "${SOURCE_PATH}/third-party/libstudxml/version")
 
@@ -22,20 +23,19 @@ else()
     set(STATIC ON)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS -DTESTS=OFF -DSAMPLES=OFF -DBENCHMARKS=OFF -DSTATIC=${STATIC}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/xlnt)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/xlnt)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/man)
-file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/man")
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_copy_pdbs()
 

--- a/ports/xlnt/vcpkg.json
+++ b/ports/xlnt/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 4,
   "description": "Cross-platform user-friendly xlsx library for C++14",
   "homepage": "https://github.com/tfussell/xlnt",
-  "license": "MIT OR BSD-3-Clause OR BSD-2-Clause OR LGPL-3.0-only OR BSL-1.0"
+  "license": "MIT OR BSD-3-Clause OR BSD-2-Clause OR LGPL-3.0-only OR BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/xlnt/vcpkg.json
+++ b/ports/xlnt/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "xlnt",
   "version": "1.5.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Cross-platform user-friendly xlsx library for C++14",
-  "homepage": "https://github.com/tfussell/xlnt"
+  "homepage": "https://github.com/tfussell/xlnt",
+  "license": "MIT OR BSD-3-Clause OR BSD-2-Clause OR LGPL-3.0-only OR BSL-1.0"
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7686,7 +7686,7 @@
     },
     "xlnt": {
       "baseline": "1.5.0",
-      "port-version": 3
+      "port-version": 4
     },
     "xlsxio": {
       "baseline": "2021-03-24",

--- a/versions/x-/xlnt.json
+++ b/versions/x-/xlnt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2e7ad7529f9ff8b7e9c59824230548f77b491cae",
+      "version": "1.5.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "225346f8b24e3d09ad6b63b928ed2e6f1cfed4d4",
       "version": "1.5.0",
       "port-version": 3


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/23635

Add patch to include `limits` in `number_formatter.cpp`. see https://github.com/tfussell/xlnt/pull/617
