### PR TITLE
[curl] Fix SSL on iOS

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -22,7 +22,7 @@ foreach(feature IN ITEMS "schannel" "sspi" "tool" "winldap")
     endif()
 endforeach()
 
-if("sectransp" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_OSX)
+if("sectransp" IN_LIST FEATURES AND NOT (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS))
     message(FATAL_ERROR "sectransp is not supported on non-Apple platforms")
 endif()
 
@@ -61,7 +61,7 @@ if("idn2" IN_LIST FEATURES)
 endif()
 
 if("sectransp" IN_LIST FEATURES)
-    list(APPEND OPTIONS -DCURL_CA_PATH=none)
+    list(APPEND OPTIONS -DCURL_CA_PATH=none -DCURL_CA_BUNDLE=none)
 endif()
 
 # UWP targets

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "curl",
   "version": "7.84.0",
+  "port-version": 1,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": null,
@@ -131,7 +132,7 @@
           "features": [
             "sectransp"
           ],
-          "platform": "osx"
+          "platform": "osx | ios"
         },
         {
           "name": "curl",
@@ -147,7 +148,7 @@
           "features": [
             "openssl"
           ],
-          "platform": "(uwp | !windows) & !osx & !mingw"
+          "platform": "(uwp | !windows) & !(osx | ios) & !mingw"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1770,7 +1770,7 @@
     },
     "curl": {
       "baseline": "7.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "curlpp": {
       "baseline": "2018-06-15",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "git-tree": "4d64a4ac7f080159be045ccbf0a7fa81ef859cfa",
+      "version": "7.84.0",
+      "port-version": 1
+    },
+    {
+      "git-tree": "90b69f8fa78155471d8079cdfd7a8b889c9971df",
+      "version": "7.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "984e0a92df662f6022989c2b5889e7d9f1c133d5",
       "version": "7.84.0",
       "port-version": 0

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -6,11 +6,6 @@
       "port-version": 1
     },
     {
-      "git-tree": "90b69f8fa78155471d8079cdfd7a8b889c9971df",
-      "version": "7.84.0",
-      "port-version": 2
-    },
-    {
       "git-tree": "984e0a92df662f6022989c2b5889e7d9f1c133d5",
       "version": "7.84.0",
       "port-version": 0


### PR DESCRIPTION
Enables secure transport SSL backend on iOS.

When CURL_CA_BUNDLE is set (defaults to /etc/ssl/cert.pem) curl sets it as CA for every request, but on iOS this file is missing and curl's `sectransp` SSL implementation can't deal with it, failing the request completely.

This change makes CURL_CA_BUNDLE to be unset, much like CURL_CA_PATH so that `sectransp` uses system CA store.

**Describe the pull request**

- #### What does your PR fix?

Fixes curl  SSL support on iOS

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all , no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes


