### PR TITLE
[guile] Added guile port

### DIFF
--- a/ports/guile/portfile.cmake
+++ b/ports/guile/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_download_distfile(GUILE_ARCHIVE 
+      URLS https://ftp.gnu.org/gnu/guile/guile-3.0.8.tar.gz
+      FILENAME guile-3.0.8.tar.gz
+      SHA512 7b2728e849a3ee482fe9a167dd76cc4835e911cc94ca0724dd51e8a813a240c6b5d2de84de16b46469ab24305b5b153a3c812fec942e007d3310bba4d1cf947d
+  )
+
+vcpkg_extract_source_archive(GUILE_SOURCES ARCHIVE ${GUILE_ARCHIVE})
+
+vcpkg_configure_make(
+    SOURCE_PATH "${GUILE_SOURCES}"
+    ADD_BIN_TO_PATH
+    AUTOCONFIG
+  )
+vcpkg_install_make()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_fixup_pkgconfig()
+
+file(
+    INSTALL "${GUILE_SOURCES}/COPYING.LESSER" 
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" 
+    RENAME copyright
+  )

--- a/ports/guile/vcpkg.json
+++ b/ports/guile/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "guile",
+  "version": "3.0.8",
+  "description": "GNU's programming and extension language",
+  "homepage": "https://www.gnu.org/software/guile/",
+  "documentation": "https://www.gnu.org/software/guile/manual/",
+  "license": "LGPL-3.0-or-later",
+  "supports": "linux",
+  "dependencies": [
+    "bdwgc",
+    {
+      "name": "gettext",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
+    "gmp",
+    "libffi",
+    "libunistring"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2756,6 +2756,10 @@
       "baseline": "2020-09-14",
       "port-version": 2
     },
+    "guile": {
+      "baseline": "3.0.8",
+      "port-version": 0
+    },
     "guilite": {
       "baseline": "2022-05-05",
       "port-version": 0

--- a/versions/g-/guile.json
+++ b/versions/g-/guile.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1c74041cde8519afb26d9fa588b8d24877d35514",
+      "version": "3.0.8",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #11252

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
This port currently only supports linux platforms.

Guile is notoriously tricky to build on non-GNU platforms so this isn't really a surprise to me. I believe these triples will be supportable with further patching/test work, but that is not something I'm able to do for this initial port.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

