### PR TITLE
[matplotplusplus] update to 1.1.0

### DIFF
--- a/ports/matplotplusplus/portfile.cmake
+++ b/ports/matplotplusplus/portfile.cmake
@@ -9,8 +9,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alandefreitas/matplotplusplus
-    REF 36d8dc6c3b94b7a71c4f129763f2c6ad8fc0b54a
-    SHA512 ac8902e953a2a9f6bd62e14e2eb0bd42e407bae6c0b2921ad16ce547e4921ba2c8d8a9cc68e75831676dce3cd89cdf8294862710e838510b68e20f8a6cdf806f
+    REF b45015e2be88e3340b400f82637b603d733d45ce  #v1.1.0
+    SHA512 c1eeaa8828a4f8c5b899b4222510e181a2036353b0bf6f1deb89b9d61273d5e4ab0d36ae0214dd171cf2737777f24fd6f250ec2d6074f6c20d3c69b7579a6a7a
     HEAD_REF master
     PATCHES
         install-3rd-libraries.patch # Remove this patch when nodesoup is added in vcpkg
@@ -33,7 +33,6 @@ vcpkg_check_features(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}
-        -DCPM_USE_LOCAL_PACKAGES=ON
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TESTS=OFF
         -DBUILD_INSTALLER=ON

--- a/ports/matplotplusplus/vcpkg.json
+++ b/ports/matplotplusplus/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "matplotplusplus",
-  "version-date": "2021-04-11",
-  "port-version": 6,
+  "version": "1.1.0",
   "description": "A C++ graphics library for data visualization",
   "homepage": "https://alandefreitas.github.io/matplotplusplus/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4517,8 +4517,8 @@
       "port-version": 1
     },
     "matplotplusplus": {
-      "baseline": "2021-04-11",
-      "port-version": 6
+      "baseline": "1.1.0",
+      "port-version": 0
     },
     "matroska": {
       "baseline": "1.6.3",

--- a/versions/m-/matplotplusplus.json
+++ b/versions/m-/matplotplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1531798151c3ba8555940c36502c02613907605a",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8554ae7ec807245bdcd27b44ddebd39608edfe53",
       "version-date": "2021-04-11",
       "port-version": 6


### PR DESCRIPTION
Fix #26347

Update matplotplusplus to the latest version 1.1.0

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static