### PR TITLE
[x264] fix configuration on systems without /bin/bash

### DIFF
--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -10,6 +10,9 @@ vcpkg_from_github(
         allow-clang-cl.patch
         configure-as.patch # Ignore ':' from `vcpkg_configure_make`
 )
+
+vcpkg_replace_string("${SOURCE_PATH}/configure" [[/bin/bash]] [[/usr/bin/env bash]])
+
 # Note on x264 versioning:
 # The pc file exports "0.164.<N>" where is the number of commits.
 # This must be fixed here because vcpkg uses a GH tarball instead of cloning the source.

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "x264",
   "version": "0.164.3095",
+  "port-version": 1,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://www.videolan.org/developers/x264.html",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7770,7 +7770,7 @@
     },
     "x264": {
       "baseline": "0.164.3095",
-      "port-version": 0
+      "port-version": 1
     },
     "x265": {
       "baseline": "3.4",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0250f3c90373d6b40b104a47f226633468c7e9a8",
+      "version": "0.164.3095",
+      "port-version": 1
+    },
+    {
       "git-tree": "e369a0924f6b28e965b0e0c8f35264b7fd5efb7f",
       "version": "0.164.3095",
       "port-version": 0

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0250f3c90373d6b40b104a47f226633468c7e9a8",
+      "git-tree": "16be87b659ccfeaba052e561f3f0a8b1b927c5d0",
       "version": "0.164.3095",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Some systems don't have `/bin/bash`, and because of that the `configure` script won't run. This PR patches the shebang to use `/usr/bin/env bash`

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)? linux

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
