### PR TITLE
[harfbuzz] Fix build error

### DIFF
--- a/ports/harfbuzz/fix-win32-build.patch
+++ b/ports/harfbuzz/fix-win32-build.patch
@@ -1,11 +1,24 @@
 diff --git a/src/meson.build b/src/meson.build
-index e336037a2..a7c501b78 100644
+index e336037..35af00e 100644
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -473,7 +473,7 @@ defs_list = [harfbuzz_def]
+@@ -349,6 +349,11 @@ hb_subset_sources = files(
+   'hb-subset.hh',
+ )
+ 
++extra_hb_cpp_args = []
++if cpp.get_argument_syntax() == 'msvc'
++  extra_hb_cpp_args += ['/bigobj']
++endif
++
+ hb_subset_headers = files(
+   'hb-subset.h',
+   'hb-subset-repacker.h'
+@@ -472,8 +477,7 @@ defs_list = [harfbuzz_def]
+ 
  version = '0.@0@.0'.format(hb_version_int)
  
- extra_hb_cpp_args = []
+-extra_hb_cpp_args = []
 -if cpp.get_id() == 'msvc'
 +if cpp.get_argument_syntax() == 'msvc'
    if get_option('default_library') != 'static'

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "harfbuzz",
   "version": "5.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2794,7 +2794,7 @@
     },
     "harfbuzz": {
       "baseline": "5.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64cea6fad2515aeabcdb82768bbb9b4b30db7af6",
+      "version": "5.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "890fd1dc4836a76fac4de6ee409c762ac0afe587",
       "version": "5.0.1",
       "port-version": 1


### PR DESCRIPTION
Fix build issue with Visual Studio 2017:
```
D:\dev\vcpkg\vcpkg-master\buildtrees\harfbuzz\src\5.0.1-11c945810e.clean\src\hb-subset.cc : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
```

Fixes #26202.