### PR TITLE
[vcpkg baseline][opencensus-cpp] De-vendor dependencies

### DIFF
--- a/ports/opencensus-cpp/fix-install.patch
+++ b/ports/opencensus-cpp/fix-install.patch
@@ -1,23 +1,32 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0ecec53..07162ed 100644
+index 0ecec53..45d994c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -29,7 +29,7 @@ project(
- option(FUZZER "Either OFF or e.g. -fsanitize=fuzzer,address" OFF)
+@@ -38,7 +38,13 @@ enable_testing()
  
- if(NOT CMAKE_CXX_STANDARD)
--  set(CMAKE_CXX_STANDARD 11)
-+  set(CMAKE_CXX_STANDARD 14)
-   set(CMAKE_CXX_STANDARD_REQUIRED ON)
- endif()
+ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+ 
+-include(OpenCensusDeps)
++find_package(absl CONFIG REQUIRED)
++find_package(prometheus-cpp CONFIG REQUIRED)
++
++if(BUILD_TESTING)
++  find_package(GTest CONFIG REQUIRED)
++  find_package(benchmark CONFIG REQUIRED)
++endif()
+ 
+ include(OpenCensusHelpers)
  
 diff --git a/cmake/OpenCensusHelpers.cmake b/cmake/OpenCensusHelpers.cmake
-index 8fdfe96..53bc877 100644
+index 8fdfe96..6667085 100644
 --- a/cmake/OpenCensusHelpers.cmake
 +++ b/cmake/OpenCensusHelpers.cmake
-@@ -37,6 +37,13 @@ function(opencensus_test NAME SRC)
+@@ -35,8 +35,15 @@ function(opencensus_test NAME SRC)
+     set(_NAME "opencensus_${NAME}")
+     add_executable(${_NAME} ${SRC})
      prepend_opencensus(DEPS "${ARGN}")
-     target_link_libraries(${_NAME} "${DEPS}" gmock gtest_main)
+-    target_link_libraries(${_NAME} "${DEPS}" gmock gtest_main)
++    target_link_libraries(${_NAME} "${DEPS}" GTest::gmock GTest::gtest_main)
      add_test(NAME ${_NAME} COMMAND ${_NAME})
 +
 +    install(
@@ -29,10 +38,12 @@ index 8fdfe96..53bc877 100644
    endif()
  endfunction()
  
-@@ -50,6 +57,13 @@ function(opencensus_benchmark NAME SRC)
+@@ -49,7 +56,14 @@ function(opencensus_benchmark NAME SRC)
+     set(_NAME "opencensus_${NAME}")
      add_executable(${_NAME} ${SRC})
      prepend_opencensus(DEPS "${ARGN}")
-     target_link_libraries(${_NAME} "${DEPS}" benchmark)
+-    target_link_libraries(${_NAME} "${DEPS}" benchmark)
++    target_link_libraries(${_NAME} "${DEPS}" benchmark::benchmark)
 +
 +    install(
 +      TARGETS ${_NAME}

--- a/ports/opencensus-cpp/portfile.cmake
+++ b/ports/opencensus-cpp/portfile.cmake
@@ -4,7 +4,8 @@ vcpkg_from_github(
     REF 62d8281899a1cfd1084793f64295329a6b5d22b3 # 2021-08-26
     SHA512 35df40d7e5ce933384fe6ba4ac2d704e0801ac47765fca97ea3f8d787886abe5c588855c3aac5745f047c1c8f2047e1f69b62340dd702042a61c3dc430ca36b4
     HEAD_REF master
-    PATCHES fix-install.patch
+    PATCHES
+        fix-install.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/opencensus-cpp/vcpkg.json
+++ b/ports/opencensus-cpp/vcpkg.json
@@ -1,13 +1,14 @@
 {
   "name": "opencensus-cpp",
   "version-date": "2021-08-26",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenCensus is a toolkit for collecting application performance and behavior data. It currently includes an API for tracing and stats.",
   "homepage": "https://github.com/census-instrumentation/opencensus-cpp",
   "license": "Apache-2.0",
   "supports": "!windows",
   "dependencies": [
     "abseil",
+    "prometheus-cpp",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -15,7 +16,11 @@
   ],
   "features": {
     "test": {
-      "description": "Build test"
+      "description": "Build test",
+      "dependencies": [
+        "benchmark",
+        "gtest"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5214,7 +5214,7 @@
     },
     "opencensus-cpp": {
       "baseline": "2021-08-26",
-      "port-version": 1
+      "port-version": 2
     },
     "opencl": {
       "baseline": "2.2",

--- a/versions/o-/opencensus-cpp.json
+++ b/versions/o-/opencensus-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12e85bfcbf3ecda837c873e30ca6e872e3a5fa89",
+      "version-date": "2021-08-26",
+      "port-version": 2
+    },
+    {
       "git-tree": "043d8a451b507daa585a8a716cf297421912d3d4",
       "version-date": "2021-08-26",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  This port used vendored dependencies.
  This PR is a follow-up on #25735 which was based on the wrong assumtion that this port uses vcpkg's abseil. In fact, it used the abseil GitHub repo at `HEAD` which caused the error on using C++ 11 instead of 14.