### PR TITLE
[vcpkg baseline][nghttp3] Fix configure when cunit was installed

### DIFF
--- a/ports/nghttp3/portfile.cmake
+++ b/ports/nghttp3/portfile.cmake
@@ -14,9 +14,13 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DENABLE_LIB_ONLY=ON
+        -DBUILD_TESTING=OFF
         "-DENABLE_STATIC_CRT=${ENABLE_STATIC_CRT}"
         "-DENABLE_STATIC_LIB=${ENABLE_STATIC_LIB}"
         "-DENABLE_SHARED_LIB=${ENABLE_SHARED_LIB}"
+        -DCMAKE_DISABLE_FIND_PACKAGE_CUnit=ON
+    MAYBE_UNUSED_VARIABLES
+        BUILD_TESTING
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/nghttp3/vcpkg.json
+++ b/ports/nghttp3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nghttp3",
   "version": "0.7.0",
+  "port-version": 1,
   "description": "Implementation of RFC 9114 HTTP/3 mapping over QUIC and RFC 9204 QPACK in C",
   "homepage": "https://github.com/ngtcp2/nghttp3",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4990,7 +4990,7 @@
     },
     "nghttp3": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ngspice": {
       "baseline": "37",

--- a/versions/n-/nghttp3.json
+++ b/versions/n-/nghttp3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf61122128fd277764b9319577d2ed3636c1d0d0",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f71e5ffcb5802adeb997b151ea1277662ff9b03f",
       "version": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
When CUnit was installed and found, nghttp3 will enable static build:
```cmake
...
if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
  # Static library (for unittests because of symbol visibility)
  add_library(nghttp3_static STATIC ${nghttp3_SOURCES})
...
```
Fix this and disable testing.

Related: https://dev.azure.com/vcpkg/public/_build/results?buildId=77177&view=results&j=878666d5-db33-5b27-9e7d-b0c7ee352005