### PR TITLE
[grpc] fix upb library order in pkgconfig

### DIFF
--- a/ports/grpc/00014-pkgconfig-upbdefs.patch
+++ b/ports/grpc/00014-pkgconfig-upbdefs.patch
@@ -7,7 +7,7 @@ index 25990a5d8a..4c7831cba5 100644
    "${gRPC_CORE_VERSION}"
    "gpr openssl absl_base absl_bind_front absl_cord absl_core_headers absl_flat_hash_map absl_flat_hash_set absl_function_ref absl_hash absl_inlined_vector absl_memory absl_optional absl_random_random absl_span absl_status absl_statusor absl_str_format absl_strings absl_synchronization absl_time absl_type_traits absl_utility absl_variant"
 -  "-lgrpc -laddress_sorting -lre2 -lupb -lcares -lz"
-+  "-lgrpc -laddress_sorting -lre2 -ldescriptor_upb_proto -lupb_fastdecode -lupb_json -lupb_reflection -lupb_textformat -lupb_utf8_range -lupb -lcares -lz"
++  "-lgrpc -laddress_sorting -lre2 -lupb_json -lupb_textformat -lupb_reflection -lupb -lupb_fastdecode -lupb_utf8_range -ldescriptor_upb_proto -lcares -lz"
    ""
    "grpc.pc")
  

--- a/ports/grpc/vcpkg.json
+++ b/ports/grpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "grpc",
   "version-semver": "1.48.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An RPC library and framework",
   "homepage": "https://github.com/grpc/grpc",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2730,7 +2730,7 @@
     },
     "grpc": {
       "baseline": "1.48.0",
-      "port-version": 1
+      "port-version": 2
     },
     "grppi": {
       "baseline": "0.4.0",

--- a/versions/g-/grpc.json
+++ b/versions/g-/grpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efed7f493dec5fdebaebdec83c521fc860b432a3",
+      "version-semver": "1.48.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "7b2206a9758481b4773a93435aa6cfe7de4bf9e5",
       "version-semver": "1.48.0",
       "port-version": 1


### PR DESCRIPTION
Use the same order for `upb` libraries in the pkgconfig patch as CMake uses.

- #### What does your PR fix?

  Fixes #26751

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

N/A

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes
