### PR TITLE
[vcpkg-msbuild-integration] Set the default value of `VcpkgConfiguration` according to `$(UseDebugLibraries)`

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.props
+++ b/scripts/buildsystems/msbuild/vcpkg.props
@@ -3,7 +3,29 @@
   <PropertyGroup>
     <VcpkgPropsImported>true</VcpkgPropsImported>
     <VcpkgEnabled Condition="'$(VcpkgEnabled)' == ''">true</VcpkgEnabled>
-    <VcpkgConfiguration Condition="'$(VcpkgConfiguration)' == ''">$(Configuration)</VcpkgConfiguration>
+  </PropertyGroup>
+
+  <!-- Set the default value of $(VcpkgConfiguration) according to $(UseDebugLibraries) and $(Configuration) -->
+  <Choose>
+    <When Condition="'$(VcpkgConfiguration)' != ''" />
+    <When Condition="'$(UseDebugLibraries)' == ''">
+      <PropertyGroup>
+        <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(UseDebugLibraries)' == 'true'">
+      <PropertyGroup>
+        <VcpkgConfiguration>Debug</VcpkgConfiguration>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <VcpkgConfiguration>Release</VcpkgConfiguration>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <PropertyGroup>
     <VcpkgUseStatic Condition="'$(VcpkgUseStatic)' == ''">false</VcpkgUseStatic>
     <VcpkgRoot Condition="'$(VcpkgRoot)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..'))</VcpkgRoot>
 

--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -109,6 +109,8 @@
   <Target Name="VcpkgTripletSelection" BeforeTargets="ClCompile">
     <Message Text="Using triplet &quot;$(VcpkgTriplet)&quot; from &quot;$(_ZVcpkgCurrentInstalledDir)&quot;"
              Importance="Normal" Condition="'$(VcpkgEnabled)' == 'true'"/>
+    <Message Text="Using normalized configuration &quot;$(_ZVcpkgNormalizedConfiguration)&quot;"
+             Importance="Normal" Condition="'$(VcpkgEnabled)' == 'true'"/>
     <Message Text="Not using Vcpkg because VcpkgEnabled is &quot;$(VcpkgEnabled)&quot;"
              Importance="Normal" Condition="'$(VcpkgEnabled)' != 'true'"/>
     <Message Text="Vcpkg is unable to link because we cannot decide between Release and Debug libraries. Please define the property VcpkgConfiguration to be 'Release' or 'Debug' (currently '$(VcpkgConfiguration)')."


### PR DESCRIPTION
… rather than `$(Configuration)` for better support of custom configuration names.

Competing resolution of https://github.com/microsoft/vcpkg/pull/9496 and https://github.com/microsoft/vcpkg/pull/22086

I think we must maintain the following invariants:

* We guess Debug or Release according to Configuration. (That is maintained here and in #22086 because the default Debug and Release configurations set `UseDebugLibraries` appropriately)
* Users must be able to override VcpkgConfiguration, and existing overrides must be maintained. (That is broken by #22086 but not by this change)
* The editor / property pages in the IDE need to show something reasonable, and edits there need to actually do what they say. (Also broken by #22086 but maintained here)

There is a small possibility of this being a breaking change if someone had a configuration named "Debug" that sets `$(UseDebugLibraries)` to `false` but that seems extremely unlikely to me.

Before:
<img width="591" alt="image" src="https://user-images.githubusercontent.com/1544943/182948014-1443da3b-7974-4a81-aa85-c50b86007422.png">

After:
<img width="591" alt="image" src="https://user-images.githubusercontent.com/1544943/182947906-9009b008-3eff-4850-924a-184586654176.png">
