### PR TITLE
[opencv4] disable optional hdf5 dependency for iOS, where it doesn't build (yet)

### DIFF
--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.6.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
       "dependencies": [
         {
           "name": "hdf5",
-          "platform": "!uwp & !(windows & (arm | arm64))"
+          "platform": "!uwp & !(windows & (arm | arm64)) & !ios"
         },
         {
           "name": "tesseract",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5274,7 +5274,7 @@
     },
     "opencv4": {
       "baseline": "4.6.0",
-      "port-version": 3
+      "port-version": 4
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "970c048b2d380fe84e110c02a99dc099f8b877d0",
+      "version": "4.6.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "18c563d48f8245b3d1e0879ecdc6c37097a89b3c",
       "version": "4.6.0",
       "port-version": 3


### PR DESCRIPTION
- [opencv4] diable hdf5 dependency on ios, as it currently doesn't build
- ./vcpkg x-add-version --all

HDF5 doesn't build on iOS (essentially same issue as #24898), and it's optional for opencv so disable it for now.

- #### What does your PR fix?
  Fixes building opencv4 on arm64-ios

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  arm64-ios. arm-ios still does not work due to broken protobuf, but I'm not personally interested in this target so did not spend the time to fix it. 

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes