### PR TITLE
[magic-enum] Update to v0.8.1

### DIFF
--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/magic_enum
-    REF v0.8.0
-    SHA512 097260c234a1b716d26b537cd80a8d3eca255422e8dce46183708a27b1d4ad1d81c6be05f1b7d300db3362eafa243cccc39c9d12f1bcbfdb0d7755701a222808
+    REF v0.8.1
+    SHA512 97b14ddfa2fec4b582f4658cea96f61510b3eb1f367d770a642136ffbaf7e5d87e6a8c950f7ac6af47cc605899d0ff8e2b9c71a19a28ad1dfaa724f003339edc
     HEAD_REF master
 )
 

--- a/ports/magic-enum/vcpkg.json
+++ b/ports/magic-enum/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-enum",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.",
   "homepage": "https://github.com/Neargye/magic_enum",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4433,7 +4433,7 @@
       "port-version": 0
     },
     "magic-enum": {
-      "baseline": "0.8.0",
+      "baseline": "0.8.1",
       "port-version": 0
     },
     "magic-get": {

--- a/versions/m-/magic-enum.json
+++ b/versions/m-/magic-enum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c67da42e72855b5d2d5d72d570fafb3a1149fa01",
+      "version": "0.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2b170feb45c6c04a727f51a40d65fd01b5f0afdc",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Update magic-enum to v0.8.1

hangelog:
https://github.com/Neargye/magic_enum/releases/tag/v0.8.1

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
