### PR TITLE
[Tesseract] Add arm64-windows

### DIFF
--- a/ports/tesseract/vcpkg.json
+++ b/ports/tesseract/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tesseract",
   "version": "4.1.1",
-  "port-version": 10,
+  "port-version": 11,
   "description": "An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.",
   "homepage": "https://github.com/tesseract-ocr/tesseract",
   "supports": "!(arm & (osx | linux))",

--- a/ports/tesseract/vcpkg.json
+++ b/ports/tesseract/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 10,
   "description": "An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.",
   "homepage": "https://github.com/tesseract-ocr/tesseract",
-  "supports": "!arm",
+  "supports": "!(arm & (osx | linux))",
   "dependencies": [
     "leptonica",
     "libarchive",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7034,7 +7034,7 @@
     },
     "tesseract": {
       "baseline": "4.1.1",
-      "port-version": 10
+      "port-version": 11
     },
     "tfhe": {
       "baseline": "1.0.1",

--- a/versions/t-/tesseract.json
+++ b/versions/t-/tesseract.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1e46d06e73e1aab9ea9e95b1b69bfa08b24770cd",
+      "git-tree": "24c99e73eaf335a9abedcfd42163c4968ca07ec3",
       "version": "4.1.1",
       "port-version": 11
     },

--- a/versions/t-/tesseract.json
+++ b/versions/t-/tesseract.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e46d06e73e1aab9ea9e95b1b69bfa08b24770cd",
+      "version": "4.1.1",
+      "port-version": 11
+    },
+    {
       "git-tree": "ac84bef93d2709f28bf4ab8341a80dab949a8cf1",
       "version": "4.1.1",
       "port-version": 10


### PR DESCRIPTION
**Describe the pull request**
It seems that with current version of tesseract it can be built for arm64-windows both on ARM machines and cross-compilation using x86-64 machines.

- #### What does your PR fix?
  Change supports clause from `!arm` to `!(arm & (osx | linux))`

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `arm64-windows`, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

