### PR TITLE
[vamp-sdk] Remove duplicated dependence on vcpkg-cmake

### DIFF
--- a/ports/vamp-sdk/portfile.cmake
+++ b/ports/vamp-sdk/portfile.cmake
@@ -5,11 +5,9 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-)
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
 
@@ -17,5 +15,4 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/vamp-sdk/vcpkg.json
+++ b/ports/vamp-sdk/vcpkg.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "vamp-sdk",
   "version": "2.10",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Library for Vamp plugins",
   "homepage": "https://www.vamp-plugins.org/develop.html",
   "license": "MIT",
@@ -11,10 +10,6 @@
     {
       "name": "libsndfile",
       "default-features": false
-    },
-    {
-      "name": "vcpkg-cmake",
-      "host": true
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7406,7 +7406,7 @@
     },
     "vamp-sdk": {
       "baseline": "2.10",
-      "port-version": 3
+      "port-version": 4
     },
     "variant-lite": {
       "baseline": "2.0.0",

--- a/versions/v-/vamp-sdk.json
+++ b/versions/v-/vamp-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be6c66cbbf45af0e78aa4456832c04bbe301b951",
+      "version": "2.10",
+      "port-version": 4
+    },
+    {
       "git-tree": "ac0236fcb60d389d21fe96a9c96c5f21f9e905b0",
       "version": "2.10",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  This port had a duplicate dependence on `vcpkg-cmake`.
