### PR TITLE
[libpq] Fix arm64-windows build with Visual Studio 2017

### DIFF
--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -110,6 +110,10 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         string(REPLACE "perl" "\"${PERL}\"" _contents "${_contents}")
         file(WRITE "${MSPROJ_PERL}" "${_contents}")
 
+        set(VCPKG_COMBINED_SHARED_LINKER_FLAGS_DEBUG "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_DEBUG} advapi32.lib shell32.lib")
+        set(VCPKG_COMBINED_STATIC_LINKER_FLAGS_DEBUG "${VCPKG_COMBINED_STATIC_LINKER_FLAGS_DEBUG} advapi32.lib shell32.lib")
+        set(VCPKG_COMBINED_SHARED_LINKER_FLAGS_RELEASE "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_RELEASE} advapi32.lib shell32.lib")
+        set(VCPKG_COMBINED_STATIC_LINKER_FLAGS_RELEASE "${VCPKG_COMBINED_STATIC_LINKER_FLAGS_RELEASE} advapi32.lib shell32.lib")
         set(CONFIG_FILE "${BUILDPATH_${_buildtype}}/src/tools/msvc/config.pl")
         file(READ "${CONFIG_FILE}" _contents)
 

--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpq",
   "version": "14.4",
+  "port-version": 1,
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "license": "PostgreSQL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4010,7 +4010,7 @@
     },
     "libpq": {
       "baseline": "14.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libpqxx": {
       "baseline": "7.7.3",

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "289842e1c5aa972bed6b6bf2af853d44a344002a",
+      "version": "14.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "2b3456bfb8b04525c44007f3c8a04b7e208d639d",
       "version": "14.4",
       "port-version": 0


### PR DESCRIPTION
libpq uses 2 windows api GetUserName and SHGetFolderPath but not add the related system libs Advapi32.lib and Shell32.lib in build process.
Fix this.

cc @Neumann-A 