### PR TITLE
[libtcod] Update to 1.22.3

### DIFF
--- a/ports/libtcod/portfile.cmake
+++ b/ports/libtcod/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtcod/libtcod
-    REF 1.22.2
-    SHA512 c02b6bb205f610416ea6cd9bdeb89a6976141e03a2cd2c44838f0d35edf2544e61af86d2ba904c6a913bbc3754592eed6063b732277bede55b79ffe3b983ee4d
+    REF 1.22.3
+    SHA512 350b741f8738f5ba3c6f282e76c1124326144111eb2444b17b1126e8ddead52cff1dba1d0ed80e6fefbb0db8f032b95d08292d73746eec149e191a8fa78651d7
     HEAD_REF main
 )
 
@@ -12,6 +12,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "sdl" CMAKE_DISABLE_FIND_PACKAGE_SDL2
         "sdl" CMAKE_DISABLE_FIND_PACKAGE_GLAD
         "threads" CMAKE_DISABLE_FIND_PACKAGE_Threads
+        "unicode" CMAKE_DISABLE_FIND_PACKAGE_utf8proc
+        "unicode" CMAKE_DISABLE_FIND_PACKAGE_unofficial-utf8proc
         "zlib" CMAKE_DISABLE_FIND_PACKAGE_ZLIB
 )
 

--- a/ports/libtcod/vcpkg.json
+++ b/ports/libtcod/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtcod",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "maintainers": "Kyle Benesch <4b796c65+github@gmail.com>",
   "description": "Common algorithms and tools for roguelikes.",
   "homepage": "https://github.com/libtcod/libtcod",
@@ -8,7 +8,6 @@
   "license": "BSD-3-Clause",
   "dependencies": [
     "stb",
-    "utf8proc",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -21,6 +20,7 @@
   "default-features": [
     "png",
     "sdl",
+    "unicode",
     "zlib"
   ],
   "features": {
@@ -39,6 +39,12 @@
     },
     "threads": {
       "description": "Support for deprecated threading functions.  If in doubt then leave this disabled."
+    },
+    "unicode": {
+      "description": "Support for non-ASCII characters.  Required for text printing functions",
+      "dependencies": [
+        "utf8proc"
+      ]
     },
     "zlib": {
       "description": "Support for REXPaint files and TCODZip archives.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4185,7 +4185,7 @@
       "port-version": 3
     },
     "libtcod": {
-      "baseline": "1.22.2",
+      "baseline": "1.22.3",
       "port-version": 0
     },
     "libtess2": {

--- a/versions/l-/libtcod.json
+++ b/versions/l-/libtcod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98a04c69b32d8e84d25d2913a2f0ad7ec7b4b833",
+      "version": "1.22.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "b8a26dfda1df684c3d88697b774c3e0a9c91f9b9",
       "version": "1.22.2",
       "port-version": 0


### PR DESCRIPTION

- #### What does your PR fix?
  Updates to the latest version.  Adds the `unicode` feature.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes. `unicode` feature is enabled by default because it toggles existing API functions.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
