### PR TITLE
[folly] update to <v2022.08.15.00>

### DIFF
--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -8,8 +8,8 @@ vcpkg_add_to_path("${PYTHON3_DIR}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/folly
-    REF 4ba3bfed38ad14d0951d82b154c44235d380f59b #v2022.07.11.00
-    SHA512 d2dd31a42475e564d01a0e7d99b59382f0afd56d89beb189e580b654650d2f9316cbeb459a038f9534881f22efd1571494926c1ea88b827de6ac56317d3c135b
+    REF 46c03de426e26f4c5a92df37ab233c586fbe369a #v2022.08.15.00
+    SHA512 6798878d6892ed79d954fb5754ee102ea04868bce4be9be5dc7c6d6c7ddcbc5573719fe09470d89c385d9e487a75d1a9abc70c29c67698b957fc68b97a8bea32
     HEAD_REF main
     PATCHES
         reorder-glog-gflags.patch
@@ -56,8 +56,6 @@ vcpkg_cmake_configure(
         -DCMAKE_DISABLE_FIND_PACKAGE_Libiberty=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_LibAIO=ON
         -DLIBAIO_FOUND=OFF
-        -DLIBURCU_FOUND=OFF
-        -DCMAKE_DISABLE_FIND_PACKAGE_LibURCU=ON
         -DCMAKE_INSTALL_DIR=share/folly
         ${FEATURE_OPTIONS}
 )

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "folly",
-  "version-string": "2022.07.11.00",
+  "version-string": "2022.08.15.00",
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2329,7 +2329,7 @@
       "port-version": 0
     },
     "folly": {
-      "baseline": "2022.07.11.00",
+      "baseline": "2022.08.15.00",
       "port-version": 0
     },
     "font-chef": {

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f046523ca3488aa4e35d11656fcb15acb5b0f4f3",
+      "version-string": "2022.08.15.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "fcb721c422a09f612a5a83519d0c163c8cc83257",
       "version-string": "2022.07.11.00",
       "port-version": 0


### PR DESCRIPTION
Fix #26330 

Update folly to the latest version v2022.08.15.00

All features are tested successfully in the following triplet:
- x64-windows
- x64-windows-static