### PR TITLE
[fluidsynth] Update to 2.2.8, improvements

### DIFF
--- a/ports/fluidsynth/fix-dependencies.patch
+++ b/ports/fluidsynth/fix-dependencies.patch
@@ -9,7 +9,15 @@ index e4ea71c..df37028 100644
 -    pkg_check_modules ( GLIB REQUIRED glib-2.0>=2.6.5 gthread-2.0>=2.6.5 )
 +    pkg_check_modules ( GLIB IMPORTED_TARGET REQUIRED glib-2.0>=2.6.5 gthread-2.0>=2.6.5 )
      list( APPEND PC_REQUIRES_PRIV "glib-2.0" "gthread-2.0")
-+    set(GLIB_LIBRARIES PkgConfig::GLIB)
++    set(GLIB_LIBRARIES PkgConfig::GLIB) # To carry libs with absolute paths, https://gitlab.kitware.com/cmake/cmake/-/issues/16154
  
      if ( GLIB_glib-2.0_VERSION AND GLIB_glib-2.0_VERSION VERSION_LESS "2.26.0" )
          message ( WARNING "Your version of glib is very old. This may cause problems with fluidsynth's sample cache on Windows. Consider updating to glib 2.26 or newer!" )
+@@ -865,6 +866,7 @@ endif ()
+ if ( CMAKE_VERSION VERSION_EQUAL "3.12.0" OR CMAKE_VERSION VERSION_GREATER "3.12.0" )
+     # retrieve all the private libs we depend on
+     get_target_property ( LIBS_PRIVATE libfluidsynth INTERFACE_LINK_LIBRARIES)
++    list(FILTER LIBS_PRIVATE EXCLUDE REGEX "^PkgConfig::") # already in 'Requires.private'
+     # make a copy
+     set ( LIBS_PRIVATE_WITH_PATH ${LIBS_PRIVATE} )
+ 

--- a/ports/fluidsynth/gentables.patch
+++ b/ports/fluidsynth/gentables.patch
@@ -1,43 +1,51 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index e913cb2..570207e 100644
+index 2803ca8..49f3505 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -268,6 +268,9 @@ generate_product_version(
- )
- endif ( WIN32 )
- 
-+find_program(GENTABLES make_tables REQUIRED)
-+execute_process(COMMAND ${GENTABLES} "${CMAKE_BINARY_DIR}/")
-+
- add_library ( libfluidsynth-OBJ OBJECT
-     ${config_SOURCES}
-     ${fluid_alsa_SOURCES}
-@@ -413,6 +416,7 @@ else ( MACOSX_FRAMEWORK )
+@@ -419,6 +419,10 @@ else ( MACOSX_FRAMEWORK )
     install ( FILES ${public_main_HEADER} DESTINATION ${INCLUDE_INSTALL_DIR} )
  endif ( MACOSX_FRAMEWORK )
  
-+if (0)
++option(VCPKG_BUILD_MAKE_TABLES "Build `make_tables`" OFF)
++if(VCPKG_BUILD_MAKE_TABLES)
++    add_subdirectory(gentables)
++elseif(0)
  # ******* Auto Generated Lookup Tables ******
  
  include(ExternalProject)
-@@ -435,3 +439,4 @@ ExternalProject_Add(gentables
+@@ -440,4 +444,11 @@ ExternalProject_Add(gentables
+         "${CMAKE_COMMAND}" --build "${GENTAB_BDIR}"
      INSTALL_COMMAND ${GENTAB_BDIR}/make_tables.exe "${CMAKE_BINARY_DIR}/"
  )
- add_dependencies(libfluidsynth-OBJ gentables)
 +endif()
++if(TARGET make_tables AND NOT CMAKE_CROSSCOMPILING)
++    set(GENTABLES make_tables)
++else()
++    find_program(GENTABLES make_tables REQUIRED)
++endif()
++add_custom_target(gentables COMMAND "${GENTABLES}" "${CMAKE_BINARY_DIR}/")
+ add_dependencies(libfluidsynth-OBJ gentables)
 diff --git a/src/gentables/CMakeLists.txt b/src/gentables/CMakeLists.txt
-index 638f299..e834e34 100644
+index 638f299..19dd9e6 100644
 --- a/src/gentables/CMakeLists.txt
 +++ b/src/gentables/CMakeLists.txt
-@@ -15,7 +15,6 @@ project (gentables C)
+@@ -12,6 +12,7 @@ unset(ENV{LDFLAGS})
+ 
+ project (gentables C)
+ 
++if (0)
  set ( CMAKE_BUILD_TYPE Debug )
  
  # hardcode ".exe" as suffix to the binary, else in case of cross-platform cross-compiling the calling cmake will not know the suffix used here and fail to find the binary
--set ( CMAKE_EXECUTABLE_SUFFIX ".exe" )
- 
+@@ -20,6 +21,7 @@ set ( CMAKE_EXECUTABLE_SUFFIX ".exe" )
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR})
-@@ -34,3 +33,5 @@ if ( WIN32 )
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
++endif()
+ 
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
+ 
+@@ -34,3 +36,5 @@ if ( WIN32 )
  else ( WIN32 )
      target_link_libraries (make_tables "m")
  endif ()

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -32,7 +32,6 @@ vcpkg_check_features(
 )
 
 set(feature_list dbus jack libinstpatch midishare opensles oboe oss sdl2 pulseaudio readline lash systemd dart)
-vcpkg_list(SET FEATURE_OPTIONS)
 foreach(_feature IN LISTS feature_list)
     list(APPEND FEATURE_OPTIONS -Denable-${_feature}:BOOL=OFF)
 endforeach()

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FluidSynth/fluidsynth
-    REF 8b00644751578ba67b709a827cbe5133d849d339 #v2.2.6
-    SHA512 37361c6fdbb54eba78e59f03c9ca702129f0fb522721dfb4e744fdc9a8721e665728fa5606bc68c2fb2ce971b4829cfc472f0a7cd72ce3fe14b3a335b098f7ec
+    REF v2.2.8
+    SHA512 8173f2d368a214cf1eb7faae2f6326db43fb094ec9c83e652f953290c3f29c34ebd0b92cbb439bea8d814d3a7e4f9dc0c18c648df1d414989d5d8b4700c79535
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fluidsynth",
-  "version": "2.2.6",
-  "port-version": 2,
+  "version": "2.2.8",
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -12,6 +12,7 @@
     {
       "name": "fluidsynth",
       "host": true,
+      "default-features": false,
       "features": [
         "buildtools"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2305,8 +2305,8 @@
       "port-version": 2
     },
     "fluidsynth": {
-      "baseline": "2.2.6",
-      "port-version": 2
+      "baseline": "2.2.8",
+      "port-version": 0
     },
     "fmem": {
       "baseline": "c-libs-2ccee3d2fb",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c9629205f0ca376ee2139ec80c48229f5723eecf",
+      "version": "2.2.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "ad0fa73283950f13ecfff01deb0688c30a57c330",
       "version": "2.2.6",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?
  Updates fluidsynth to 2.2.8.
  Fixes broken `sndfile` feature control.
  Fixes broken pc file (cf. https://github.com/microsoft/vcpkg/pull/23898#issuecomment-1085792419).
  Re-integrates the (host) tool build into the main build, silencing a warning from `vcpkg_cmake_configure`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
