### PR TITLE
[opus/x265] Fix version in pkgconfig

### DIFF
--- a/ports/opus/fix-pkgconfig-version.patch
+++ b/ports/opus/fix-pkgconfig-version.patch
@@ -1,0 +1,13 @@
+diff --git a/opus_functions.cmake b/opus_functions.cmake
+index a3ac1c0..ef2d4c0 100644
+--- a/opus_functions.cmake
++++ b/opus_functions.cmake
+@@ -43,6 +43,8 @@ function(get_library_version OPUS_LIBRARY_VERSION OPUS_LIBRARY_VERSION_MAJOR)
+ endfunction()
+ 
+ function(get_package_version PACKAGE_VERSION)
++  set(PACKAGE_VERSION "0" CACHE STRING "opus package version")
++  return()
+   find_package(Git)
+   if(Git_FOUND AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git")
+     execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --match "v*"

--- a/ports/opus/portfile.cmake
+++ b/ports/opus/portfile.cmake
@@ -1,43 +1,44 @@
 vcpkg_from_github(
-  OUT_SOURCE_PATH
-  SOURCE_PATH
-  REPO
-  xiph/opus
-  REF
-  5c94ec3205c30171ffd01056f5b4622b7c0ab54c
-  SHA512
-  2423b1fc86d5b46c32d8e3bde5fc2b410a5c25c001995ce234a94a3a6c7a8b1446fdf19eafe9d6a8a7356fe0857697053db5eb8380d18f8111818aa770b4c4ea
-  HEAD_REF
-  master)
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO xiph/opus
+    REF 5c94ec3205c30171ffd01056f5b4622b7c0ab54c
+    SHA512 2423b1fc86d5b46c32d8e3bde5fc2b410a5c25c001995ce234a94a3a6c7a8b1446fdf19eafe9d6a8a7356fe0857697053db5eb8380d18f8111818aa770b4c4ea
+    HEAD_REF master
+    PATCHES fix-pkgconfig-version.patch
+)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-  avx AVX_SUPPORTED
+    FEATURES
+        avx AVX_SUPPORTED
 )
 
 if(VCPKG_TARGET_IS_MINGW)
-  set(STACK_PROTECTOR OFF)
-  string(APPEND VCPKG_C_FLAGS "-D_FORTIFY_SOURCE=0")
-  string(APPEND VCPKG_CXX_FLAGS "-D_FORTIFY_SOURCE=0")
+    set(STACK_PROTECTOR OFF)
+    string(APPEND VCPKG_C_FLAGS "-D_FORTIFY_SOURCE=0")
+    string(APPEND VCPKG_CXX_FLAGS "-D_FORTIFY_SOURCE=0")
 else()
-  set(STACK_PROTECTOR ON)
+    set(STACK_PROTECTOR ON)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}
-            -DOPUS_STACK_PROTECTOR=${STACK_PROTECTOR}
-    PREFER_NINJA)
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Opus)
+        -DPACKAGE_VERSION=1.3.1
+        -DOPUS_STACK_PROTECTOR=${STACK_PROTECTOR}
+        -DOPUS_INSTALL_PKG_CONFIG_MODULE=ON
+        -DOPUS_INSTALL_CMAKE_CONFIG_MODULE=ON
+        -DOPUS_BUILD_PROGRAMS=OFF
+        -DOPUS_BUILD_TESTING=OFF
+)
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Opus)
 vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES m)
 
-file(INSTALL
-     ${SOURCE_PATH}/COPYING
-     DESTINATION
-     ${CURRENT_PACKAGES_DIR}/share/opus
-     RENAME copyright)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
-                    ${CURRENT_PACKAGES_DIR}/lib/cmake
-                    ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
+                    "${CURRENT_PACKAGES_DIR}/lib/cmake"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/opus/vcpkg.json
+++ b/ports/opus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "opus",
-  "version-string": "1.3.1",
+  "version": "1.3.1",
   "port-version": 6,
   "description": "Totally open, royalty-free, highly versatile audio codec",
   "homepage": "https://github.com/xiph/opus",

