### PR TITLE
[vcpkg baseline][kf5globalaccel] Fix baseline

### DIFF
--- a/ports/kf5globalaccel/make_x11_required.patch
+++ b/ports/kf5globalaccel/make_x11_required.patch
@@ -1,0 +1,28 @@
+﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f78b454..4858674 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,19 +48,19 @@ find_package(KF5DBusAddons ${KF_DEP_VERSION} REQUIRED)
+ find_package(KF5WindowSystem ${KF_DEP_VERSION} REQUIRED)
+ 
+ # no X11 stuff on mac
+-if (NOT APPLE)
+-    find_package(XCB MODULE COMPONENTS XCB KEYSYMS XKB OPTIONAL_COMPONENTS XTEST)
++if (NOT APPLE AND ENABLE_X11EXTRAS)
++    find_package(XCB MODULE REQUIRED COMPONENTS XCB KEYSYMS XKB OPTIONAL_COMPONENTS XTEST)
+     set_package_properties(XCB PROPERTIES DESCRIPTION "X protocol C-language Binding"
+                        URL "http://xcb.freedesktop.org"
+                        TYPE OPTIONAL
+                       )
+ 
+-    find_package(X11)
++    find_package(X11 REQUIRED)
+ endif()
+ 
+ set(HAVE_X11 0)
+ 
+-if(X11_FOUND AND XCB_XCB_FOUND)
++if(X11_FOUND AND XCB_XCB_FOUND AND ENABLE_X11EXTRAS)
+     set(HAVE_X11 1)
+     find_package(Qt5 ${REQUIRED_QT_VERSION} CONFIG REQUIRED X11Extras)
+ endif()

--- a/ports/kf5globalaccel/portfile.cmake
+++ b/ports/kf5globalaccel/portfile.cmake
@@ -6,11 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES "make_x11_required.patch"
 )
-vcpkg_check_features(
-    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-      xllextas ENABLE_X11EXTRAS
-)
+
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
 
@@ -18,7 +14,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
-        ${FEATURE_OPTIONS}
+        -DENABLE_X11_EXTRAS=${VCPKG_TARGET_IS_LINUX}
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5globalaccel/portfile.cmake
+++ b/ports/kf5globalaccel/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
-        -DENABLE_X11_EXTRAS=${VCPKG_TARGET_IS_LINUX}
+        -DENABLE_X11EXTRAS=${VCPKG_TARGET_IS_LINUX}
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5globalaccel/portfile.cmake
+++ b/ports/kf5globalaccel/portfile.cmake
@@ -4,20 +4,21 @@ vcpkg_from_github(
     REF v5.89.0
     SHA512 824e4d6204189290dcc542ef3004ad2e2e2f83620dbf381ab78edbef996f412996709b9b49b72aad7c23deeeb6be274906b4cbbbd49498be081330e89c5674de
     HEAD_REF master
+    PATCHES "make_x11_required.patch"
 )
-
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+      xllextas ENABLE_X11EXTRAS
+)
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
-
-if(NOT VCPKG_TARGET_IS_LINUX)
-  list(APPEND KGLOBALACCEL_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_X11=ON)
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
-        ${KGLOBALACCEL_OPTIONS}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5globalaccel/vcpkg.json
+++ b/ports/kf5globalaccel/vcpkg.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kf5globalaccel",
   "version": "5.89.0",
   "port-version": 3,
@@ -15,6 +14,10 @@
     "qt5-base",
     "qt5-tools",
     {
+      "name": "qt5-x11extras",
+      "platform": "linux"
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
@@ -22,14 +25,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "x11extras": {
-      "description": "Enable x11extras",
-      "supports": "linux",
-      "dependencies": [
-        "qt5-x11extras"
-      ]
-    }
-  }
+  ]
 }

--- a/ports/kf5globalaccel/vcpkg.json
+++ b/ports/kf5globalaccel/vcpkg.json
@@ -1,7 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kf5globalaccel",
   "version": "5.89.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "lobal desktop keyboard shortcuts",
   "homepage": "https://api.kde.org/frameworks/kglobalaccel/html/index.html",
   "dependencies": [
@@ -14,10 +15,6 @@
     "qt5-base",
     "qt5-tools",
     {
-      "name": "qt5-x11extras",
-      "platform": "linux"
-    },
-    {
       "name": "vcpkg-cmake",
       "host": true
     },
@@ -25,5 +22,15 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "x11extras": {
+      "description": "Enable x11extras",
+      "dependencies": [
+        "qt5-x11extras"
+      ],
+      "supports": "linux"
+    }
+  
+  }
 }

--- a/ports/kf5globalaccel/vcpkg.json
+++ b/ports/kf5globalaccel/vcpkg.json
@@ -26,11 +26,10 @@
   "features": {
     "x11extras": {
       "description": "Enable x11extras",
+      "supports": "linux",
       "dependencies": [
         "qt5-x11extras"
-      ],
-      "supports": "linux"
+      ]
     }
-  
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3266,7 +3266,7 @@
     },
     "kf5globalaccel": {
       "baseline": "5.89.0",
-      "port-version": 2
+      "port-version": 3
     },
     "kf5guiaddons": {
       "baseline": "5.89.0",

--- a/versions/k-/kf5globalaccel.json
+++ b/versions/k-/kf5globalaccel.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6bbc627f2a72c4776ae67aa40e2f2aba583f8515",
+      "git-tree": "12a2d7458be3768c8fefca6986a678aad429b66e",
       "version": "5.89.0",
       "port-version": 3
     },

--- a/versions/k-/kf5globalaccel.json
+++ b/versions/k-/kf5globalaccel.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3c745b83f873cb1e829a3628ff704c3945a1fef6",
+      "git-tree": "6bbc627f2a72c4776ae67aa40e2f2aba583f8515",
       "version": "5.89.0",
       "port-version": 3
     },

--- a/versions/k-/kf5globalaccel.json
+++ b/versions/k-/kf5globalaccel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c745b83f873cb1e829a3628ff704c3945a1fef6",
+      "version": "5.89.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "610034ef9764b5d45569588235e9a5838ae05757",
       "version": "5.89.0",
       "port-version": 2


### PR DESCRIPTION

Makes qt5-x11extras a feature to fix conditional transitive dependencies.
https://dev.azure.com/vcpkg/public/_build/results?buildId=77258&view=results

