### PR TITLE
[osgearth] Fix errors that occur in the osgearth config file on some platforms

### DIFF
--- a/ports/osgearth/fix-osgearth-config.patch
+++ b/ports/osgearth/fix-osgearth-config.patch
@@ -1,0 +1,27 @@
+diff --git a/osgEarthConfig.cmake.in b/osgEarthConfig.cmake.in
+index 3f27dffe9..354e0f7dc 100644
+--- a/osgEarthConfig.cmake.in
++++ b/osgEarthConfig.cmake.in
+@@ -13,11 +13,11 @@ endif()
+ set(osgearth_DEFINITIONS ${${XPREFIX}_CFLAGS})
+ 
+ find_path(osgearth_INCLUDE_DIR
+-    NAMES OSGEARTH/RTREE.H
++    NAMES osgEarth/rtree.h
+     HINTS ${${XPREFIX}_INCLUDE_DIRS}
+ )
+ 
+-set(OSGEARTH_NAMES osgearth)
++set(OSGEARTH_NAMES osgEarth)
+ 
+ find_library(osgearth_LIBRARY
+     NAMES ${OSGEARTH_NAMES}
+@@ -38,6 +38,8 @@ find_package_handle_standard_args(osgearth DEFAULT_MSG
+ 
+ string (REPLACE ";" " " osgearth_LDFLAGS "${osgearth_LDFLAGS}")
+ 
++add_library(osgearth @OSGEARTH_DYNAMIC_OR_STATIC@ IMPORTED)
++
+ set_target_properties(osgearth
+   PROPERTIES
+   IMPORTED_LOCATION             "${osgearth_LIBRARIES}"

--- a/ports/osgearth/fix-osgearth-config.patch
+++ b/ports/osgearth/fix-osgearth-config.patch
@@ -20,7 +20,7 @@ index 3f27dffe9..354e0f7dc 100644
  
  string (REPLACE ";" " " osgearth_LDFLAGS "${osgearth_LDFLAGS}")
  
-+add_library(osgearth @OSGEARTH_DYNAMIC_OR_STATIC@ IMPORTED)
++add_library(osgEarth UNKNOWN IMPORTED)
 +
  set_target_properties(osgearth
    PROPERTIES

--- a/ports/osgearth/portfile.cmake
+++ b/ports/osgearth/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         find-package.patch
         remove-tool-debug-suffix.patch
 		remove-lerc-gltf.patch
+		fix-osgearth-config.patch
 )
 
 if("tools" IN_LIST FEATURES)

--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "osgearth",
   "version": "3.3",
+  "port-version": 1,
   "description": "osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2021 Pelican Mapping.",
   "homepage": "https://github.com/gwaldron/osgearth",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5330,7 +5330,7 @@
     },
     "osgearth": {
       "baseline": "3.3",
-      "port-version": 0
+      "port-version": 1
     },
     "osi": {
       "baseline": "0.108.6",

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1198ef439cf8f6851e6b3accbe668c34a46c8ba6",
+      "version": "3.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "6e95d7000b08e777779b6b0c6d2dbf35686b87a4",
       "version": "3.3",
       "port-version": 0

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1198ef439cf8f6851e6b3accbe668c34a46c8ba6",
+      "git-tree": "1091743df235c6472d30b157723f82e6d3473cc9",
       "version": "3.3",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes the exported target in osgEarthConfig.cmake. Though it seems to work on Windows, on other platforms (e.g. Linux) the capitalization of the `find_path` argument causes the operation to fail, and the lack of the library definition causes an error upon attempting to set that target's properties.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
