### PR TITLE
[gdk-pixbuf] Enable build in CI.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -270,7 +270,6 @@ ftgl:arm-uwp=fail
 functions-framework-cpp:x64-uwp=fail
 
 gazebo:x64-linux=fail
-gdk-pixbuf:x64-windows-static=fail
 # gsoap does not offer stable public source downloads
 gsoap:x64-windows        = skip
 gsoap:x86-windows        = skip


### PR DESCRIPTION
https://dev.azure.com/vcpkg/public/_build/results?buildId=76107
PASSING, REMOVE FROM FAIL LIST: gdk-pixbuf:x64-windows-static (C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt).
