### PR TITLE
[google-cloud-cpp] Fix wrong parameter "${FEATURES}"

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -21,17 +21,17 @@ list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "googleapis")
 # are invalid in `vcpkg` features, we use dashes (`-`) as a separator
 # for the `vcpkg` feature name, and convert it here to something that
 # `google-cloud-cpp` would like.
-if ("dialogflow-cx" IN_LIST "${FEATURES}")
+if ("dialogflow-cx" IN_LIST FEATURES)
     list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "dialogflow-cx")
     list(APPEND GOOGLE_CLOUD_CPP_ENABLE "dialogflow_cx")
 endif ()
-if ("dialogflow-es" IN_LIST "${FEATURES}")
+if ("dialogflow-es" IN_LIST FEATURES)
     list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "dialogflow-es")
     list(APPEND GOOGLE_CLOUD_CPP_ENABLE "dialogflow_es")
 endif ()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         "-DGOOGLE_CLOUD_CPP_ENABLE=${GOOGLE_CLOUD_CPP_ENABLE}"
@@ -44,7 +44,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 foreach(feature IN LISTS FEATURES)
     set(config_path "lib/cmake/google_cloud_cpp_${feature}")
     # Most features get their own package in `google-cloud-cpp`.
@@ -72,6 +72,6 @@ endforeach()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake"
                     "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
                     "${CURRENT_PACKAGES_DIR}/debug/share")
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.1.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2646,7 +2646,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a70cc631d25b110ce203a0f571689304fb0e8595",
+      "version": "2.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a68fd18fa28b5bbe4807c7ed32ed45c0d4392dd1",
       "version": "2.1.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #26442
  This is a regression from PR https://github.com/microsoft/vcpkg/pull/25369, `"${FEATURES}"` cause features `dialogflow-es` and `dialogflow-cx` invalid, change to `FEATURES` fix this issue.
  All features test pass on `x64-windows`.

