### PR TITLE
[aws-c-common/aws-c-io ] update to the latest version

### DIFF
--- a/ports/aws-c-common/portfile.cmake
+++ b/ports/aws-c-common/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-common
-    REF fdd4a10243903260f412f587cc748f0ac79629b4 # v0.6.9
-    SHA512 969c9b85af58fc144480f6548e78126cf3fe758951ecbdffb579163b9a505a7ea58c32430390102ff620e828bf241dd24c0167f205306949d36dcf4504efa09a
+    REF 68f28f8df258390744f3c5b460250f8809161041 # v0.6.20
+    SHA512 a8be405e0e1586a06db038a0068df2c9277772ff7b8df2c542d18d2aae4b2bc0fd89de668ab10d84476446834390e4e27383b68d86c7d9f0d0749b57802866f1
     HEAD_REF master
     PATCHES
         disable-internal-crt-option.patch # Disable internal crt option because vcpkg contains crt processing flow

--- a/ports/aws-c-common/vcpkg.json
+++ b/ports/aws-c-common/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "aws-c-common",
-  "version": "0.6.9",
-  "port-version": 2,
+  "version": "0.6.20",
   "description": "AWS common library for C",
   "homepage": "https://github.com/awslabs/aws-c-common",
   "supports": "!(windows & arm) & !uwp",

--- a/ports/aws-c-io/portfile.cmake
+++ b/ports/aws-c-io/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-io
-    REF 57b00febac48e78f8bf8cff4c82a249e6648842a # v0.10.7
-    SHA512 ffcf5ba4ccdff23ca390fc4eb935f88040447589886348234aa1c24b531401521df99a6ac578c1679a3c1a06dfcef6deb833a0b9d53e31d42576a3ad03ade6fc
+    REF cfe553a770e9c2d1c93b8cdfb870b9f2a46b436e # v0.10.22
+    SHA512 7a741f5b1c895ceb11f73b67828fd3623c180cb8a3863f3b63a67ac1437d2c47911d50510777b13ee66fd0a009ab09a8c83fd036a0fca2f25a0835f48f023de7
     HEAD_REF master
     PATCHES fix-cmake-target-path.patch
 )

--- a/ports/aws-c-io/vcpkg.json
+++ b/ports/aws-c-io/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "aws-c-io",
-  "version": "0.10.7",
-  "port-version": 2,
+  "version": "0.10.22",
   "description": "Handles all IO and TLS work for application protocols.",
   "homepage": "https://github.com/awslabs/aws-c-io",
   "supports": "!(windows & arm) & !uwp",

--- a/versions/a-/aws-c-common.json
+++ b/versions/a-/aws-c-common.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f38081d38190d2b787b38df2ffe3804fea7746b",
+      "version": "0.6.20",
+      "port-version": 0
+    },
+    {
       "git-tree": "56b4972c2535a4e8991826b6c595e433b0e80bf9",
       "version": "0.6.9",
       "port-version": 2

--- a/versions/a-/aws-c-io.json
+++ b/versions/a-/aws-c-io.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4dc402977f4ed08054b2661b89a211064005e280",
+      "version": "0.10.22",
+      "port-version": 0
+    },
+    {
       "git-tree": "7456b996bdeeeeb59fb39770d797fa2966d0a951",
       "version": "0.10.7",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -273,8 +273,8 @@
       "port-version": 2
     },
     "aws-c-common": {
-      "baseline": "0.6.9",
-      "port-version": 2
+      "baseline": "0.6.20",
+      "port-version": 0
     },
     "aws-c-compression": {
       "baseline": "0.2.14",
@@ -289,8 +289,8 @@
       "port-version": 2
     },
     "aws-c-io": {
-      "baseline": "0.10.7",
-      "port-version": 2
+      "baseline": "0.10.22",
+      "port-version": 0
     },
     "aws-c-mqtt": {
       "baseline": "0.7.6",


### PR DESCRIPTION

**Describe the pull request**

- #### What does your PR fix?
  Updates:
  * aws-c-common from 0.6.9 -> 0.6.20
  * aws-c-io from 0.10.7 -> 0.10.22

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No changes to supported triplets. No change to CI Baseline

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes; I grouped both these updates into one - I can change that if required.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
