### PR TITLE
[crashrpt] Fix build error

### DIFF
--- a/ports/crashrpt/002-fix-wtl-includepath.patch
+++ b/ports/crashrpt/002-fix-wtl-includepath.patch
@@ -1,0 +1,148 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ed9e3d3..d842aa7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -122,7 +122,7 @@ if(NOT TINYXML_INCLUDE_DIR)
+   message(FATAL_ERROR "tinyxml include dir not found")
+ endif()
+ 
+-find_path(WTL_INCLUDE_DIR wtl/atlapp.h)
++find_path(WTL_INCLUDE_DIR atlapp.h)
+ if(NOT WTL_INCLUDE_DIR)
+   message(FATAL_ERROR "WTL include dir not found")
+ endif()
+diff --git a/processing/crashrptprobe/CrashRptProbe.rc b/processing/crashrptprobe/CrashRptProbe.rc
+index e12b8e9..a08f63e 100644
+--- a/processing/crashrptprobe/CrashRptProbe.rc
++++ b/processing/crashrptprobe/CrashRptProbe.rc
+@@ -7,7 +7,7 @@
+ //
+ // Generated from the TEXTINCLUDE 2 resource.
+ //
+-#include "wtl/atlres.h"
++#include "atlres.h"
+ 
+ /////////////////////////////////////////////////////////////////////////////
+ #undef APSTUDIO_READONLY_SYMBOLS
+@@ -32,7 +32,7 @@ END
+ 
+ 2 TEXTINCLUDE 
+ BEGIN
+-    "#include ""wtl/atlres.h""\r\n"
++    "#include ""atlres.h""\r\n"
+     "\0"
+ END
+ 
+diff --git a/processing/crashrptprobe/stdafx.h b/processing/crashrptprobe/stdafx.h
+index 0b60659..2b027b2 100644
+--- a/processing/crashrptprobe/stdafx.h
++++ b/processing/crashrptprobe/stdafx.h
+@@ -70,13 +70,13 @@ namespace ATL
+ };
+ #endif // _WTL_SUPPORT_SDK_ATL3
+ 
+-#include <wtl/atlapp.h>
++#include <atlapp.h>
+ extern CAppModule _Module;
+ #include <atlwin.h>
+ 
+ // CString-related includes
+ #define _WTL_USE_CSTRING
+-#include <wtl/atlmisc.h>
++#include <atlmisc.h>
+ 
+ #if _MSC_VER<1400
+ #define WCSNCPY_S(strDest, sizeInBytes, strSource, count) wcsncpy(strDest, strSource, count)
+diff --git a/reporting/crashrpt/CrashRpt.rc b/reporting/crashrpt/CrashRpt.rc
+index a8c821b..95e7502 100644
+--- a/reporting/crashrpt/CrashRpt.rc
++++ b/reporting/crashrpt/CrashRpt.rc
+@@ -7,7 +7,7 @@
+ //
+ // Generated from the TEXTINCLUDE 2 resource.
+ //
+-#include "wtl/atlres.h"
++#include "atlres.h"
+ 
+ /////////////////////////////////////////////////////////////////////////////
+ #undef APSTUDIO_READONLY_SYMBOLS
+@@ -32,7 +32,7 @@ END
+ 
+ 2 TEXTINCLUDE 
+ BEGIN
+-    "#include ""wtl/atlres.h""\r\n"
++    "#include ""atlres.h""\r\n"
+     "\0"
+ END
+ 
+diff --git a/reporting/crashrpt/StdAfx.h b/reporting/crashrpt/StdAfx.h
+index 13bbe50..3ed0a55 100644
+--- a/reporting/crashrpt/StdAfx.h
++++ b/reporting/crashrpt/StdAfx.h
+@@ -54,12 +54,12 @@ namespace ATL
+ };
+ #endif // _WTL_SUPPORT_SDK_ATL3
+ 
+-#include <wtl/atlapp.h>
++#include <atlapp.h>
+ extern CAppModule _Module;
+ #include <atlwin.h>
+ // CString-related includes
+ #define _WTL_USE_CSTRING
+-#include <wtl/atlmisc.h>
++#include <atlmisc.h>
+ #include <new.h>
+ #include <map>
+ #include <set>
+diff --git a/reporting/crashsender/CrashSender.rc b/reporting/crashsender/CrashSender.rc
+index e10e269..0502962 100644
+--- a/reporting/crashsender/CrashSender.rc
++++ b/reporting/crashsender/CrashSender.rc
+@@ -7,7 +7,7 @@
+ //
+ // Generated from the TEXTINCLUDE 2 resource.
+ //
+-#include "wtl/atlres.h"
++#include "atlres.h"
+ 
+ /////////////////////////////////////////////////////////////////////////////
+ #undef APSTUDIO_READONLY_SYMBOLS
+@@ -243,7 +243,7 @@ END
+ 
+ 2 TEXTINCLUDE 
+ BEGIN
+-    "#include ""wtl/atlres.h""\r\n"
++    "#include ""atlres.h""\r\n"
+     "\0"
+ END
+ 
+diff --git a/reporting/crashsender/stdafx.h b/reporting/crashsender/stdafx.h
+index 4494d3a..9bbbe3a 100644
+--- a/reporting/crashsender/stdafx.h
++++ b/reporting/crashsender/stdafx.h
+@@ -61,19 +61,19 @@ namespace ATL
+ };
+ #endif // _WTL_SUPPORT_SDK_ATL3
+ 
+-#include <wtl/atlapp.h>
++#include <atlapp.h>
+ 
+ extern CAppModule _Module;
+ 
+ #include <atlwin.h>
+ 
+-#include <wtl/atlframe.h>
+-#include <wtl/atlctrls.h>
+-#include <wtl/atldlgs.h>
+-#include <wtl/atlctrlx.h>
++#include <atlframe.h>
++#include <atlctrls.h>
++#include <atldlgs.h>
++#include <atlctrlx.h>
+ 
+ #define _WTL_USE_CSTRING
+-#include <wtl/atlmisc.h>
++#include <atlmisc.h>
+ 
+ #include <string>
+ #include <vector>

--- a/ports/crashrpt/003-add-definition-UNICODE.patch
+++ b/ports/crashrpt/003-add-definition-UNICODE.patch
@@ -1,0 +1,39 @@
+diff --git a/processing/crashrptprobe/CMakeLists.txt b/processing/crashrptprobe/CMakeLists.txt
+index c513c6d..8ac306a 100644
+--- a/processing/crashrptprobe/CMakeLists.txt
++++ b/processing/crashrptprobe/CMakeLists.txt
+@@ -13,7 +13,7 @@ list(REMOVE_ITEM srcs_using_precomp  ./CrashRptProbe.rc ./CrashRptProbe.def ./st
+ add_msvc_precompiled_header(stdafx.h ./stdafx.cpp srcs_using_precomp)
+ 
+ # Define _UNICODE (use wide-char encoding)
+-add_definitions(-D_UNICODE)
++add_definitions(-D_UNICODE -DUNICODE)
+ 
+ fix_default_compiler_settings_()
+ 
+diff --git a/reporting/crashrpt/CMakeLists.txt b/reporting/crashrpt/CMakeLists.txt
+index c7e4fd6..da9cef1 100644
+--- a/reporting/crashrpt/CMakeLists.txt
++++ b/reporting/crashrpt/CMakeLists.txt
+@@ -12,7 +12,7 @@ list(REMOVE_ITEM srcs_using_precomp ./CrashRpt.rc ./StdAfx.cpp ./CrashRpt.def)
+ add_msvc_precompiled_header(stdafx.h ./StdAfx.cpp srcs_using_precomp)
+ 
+ # Define _UNICODE (use wide-char encoding)
+-add_definitions(-D_UNICODE -D_CRT_SECURE_NO_DEPRECATE)
++add_definitions(-D_UNICODE -DUNICODE -D_CRT_SECURE_NO_DEPRECATE)
+ 
+ # Modify default compiler settings
+ fix_default_compiler_settings_()
+diff --git a/reporting/crashsender/CMakeLists.txt b/reporting/crashsender/CMakeLists.txt
+index aa4ab8a..f081254 100644
+--- a/reporting/crashsender/CMakeLists.txt
++++ b/reporting/crashsender/CMakeLists.txt
+@@ -15,7 +15,7 @@ list(APPEND source_files
+ 	${CMAKE_SOURCE_DIR}/reporting/CrashRpt/SharedMem.cpp)
+ 	
+ # Define _UNICODE (use wide-char encoding)
+-add_definitions(-D_UNICODE )
++add_definitions(-D_UNICODE -DUNICODE)
+ 
+ fix_default_compiler_settings_()
+ 

--- a/ports/crashrpt/portfile.cmake
+++ b/ports/crashrpt/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_git(
     PATCHES
         001-add-install-target-and-find-deps.patch
         002-fix-wtl-includepath.patch
+        003-add-definition-UNICODE.patch
 )
 
 # Remove vendored dependencies to ensure they are not picked up by the build
@@ -33,18 +34,15 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         demos CRASHRPT_BUILD_DEMOS
 )
 
-# PREFER_NINJA is not used below since CrashSender fails to build with errors like this one:
-# C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.23.28105\ATLMFC\include\atlconv.h(788): error C2440: 'return': cannot convert from 'LPCTSTR' to 'LPCOLESTR'
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    # PREFER_NINJA
     OPTIONS
         -DCRASHRPT_BUILD_SHARED_LIBS=${CRASHRPT_BUILD_SHARED_LIBS}
         -DCRASHRPT_LINK_CRT_AS_DLL=${CRASHRPT_LINK_CRT_AS_DLL}
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
 

