### PR TITLE
[arrayfire] Fix usage

### DIFF
--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -45,7 +45,6 @@ set(AF_DEFAULT_VCPKG_CMAKE_FLAGS
   -DAF_CPU_THREAD_PATH=${CPU_THREADS_PATH} # for building the arrayfire cpu threads lib
   -DAF_FORGE_PATH=${FORGE_PATH} # forge headers for building the graphics lib
   -DAF_BUILD_FORGE=OFF
-  -DAF_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT} # for CMake configs/targets
 )
 
 # bin/dll directory for Windows non-static builds for the unified backend dll
@@ -74,12 +73,18 @@ vcpkg_cmake_configure(
   OPTIONS
     ${AF_DEFAULT_VCPKG_CMAKE_FLAGS}
     ${AF_BACKEND_FEATURE_OPTIONS}
+  OPTIONS_DEBUG
+    -DAF_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/debug/share/${PORT} # for CMake configs/targets
+  OPTIONS_RELEASE
+    -DAF_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT} # for CMake configs/targets
   MAYBE_UNUSED_VARIABLES
     AF_CPU_THREAD_PATH
 )
 vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/examples")

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -74,9 +74,9 @@ vcpkg_cmake_configure(
     ${AF_DEFAULT_VCPKG_CMAKE_FLAGS}
     ${AF_BACKEND_FEATURE_OPTIONS}
   OPTIONS_DEBUG
-    -DAF_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/debug/share/${PORT} # for CMake configs/targets
+    -DAF_INSTALL_CMAKE_DIR="${CURRENT_PACKAGES_DIR}/debug/share/${PORT}" # for CMake configs/targets
   OPTIONS_RELEASE
-    -DAF_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT} # for CMake configs/targets
+    -DAF_INSTALL_CMAKE_DIR="${CURRENT_PACKAGES_DIR}/share/${PORT}" # for CMake configs/targets
   MAYBE_UNUSED_VARIABLES
     AF_CPU_THREAD_PATH
 )

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrayfire",
   "version-semver": "3.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "homepage": "https://github.com/arrayfire/arrayfire",
   "license": "BSD-3-Clause",

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39a0202b2d29cd9d709efc1bdd7c5f996671172f",
+      "version-semver": "3.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "137eb0d15f469e75ad3255cf1de871d83b3dff49",
       "version-semver": "3.8.0",
       "port-version": 1

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39a0202b2d29cd9d709efc1bdd7c5f996671172f",
+      "git-tree": "9ce1cae30cfcfd85b9858f5f46a59136cce97e59",
       "version-semver": "3.8.0",
       "port-version": 2
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -182,7 +182,7 @@
     },
     "arrayfire": {
       "baseline": "3.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "arrow": {
       "baseline": "9.0.0",


### PR DESCRIPTION
The exported cmake config files are not fixed, and the debug share installation dir is incorrect.
Fix that.

Fixes #26763.

Already use the user provided sample code to test this changes successfully:
```cmake
cmake_minimum_required(VERSION 3.15)

project(vcpkg-test CXX)

find_package(ArrayFire REQUIRED)

add_executable(vcpkg-test src/main.cxx)
target_compile_features(vcpkg-test PRIVATE cxx_std_17)

target_link_libraries(vcpkg-test
    PRIVATE
        ArrayFire::afopencl)
```