### PR TITLE
[pybind11] Fix usage

### DIFF
--- a/ports/pybind11/fix-usage.patch
+++ b/ports/pybind11/fix-usage.patch
@@ -1,0 +1,24 @@
+diff --git a/tools/pybind11Tools.cmake b/tools/pybind11Tools.cmake
+index 5535e87..6576b2e 100644
+--- a/tools/pybind11Tools.cmake
++++ b/tools/pybind11Tools.cmake
+@@ -130,15 +130,16 @@ if(CMAKE_VERSION VERSION_LESS 3.11)
+     APPEND
+     PROPERTY INTERFACE_LINK_LIBRARIES pybind11::pybind11 $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
+ else()
++  add_library(pybind11::_ClassicPythonLibraries IMPORTED INTERFACE)
++  target_link_libraries(pybind11::_ClassicPythonLibraries INTERFACE ${PYTHON_LIBRARIES})
+   target_link_libraries(
+     pybind11::module
+     INTERFACE
+       pybind11::python_link_helper
+-      "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:$<BUILD_INTERFACE:${PYTHON_LIBRARIES}>>"
+-  )
++      "$<$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Cygwin>>:pybind11::_ClassicPythonLibraries>")
+ 
+   target_link_libraries(pybind11::embed INTERFACE pybind11::pybind11
+-                                                  $<BUILD_INTERFACE:${PYTHON_LIBRARIES}>)
++                                                  pybind11::_ClassicPythonLibraries)
+ 
+ endif()
+ 

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v2.10.0
     SHA512 93112ce530a0652b2b4458a137b4a35f2fd8607f82ad96698ef422128d0b53e16e1d06c239ee4643b821acafae09c74eb0f72bc4ee5584aa9fcdaff4d79980d9
     HEAD_REF master
+    PATCHES fix-usage.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pybind11",
   "version": "2.10.0",
+  "port-version": 1,
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5730,7 +5730,7 @@
     },
     "pybind11": {
       "baseline": "2.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "pystring": {
       "baseline": "1.1.3",

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c6350f32b68fc7216251526449e5d6b5342b2a9",
+      "version": "2.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "84251d247cc46bde6696ad9043326981370e1a79",
       "version": "2.10.0",
       "port-version": 0


### PR DESCRIPTION
Fix usage issue:
```
1>LINK : fatal error LNK1104: cannot open file 'optimized.lib'
```
This is because the keywords including debug/optimization cannot be used in target_link_libraries or cmake expression.
And the upstream fixing this issue in https://github.com/pybind/pybind11/pull/4123 and I confirmed that works.

Fix #26220