### PR TITLE
[atk] fix supports

### DIFF
--- a/ports/atk/portfile.cmake
+++ b/ports/atk/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 set(ATK_VERSION 2.38.0)
 
 vcpkg_from_gitlab(

--- a/ports/atk/portfile.cmake
+++ b/ports/atk/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 set(ATK_VERSION 2.38.0)
 

--- a/ports/atk/vcpkg.json
+++ b/ports/atk/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "atk",
   "version": "2.38.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GNOME Accessibility Toolkit",
   "homepage": "https://developer.gnome.org/atk/",
   "license": "GPL-2.0-only",
-  "supports": "!arm",
+  "supports": "!arm & !staticcrt",
   "dependencies": [
     "gettext",
     "glib",

--- a/ports/atk/vcpkg.json
+++ b/ports/atk/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "GNOME Accessibility Toolkit",
   "homepage": "https://developer.gnome.org/atk/",
   "license": "GPL-2.0-only",
-  "supports": "!arm & !staticcrt",
+  "supports": "!arm",
   "dependencies": [
     "gettext",
     "glib",

--- a/versions/a-/atk.json
+++ b/versions/a-/atk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d5f3d96f92caa5e2844ec4d59e48afc5a90e672c",
+      "git-tree": "bd56d0a1da41bd3599d64238cdd93f94e9b3873f",
       "version": "2.38.0",
       "port-version": 2
     },

--- a/versions/a-/atk.json
+++ b/versions/a-/atk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bd56d0a1da41bd3599d64238cdd93f94e9b3873f",
+      "git-tree": "e6aebc3163947c210e176a1e9ab0ddd1c6c7d0bf",
       "version": "2.38.0",
       "port-version": 2
     },

--- a/versions/a-/atk.json
+++ b/versions/a-/atk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5f3d96f92caa5e2844ec4d59e48afc5a90e672c",
+      "version": "2.38.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "4034b57da4c9eeb30d6904339be721b7e45f8a89",
       "version": "2.38.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -218,7 +218,7 @@
     },
     "atk": {
       "baseline": "2.38.0",
-      "port-version": 1
+      "port-version": 2
     },
     "atkmm": {
       "baseline": "2.36.1",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/26661

Error message:
```
Building package atk[core]:x64-windows-static...
-- Note: atk only supports dynamic library linkage. Building dynamic library.
CMake Error at scripts/cmake/vcpkg_check_linkage.cmake:25 (message):
  Refusing to build unexpected dynamic library against the static CRT.
```