### PR TITLE
[ncurses] Add file(MAKE_DIRECTORY) to create the missing directories

### DIFF
--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -9,8 +9,8 @@ vcpkg_download_distfile(
     SHA512 5373f228cba6b7869210384a607a2d7faecfcbfef6dbfcd7c513f4e84fbd8bcad53ac7db2e7e84b95582248c1039dcfc7c4db205a618f7da22a166db482f0105
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
+vcpkg_extract_source_archive(
+    SOURCE_PATH
     ARCHIVE "${ARCHIVE_PATH}"
 )
 
@@ -50,7 +50,7 @@ set(OPTIONS_RELEASE
 )
 
 vcpkg_configure_make(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${OPTIONS}
     OPTIONS_DEBUG ${OPTIONS_DEBUG}
     OPTIONS_RELEASE ${OPTIONS_RELEASE}

--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -38,6 +38,9 @@ if(VCPKG_TARGET_IS_MINGW)
     )
 endif()
 
+file(MAKE_DIRECTORY "${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig")
+file(MAKE_DIRECTORY "${CURRENT_INSTALLED_DIR}/lib/pkgconfig")
+
 set(OPTIONS_DEBUG
     "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig"
     --with-debug

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,9 +1,12 @@
 {
   "name": "ncurses",
   "version": "6.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "free software emulation of curses in System V Release 4.0",
   "homepage": "https://invisible-island.net/ncurses/announce.html",
   "license": "MIT",
-  "supports": "!windows | mingw"
+  "supports": "!windows | mingw",
+  "dependencies": [
+    "pkgconf"
+  ]
 }

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -5,8 +5,5 @@
   "description": "free software emulation of curses in System V Release 4.0",
   "homepage": "https://invisible-island.net/ncurses/announce.html",
   "license": "MIT",
-  "supports": "!windows | mingw",
-  "dependencies": [
-    "pkgconf"
-  ]
+  "supports": "!windows | mingw"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4958,7 +4958,7 @@
     },
     "ncurses": {
       "baseline": "6.3",
-      "port-version": 1
+      "port-version": 2
     },
     "neargye-semver": {
       "baseline": "0.3.0",

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c29099ec93dff83bfea876e14d6780795fa6768",
+      "version": "6.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "ea7aecbf38cef7f64f929c679d55812e679ca496",
       "version": "6.3",
       "port-version": 1

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2c29099ec93dff83bfea876e14d6780795fa6768",
+      "git-tree": "f61c866b4032d902b9c31cec60a4418615ae921b",
       "version": "6.3",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/26677
  
  Since ncurses always need the below make options:
```
  "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig"
  "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/lib/pkgconfig"
```
  If this port install in a new vcpkg, it will failed with following error because there is no pkgconfig folder.
```
  configure: error: expected a pathname, not ""
```
  For fixing this issue, add `file(MAKE_DIRECTORY)` to create the missing directories.

  No feature need to test.