### PR TITLE
[dpdk] Update to v22.07

### DIFF
--- a/ports/dpdk/portfile.cmake
+++ b/ports/dpdk/portfile.cmake
@@ -24,7 +24,7 @@ if(VCPKG_TARGET_IS_LINUX)
   endif()
 endif()
 
-set(PORT_VERSION 22.03)
+set(PORT_VERSION 22.07)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO DPDK/dpdk

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dpdk",
-  "version-string": "22.03",
-  "port-version": 3,
+  "version-string": "22.07",
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/index.html",
@@ -34,13 +33,7 @@
       "description": "Build and install kernel modules"
     },
     "tests": {
-      "description": "Build and install tests",
-      "dependencies": [
-        {
-          "name": "libarchive",
-          "default-features": false
-        }
-      ]
+      "description": "Build and install tests"
     },
     "trace": {
       "description": "Build with fast path traces enabled"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1977,8 +1977,8 @@
       "port-version": 0
     },
     "dpdk": {
-      "baseline": "22.03",
-      "port-version": 3
+      "baseline": "22.07",
+      "port-version": 0
     },
     "dpp": {
       "baseline": "10.0.17",

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f09ca3077d7bc3f4ceaf558cdb9518ab94cbbe18",
+      "version-string": "22.07",
+      "port-version": 0
+    },
+    {
       "git-tree": "b097f29e77f314135bad880b342548826bb99108",
       "version-string": "22.03",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Update DPDK to v22.07

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

Also removed the "libarchive" dependency for the "tests" feature because it is already defined in the main dependency of this port.
