### PR TITLE
[gklib] Add new port

### DIFF
--- a/ports/gklib/fix-CMakeExport.patch
+++ b/ports/gklib/fix-CMakeExport.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9cd1b4b..9288428 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,15 +17,23 @@ else(MSVC)
+ endif(MSVC)
+ 
+ add_library(GKlib ${GKlib_sources} ${win32_sources})
++target_include_directories(GKlib INTERFACE $<INSTALL_INTERFACE:include>)
+ 
+ if(UNIX)
+   target_link_libraries(GKlib m)
+ endif(UNIX)
+ 
+-include_directories("test")
+-add_subdirectory("test")
++# include_directories("test")
++# add_subdirectory("test")
+ 
+-install(TARGETS GKlib
++install(TARGETS GKlib EXPORT unofficial-gklib-config
+   ARCHIVE DESTINATION lib/${LINSTALL_PATH}
+   LIBRARY DESTINATION lib/${LINSTALL_PATH})
++
++install(EXPORT unofficial-gklib-config
++  NAMESPACE unofficial::gklib::
++  DESTINATION share/unofficial-gklib
++  FILE unofficial-gklib-config.cmake
++)
++
+ install(FILES ${GKlib_includes} DESTINATION include/${HINSTALL_PATH})

--- a/ports/gklib/portfile.cmake
+++ b/ports/gklib/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KarypisLab/GKlib
+    REF 3eabb216ac97e11ce7e7a9b90f4c90778d9e7c18 #v5.1.1
+    SHA512 1359ec14357419e3f5fea1fab8e9edf4aee214078ea8401405edb67b92b56254048a39b7a264ad3feb30dceb99cf110168d869126396d8adef1c023f8f1de5e9
+    HEAD_REF master
+    PATCHES fix-CMakeExport.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-gklib)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/gklib/vcpkg.json
+++ b/ports/gklib/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "gklib",
+  "version": "5.1.1",
+  "description": "A library of various helper routines and frameworks used by many of the lab's software",
+  "homepage": "https://github.com/KarypisLab/GKlib",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2556,6 +2556,10 @@
       "baseline": "1.4.0",
       "port-version": 1
     },
+    "gklib": {
+      "baseline": "5.1.1",
+      "port-version": 0
+    },
     "gl2ps": {
       "baseline": "1.4.2",
       "port-version": 1

--- a/versions/g-/gklib.json
+++ b/versions/g-/gklib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7c488fd5d9f0ebb656b7a894d6035f5120c221d0",
+      "version": "5.1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
The upstream of `metis` is gone, the new source [metis]( https://github.com/KarypisLab/METIS) need `gklib` as dependency, add new port `gklib`.