### PR TITLE
[directx-headers, directxtk, directxtk12, directxtex, directxmesh, uvatlas] ports updated for July 2022

### DIFF
--- a/ports/directx-headers/portfile.cmake
+++ b/ports/directx-headers/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectX-Headers
-    REF v1.602.0
-    SHA512 75d81191e3e0b60bc901f04fcb9cf53f0faae7f0c196a1b04f2b9199c72243d4dddaeacad29d82ca7ccb209b16d07b4f1b71a58368fccad13c4d8421e0c9f0d9
-    HEAD_REF master
+    REF v1.606.3-r1
+    SHA512 a6a9337446f890bb44872ecc9ae0a6feed8e790331ab5bc861e5eea4c552fbbe06655c20b46b8683a76dadf58aaeb0591430e3a4ac2629a41448f1f32f6edc3f
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/directx-headers/vcpkg.json
+++ b/ports/directx-headers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx-headers",
-  "version": "1.602.0",
+  "version": "1.606.3",
   "description": "Official DirectX 12 Headers",
   "homepage": "https://devblogs.microsoft.com/directx/",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMesh
-    REF may2022
-    SHA512 f82ac5bf8211cb5699caf79cf2fb13eb23b4c3c8de807bc114966cc8e933b3bdb2c98940c9add74ee9ad0addb1bdf91dd16cbe2efe2db2afd96f69fd3871d556
+    REF jul2022
+    SHA512 a356aaa85c3af745cdef2126a999a12e4e99d28a71564eeb56463afc3a99cc74e0bfa8505da90170224855cea897af34be3ea28dde3f5c3841f6fcb93f7b5e25
     HEAD_REF main
 )
 
@@ -30,14 +30,14 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/directxmesh/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxmesh)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MESHCONVERT_EXE
-    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/may2022/meshconvert.exe"
-    FILENAME "meshconvert-may2022.exe"
-    SHA512 0fcc3728425bc9681bdc4e1fae79a0f3da638d1b43597171e6829fca85cec8e7f1aa30a51c2f9457074c0a7bb9f358da06df666b6ae054266ceb1c9c38874547
+    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/jul2022/meshconvert.exe"
+    FILENAME "meshconvert-jul2022.exe"
+    SHA512 881de2e574c129c1a91f36d93c268ebc2b28d4809d4d6b79f075d3cd728cf7cfdd22541e06a764c35ea2be89666769daf3b98fdcaf1b9334a52ff6672f51705a
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxmesh/")
@@ -46,7 +46,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${MESHCONVERT_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxmesh/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-may2022.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-jul2022.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxmesh/vcpkg.json
+++ b/ports/directxmesh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmesh",
-  "version-date": "2022-05-09",
+  "version-date": "2022-07-29",
   "description": "DirectXMesh geometry processing library",
   "homepage": "https://github.com/Microsoft/DirectXMesh",
   "documentation": "https://github.com/microsoft/DirectXMesh/wiki",

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF may2022
-    SHA512 b5783c55a1faa9ac616f93d13af91d072e5cef65bcb02c402f2a4d072036135ae610264dc5ebe4e15c56b152c0b3fd0fb87666ab16e74507218906f4210687db
+    REF jul2022
+    SHA512 21b21dfff8bbedabfcb7d3694d750370304382ce0a9847c4ff3c153a3b6a6c5b61fc4051eb95b210e186107092488572757c43e1ca37319e763d49b0bca49dd4
     HEAD_REF main
 )
 
