### PR TITLE
[vcpkg baseline][dpp] Add DISABLE_PARALLEL_CONFIGURE

### DIFF
--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
 )
 
 vcpkg_cmake_install()

--- a/ports/dpp/vcpkg.json
+++ b/ports/dpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dpp",
   "version": "10.0.17",
+  "port-version": 1,
   "description": "D++ Extremely Lightweight C++ Discord Library.",
   "homepage": "https://dpp.dev/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1982,7 +1982,7 @@
     },
     "dpp": {
       "baseline": "10.0.17",
-      "port-version": 0
+      "port-version": 1
     },
     "draco": {
       "baseline": "1.5.2",

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be573eeac83a526231011339e0a64c28b513bbd5",
+      "version": "10.0.17",
+      "port-version": 1
+    },
+    {
       "git-tree": "aee1785670d15751e08e0fee3426faf2d8559ee9",
       "version": "10.0.17",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  In VCPKG CI testing, dpp failed with following error:
```
  CMake Error at CMakeLists.txt:54 (configure_file):
  No such file or directory
```

   This issue is because the upstream's CMakeLists.txt file contains following codes:
`  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/dpp/dpp.rc.in" "${CMAKE_CURRENT_SOURCE_DIR}/src/dpp/dpp.rc" NEWLINE_STYLE WIN32)`
  
   The file operation here may cause the same file to be operated at the same time during parallel config, resulting in the above error. This issue could be fixed by adding `DISABLE_PARALLEL_CONFIGURE` in the config step.