### PR TITLE
[Tesseract] add support [arm-osx] and [arm-linux]

### DIFF
--- a/ports/tesseract/vcpkg.json
+++ b/ports/tesseract/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "tesseract",
   "version": "5.2.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.",
   "homepage": "https://github.com/tesseract-ocr/tesseract",
   "license": "Apache-2.0",
-  "supports": "!(arm & (osx | linux))",
+  "supports": "!uwp",
   "dependencies": [
     "curl",
     "leptonica",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7046,7 +7046,7 @@
     },
     "tesseract": {
       "baseline": "5.2.0",
-      "port-version": 1
+      "port-version": 2
     },
     "tfhe": {
       "baseline": "1.0.1",

--- a/versions/t-/tesseract.json
+++ b/versions/t-/tesseract.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d9b7d5ba2e222ee4fb62d4d5f03992e9232a97d",
+      "version": "5.2.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "ea93f36603ca265da43ef28d6583871ef3d97b43",
       "version": "5.2.0",
       "port-version": 1


### PR DESCRIPTION
Fix #23397
Add support `arm-osx` and `arm-linux`.

Note: Since the dependency port `libarchive` doesn't support uwp, I changed it to ` !uwp`.
https://github.com/microsoft/vcpkg/blob/e99d9a4facea9d7e15a91212364d7a12762b7512/ports/libarchive/vcpkg.json#L8

All features are tested successfully in the following triplet:

- arm64-osx
- arm64-linux
