### PR TITLE
[sdl2-image] fix dynamic build on macOS

### DIFF
--- a/ports/sdl2-image/CMakeLists.txt
+++ b/ports/sdl2-image/CMakeLists.txt
@@ -42,6 +42,13 @@ if (APPLE)
     target_compile_options(SDL2_image BEFORE PRIVATE
         "-x" "objective-c"
     )
+    target_link_libraries(SDL2_image PRIVATE
+        "-framework CoreFoundation"
+        "-framework CoreGraphics"
+        "-framework CoreServices"
+        "-framework Foundation"
+        "-framework ImageIO"
+    )
 endif()
 
 set_target_properties(SDL2_image PROPERTIES DEFINE_SYMBOL DLL_EXPORT)

--- a/ports/sdl2-image/vcpkg.json
+++ b/ports/sdl2-image/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2-image",
   "version": "2.0.5",
-  "port-version": 6,
+  "port-version": 7,
   "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://www.libsdl.org/projects/SDL_image",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6518,7 +6518,7 @@
     },
     "sdl2-image": {
       "baseline": "2.0.5",
-      "port-version": 6
+      "port-version": 7
     },
     "sdl2-mixer": {
       "baseline": "2.6.1",

--- a/versions/s-/sdl2-image.json
+++ b/versions/s-/sdl2-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4890f12d4639bf57d7eac19097b5903c06574184",
+      "version": "2.0.5",
+      "port-version": 7
+    },
+    {
       "git-tree": "e1ed993b97bc76d5a8abdf4e9e8e148903078a70",
       "version": "2.0.5",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes dynamic build of sdl2-image on macOS

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No change needed

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
