### PR TITLE
[dxut, effects11] update ports for August 2022 release

### DIFF
--- a/ports/dxut/portfile.cmake
+++ b/ports/dxut/portfile.cmake
@@ -3,17 +3,24 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/DXUT
-    REF may2022
-    SHA512 ea8ba759666acb4520c2dc1754e937433a1c54f1c83fe15396c573a6513d9b3fd49d1712eae9fc42fff9cddc4f3a4a759a7fc99377ef9750c6c55813d8c90000
+    REF aug2022
+    SHA512 33552c4ced7a2e5653e3af9eda19dc48e3794c67e02b1588a96f2b964e552137930f5b6a9ff26b9377074137a743cbf7bd654b3d17bca442a7b667eff6d9eff8
     HEAD_REF main
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        dxtk DIRECTXTK_INTEGRATION
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/dxut/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/dxut)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/dxut/vcpkg.json
+++ b/ports/dxut/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dxut",
-  "version": "11.27",
+  "version": "11.28",
   "description": "A \"GLUT\"-like framework for Direct3D 11.x Win32 desktop applications",
   "homepage": "https://github.com/Microsoft/DXUT",
   "documentation": "https://github.com/microsoft/DXUT/wiki",
@@ -16,5 +16,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "dxtk": {
+      "description": "Support integration with DirectX Tool Kit for DX11",
+      "dependencies": [
+        "directxtk"
+      ]
+    }
+  }
 }

--- a/ports/effects11/portfile.cmake
+++ b/ports/effects11/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/FX11
-    REF may2022
-    SHA512 e395071430d7e6cd717729846e8d0f44700185597684f722cceb084df2a89b89ef7c04b5dfe948790640134838f409f0a3071e5d74760f8a9fcd74b0840ce78c
+    REF aug2022
+    SHA512 babb9fb5f2ee822d21e7262e4d0a9fce8383c2415d6c59f4101b782688ea4a7818411a922c60fc88da136bf427eec4e57da3610955d4cdbf11a77b61fd9bba14
     HEAD_REF main
 )
 
@@ -13,7 +13,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/effects11/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/effects11)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/effects11/vcpkg.json
+++ b/ports/effects11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "effects11",
-  "version": "11.27",
+  "version": "11.28",
   "description": "Effects for Direct3D 11 (FX11) is a management runtime for authoring HLSL shaders, render state, and runtime variables together.",
   "homepage": "https://github.com/Microsoft/FX11",
   "documentation": "https://github.com/microsoft/FX11/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2021,7 +2021,7 @@
       "port-version": 4
     },
     "dxut": {
-      "baseline": "11.27",
+      "baseline": "11.28",
       "port-version": 0
     },
     "eabase": {
@@ -2073,7 +2073,7 @@
       "port-version": 1
     },
     "effects11": {
-      "baseline": "11.27",
+      "baseline": "11.28",
       "port-version": 0
     },
     "effolkronium-random": {

--- a/versions/d-/dxut.json
+++ b/versions/d-/dxut.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b3dc36eb04da0286e4e2c5515a07cf7dbda4c03",
+      "version": "11.28",
+      "port-version": 0
+    },
+    {
       "git-tree": "5b6c7ea3b64d6446296a16c7ad5f8ebdeb2e9915",
       "version": "11.27",
       "port-version": 0

--- a/versions/e-/effects11.json
+++ b/versions/e-/effects11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d625012c718899dec9245d795413c2e86b52906d",
+      "version": "11.28",
+      "port-version": 0
+    },
+    {
       "git-tree": "8a08f12302be72c15cea701a71122e62f4b7df5a",
       "version": "11.27",
       "port-version": 0


### PR DESCRIPTION
Minor servicing update for DXUT and FX11 GitHub projects primarily to add use of SDL recommended "/guard:ehcont" when supported.

Also added a new [dxtk] feature to the DXUT port to support mixing with **directxtk** without link conflicts--this was supported for MSBuild only before, but is now supported as a build option for the CMake upstream.
