### PR TITLE
[boost-log] link synchronize.lib explicitly

### DIFF
--- a/ports/boost-log/portfile.cmake
+++ b/ports/boost-log/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF boost-1.79.0
     SHA512 da3fff9756f991a6b3a1529499c4f58fa4ac6167c2dfaf1b7debd45e5a2c1f0687dee1e0edb21d28859971f9e0afab3e1aae3a48b6a39a98dc6d52a697b0f2c4
     HEAD_REF master
+    PATCHES synchro.patch
 )
 
 file(READ "${SOURCE_PATH}/build/Jamfile.v2" _contents)

--- a/ports/boost-log/synchro.patch
+++ b/ports/boost-log/synchro.patch
@@ -1,0 +1,22 @@
+diff --git a/build/Jamfile.v2 b/build/Jamfile.v2
+index c1555a339..d2cfe1358 100644
+--- a/build/Jamfile.v2
++++ b/build/Jamfile.v2
+@@ -32,7 +32,8 @@ lib advapi32 ;
+ lib secur32 ;
+ lib ws2_32 ;
+ lib mswsock ;
+-explicit psapi advapi32 secur32 ws2_32 mswsock ;
++lib synchronization ;
++explicit psapi advapi32 secur32 ws2_32 mswsock synchronization;
+ 
+ # UNIX libs
+ lib rt ;
+@@ -212,6 +213,7 @@ project boost/log
+         <target-os>windows:<library>ws2_32
+         <target-os>windows:<library>mswsock
+         <target-os>windows:<library>advapi32
++        <target-os>windows:<library>synchronization
+ 
+         <target-os>cygwin:<define>BOOST_USE_WINDOWS_H
+         # Boost.Interprocess does not compile on Cygwin: https://github.com/boostorg/interprocess/issues/76

--- a/ports/boost-log/vcpkg.json
+++ b/ports/boost-log/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boost-log",
   "version": "1.79.0",
+  "port-version": 1,
   "description": "Boost log module",
   "homepage": "https://github.com/boostorg/log",
   "license": "BSL-1.0",

--- a/versions/b-/boost-log.json
+++ b/versions/b-/boost-log.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4031440dd0e220e36b82fcb75b0331d70d93128",
+      "version": "1.79.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "311052ccd7332a0eb6d4a80af653a65fe390f7f4",
       "version": "1.79.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -826,7 +826,7 @@
     },
     "boost-log": {
       "baseline": "1.79.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-logic": {
       "baseline": "1.79.0",


### PR DESCRIPTION
fixes https://github.com/microsoft/vcpkg/discussions/22762#discussioncomment-2126877 (and also clang-cl builds)
breaks probably some (no longer supported) lower version windows builds
