### PR TITLE
[alpaka] Add new port

### DIFF
--- a/ports/alpaka/portfile.cmake
+++ b/ports/alpaka/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO alpaka-group/alpaka
+    REF 0.9.0
+    SHA512 c079c0101a1e1c0d244c074e19fcefa6c15751fbb6be072c6f245e515dece8700a40fd101b2b0ba5f9760f4545bf23e1917ea9804accbe16a45039f8b0ed8a01
+    HEAD_REF develop
+)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}")
+    
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/alpaka")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/alpaka/usage
+++ b/ports/alpaka/usage
@@ -1,0 +1,4 @@
+alpaka provides CMake targets:
+
+    find_package(alpaka CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE alpaka::alpaka)

--- a/ports/alpaka/vcpkg.json
+++ b/ports/alpaka/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "alpaka",
+  "version": "0.9.0",
+  "description": "The alpaka library is a header-only abstraction library for accelerator development",
+  "homepage": "https://github.com/alpaka-group/alpaka",
+  "license": "MPL-2.0",
+  "dependencies": [
+    {
+      "name": "boost-core",
+      "version>=": "1.74"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.74"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/alpaka.json
+++ b/versions/a-/alpaka.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fa2a5d53283561fed784514fd0063badc589eb39",
+      "version": "0.9.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -72,6 +72,10 @@
       "baseline": "0.2.0",
       "port-version": 0
     },
+    "alpaka": {
+      "baseline": "0.9.0",
+      "port-version": 0
+    },
     "alsa": {
       "baseline": "1.2.6.1",
       "port-version": 0


### PR DESCRIPTION
This PR adds a new port called `alpaka`, which adds the [alpaka](https://github.com/alpaka-group/alpaka) header-only library.
There is already an equally named [package on spack](https://packages.spack.io/package.html?name=alpaka).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
Alpaka supports Windows, Linux and MacOS. It should work on all triplets.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I tried.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes