### PR TITLE
[metis] Add mirror URLs for metis port

### DIFF
--- a/ports/metis/portfile.cmake
+++ b/ports/metis/portfile.cmake
@@ -6,8 +6,8 @@ set(METIS_VERSION 5.1.0)
 vcpkg_download_distfile(ARCHIVE
     URLS
         "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-${METIS_VERSION}.tar.gz"
-        "https://github.com/mfem/tpls/blob/gh-pages/metis-${METIS_VERSION}.tar.gz?raw=true"
-        "https://github.com/hojatollahgholami/thirdpartyOpenfoam/blob/main/metis-${METIS_VERSION}.tar.gz?raw=true"
+        "https://github.com/mfem/tpls/blob/04a8d38f7d2fe4910405feddf067e0b0e962cf27/metis-${METIS_VERSION}.tar.gz?raw=true"
+        "https://github.com/hojatollahgholami/thirdpartyOpenfoam/blob/3130f101ba0fab6895d632a23bc382a03cccb1a3/metis-${METIS_VERSION}.tar.gz?raw=true"
     FILENAME "metis-${METIS_VERSION}.tar.gz"
     SHA512 deea47749d13bd06fbeaf98a53c6c0b61603ddc17a43dae81d72c8015576f6495fd83c11b0ef68d024879ed5415c14ebdbd87ce49c181bdac680573bea8bdb25
 )

--- a/ports/metis/portfile.cmake
+++ b/ports/metis/portfile.cmake
@@ -27,18 +27,16 @@ vcpkg_extract_source_archive_ex(
         fix-INT_MIN_define.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/metis)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/metis)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/metis)
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/metis/portfile.cmake
+++ b/ports/metis/portfile.cmake
@@ -4,7 +4,10 @@ set(OPTIONS -DSHARED=OFF)
 set(METIS_VERSION 5.1.0)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-${METIS_VERSION}.tar.gz"
+    URLS
+        "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-${METIS_VERSION}.tar.gz"
+        "https://github.com/mfem/tpls/blob/gh-pages/metis-${METIS_VERSION}.tar.gz?raw=true"
+        "https://github.com/hojatollahgholami/thirdpartyOpenfoam/blob/main/metis-${METIS_VERSION}.tar.gz?raw=true"
     FILENAME "metis-${METIS_VERSION}.tar.gz"
     SHA512 deea47749d13bd06fbeaf98a53c6c0b61603ddc17a43dae81d72c8015576f6495fd83c11b0ef68d024879ed5415c14ebdbd87ce49c181bdac680573bea8bdb25
 )

--- a/ports/metis/vcpkg.json
+++ b/ports/metis/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "metis",
   "version-string": "5.1.0",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Serial Graph Partitioning and Fill-reducing Matrix Ordering",
   "homepage": "https://glaros.dtc.umn.edu/gkhome/metis/metis/overview"
 }

--- a/ports/metis/vcpkg.json
+++ b/ports/metis/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "metis",
-  "version-string": "5.1.0",
+  "version": "5.1.0",
   "port-version": 9,
   "description": "Serial Graph Partitioning and Fill-reducing Matrix Ordering",
   "homepage": "https://glaros.dtc.umn.edu/gkhome/metis/metis/overview",

--- a/ports/metis/vcpkg.json
+++ b/ports/metis/vcpkg.json
@@ -3,5 +3,16 @@
   "version-string": "5.1.0",
   "port-version": 9,
   "description": "Serial Graph Partitioning and Fill-reducing Matrix Ordering",
-  "homepage": "https://glaros.dtc.umn.edu/gkhome/metis/metis/overview"
+  "homepage": "https://glaros.dtc.umn.edu/gkhome/metis/metis/overview",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4550,7 +4550,7 @@
     },
     "metis": {
       "baseline": "5.1.0",
-      "port-version": 8
+      "port-version": 9
     },
     "metrohash": {
       "baseline": "1.1.3",

--- a/versions/m-/metis.json
+++ b/versions/m-/metis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee8e1a1c2388cff43ef210db9bc3bfff389ce44a",
+      "version-string": "5.1.0",
+      "port-version": 9
+    },
+    {
       "git-tree": "f3670208e9dc0b726c3c009e37f2398b7f2acca3",
       "version-string": "5.1.0",
       "port-version": 8

--- a/versions/m-/metis.json
+++ b/versions/m-/metis.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "ee8e1a1c2388cff43ef210db9bc3bfff389ce44a",
-      "version-string": "5.1.0",
+      "git-tree": "11b23823ea7827faac359205ee84dd549abb639b",
+      "version": "5.1.0",
       "port-version": 9
     },
     {


### PR DESCRIPTION
The metis port fails to build for several days already because the main URL is not working anymore. The same package is hosted also by other packages. This is a quick fix to unblock building the package. The proper and non-trivial fix involves updating and decoupling the port to use the new home of the package at https://github.com/KarypisLab/metis and https://github.com/KarypisLab/GKlib.
Fixes #25764 