### PR TITLE
[raylib] update to 4.2.0

### DIFF
--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -17,8 +17,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO raysan5/raylib
-    REF 4.0.0
-    SHA512 e9ffab14ab902e3327202e68ca139209ff24100dab62eb03fef50adf363f81e2705d81e709c58cf1514e68e6061c8963555bd2d00744daacc3eb693825fc3417
+    REF bf2ad9df5fdcaa385b2a7f66fd85632eeebbadaa   #v4.2.0
+    SHA512 f6b1738d96fef89059062f570f67aaa8b143ccfbee78abfe5fbb25083371a4c432f3d1d0d357e4b475b4b72a6db7823c2341b70ac947759603b033c2b0acec47
     HEAD_REF master
     PATCHES ${patches}
 )
@@ -42,7 +42,6 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_EXAMPLES=OFF
-        -DBUILD_GAMES=OFF
         -DSHARED=${SHARED}
         -DSTATIC=${STATIC}
         -DUSE_EXTERNAL_GLFW=OFF # externl glfw3 causes build errors on Windows

--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -17,7 +17,7 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO raysan5/raylib
-    REF bf2ad9df5fdcaa385b2a7f66fd85632eeebbadaa   #v4.2.0
+    REF bf2ad9df5fdcaa385b2a7f66fd85632eeebbadaa #v4.2.0
     SHA512 f6b1738d96fef89059062f570f67aaa8b143ccfbee78abfe5fbb25083371a4c432f3d1d0d357e4b475b4b72a6db7823c2341b70ac947759603b033c2b0acec47
     HEAD_REF master
     PATCHES ${patches}

--- a/ports/raylib/vcpkg.json
+++ b/ports/raylib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "raylib",
-  "version-semver": "4.0.0",
-  "port-version": 3,
+  "version-semver": "4.2.0",
   "description": "A simple and easy-to-use library to enjoy videogames programming",
   "homepage": "https://github.com/raysan5/raylib",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6217,8 +6217,8 @@
       "port-version": 1
     },
     "raylib": {
-      "baseline": "4.0.0",
-      "port-version": 3
+      "baseline": "4.2.0",
+      "port-version": 0
     },
     "rbdl": {
       "baseline": "3.2.0",

--- a/versions/r-/raylib.json
+++ b/versions/r-/raylib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d9de76a6ecdbf6593109974a10f5838ba37a528",
+      "git-tree": "84270f09d9ecfed2207ea866910905fdfcf8b229",
       "version-semver": "4.2.0",
       "port-version": 0
     },

--- a/versions/r-/raylib.json
+++ b/versions/r-/raylib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d9de76a6ecdbf6593109974a10f5838ba37a528",
+      "version-semver": "4.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0b15021a8c0247cf83d5e4ca352b7e53b510b743",
       "version-semver": "4.0.0",
       "port-version": 3


### PR DESCRIPTION
Fix #26315 

Update raylib to the latest version 4.2.0

Remove `BUILD_GAMES ` because option not used in CMakeLists.txt

All features are tested successfully in the following triplet:
- x86-windows
- x64-widnows
- x64-windows-static