### PR TITLE
[freetype] Make sure pkgconfig is found when crosscompiling

### DIFF
--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -26,10 +26,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         brotli      FT_DISABLE_BROTLI
 )
 
+vcpkg_find_acquire_program(PKGCONFIG)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DFT_DISABLE_HARFBUZZ=ON
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/freetype/vcpkg.json
+++ b/ports/freetype/vcpkg.json
@@ -6,6 +6,10 @@
   "license": "FTL OR GPL-2.0-or-later",
   "dependencies": [
     {
+      "name": "pkgconf",
+      "host": true
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },

--- a/versions/f-/freetype.json
+++ b/versions/f-/freetype.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bf7afc9d9fa4aba9747dfc7902c60ea7cfa09e72",
+      "git-tree": "c59f097bbc101fe1b8fdde8e26547b956eae6326",
       "version": "2.12.1",
       "port-version": 0
     },


### PR DESCRIPTION
Make sure host dependency pkgconfig is found when building freetype

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/25790

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
