### PR TITLE
[asiosdk] The find script failed on multiple inclusion

### DIFF
--- a/ports/asiosdk/Findasiosdk.cmake
+++ b/ports/asiosdk/Findasiosdk.cmake
@@ -3,6 +3,13 @@ else(WIN32)
   message(FATAL_ERROR "Findasiosdk.cmake: Unsupported platform ${CMAKE_SYSTEM_NAME}" )
 endif(WIN32)
 
+# if this script is invoked multiple times, we end up adding
+# "asiosdk" to the directory multiple times, leading to incorrect
+# include paths
+if (ASIOSDK_ROOT_DIR)
+    return()
+endif()
+
 find_path(
   ASIOSDK_ROOT_DIR
   asiosdk

--- a/ports/asiosdk/vcpkg.json
+++ b/ports/asiosdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "asiosdk",
   "version": "2.3.3",
-  "port-version": 4,
+  "port-version": 5,
   "description": "ASIO is a low latency audio API from Steinberg.",
   "homepage": "https://www.steinberg.net/en/company/developers.html",
   "supports": "windows & !(arm | uwp)"

--- a/versions/a-/asiosdk.json
+++ b/versions/a-/asiosdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75f1c1ef95024543bf7298ba4389eafe67b9f473",
+      "version": "2.3.3",
+      "port-version": 5
+    },
+    {
       "git-tree": "101bbdad9205db5b4249eae8b47bf8c5f73493a8",
       "version": "2.3.3",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -194,7 +194,7 @@
     },
     "asiosdk": {
       "baseline": "2.3.3",
-      "port-version": 4
+      "port-version": 5
     },
     "asmjit": {
       "baseline": "2021-10-26",


### PR DESCRIPTION
Since it first tries to locate the directory and then unconditionally
adds a subdirectory to it, running this script twice resulted in an
incorrect path (the last node was added multiple times).

We now check whether the script already ran and then abort.

- #### What does your PR fix?

Incorrect include path on multiple runs of finding asiosdk

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes, port versions are updated
