### PR TITLE
[bitar] Add new port for biar

### DIFF
--- a/ports/bitar/portfile.cmake
+++ b/ports/bitar/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO ljishen/bitar
+  REF v0.0.4
+  SHA512 1b4e645c3d51ba662faa2fca256edb89860f8eeab59d1d51a282ba1ae3a3c6fd497450ddc5c5db473f431651bfecf743d185230d4c4a51de97a0475333ea176b
+  HEAD_REF main)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    -DVCPKG_ROOT=${VCPKG_ROOT_DIR}
+    -DBITAR_FETCHCONTENT_OVERWRITE_CONFIGURATION=OFF)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(
+  INSTALL "${SOURCE_PATH}/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright)

--- a/ports/bitar/vcpkg.json
+++ b/ports/bitar/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "bitar",
+  "version": "0.0.4",
+  "description": "Bitar is a C++ library to simplify accessing hardware compression/decompression accelerators.",
+  "homepage": "https://github.com/ljishen/bitar",
+  "license": "MIT",
+  "supports": "linux | freebsd",
+  "dependencies": [
+    {
+      "name": "abseil",
+      "features": [
+        "cxx17"
+      ]
+    },
+    {
+      "name": "dpdk",
+      "version>=": "22.03#3"
+    },
+    "fmt",
+    "magic-enum",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/b-/bitar.json
+++ b/versions/b-/bitar.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e3d713adacf64e6791f33daed5b9bda7abd0bfe0",
+      "version": "0.0.4",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -476,6 +476,10 @@
       "baseline": "3.0",
       "port-version": 1
     },
+    "bitar": {
+      "baseline": "0.0.4",
+      "port-version": 0
+    },
     "bitmagic": {
       "baseline": "7.11.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Add a new port for Bitar, a library for simplifying accessing hardware compression/decompression accelerators.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
