### PR TITLE
[nuget] Update to 6.2.1

### DIFF
--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -95,22 +95,22 @@
         <sha512>1a98beebd1bb6929cbe98b86a3b77fb1ae4508b86cdcb64696b20c3a3336a2b5c8518e19a21092f1c98a46202c048dba819dc52bef122485ac34b888b77e59b2</sha512>
     </tool>
     <tool name="nuget" os="windows">
-        <version>5.11.0</version>
+        <version>6.2.1</version>
         <exeRelativePath>nuget.exe</exeRelativePath>
-        <url>https://dist.nuget.org/win-x86-commandline/v5.11.0/nuget.exe</url>
-        <sha512>06a337c9404dec392709834ef2cdbdce611e104b510ef40201849595d46d242151749aef65bc2d7ce5ade9ebfda83b64c03ce14c8f35ca9957a17a8c02b8c4b7</sha512>
+        <url>https://dist.nuget.org/win-x86-commandline/v6.2.1/nuget.exe</url>
+        <sha512>dbb8c13d93a8c0071f45b1fe733ee7a888078dcec5bbcb4dfb49ab8c3970c7513f608bd3bc80b0bfb4764a505ea017cac2ead3656e1a5aa7f3a770c8e3e35825</sha512>
     </tool>
     <tool name="nuget" os="linux">
-        <version>5.11.0</version>
+        <version>6.2.1</version>
         <exeRelativePath>nuget.exe</exeRelativePath>
-        <url>https://dist.nuget.org/win-x86-commandline/v5.11.0/nuget.exe</url>
-        <sha512>06a337c9404dec392709834ef2cdbdce611e104b510ef40201849595d46d242151749aef65bc2d7ce5ade9ebfda83b64c03ce14c8f35ca9957a17a8c02b8c4b7</sha512>
+        <url>https://dist.nuget.org/win-x86-commandline/v6.2.1/nuget.exe</url>
+        <sha512>dbb8c13d93a8c0071f45b1fe733ee7a888078dcec5bbcb4dfb49ab8c3970c7513f608bd3bc80b0bfb4764a505ea017cac2ead3656e1a5aa7f3a770c8e3e35825</sha512>
     </tool>
     <tool name="nuget" os="osx">
-        <version>5.11.0</version>
+        <version>6.2.1</version>
         <exeRelativePath>nuget.exe</exeRelativePath>
-        <url>https://dist.nuget.org/win-x86-commandline/v5.11.0/nuget.exe</url>
-        <sha512>06a337c9404dec392709834ef2cdbdce611e104b510ef40201849595d46d242151749aef65bc2d7ce5ade9ebfda83b64c03ce14c8f35ca9957a17a8c02b8c4b7</sha512>
+        <url>https://dist.nuget.org/win-x86-commandline/v6.2.1/nuget.exe</url>
+        <sha512>dbb8c13d93a8c0071f45b1fe733ee7a888078dcec5bbcb4dfb49ab8c3970c7513f608bd3bc80b0bfb4764a505ea017cac2ead3656e1a5aa7f3a770c8e3e35825</sha512>
     </tool>
     <tool name="coscli" os="windows">
         <version>0.11.0</version>


### PR DESCRIPTION
Update nuget to 6.2.1 to fix upstream bug:
```
response status code does not indicate success: 409 (This package version already exists).
```