### PR TITLE
[freetype] Add feature to include error strings.

### DIFF
--- a/ports/freetype/error-strings.patch
+++ b/ports/freetype/error-strings.patch
@@ -1,0 +1,37 @@
+From 5672a353682a68cb76a03179739bdec0a2f5cf0e Mon Sep 17 00:00:00 2001
+From: Sean Farrell <sean.farrell@rioki.org>
+Date: Fri, 19 Aug 2022 15:32:19 +0200
+Subject: [PATCH] Adds config support for error strings.
+
+---
+ CMakeLists.txt | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index feb4be39a..4eea860e8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -215,6 +215,8 @@ cmake_dependent_option(FT_REQUIRE_BROTLI
+   "Require support of compressed WOFF2 fonts." OFF
+   "NOT FT_DISABLE_BROTLI" OFF)
+ 
++option(FT_ENABLE_ERROR_STRINGS
++  "Enable suport for meaningful error descriptions" OFF)
+ 
+ # Disallow in-source builds
+ if ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+@@ -353,6 +355,11 @@ if (BROTLIDEC_FOUND)
+     "/\\* +(#define +FT_CONFIG_OPTION_USE_BROTLI) +\\*/" "\\1"
+     FTOPTION_H "${FTOPTION_H}")
+ endif ()
++if (FT_ENABLE_ERROR_STRINGS)
++  string(REGEX REPLACE
++    "/\\* +(#define +FT_CONFIG_OPTION_ERROR_STRINGS) +\\*/" "\\1"
++    FTOPTION_H "${FTOPTION_H}")
++endif ()
+ 
+ set(FTOPTION_H_NAME "${PROJECT_BINARY_DIR}/include/freetype/config/ftoption.h")
+ if (EXISTS "${FTOPTION_H_NAME}")
+-- 
+2.33.0.windows.2
+

--- a/ports/freetype/error-strings.patch
+++ b/ports/freetype/error-strings.patch
@@ -16,7 +16,7 @@ index feb4be39a..4eea860e8 100644
    "NOT FT_DISABLE_BROTLI" OFF)
  
 +option(FT_ENABLE_ERROR_STRINGS
-+  "Enable suport for meaningful error descriptions" OFF)
++  "Enable support for meaningful error descriptions" OFF)
  
  # Disallow in-source builds
  if ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -11,19 +11,21 @@ vcpkg_from_sourceforge(
         brotli-static.patch
         bzip2.patch
         fix-exports.patch
+        error-strings.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        zlib        FT_REQUIRE_ZLIB
-        bzip2       FT_REQUIRE_BZIP2
-        png         FT_REQUIRE_PNG
-        brotli      FT_REQUIRE_BROTLI
+        zlib          FT_REQUIRE_ZLIB
+        bzip2         FT_REQUIRE_BZIP2
+        error-strings FT_ENABLE_ERROR_STRINGS
+        png           FT_REQUIRE_PNG
+        brotli        FT_REQUIRE_BROTLI
     INVERTED_FEATURES
-        zlib        FT_DISABLE_ZLIB
-        bzip2       FT_DISABLE_BZIP2
-        png         FT_DISABLE_PNG
-        brotli      FT_DISABLE_BROTLI
+        zlib          FT_DISABLE_ZLIB
+        bzip2         FT_DISABLE_BZIP2
+        png           FT_DISABLE_PNG
+        brotli        FT_DISABLE_BROTLI
 )
 
 vcpkg_cmake_configure(

--- a/ports/freetype/vcpkg.json
+++ b/ports/freetype/vcpkg.json
@@ -35,7 +35,7 @@
       ]
     },
     "error-strings": {
-      "description": "Enable suport for meaningful error descriptions."
+      "description": "Enable support for meaningful error descriptions."
     },
     "png": {
       "description": "Support PNG compressed OpenType embedded bitmaps.",

--- a/ports/freetype/vcpkg.json
+++ b/ports/freetype/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "freetype",
   "version": "2.12.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library to render fonts.",
   "homepage": "https://www.freetype.org/",
   "license": "FTL OR GPL-2.0-or-later",
@@ -33,6 +33,9 @@
       "dependencies": [
         "bzip2"
       ]
+    },
+    "error-strings": {
+      "description": "Enable suport for meaningful error descriptions."
     },
     "png": {
       "description": "Support PNG compressed OpenType embedded bitmaps.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2390,7 +2390,7 @@
     },
     "freetype": {
       "baseline": "2.12.1",
-      "port-version": 1
+      "port-version": 2
     },
     "freetype-gl": {
       "baseline": "2022-01-17",

--- a/versions/f-/freetype.json
+++ b/versions/f-/freetype.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "456320c11f4403f7f076df2805698b08fe8a81f2",
+      "version": "2.12.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "f62a602dce6f188e2e4324b46995b2c79a97759a",
       "version": "2.12.1",
       "port-version": 1

--- a/versions/f-/freetype.json
+++ b/versions/f-/freetype.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "456320c11f4403f7f076df2805698b08fe8a81f2",
+      "git-tree": "f1d6772ea2cb8cd74146b263b5dab534a10dd641",
       "version": "2.12.1",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Adds necessary CMake code to turn FT_CONFIG_OPTION_ERROR_STRINGS on. This makes FT_Error_String return useful strings. This feature is off by default.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  As far as I know, yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