--- a/ports/crashrpt/portfile.cmake
+++ b/ports/crashrpt/portfile.cmake
@@ -12,13 +12,14 @@ vcpkg_from_git(
     REF 4616504670be5a425a525376648d912a72ce18f2
     PATCHES
         001-add-install-target-and-find-deps.patch
+        002-fix-wtl-includepath.patch
 )
 
 # Remove vendored dependencies to ensure they are not picked up by the build
 # Vendored minizip is still used since it contains modifications needed for CrashRpt
 foreach(DEPENDENCY dbghelp jpeg libogg libpng libtheora tinyxml wtl zlib)
-    if(EXISTS ${SOURCE_PATH}/thirdparty/${DEPENDENCY})
-        file(REMOVE_RECURSE ${SOURCE_PATH}/thirdparty/${DEPENDENCY})
+    if(EXISTS "${SOURCE_PATH}/thirdparty/${DEPENDENCY}")
+        file(REMOVE_RECURSE "${SOURCE_PATH}/thirdparty/${DEPENDENCY}")
     endif()
 endforeach()
 
@@ -35,7 +36,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 # PREFER_NINJA is not used below since CrashSender fails to build with errors like this one:
 # C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.23.28105\ATLMFC\include\atlconv.h(788): error C2440: 'return': cannot convert from 'LPCTSTR' to 'LPCOLESTR'
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     # PREFER_NINJA
     OPTIONS
         -DCRASHRPT_BUILD_SHARED_LIBS=${CRASHRPT_BUILD_SHARED_LIBS}
@@ -49,4 +50,4 @@ vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/License.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/crashrpt/vcpkg.json
+++ b/ports/crashrpt/vcpkg.json
@@ -13,7 +13,11 @@
     "libtheora",
     "tinyxml",
     "wtl",
-    "zlib"
+    "zlib",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
   ],
   "features": {
     "demos": {

--- a/ports/crashrpt/vcpkg.json
+++ b/ports/crashrpt/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 3,
   "description": "A crash reporting system for Windows applications",
   "homepage": "http://crashrpt.sourceforge.net/",
+  "license": "BSD-3-Clause-Clear",
   "supports": "!osx & !linux & !uwp & (x86 | x64)",
   "dependencies": [
     "dbghelp",
@@ -12,12 +13,12 @@
     "libpng",
     "libtheora",
     "tinyxml",
-    "wtl",
-    "zlib",
     {
       "name": "vcpkg-cmake",
       "host": true
-    }
+    },
+    "wtl",
+    "zlib"
   ],
   "features": {
     "demos": {

--- a/ports/crashrpt/vcpkg.json
+++ b/ports/crashrpt/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 3,
   "description": "A crash reporting system for Windows applications",
   "homepage": "http://crashrpt.sourceforge.net/",
-  "license": "BSD-3-Clause-Clear",
+  "license": "BSD-3-Clause",
   "supports": "!osx & !linux & !uwp & (x86 | x64)",
   "dependencies": [
     "dbghelp",

--- a/ports/crashrpt/vcpkg.json
+++ b/ports/crashrpt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashrpt",
   "version": "1.4.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A crash reporting system for Windows applications",
   "homepage": "http://crashrpt.sourceforge.net/",
   "supports": "!osx & !linux & !uwp & (x86 | x64)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1706,7 +1706,7 @@
     },
     "crashrpt": {
       "baseline": "1.4.3",
-      "port-version": 2
+      "port-version": 3
     },
     "crc32c": {
       "baseline": "1.1.2",

--- a/versions/c-/crashrpt.json
+++ b/versions/c-/crashrpt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "76a634b829e7619aa290e80fa1d83776e3a59554",
+      "git-tree": "bb5e94d69da827d776c42545cdda4ca0e5565629",
       "version": "1.4.3",
       "port-version": 3
     },

--- a/versions/c-/crashrpt.json
+++ b/versions/c-/crashrpt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f058d315d4006c72a0aa20ac774156853a6fe91",
+      "version": "1.4.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "896d96ee0613edabd92048142803845fa11baa68",
       "version": "1.4.3",
       "port-version": 2

--- a/versions/c-/crashrpt.json
+++ b/versions/c-/crashrpt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9f058d315d4006c72a0aa20ac774156853a6fe91",
+      "git-tree": "76a634b829e7619aa290e80fa1d83776e3a59554",
       "version": "1.4.3",
       "port-version": 3
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #26171, since the header files path of `wtl` changed to `include/`, so `crashrpt` build failed with fatal error. Adding patch `002-fix-wtl-includepath.patch` to fix this issue.
`003-add-definition-UNICODE.patch` fix build error use `vcpkg_cmake_configure` in `portfile.cmake`:
```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.32.31326\ATLMFC\include\atlconv.h(816): error C2440: 'return': cannot convert from 'LPCTSTR' to 'LPCOLESTR'
```