### PR TITLE
[X264] Add arm64-windows by disabling asm

### DIFF
--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -19,6 +19,11 @@ if(VCPKG_TARGET_IS_WINDOWS)
     z_vcpkg_determine_autotools_target_cpu(HOST_ARCH)
     list(APPEND OPTIONS --build=${BUILD_ARCH}-pc-mingw32)
     list(APPEND OPTIONS --host=${HOST_ARCH}-pc-mingw32)
+    
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        list(APPEND OPTIONS --disable-asm)
+    endif()
+    
     set(ENV{AS} "${NASM}")
 endif()
 

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -4,7 +4,6 @@
   "port-version": 5,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://github.com/mirror/x264",
-  "supports": "!(arm & windows)",
   "dependencies": [
     {
       "name": "pthread",

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x264",
   "version-string": "164-5db6aa6cab1b146",
-  "port-version": 4,
+  "port-version": 5,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://github.com/mirror/x264",
   "supports": "!(arm & windows)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7710,7 +7710,7 @@
     },
     "x264": {
       "baseline": "164-5db6aa6cab1b146",
-      "port-version": 4
+      "port-version": 5
     },
     "x265": {
       "baseline": "3.4",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e5fcc84d89acf766a6094300203b3deeaaeed67",
+      "version-string": "164-5db6aa6cab1b146",
+      "port-version": 5
+    },
+    {
       "git-tree": "7eea109502309e62a578bcc69811ad0659e00f9d",
       "version-string": "164-5db6aa6cab1b146",
       "port-version": 4

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1e5fcc84d89acf766a6094300203b3deeaaeed67",
+      "git-tree": "59d158d37c92adf78716bc36f80a82853149e368",
       "version-string": "164-5db6aa6cab1b146",
       "port-version": 5
     },


### PR DESCRIPTION
**Describe the pull request**
These changes enable build of arm64-windows triplet for x264 by passing `--disable-asm` option.

- #### What does your PR fix?
  Adds `arm64-windows` support

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

