### PR TITLE
[vcpkg baseline][kf5globalaccel] Fix build on windows when x11 is around

### DIFF
--- a/ports/kf5globalaccel/portfile.cmake
+++ b/ports/kf5globalaccel/portfile.cmake
@@ -9,10 +9,15 @@ vcpkg_from_github(
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
 
+if(NOT VCPKG_TARGET_IS_LINUX)
+  list(APPEND KGLOBALACCEL_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_X11=ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
+        ${KGLOBALACCEL_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5globalaccel/vcpkg.json
+++ b/ports/kf5globalaccel/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5globalaccel",
   "version": "5.89.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "lobal desktop keyboard shortcuts",
   "homepage": "https://api.kde.org/frameworks/kglobalaccel/html/index.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3258,7 +3258,7 @@
     },
     "kf5globalaccel": {
       "baseline": "5.89.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5guiaddons": {
       "baseline": "5.89.0",

--- a/versions/k-/kf5globalaccel.json
+++ b/versions/k-/kf5globalaccel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "610034ef9764b5d45569588235e9a5838ae05757",
+      "version": "5.89.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5a4dc9bc81874eec1192fa77b8a04ab67fb75239",
       "version": "5.89.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes a spurious build issue which depends on the presence of x11 on the target system (see https://github.com/microsoft/vcpkg/pull/25670)