### PR TITLE
[bdwgc] Installing pkg-config files for debug builds

### DIFF
--- a/ports/bdwgc/portfile.cmake
+++ b/ports/bdwgc/portfile.cmake
@@ -12,8 +12,6 @@ vcpkg_cmake_configure(
         -Denable_cplusplus=ON
         -Denable_docs=OFF
         -DCFLAGS_EXTRA=-I${CURRENT_INSTALLED_DIR}/include # for libatomic_ops
-    OPTIONS_DEBUG
-        -Dinstall_headers=OFF
 )
 
 vcpkg_cmake_install()
@@ -21,6 +19,7 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/bdwgc)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/bdwgc/vcpkg.json
+++ b/ports/bdwgc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "bdwgc",
   "version": "8.2.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The Boehm-Demers-Weiser conservative C/C++ Garbage Collector (libgc, bdwgc, boehm-gc)",
   "homepage": "http://www.hboehm.info/gc/",
   "dependencies": [

--- a/versions/b-/bdwgc.json
+++ b/versions/b-/bdwgc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fe23b71dde5d4abc9a755c359a583b8d7ba3035",
+      "version": "8.2.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "1cf3b7a458af2eba78e5af9674e8f6d28b53e254",
       "version": "8.2.0",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -422,7 +422,7 @@
     },
     "bdwgc": {
       "baseline": "8.2.0",
-      "port-version": 3
+      "port-version": 4
     },
     "beast": {
       "baseline": "0",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
This PR fixes incorrect library output for debug builds, resulting in missing `.pc` files

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
- all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
