### PR TITLE
[json-c] Disable tests

### DIFF
--- a/ports/json-c/portfile.cmake
+++ b/ports/json-c/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/json-c/vcpkg.json
+++ b/ports/json-c/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "json-c",
   "version-date": "2022-06-26",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A JSON implementation in C",
   "homepage": "https://github.com/json-c/json-c",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3118,7 +3118,7 @@
     },
     "json-c": {
       "baseline": "2022-06-26",
-      "port-version": 1
+      "port-version": 2
     },
     "json-dto": {
       "baseline": "0.3.1",

--- a/versions/j-/json-c.json
+++ b/versions/j-/json-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2090ebb6a6e0be1d0f6331c266bd0bc6eef1cd57",
+      "version-date": "2022-06-26",
+      "port-version": 2
+    },
+    {
       "git-tree": "c24e9a9cbc53b10a7235087cc58e89924415b281",
       "version-date": "2022-06-26",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
  Disables build of tests. This fixes building with mingw which stumbles over "%zu" format placeholder in `test_parse.c`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes