### PR TITLE
[hyperscan] Requires pkgconfig

### DIFF
--- a/ports/hyperscan/add-features.patch
+++ b/ports/hyperscan/add-features.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f54dcd6..08dc942 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -479,11 +479,11 @@ endif()
+ 
+ # we need static libs for Chimera - too much deep magic for shared libs
+ if (CORRECT_PCRE_VERSION AND PCRE_BUILD_SOURCE AND BUILD_STATIC_LIBS)
+-    set(BUILD_CHIMERA TRUE)
++    set(BUILD_CHIMERA TRUE CACHE BOOL TRUE)
+ endif()
+ 
+ add_subdirectory(unit)
+-if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt)
++if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt AND BUILD_TOOLS)
+     add_subdirectory(tools)
+ endif()
+ if (EXISTS ${CMAKE_SOURCE_DIR}/chimera/CMakeLists.txt AND BUILD_CHIMERA)
+@@ -531,11 +531,11 @@ endif()
+ 
+ # we need static libs for Chimera - too much deep magic for shared libs
+ if (CORRECT_PCRE_VERSION AND PCRE_BUILD_SOURCE AND BUILD_STATIC_LIBS)
+-    set(BUILD_CHIMERA TRUE)
++    set(BUILD_CHIMERA TRUE CACHE BOOL TRUE)
+ endif()
+ 
+ add_subdirectory(unit)
+-if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt)
++if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt AND BUILD_TOOLS)
+     add_subdirectory(tools)
+ endif()
+ if (EXISTS ${CMAKE_SOURCE_DIR}/chimera/CMakeLists.txt AND BUILD_CHIMERA)

--- a/ports/hyperscan/fix-dependency-pcre.patch
+++ b/ports/hyperscan/fix-dependency-pcre.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1a12bee..f54dcd6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,7 +6,7 @@ set (HS_MINOR_VERSION 4)
+ set (HS_PATCH_VERSION 0)
+ set (HS_VERSION ${HS_MAJOR_VERSION}.${HS_MINOR_VERSION}.${HS_PATCH_VERSION})
+ 
+-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
++list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+ include(CheckCCompilerFlag)
+ include(CheckCXXCompilerFlag)
+ include(CheckCXXSymbolExists)
+diff --git a/cmake/pcre.cmake b/cmake/pcre.cmake
+index e0acda5..f02a2f3 100644
+--- a/cmake/pcre.cmake
++++ b/cmake/pcre.cmake
+@@ -52,7 +52,9 @@ if (PCRE_BUILD_SOURCE)
+ else ()
+     # pkgconf should save us
+     find_package(PkgConfig)
+-    pkg_check_modules(PCRE libpcre>=${PCRE_REQUIRED_VERSION})
++    pkg_check_modules(PCRE libpcre>=${PCRE_REQUIRED_VERSION} IMPORTED_TARGET)
++    set(PCRE_LDFLAGS PkgConfig::PCRE)
++    add_library(pcre ALIAS PkgConfig::PCRE)
+     if (PCRE_FOUND)
+         set(CORRECT_PCRE_VERSION TRUE)
+         message(STATUS "PCRE version ${PCRE_REQUIRED_VERSION} or above")

--- a/ports/hyperscan/portfile.cmake
+++ b/ports/hyperscan/portfile.cmake
@@ -13,17 +13,20 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
+vcpkg_find_acquire_program(PKGCONFIG)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS "-DPYTHON_EXECUTABLE=${PYTHON3}"
+    OPTIONS
+        "-DPYTHON_EXECUTABLE=${PYTHON3}"
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
 )
 
 vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_fixup_pkgconfig()

--- a/ports/hyperscan/portfile.cmake
+++ b/ports/hyperscan/portfile.cmake
@@ -11,6 +11,13 @@ vcpkg_from_github(
     PATCHES
         0001-remove-Werror.patch
         fix-dependency-pcre.patch
+        add-features.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools   BUILD_TOOLS
+        chimera BUILD_CHIMERA
 )
 
 vcpkg_find_acquire_program(PYTHON3)
@@ -19,6 +26,7 @@ vcpkg_find_acquire_program(PKGCONFIG)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         "-DPYTHON_EXECUTABLE=${PYTHON3}"
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
 )

--- a/ports/hyperscan/portfile.cmake
+++ b/ports/hyperscan/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         0001-remove-Werror.patch
+        fix-dependency-pcre.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/hyperscan/vcpkg.json
+++ b/ports/hyperscan/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "hyperscan",
   "version": "5.4.0",
+  "port-version": 1,
   "description": "A regular expression library with O(length of input) match times that takes advantage of Intel hardware to provide blazing speed.",
   "homepage": "https://www.hyperscan.io",
   "license": "BSD-3-Clause",

--- a/ports/hyperscan/vcpkg.json
+++ b/ports/hyperscan/vcpkg.json
@@ -26,11 +26,24 @@
     "boost-type-traits",
     "boost-unordered",
     "boost-utility",
-    "pcre",
     "ragel",
     {
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "chimera": {
+      "description": "Build chimera",
+      "dependencies": [
+        "pcre"
+      ]
+    },
+    "tools": {
+      "description": "Build tools",
+      "dependencies": [
+        "pcre"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2866,7 +2866,7 @@
     },
     "hyperscan": {
       "baseline": "5.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "hypodermic": {
       "baseline": "2.5.3",

--- a/versions/h-/hyperscan.json
+++ b/versions/h-/hyperscan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3166bb150400d0e12bedc938f95b55654436e4ad",
+      "version": "5.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "72c36aba3fff7cd403bdf02ad8f691ced9da30a9",
       "version": "5.4.0",
       "port-version": 0


### PR DESCRIPTION
This port requires pkgconfig to find dependency pcre:
```
-- Checking for module 'libpcre>=8.41'
--   Found libpcre, version 8.45
```

Related: https://github.com/microsoft/vcpkg/pull/25766