@@ -62,28 +62,28 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtex/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtex)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     TEXASSEMBLE_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/may2022/texassemble.exe"
-    FILENAME "texassemble-may2022.exe"
-    SHA512 22963920f3047533d2ec6d9751f4d2eb4d530e6c4a96099322a070f5f311785d79d07c2e79fd05daa9992deba116f630de14436df4f42b415d7511fd6193241e
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/jul2022/texassemble.exe"
+    FILENAME "texassemble-jul2022.exe"
+    SHA512 72b47e30f810481f2af00cf45eb5789ae78c3ce0cc385f8168a74f178798cefa69b837060fe0ff4cf8dedaf8d1e489bbf4b3e1453c821df478636aca73f89b43
   )
 
   vcpkg_download_distfile(
     TEXCONV_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/may2022/texconv.exe"
-    FILENAME "texconv-may2022.exe"
-    SHA512 9f0c9307f00062883be8a2afff0f6428020d9f056db5a2f175ea3ff72e50f6fd5c57b2dbc448fe8352a86837b318bd3874995dc87d741bdeb413060618a0b08f
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/jul2022/texconv.exe"
+    FILENAME "texconv-jul2022.exe"
+    SHA512 6fe66d90a33510005f3dcc0190aef4e0139d077ee7aeeef015b1e9204149384d46d02e0d9274b68e6f4299b64d3c4eb57fc4bfa6bfefc317699e624ae332abb6
   )
 
   vcpkg_download_distfile(
     TEXDIAG_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/may2022/texdiag.exe"
-    FILENAME "texdiag-may2022.exe"
-    SHA512 01fc96ea5cc286dfea097d3b8bedb92d41dbbab949953315e640ee019578c33e2e1b0db476e51576c92763bacfa4cdf270ebad7cac1c59b185d5fdc0752f0393
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/jul2022/texdiag.exe"
+    FILENAME "texdiag-jul2022.exe"
+    SHA512 804a361293b5350d722604f5150a72751e1c25642986a505e83e0b33be8f53535ea42b6adbbc0b0b88e16d494012e9d02150c60e0ce0115fba30a84e7c2a14bd
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
@@ -94,9 +94,9 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${TEXDIAG_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-jul2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-jul2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-jul2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtex",
-  "version-date": "2022-05-09",
+  "version-date": "2022-07-29",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF jun2022
-    SHA512 683adec36945611150393bb198f54a7d1e072cc9b41dd47ca9ee14459babff867d730b7031602383ed9373500f1541a5091021927bc15df59d47a3b2a1b3588c
+    REF jul2022
+    SHA512 1f16d682e2ed7d177ec7ab0f5ecbcfd11f85478eff52db781403c6c1dca8945521da3a5fd926ea46a4d319c94bc0f21eacea7b456da4283ccac21614e3338f58
     HEAD_REF main
 )
 
@@ -37,16 +37,16 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jun2022/MakeSpriteFont.exe"
-    FILENAME "makespritefont-jun2022.exe"
-    SHA512 7cdc80e12a4a7be70733d582e4f613055a549345f83e24035cfce42d37568c4934c1bb68df5238f41df9d7fa0e84095aeb227d23450323e31a5d1d68cb505842
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jul2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-jul2022.exe"
+    SHA512 fd039070fad3dee3fe146d2cd4950f599f680cb4abd370e7c21bedeb8c0a970455ad2eac463fc6d198505b6bbdabebfcc453bf74c317f6a10bf2e2f9a0bfc418
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jun2022/XWBTool.exe"
-    FILENAME "xwbtool-jun2022.exe"
-    SHA512 b5782323e241641a429f66ad1ac511cfdfd6301851474dafdde274a4f93b49877406d5d0ab992097be7afe8db90fdb9488a9d6de5afce7e086df2e66a5bbca12
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jul2022/XWBTool.exe"
+    FILENAME "xwbtool-jul2022.exe"
+    SHA512 6276e17241afc8c0b82789b99667577394eedf001fa2d4b3acdfac847744c3ac5ec9a8072a1e3e9f247386711232aab93f066a0689f4f9f7d84744dc3862ea05
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -56,8 +56,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-jun2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-jun2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-jul2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-jul2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk",
-  "version-date": "2022-06-15",
+  "version-date": "2022-07-29",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF jun2022c
-    SHA512 48c923920634c74fd0e9a40d29a01d8a6afe321cb3e41145f76bdcc63320a5bb1552a52550b975dbd7d238c576bf75e3e7d5024f347e2cce80495f05313a1a94
+    REF jul2022
+    SHA512 54e58e181fec16f6bc9b27ad9e8267bc23601912f18759d99b278c4086cc0979ff18fe80db8ee7cbb9dfa7e38d0c892b665f005ffbb60f9d0ccdbe69093b6b5d
     HEAD_REF main
 )
 
@@ -27,16 +27,16 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk12)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jun2022/MakeSpriteFont.exe"
-    FILENAME "makespritefont-jun2022.exe"
-    SHA512 7cdc80e12a4a7be70733d582e4f613055a549345f83e24035cfce42d37568c4934c1bb68df5238f41df9d7fa0e84095aeb227d23450323e31a5d1d68cb505842
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jul2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-jul2022.exe"
+    SHA512 fd039070fad3dee3fe146d2cd4950f599f680cb4abd370e7c21bedeb8c0a970455ad2eac463fc6d198505b6bbdabebfcc453bf74c317f6a10bf2e2f9a0bfc418
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jun2022/XWBTool.exe"
-    FILENAME "xwbtool-jun2022.exe"
-    SHA512 b5782323e241641a429f66ad1ac511cfdfd6301851474dafdde274a4f93b49877406d5d0ab992097be7afe8db90fdb9488a9d6de5afce7e086df2e66a5bbca12
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jul2022/XWBTool.exe"
+    FILENAME "xwbtool-jul2022.exe"
+    SHA512 6276e17241afc8c0b82789b99667577394eedf001fa2d4b3acdfac847744c3ac5ec9a8072a1e3e9f247386711232aab93f066a0689f4f9f7d84744dc3862ea05
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -46,8 +46,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-jun2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-jun2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-jul2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-jul2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-date": "2022-07-19",
+  "version-date": "2022-07-29",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
-    REF may2022
-    SHA512 132c7570acd14e69f9a9888ce62aaa58f78d7d7e933bd3648af7208689693906fe6d8e17f4f41ba46a5151e09a0012874b0d11b96f30246337208c4f6f5ef8db
+    REF jul2022
+    SHA512 fe857766d598c73badba6eda3128775f9195d0a1a7658e9b48a77dd631da4bbd31ab946bc98f8e9b229a6bc99a785ac3da693cb655be0f6a1393ad176e26b688
     HEAD_REF main
 )
 
