### PR TITLE
[pdal] Prepare for nlohmann-json 3.11.x

### DIFF
--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -23,10 +23,14 @@ endforeach()
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/vendor/nanoflann"
     "${SOURCE_PATH}/vendor/nlohmann"
+    "${SOURCE_PATH}/pdal/JsonFwd.hpp"
 )
 file(INSTALL "${CURRENT_INSTALLED_DIR}/include/nanoflann.hpp" DESTINATION "${SOURCE_PATH}/vendor/nanoflann")
 file(INSTALL "${CURRENT_INSTALLED_DIR}/include/nlohmann/json.hpp" DESTINATION "${SOURCE_PATH}/vendor/nlohmann/nlohmann")
 file(APPEND "${SOURCE_PATH}/vendor/nlohmann/nlohmann/json.hpp" "namespace NL = nlohmann;\n")
+file(INSTALL "${CURRENT_INSTALLED_DIR}/include/nlohmann/json_fwd.hpp" DESTINATION "${SOURCE_PATH}/pdal")
+file(RENAME "${SOURCE_PATH}/pdal/json_fwd.hpp" "${SOURCE_PATH}/pdal/JsonFwd.hpp")
+file(APPEND "${SOURCE_PATH}/pdal/JsonFwd.hpp" "namespace NL = nlohmann;\n")
 
 unset(ENV{OSGEO4W_HOME})
 

--- a/ports/pdal/vcpkg.json
+++ b/ports/pdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pdal",
   "version": "2.4.0",
+  "port-version": 1,
   "description": "PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.",
   "homepage": "https://pdal.io/",
   "license": null,

--- a/ports/pdal/vcpkg.json
+++ b/ports/pdal/vcpkg.json
@@ -18,6 +18,7 @@
     "libgeotiff",
     "libxml2",
     "nanoflann",
+    "nlohmann-json",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5446,7 +5446,7 @@
     },
     "pdal": {
       "baseline": "2.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "pdal-c": {
       "baseline": "2.1",

--- a/versions/p-/pdal.json
+++ b/versions/p-/pdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c5321217b19b80c58854e9cd2141633e00c0fc7",
+      "version": "2.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "674fea8cc4044272fef94a061252c4aeb4e6373c",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
In nlohmann-json 3.11.0, json_fwd.hpp changed.
Replace PDAL's internal copy of the file as part of the de-vendoring process.

This PR is a requirement for #26124 to move forward.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No change, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes