### PR TITLE
[szip] add definitions for the try_run call for iOS

### DIFF
--- a/ports/szip/portfile.cmake
+++ b/ports/szip/portfile.cmake
@@ -14,11 +14,23 @@ vcpkg_extract_source_archive_ex(
         mingw-lib-names.patch
 )
 
+if (VCPKG_TARGET_IS_IOS)
+    # when cross-compiling, try_run will not work.
+    # LFS "large file support" is keyed on 
+    # 1) 64-bit off_t (https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/transition/transition.html table 2-1)
+    # 2) stat works properly, which is true
+    set(extra_opts 
+        -DTEST_LFS_WORKS_RUN=TRUE
+        -DTEST_LFS_WORKS_RUN__TRYRUN_OUTPUT=""
+    )
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSZIP_INSTALL_DATA_DIR=share/szip/data
         -DSZIP_INSTALL_CMAKE_DIR=share/szip
+        ${extra_opts}
 )
 
 vcpkg_cmake_install()

--- a/ports/szip/vcpkg.json
+++ b/ports/szip/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "szip",
   "version": "2.1.1",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Szip compression software, providing lossless compression of scientific data",
   "homepage": "https://support.hdfgroup.org/ftp/lib-external/szip",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6974,7 +6974,7 @@
     },
     "szip": {
       "baseline": "2.1.1",
-      "port-version": 8
+      "port-version": 9
     },
     "tabulate": {
       "baseline": "2019-01-06",

--- a/versions/s-/szip.json
+++ b/versions/s-/szip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f07c4350652c50e80bc78edb3db20a1c748d99ec",
+      "version": "2.1.1",
+      "port-version": 9
+    },
+    {
       "git-tree": "0c8569ffc46401d06cff22755c0b95953ce5e828",
       "version": "2.1.1",
       "port-version": 8


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes building szip for iOS

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
arm64-ios and arm-ios were tested, and they build. I currently have no way to confirm functionality, but I have checked that my additions should be correct in theory.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

It seems like it. My comments may be too verbose, but I think they're helpful to know why the cached output is correct and acceptable. 

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes