### PR TITLE
[gstreamer] Add opus support

### DIFF
--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -143,6 +143,12 @@ else()
     set(PLUGIN_BASE_X11 disabled)
 endif()
 
+if ("opus" IN_LIST FEATURES)
+    set(PLUGIN_BASE_OPUS enabled)
+else()
+    set(PLUGIN_BASE_OPUS disabled)
+endif()
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(LIBRARY_LINKAGE "shared")
 else()
@@ -203,6 +209,7 @@ vcpkg_configure_meson(
         -Dgst-plugins-base:pango=disabled
         -Dgst-plugins-base:gl-graphene=${GL_GRAPHENE}
         -Dgst-plugins-base:x11=${PLUGIN_BASE_X11}
+        -Dgst-plugins-base:opus=${PLUGIN_BASE_OPUS}
         ${PLUGIN_BASE_WIN}
         # gst-plugins-good
         -Dgst-plugins-good:default_library=${LIBRARY_LINKAGE}

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.19.2",
-  "port-version": 7,
+  "port-version": 8,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",
@@ -60,6 +60,12 @@
       "supports": "!arm",
       "dependencies": [
         "graphene"
+      ]
+    },
+    "opus": {
+      "description": "Opus de/encoding via libopus",
+      "dependencies": [
+        "opus"
       ]
     },
     "plugins-bad": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2758,7 +2758,7 @@
     },
     "gstreamer": {
       "baseline": "1.19.2",
-      "port-version": 7
+      "port-version": 8
     },
     "gtest": {
       "baseline": "1.12.1",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34e4471f1313a9d9ce220e461dde37a331c5bf47",
+      "version": "1.19.2",
+      "port-version": 8
+    },
+    {
       "git-tree": "88e3063c417fe72ab1532ad99494b71c8037d8b5",
       "version": "1.19.2",
       "port-version": 7


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vcpkg/issues/26595

Add `opus` support for `gstreamer`.

Tested feature in the following triplets:

- x64-windows
- x64-windows-static
- x86-windows