### PR TITLE
[configure_make] fix regression: don't set C*_FOR_BUILD environment variables for ios

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -384,7 +384,7 @@ function(vcpkg_configure_make)
             # Currently needed for arm because objdump yields: "unrecognised machine type (0x1c4) in Import Library Format archive"
             list(APPEND arg_OPTIONS lt_cv_deplibs_check_method=pass_all)
         endif()
-    elseif(NOT VCPKG_TARGET_IS_OSX)
+    elseif(NOT VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_IS_IOS)
         # Because OSX dosn't like CMAKE_C(XX)_COMPILER (cc) in CC/CXX and rather wants to have gcc/g++
         function(z_vcpkg_make_set_env envvar cmakevar)
             set(prog "${VCPKG_DETECTED_CMAKE_${cmakevar}} ${ARGN}")


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes building gettext for ios, which regressed in 624f1b4ecaf652e074f4cc547f9a4679a28d2222

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  arm64-ios, arm-ios

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes
