### PR TITLE
[opencv4,dv-processing] no absolute paths

### DIFF
--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -36,9 +36,6 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME "dv-processing" CONFIG_PATH "share/dv-proc
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-if (VCPKG_TARGET_IS_WINDOWS)
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug")
-else()
-        vcpkg_fixup_pkgconfig()
-endif()
+vcpkg_fixup_pkgconfig(SKIP_CHECK)
+
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dv-processing",
   "version": "1.5.1",
+  "port-version": 1,
   "description": "Generic algorithms for event cameras.",
   "homepage": "https://gitlab.com/inivation/dv/dv-processing",
   "license": "Apache-2.0",

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -382,7 +382,6 @@ vcpkg_cmake_configure(
         -DOPENCV_DLLVERSION=4
         -DOPENCV_DEBUG_POSTFIX=d
         -DOPENCV_GENERATE_SETUPVARS=OFF
-        -DOPENCV_GENERATE_PKGCONFIG=ON
         # Do not build docs/examples
         -DBUILD_DOCS=OFF
         -DBUILD_EXAMPLES=OFF

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.6.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2014,7 +2014,7 @@
     },
     "dv-processing": {
       "baseline": "1.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "dx": {
       "baseline": "1.0.1",
@@ -5250,7 +5250,7 @@
     },
     "opencv4": {
       "baseline": "4.6.0",
-      "port-version": 2
+      "port-version": 3
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/d-/dv-processing.json
+++ b/versions/d-/dv-processing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d2e7b2c11eaa6b13ce5b08447411a885adc2036",
+      "version": "1.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "5fb27b7a8c1ee9bd01035958e7b3b3a487a89dd8",
       "version": "1.5.1",
       "port-version": 0

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18c563d48f8245b3d1e0879ecdc6c37097a89b3c",
+      "version": "4.6.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "57554ec83d4e4667344f005a1f61be8164cbf58a",
       "version": "4.6.0",
       "port-version": 2


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/issues/20469

opencv4's pkgconfig support is deprecated and [non functional](https://github.com/microsoft/vcpkg-tool/pull/172#issuecomment-1225687721).