### PR TITLE
[bdwgc] Update to v8.2.2

### DIFF
--- a/ports/bdwgc/portfile.cmake
+++ b/ports/bdwgc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ivmai/bdwgc
-    REF 5fab1a01931a1a6934ccf1d5eaa1e51f0a8dac4d # v8.2.0-20211115
-    SHA512 b1a97aad10df33bb242985eb48f1bb2d3082d88f26c34014efce3d0f233bcd18a0f43f1bd960600ad9e22bcb19ebf04e573c74dfc1abfb771aa6b8525053c14b
+    REF v8.2.2
+    SHA512 da6a2de30f096610ea1c0de1ff7a3ab434debaa39199bc1426daff620901fc76e5747e43171d742b17f4afa3c77ef447cba4fda69d76a711e108f3f03af917ca
     HEAD_REF master
 )
 

--- a/ports/bdwgc/vcpkg.json
+++ b/ports/bdwgc/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "bdwgc",
-  "version": "8.2.0",
-  "port-version": 4,
+  "version": "8.2.2",
   "description": "The Boehm-Demers-Weiser conservative C/C++ Garbage Collector (libgc, bdwgc, boehm-gc)",
-  "homepage": "http://www.hboehm.info/gc/",
+  "homepage": "https://www.hboehm.info/gc/",
+  "license": "MIT",
   "dependencies": [
     "libatomic-ops",
     {

--- a/versions/b-/bdwgc.json
+++ b/versions/b-/bdwgc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f99370553e85e9f6a10878253cdee86883b0ff30",
+      "version": "8.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "8fe23b71dde5d4abc9a755c359a583b8d7ba3035",
       "version": "8.2.0",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -425,8 +425,8 @@
       "port-version": 5
     },
     "bdwgc": {
-      "baseline": "8.2.0",
-      "port-version": 4
+      "baseline": "8.2.2",
+      "port-version": 0
     },
     "beast": {
       "baseline": "0",


### PR DESCRIPTION
* Change REF from 5fab1a019 (v8.2.0-20211115) to v8.2.2

* Update version, reset port-version

* Use https in homepage

**Describe the pull request**

- #### What does your PR fix?
  Update from intermediate snapshot to a stable release

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
