### PR TITLE
[openal-soft] fix mingw x86 build

### DIFF
--- a/ports/openal-soft/0001-fix-mingw-x86-build.patch
+++ b/ports/openal-soft/0001-fix-mingw-x86-build.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1984ac9..0d1690a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -472,7 +472,7 @@ if(CMAKE_SIZEOF_VOID_P MATCHES "4" AND HAVE_SSE2)
+             # assumes the stack is suitably aligned. Older Linux code or other
+             # OSs don't guarantee this on 32-bit, so externally-callable
+             # functions need to ensure an aligned stack.
+-            set(EXPORT_DECL "${EXPORT_DECL} __attribute__((force_align_arg_pointer))")
++            set(EXPORT_DECL "${EXPORT_DECL}__attribute__((force_align_arg_pointer))")
+         endif()
+     endif()
+ endif()

--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF dc83d99c95a42c960150ddeee06c124134b52208 # openal-soft-1.22.2
     SHA512 3fbbdfbb2609ef8187d20ce74b2fb8082037288f3fd80df71d360705d8efdadfe8f62811af1cd824cb6572c8c3479b370f8ae3819b8b8bb0b20c34f7a73cc530
     HEAD_REF master
+    PATCHES
+        0001-fix-mingw-x86-build.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -75,6 +77,8 @@ vcpkg_cmake_configure(
         ALSOFT_CONFIG
         ALSOFT_CPUEXT_NEON
         ALSOFT_HRTF_DEFS
+        ALSOFT_BACKEND_WINMM
+        ALSOFT_BACKEND_DSOUND
         CMAKE_DISABLE_FIND_PACKAGE_WindowsSDK
 )
 

--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openal-soft",
   "version-semver": "1.22.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
   "homepage": "https://github.com/kcat/openal-soft",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5250,7 +5250,7 @@
     },
     "openal-soft": {
       "baseline": "1.22.2",
-      "port-version": 3
+      "port-version": 4
     },
     "openblas": {
       "baseline": "0.3.21",

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f028dc8de3d983f0844c0b586c1b6ddfad5d899",
+      "version-semver": "1.22.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "a0e8008cd2061bcaeaf0ed725438edae4386aac1",
       "version-semver": "1.22.2",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Fixes the build error using the mingw x86 triplet and suppressed two unused variable warnings

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yeah

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes
