### PR TITLE
[dartsim] Enable dart-gui

### DIFF
--- a/ports/dartsim/portfile.cmake
+++ b/ports/dartsim/portfile.cmake
@@ -20,7 +20,6 @@ vcpkg_cmake_configure(
         -DDART_SKIP_FLANN=ON
         -DDART_SKIP_IPOPT=ON
         -DDART_SKIP_NLOPT=ON
-        -DDART_SKIP_OPENGL=ON
         -DDART_SKIP_pagmo=ON
         -Durdfdom_headers_VERSION_MAJOR=1 # urdfdom-headers does not expose a header macro for its version.
         -Durdfdom_headers_VERSION_MINOR=0 # versions of at least 1.0.0 use std:: constructs in their ABI instead of boost:: ones.

--- a/ports/dartsim/vcpkg.json
+++ b/ports/dartsim/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dartsim",
   "version": "6.12.2",
+  "port-version": 1,
   "description": "Dynamic Animation and Robotics Toolkit",
   "homepage": "https://dartsim.github.io/",
   "license": "BSD-2-Clause",
@@ -20,8 +21,10 @@
     "eigen3",
     "fcl",
     "fmt",
+    "freeglut",
     "octomap",
     "ode",
+    "opengl",
     "tinyxml2",
     "urdfdom",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1814,7 +1814,7 @@
     },
     "dartsim": {
       "baseline": "6.12.2",
-      "port-version": 0
+      "port-version": 1
     },
     "dataframe": {
       "baseline": "1.19.0",

--- a/versions/d-/dartsim.json
+++ b/versions/d-/dartsim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "746ffa24744bf10e2ce9b04332c8dcde2222ba39",
+      "version": "6.12.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "887126d7800fe033a8e70bfa369e0b990434c921",
       "version": "6.12.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/26479

  Add missing dependencies `opengl` and `freeglut`, and disable `DART_SKIP_OPENGL` to enable `dart-gui` generation.