### PR TITLE
[gdk-pixbuf] update to 2.42.9

### DIFF
--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_meson(
         -Djpeg=enabled              # Enable JPEG loader (requires libjpeg), disabled on Windows if "native_windows_loaders" is used
         -Dintrospection=disabled    # Whether to generate the API introspection data (requires GObject-Introspection)
         -Drelocatable=true          # Whether to enable application bundle relocation support
+        -Dtests=false
         -Dinstalled_tests=false
         -Dgio_sniffing=false        # Perform file type detection using GIO (Unused on MacOS and Windows)
         -Dbuiltin_loaders=all       # since it is unclear where loadable plugins should be located;

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -1,12 +1,12 @@
 set(GDK_PIXBUF_VERSION 2.42)
-set(GDK_PIXBUF_PATCH 8)
+set(GDK_PIXBUF_PATCH 9)
 
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.gnome.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/gdk-pixbuf
     REF "${GDK_PIXBUF_VERSION}.${GDK_PIXBUF_PATCH}"
-    SHA512 ea3b7d47f2ef3dbb88f640629e03eb4fab4a371da2545c199274d75b993b176af0c69ea72b46d5fadf58f82dff9a809fe1e0a4802ad1f1f13eaa9d757ebfeb4c
+    SHA512 3406f47b413fe3860df410a0cc0076ce47d10605b39347105690c85616739e67e5dfd0804efcad758614b0c8d1369e410b9efaa704a234bfd19686b82595b9e1
     HEAD_REF master
     PATCHES
         fix_build_error_windows.patch

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdk-pixbuf",
-  "version": "2.42.8",
-  "port-version": 3,
+  "version": "2.42.9",
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-only",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -275,6 +275,9 @@ functions-framework-cpp:x64-uwp=fail
 # VS 2022 Update 3 seems to have broken Gazebo: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1522474
 gazebo:x64-windows=fail
 gazebo:x64-linux=fail
+
+gdk-pixbuf:x64-windows-static=fail
+gdk-pixbuf:x64-windows-static-md=fail
 # gsoap does not offer stable public source downloads
 gsoap:x64-windows        = skip
 gsoap:x86-windows        = skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2493,8 +2493,8 @@
       "port-version": 1
     },
     "gdk-pixbuf": {
-      "baseline": "2.42.8",
-      "port-version": 3
+      "baseline": "2.42.9",
+      "port-version": 0
     },
     "gemmlowp": {
       "baseline": "2021-09-28",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4d20ae662c74ed3f4bfec74bb57a68747564c96",
+      "version": "2.42.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "6662972ebf092397b1d94122ecfc754f0b81eeee",
       "version": "2.42.8",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #26533 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `x64-windows-static` and `x64-windows-static-md` have been broken before but where cascaded by glibs' inability to be built statically on those platforms, too. The CI baseline has been updated accordingly.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
