### PR TITLE
[nlohmann-json] Update to 3.11.2

### DIFF
--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nlohmann/json
-    REF v3.10.5
-    SHA512 4a9d6416f383e76bf95425fc02a4e12c605fcbcae910b704e354396a493454cf8a1ffbecba11f231e020ffd2842908df7e67dbc09f62d1202d40b6815c24cfd2
+    REF v3.11.2
+    SHA512 70097c9bcd7a91254acbd41b8b68a6aaa371fc2dd7011f472917f69f1e2d2986155a0339dad791699d542e4a3be44dc49ae72ff73d0ee0ea4b34183296ce19a0 
     HEAD_REF master
 )
 
@@ -24,7 +24,7 @@ vcpkg_cmake_configure(
         -DJSON_ImplicitConversions=${nlohmann-json_IMPLICIT_CONVERSIONS}
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "nlohmann_json" CONFIG_PATH "lib/cmake/nlohmann_json")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "nlohmann_json" CONFIG_PATH "share/cmake/nlohmann_json")
 vcpkg_fixup_pkgconfig()
 
 vcpkg_replace_string(
@@ -39,9 +39,7 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/nlohmann_json.natvis")
     )
 endif()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/nlohmann_json.natvis")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.MIT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nlohmann-json/usage
+++ b/ports/nlohmann-json/usage
@@ -9,4 +9,4 @@ The package nlohmann-json can be configured to not provide implicit conversions 
 
 For more information, see the docs here:
     
-    https://json.nlohmann.me/features/macros/#json_use_implicit_conversions
+    https://json.nlohmann.me/api/macros/json_use_implicit_conversions/

--- a/ports/nlohmann-json/vcpkg.json
+++ b/ports/nlohmann-json/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nlohmann-json",
-  "version-semver": "3.10.5",
-  "port-version": 3,
+  "version-semver": "3.11.2",
   "description": "JSON for Modern C++",
   "homepage": "https://github.com/nlohmann/json",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4945,8 +4945,8 @@
       "port-version": 2
     },
     "nlohmann-json": {
-      "baseline": "3.10.5",
-      "port-version": 3
+      "baseline": "3.11.2",
+      "port-version": 0
     },
     "nlopt": {
       "baseline": "2.7.1",

--- a/versions/n-/nlohmann-json.json
+++ b/versions/n-/nlohmann-json.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "caa64b8c731ac2457575ea3c5f1827bc82ecac84",
+      "version-semver": "3.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "91f188e19b106e7d316de593e98f3319f8f5ec25",
       "version-semver": "3.10.5",
       "port-version": 3


### PR DESCRIPTION
- #### What does your PR fix?
  Adds the latest version of `nlohmann-json` https://github.com/nlohmann/json/releases/tag/v3.11.2.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Unchanged. No.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
