### PR TITLE
sdl2: Add patch fixing non-threaded emscripten build

### DIFF
--- a/ports/sdl2/0005-emscripten-fix-undefined-symbol-errors-in-non-threaded.patch
+++ b/ports/sdl2/0005-emscripten-fix-undefined-symbol-errors-in-non-threaded.patch
@@ -1,0 +1,129 @@
+diff --git a/src/video/emscripten/SDL_emscriptenframebuffer.c b/src/video/emscripten/SDL_emscriptenframebuffer.c
+index 372c6f5ac85..03fea04efa3 100644
+--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
++++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
+@@ -59,10 +59,19 @@ int Emscripten_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * form
+     return 0;
+ }
+ 
+-static void
+-Emscripten_UpdateWindowFramebufferWorker(SDL_Surface* surface)
++int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rect * rects, int numrects)
+ {
+-    EM_ASM_INT({
++    SDL_Surface *surface;
++
++    SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
++    surface = data->surface;
++    if (!surface) {
++        return SDL_SetError("Couldn't find framebuffer surface for window");
++    }
++
++    /* Send the data to the display */
++
++    MAIN_THREAD_EM_ASM({
+         var w = $0;
+         var h = $1;
+         var pixels = $2;
+@@ -147,31 +156,7 @@ Emscripten_UpdateWindowFramebufferWorker(SDL_Surface* surface)
+         }
+ 
+         SDL2.ctx.putImageData(SDL2.image, 0, 0);
+-        return 0;
+     }, surface->w, surface->h, surface->pixels);
+-}
+-
+-int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rect * rects, int numrects)
+-{
+-    SDL_Surface *surface;
+-
+-    SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+-    surface = data->surface;
+-    if (!surface) {
+-        return SDL_SetError("Couldn't find framebuffer surface for window");
+-    }
+-
+-    /* Send the data to the display */
+-
+-    if (emscripten_is_main_runtime_thread()) {
+-        Emscripten_UpdateWindowFramebufferWorker(surface);
+-    } else {
+-        emscripten_sync_run_in_main_runtime_thread(
+-            EM_FUNC_SIG_VI,
+-            Emscripten_UpdateWindowFramebufferWorker,
+-            (uint32_t)surface
+-        );
+-    }
+ 
+     if (emscripten_has_asyncify() && SDL_GetHintBoolean(SDL_HINT_EMSCRIPTEN_ASYNCIFY, SDL_TRUE)) {
+         /* give back control to browser for screen refresh */
+diff --git a/src/video/emscripten/SDL_emscriptenmouse.c b/src/video/emscripten/SDL_emscriptenmouse.c
+index e4148072503..38e394ac104 100644
+--- a/src/video/emscripten/SDL_emscriptenmouse.c
++++ b/src/video/emscripten/SDL_emscriptenmouse.c
+@@ -63,10 +63,20 @@ Emscripten_CreateDefaultCursor()
+     return Emscripten_CreateCursorFromString("default", SDL_FALSE);
+ }
+ 
+-static const char*
+-Emscripten_GetCursorUrl(int w, int h, int hot_x, int hot_y, void* pixels)
++
++static SDL_Cursor*
++Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
+ {
+-    return (const char *)EM_ASM_INT({
++    const char *cursor_url = NULL;
++    SDL_Surface *conv_surf;
++
++    conv_surf = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ABGR8888, 0);
++
++    if (!conv_surf) {
++        return NULL;
++    }
++
++    cursor_url = (const char *)MAIN_THREAD_EM_ASM_INT({
+         var w = $0;
+         var h = $1;
+         var hot_x = $2;
+@@ -114,40 +124,7 @@ Emscripten_GetCursorUrl(int w, int h, int hot_x, int hot_y, void* pixels)
+         stringToUTF8(url, urlBuf, url.length + 1);
+ 
+         return urlBuf;
+-    }, w, h, hot_x, hot_y, pixels);
+-}
+-
+-static SDL_Cursor*
+-Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
+-{
+-    const char *cursor_url = NULL;
+-    SDL_Surface *conv_surf;
+-
+-    conv_surf = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ABGR8888, 0);
+-
+-    if (!conv_surf) {
+-        return NULL;
+-    }
+-
+-    if (emscripten_is_main_runtime_thread()) {
+-        cursor_url = Emscripten_GetCursorUrl(
+-            surface->w,
+-            surface->h,
+-            hot_x,
+-            hot_y,
+-            conv_surf->pixels
+-        );
+-    } else {
+-        cursor_url = (const char *)emscripten_sync_run_in_main_runtime_thread(
+-            EM_FUNC_SIG_IIIIIII,
+-            Emscripten_GetCursorUrl,
+-            surface->w,
+-            surface->h,
+-            hot_x,
+-            hot_y,
+-            conv_surf->pixels
+-        );
+-    }
++    }, surface->w, surface->h, hot_x, hot_y, conv_surf->pixels);
+ 
+     SDL_FreeSurface(conv_surf);
+ 

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         0002-sdl2-skip-ibus-on-linux.patch
         0003-sdl2-disable-sdlmain-target-search-on-uwp.patch
         0004-Define-crt-macros.patch
+        0005-emscripten-fix-undefined-symbol-errors-in-non-threaded.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.0.22",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6486,7 +6486,7 @@
     },
     "sdl2": {
       "baseline": "2.0.22",
-      "port-version": 1
+      "port-version": 2
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c14a0021322c01cb256a4a54ea48a9ddf8023622",
+      "version": "2.0.22",
+      "port-version": 2
+    },
+    {
       "git-tree": "879012d1bbd3ae67fc697109eedbe6ff713c2c34",
       "version": "2.0.22",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Fixes regression introduced by changeset 5e7cbdceacd2b3cb85e057963fdb605136805bd3 where emscripten builds of sdl2 that do not use threading will fail during linking time with
```
error: undefined symbol: emscripten_sync_run_in_main_runtime_thread_ (referenced by top-level compiled C/C++ code)
```
Source of the fix here: https://github.com/libsdl-org/SDL/pull/5773

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  emscripten, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
