### PR TITLE
[quantlib] update to v1.27

### DIFF
--- a/ports/quantlib/portfile.cmake
+++ b/ports/quantlib/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lballabio/QuantLib
-    REF QuantLib-v1.26
-    SHA512 597dcb4aa3e2701bea758c7b0c62ca0b303a16eda5f324b349ba4e8cc011f6a256fb26d5c42f2bb432da06df1c7b5ec208195e1104e620b69d2a7e8265fd6470
+    REF QuantLib-v1.27
+    SHA512 c763e7083e1e832d39adb507cc6b34b1ad0a0b7f2b7ffe390428f93fb1df84fcbbf43bcb31dd2f2381da2ac563c88a10fbd932ea5155bd43c604025960039b58
     HEAD_REF master
 )
 

--- a/ports/quantlib/vcpkg.json
+++ b/ports/quantlib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "quantlib",
-  "version": "1.26",
-  "port-version": 1,
+  "version": "1.27",
   "description": "The QuantLib C++ library",
   "homepage": "https://www.quantlib.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6105,8 +6105,8 @@
       "port-version": 1
     },
     "quantlib": {
-      "baseline": "1.26",
-      "port-version": 1
+      "baseline": "1.27",
+      "port-version": 0
     },
     "quaternions": {
       "baseline": "1.0.0",

--- a/versions/q-/quantlib.json
+++ b/versions/q-/quantlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b757843f94ec0950f693324ea419498a12e415f",
+      "version": "1.27",
+      "port-version": 0
+    },
+    {
       "git-tree": "f5eb0f25fa5fdff2d0fd4b5cc1f1bb2e98033b59",
       "version": "1.26",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?

Updates QuantLib from v1.26 to v1.27.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

All supported except windows dynamic, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes