### PR TITLE
[libsquish] Fix usage

### DIFF
--- a/ports/libsquish/export-target.patch
+++ b/ports/libsquish/export-target.patch
@@ -1,8 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a3ecdde..94c7b3d 100644
+index a3ecdde..6aa9e64 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -120,8 +120,14 @@ INCLUDE(GNUInstallDirs)
+@@ -75,6 +75,8 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+ 
+ ADD_LIBRARY(squish ${SQUISH_SRCS} ${SQUISH_HDRS})
+ 
++TARGET_INCLUDE_DIRECTORIES(squish PUBLIC $<INSTALL_INTERFACE:include>)
++
+ INCLUDE(GenerateExportHeader)
+ GENERATE_EXPORT_HEADER(squish
+     EXPORT_FILE_NAME ${CMAKE_CURRENT_SOURCE_DIR}/squish_export.h
+@@ -120,8 +122,14 @@ INCLUDE(GNUInstallDirs)
  
  INSTALL(
      TARGETS squish

--- a/ports/libsquish/vcpkg.json
+++ b/ports/libsquish/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsquish",
   "version": "1.15",
-  "port-version": 11,
+  "port-version": 12,
   "description": "Open source DXT compression library.",
   "homepage": "https://sourceforge.net/projects/libsquish",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4114,7 +4114,7 @@
     },
     "libsquish": {
       "baseline": "1.15",
-      "port-version": 11
+      "port-version": 12
     },
     "libsrt": {
       "baseline": "1.5.0",

--- a/versions/l-/libsquish.json
+++ b/versions/l-/libsquish.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a7a36071f8261b00c8720cbf8024df31c15650f",
+      "version": "1.15",
+      "port-version": 12
+    },
+    {
       "git-tree": "3c259e069413fc51d82423f6c9842ad285e210e9",
       "version": "1.15",
       "port-version": 11


### PR DESCRIPTION
Export the `INTERFACE_INCLUDE_DIRECTORIES` to fix the usage issue.

Fixes #26343.