### PR TITLE
[vcpkg_copy_tool_dependencies] Switch to cmake function file(GET_RUNTIME_DEPENDENCIES)

### DIFF
--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -5,18 +5,40 @@ function(z_vcpkg_copy_tool_dependencies_search tool_dir path_to_search)
         set(count 0)
     endif()
     file(GLOB tools "${tool_dir}/*.exe" "${tool_dir}/*.dll" "${tool_dir}/*.pyd")
-    foreach(tool IN LISTS tools)
-        vcpkg_execute_required_process(
-            COMMAND "${Z_VCPKG_POWERSHELL_CORE}" -noprofile -executionpolicy Bypass -nologo
-                -file "${SCRIPTS}/buildsystems/msbuild/applocal.ps1"
-                -targetBinary "${tool}"
-                -installedDir "${path_to_search}"
-                -verbose
-            WORKING_DIRECTORY "${VCPKG_ROOT_DIR}"
-            LOGNAME copy-tool-dependencies-${count}
-        )
-        math(EXPR count "${count} + 1")
-    endforeach()
+    if (CMAKE_MAJOR_VERSION VERSION_GREATER_EQUAL 3 AND CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 16)
+        foreach(tool IN LISTS tools)
+            file(GET_RUNTIME_DEPENDENCIES
+                RESOLVED_DEPENDENCIES_VAR RESOLVED_DEPS
+                UNRESOLVED_DEPENDENCIES_VAR UNRESOLVED_DEPS
+                CONFLICTING_DEPENDENCIES_PREFIX CONFLICT_DEPS
+                LIBRARIES "${tool}"
+                DIRECTORIES "${CURRENT_INSTALLED_DIR}/bin" "${CURRENT_PACKAGES_DIR}/bin"
+            )
+            debug_message("Found dependencies: ${RESOLVED_DEPS};${CONFLICT_DEPS}\nNot found: ${UNRESOLVED_DEPS}")
+            foreach(dependency IN LISTS RESOLVED_DEPS CONFLICT_DEPS)
+                # The native path will break MATCHES
+                file(TO_CMAKE_PATH "${dependency}" dependency)
+                if ("${dependency}" MATCHES "^${CURRENT_PACKAGES_DIR}" OR "${dependency}" MATCHES "^${CURRENT_INSTALLED_DIR}")
+                    debug_message("COPY dependency ${dependency}...")
+                    file(COPY "${dependency}" DESTINATION "${tool_dir}")
+                endif()
+            endforeach()
+            math(EXPR count "${count} + 1")
+        endforeach()
+    else()
+        foreach(tool IN LISTS tools)
+            vcpkg_execute_required_process(
+                COMMAND "${Z_VCPKG_POWERSHELL_CORE}" -noprofile -executionpolicy Bypass -nologo
+                    -file "${SCRIPTS}/buildsystems/msbuild/applocal.ps1"
+                    -targetBinary "${tool}"
+                    -installedDir "${path_to_search}"
+                    -verbose
+                WORKING_DIRECTORY "${VCPKG_ROOT_DIR}"
+                LOGNAME copy-tool-dependencies-${count}
+            )
+            math(EXPR count "${count} + 1")
+        endforeach()
+    endif()
     set(Z_VCPKG_COPY_TOOL_DEPENDENCIES_COUNT ${count} CACHE INTERNAL "")
 endfunction()
 
@@ -26,9 +48,11 @@ function(vcpkg_copy_tool_dependencies tool_dir)
     endif()
 
     if(VCPKG_TARGET_IS_WINDOWS)
-        find_program(Z_VCPKG_POWERSHELL_CORE pwsh)
-        if (NOT Z_VCPKG_POWERSHELL_CORE)
-            message(FATAL_ERROR "Could not find PowerShell Core; please open an issue to report this.")
+        if (CMAKE_MAJOR_VERSION VERSION_LESS 3 OR CMAKE_MINOR_VERSION VERSION_LESS 16)
+            find_program(Z_VCPKG_POWERSHELL_CORE pwsh)
+            if (NOT Z_VCPKG_POWERSHELL_CORE)
+                message(FATAL_ERROR "Could not find PowerShell Core; please open an issue to report this.")
+            endif()
         endif()
         cmake_path(RELATIVE_PATH tool_dir
             BASE_DIRECTORY "${CURRENT_PACKAGES_DIR}"


### PR DESCRIPTION
Currently, `vcpkg_copy_tool_dependencies` calls the ps1 script `applocal.ps1` on Windows to perform the function of analyzing dependencies and copying dependencies, which is affected by the powershell version and the Visual Studio English language package.
Switch to cmake functions to avoid these issues.

- [x] vcpkg_copy_tool_dependencies
- [ ] magnumdeploy.ps1
- [ ] k4adeploy.ps1
- [ ] openni2deploy.ps1
- [ ] qtdeploy.ps1
- [ ] vcpkg.cmake

Related official document: https://cmake.org/cmake/help/latest/command/file.html#get-runtime-dependencies

Resolve: https://github.com/microsoft/vcpkg/issues/17448 https://github.com/microsoft/vcpkg/issues/17890 https://github.com/microsoft/vcpkg/issues/16721 https://github.com/microsoft/vcpkg/issues/14339 https://github.com/microsoft/vcpkg/issues/10619 https://github.com/microsoft/vcpkg/issues/12849