### PR TITLE
Fix vcpkg.jsons that don't conform with our schema

### DIFF
--- a/ports/iniparser/vcpkg.json
+++ b/ports/iniparser/vcpkg.json
@@ -3,5 +3,6 @@
   "version-date": "2020-04-06",
   "port-version": 3,
   "description": "C library for parsing INI-style files",
-  "homepage": "https://github.com/ndevilla/iniparser"
+  "homepage": "https://github.com/ndevilla/iniparser",
+  "license": "MIT"
 }

--- a/ports/iniparser/vcpkg.json
+++ b/ports/iniparser/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "iniparser",
-  "version-string": "2020-04-06",
-  "port-version": 2,
+  "version-date": "2020-04-06",
+  "port-version": 3,
   "description": "C library for parsing INI-style files",
-  "homepage": "ndevilla.free.fr/iniparser"
+  "homepage": "https://github.com/ndevilla/iniparser"
 }

--- a/ports/nifticlib/vcpkg.json
+++ b/ports/nifticlib/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "nifticlib",
-  "version-string": "2020-04-30",
-  "port-version": 1,
+  "version-date": "2020-04-30",
+  "port-version": 2,
   "description": "Nifticlib is a C I/O library for reading and writing files in the nifti-1 data format.",
-  "homepage": "NIFTI-Imaging/nifti_clib",
+  "homepage": "https://github.com/NIFTI-Imaging/nifti_clib",
   "supports": "!uwp",
   "dependencies": [
     "zlib"

--- a/ports/nifticlib/vcpkg.json
+++ b/ports/nifticlib/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 2,
   "description": "Nifticlib is a C I/O library for reading and writing files in the nifti-1 data format.",
   "homepage": "https://github.com/NIFTI-Imaging/nifti_clib",
+  "license": null,
   "supports": "!uwp",
   "dependencies": [
     "zlib"

--- a/ports/thor/vcpkg.json
+++ b/ports/thor/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "thor",
   "version": "2.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Extends the multimedia library SFML with higher-level features",
-  "homepage": "www.bromeon.ch/libraries/thor",
+  "homepage": "https://bromeon.ch/libraries/thor/",
   "license": "Zlib",
   "dependencies": [
     "aurora",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3014,7 +3014,7 @@
     },
     "iniparser": {
       "baseline": "2020-04-06",
-      "port-version": 2
+      "port-version": 3
     },
     "inja": {
       "baseline": "3.3.0",
@@ -4922,7 +4922,7 @@
     },
     "nifticlib": {
       "baseline": "2020-04-30",
-      "port-version": 1
+      "port-version": 2
     },
     "nlohmann-fifo-map": {
       "baseline": "2018.05.07",
@@ -7046,7 +7046,7 @@
     },
     "thor": {
       "baseline": "2.0",
-      "port-version": 5
+      "port-version": 6
     },
     "threadpool": {
       "baseline": "0.2.5",

--- a/versions/i-/iniparser.json
+++ b/versions/i-/iniparser.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9fd21e23fb64c8d035dfa8cc534607325f93f146",
+      "git-tree": "b1a9b214d253fa9d677b4ed158bd5e0d0e4e8a31",
       "version-date": "2020-04-06",
       "port-version": 3
     },

--- a/versions/i-/iniparser.json
+++ b/versions/i-/iniparser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9fd21e23fb64c8d035dfa8cc534607325f93f146",
+      "version-date": "2020-04-06",
+      "port-version": 3
+    },
+    {
       "git-tree": "4c89c4448c92e7d793775802d4d6cba832af7457",
       "version-string": "2020-04-06",
       "port-version": 2

--- a/versions/n-/nifticlib.json
+++ b/versions/n-/nifticlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c8183f8e443e89157456125afb06c32eef47140f",
+      "git-tree": "bee84e9bdd74b5b80c68eb3c8933a86a51b37915",
       "version-date": "2020-04-30",
       "port-version": 2
     },

--- a/versions/n-/nifticlib.json
+++ b/versions/n-/nifticlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8183f8e443e89157456125afb06c32eef47140f",
+      "version-date": "2020-04-30",
+      "port-version": 2
+    },
+    {
       "git-tree": "e27d9a2c6e8d4b8b00fc3d1adb0f54f06fa5adee",
       "version-string": "2020-04-30",
       "port-version": 1

--- a/versions/t-/thor.json
+++ b/versions/t-/thor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d337ec42ced0695748c94113eb08515810e3408f",
+      "version": "2.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "45ba80aa43a83b1c810d757922428538f82d8123",
       "version": "2.0",
       "port-version": 5


### PR DESCRIPTION
iniparser's homepage is not a valid URI. ndevilla.free.fr/iniparser says that the homepage has moved to github, so just replaced it with that. Note that portfile.cmake already uses vcpkg_from_github.

nifticlib was referring to a github organization and used vcpkg_from_github in its homepage.

thor was missing a scheme. Using https gave an invalid certificate but http redirected to the site I put here.
