### PR TITLE
[libwebp] Update to 1.2.4

### DIFF
--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libwebp
-    REF v1.2.3
-    SHA512 27f86817350e6d0e215c449665046df8c63203344f9a2846770af292ce8fee486a72adfd5e1122aa67e7d2f3e3972cd8423da95fee7edf10c9848bcbda46264c
+    REF v1.2.4
+    SHA512 85c7d2bd1697ed6f18d565056d0105edd63697f144d2c935e9c0563ff09f4acc56d4ac509668f920e8d5dc3c74b53a42f65265fc758fed173cb2168c4d6a551c
     HEAD_REF master
     PATCHES
         0002-cmake-config.patch
@@ -79,13 +79,3 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
 endif()
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-# For compatibility
-file(READ "${CURRENT_PACKAGES_DIR}/share/WebP/WebPTargets.cmake" contents)
-string(APPEND contents "
-if(NOT TARGET WebP::libwebpmux)
-  add_library(WebP::libwebpmux INTERFACE IMPORTED)
-  set_target_properties(WebP::libwebpmux PROPERTIES INTERFACE_LINK_LIBRARIES WebP::webpmux)
-endif()
-")
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/WebP/WebPTargets.cmake" "${contents}")

--- a/ports/libwebp/vcpkg.json
+++ b/ports/libwebp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libwebp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "WebP codec: library to encode and decode images in WebP format",
   "homepage": "https://github.com/webmproject/libwebp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4253,7 +4253,7 @@
       "port-version": 1
     },
     "libwebp": {
-      "baseline": "1.2.3",
+      "baseline": "1.2.4",
       "port-version": 0
     },
     "libwebsockets": {

--- a/versions/l-/libwebp.json
+++ b/versions/l-/libwebp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6bce9ad4c595a817fb1f227661c5bc955b177754",
+      "version": "1.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "e2b9421b3093512c54494cf01a3fd6edb7424e02",
       "version": "1.2.3",
       "port-version": 0


### PR DESCRIPTION
Updated to latest release.  Removed the webpmux->libwebpmux fixup, as it has been addressed upstream.

https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.2.4

- #### What does your PR fix?
  Updates to new libwebp release version

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes