### PR TITLE
[Turbobase64] Adopt maintainer guidelines

### DIFF
--- a/ports/turbobase64/CMakeLists.txt
+++ b/ports/turbobase64/CMakeLists.txt
@@ -34,37 +34,33 @@ else ()
 endif ()
 
 if (ARCH_AMD64)
-    add_library(base64
+    add_library(tb64
                 $<TARGET_OBJECTS:base64_scalar>
                 $<TARGET_OBJECTS:base64_ssse3>
                 $<TARGET_OBJECTS:base64_avx>
                 $<TARGET_OBJECTS:base64_avx2>)
 else ()
-    add_library(base64
+    add_library(tb64
                 $<TARGET_OBJECTS:base64_scalar>
                 $<TARGET_OBJECTS:base64_ssse3>)
 endif ()
 
 # End of Yandex code
 
-target_include_directories(base64 SYSTEM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-set_target_properties(base64 PROPERTIES PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/turbob64.h")
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
-install(TARGETS base64
-        EXPORT base64Config
-        RUNTIME DESTINATION "bin"
-        LIBRARY DESTINATION "lib"
-        ARCHIVE DESTINATION "lib"
-        PUBLIC_HEADER DESTINATION "include"
-        COMPONENT dev
+target_include_directories(tb64 PUBLIC 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         )
 
-export(TARGETS base64
-       NAMESPACE TURBO::
-       FILE "share/base64/base64Config.cmake"
-       )
+install(TARGETS tb64
+        EXPORT unofficial-turbobase64-config
+        )
+install(FILES "${CMAKE_SOURCE_DIR}/turbob64.h" TYPE INCLUDE)
 
-install(EXPORT base64Config
-        DESTINATION "share/base64"
-        NAMESPACE TURBO::
+install(EXPORT unofficial-turbobase64-config
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-turbobase64"
+        NAMESPACE unofficial::turbobase64::
         )

--- a/ports/turbobase64/portfile.cmake
+++ b/ports/turbobase64/portfile.cmake
@@ -6,14 +6,15 @@ vcpkg_from_github(
         HEAD_REF master
 )
 
-configure_file(${CURRENT_PORT_DIR}/CMakeLists.txt ${SOURCE_PATH}/CMakeLists.txt COPYONLY)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION  "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
-        SOURCE_PATH ${SOURCE_PATH}
-        PREFER_NINJA
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-${PORT}")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/turbobase64/vcpkg.json
+++ b/ports/turbobase64/vcpkg.json
@@ -1,8 +1,19 @@
 {
   "name": "turbobase64",
   "version-date": "2020-01-12",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Fastest Base64 SIMD/Neon library",
   "homepage": "https://github.com/powturbo/Turbo-Base64",
-  "supports": "!windows"
+  "license": "GPL-3.0-only",
+  "supports": "!windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7298,7 +7298,7 @@
     },
     "turbobase64": {
       "baseline": "2020-01-12",
-      "port-version": 2
+      "port-version": 3
     },
     "tvision": {
       "baseline": "2021-08-10",

--- a/versions/t-/turbobase64.json
+++ b/versions/t-/turbobase64.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20d23821ef39944689c9ec0e8cf02d17c7b68901",
+      "version-date": "2020-01-12",
+      "port-version": 3
+    },
+    {
       "git-tree": "1077b7996d7d22e798b337bc29177a566ec64e4b",
       "version-date": "2020-01-12",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  During the review of #25091 by @BillyONeal it was noted that this port doesn't follow the maintainer guidelines. This PR rectifies the following points:
    - Use the upstream library name [`tb64`](https://github.com/powturbo/Turbo-Base64/blob/95ba56a9b041f9933f5cd2bbb2ee4e083468c20a/makefile#L109)
    - Place the exported cmake targets in the `unofficial` namespace as per [`maintainer-guide.md`](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md#add-cmake-exports-in-an-unofficial--namespace)
    - Add the license identifier to the port manifest.
    - Refactor the usage of deprecated port functions.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
