### PR TITLE
[jasper] disable opengl feature on ios, allowing it to build

### DIFF
--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 6,
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/mdadams/jasper",
+  "license": null,
   "dependencies": [
     "libjpeg-turbo",
     {

--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "jasper",
   "version": "2.0.33",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/mdadams/jasper",
   "dependencies": [
@@ -28,7 +28,7 @@
           "features": [
             "opengl"
           ],
-          "platform": "!(windows & arm) & !uwp"
+          "platform": "!(windows & arm) & !uwp & !ios"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3090,7 +3090,7 @@
     },
     "jasper": {
       "baseline": "2.0.33",
-      "port-version": 5
+      "port-version": 6
     },
     "jbig2dec": {
       "baseline": "0.19",

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9fae17938a71e1c43534ee8f15d9e2204ca23a1",
+      "version": "2.0.33",
+      "port-version": 6
+    },
+    {
       "git-tree": "e5220ea6a54e25d777f853a2c77196be67da02f3",
       "version": "2.0.33",
       "port-version": 5

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9fae17938a71e1c43534ee8f15d9e2204ca23a1",
+      "git-tree": "fb8dca022aa130726431991cc9c70cc3162ea657",
       "version": "2.0.33",
       "port-version": 6
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes compiling jasper on ios

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  arm64-ios

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