--- a/ports/opus/vcpkg.json
+++ b/ports/opus/vcpkg.json
@@ -4,6 +4,17 @@
   "port-version": 6,
   "description": "Totally open, royalty-free, highly versatile audio codec",
   "homepage": "https://github.com/xiph/opus",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "avx": {
       "description": "Builds the library with avx instruction set"

--- a/ports/opus/vcpkg.json
+++ b/ports/opus/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opus",
   "version": "1.3.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Totally open, royalty-free, highly versatile audio codec",
   "homepage": "https://github.com/xiph/opus",
   "license": "BSD-3-Clause",

--- a/ports/x265/fix-pkgconfig-version.patch
+++ b/ports/x265/fix-pkgconfig-version.patch
@@ -1,0 +1,13 @@
+diff --git a/source/cmake/version.cmake b/source/cmake/version.cmake
+index b1e995f..d7df148 100644
+--- a/source/cmake/version.cmake
++++ b/source/cmake/version.cmake
+@@ -7,7 +7,7 @@ find_package(Git QUIET) # present in 2.8.8
+ 
+ # defaults, in case everything below fails
+ set(X265_VERSION "unknown")
+-set(X265_LATEST_TAG "0.0")
++set(X265_LATEST_TAG "0.0" CACHE STRING "x265 version")
+ set(X265_TAG_DISTANCE "0")
+ 
+ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../.hg_archival.txt)

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         disable-install-pdb.patch
+        fix-pkgconfig-version.patch
 )
 
 set(ASSEMBLY_OPTIONS "-DENABLE_ASSEMBLY=OFF")
@@ -22,6 +23,7 @@ vcpkg_cmake_configure(
         ${ASSEMBLY_OPTIONS}
         -DENABLE_SHARED=${ENABLE_SHARED}
         -DENABLE_LIBNUMA=OFF
+        -DX265_LATEST_TAG=3.4
     OPTIONS_DEBUG
         -DENABLE_CLI=OFF
     MAYBE_UNUSED_VARIABLES

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x265",
   "version": "3.4",
-  "port-version": 6,
+  "port-version": 7,
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
   "homepage": "https://github.com/videolan/x265",
   "license": "GPL-2.0",

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 7,
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
   "homepage": "https://github.com/videolan/x265",
-  "license": "GPL-2.0",
+  "license": "GPL-2.0-or-later",
   "supports": "!(uwp | arm)",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5330,7 +5330,7 @@
     },
     "opus": {
       "baseline": "1.3.1",
-      "port-version": 6
+      "port-version": 7
     },
     "opusfile": {
       "baseline": "0.12",
@@ -7714,7 +7714,7 @@
     },
     "x265": {
       "baseline": "3.4",
-      "port-version": 6
+      "port-version": 7
     },
     "xalan-c": {
       "baseline": "1.12",

--- a/versions/o-/opus.json
+++ b/versions/o-/opus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8db6dcfda566f3822159cde54020c73a8c170c7a",
+      "version": "1.3.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "e718de4be5f3dcb0e0c7922a9ef7ef13bf5148b3",
       "version-string": "1.3.1",
       "port-version": 6

--- a/versions/o-/opus.json
+++ b/versions/o-/opus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8db6dcfda566f3822159cde54020c73a8c170c7a",
+      "git-tree": "ad2b9149564516603dab6b996af3d4bc7ba29017",
       "version": "1.3.1",
       "port-version": 7
     },

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f1df79aba5921d6feda30b4d497f14cd51700c74",
+      "git-tree": "994e11b88e86c790b503ec381185f33833b351f9",
       "version": "3.4",
       "port-version": 7
     },

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1df79aba5921d6feda30b4d497f14cd51700c74",
+      "version": "3.4",
+      "port-version": 7
+    },
+    {
       "git-tree": "15ee257957dfa5a194cf602c160713369b7c313a",
       "version": "3.4",
       "port-version": 6


### PR DESCRIPTION
Version control file (such as .git) is used in the source to extract the version number, but this is not available in the direct download package.
Add a fixed patch and pass in the version number to avoid extra changes to the source files.

Fixes #26369.
Fixes https://github.com/microsoft/vcpkg/issues/25680.