### PR TITLE
[arrayfire] Fix feature opencl dependency clFFT

### DIFF
--- a/ports/arrayfire/fix-dependency-clfft.patch
+++ b/ports/arrayfire/fix-dependency-clfft.patch
@@ -1,0 +1,14 @@
+diff --git a/src/backend/opencl/CMakeLists.txt b/src/backend/opencl/CMakeLists.txt
+index f970da0..b543433 100644
+--- a/src/backend/opencl/CMakeLists.txt
++++ b/src/backend/opencl/CMakeLists.txt
+@@ -12,7 +12,8 @@ set_property(CACHE AF_OPENCL_BLAS_LIBRARY PROPERTY STRINGS "clBLAS" "CLBlast")
+ 
+ af_deprecate(OPENCL_BLAS_LIBRARY AF_OPENCL_BLAS_LIBRARY)
+ 
+-include(build_clFFT)
++find_package(clFFT CONFIG REQUIRED)
++add_library(clFFT::clFFT ALIAS clFFT)
+ 
+ file(GLOB kernel_src kernel/*.cl kernel/KParam.hpp)
+ 

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -7,7 +7,8 @@ vcpkg_from_github(
   PATCHES
     build.patch
     Fix-constexpr-error-with-vs2019-with-half.patch
-  )
+    fix-dependency-clfft.patch
+)
 
 # arrayfire cpu thread lib needed as a submodule for the CPU backend
 vcpkg_from_github(
@@ -16,7 +17,7 @@ vcpkg_from_github(
   REF b666773940269179f19ef11c8f1eb77005e85d9a
   SHA512 b3e8b54acf3a588b1f821c2774d5da2d8f8441962c6d99808d513f7117278b9066eb050b8b501bddbd3882e68eb5cc5da0b2fca54e15ab1923fe068a3fe834f5
   HEAD_REF master
-  )
+)
 
 # Get forge. We only need headers and aren't actually linking.
 # We don't want to use the vcpkg dependency since it is broken in many
@@ -45,7 +46,7 @@ set(AF_DEFAULT_VCPKG_CMAKE_FLAGS
   -DAF_FORGE_PATH=${FORGE_PATH} # forge headers for building the graphics lib
   -DAF_BUILD_FORGE=OFF
   -DAF_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT} # for CMake configs/targets
-  )
+)
 
 # bin/dll directory for Windows non-static builds for the unified backend dll
 if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -73,7 +74,9 @@ vcpkg_cmake_configure(
   OPTIONS
     ${AF_DEFAULT_VCPKG_CMAKE_FLAGS}
     ${AF_BACKEND_FEATURE_OPTIONS}
-  )
+  MAYBE_UNUSED_VARIABLES
+    AF_CPU_THREAD_PATH
+)
 vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arrayfire",
   "version-semver": "3.8.0",
+  "port-version": 1,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "supports": "x64",
   "dependencies": [
@@ -39,6 +40,7 @@
     "opencl": {
       "description": "ArrayFire OpenCL backend",
       "dependencies": [
+        "clfft",
         "opencl"
       ]
     },

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -3,6 +3,8 @@
   "version-semver": "3.8.0",
   "port-version": 1,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
+  "homepage": "https://github.com/arrayfire/arrayfire",
+  "license": "BSD-3-Clause",
   "supports": "x64",
   "dependencies": [
     "boost-compute",

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "366a6115d4c20c44ee29ae526096b1eb9d87bf58",
+      "git-tree": "137eb0d15f469e75ad3255cf1de871d83b3dff49",
       "version-semver": "3.8.0",
       "port-version": 1
     },

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "366a6115d4c20c44ee29ae526096b1eb9d87bf58",
+      "version-semver": "3.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e6c5e8b4e1c52380ebd2050683a185c44a2dbae4",
       "version-semver": "3.8.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -182,7 +182,7 @@
     },
     "arrayfire": {
       "baseline": "3.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "arrow": {
       "baseline": "9.0.0",


### PR DESCRIPTION
```
[465/466] cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --intdir=src\backend\opencl\CMakeFiles\afopencl.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1433~1.316\bin\Hostx64\x64\link.exe  @CMakeFiles\afopencl.rsp  /out:bin\afopencl.dll /implib:src\backend\opencl\afopencl.lib /pdb:bin\afopencl.pdb /dll /version:3.8 /machine:x64 /nologo    /debug /INCREMENTAL  && cd ."
FAILED: bin/afopencl.dll src/backend/opencl/afopencl.lib 
cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --intdir=src\backend\opencl\CMakeFiles\afopencl.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1433~1.316\bin\Hostx64\x64\link.exe  @CMakeFiles\afopencl.rsp  /out:bin\afopencl.dll /implib:src\backend\opencl\afopencl.lib /pdb:bin\afopencl.pdb /dll /version:3.8 /machine:x64 /nologo    /debug /INCREMENTAL  && cd ."
LINK Pass 1: command "C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1433~1.316\bin\Hostx64\x64\link.exe @CMakeFiles\afopencl.rsp /out:bin\afopencl.dll /implib:src\backend\opencl\afopencl.lib /pdb:bin\afopencl.pdb /dll /version:3.8 /machine:x64 /nologo /debug /INCREMENTAL /MANIFEST /MANIFESTFILE:src\backend\opencl\CMakeFiles\afopencl.dir/intermediate.manifest src\backend\opencl\CMakeFiles\afopencl.dir/manifest.res" failed (exit code 1104) with the following output:
LINK : fatal error LNK1104: cannot open file 'third_party\clFFT\lib\import\clFFT.lib'
```
Change vendor clfft to our port clfft to resolve this issue.

Fixes #26763