### PR TITLE
[vcpkg baseline][graphviz] Disable parallel build

### DIFF
--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -52,7 +52,7 @@ vcpkg_cmake_configure(
         ${EXTRA_CMAKE_OPTION}
 )
 
-vcpkg_cmake_install()
+vcpkg_cmake_install(DISABLE_PARALLEL)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/graphviz/vcpkg.json
+++ b/ports/graphviz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "graphviz",
   "version-semver": "2.49.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Graph Visualization Tools",
   "homepage": "https://graphviz.org/",
   "license": "EPL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2698,7 +2698,7 @@
     },
     "graphviz": {
       "baseline": "2.49.1",
-      "port-version": 4
+      "port-version": 5
     },
     "greatest": {
       "baseline": "1.5.0",

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d785814e6645604fad637a4cb66d9c308316c5d7",
+      "version-semver": "2.49.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "14f5333a2eb91b052b2691132f48aefced3bf1df",
       "version-semver": "2.49.1",
       "port-version": 4


### PR DESCRIPTION
Fix build error:
```
[80/429] C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1432~1.313\bin\Hostx64\x64\cl.exe   -DDIGCOLA -DENABLE_LTDL -DGVC_EXPORTS -DORTHO -DSFDP -D_BLD_gvc=1 -ID:\buildtrees\graphviz\x64-windows-dbg -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\common -ID:\buildtrees\graphviz\x64-windows-dbg\lib\common -ID:\installed\x64-windows\include -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\cdt -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\cgraph -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\gvc -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\pack -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\pathplan -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\xdot -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\windows\dependencies\libraries\x64\include /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /MP  /wd4996 /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1 /showIncludes /Folib\common\CMakeFiles\common_obj.dir\htmlparse.c.obj /Fdlib\common\CMakeFiles\common_obj.dir\ /FS -c D:\buildtrees\graphviz\x64-windows-dbg\lib\common\htmlparse.c
FAILED: lib/common/CMakeFiles/common_obj.dir/htmlparse.c.obj 
C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1432~1.313\bin\Hostx64\x64\cl.exe   -DDIGCOLA -DENABLE_LTDL -DGVC_EXPORTS -DORTHO -DSFDP -D_BLD_gvc=1 -ID:\buildtrees\graphviz\x64-windows-dbg -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\common -ID:\buildtrees\graphviz\x64-windows-dbg\lib\common -ID:\installed\x64-windows\include -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\cdt -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\cgraph -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\gvc -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\pack -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\pathplan -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\lib\xdot -ID:\buildtrees\graphviz\src\2.49.1-1bd4140719.clean\windows\dependencies\libraries\x64\include /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /MP  /wd4996 /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1 /showIncludes /Folib\common\CMakeFiles\common_obj.dir\htmlparse.c.obj /Fdlib\common\CMakeFiles\common_obj.dir\ /FS -c D:\buildtrees\graphviz\x64-windows-dbg\lib\common\htmlparse.c
c1: fatal error C1083: Cannot open source file: 'D:\buildtrees\graphviz\x64-windows-dbg\lib\common\htmlparse.c': No such file or directory
```
Related code:
```cmake
BISON_TARGET(HTMLparse ${CMAKE_CURRENT_SOURCE_DIR}/htmlparse.y ${CMAKE_CURRENT_BINARY_DIR}/htmlparse.c)
```

Related: #26326.