### PR TITLE
[libsrt] Add bonding support

### DIFF
--- a/ports/libsrt/portfile.cmake
+++ b/ports/libsrt/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         tool ENABLE_APPS
+        bonding ENABLE_BONDING
 )
 
 vcpkg_cmake_configure(
@@ -30,7 +31,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/libsrt/vcpkg.json
+++ b/ports/libsrt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsrt",
   "version": "1.5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Secure Reliable Transport (SRT) is an open source transport technology that optimizes streaming performance across unpredictable networks, such as the Internet.",
   "homepage": "https://github.com/Haivision/srt",
   "license": "MPL-2.0",
@@ -18,6 +18,9 @@
     }
   ],
   "features": {
+    "bonding": {
+      "description": "Enables the Connection Bonding feature"
+    },
     "tool": {
       "description": "Builds libsrt executable"
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4158,7 +4158,7 @@
     },
     "libsrt": {
       "baseline": "1.5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libsrtp": {
       "baseline": "2.4.2",

--- a/versions/l-/libsrt.json
+++ b/versions/l-/libsrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00e56b5f80be0e6a959bf121d906edb2255c7764",
+      "version": "1.5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "67081a32f9ebb0639c8cdf50daf0da4db33dfd37",
       "version": "1.5.0",
       "port-version": 1


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vcpkg/issues/26806

Add feature `bonding` to enable connection bonding feature.

Tested feature in the following triplets:

- x64-windows
- x64-windows-static
- x86-windows