### PR TITLE
[libjpeg-turbo] Update to 2.1.4

### DIFF
--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libjpeg-turbo/libjpeg-turbo
-    REF c5f269eb9665435271c05fbcaf8721fa58e9eafa # 2.1.3
-    SHA512 5d1c3cbbc7628339cfedc0f81a65ceb972aba2b8ffcc72d001f87526d0ff468f83665c78165051aa95c39200d9aaa6aee76e01266a4ea9cddb678dc6ef17ec27
+    REF 2.1.4
+    SHA512 d3e92d614168355827e0ed884ff847cc7df8f6f1fb7b673c6c99afdf61fdfc0372afe5d30fdbf5e743335e2a7a27ca9f510c67d213e5cb2315a8d946e9414575
     HEAD_REF master
     PATCHES
         add-options-for-exes-docs-headers.patch

--- a/ports/libjpeg-turbo/vcpkg.json
+++ b/ports/libjpeg-turbo/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libjpeg-turbo",
-  "version": "2.1.3",
-  "port-version": 3,
+  "version": "2.1.4",
   "description": "libjpeg-turbo is a JPEG image codec that uses SIMD instructions (MMX, SSE2, NEON, AltiVec) to accelerate baseline JPEG compression and decompression on x86, x86-64, ARM, and PowerPC systems.",
   "homepage": "https://github.com/libjpeg-turbo/libjpeg-turbo",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3761,8 +3761,8 @@
       "port-version": 4
     },
     "libjpeg-turbo": {
-      "baseline": "2.1.3",
-      "port-version": 3
+      "baseline": "2.1.4",
+      "port-version": 0
     },
     "libjuice": {
       "baseline": "1.0.3",

--- a/versions/l-/libjpeg-turbo.json
+++ b/versions/l-/libjpeg-turbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07c9848d16ee346b314e87e6c0d856bfb0745af9",
+      "version": "2.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "f3ab7c40b47aa03953467e7697d3eea7b60d624e",
       "version": "2.1.3",
       "port-version": 3


### PR DESCRIPTION
Updates to latest release.  https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.1.4

- #### What does your PR fix?
  Updates to libjpeg-turbo 2.1.4

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes