### PR TITLE
[pixman] add mips64 support

### DIFF
--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -27,6 +27,12 @@ elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "arm")
                -Dsse2=disabled
                -Dssse3=disabled
        )
+elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "mips")
+    list(APPEND OPTIONS
+            -Dmmx=disabled
+            -Dsse2=disabled
+            -Dssse3=disabled
+    )
 endif()
 
 set(PIXMAN_VERSION 0.40.0)

--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -21,18 +21,16 @@ elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
             -Dsse2=enabled
             -Dssse3=enabled)
 elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "arm")
-   list(APPEND OPTIONS
-               #-Darm-simd=enabled does not work with arm64-windows
-               -Dmmx=disabled
-               -Dsse2=disabled
-               -Dssse3=disabled
-       )
+    list(APPEND OPTIONS
+            #-Darm-simd=enabled does not work with arm64-windows
+            -Dmmx=disabled
+            -Dsse2=disabled
+            -Dssse3=disabled)
 elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "mips")
     list(APPEND OPTIONS
             -Dmmx=disabled
             -Dsse2=disabled
-            -Dssse3=disabled
-    )
+            -Dssse3=disabled)
 endif()
 
 set(PIXMAN_VERSION 0.40.0)

--- a/ports/pixman/vcpkg.json
+++ b/ports/pixman/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pixman",
   "version": "0.40.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.",
   "homepage": "https://www.cairographics.org/releases",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5522,7 +5522,7 @@
     },
     "pixman": {
       "baseline": "0.40.0",
-      "port-version": 2
+      "port-version": 3
     },
     "pkgconf": {
       "baseline": "1.8.0",

--- a/versions/p-/pixman.json
+++ b/versions/p-/pixman.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b78deaa194593587d680a5642ffb2b2194bfcbda",
+      "version": "0.40.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "85d5aa0bbd91cff8853d0767bc9dc73e97156291",
       "version": "0.40.0",
       "port-version": 2

--- a/versions/p-/pixman.json
+++ b/versions/p-/pixman.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b78deaa194593587d680a5642ffb2b2194bfcbda",
+      "git-tree": "f6930f7300af86c20679b38f53bbdbc1a1310eed",
       "version": "0.40.0",
       "port-version": 3
     },


### PR DESCRIPTION
Add support for mips64.

- #### What does your PR fix?
  Fix build failure for mips64.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  linux, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Basically.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
