### PR TITLE
[openssl] Fix pc files

### DIFF
--- a/ports/openssl/unix/CMakeLists.txt
+++ b/ports/openssl/unix/CMakeLists.txt
@@ -227,6 +227,7 @@ else()
             ${DISABLES}
             ${PLATFORM}
             "--prefix=${CMAKE_INSTALL_PREFIX}"
+            "--libdir=${CMAKE_INSTALL_PREFIX}/lib"
             "--openssldir=/etc/ssl"
             ${CFLAGS}
             VERBATIM

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version": "3.0.5",
-  "port-version": 2,
+  "port-version": 3,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5266,7 +5266,7 @@
     },
     "openssl": {
       "baseline": "3.0.5",
-      "port-version": 2
+      "port-version": 3
     },
     "openssl-unix": {
       "baseline": "1.1.1h",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4fd408544a2a6635ce994badc226aa945c8f78a",
+      "version": "3.0.5",
+      "port-version": 3
+    },
+    {
       "git-tree": "1172be56343ba751b0fe10a0fbb6acedc7871e65",
       "version": "3.0.5",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes `libdir` in the generated pc files for non-windows: Before this change, it was exported as `${prefix}/lib64`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes