### PR TITLE
[google-cloud-cpp] Fix features dialogflow-* CMake export

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -59,7 +59,7 @@ foreach(feature IN LISTS FEATURES)
 endforeach()
 # These packages are automatically installed depending on what features are
 # enabled.
-foreach(suffix common googleapis grpc_utils rest_internal)
+foreach(suffix common googleapis grpc_utils rest_internal dialogflow_cx dialogflow_es)
     set(config_path "lib/cmake/google_cloud_cpp_${suffix}")
     if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
         continue()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2650,7 +2650,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e675db53dae8b88be806ecd93411810ee8048d7",
+      "version": "2.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "a70cc631d25b110ce203a0f571689304fb0e8595",
       "version": "2.1.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #26442
  Sorry, I missed the following bug, PR #26459 does not fully fix the bugs of these two features. This PR will fix features `dialogflow-cx` and `dialogflow-es` CMake export.

> Another thing I noticed is that, after the previous change is done and once the process finished compiling, some files and folders were missing in the "packages" folder
> 
> In the file "install-x64-windows-rel-out.log" I see (among other lines)
> 
> ```
> -- Installing: C:/files/repos/other-external/vcpkg/packages/google-cloud-cpp_x64-windows/lib/pkgconfig/google_cloud_cpp_dialogflow_es.pc
> -- Installing: C:/files/repos/other-external/vcpkg/packages/google-cloud-cpp_x64-windows/lib/cmake/google_cloud_cpp_dialogflow_es/google_cloud_cpp_dialogflow_es-config.cmake
> -- Installing: C:/files/repos/other-external/vcpkg/packages/google-cloud-cpp_x64-windows/lib/cmake/google_cloud_cpp_dialogflow_es/google_cloud_cpp_dialogflow_es-config-version.cmake
> -- Installing: C:/files/repos/other-external/vcpkg/packages/google-cloud-cpp_x64-windows/lib/pkgconfig/google_cloud_cpp_dialogflow_es_protos.pc
> 
