### PR TITLE
[harfbuzz] fix build on arm osx

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -36,7 +36,7 @@ list(APPEND FEATURE_OPTIONS -Dfreetype=enabled) #Enable freetype interop helpers
     #list(APPEND FEATURE_OPTIONS -Dgdi=enabled) # enable gdi helpers and uniscribe shaper backend (windows only)
 #endif()
 
-
+set(ENV{CXXFLAGS} "$ENV{CXXFLAGS} -Wno-error")
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "harfbuzz",
   "version": "5.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2794,7 +2794,7 @@
     },
     "harfbuzz": {
       "baseline": "5.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a705eebb7d2f6255c2619912ed6d0d9dca7de9e0",
+      "version": "5.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "64cea6fad2515aeabcdb82768bbb9b4b30db7af6",
       "version": "5.0.1",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Build error:

```
[52/65] /Library/Developer/CommandLineTools/usr/bin/c++ -Isrc/libharfbuzz.a.p -Isrc -I../src/3.2.0-8c7a14e743.clean/src -I. -I../src/3.2.0-8c7a14e743.clean -I/Users/sokolov/AbyssEngine/build/vcpkg_installed/arm64-osx/lib/pkgconfig/../../include -I/Users/sokolov/AbyssEngine/build/vcpkg_installed/arm64-osx/lib/pkgconfig/../../include/libpng16 -I/Users/sokolov/AbyssEngine/build/vcpkg_installed/arm64-osx/include -fcolor-diagnostics -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++11 -fno-rtti -O0 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fvisibility-inlines-hidden -DHAVE_CONFIG_H -fPIC -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -O3 -DNDEBUG -Wno-non-virtual-dtor -MD -MQ src/libharfbuzz.a.p/hb-coretext.cc.o -MF src/libharfbuzz.a.p/hb-coretext.cc.o.d -o src/libharfbuzz.a.p/hb-coretext.cc.o -c ../src/3.2.0-8c7a14e743.clean/src/hb-coretext.cc
FAILED: src/libharfbuzz.a.p/hb-coretext.cc.o
/Library/Developer/CommandLineTools/usr/bin/c++ -Isrc/libharfbuzz.a.p -Isrc -I../src/3.2.0-8c7a14e743.clean/src -I. -I../src/3.2.0-8c7a14e743.clean -I/Users/sokolov/AbyssEngine/build/vcpkg_installed/arm64-osx/lib/pkgconfig/../../include -I/Users/sokolov/AbyssEngine/build/vcpkg_installed/arm64-osx/lib/pkgconfig/../../include/libpng16 -I/Users/sokolov/AbyssEngine/build/vcpkg_installed/arm64-osx/include -fcolor-diagnostics -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++11 -fno-rtti -O0 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fvisibility-inlines-hidden -DHAVE_CONFIG_H -fPIC -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -O3 -DNDEBUG -Wno-non-virtual-dtor -MD -MQ src/libharfbuzz.a.p/hb-coretext.cc.o -MF src/libharfbuzz.a.p/hb-coretext.cc.o.d -o src/libharfbuzz.a.p/hb-coretext.cc.o -c ../src/3.2.0-8c7a14e743.clean/src/hb-coretext.cc
../src/3.2.0-8c7a14e743.clean/src/hb-coretext.cc:900:14: error: variable 'status_and' set but not used [-Werror,-Wunused-but-set-variable]
    uint32_t status_and = ~0, status_or = 0;
             ^
1 error generated.
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
