### PR TITLE
[zlib] Fix CVE-2022-37434

### DIFF
--- a/ports/zlib/CVE-2022-37434-1eb7682f84.patch
+++ b/ports/zlib/CVE-2022-37434-1eb7682f84.patch
@@ -1,0 +1,29 @@
+From 1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d Mon Sep 17 00:00:00 2001
+From: Mark Adler <fork@madler.net>
+Date: Mon, 8 Aug 2022 10:50:09 -0700
+Subject: [PATCH] Fix extra field processing bug that dereferences NULL
+ state->head.
+
+The recent commit to fix a gzip header extra field processing bug
+introduced the new bug fixed here.
+---
+ inflate.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/inflate.c b/inflate.c
+index 7a7289749..2a3c4fe98 100644
+--- a/inflate.c
++++ b/inflate.c
+@@ -763,10 +763,10 @@ int flush;
+                 copy = state->length;
+                 if (copy > have) copy = have;
+                 if (copy) {
+-                    len = state->head->extra_len - state->length;
+                     if (state->head != Z_NULL &&
+                         state->head->extra != Z_NULL &&
+-                        len < state->head->extra_max) {
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/ports/zlib/CVE-2022-37434-eff308af42.patch
+++ b/ports/zlib/CVE-2022-37434-eff308af42.patch
@@ -1,0 +1,32 @@
+From eff308af425b67093bab25f80f1ae950166bece1 Mon Sep 17 00:00:00 2001
+From: Mark Adler <fork@madler.net>
+Date: Sat, 30 Jul 2022 15:51:11 -0700
+Subject: [PATCH] Fix a bug when getting a gzip header extra field with
+ inflate().
+
+If the extra field was larger than the space the user provided with
+inflateGetHeader(), and if multiple calls of inflate() delivered
+the extra header data, then there could be a buffer overflow of the
+provided space. This commit assures that provided space is not
+exceeded.
+---
+ inflate.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/inflate.c b/inflate.c
+index 7be8c6366..7a7289749 100644
+--- a/inflate.c
++++ b/inflate.c
+@@ -763,9 +763,10 @@ int flush;
+                 copy = state->length;
+                 if (copy > have) copy = have;
+                 if (copy) {
++                    len = state->head->extra_len - state->length;
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        len < state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
         0001-Prevent-invalid-inclusions-when-HAVE_-is-set-to-0.patch
         debug-postfix-mingw.patch
         0002-android-build-mingw.patch
+        CVE-2022-37434-eff308af42.patch
+        CVE-2022-37434-1eb7682f84.patch
 )
 
 # This is generated during the cmake build

--- a/ports/zlib/vcpkg.json
+++ b/ports/zlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zlib",
   "version": "1.2.12",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A compression library",
   "homepage": "https://www.zlib.net/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8014,7 +8014,7 @@
     },
     "zlib": {
       "baseline": "1.2.12",
-      "port-version": 1
+      "port-version": 2
     },
     "zlib-ng": {
       "baseline": "2.0.6",

--- a/versions/z-/zlib.json
+++ b/versions/z-/zlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ecfad3bd4e5c5c217b58c6187c7f2b9298964d2f",
+      "version": "1.2.12",
+      "port-version": 2
+    },
+    {
       "git-tree": "ecc4c064d4911faf12d8bf5fd6bcd5c556d89774",
       "version": "1.2.12",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes CVE-2022-37434 for zlib through 1.2.12

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
Same as before

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `Yes`