### PR TITLE
[libmysql] Add ncurses dependency

### DIFF
--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -2,10 +2,6 @@ if (EXISTS "${CURRENT_INSTALLED_DIR}/include/mysql/mysql.h")
     message(FATAL_ERROR "FATAL ERROR: ${PORT} and libmariadb are incompatible.")
 endif()
 
-if (VCPKG_TARGET_IS_LINUX)
-    message(WARNING "${PORT} needs ncurses on LINUX, please install ncurses first.\nOn Debian/Ubuntu, package name is libncurses5-dev, on Redhat and derivates it is ncurses-devel.")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mysql/mysql-server

--- a/ports/libmysql/vcpkg.json
+++ b/ports/libmysql/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmysql",
   "version": "8.0.20",
-  "port-version": 7,
+  "port-version": 8,
   "description": "A MySQL client library for C development",
   "homepage": "https://github.com/mysql/mysql-server",
   "license": "GPL-2.0-or-later",
@@ -15,6 +15,10 @@
     "icu",
     "libevent",
     "lz4",
+    {
+      "name": "ncurses",
+      "platform": "!windows | mingw"
+    },
     "openssl",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3878,7 +3878,7 @@
     },
     "libmysql": {
       "baseline": "8.0.20",
-      "port-version": 7
+      "port-version": 8
     },
     "libnice": {
       "baseline": "0.1.18",

--- a/versions/l-/libmysql.json
+++ b/versions/l-/libmysql.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0337316bdcf6acfc791eb6fac2c490db774b24e",
+      "version": "8.0.20",
+      "port-version": 8
+    },
+    {
       "git-tree": "bde440f72e606ffbfcfba3393813261aa91e5c05",
       "version": "8.0.20",
       "port-version": 7


### PR DESCRIPTION
Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>

Add ncurses dependency to manifest

- #### What does your PR fix?
  Fixes #16555

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Triplet support not modified

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes 

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
