### PR TITLE
[libffi] add misp64 support

### DIFF
--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 # config variables for ffi.h.in
 set(VERSION 3.4.2)
 
-set(KNOWN_PROCESSORS x86 x86_64 amd64 arm arm64 i386 i686 armv7l armv7-a aarch64)
+set(KNOWN_PROCESSORS x86 x86_64 amd64 arm arm64 i386 i686 armv7l armv7-a aarch64 mips64el)
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" lower_system_processor)
 
@@ -29,6 +29,8 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows" AND VCPKG_TARGET_ARCHITECTURE STREQUA
     set(TARGET X86_WIN64)
 elseif(lower_system_processor MATCHES "arm64|aarch64")
     set(TARGET ARM64)
+elseif(lower_system_processor MATCHES "mips64")
+    set(TARGET MIPS64)
 elseif(lower_system_processor MATCHES "arm")
     set(TARGET ARM)
 elseif(CMAKE_SYSTEM_NAME MATCHES "BSD" AND CMAKE_SIZEOF_VOID_P EQUAL 4)
@@ -43,7 +45,7 @@ else()
     message(FATAL_ERROR "Cannot determine target. Please consult ${CMAKE_CURRENT_SOURCE_DIR}/configure.ac and add your platform to this CMake file.")
 endif()
 
-if("${TARGET}" STREQUAL "X86_64")
+if("${TARGET}" STREQUAL "X86_64" OR "${TARGET}" STREQUAL "MIPS64")
     set(HAVE_LONG_DOUBLE 1)
 else()
     set(HAVE_LONG_DOUBLE 0)
@@ -58,6 +60,8 @@ if ("${TARGET}" STREQUAL "ARM_WIN64" OR "${TARGET}" STREQUAL "ARM64")
     file(COPY src/aarch64/ffitarget.h DESTINATION ${CMAKE_BINARY_DIR}/include)
 elseif ("${TARGET}" STREQUAL "ARM_WIN32" OR "${TARGET}" STREQUAL "ARM")
     file(COPY src/arm/ffitarget.h DESTINATION ${CMAKE_BINARY_DIR}/include)
+elseif ("${TARGET}" MATCHES "MIPS")
+    file(COPY src/mips/ffitarget.h DESTINATION ${CMAKE_BINARY_DIR}/include)
 else()
     file(COPY src/x86/ffitarget.h DESTINATION ${CMAKE_BINARY_DIR}/include)
 endif()
@@ -85,6 +89,10 @@ elseif("${TARGET}" STREQUAL "ARM_WIN32" OR "${TARGET}" STREQUAL "ARM")
     set(FFI_SOURCES
         ${FFI_SOURCES}
         src/arm/ffi.c)
+elseif("${TARGET}" MATCHES "MIPS")
+    set(FFI_SOURCES
+        ${FFI_SOURCES}
+        src/mips/ffi.c)
 else()
     set(FFI_SOURCES
         ${FFI_SOURCES}
@@ -189,6 +197,8 @@ elseif("${TARGET}" STREQUAL "ARM_WIN64")
     endif()
 elseif("${TARGET}" STREQUAL "ARM64")
     add_assembly(src/aarch64/sysv.S)
+elseif("${TARGET}" MATCHES "MIPS")
+    add_assembly(src/mips/n32.S)
 else()
     message(FATAL_ERROR "Target not implemented")
 endif()

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libffi",
   "version": "3.4.2",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3622,7 +3622,7 @@
     },
     "libffi": {
       "baseline": "3.4.2",
-      "port-version": 5
+      "port-version": 6
     },
     "libfido2": {
       "baseline": "1.10.0",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d484f79a6c1e9cd25a8a4791af0c9a40fc26b51",
+      "version": "3.4.2",
+      "port-version": 6
+    },
+    {
       "git-tree": "14f8b4d7dc645ea8f2ddfe77eeaaeef55f123cb5",
       "version": "3.4.2",
       "port-version": 5


### PR DESCRIPTION
Add support for mips64el.

- #### What does your PR fix?
  Fix configuration failure for mips64.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  linux, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Basically

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
