### PR TITLE
[mbedtls] Update to 3.2.1

### DIFF
--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -37,7 +37,3 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME MbedTLS CONFIG_PATH cmake)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-if (VCPKG_TARGET_IS_WINDOWS AND pthreads IN_LIST FEATURES)
-    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-endif ()

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -3,11 +3,11 @@ set(VCPKG_LIBRARY_LINKAGE static)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ARMmbed/mbedtls
-    REF v2.28.1
-    SHA512 b71d052acfb83daff11e0182f32b0ad0af7c59d2b74bd19f270531a3da9ed3ce1d3adcaf756e161bf05a10fe1b6b7753e360e9dbb5b7b123f09201b1202ef689
+    REF 869298bffeea13b205343361b7a7daf2b210e33d #3.2.1
+    SHA512 49bf05b986746e73900dbe90701c1b8c8319cbf24fe09d5ffb395c33af1f692ccc8ef58e5212da818545541703b9a6843e3ee3cd88fb939fa93f79372a917a2d
     HEAD_REF mbedtls-2.28
     PATCHES
-        enable-pthread.patch
+        #enable-pthread.patch
 )
 
 vcpkg_check_features(
@@ -17,22 +17,27 @@ vcpkg_check_features(
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DENABLE_TESTING=OFF
+        -DMBEDTLS_FATAL_WARNINGS=OFF
+        -DGEN_FILES=OFF
+        -DUNSAFE_BUILD=OFF
+        -DDISABLE_PACKAGE_CONFIG_AND_INSTALL=OFF
         -DENABLE_PROGRAMS=OFF
-        -DMBEDTLS_FATAL_WARNINGS=FALSE
+        -DENABLE_TESTING=OFF
 )
 
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_cmake_config_fixup(PACKAGE_NAME MbedTLS CONFIG_PATH cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 if (VCPKG_TARGET_IS_WINDOWS AND pthreads IN_LIST FEATURES)
-    file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 endif ()
-
-vcpkg_copy_pdbs()

--- a/ports/mbedtls/vcpkg.json
+++ b/ports/mbedtls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mbedtls",
-  "version": "2.28.1",
+  "version": "3.2.1",
   "description": "An open source, portable, easy to use, readable and flexible SSL library",
   "homepage": "https://github.com/ARMmbed/mbedtls",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes #25703.


Requies:
- [ ] oatpp-mbedtls update (header files removed),  upstream issue: https://github.com/oatpp/oatpp-mbedtls/issues/10
- [ ] openvnp3 update (public class member converted to private), upstream issue: https://github.com/OpenVPN/openvpn3/issues/200