### PR TITLE
[rioki-glow] Adds new port glow 0.2.0

### DIFF
--- a/ports/rioki-glow/portfile.cmake
+++ b/ports/rioki-glow/portfile.cmake
@@ -1,0 +1,16 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO rioki/glow
+    REF v0.2.0
+    SHA512 ff81b56ce8bbceb5119c5cf48764cc1978bb0d3c4cddccc85ef0d3f7c85188c1dab53e083e09509d6ca96e4ac30ba277fc6915ba9ae388422c35cc8cd08c3978
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "rioki_glow")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rioki-glow/vcpkg.json
+++ b/ports/rioki-glow/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "rioki-glow",
+  "version-semver": "0.2.0",
+  "description": "OpenGL Object Wrapper",
+  "homepage": "https://github.com/rioki/glow",
+  "license": "MIT",
+  "dependencies": [
+    "glew",
+    "glm",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6320,6 +6320,10 @@
       "baseline": "0.6.0",
       "port-version": 0
     },
+    "rioki-glow": {
+      "baseline": "0.2.0",
+      "port-version": 0
+    },
     "rmlui": {
       "baseline": "4.4",
       "port-version": 0

--- a/versions/r-/rioki-glow.json
+++ b/versions/r-/rioki-glow.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c7d83181fde1e5535022c2dc3fccfaa38c37c3ab",
+      "version-semver": "0.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?

  Adds the new port of glow, in version 0.2.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
  All, yes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  To the best of my knowledge yes. 
  The name conflict was discussed here: https://github.com/microsoft/vcpkg/discussions/24676

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
