### PR TITLE
[windres-rc] support --define, --include-dir

### DIFF
--- a/scripts/buildsystems/make_wrapper/windres-rc
+++ b/scripts/buildsystems/make_wrapper/windres-rc
@@ -75,7 +75,8 @@ func_windres_wrapper ()
 		;;
 	--include-dir*)
 		eat=1
-		set x "$@" "-I $2"
+		func_file_conv "$2"
+		set x "$@" "-I $file"
 		shift
 		;;
 	-o)

--- a/scripts/buildsystems/make_wrapper/windres-rc
+++ b/scripts/buildsystems/make_wrapper/windres-rc
@@ -68,6 +68,16 @@ func_windres_wrapper ()
       eat=
     else
       case $1 in
+	--define*)
+		eat=1
+		set x "$@" "-d $2"
+		shift
+		;;
+	--include-dir*)
+		eat=1
+		set x "$@" "-I $2"
+		shift
+		;;
 	-o)
 	  eat=1
 	  func_file_conv "$2"


### PR DESCRIPTION
**Describe the pull request**
  Adds support for missing windres CLI switches:` --define` and  `--include`

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Not applicable

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
 Not applicable
