### PR TITLE
[osgearth] Fix naming of target and exported variables

### DIFF
--- a/ports/osgearth/fix-osgearth-config.patch
+++ b/ports/osgearth/fix-osgearth-config.patch
@@ -1,27 +1,85 @@
 diff --git a/osgEarthConfig.cmake.in b/osgEarthConfig.cmake.in
-index 3f27dffe9..354e0f7dc 100644
+index 3f27dffe9..4141ff939 100644
 --- a/osgEarthConfig.cmake.in
 +++ b/osgEarthConfig.cmake.in
-@@ -13,11 +13,11 @@ endif()
- set(osgearth_DEFINITIONS ${${XPREFIX}_CFLAGS})
+@@ -6,52 +6,54 @@ set(XPREFIX OSGEARTH)
  
- find_path(osgearth_INCLUDE_DIR
--    NAMES OSGEARTH/RTREE.H
-+    NAMES osgEarth/rtree.h
+ 
+ 
+-if (osgearth_USE_STATIC_LIBS)
++if (osgEarth_USE_STATIC_LIBS)
+     set(XPREFIX ${XPREFIX}_STATIC)
+ endif()
+ 
+-set(osgearth_DEFINITIONS ${${XPREFIX}_CFLAGS})
++set(osgEarth_DEFINITIONS ${${XPREFIX}_CFLAGS})
+ 
+-find_path(osgearth_INCLUDE_DIR
++find_path(osgEarth_INCLUDE_DIR
+     NAMES OSGEARTH/RTREE.H
      HINTS ${${XPREFIX}_INCLUDE_DIRS}
  )
  
 -set(OSGEARTH_NAMES osgearth)
 +set(OSGEARTH_NAMES osgEarth)
  
- find_library(osgearth_LIBRARY
+-find_library(osgearth_LIBRARY
++find_library(osgEarth_LIBRARY
      NAMES ${OSGEARTH_NAMES}
-@@ -38,6 +38,8 @@ find_package_handle_standard_args(osgearth DEFAULT_MSG
+     HINTS ${${XPREFIX}_LIBRARY_DIRS}
+ )
  
- string (REPLACE ";" " " osgearth_LDFLAGS "${osgearth_LDFLAGS}")
+-set(osgearth_LIBRARIES    ${osgearth_LIBRARY})
+-set(osgearth_LIBRARY_DIRS ${${XPREFIX}_LIBRARY_DIRS})
+-set(osgearth_LIBRARY_DIR  ${osgearth_LIBRARY_DIRS})
+-set(osgearth_INCLUDE_DIRS ${osgearth_INCLUDE_DIR})
+-set(osgearth_LDFLAGS      ${${XPREFIX}_LDFLAGS})
++set(osgEarth_LIBRARIES    ${osgEarth_LIBRARY})
++set(osgEarth_LIBRARY_DIRS ${${XPREFIX}_LIBRARY_DIRS})
++set(osgEarth_LIBRARY_DIR  ${osgEarth_LIBRARY_DIRS})
++set(osgEarth_INCLUDE_DIRS ${osgEarth_INCLUDE_DIR})
++set(osgEarth_LDFLAGS      ${${XPREFIX}_LDFLAGS})
  
+ include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(osgearth DEFAULT_MSG
+-    osgearth_LIBRARY
+-    osgearth_INCLUDE_DIR
++find_package_handle_standard_args(osgEarth DEFAULT_MSG
++    osgEarth_LIBRARY
++    osgEarth_INCLUDE_DIR
+ )
+ 
+-string (REPLACE ";" " " osgearth_LDFLAGS "${osgearth_LDFLAGS}")
++string (REPLACE ";" " " osgEarth_LDFLAGS "${osgEarth_LDFLAGS}")
+ 
+-set_target_properties(osgearth
 +add_library(osgEarth UNKNOWN IMPORTED)
 +
- set_target_properties(osgearth
++set_target_properties(osgEarth
    PROPERTIES
-   IMPORTED_LOCATION             "${osgearth_LIBRARIES}"
+-  IMPORTED_LOCATION             "${osgearth_LIBRARIES}"
+-  INTERFACE_INCLUDE_DIRECTORIES "${osgearth_INCLUDE_DIRS}"
+-  INTERFACE_LINK_LIBRARIES      "${osgearth_LDFLAGS}"
+-  INTERFACE_COMPILE_OPTIONS     "${osgearth_DEFINITIONS}"
++  IMPORTED_LOCATION             "${osgEarth_LIBRARIES}"
++  INTERFACE_INCLUDE_DIRECTORIES "${osgEarth_INCLUDE_DIRS}"
++  INTERFACE_LINK_LIBRARIES      "${osgEarth_LDFLAGS}"
++  INTERFACE_COMPILE_OPTIONS     "${osgEarth_DEFINITIONS}"
+ )
+ 
+-  message(STATUS "osgearth_FOUND: ${osgearth_FOUND}")
+-  message(STATUS "osgearth_INCLUDE_DIRS: ${osgearth_INCLUDE_DIRS}")
+-  message(STATUS "osgearth_LIBRARIES: ${osgearth_LIBRARIES}")
+-  message(STATUS "osgearth_LDFLAGS: ${osgearth_LDFLAGS}")
+-  message(STATUS "osgearth_DEFINITIONS: ${osgearth_DEFINITIONS}")
++  message(STATUS "osgEarth_FOUND: ${osgEarth_FOUND}")
++  message(STATUS "osgEarth_INCLUDE_DIRS: ${osgEarth_INCLUDE_DIRS}")
++  message(STATUS "osgEarth_LIBRARIES: ${osgEarth_LIBRARIES}")
++  message(STATUS "osgEarth_LDFLAGS: ${osgEarth_LDFLAGS}")
++  message(STATUS "osgEarth_DEFINITIONS: ${osgEarth_DEFINITIONS}")
+ 
+ 
+ 
+-check_required_components(osgearth)
+\ No newline at end of file
++check_required_components(osgEarth)

--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osgearth",
   "version": "3.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2021 Pelican Mapping.",
   "homepage": "https://github.com/gwaldron/osgearth",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5346,7 +5346,7 @@
     },
     "osgearth": {
       "baseline": "3.3",
-      "port-version": 1
+      "port-version": 2
     },
     "osi": {
       "baseline": "0.108.6",

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6f1f5c8fd268a733ce4774fcc79a6d71d9a6a003",
+      "git-tree": "5a9e3fa28dc78e768ff9ef2ca4ff09b51b774cbb",
       "version": "3.3",
       "port-version": 2
     },

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f1f5c8fd268a733ce4774fcc79a6d71d9a6a003",
+      "version": "3.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "1091743df235c6472d30b157723f82e6d3473cc9",
       "version": "3.3",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**
Fixes some errors with the osgEarth CMake config introduced in #26024.

- #### What does your PR fix?
  The change to the target name suggested in https://github.com/microsoft/vcpkg/pull/26024#discussion_r933693922 only covered that single usage of the target. It needs to be followed up by changing the exported variables and the call to `set_target_properties` to match the new target name.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
