### PR TITLE
[protobuf] update to 3.21.4

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,10 +1,10 @@
-set(version 3.21.3)
+set(version 3.21.4)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF b1eb1260fce7308081822413a0cba77365e7a6ab #v3.21.3
-    SHA512 71bdd8e997fdb7d3f8ef6f4f5ac79a69b84283f8e7962809b64aab6778ec6f7051c52af8b1501ec78c63edfe668af4bed43bfc132e17baa8d8e465c0d5a5d770
+    REF c9869dc7803eb0a21d7e589c40ff4f9288cd34ae #v3.21.4
+    SHA512 99f90020bfc21f717341cf88b43950ede4ba4bd75357397eb2517cb4f6699ae88dcabd65e666df7321b9ba5203b18603fa1c4e97d924aa7978b1ba6b63216fbb
     HEAD_REF master
     PATCHES
         fix-static-build.patch

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf",
-  "version": "3.21.3",
+  "version": "3.21.4",
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5665,7 +5665,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "3.21.3",
+      "baseline": "3.21.4",
       "port-version": 0
     },
     "protobuf-c": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "",
+      "git-tree": "b66573195da9e32b3396e253b520ad498617405b",
       "version": "3.21.4",
       "port-version": 0
     },

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "",
+      "version": "3.21.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "3ed82c1c5eef7b766d472f71c5ccebcff30cb7bd",
       "version": "3.21.3",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  update protobuf to 3.21.4: https://github.com/protocolbuffers/protobuf/releases/tag/v21.4

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Same as previous version, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
