### PR TITLE
Libswscale aarch64 fix

### DIFF
--- a/ports/ffmpeg/0020-fix-aarch64-libswscale.patch
+++ b/ports/ffmpeg/0020-fix-aarch64-libswscale.patch
@@ -1,0 +1,28 @@
+diff --git a/libswscale/aarch64/yuv2rgb_neon.S b/libswscale/aarch64/yuv2rgb_neon.S
+index af677afe6..f4b220fb6 100644
+--- a/libswscale/aarch64/yuv2rgb_neon.S	
++++ b/libswscale/aarch64/yuv2rgb_neon.S
+@@ -169,19 +169,19 @@ function ff_\ifmt\()_to_\ofmt\()_neon, export=1
+     sqdmulh             v26.8H, v26.8H, v0.8H                           // ((Y1*(1<<3) - y_offset) * y_coeff) >> 15
+     sqdmulh             v27.8H, v27.8H, v0.8H                           // ((Y2*(1<<3) - y_offset) * y_coeff) >> 15
+ 
+-.ifc \ofmt,argb // 1 2 3 0
++.ifc \ofmt,argb
+     compute_rgba        v5.8B,v6.8B,v7.8B,v4.8B, v17.8B,v18.8B,v19.8B,v16.8B
+ .endif
+ 
+-.ifc \ofmt,rgba // 0 1 2 3
++.ifc \ofmt,rgba
+     compute_rgba        v4.8B,v5.8B,v6.8B,v7.8B, v16.8B,v17.8B,v18.8B,v19.8B
+ .endif
+ 
+-.ifc \ofmt,abgr // 3 2 1 0
++.ifc \ofmt,abgr
+     compute_rgba        v7.8B,v6.8B,v5.8B,v4.8B, v19.8B,v18.8B,v17.8B,v16.8B
+ .endif
+ 
+-.ifc \ofmt,bgra // 2 1 0 3
++.ifc \ofmt,bgra
+     compute_rgba        v6.8B,v5.8B,v4.8B,v7.8B, v18.8B,v17.8B,v16.8B,v19.8B
+ .endif
+ 

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_from_github(
         ${PATCHES}
         0018-libaom-Dont-use-aom_codec_av1_dx_algo.patch
         0019-libx264-Do-not-explicitly-set-X264_API_IMPORTS.patch
+        0020-fix-aarch64-libswscale.patch
 )
 
 if (SOURCE_PATH MATCHES " ")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.1",
-  "port-version": 15,
+  "port-version": 16,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2250,7 +2250,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.1",
-      "port-version": 15
+      "port-version": 16
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0aee15f22c29078cc18d6324f3f622ef6e94deba",
+      "version": "4.4.1",
+      "port-version": 16
+    },
+    {
       "git-tree": "d42747aed3213bf6d62a4a986fb915bdfd854a08",
       "version": "4.4.1",
       "port-version": 15


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes an issue with FFMPEG for aarch64 where the gas-preprocessor.pl script won't match the conditionals that have comments at the end. This results in none of the conditions matching, none of the `compute_rgba` macro calls being injected, and intermediate data being output at runtime instead.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  arm64-uwp (maybe all arm64, I was only working with UWP), No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  From my understanding, yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes.
