### PR TITLE
[gtl] Update to 1.1.1

### DIFF
--- a/ports/gtl/portfile.cmake
+++ b/ports/gtl/portfile.cmake
@@ -3,14 +3,18 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO greg7mdp/gtl
-    REF 1.00
-    SHA512 842a5e2634919a04fdd87995a8ada2f949c51a070a7c175043e0f9105a93248325023f85b28f9406276c2912a0fb4015a2e9ba30113d4a0214492da0dc5e5716
+    REF v1.1.1
+    SHA512 f5e3f17c27a5cb10b87312b92dea73edc7dba8cf51b7bc520b625196a70b05d5aa02e975a2c96b69f60cc617488e218497c0825d944bcd298ae19afc9035c6a4
     HEAD_REF main
 )
 
 # Use greg7mdp/gtl's own build process, skipping examples and tests
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DGTL_BUILD_TESTS=OFF
+        -DGTL_BUILD_EXAMPLES=OFF
+        -DGTL_BUILD_BENCHMARKS=OFF
 )
 vcpkg_cmake_install()
 

--- a/ports/gtl/vcpkg.json
+++ b/ports/gtl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtl",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Greg's Template Library of useful classes.",
   "license": "Apache-2.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2737,7 +2737,7 @@
       "port-version": 0
     },
     "gtl": {
-      "baseline": "1.0.0",
+      "baseline": "1.1.1",
       "port-version": 0
     },
     "gts": {

--- a/versions/g-/gtl.json
+++ b/versions/g-/gtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "402d0bbe9e7c54a0d7ee6099d4ccd4ddea95638b",
+      "version": "1.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "52665bb6e7f0bbe30ffabc59521a937072ecc9e2",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
Update version of gtl library to 1.1.1

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all,no

- #### Does your PR follow the [maintainer guide]
(https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  I think so

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
