### PR TITLE
[libpng] fix mips64 support

### DIFF
--- a/ports/libpng/fix-msa-support-for-mips.patch
+++ b/ports/libpng/fix-msa-support-for-mips.patch
@@ -1,15 +1,25 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6c1d632..8bd9aa9 100644
+index 6c1d632..a2a0d0d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -173,6 +173,10 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "mipsel*" OR
+@@ -158,8 +158,8 @@ endif()
+ # set definitions and sources for MIPS
+ if(CMAKE_SYSTEM_PROCESSOR MATCHES "mipsel*" OR
+    CMAKE_SYSTEM_PROCESSOR MATCHES "mips64el*")
+-  set(PNG_MIPS_MSA_POSSIBLE_VALUES on off)
+-  set(PNG_MIPS_MSA "on" CACHE STRING "Enable MIPS_MSA optimizations:
++  set(PNG_MIPS_MSA_POSSIBLE_VALUES on off check)
++  set(PNG_MIPS_MSA "check" CACHE STRING "Enable MIPS_MSA optimizations:
+      off: disable the optimizations")
+   set_property(CACHE PNG_MIPS_MSA PROPERTY STRINGS
+      ${PNG_MIPS_MSA_POSSIBLE_VALUES})
+@@ -173,6 +173,8 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "mipsel*" OR
        mips/filter_msa_intrinsics.c)
      if(${PNG_MIPS_MSA} STREQUAL "on")
        add_definitions(-DPNG_MIPS_MSA_OPT=2)
-+      if("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "7")
-+        add_definitions(-D__mips_msa)
-+        add_compile_options(-mmsa -mhard-float -mfp64)
-+      endif()
++    else()
++      add_definitions(-DPNG_MIPS_MSA_CHECK_SUPPORTED)
      endif()
    else()
      add_definitions(-DPNG_MIPS_MSA_OPT=0)
+     

--- a/ports/libpng/fix-msa-support-for-mips.patch
+++ b/ports/libpng/fix-msa-support-for-mips.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6c1d632..8bd9aa9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -173,6 +173,10 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "mipsel*" OR
+       mips/filter_msa_intrinsics.c)
+     if(${PNG_MIPS_MSA} STREQUAL "on")
+       add_definitions(-DPNG_MIPS_MSA_OPT=2)
++      if("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "7")
++        add_definitions(-D__mips_msa)
++        add_compile_options(-mmsa -mhard-float -mfp64)
++      endif()
+     endif()
+   else()
+     add_definitions(-DPNG_MIPS_MSA_OPT=0)

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -43,6 +43,7 @@ vcpkg_from_github(
         fix-export-targets.patch
         pkgconfig.patch
         macos-arch-fix.patch
+        fix-msa-support-for-mips.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PNG_SHARED)

--- a/ports/libpng/vcpkg.json
+++ b/ports/libpng/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpng",
   "version": "1.6.37",
-  "port-version": 18,
+  "port-version": 19,
   "description": "libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files",
   "homepage": "https://github.com/glennrp/libpng",
   "license": "libpng-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3974,7 +3974,7 @@
     },
     "libpng": {
       "baseline": "1.6.37",
-      "port-version": 18
+      "port-version": 19
     },
     "libpopt": {
       "baseline": "1.16",

--- a/versions/l-/libpng.json
+++ b/versions/l-/libpng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "56f1b57ee6b5b56accabff295006ba0c51a17060",
+      "git-tree": "85dc7678690f09c78cc366b1f13498c41be51aff",
       "version": "1.6.37",
       "port-version": 19
     },

--- a/versions/l-/libpng.json
+++ b/versions/l-/libpng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "56f1b57ee6b5b56accabff295006ba0c51a17060",
+      "version": "1.6.37",
+      "port-version": 19
+    },
+    {
       "git-tree": "5e3ec787e7c6f09dd162648b700aeb712af0ffd2",
       "version": "1.6.37",
       "port-version": 18


### PR DESCRIPTION
Add support for mips64.

- #### What does your PR fix?
  fix build failure for mips64.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  linux, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Basically.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
