### PR TITLE
[opensp] minor fixes, new .pc file

### DIFF
--- a/ports/libopensp/opensp.pc.in
+++ b/ports/libopensp/opensp.pc.in
@@ -1,0 +1,12 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include/OpenSP
+
+Name: opensp
+Description: SGML parser algorithm library
+Version: @OPENSP_VERSION@
+Libs: -L${libdir} -losp
+Libs.private: @EXTRA_LIBS@
+Cflags: -I${includedir}
+Cflags.private:

--- a/ports/libopensp/portfile.cmake
+++ b/ports/libopensp/portfile.cmake
@@ -28,9 +28,9 @@ if (VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
 
     vcpkg_cmake_install()
 else()
-    set(EXTRA_OPTS "")
     if(VCPKG_TARGET_IS_OSX)
-        list(APPEND EXTRA_OPTS "LDFLAGS=-framework CoreFoundation \$LDFLAGS") # libintl links to it
+        # libintl links to those
+        set(EXTRA_LIBS "-framework CoreFoundation -lintl -liconv") 
     endif()
 
     vcpkg_configure_make(
@@ -38,12 +38,13 @@ else()
         SOURCE_PATH "${SOURCE_PATH}"
         OPTIONS
             --disable-doc-build
-            ${EXTRA_OPTS}
+            "LDFLAGS=${EXTRA_LIBS} \$LDFLAGS"
     )
 
     vcpkg_install_make()
 endif()
 
+configure_file("${CMAKE_CURRENT_LIST_DIR}/opensp.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/opensp.pc" @ONLY)
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 

--- a/ports/libopensp/portfile.cmake
+++ b/ports/libopensp/portfile.cmake
@@ -54,4 +54,5 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libopensp/vcpkg.json
+++ b/ports/libopensp/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "1.5.2",
   "description": "SGML parser algorithm",
   "homepage": "http://openjade.sourceforge.net",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "gettext",

--- a/ports/libopensp/vcpkg.json
+++ b/ports/libopensp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libopensp",
   "version": "1.5.2",
+  "port-version": 1,
   "description": "SGML parser algorithm",
   "homepage": "http://openjade.sourceforge.net",
   "license": "MIT",

--- a/ports/libopensp/windows_cmake_build.diff
+++ b/ports/libopensp/windows_cmake_build.diff
@@ -1,12 +1,8 @@
 diff -Nru -x '*~' OpenSP-1.5.2.orig/CMakeLists.txt OpenSP-1.5.2/CMakeLists.txt
 --- OpenSP-1.5.2.orig/CMakeLists.txt	1970-01-01 02:00:00.000000000 +0200
 +++ OpenSP-1.5.2/CMakeLists.txt	2014-08-24 17:23:19.941495700 +0300
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,20 @@
 +project(opensp)
-+
-+set (VERSION_MAJOR 1)
-+set (VERSION_MINOR 5)
-+set (VERSION_PATH 2)
 +
 +cmake_minimum_required(VERSION 2.6)
 +
@@ -54,7 +50,7 @@ diff -Nru -x '*~' OpenSP-1.5.2.orig/config.h OpenSP-1.5.2/config.h
  #define SP_HAVE_SETMODE
  #define SP_DLLEXPORT __declspec(dllexport)
  #define SP_DLLIMPORT __declspec(dllimport)
-@@ -301,15 +312,8 @@
+@@ -301,12 +312,5 @@
  #define PATH_SEPARATOR ':'
  #endif
  
@@ -66,12 +62,7 @@ diff -Nru -x '*~' OpenSP-1.5.2.orig/config.h OpenSP-1.5.2/config.h
 -#endif
 -
  // NOTE: This is processed as a Makefile, not as a header by autoconf.
--#define SP_PACKAGE "OpenSP"
--#define SP_VERSION "1.5.2"
-+#define SP_PACKAGE "@PACKAGE@"
-+#define SP_VERSION "@VERSION@"
- 
- #endif /* not config_INCLUDED */
+ #define SP_PACKAGE "OpenSP"
 diff -Nru -x '*~' OpenSP-1.5.2.orig/generic/SGMLApplication.h OpenSP-1.5.2/generic/SGMLApplication.h
 --- OpenSP-1.5.2.orig/generic/SGMLApplication.h	2005-05-14 12:17:41.000000000 +0300
 +++ OpenSP-1.5.2/generic/SGMLApplication.h	2014-08-24 17:23:19.957120700 +0300

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3930,7 +3930,7 @@
     },
     "libopensp": {
       "baseline": "1.5.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libopusenc": {
       "baseline": "0.2.1",

--- a/versions/l-/libopensp.json
+++ b/versions/l-/libopensp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c38530c26ffb1fc7fb2e0bd40f76ca8fa2bfb57",
+      "version": "1.5.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "4b7d728266ee8b4e03f27a619cbf9efc9484cbb6",
       "version": "1.5.2",
       "port-version": 0

--- a/versions/l-/libopensp.json
+++ b/versions/l-/libopensp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c52391221569480b2e639b0e07a9e809e7711320",
+      "git-tree": "4b7d728266ee8b4e03f27a619cbf9efc9484cbb6",
       "version": "1.5.2",
       "port-version": 0
     }


### PR DESCRIPTION
- #### What does your PR fix?
  - Fixes version missing from `.config.h` on Windows
  - Installs a .pc file

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes