### PR TITLE
[cryptopp]: Fix compilation with clang-cl

### DIFF
--- a/ports/cryptopp/cmake.patch
+++ b/ports/cryptopp/cmake.patch
@@ -2,6 +2,43 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index fb43b95..c39e470 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -281,26 +281,6 @@ function(CheckCompileOption opt var)
+ endfunction(CheckCompileOption)
+
+ function(CheckCompileLinkOption opt var prog)
+-
+-  if (MSVC)
+-
+-    # TODO: improve this...
+-    CHECK_CXX_COMPILER_FLAG(${opt} ${var})
+-
+-  elseif (APPLE)
+-
+-    message(STATUS "Performing Test ${var}")
+-    try_compile(COMMAND_SUCCESS ${CMAKE_BINARY_DIR} ${prog} COMPILE_DEFINITIONS ${opt})
+-    if (COMMAND_SUCCESS)
+-      set(${var} 1 PARENT_SCOPE)
+-      message(STATUS "Performing Test ${var} - Success")
+-    else ()
+-      set(${var} 0 PARENT_SCOPE)
+-      message(STATUS "Performing Test ${var} - Failed")
+-    endif ()
+-
+-  else ()
+-
+     message(STATUS "Performing Test ${var}")
+     try_compile(COMMAND_SUCCESS ${CMAKE_BINARY_DIR} ${prog} COMPILE_DEFINITIONS ${opt})
+     if (COMMAND_SUCCESS)
+@@ -310,9 +290,6 @@ function(CheckCompileLinkOption opt var prog)
+       set(${var} 0 PARENT_SCOPE)
+       message(STATUS "Performing Test ${var} - Failed")
+     endif ()
+-
+-  endif ()
+-
+ endfunction(CheckCompileLinkOption)
+
+ function(AddCompileOption opt)
 @@ -451,6 +451,10 @@ if (MSVC)
    endif()
  endif ()
@@ -13,6 +50,17 @@ index fb43b95..c39e470 100644
  # Enable PIC for all target machines except 32-bit i386 due to register pressures.
  if (NOT CRYPTOPP_I386)
    SET(CMAKE_POSITION_INDEPENDENT_CODE 1)
+@@ -605,8 +605,8 @@ endif ()
+ # New as of Pull Request 461, http://github.com/weidai11/cryptopp/pull/461.
+ # Must use CMAKE_CXX_COMPILER here due to XLC 13.1 and LLVM front-end.
+ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Intel" OR CMAKE_CXX_COMPILER MATCHES "xlC")
+-
+-  if (CRYPTOPP_AMD64 OR CRYPTOPP_I386)
++  # If CMAKE_CXX_COMPILER_ID is Clang and MSVC is true then we are using clang-cl
++  if (CRYPTOPP_AMD64 OR CRYPTOPP_I386 OR MSVC)
+
+     # For Darwin and a GCC port compiler, we need to check for -Wa,-q first. -Wa,-q
+     # is a GCC option, and it tells GCC to use the Clang Integrated Assembler. We
 @@ -1022,10 +1026,10 @@ endif ()
  # add_compile_definitions added in CMake 3.12
  if (${CMAKE_VERSION} VERSION_LESS "3.12")

--- a/ports/cryptopp/patch.patch
+++ b/ports/cryptopp/patch.patch
@@ -1,7 +1,29 @@
+diff --git a/config_cxx.h b/config_cxx.h
+index 03153ba..6d9187d 100644
+--- a/config_cxx.h
++++ b/config_cxx.h
+@@ -214,7 +214,7 @@
+ // Also see https://github.com/weidai11/cryptopp/issues/980. I'm not sure what
+ // to do when the compiler defines __cpp_lib_uncaught_exceptions but the platform
+ // does not support std::uncaught_exceptions. What was Apple thinking???
+-#if defined(__clang__)
++#if defined(__clang__) && !defined(CRYPTOPP_MSC_VERSION)
+ # if __EXCEPTIONS && __has_feature(cxx_exceptions)
+ #  if __cpp_lib_uncaught_exceptions >= 201411L
+ #   define CRYPTOPP_CXX17_UNCAUGHT_EXCEPTIONS 1
 diff --git a/config_os.h b/config_os.h
 index da27de22..9703f77d 100644
 --- a/config_os.h
 +++ b/config_os.h
+@@ -29,7 +29,7 @@
+ // https://www.cryptopp.com/wiki/Release_Process#Self_Tests
+ // The problems with Clang pretending to be other compilers is
+ // discussed at http://github.com/weidai11/cryptopp/issues/147.
+-#if (defined(_MSC_VER) && defined(__clang__) && \
++#if (defined(_MSC_VER) && _MSC_VER < 1930 && defined(__clang__) && \
+    !(defined( __clang_analyzer__)) && !defined(__INTEL_LLVM_COMPILER))
+ # error: "Unsupported configuration"
+ #endif
 @@ -126,6 +126,7 @@
  #endif
  

--- a/ports/cryptopp/vcpkg.json
+++ b/ports/cryptopp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cryptopp",
   "version": "8.6.0",
+  "port-version": 1,
   "description": "Crypto++ is a free C++ class library of cryptographic schemes.",
   "homepage": "https://github.com/weidai11/cryptopp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1730,7 +1730,7 @@
     },
     "cryptopp": {
       "baseline": "8.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cspice": {
       "baseline": "67",

--- a/versions/c-/cryptopp.json
+++ b/versions/c-/cryptopp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0205883588a92221923d9d68d48fa27feb8b8ac",
+      "version": "8.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0d47535ac1767600626347e025079450a909c6ba",
       "version": "8.6.0",
       "port-version": 0

--- a/versions/c-/cryptopp.json
+++ b/versions/c-/cryptopp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b0205883588a92221923d9d68d48fa27feb8b8ac",
+      "git-tree": "9d23fcfb280c3508aabac1d7e0f83440dcb8627f",
       "version": "8.6.0",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes compilation on Windows using clang-cl, by performing the following:
  * Add clang-cl 12.0+ to supported configurations
  * Use MSVC path to detect CRYPTOPP_CXX17_UNCAUGHT_EXCEPTIONS