@@ -30,14 +30,14 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/uvatlas/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/uvatlas)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     UVATLASTOOL_EXE
-    URLS "https://github.com/Microsoft/UVAtlas/releases/download/may2022/uvatlastool.exe"
-    FILENAME "uvatlastool-may2022.exe"
-    SHA512 8a58e54881b16dc2e2489cfb605c02d5368bbfe02182c4d64ee1e903496d2ebcfc9cfaca63d602572c2241109c4ee4591aa7bb4f8da65daeead99b8144049b84
+    URLS "https://github.com/Microsoft/UVAtlas/releases/download/jul2022/uvatlastool.exe"
+    FILENAME "uvatlastool-jul2022.exe"
+    SHA512 3c1f7d25f10a85895d75d4102e127af857c4eae1bb3773b84e0f48e30ba9be517469b1a7504c6859e5b75481fea427052af21f3491f6993bf3dc360829c086b8
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/uvatlas/")
@@ -46,7 +46,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${UVATLASTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/uvatlas/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-may2022.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-jul2022.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uvatlas",
-  "version-date": "2022-05-09",
+  "version-date": "2022-07-30",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1889,7 +1889,7 @@
       "port-version": 0
     },
     "directx-headers": {
-      "baseline": "1.602.0",
+      "baseline": "1.606.3",
       "port-version": 0
     },
     "directxmath": {
@@ -1897,7 +1897,7 @@
       "port-version": 0
     },
     "directxmesh": {
-      "baseline": "2022-05-09",
+      "baseline": "2022-07-29",
       "port-version": 0
     },
     "directxsdk": {
@@ -1905,15 +1905,15 @@
       "port-version": 5
     },
     "directxtex": {
-      "baseline": "2022-05-09",
+      "baseline": "2022-07-29",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "2022-06-15",
+      "baseline": "2022-07-29",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2022-07-19",
+      "baseline": "2022-07-29",
       "port-version": 0
     },
     "dirent": {
@@ -7381,7 +7381,7 @@
       "port-version": 2
     },
     "uvatlas": {
-      "baseline": "2022-05-09",
+      "baseline": "2022-07-30",
       "port-version": 0
     },
     "uvw": {

--- a/versions/d-/directx-headers.json
+++ b/versions/d-/directx-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "561f4b44e30ab8806b2983ebdabeaeeebabb48e0",
+      "version": "1.606.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f6271f7dc1af5888b39b0443ff7ecc9d01f1db94",
       "version": "1.602.0",
       "port-version": 0

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a526999086b61e5dc7c587245ae5982ec93c0e5",
+      "version-date": "2022-07-29",
+      "port-version": 0
+    },
+    {
       "git-tree": "bf2c810ddbc4a551cb5fb561092bb6fe67ed986f",
       "version-date": "2022-05-09",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e383685c947595287b5fbc51436378981c248793",
+      "version-date": "2022-07-29",
+      "port-version": 0
+    },
+    {
       "git-tree": "269e245ad8428d3a09059bc195bae935613478af",
       "version-date": "2022-05-09",
       "port-version": 0

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88703e36f97fb7bb6ea188832dc8b114a32e5a3f",
+      "version-date": "2022-07-29",
+      "port-version": 0
+    },
+    {
       "git-tree": "3cdf135528218c71f3aaf4f2ca69d7bc57b160a4",
       "version-date": "2022-06-15",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c42e95e0d216b600b858046a75d0bc80c0cb410",
+      "version-date": "2022-07-29",
+      "port-version": 0
+    },
+    {
       "git-tree": "406076922dc0aec8b45b0024e00b0718fd6eb65f",
       "version-date": "2022-07-19",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb57b16dfc29cefbae6f35fd3e09376e0291b2bd",
+      "version-date": "2022-07-30",
+      "port-version": 0
+    },
+    {
       "git-tree": "2ac8444f59bd76ba38a620d4e0fe1a6a64969873",
       "version-date": "2022-05-09",
       "port-version": 0


### PR DESCRIPTION
This PR updates **directxtk**, **directxtk12**, **directxtex**, **directxmesh**, and **uvatlas** for the July 2022 releases. These releases include some minor new features, bug fixes, and updates to the CMake projects to build with ``/guard:ehcont`` for x64/arm64 with VS 2019 16.9 or later.

This PR also updates **directx-headers** for the DirectX 12 Agility SDK 1.606 release. Upstream changes were needed as this release includes ABI fixes for MinGW building for DirectX 12.
