### PR TITLE
[sdl2] add 'wayland' feature

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -19,12 +19,16 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        vulkan  SDL_VULKAN
-        x11     SDL_X11_SHARED
+        vulkan   SDL_VULKAN
+        x11      SDL_X11_SHARED
+        wayland  SDL_WAYLAND_SHARED
 )
 
 if ("x11" IN_LIST FEATURES)
     message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
+endif()
+if ("wayland" IN_LIST FEATURES)
+    message(WARNING "You will need to install Wayland dependencies to use feature wayland:\nsudo apt install libwayland-dev libxkbcommon-dev libegl1-mesa-dev\n")
 endif()
 
 if(VCPKG_TARGET_IS_UWP)

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.0.22",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",
@@ -18,6 +18,10 @@
   "features": {
     "vulkan": {
       "description": "Vulkan functionality for SDL"
+    },
+    "wayland": {
+      "description": "Dynamically load Wayland support",
+      "supports": "linux"
     },
     "x11": {
       "description": "Dynamically load X11 support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6498,7 +6498,7 @@
     },
     "sdl2": {
       "baseline": "2.0.22",
-      "port-version": 2
+      "port-version": 3
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69c64474577715f87366d9374b0483256f305f1e",
+      "version": "2.0.22",
+      "port-version": 3
+    },
+    {
       "git-tree": "c14a0021322c01cb256a4a54ea48a9ddf8023622",
       "version": "2.0.22",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?

Adds a new feature to the sdl2 port for loading wayland shared.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
linux only

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yeah

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yeah
