### PR TITLE
[tree-sitter] fix typo in version number

### DIFF
--- a/ports/tree-sitter/CMakeLists.txt
+++ b/ports/tree-sitter/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 project(
   tree-sitter
   LANGUAGES C
-  VERSION 0.26.0
+  VERSION 0.20.6
 )
 
 set(TS_SOVERSION_MAJOR 0)

--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO tree-sitter/tree-sitter
-  REF ccd6bf554d922596ce905730d98a77af368bba5c #v0.26.0
+  REF ccd6bf554d922596ce905730d98a77af368bba5c #v0.20.6
   SHA512 ab7eeecafc9d7d17093e25479903fa8c77a84ce4c3a41d737d49bcf9348ab6cc55cf3d6cce0229781292c2b05342fbf45641e40545ea3fde09e441e02f2cdb83
   HEAD_REF master
   PATCHES pkgconfig.patch

--- a/ports/tree-sitter/vcpkg.json
+++ b/ports/tree-sitter/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version-semver": "0.26.0",
+  "version-semver": "0.20.6",
   "description": "An incremental parsing system for programming tools.",
   "homepage": "https://github.com/tree-sitter/tree-sitter",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7241,7 +7241,7 @@
       "port-version": 4
     },
     "tree-sitter": {
-      "baseline": "0.26.0",
+      "baseline": "0.20.6",
       "port-version": 0
     },
     "treehh": {

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a96085943d7eb28c30fa8d53eb5452e4dccdfd93",
+      "version-semver": "0.20.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "a912cc848f08c05d9cbd87e24e47194b0ad43bd6",
       "version-semver": "0.26.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes a typo in the version-number, see https://github.com/microsoft/vcpkg/pull/26058#issuecomment-1207187285

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  NA

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

