### PR TITLE
fix open62541 ports with amalgamation feature

### DIFF
--- a/ports/open62541/fix_amalgamate_argument_length_limit.patch
+++ b/ports/open62541/fix_amalgamate_argument_length_limit.patch
@@ -1,0 +1,74 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bd9203f..8c7d3ae 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1118,22 +1118,34 @@ add_custom_target(open62541-generator-statuscode DEPENDS
+         ${PROJECT_BINARY_DIR}/src_generated/open62541/statuscodes.c)
+ 
+ if(UA_ENABLE_AMALGAMATION)
++    set(OUTPUT_CONTENTS "")
++    foreach(HEADER IN LISTS ${exported_headers} ${default_plugin_headers} ${ua_architecture_headers})
++        set(OUTPUT_CONTENTS "${OUTPUT_CONTENTS}${HEADER}\n")
++    endforeach(HEADER)
++    FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/open62541.h.in ${OUTPUT_CONTENTS})
++
+     # single-file release
+     add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/open62541.h
+                        PRE_BUILD
+                        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/amalgamate.py
+                                ${OPEN62541_VER_COMMIT} ${CMAKE_CURRENT_BINARY_DIR}/open62541.h
+-                               ${exported_headers} ${default_plugin_headers} ${ua_architecture_headers}
++                               ${CMAKE_CURRENT_BINARY_DIR}/open62541.h.in
+                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tools/amalgamate.py
+-                               ${exported_headers} ${default_plugin_headers} ${ua_architecture_headers})
+-
++                               ${CMAKE_CURRENT_BINARY_DIR}/open62541.h.in)
++
++    set(OUTPUT_CONTENTS "")
++    foreach(SOURCE IN LISTS ${internal_headers} ${lib_sources} ${default_plugin_sources} ${ua_architecture_sources})
++        set(OUTPUT_CONTENTS "${OUTPUT_CONTENTS}${SOURCE}\n")
++    endforeach(SOURCE)
++    FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/open62541.c.in ${OUTPUT_CONTENTS})
++    
+     add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/open62541.c
+                        PRE_BUILD
+                        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tools/amalgamate.py
+                                ${OPEN62541_VER_COMMIT} ${CMAKE_CURRENT_BINARY_DIR}/open62541.c
+-                               ${internal_headers} ${lib_sources} ${default_plugin_sources} ${ua_architecture_sources}
++                               ${CMAKE_CURRENT_BINARY_DIR}/open62541.c.in
+                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tools/amalgamate.py ${internal_headers}
+-                               ${lib_sources} ${default_plugin_sources} ${ua_architecture_sources} )
++                               ${CMAKE_CURRENT_BINARY_DIR}/open62541.c.in)
+ 
+     add_custom_target(open62541-amalgamation-source DEPENDS ${PROJECT_BINARY_DIR}/open62541.c)
+     add_custom_target(open62541-amalgamation-header DEPENDS ${PROJECT_BINARY_DIR}/open62541.h)
+diff --git a/tools/amalgamate.py b/tools/amalgamate.py
+index 1c91388..3c27355 100644
+--- a/tools/amalgamate.py
++++ b/tools/amalgamate.py
+@@ -14,7 +14,7 @@ import io
+ parser = argparse.ArgumentParser()
+ parser.add_argument('version', help='file version')
+ parser.add_argument('outfile', help='outfile with extension .c/.h')
+-parser.add_argument('inputs', nargs='*', action='store', help='input filenames')
++parser.add_argument('inputs', help='input filenames')
+ args = parser.parse_args()
+ 
+ outname = args.outfile.split("/")[-1]
+@@ -65,7 +65,15 @@ else:
+ #define %s
+ ''' % (outname.upper() + u"_H_", outname.upper() + u"_H_"))
+ 
+-for fname in args.inputs:
++inputFiles = []
++with io.open(args.inputs, encoding='utf8') as fi:
++    for line in fi:
++        line = line.strip()
++        if line == '':
++            continue
++        inputFiles.append(line)
++
++for fname in inputFiles:
+     with io.open(fname, encoding='utf8', errors='replace') as infile:
+         file.write(u"\n/*********************************** amalgamated original file \"" + fname + u"\" ***********************************/\n\n")
+         print ("Integrating file '" + fname + "'...", end=""),

--- a/ports/open62541/portfile.cmake
+++ b/ports/open62541/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         openssl.patch
+        fix_amalgamate_argument_length_limit.patch
 )
 
 vcpkg_check_features(
@@ -23,11 +24,16 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
 vcpkg_add_to_path("${PYTHON3_DIR}")
 
+set(CONFIGURE_OPTIONS ${FEATURE_OPTIONS} -DOPEN62541_VERSION=${VERSION})
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    set(CONFIGURE_OPTIONS ${CONFIGURE_OPTIONS} -DBUILD_SHARED_LIBS=ON -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        ${FEATURE_OPTIONS}
-        -DOPEN62541_VERSION=${VERSION}
+        ${CONFIGURE_OPTIONS}
     OPTIONS_DEBUG
         -DCMAKE_DEBUG_POSTFIX=d
 )
@@ -36,6 +42,7 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
+
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/open62541/vcpkg.json
+++ b/ports/open62541/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "open62541",
   "version": "1.2.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.",
   "homepage": "https://open62541.org",
   "license": "MPL-2.0",


### PR DESCRIPTION
**fix open62541 ports with amalgamation feature**

- #### What does your PR fix?
  Fixes open62541 ports with amalgamation feature compiling error on windows due to argument length limit

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
