### PR TITLE
[tesseract] enable on arm64 osx

### DIFF
--- a/ports/tesseract/vcpkg.json
+++ b/ports/tesseract/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "tesseract",
   "version": "5.2.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.",
   "homepage": "https://github.com/tesseract-ocr/tesseract",
   "license": "Apache-2.0",
-  "supports": "!(arm & (osx | linux))",
+  "supports": "!(arm & linux)",
   "dependencies": [
     "curl",
     "leptonica",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7122,7 +7122,7 @@
     },
     "tesseract": {
       "baseline": "5.2.0",
-      "port-version": 1
+      "port-version": 2
     },
     "tfhe": {
       "baseline": "1.0.1",

--- a/versions/t-/tesseract.json
+++ b/versions/t-/tesseract.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1f744cece33deac53dcc458b75be788e7f2e92a",
+      "version": "5.2.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "ea93f36603ca265da43ef28d6583871ef3d97b43",
       "version": "5.2.0",
       "port-version": 1


### PR DESCRIPTION
Enable the tesseract port on arm64-osx

I downloaded the tesseract data and tested it, and it seemed to give good results. 

- #### What does your PR fix?
  Fixes error for unsupported port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  arm64-osx is support, which is an unofficial triplet, so no need to update baseline

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
