### PR TITLE
[superlu] Fix superlu.lib missing

### DIFF
--- a/ports/superlu/portfile.cmake
+++ b/ports/superlu/portfile.cmake
@@ -23,9 +23,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_fixup_pkgconfig()

--- a/ports/superlu/portfile.cmake
+++ b/ports/superlu/portfile.cmake
@@ -1,3 +1,7 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiaoyeli/superlu
@@ -9,21 +13,19 @@ vcpkg_from_github(
       remove-make.inc.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
     -DXSDK_ENABLE_Fortran=OFF
     -Denable_tests=OFF
     -Denable_blaslib=OFF
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
-vcpkg_copy_pdbs()
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/License.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_fixup_pkgconfig()

--- a/ports/superlu/vcpkg.json
+++ b/ports/superlu/vcpkg.json
@@ -4,8 +4,8 @@
   "port-version": 6,
   "description": "Supernodal sparse direct solver.",
   "homepage": "https://github.com/xiaoyeli/superlu",
-  "supports": "!(uwp | arm)",
   "license": "BSD-4-Clause-UC",
+  "supports": "!(uwp | arm)",
   "dependencies": [
     "blas",
     {

--- a/ports/superlu/vcpkg.json
+++ b/ports/superlu/vcpkg.json
@@ -1,11 +1,20 @@
 {
   "name": "superlu",
   "version-date": "2020-01-07",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Supernodal sparse direct solver.",
   "homepage": "https://github.com/xiaoyeli/superlu",
   "supports": "!(uwp | arm)",
+  "license": "BSD-4-Clause-UC",
   "dependencies": [
-    "blas"
+    "blas",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6946,7 +6946,7 @@
     },
     "superlu": {
       "baseline": "2020-01-07",
-      "port-version": 5
+      "port-version": 6
     },
     "symengine": {
       "baseline": "0.9.0",

--- a/versions/s-/superlu.json
+++ b/versions/s-/superlu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "11fd793ec04d8f07b56b75a5b9938c355bf3f144",
+      "git-tree": "6b8a53560265803d6b0b5b284b88abf0ae48650d",
       "version-date": "2020-01-07",
       "port-version": 6
     },

--- a/versions/s-/superlu.json
+++ b/versions/s-/superlu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11fd793ec04d8f07b56b75a5b9938c355bf3f144",
+      "version-date": "2020-01-07",
+      "port-version": 6
+    },
+    {
       "git-tree": "5bee1e0197c0e768c6ee8b9acdf815b4d46b5978",
       "version-date": "2020-01-07",
       "port-version": 5


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/26031

  After inspection, the code of upstream does not use `_declspec(dllexport)` , so let this port be `ONLY_STATIC_LIBRARY` under windows.

  No feature need to test.
