### PR TITLE
[dv-processing] Update to hotfix release 1.5.1

### DIFF
--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
         GITLAB_URL https://gitlab.com/inivation
         OUT_SOURCE_PATH SOURCE_PATH
         REPO dv/dv-processing
-        REF 96d082a862bb1e5bfdc79b39aa09e7a50c2dac49
-        SHA512 cf74e8a6f94f690e159778b59eb2e4d9c8f51f09437e94a507a2ec8f42e167fe6d1413ba91ab608624a02b4b479b27f454e7b7792d125ce5a163f4aa98e774cc
+        REF 6029bb4ecc06566b5f68375c68f00dfe78587baa
+        SHA512 9d0928e6ded1dab147814f380c57fb5b2c467c213c1fd12dddad9982e7d6a94a7bef526fcd248dd672b4b84753a44599b10d7794640ec63027152cd33b675787
         HEAD_REF rel_1.5
 )
 

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dv-processing",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Generic algorithms for event cameras.",
   "homepage": "https://gitlab.com/inivation/dv/dv-processing",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2009,7 +2009,7 @@
       "port-version": 2
     },
     "dv-processing": {
-      "baseline": "1.5.0",
+      "baseline": "1.5.1",
       "port-version": 0
     },
     "dx": {

--- a/versions/d-/dv-processing.json
+++ b/versions/d-/dv-processing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fb27b7a8c1ee9bd01035958e7b3b3a487a89dd8",
+      "version": "1.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e45cf567d2617df07999f47cff84636f513a0c1c",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
Updates dv-processing to version 1.5.1.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes
