### PR TITLE
[OpenBLAS] Upgrade to 0.3.21 and add arm64-windows support

### DIFF
--- a/ports/openblas/fix-space-path.patch
+++ b/ports/openblas/fix-space-path.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/prebuild.cmake b/cmake/prebuild.cmake
-index 58ca1eb..e2f2134 100644
+index 60b7637..a8b34ef 100644
 --- a/cmake/prebuild.cmake
 +++ b/cmake/prebuild.cmake
-@@ -490,14 +490,14 @@ else(NOT CMAKE_CROSSCOMPILING)
+@@ -1322,14 +1322,14 @@ else(NOT CMAKE_CROSSCOMPILING)
  
    set(GETARCH_DIR "${PROJECT_BINARY_DIR}/getarch_build")
    set(GETARCH_BIN "getarch${CMAKE_EXECUTABLE_SUFFIX}")
@@ -19,9 +19,9 @@ index 58ca1eb..e2f2134 100644
 -      COPY_FILE ${PROJECT_BINARY_DIR}/${GETARCH_BIN}
 +      COPY_FILE "${PROJECT_BINARY_DIR}/${GETARCH_BIN}"
      )
-   
+ 
      if (NOT ${GETARCH_RESULT})
-@@ -518,14 +518,14 @@ execute_process(COMMAND "${BLASHELPER_BINARY_DIR}/${GETARCH_BIN}" 1 OUTPUT_VARIA
+@@ -1367,14 +1367,14 @@ execute_process(COMMAND "${BLASHELPER_BINARY_DIR}/${GETARCH_BIN}" 1 OUTPUT_VARIA
  
    set(GETARCH2_DIR "${PROJECT_BINARY_DIR}/getarch2_build")
    set(GETARCH2_BIN "getarch_2nd${CMAKE_EXECUTABLE_SUFFIX}")

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xianyi/OpenBLAS
-    REF 0b678b19dc03f2a999d6e038814c4c50b9640a4e # v0.3.20
-    SHA512 6e32f7dfc5dde46570873810c1da09d102f76ccfce41a5adbaeef2fccada54f9ab07e1ee541a6d55e138e6500392a6f55236f4f3a7766803358e5a6205334946 
+    REF b89fb708caa5a5a32de8f4306c4ff132e0228e9a # v0.3.21
+    SHA512 495e885409f0c6178332cddd685f3c002dc92e7af251c4e4eb3da6935ef6e81565c2505d436245b9bf53ce58649764e0471dc43b7f5f30b6ed092366cbbc2d5c
     HEAD_REF develop
     PATCHES
         uwp.patch
@@ -53,6 +53,10 @@ elseif(NOT (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW))
                 -DNOFORTRAN=ON
                 -DBU=_  #required for all blas functions to append extra _ using NAME
     )
+endif()
+
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    list(APPEND OPENBLAS_EXTRA_OPTIONS -DCORE=GENERIC)
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "openblas",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/xianyi/OpenBLAS",
   "license": "BSD-3-Clause",
-  "supports": "!(windows & arm)",
+  "supports": "!(arm & uwp)",
   "dependencies": [
     {
       "name": "openblas",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -201,6 +201,7 @@ discord-rpc:x64-uwp=fail
 # requires g++11
 discordcoreapi:x64-linux=fail
 dlib:arm-uwp=fail
+dlib:arm64-windows=fail
 dlib:x64-uwp=fail
 dmlc:arm-uwp=fail
 dmlc:x64-uwp=fail
@@ -234,6 +235,7 @@ embree2:arm64-osx=skip
 embree2:arm64-osx=skip
 epsilon:arm-uwp=fail
 epsilon:x64-uwp=fail
+faiss:arm64-windows=fail
 fastrtps:arm-uwp=fail
 fastrtps:x64-uwp=fail
 fastrtps:x64-windows-static=fail
@@ -279,6 +281,7 @@ gsoap:x86-windows        = skip
 gsoap:x64-windows-static = skip
 gsoap:x64-windows-static-md = skip
 
+geogram:arm64-windows=fail
 # Port geotrans source ftp://ftp.nga.mil server
 # extremely slow may take several hours to download
 geotrans:x64-linux           = skip
@@ -1039,6 +1042,7 @@ shogun:x64-windows-static-md=skip
 shogun:x86-windows        = skip
 signalrclient:x64-uwp=fail
 signalrclient:arm-uwp=fail
+simbody:arm64-windows=fail
 skia:arm-uwp=fail
 skia:x64-uwp=fail
 sleef:x86-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5157,7 +5157,7 @@
       "port-version": 2
     },
     "openblas": {
-      "baseline": "0.3.20",
+      "baseline": "0.3.21",
       "port-version": 0
     },
     "opencascade": {

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17b5c709377ee3e375a3b6b165ac9acb9752c3f6",
+      "version": "0.3.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "abd8d8b0d0286d963399d79e3e8b6f7f8e12117b",
       "version": "0.3.20",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Upgrades to 0.3.21 and adds `arm64-windows` triplet. `arm-uwp` removed

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  !(arm & uwp), Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

