### PR TITLE
[sqlcipher] update to 4.5.2

### DIFF
--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sqlcipher/sqlcipher
-    REF v4.5.1
-    SHA512 157ab90e1b80ae9ae85c68c6b77008fe8ab5b526cbb2604297a5ba54279286b4cac1fecd0db552e0113a75ff61a198f649611b8bde4dec5156c443e7b7fbe0c3
+    REF v4.5.2
+    SHA512 1de5b219392bb976631857e32b4523258fd660fedb558d478e536b7e10c711c72c7e7c9062e45bd8a5ceaecbc1fee717935d2357f6811c3ddf76702167f4601b
     HEAD_REF master
 )
 

--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -55,16 +55,15 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     tool SQLITE3_SKIP_TOOLS
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
         -DSQLITE3_SKIP_TOOLS=ON
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/${PORT} TARGET_PATH share/${PORT})
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH share/${PORT})
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 

--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -38,14 +38,14 @@ message(STATUS "Pre-building ${TARGET_TRIPLET}")
 vcpkg_execute_required_process(
 	COMMAND ${NMAKE} -f Makefile.msc /A /NOLOGO clean tcl
 	${NMAKE_OPTIONS}
-	WORKING_DIRECTORY ${SOURCE_PATH}
+	WORKING_DIRECTORY "${SOURCE_PATH}"
 	LOGNAME pre-build-${TARGET_TRIPLET}
 )
 message(STATUS "Pre-building ${TARGET_TRIPLET} done")
 
 # The rest of the build process with the CMakeLists.txt is merely a copy of sqlite3
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION "${SOURCE_PATH}")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -65,19 +65,19 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH share/${PORT})
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-if(NOT SQLITE3_SKIP_TOOLS AND EXISTS ${CURRENT_PACKAGES_DIR}/tools/${PORT}/sqlcipher-bin${VCPKG_HOST_EXECUTABLE_SUFFIX})
-    file(RENAME ${CURRENT_PACKAGES_DIR}/tools/${PORT}/sqlcipher-bin${VCPKG_HOST_EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/${PORT}/sqlcipher${VCPKG_HOST_EXECUTABLE_SUFFIX})
+if(NOT SQLITE3_SKIP_TOOLS AND EXISTS "${CURRENT_PACKAGES_DIR}/tools/${PORT}/sqlcipher-bin${VCPKG_HOST_EXECUTABLE_SUFFIX}")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/tools/${PORT}/sqlcipher-bin${VCPKG_HOST_EXECUTABLE_SUFFIX}" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/sqlcipher${VCPKG_HOST_EXECUTABLE_SUFFIX}")
 endif()
 
 configure_file(
-    ${CMAKE_CURRENT_LIST_DIR}/sqlcipher-config.in.cmake
-    ${CURRENT_PACKAGES_DIR}/share/${PORT}/sqlcipher-config.cmake
+    "${CMAKE_CURRENT_LIST_DIR}/sqlcipher-config.in.cmake"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/sqlcipher-config.cmake"
     @ONLY
 )
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_copy_pdbs()
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")

--- a/ports/sqlcipher/vcpkg.json
+++ b/ports/sqlcipher/vcpkg.json
@@ -3,10 +3,19 @@
   "version": "4.5.2",
   "description": "SQLCipher extends the SQLite database library to add security enhancements that make it more suitable for encrypted local data storage.",
   "homepage": "https://www.zetetic.net/sqlcipher",
+  "license": null,
   "supports": "windows & !uwp & !static",
   "dependencies": [
     "openssl",
-    "tcl"
+    "tcl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "features": {
     "geopoly": {

--- a/ports/sqlcipher/vcpkg.json
+++ b/ports/sqlcipher/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlcipher",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "SQLCipher extends the SQLite database library to add security enhancements that make it more suitable for encrypted local data storage.",
   "homepage": "https://www.zetetic.net/sqlcipher",
   "supports": "windows & !uwp & !static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6837,7 +6837,7 @@
       "port-version": 1
     },
     "sqlcipher": {
-      "baseline": "4.5.1",
+      "baseline": "4.5.2",
       "port-version": 0
     },
     "sqlite-modern-cpp": {

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8fb958aa7911128c5eaa49add59f634c3be4c32c",
+      "git-tree": "3ecd002c1b7d57862e468171c3a1af413f692cc5",
       "version": "4.5.2",
       "port-version": 0
     },

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fb958aa7911128c5eaa49add59f634c3be4c32c",
+      "version": "4.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "3803a9648861130c25517c8b330c17d054fe6cd7",
       "version": "4.5.1",
       "port-version": 0

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3ecd002c1b7d57862e468171c3a1af413f692cc5",
+      "git-tree": "56c606b11bcc5de6e0a93cde32b9c876539d6df4",
       "version": "4.5.2",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes / Updates sqlcipher to 4.5.2

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  no change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
