### PR TITLE
[boost] Add version constraints

### DIFF
--- a/ports/boost-accumulators/vcpkg.json
+++ b/ports/boost-accumulators/vcpkg.json
@@ -1,30 +1,95 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-accumulators",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost accumulators module",
   "homepage": "https://github.com/boostorg/accumulators",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
-    "boost-circular-buffer",
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
-    "boost-fusion",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-numeric-conversion",
-    "boost-parameter",
-    "boost-preprocessor",
-    "boost-range",
-    "boost-serialization",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-ublas",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-circular-buffer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-ublas",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-algorithm/vcpkg.json
+++ b/ports/boost-algorithm/vcpkg.json
@@ -1,27 +1,83 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-algorithm",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost algorithm module",
   "homepage": "https://github.com/boostorg/algorithm",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
-    "boost-bind",
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
-    "boost-exception",
-    "boost-function",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-range",
-    "boost-regex",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-unordered",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-regex",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-unordered",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-align/vcpkg.json
+++ b/ports/boost-align/vcpkg.json
@@ -1,14 +1,31 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-align",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost align module",
   "homepage": "https://github.com/boostorg/align",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-static-assert",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-any/vcpkg.json
+++ b/ports/boost-any/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-any",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost any module",
   "homepage": "https://github.com/boostorg/any",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-index",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-array/vcpkg.json
+++ b/ports/boost-array/vcpkg.json
@@ -1,15 +1,35 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-array",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost array module",
   "homepage": "https://github.com/boostorg/array",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-asio/vcpkg.json
+++ b/ports/boost-asio/vcpkg.json
@@ -1,36 +1,90 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-asio",
   "version": "1.80.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Boost asio module",
   "homepage": "https://github.com/boostorg/asio",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-align",
-    "boost-array",
-    "boost-assert",
-    "boost-bind",
-    "boost-chrono",
-    "boost-config",
+    {
+      "name": "boost-align",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-chrono",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-context",
-      "platform": "!uwp & !emscripten"
+      "platform": "!uwp & !emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-core",
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-coroutine",
-      "platform": "!(arm & windows) & !uwp & !emscripten"
+      "platform": "!(arm & windows) & !uwp & !emscripten",
+      "version>=": "1.80.0#2"
     },
-    "boost-date-time",
-    "boost-exception",
-    "boost-function",
-    "boost-regex",
-    "boost-smart-ptr",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-date-time",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-regex",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ],
   "features": {
     "ssl": {

--- a/ports/boost-assert/vcpkg.json
+++ b/ports/boost-assert/vcpkg.json
@@ -1,11 +1,19 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-assert",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost assert module",
   "homepage": "https://github.com/boostorg/assert",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-assign/vcpkg.json
+++ b/ports/boost-assign/vcpkg.json
@@ -1,21 +1,59 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-assign",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost assign module",
   "homepage": "https://github.com/boostorg/assign",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-config",
-    "boost-core",
-    "boost-move",
-    "boost-preprocessor",
-    "boost-ptr-container",
-    "boost-range",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-ptr-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-atomic/vcpkg.json
+++ b/ports/boost-atomic/vcpkg.json
@@ -1,27 +1,58 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-atomic",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost atomic module",
   "homepage": "https://github.com/boostorg/atomic",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-align",
-    "boost-assert",
+    {
+      "name": "boost-align",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-predef",
-    "boost-preprocessor",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
-    "boost-winapi",
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-beast/vcpkg.json
+++ b/ports/boost-beast/vcpkg.json
@@ -1,31 +1,96 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-beast",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost beast module",
   "homepage": "https://github.com/boostorg/beast",
   "license": "BSL-1.0",
   "supports": "!emscripten",
   "dependencies": [
-    "boost-asio",
-    "boost-assert",
-    "boost-bind",
-    "boost-config",
-    "boost-container",
-    "boost-container-hash",
-    "boost-core",
-    "boost-endian",
-    "boost-intrusive",
-    "boost-logic",
-    "boost-mp11",
-    "boost-optional",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-type-index",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
-    "boost-winapi"
+    {
+      "name": "boost-asio",
+      "version>=": "1.80.0#2"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-endian",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-intrusive",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-logic",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-bimap/vcpkg.json
+++ b/ports/boost-bimap/vcpkg.json
@@ -1,24 +1,71 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-bimap",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost bimap module",
   "homepage": "https://github.com/boostorg/bimap",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-concept-check",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-iterator",
-    "boost-lambda",
-    "boost-mpl",
-    "boost-multi-index",
-    "boost-preprocessor",
-    "boost-serialization",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lambda",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multi-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-bind/vcpkg.json
+++ b/ports/boost-bind/vcpkg.json
@@ -1,12 +1,23 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-bind",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost bind module",
   "homepage": "https://github.com/boostorg/bind",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-build/vcpkg.json
+++ b/ports/boost-build/vcpkg.json
@@ -1,11 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-build",
   "version": "1.80.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Boost.Build",
   "homepage": "https://github.com/boostorg/build",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-uninstall"
+    {
+      "name": "boost-uninstall",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-callable-traits/vcpkg.json
+++ b/ports/boost-callable-traits/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-callable-traits",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost callable_traits module",
   "homepage": "https://github.com/boostorg/callable_traits",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-chrono/vcpkg.json
+++ b/ports/boost-chrono/vcpkg.json
@@ -1,34 +1,86 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-chrono",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost chrono module",
   "homepage": "https://github.com/boostorg/chrono",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-integer",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-move",
-    "boost-mpl",
-    "boost-predef",
-    "boost-ratio",
-    "boost-static-assert",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-utility",
-    "boost-vcpkg-helpers",
-    "boost-winapi",
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-ratio",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-circular-buffer/vcpkg.json
+++ b/ports/boost-circular-buffer/vcpkg.json
@@ -1,18 +1,47 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-circular-buffer",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost circular_buffer module",
   "homepage": "https://github.com/boostorg/circular_buffer",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
-    "boost-move",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-compatibility/vcpkg.json
+++ b/ports/boost-compatibility/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-compatibility",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost compatibility module",
   "homepage": "https://github.com/boostorg/compatibility",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-compute/vcpkg.json
+++ b/ports/boost-compute/vcpkg.json
@@ -1,40 +1,124 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-compute",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost compute module",
   "homepage": "https://github.com/boostorg/compute",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-algorithm",
-    "boost-array",
-    "boost-assert",
-    "boost-chrono",
-    "boost-config",
-    "boost-core",
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-chrono",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-filesystem",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-function",
-    "boost-function-types",
-    "boost-fusion",
-    "boost-iterator",
-    "boost-lexical-cast",
-    "boost-mpl",
-    "boost-optional",
-    "boost-preprocessor",
-    "boost-property-tree",
-    "boost-proto",
-    "boost-range",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-thread",
-    "boost-throw-exception",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-utility",
-    "boost-uuid",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-tree",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-proto",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-uuid",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-concept-check/vcpkg.json
+++ b/ports/boost-concept-check/vcpkg.json
@@ -1,14 +1,31 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-concept-check",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost concept_check module",
   "homepage": "https://github.com/boostorg/concept_check",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-preprocessor",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-config/vcpkg.json
+++ b/ports/boost-config/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-config",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost config module",
   "homepage": "https://github.com/boostorg/config",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-container-hash/vcpkg.json
+++ b/ports/boost-container-hash/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-container-hash",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost container_hash module",
   "homepage": "https://github.com/boostorg/container_hash",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-detail",
-    "boost-integer",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-container/vcpkg.json
+++ b/ports/boost-container/vcpkg.json
@@ -1,27 +1,58 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-container",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost container module",
   "homepage": "https://github.com/boostorg/container",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-intrusive",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-intrusive",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-move",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
-    "boost-winapi",
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-context/vcpkg.json
+++ b/ports/boost-context/vcpkg.json
@@ -1,27 +1,55 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-context",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost context module",
   "homepage": "https://github.com/boostorg/context",
   "license": "BSL-1.0",
   "supports": "!uwp & !emscripten",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mp11",
-    "boost-pool",
-    "boost-predef",
-    "boost-smart-ptr",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-pool",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-contract/vcpkg.json
+++ b/ports/boost-contract/vcpkg.json
@@ -1,35 +1,90 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-contract",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost contract module",
   "homepage": "https://github.com/boostorg/contract",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-any",
-    "boost-assert",
+    {
+      "name": "boost-any",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-exception",
-    "boost-function",
-    "boost-function-types",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mpl",
-    "boost-optional",
-    "boost-preprocessor",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-thread",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-utility",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-conversion/vcpkg.json
+++ b/ports/boost-conversion/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-conversion",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost conversion module",
   "homepage": "https://github.com/boostorg/conversion",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-smart-ptr",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-convert/vcpkg.json
+++ b/ports/boost-convert/vcpkg.json
@@ -1,21 +1,59 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-convert",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost convert module",
   "homepage": "https://github.com/boostorg/convert",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-function-types",
-    "boost-lexical-cast",
-    "boost-math",
-    "boost-mpl",
-    "boost-optional",
-    "boost-parameter",
-    "boost-range",
-    "boost-spirit",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-math",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-spirit",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-core/vcpkg.json
+++ b/ports/boost-core/vcpkg.json
@@ -1,14 +1,31 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-core",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost core module",
   "homepage": "https://github.com/boostorg/core",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-coroutine/vcpkg.json
+++ b/ports/boost-coroutine/vcpkg.json
@@ -1,34 +1,68 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-coroutine",
   "version": "1.80.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Boost coroutine module",
   "homepage": "https://github.com/boostorg/coroutine",
   "license": "BSL-1.0",
   "supports": "!(arm & windows) & !uwp & !emscripten",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-context",
-      "platform": "!uwp & !emscripten"
+      "platform": "!uwp & !emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-core",
-    "boost-exception",
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-move",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-coroutine2/vcpkg.json
+++ b/ports/boost-coroutine2/vcpkg.json
@@ -1,17 +1,29 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-coroutine2",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost coroutine2 module",
   "homepage": "https://github.com/boostorg/coroutine2",
   "license": "BSL-1.0",
   "supports": "!emscripten",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-context",
-      "platform": "!uwp & !emscripten"
+      "platform": "!uwp & !emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-crc/vcpkg.json
+++ b/ports/boost-crc/vcpkg.json
@@ -1,14 +1,31 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-crc",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost crc module",
   "homepage": "https://github.com/boostorg/crc",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-config",
-    "boost-integer",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-date-time/vcpkg.json
+++ b/ports/boost-date-time/vcpkg.json
@@ -1,34 +1,86 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-date-time",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost date_time module",
   "homepage": "https://github.com/boostorg/date_time",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-algorithm",
-    "boost-assert",
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-io",
-    "boost-lexical-cast",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-numeric-conversion",
-    "boost-range",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-tokenizer",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
-    "boost-winapi",
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tokenizer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-describe/vcpkg.json
+++ b/ports/boost-describe/vcpkg.json
@@ -1,11 +1,19 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-describe",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost describe module",
   "homepage": "https://github.com/boostorg/describe",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-mp11",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-detail/vcpkg.json
+++ b/ports/boost-detail/vcpkg.json
@@ -1,15 +1,35 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-detail",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost detail module",
   "homepage": "https://github.com/boostorg/detail",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-preprocessor",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-dll/vcpkg.json
+++ b/ports/boost-dll/vcpkg.json
@@ -1,28 +1,76 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-dll",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost dll module",
   "homepage": "https://github.com/boostorg/dll",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-filesystem",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-function",
-    "boost-move",
-    "boost-predef",
-    "boost-smart-ptr",
-    "boost-spirit",
-    "boost-static-assert",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-type-index",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
-    "boost-winapi"
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-spirit",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-dynamic-bitset/vcpkg.json
+++ b/ports/boost-dynamic-bitset/vcpkg.json
@@ -1,18 +1,47 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-dynamic-bitset",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost dynamic_bitset module",
   "homepage": "https://github.com/boostorg/dynamic_bitset",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-integer",
-    "boost-move",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-endian/vcpkg.json
+++ b/ports/boost-endian/vcpkg.json
@@ -1,14 +1,31 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-endian",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost endian module",
   "homepage": "https://github.com/boostorg/endian",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-exception/vcpkg.json
+++ b/ports/boost-exception/vcpkg.json
@@ -1,26 +1,54 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-exception",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost exception module",
   "homepage": "https://github.com/boostorg/exception",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-smart-ptr",
-    "boost-throw-exception",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-fiber/vcpkg.json
+++ b/ports/boost-fiber/vcpkg.json
@@ -1,37 +1,69 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-fiber",
   "version": "1.80.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Boost fiber module",
   "homepage": "https://github.com/boostorg/fiber",
   "license": "BSL-1.0",
   "supports": "!uwp & !arm & !emscripten",
   "dependencies": [
-    "boost-algorithm",
-    "boost-assert",
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-context",
-      "platform": "!uwp & !emscripten"
+      "platform": "!uwp & !emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-core",
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-filesystem",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-format",
-    "boost-intrusive",
+    {
+      "name": "boost-format",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-intrusive",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-predef",
-    "boost-smart-ptr",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-filesystem/vcpkg.json
+++ b/ports/boost-filesystem/vcpkg.json
@@ -1,34 +1,83 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-filesystem",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost filesystem module",
   "homepage": "https://github.com/boostorg/filesystem",
   "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
-    "boost-assert",
-    "boost-atomic",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-atomic",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-detail",
-    "boost-io",
-    "boost-iterator",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-predef",
-    "boost-smart-ptr",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
-    "boost-winapi",
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-flyweight/vcpkg.json
+++ b/ports/boost-flyweight/vcpkg.json
@@ -1,24 +1,71 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-flyweight",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost flyweight module",
   "homepage": "https://github.com/boostorg/flyweight",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-detail",
-    "boost-interprocess",
-    "boost-mpl",
-    "boost-multi-index",
-    "boost-parameter",
-    "boost-preprocessor",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-interprocess",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multi-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-foreach/vcpkg.json
+++ b/ports/boost-foreach/vcpkg.json
@@ -1,16 +1,39 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-foreach",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost foreach module",
   "homepage": "https://github.com/boostorg/foreach",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-range",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-format/vcpkg.json
+++ b/ports/boost-format/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-format",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost format module",
   "homepage": "https://github.com/boostorg/format",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-optional",
-    "boost-smart-ptr",
-    "boost-throw-exception",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-function-types/vcpkg.json
+++ b/ports/boost-function-types/vcpkg.json
@@ -1,16 +1,39 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-function-types",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost function_types module",
   "homepage": "https://github.com/boostorg/function_types",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-detail",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-function/vcpkg.json
+++ b/ports/boost-function/vcpkg.json
@@ -1,20 +1,55 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-function",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost function module",
   "homepage": "https://github.com/boostorg/function",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-bind",
-    "boost-config",
-    "boost-core",
-    "boost-integer",
-    "boost-preprocessor",
-    "boost-throw-exception",
-    "boost-type-index",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-functional/vcpkg.json
+++ b/ports/boost-functional/vcpkg.json
@@ -1,19 +1,51 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-functional",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost functional module",
   "homepage": "https://github.com/boostorg/functional",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-function",
-    "boost-function-types",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-fusion/vcpkg.json
+++ b/ports/boost-fusion/vcpkg.json
@@ -1,21 +1,59 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-fusion",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost fusion module",
   "homepage": "https://github.com/boostorg/fusion",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-function-types",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-static-assert",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-geometry/vcpkg.json
+++ b/ports/boost-geometry/vcpkg.json
@@ -1,43 +1,147 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-geometry",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost geometry module",
   "homepage": "https://github.com/boostorg/geometry",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-algorithm",
-    "boost-any",
-    "boost-array",
-    "boost-assert",
-    "boost-concept-check",
-    "boost-config",
-    "boost-container",
-    "boost-core",
-    "boost-function-types",
-    "boost-fusion",
-    "boost-integer",
-    "boost-iterator",
-    "boost-lexical-cast",
-    "boost-math",
-    "boost-move",
-    "boost-mpl",
-    "boost-multiprecision",
-    "boost-numeric-conversion",
-    "boost-polygon",
-    "boost-qvm",
-    "boost-range",
-    "boost-rational",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-thread",
-    "boost-throw-exception",
-    "boost-tokenizer",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-variant",
-    "boost-variant2",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-any",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-math",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multiprecision",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-polygon",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-qvm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-rational",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tokenizer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant2",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-gil/vcpkg.json
+++ b/ports/boost-gil/vcpkg.json
@@ -1,21 +1,59 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-gil",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost gil module",
   "homepage": "https://github.com/boostorg/gil",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-concept-check",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-integer",
-    "boost-iterator",
-    "boost-mp11",
-    "boost-preprocessor",
-    "boost-type-traits",
-    "boost-variant2",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant2",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-graph-parallel/vcpkg.json
+++ b/ports/boost-graph-parallel/vcpkg.json
@@ -1,52 +1,133 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-graph-parallel",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost graph_parallel module",
   "homepage": "https://github.com/boostorg/graph_parallel",
   "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
-    "boost-algorithm",
-    "boost-assert",
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-concept-check",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-detail",
-    "boost-dynamic-bitset",
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-dynamic-bitset",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-filesystem",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-foreach",
-    "boost-function",
-    "boost-graph",
-    "boost-iterator",
-    "boost-lexical-cast",
+    {
+      "name": "boost-foreach",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-graph",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
     {
       "name": "boost-mpi",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-mpl",
-    "boost-optional",
-    "boost-property-map",
-    "boost-property-map-parallel",
-    "boost-random",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-variant",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-map",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-map-parallel",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-random",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     "mpi",
     {
       "name": "vcpkg-cmake",

--- a/ports/boost-graph/vcpkg.json
+++ b/ports/boost-graph/vcpkg.json
@@ -1,60 +1,190 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-graph",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost graph module",
   "homepage": "https://github.com/boostorg/graph",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-algorithm",
-    "boost-any",
-    "boost-array",
-    "boost-assert",
-    "boost-bimap",
-    "boost-bind",
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-any",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bimap",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-concept-check",
-    "boost-config",
-    "boost-container-hash",
-    "boost-conversion",
-    "boost-core",
-    "boost-detail",
-    "boost-foreach",
-    "boost-function",
-    "boost-integer",
-    "boost-iterator",
-    "boost-lexical-cast",
-    "boost-math",
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-foreach",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-math",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-move",
-    "boost-mpl",
-    "boost-multi-index",
-    "boost-optional",
-    "boost-parameter",
-    "boost-preprocessor",
-    "boost-property-map",
-    "boost-property-tree",
-    "boost-random",
-    "boost-range",
-    "boost-regex",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-spirit",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-tti",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-unordered",
-    "boost-utility",
-    "boost-vcpkg-helpers",
-    "boost-xpressive",
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multi-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-map",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-tree",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-random",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-regex",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-spirit",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tti",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-unordered",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-xpressive",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-hana/vcpkg.json
+++ b/ports/boost-hana/vcpkg.json
@@ -1,15 +1,35 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-hana",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost hana module",
   "homepage": "https://github.com/boostorg/hana",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-fusion",
-    "boost-mpl",
-    "boost-tuple",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-heap/vcpkg.json
+++ b/ports/boost-heap/vcpkg.json
@@ -1,22 +1,63 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-heap",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost heap module",
   "homepage": "https://github.com/boostorg/heap",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
-    "boost-bind",
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
-    "boost-intrusive",
-    "boost-iterator",
-    "boost-parameter",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-intrusive",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-histogram/vcpkg.json
+++ b/ports/boost-histogram/vcpkg.json
@@ -1,16 +1,39 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-histogram",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost histogram module",
   "homepage": "https://github.com/boostorg/histogram",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-mp11",
-    "boost-serialization",
-    "boost-throw-exception",
-    "boost-variant2",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant2",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-hof/vcpkg.json
+++ b/ports/boost-hof/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-hof",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost hof module",
   "homepage": "https://github.com/boostorg/hof",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-icl/vcpkg.json
+++ b/ports/boost-icl/vcpkg.json
@@ -1,25 +1,75 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-icl",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost icl module",
   "homepage": "https://github.com/boostorg/icl",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-concept-check",
-    "boost-config",
-    "boost-container",
-    "boost-core",
-    "boost-date-time",
-    "boost-detail",
-    "boost-iterator",
-    "boost-move",
-    "boost-mpl",
-    "boost-range",
-    "boost-rational",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-date-time",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-rational",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-integer/vcpkg.json
+++ b/ports/boost-integer/vcpkg.json
@@ -1,16 +1,39 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-integer",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost integer module",
   "homepage": "https://github.com/boostorg/integer",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-interprocess/vcpkg.json
+++ b/ports/boost-interprocess/vcpkg.json
@@ -1,21 +1,59 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-interprocess",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost interprocess module",
   "homepage": "https://github.com/boostorg/interprocess",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-container",
-    "boost-core",
-    "boost-integer",
-    "boost-intrusive",
-    "boost-move",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-unordered",
-    "boost-vcpkg-helpers",
-    "boost-winapi"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-intrusive",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-unordered",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-interval/vcpkg.json
+++ b/ports/boost-interval/vcpkg.json
@@ -1,13 +1,27 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-interval",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost interval module",
   "homepage": "https://github.com/boostorg/interval",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-detail",
-    "boost-logic",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-logic",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-intrusive/vcpkg.json
+++ b/ports/boost-intrusive/vcpkg.json
@@ -1,16 +1,39 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-intrusive",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost intrusive module",
   "homepage": "https://github.com/boostorg/intrusive",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-move",
-    "boost-static-assert",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-io/vcpkg.json
+++ b/ports/boost-io/vcpkg.json
@@ -1,11 +1,19 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-io",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost io module",
   "homepage": "https://github.com/boostorg/io",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-iostreams/vcpkg.json
+++ b/ports/boost-iostreams/vcpkg.json
@@ -1,38 +1,99 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-iostreams",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost iostreams module",
   "homepage": "https://github.com/boostorg/iostreams",
   "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-detail",
-    "boost-function",
-    "boost-integer",
-    "boost-iterator",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mpl",
-    "boost-numeric-conversion",
-    "boost-preprocessor",
-    "boost-random",
-    "boost-range",
-    "boost-regex",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-random",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-regex",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-iterator/vcpkg.json
+++ b/ports/boost-iterator/vcpkg.json
@@ -1,24 +1,71 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-iterator",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost iterator module",
   "homepage": "https://github.com/boostorg/iterator",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-concept-check",
-    "boost-config",
-    "boost-conversion",
-    "boost-core",
-    "boost-detail",
-    "boost-function-types",
-    "boost-fusion",
-    "boost-mpl",
-    "boost-optional",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-json/vcpkg.json
+++ b/ports/boost-json/vcpkg.json
@@ -1,27 +1,58 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-json",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost json module",
   "homepage": "https://github.com/boostorg/json",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-align",
-    "boost-assert",
+    {
+      "name": "boost-align",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-container",
-    "boost-core",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mp11",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-lambda/vcpkg.json
+++ b/ports/boost-lambda/vcpkg.json
@@ -1,20 +1,55 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-lambda",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost lambda module",
   "homepage": "https://github.com/boostorg/lambda",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-bind",
-    "boost-config",
-    "boost-core",
-    "boost-detail",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-lambda2/vcpkg.json
+++ b/ports/boost-lambda2/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-lambda2",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost lambda2 module",
   "homepage": "https://github.com/boostorg/lambda2",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-leaf/vcpkg.json
+++ b/ports/boost-leaf/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-leaf",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost leaf module",
   "homepage": "https://github.com/boostorg/leaf",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-lexical-cast/vcpkg.json
+++ b/ports/boost-lexical-cast/vcpkg.json
@@ -1,21 +1,59 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-lexical-cast",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost lexical_cast module",
   "homepage": "https://github.com/boostorg/lexical_cast",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
-    "boost-config",
-    "boost-container",
-    "boost-core",
-    "boost-integer",
-    "boost-numeric-conversion",
-    "boost-range",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-local-function/vcpkg.json
+++ b/ports/boost-local-function/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-local-function",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost local_function module",
   "homepage": "https://github.com/boostorg/local_function",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-scope-exit",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-scope-exit",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-locale/vcpkg.json
+++ b/ports/boost-locale/vcpkg.json
@@ -1,31 +1,71 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-locale",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost locale module",
   "homepage": "https://github.com/boostorg/locale",
   "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-function",
-    "boost-iterator",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-predef",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-thread",
-    "boost-type-traits",
-    "boost-unordered",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-unordered",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "libiconv",
       "platform": "!uwp & !windows & !mingw"

--- a/ports/boost-lockfree/vcpkg.json
+++ b/ports/boost-lockfree/vcpkg.json
@@ -1,25 +1,75 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-lockfree",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost lockfree module",
   "homepage": "https://github.com/boostorg/lockfree",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-align",
-    "boost-array",
-    "boost-assert",
-    "boost-atomic",
-    "boost-config",
-    "boost-core",
-    "boost-integer",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-parameter",
-    "boost-predef",
-    "boost-static-assert",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-align",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-atomic",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-log/vcpkg.json
+++ b/ports/boost-log/vcpkg.json
@@ -1,65 +1,196 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-log",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost log module",
   "homepage": "https://github.com/boostorg/log",
   "license": "BSL-1.0",
   "supports": "!uwp & !emscripten",
   "dependencies": [
-    "boost-align",
-    "boost-array",
-    "boost-asio",
-    "boost-assert",
-    "boost-atomic",
-    "boost-bind",
+    {
+      "name": "boost-align",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-asio",
+      "version>=": "1.80.0#2"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-atomic",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-container",
-    "boost-core",
-    "boost-date-time",
-    "boost-exception",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-date-time",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-filesystem",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-function-types",
-    "boost-fusion",
-    "boost-interprocess",
-    "boost-intrusive",
-    "boost-io",
-    "boost-iterator",
-    "boost-lexical-cast",
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-interprocess",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-intrusive",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-move",
-    "boost-mpl",
-    "boost-optional",
-    "boost-parameter",
-    "boost-phoenix",
-    "boost-predef",
-    "boost-preprocessor",
-    "boost-property-tree",
-    "boost-proto",
-    "boost-random",
-    "boost-range",
-    "boost-regex",
-    "boost-smart-ptr",
-    "boost-spirit",
-    "boost-static-assert",
-    "boost-system",
-    "boost-thread",
-    "boost-throw-exception",
-    "boost-type-index",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
-    "boost-winapi",
-    "boost-xpressive",
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-phoenix",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-tree",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-proto",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-random",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-regex",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-spirit",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-xpressive",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-logic/vcpkg.json
+++ b/ports/boost-logic/vcpkg.json
@@ -1,12 +1,23 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-logic",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost logic module",
   "homepage": "https://github.com/boostorg/logic",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-math/vcpkg.json
+++ b/ports/boost-math/vcpkg.json
@@ -1,29 +1,66 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-math",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost math module",
   "homepage": "https://github.com/boostorg/math",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
-    "boost-integer",
-    "boost-lexical-cast",
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-predef",
-    "boost-random",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-random",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-metaparse/vcpkg.json
+++ b/ports/boost-metaparse/vcpkg.json
@@ -1,16 +1,39 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-metaparse",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost metaparse module",
   "homepage": "https://github.com/boostorg/metaparse",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-mpl",
-    "boost-predef",
-    "boost-preprocessor",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,11 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-modular-build-helper",
   "version": "1.80.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Internal vcpkg port used to build Boost libraries",
   "license": "MIT",
   "dependencies": [
-    "boost-uninstall",
+    {
+      "name": "boost-uninstall",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-move/vcpkg.json
+++ b/ports/boost-move/vcpkg.json
@@ -1,15 +1,35 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-move",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost move module",
   "homepage": "https://github.com/boostorg/move",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-static-assert",
-    "boost-vcpkg-helpers",
-    "boost-winapi"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-mp11/vcpkg.json
+++ b/ports/boost-mp11/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-mp11",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost mp11 module",
   "homepage": "https://github.com/boostorg/mp11",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-mpi/vcpkg.json
+++ b/ports/boost-mpi/vcpkg.json
@@ -1,37 +1,95 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-mpi",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost mpi module",
   "homepage": "https://github.com/boostorg/mpi",
   "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-foreach",
-    "boost-function",
-    "boost-graph",
-    "boost-integer",
-    "boost-iterator",
-    "boost-lexical-cast",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-foreach",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-graph",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mpl",
-    "boost-optional",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     "mpi",
     {
       "name": "vcpkg-cmake",
@@ -48,7 +106,8 @@
           "features": [
             "python3"
           ],
-          "platform": "!uwp & !emscripten & !ios & !android"
+          "platform": "!uwp & !emscripten & !ios & !android",
+          "version>=": "1.80.0#1"
         },
         "python3"
       ]

--- a/ports/boost-mpl/vcpkg.json
+++ b/ports/boost-mpl/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-mpl",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost mpl module",
   "homepage": "https://github.com/boostorg/mpl",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-predef",
-    "boost-preprocessor",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-msm/vcpkg.json
+++ b/ports/boost-msm/vcpkg.json
@@ -1,27 +1,83 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-msm",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost msm module",
   "homepage": "https://github.com/boostorg/msm",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-any",
-    "boost-assert",
-    "boost-bind",
-    "boost-circular-buffer",
-    "boost-config",
-    "boost-core",
-    "boost-function",
-    "boost-fusion",
-    "boost-mpl",
-    "boost-parameter",
-    "boost-phoenix",
-    "boost-preprocessor",
-    "boost-proto",
-    "boost-serialization",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-any",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-circular-buffer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-phoenix",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-proto",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-multi-array/vcpkg.json
+++ b/ports/boost-multi-array/vcpkg.json
@@ -1,20 +1,55 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-multi-array",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost multi_array module",
   "homepage": "https://github.com/boostorg/multi_array",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
-    "boost-functional",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-functional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-multi-index/vcpkg.json
+++ b/ports/boost-multi-index/vcpkg.json
@@ -1,28 +1,87 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-multi-index",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost multi_index module",
   "homepage": "https://github.com/boostorg/multi_index",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-bind",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-foreach",
-    "boost-integer",
-    "boost-iterator",
-    "boost-move",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-foreach",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-multiprecision/vcpkg.json
+++ b/ports/boost-multiprecision/vcpkg.json
@@ -1,19 +1,51 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-multiprecision",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost multiprecision module",
   "homepage": "https://github.com/boostorg/multiprecision",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-integer",
-    "boost-lexical-cast",
-    "boost-math",
-    "boost-predef",
-    "boost-random",
-    "boost-throw-exception",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-math",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-random",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-nowide/vcpkg.json
+++ b/ports/boost-nowide/vcpkg.json
@@ -1,24 +1,35 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-nowide",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost nowide module",
   "homepage": "https://github.com/boostorg/nowide",
   "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-filesystem",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-numeric-conversion/vcpkg.json
+++ b/ports/boost-numeric-conversion/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-numeric-conversion",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost numeric_conversion module",
   "homepage": "https://github.com/boostorg/numeric_conversion",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-conversion",
-    "boost-core",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-odeint/vcpkg.json
+++ b/ports/boost-odeint/vcpkg.json
@@ -1,37 +1,105 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-odeint",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost odeint module",
   "homepage": "https://github.com/boostorg/odeint",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
-    "boost-bind",
-    "boost-compute",
-    "boost-config",
-    "boost-core",
-    "boost-function",
-    "boost-fusion",
-    "boost-iterator",
-    "boost-math",
-    "boost-mpl",
-    "boost-multi-array",
-    "boost-preprocessor",
-    "boost-range",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-ublas",
-    "boost-units",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-compute",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-math",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multi-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-ublas",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-units",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ],
   "features": {
     "mpi": {
       "description": "Support parallelization with MPI",
       "dependencies": [
-        "boost-mpi"
+        {
+          "name": "boost-mpi",
+          "version>=": "1.80.0#1"
+        }
       ]
     }
   }

--- a/ports/boost-optional/vcpkg.json
+++ b/ports/boost-optional/vcpkg.json
@@ -1,20 +1,55 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-optional",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost optional module",
   "homepage": "https://github.com/boostorg/optional",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-detail",
-    "boost-move",
-    "boost-predef",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-outcome/vcpkg.json
+++ b/ports/boost-outcome/vcpkg.json
@@ -1,14 +1,31 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-outcome",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost outcome module",
   "homepage": "https://github.com/boostorg/outcome",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-exception",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-parameter-python/vcpkg.json
+++ b/ports/boost-parameter-python/vcpkg.json
@@ -1,18 +1,33 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-parameter-python",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost parameter_python module",
   "homepage": "https://github.com/boostorg/parameter_python",
   "license": "BSL-1.0",
   "supports": "!emscripten",
   "dependencies": [
-    "boost-mpl",
-    "boost-parameter",
-    "boost-preprocessor",
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-python",
-      "platform": "!uwp & !emscripten & !ios & !android"
+      "platform": "!uwp & !emscripten & !ios & !android",
+      "version>=": "1.80.0#1"
     },
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-parameter/vcpkg.json
+++ b/ports/boost-parameter/vcpkg.json
@@ -1,20 +1,55 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-parameter",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost parameter module",
   "homepage": "https://github.com/boostorg/parameter",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-function",
-    "boost-fusion",
-    "boost-mp11",
-    "boost-mpl",
-    "boost-optional",
-    "boost-preprocessor",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-pfr/vcpkg.json
+++ b/ports/boost-pfr/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-pfr",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost pfr module",
   "homepage": "https://github.com/boostorg/pfr",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-phoenix/vcpkg.json
+++ b/ports/boost-phoenix/vcpkg.json
@@ -1,24 +1,71 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-phoenix",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost phoenix module",
   "homepage": "https://github.com/boostorg/phoenix",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-bind",
-    "boost-config",
-    "boost-core",
-    "boost-function",
-    "boost-fusion",
-    "boost-mpl",
-    "boost-predef",
-    "boost-preprocessor",
-    "boost-proto",
-    "boost-range",
-    "boost-smart-ptr",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-proto",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-poly-collection/vcpkg.json
+++ b/ports/boost-poly-collection/vcpkg.json
@@ -1,18 +1,47 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-poly-collection",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost poly_collection module",
   "homepage": "https://github.com/boostorg/poly_collection",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-iterator",
-    "boost-mp11",
-    "boost-mpl",
-    "boost-type-erasure",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-erasure",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-polygon/vcpkg.json
+++ b/ports/boost-polygon/vcpkg.json
@@ -1,11 +1,19 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-polygon",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost polygon module",
   "homepage": "https://github.com/boostorg/polygon",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-pool/vcpkg.json
+++ b/ports/boost-pool/vcpkg.json
@@ -1,16 +1,39 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-pool",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost pool module",
   "homepage": "https://github.com/boostorg/pool",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-integer",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
-    "boost-winapi"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-predef/vcpkg.json
+++ b/ports/boost-predef/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-predef",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost predef module",
   "homepage": "https://github.com/boostorg/predef",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-preprocessor/vcpkg.json
+++ b/ports/boost-preprocessor/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-preprocessor",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost preprocessor module",
   "homepage": "https://github.com/boostorg/preprocessor",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-process/vcpkg.json
+++ b/ports/boost-process/vcpkg.json
@@ -1,30 +1,81 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-process",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost process module",
   "homepage": "https://github.com/boostorg/process",
   "license": "BSL-1.0",
   "supports": "!emscripten",
   "dependencies": [
-    "boost-algorithm",
-    "boost-asio",
-    "boost-config",
-    "boost-core",
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-asio",
+      "version>=": "1.80.0#2"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-filesystem",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-fusion",
-    "boost-io",
-    "boost-iterator",
-    "boost-move",
-    "boost-optional",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-tokenizer",
-    "boost-type-index",
-    "boost-utility",
-    "boost-vcpkg-helpers",
-    "boost-winapi"
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tokenizer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-program-options/vcpkg.json
+++ b/ports/boost-program-options/vcpkg.json
@@ -1,32 +1,78 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-program-options",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost program_options module",
   "homepage": "https://github.com/boostorg/program_options",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-any",
-    "boost-bind",
+    {
+      "name": "boost-any",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-detail",
-    "boost-function",
-    "boost-iterator",
-    "boost-lexical-cast",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-tokenizer",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tokenizer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-property-map-parallel/vcpkg.json
+++ b/ports/boost-property-map-parallel/vcpkg.json
@@ -1,26 +1,68 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-property-map-parallel",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost property_map_parallel module",
   "homepage": "https://github.com/boostorg/property_map_parallel",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-concept-check",
-    "boost-config",
-    "boost-function",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-mpi",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-mpl",
-    "boost-multi-index",
-    "boost-optional",
-    "boost-property-map",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multi-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-map",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-property-map/vcpkg.json
+++ b/ports/boost-property-map/vcpkg.json
@@ -1,25 +1,75 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-property-map",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost property_map module",
   "homepage": "https://github.com/boostorg/property_map",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-any",
-    "boost-assert",
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
-    "boost-function",
-    "boost-iterator",
-    "boost-lexical-cast",
-    "boost-mpl",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-index",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-any",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-property-tree/vcpkg.json
+++ b/ports/boost-property-tree/vcpkg.json
@@ -1,25 +1,75 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-property-tree",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost property_tree module",
   "homepage": "https://github.com/boostorg/property_tree",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-any",
-    "boost-assert",
-    "boost-bind",
-    "boost-config",
-    "boost-core",
-    "boost-format",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-multi-index",
-    "boost-optional",
-    "boost-range",
-    "boost-serialization",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-any",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-format",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multi-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-proto/vcpkg.json
+++ b/ports/boost-proto/vcpkg.json
@@ -1,20 +1,55 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-proto",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost proto module",
   "homepage": "https://github.com/boostorg/proto",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-fusion",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-range",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-ptr-container/vcpkg.json
+++ b/ports/boost-ptr-container/vcpkg.json
@@ -1,24 +1,71 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-ptr-container",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost ptr_container module",
   "homepage": "https://github.com/boostorg/ptr_container",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
-    "boost-circular-buffer",
-    "boost-config",
-    "boost-core",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-range",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-unordered",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-circular-buffer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-unordered",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-python/vcpkg.json
+++ b/ports/boost-python/vcpkg.json
@@ -1,41 +1,111 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-python",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost python module",
   "homepage": "https://github.com/boostorg/python",
   "license": "BSL-1.0",
   "supports": "!uwp & !emscripten & !ios & !android",
   "dependencies": [
-    "boost-align",
-    "boost-bind",
+    {
+      "name": "boost-align",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-conversion",
-    "boost-core",
-    "boost-detail",
-    "boost-foreach",
-    "boost-function",
-    "boost-graph",
-    "boost-integer",
-    "boost-iterator",
-    "boost-lexical-cast",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-foreach",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-graph",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mpl",
-    "boost-numeric-conversion",
-    "boost-preprocessor",
-    "boost-property-map",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-map",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-qvm/vcpkg.json
+++ b/ports/boost-qvm/vcpkg.json
@@ -1,10 +1,15 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-qvm",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost qvm module",
   "homepage": "https://github.com/boostorg/qvm",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-random/vcpkg.json
+++ b/ports/boost-random/vcpkg.json
@@ -1,32 +1,78 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-random",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost random module",
   "homepage": "https://github.com/boostorg/random",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-dynamic-bitset",
-    "boost-integer",
-    "boost-io",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-dynamic-bitset",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-range",
-    "boost-static-assert",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-range/vcpkg.json
+++ b/ports/boost-range/vcpkg.json
@@ -1,27 +1,83 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-range",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost range module",
   "homepage": "https://github.com/boostorg/range",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
-    "boost-concept-check",
-    "boost-config",
-    "boost-container-hash",
-    "boost-conversion",
-    "boost-core",
-    "boost-detail",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-optional",
-    "boost-preprocessor",
-    "boost-regex",
-    "boost-static-assert",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-regex",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-ratio/vcpkg.json
+++ b/ports/boost-ratio/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-ratio",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost ratio module",
   "homepage": "https://github.com/boostorg/ratio",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-integer",
-    "boost-mpl",
-    "boost-rational",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-rational",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-rational/vcpkg.json
+++ b/ports/boost-rational/vcpkg.json
@@ -1,18 +1,47 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-rational",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost rational module",
   "homepage": "https://github.com/boostorg/rational",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-integer",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-regex/vcpkg.json
+++ b/ports/boost-regex/vcpkg.json
@@ -1,31 +1,74 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-regex",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost regex module",
   "homepage": "https://github.com/boostorg/regex",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-concept-check",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-integer",
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mpl",
-    "boost-predef",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-safe-numerics/vcpkg.json
+++ b/ports/boost-safe-numerics/vcpkg.json
@@ -1,16 +1,39 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-safe-numerics",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost safe_numerics module",
   "homepage": "https://github.com/boostorg/safe_numerics",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
-    "boost-integer",
-    "boost-logic",
-    "boost-mp11",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-logic",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-scope-exit/vcpkg.json
+++ b/ports/boost-scope-exit/vcpkg.json
@@ -1,15 +1,35 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-scope-exit",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost scope_exit module",
   "homepage": "https://github.com/boostorg/scope_exit",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-function",
-    "boost-preprocessor",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-serialization/vcpkg.json
+++ b/ports/boost-serialization/vcpkg.json
@@ -1,40 +1,110 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-serialization",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost serialization module",
   "homepage": "https://github.com/boostorg/serialization",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-detail",
-    "boost-function",
-    "boost-integer",
-    "boost-io",
-    "boost-iterator",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-move",
-    "boost-mpl",
-    "boost-optional",
-    "boost-predef",
-    "boost-preprocessor",
-    "boost-smart-ptr",
-    "boost-spirit",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-unordered",
-    "boost-utility",
-    "boost-variant",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-spirit",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-unordered",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-signals2/vcpkg.json
+++ b/ports/boost-signals2/vcpkg.json
@@ -1,26 +1,79 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-signals2",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost signals2 module",
   "homepage": "https://github.com/boostorg/signals2",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-bind",
-    "boost-config",
-    "boost-core",
-    "boost-function",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-optional",
-    "boost-parameter",
-    "boost-predef",
-    "boost-preprocessor",
-    "boost-smart-ptr",
-    "boost-throw-exception",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-variant",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-smart-ptr/vcpkg.json
+++ b/ports/boost-smart-ptr/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-smart-ptr",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost smart_ptr module",
   "homepage": "https://github.com/boostorg/smart_ptr",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-move",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-sort/vcpkg.json
+++ b/ports/boost-sort/vcpkg.json
@@ -1,15 +1,35 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-sort",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost sort module",
   "homepage": "https://github.com/boostorg/sort",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-range",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-spirit/vcpkg.json
+++ b/ports/boost-spirit/vcpkg.json
@@ -1,39 +1,131 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-spirit",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost spirit module",
   "homepage": "https://github.com/boostorg/spirit",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-array",
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-endian",
-    "boost-function",
-    "boost-function-types",
-    "boost-fusion",
-    "boost-integer",
-    "boost-io",
-    "boost-iterator",
-    "boost-move",
-    "boost-mpl",
-    "boost-optional",
-    "boost-phoenix",
-    "boost-pool",
-    "boost-preprocessor",
-    "boost-proto",
-    "boost-range",
-    "boost-regex",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-thread",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-unordered",
-    "boost-utility",
-    "boost-variant",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-endian",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-phoenix",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-pool",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-proto",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-regex",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-unordered",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-stacktrace/vcpkg.json
+++ b/ports/boost-stacktrace/vcpkg.json
@@ -1,28 +1,59 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-stacktrace",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost stacktrace module",
   "homepage": "https://github.com/boostorg/stacktrace",
   "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
-    "boost-array",
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-predef",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
-    "boost-winapi",
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-statechart/vcpkg.json
+++ b/ports/boost-statechart/vcpkg.json
@@ -1,22 +1,63 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-statechart",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost statechart module",
   "homepage": "https://github.com/boostorg/statechart",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-bind",
-    "boost-config",
-    "boost-conversion",
-    "boost-core",
-    "boost-detail",
-    "boost-function",
-    "boost-mpl",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-thread",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-static-assert/vcpkg.json
+++ b/ports/boost-static-assert/vcpkg.json
@@ -1,11 +1,19 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-static-assert",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost static_assert module",
   "homepage": "https://github.com/boostorg/static_assert",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-static-string/vcpkg.json
+++ b/ports/boost-static-string/vcpkg.json
@@ -1,15 +1,35 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-static-string",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost static_string module",
   "homepage": "https://github.com/boostorg/static_string",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-container-hash",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-stl-interfaces/vcpkg.json
+++ b/ports/boost-stl-interfaces/vcpkg.json
@@ -1,13 +1,27 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-stl-interfaces",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost stl_interfaces module",
   "homepage": "https://github.com/boostorg/stl_interfaces",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-system/vcpkg.json
+++ b/ports/boost-system/vcpkg.json
@@ -1,24 +1,46 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-system",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost system module",
   "homepage": "https://github.com/boostorg/system",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-throw-exception",
-    "boost-variant2",
-    "boost-vcpkg-helpers",
-    "boost-winapi",
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant2",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-test/vcpkg.json
+++ b/ports/boost-test/vcpkg.json
@@ -1,38 +1,99 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-test",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost test module",
   "homepage": "https://github.com/boostorg/test",
   "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
-    "boost-algorithm",
-    "boost-assert",
-    "boost-bind",
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-detail",
-    "boost-exception",
-    "boost-function",
-    "boost-io",
-    "boost-iterator",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mpl",
-    "boost-numeric-conversion",
-    "boost-optional",
-    "boost-preprocessor",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-thread/vcpkg.json
+++ b/ports/boost-thread/vcpkg.json
@@ -1,48 +1,142 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-thread",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost thread module",
   "homepage": "https://github.com/boostorg/thread",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-algorithm",
-    "boost-assert",
-    "boost-atomic",
-    "boost-bind",
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-atomic",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-chrono",
-    "boost-concept-check",
-    "boost-config",
-    "boost-container",
-    "boost-container-hash",
-    "boost-core",
-    "boost-date-time",
-    "boost-exception",
-    "boost-function",
-    "boost-intrusive",
-    "boost-io",
-    "boost-iterator",
-    "boost-lexical-cast",
+    {
+      "name": "boost-chrono",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-date-time",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-intrusive",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-move",
-    "boost-optional",
-    "boost-predef",
-    "boost-preprocessor",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers",
-    "boost-winapi",
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-throw-exception/vcpkg.json
+++ b/ports/boost-throw-exception/vcpkg.json
@@ -1,12 +1,23 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-throw-exception",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost throw_exception module",
   "homepage": "https://github.com/boostorg/throw_exception",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-timer/vcpkg.json
+++ b/ports/boost-timer/vcpkg.json
@@ -1,26 +1,54 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-timer",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost timer module",
   "homepage": "https://github.com/boostorg/timer",
   "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-chrono",
-    "boost-config",
-    "boost-core",
-    "boost-io",
+    {
+      "name": "boost-chrono",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-predef",
-    "boost-system",
-    "boost-throw-exception",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-tokenizer/vcpkg.json
+++ b/ports/boost-tokenizer/vcpkg.json
@@ -1,16 +1,39 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-tokenizer",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost tokenizer module",
   "homepage": "https://github.com/boostorg/tokenizer",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-iterator",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-tti/vcpkg.json
+++ b/ports/boost-tti/vcpkg.json
@@ -1,15 +1,35 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-tti",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost tti module",
   "homepage": "https://github.com/boostorg/tti",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-function-types",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-tuple/vcpkg.json
+++ b/ports/boost-tuple/vcpkg.json
@@ -1,14 +1,31 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-tuple",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost tuple module",
   "homepage": "https://github.com/boostorg/tuple",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-core",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-type-erasure/vcpkg.json
+++ b/ports/boost-type-erasure/vcpkg.json
@@ -1,33 +1,82 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-type-erasure",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost type_erasure module",
   "homepage": "https://github.com/boostorg/type_erasure",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-config",
-    "boost-core",
-    "boost-fusion",
-    "boost-iterator",
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mp11",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-smart-ptr",
-    "boost-thread",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-vcpkg-helpers",
-    "boost-vmd",
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vmd",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-type-index/vcpkg.json
+++ b/ports/boost-type-index/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-type-index",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost type_index module",
   "homepage": "https://github.com/boostorg/type_index",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-preprocessor",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-type-traits/vcpkg.json
+++ b/ports/boost-type-traits/vcpkg.json
@@ -1,12 +1,23 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-type-traits",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost type_traits module",
   "homepage": "https://github.com/boostorg/type_traits",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-static-assert",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-typeof/vcpkg.json
+++ b/ports/boost-typeof/vcpkg.json
@@ -1,13 +1,27 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-typeof",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost typeof module",
   "homepage": "https://github.com/boostorg/typeof",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-preprocessor",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-ublas/vcpkg.json
+++ b/ports/boost-ublas/vcpkg.json
@@ -1,23 +1,67 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-ublas",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost ublas module",
   "homepage": "https://github.com/boostorg/ublas",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-compute",
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
-    "boost-interval",
-    "boost-iterator",
-    "boost-mpl",
-    "boost-range",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-compute",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-interval",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-uninstall/vcpkg.json
+++ b/ports/boost-uninstall/vcpkg.json
@@ -1,6 +1,8 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-uninstall",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Internal vcpkg port used to uninstall Boost",
   "license": "MIT"
 }

--- a/ports/boost-units/vcpkg.json
+++ b/ports/boost-units/vcpkg.json
@@ -1,22 +1,63 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-units",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost units module",
   "homepage": "https://github.com/boostorg/units",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-integer",
-    "boost-io",
-    "boost-lambda",
-    "boost-math",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-static-assert",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lambda",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-math",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-unordered/vcpkg.json
+++ b/ports/boost-unordered/vcpkg.json
@@ -1,21 +1,59 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-unordered",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost unordered module",
   "homepage": "https://github.com/boostorg/unordered",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-move",
-    "boost-mp11",
-    "boost-predef",
-    "boost-preprocessor",
-    "boost-throw-exception",
-    "boost-tuple",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-utility/vcpkg.json
+++ b/ports/boost-utility/vcpkg.json
@@ -1,17 +1,43 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-utility",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost utility module",
   "homepage": "https://github.com/boostorg/utility",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-core",
-    "boost-io",
-    "boost-preprocessor",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-uuid/vcpkg.json
+++ b/ports/boost-uuid/vcpkg.json
@@ -1,25 +1,75 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-uuid",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost uuid module",
   "homepage": "https://github.com/boostorg/uuid",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-io",
-    "boost-move",
-    "boost-numeric-conversion",
-    "boost-predef",
-    "boost-random",
-    "boost-serialization",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-tti",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
-    "boost-winapi"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-random",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tti",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-variant/vcpkg.json
+++ b/ports/boost-variant/vcpkg.json
@@ -1,25 +1,75 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-variant",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost variant module",
   "homepage": "https://github.com/boostorg/variant",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-bind",
-    "boost-config",
-    "boost-container-hash",
-    "boost-core",
-    "boost-detail",
-    "boost-integer",
-    "boost-move",
-    "boost-mpl",
-    "boost-preprocessor",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-index",
-    "boost-type-traits",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-variant2/vcpkg.json
+++ b/ports/boost-variant2/vcpkg.json
@@ -1,13 +1,27 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-variant2",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost variant2 module",
   "homepage": "https://github.com/boostorg/variant2",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-mp11",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-vcpkg-helpers/vcpkg.json
+++ b/ports/boost-vcpkg-helpers/vcpkg.json
@@ -1,9 +1,14 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-vcpkg-helpers",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Internal vcpkg port used to modularize Boost",
   "license": "MIT",
   "dependencies": [
-    "boost-uninstall"
+    {
+      "name": "boost-uninstall",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-vmd/vcpkg.json
+++ b/ports/boost-vmd/vcpkg.json
@@ -1,11 +1,19 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-vmd",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost vmd module",
   "homepage": "https://github.com/boostorg/vmd",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-preprocessor",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-wave/vcpkg.json
+++ b/ports/boost-wave/vcpkg.json
@@ -1,42 +1,104 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-wave",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost wave module",
   "homepage": "https://github.com/boostorg/wave",
   "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
-    "boost-assert",
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-build",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-concept-check",
-    "boost-config",
-    "boost-core",
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-filesystem",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-format",
-    "boost-iterator",
-    "boost-lexical-cast",
+    {
+      "name": "boost-format",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-modular-build-helper",
-      "host": true
+      "host": true,
+      "version>=": "1.80.0#2"
     },
-    "boost-mpl",
-    "boost-multi-index",
-    "boost-optional",
-    "boost-pool",
-    "boost-preprocessor",
-    "boost-serialization",
-    "boost-smart-ptr",
-    "boost-spirit",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-vcpkg-helpers",
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multi-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-pool",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-spirit",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/boost-winapi/vcpkg.json
+++ b/ports/boost-winapi/vcpkg.json
@@ -1,12 +1,23 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-winapi",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost winapi module",
   "homepage": "https://github.com/boostorg/winapi",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-config",
-    "boost-predef",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-xpressive/vcpkg.json
+++ b/ports/boost-xpressive/vcpkg.json
@@ -1,32 +1,103 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-xpressive",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost xpressive module",
   "homepage": "https://github.com/boostorg/xpressive",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-assert",
-    "boost-config",
-    "boost-conversion",
-    "boost-core",
-    "boost-exception",
-    "boost-fusion",
-    "boost-integer",
-    "boost-iterator",
-    "boost-lexical-cast",
-    "boost-mpl",
-    "boost-numeric-conversion",
-    "boost-optional",
-    "boost-preprocessor",
-    "boost-proto",
-    "boost-range",
-    "boost-smart-ptr",
-    "boost-spirit",
-    "boost-static-assert",
-    "boost-throw-exception",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-utility",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-proto",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-spirit",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost-yap/vcpkg.json
+++ b/ports/boost-yap/vcpkg.json
@@ -1,13 +1,27 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-yap",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost yap module",
   "homepage": "https://github.com/boostorg/yap",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-hana",
-    "boost-preprocessor",
-    "boost-type-index",
-    "boost-vcpkg-helpers"
+    {
+      "name": "boost-hana",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.80.0#1"
+    }
   ]
 }

--- a/ports/boost/vcpkg.json
+++ b/ports/boost/vcpkg.json
@@ -1,206 +1,612 @@
 {
+  "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost",
   "version": "1.80.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Peer-reviewed portable C++ source libraries",
   "homepage": "https://boost.org",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-accumulators",
-    "boost-algorithm",
-    "boost-align",
-    "boost-any",
-    "boost-array",
-    "boost-asio",
-    "boost-assert",
-    "boost-assign",
-    "boost-atomic",
+    {
+      "name": "boost-accumulators",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-algorithm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-align",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-any",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-asio",
+      "version>=": "1.80.0#2"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-assign",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-atomic",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-beast",
-      "platform": "!emscripten"
+      "platform": "!emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-bimap",
-    "boost-bind",
-    "boost-callable-traits",
-    "boost-chrono",
-    "boost-circular-buffer",
-    "boost-compatibility",
-    "boost-compute",
-    "boost-concept-check",
-    "boost-config",
-    "boost-container",
-    "boost-container-hash",
+    {
+      "name": "boost-bimap",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-bind",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-callable-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-chrono",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-circular-buffer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-compatibility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-compute",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-concept-check",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-container-hash",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-context",
-      "platform": "!uwp & !emscripten"
+      "platform": "!uwp & !emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-contract",
-    "boost-conversion",
-    "boost-convert",
-    "boost-core",
+    {
+      "name": "boost-contract",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-convert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-coroutine",
-      "platform": "!(arm & windows) & !uwp & !emscripten"
+      "platform": "!(arm & windows) & !uwp & !emscripten",
+      "version>=": "1.80.0#2"
     },
     {
       "name": "boost-coroutine2",
-      "platform": "!emscripten"
+      "platform": "!emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-crc",
-    "boost-date-time",
-    "boost-describe",
-    "boost-detail",
-    "boost-dll",
-    "boost-dynamic-bitset",
-    "boost-endian",
-    "boost-exception",
+    {
+      "name": "boost-crc",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-date-time",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-describe",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-detail",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-dll",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-dynamic-bitset",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-endian",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-exception",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-fiber",
-      "platform": "!uwp & !arm & !emscripten"
+      "platform": "!uwp & !arm & !emscripten",
+      "version>=": "1.80.0#2"
     },
     {
       "name": "boost-filesystem",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-flyweight",
-    "boost-foreach",
-    "boost-format",
-    "boost-function",
-    "boost-function-types",
-    "boost-functional",
-    "boost-fusion",
-    "boost-geometry",
-    "boost-gil",
-    "boost-graph",
-    "boost-hana",
-    "boost-heap",
-    "boost-histogram",
-    "boost-hof",
-    "boost-icl",
-    "boost-integer",
-    "boost-interprocess",
-    "boost-interval",
-    "boost-intrusive",
-    "boost-io",
+    {
+      "name": "boost-flyweight",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-foreach",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-format",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-function-types",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-functional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-fusion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-geometry",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-gil",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-graph",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-hana",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-heap",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-histogram",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-hof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-icl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-integer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-interprocess",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-interval",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-intrusive",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-io",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-iostreams",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-iterator",
-    "boost-json",
-    "boost-lambda",
-    "boost-lambda2",
-    "boost-leaf",
-    "boost-lexical-cast",
-    "boost-local-function",
+    {
+      "name": "boost-iterator",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-json",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lambda",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lambda2",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-leaf",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-local-function",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-locale",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-lockfree",
+    {
+      "name": "boost-lockfree",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-log",
-      "platform": "!uwp & !emscripten"
+      "platform": "!uwp & !emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-logic",
-    "boost-math",
-    "boost-metaparse",
-    "boost-move",
-    "boost-mp11",
-    "boost-mpl",
-    "boost-msm",
-    "boost-multi-array",
-    "boost-multi-index",
-    "boost-multiprecision",
-    "boost-nowide",
-    "boost-numeric-conversion",
-    "boost-odeint",
-    "boost-optional",
-    "boost-outcome",
-    "boost-parameter",
+    {
+      "name": "boost-logic",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-math",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-metaparse",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-move",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mp11",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-mpl",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-msm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multi-array",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multi-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-multiprecision",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-nowide",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-numeric-conversion",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-odeint",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-optional",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-outcome",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-parameter",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-parameter-python",
-      "platform": "!emscripten"
+      "platform": "!emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-pfr",
-    "boost-phoenix",
-    "boost-poly-collection",
-    "boost-polygon",
-    "boost-pool",
-    "boost-predef",
-    "boost-preprocessor",
+    {
+      "name": "boost-pfr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-phoenix",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-poly-collection",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-polygon",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-pool",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-predef",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-preprocessor",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-process",
-      "platform": "!emscripten"
+      "platform": "!emscripten",
+      "version>=": "1.80.0#1"
     },
-    "boost-program-options",
-    "boost-property-map",
-    "boost-property-tree",
-    "boost-proto",
-    "boost-ptr-container",
+    {
+      "name": "boost-program-options",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-map",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-property-tree",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-proto",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-ptr-container",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-python",
-      "platform": "!uwp & !emscripten & !ios & !android"
+      "platform": "!uwp & !emscripten & !ios & !android",
+      "version>=": "1.80.0#1"
     },
-    "boost-qvm",
-    "boost-random",
-    "boost-range",
-    "boost-ratio",
-    "boost-rational",
-    "boost-regex",
-    "boost-safe-numerics",
-    "boost-scope-exit",
-    "boost-serialization",
-    "boost-signals2",
-    "boost-smart-ptr",
-    "boost-sort",
-    "boost-spirit",
+    {
+      "name": "boost-qvm",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-random",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-range",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-ratio",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-rational",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-regex",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-safe-numerics",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-scope-exit",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-signals2",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-smart-ptr",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-sort",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-spirit",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-stacktrace",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-statechart",
-    "boost-static-assert",
-    "boost-static-string",
-    "boost-stl-interfaces",
-    "boost-system",
+    {
+      "name": "boost-statechart",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-assert",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-static-string",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-stl-interfaces",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-system",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-test",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-thread",
-    "boost-throw-exception",
-    "boost-timer",
-    "boost-tokenizer",
-    "boost-tti",
-    "boost-tuple",
-    "boost-type-erasure",
-    "boost-type-index",
-    "boost-type-traits",
-    "boost-typeof",
-    "boost-ublas",
-    "boost-units",
-    "boost-unordered",
-    "boost-utility",
-    "boost-uuid",
-    "boost-variant",
-    "boost-variant2",
-    "boost-vmd",
+    {
+      "name": "boost-thread",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-throw-exception",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-timer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tokenizer",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tti",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-tuple",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-erasure",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-index",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-type-traits",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-typeof",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-ublas",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-units",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-unordered",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-utility",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-uuid",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-variant2",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-vmd",
+      "version>=": "1.80.0#1"
+    },
     {
       "name": "boost-wave",
-      "platform": "!uwp"
+      "platform": "!uwp",
+      "version>=": "1.80.0#1"
     },
-    "boost-winapi",
-    "boost-xpressive",
-    "boost-yap"
+    {
+      "name": "boost-winapi",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-xpressive",
+      "version>=": "1.80.0#1"
+    },
+    {
+      "name": "boost-yap",
+      "version>=": "1.80.0#1"
+    }
   ],
   "features": {
     "mpi": {
       "description": "Build with MPI support",
       "dependencies": [
-        "boost-graph-parallel",
-        "boost-mpi",
-        "boost-property-map-parallel"
+        {
+          "name": "boost-graph-parallel",
+          "version>=": "1.80.0#1"
+        },
+        {
+          "name": "boost-mpi",
+          "version>=": "1.80.0#1"
+        },
+        {
+          "name": "boost-property-map-parallel",
+          "version>=": "1.80.0#1"
+        }
       ]
     }
   }

--- a/scripts/boost/generate-ports.ps1
+++ b/scripts/boost/generate-ports.ps1
@@ -24,12 +24,156 @@ else {
 # Clear this array when moving to a new boost version
 $portVersions = @{
     #e.g. "boost-asio" = 1;
-    "boost-fiber" = 1;
-    "boost-coroutine" = 1;
-    "boost" = 1;
-    "boost-asio" = 1;
-    "boost-build" = 1;
-    "boost-modular-build-helper" = 1;
+    "boost" = 2;
+    "boost-accumulators" = 1;
+    "boost-algorithm" = 1;
+    "boost-align" = 1;
+    "boost-any" = 1;
+    "boost-array" = 1;
+    "boost-asio" = 2;
+    "boost-assert" = 1;
+    "boost-assign" = 1;
+    "boost-atomic" = 1;
+    "boost-beast" = 1;
+    "boost-bimap" = 1;
+    "boost-bind" = 1;
+    "boost-build" = 2;
+    "boost-callable-traits" = 1;
+    "boost-chrono" = 1;
+    "boost-circular-buffer" = 1;
+    "boost-compatibility" = 1;
+    "boost-compute" = 1;
+    "boost-concept-check" = 1;
+    "boost-config" = 1;
+    "boost-container" = 1;
+    "boost-container-hash" = 1;
+    "boost-context" = 1;
+    "boost-contract" = 1;
+    "boost-conversion" = 1;
+    "boost-convert" = 1;
+    "boost-core" = 1;
+    "boost-coroutine" = 2;
+    "boost-coroutine2" = 1;
+    "boost-crc" = 1;
+    "boost-date-time" = 1;
+    "boost-describe" = 1;
+    "boost-detail" = 1;
+    "boost-dll" = 1;
+    "boost-dynamic-bitset" = 1;
+    "boost-endian" = 1;
+    "boost-exception" = 1;
+    "boost-fiber" = 2;
+    "boost-filesystem" = 1;
+    "boost-flyweight" = 1;
+    "boost-foreach" = 1;
+    "boost-format" = 1;
+    "boost-function" = 1;
+    "boost-functional" = 1;
+    "boost-function-types" = 1;
+    "boost-fusion" = 1;
+    "boost-geometry" = 1;
+    "boost-gil" = 1;
+    "boost-graph" = 1;
+    "boost-graph-parallel" = 1;
+    "boost-hana" = 1;
+    "boost-heap" = 1;
+    "boost-histogram" = 1;
+    "boost-hof" = 1;
+    "boost-icl" = 1;
+    "boost-integer" = 1;
+    "boost-interprocess" = 1;
+    "boost-interval" = 1;
+    "boost-intrusive" = 1;
+    "boost-io" = 1;
+    "boost-iostreams" = 1;
+    "boost-iterator" = 1;
+    "boost-json" = 1;
+    "boost-lambda" = 1;
+    "boost-lambda2" = 1;
+    "boost-leaf" = 1;
+    "boost-lexical-cast" = 1;
+    "boost-locale" = 1;
+    "boost-local-function" = 1;
+    "boost-lockfree" = 1;
+    "boost-log" = 1;
+    "boost-logic" = 1;
+    "boost-math" = 1;
+    "boost-metaparse" = 1;
+    "boost-modular-build-helper" = 2;
+    "boost-move" = 1;
+    "boost-mp11" = 1;
+    "boost-mpi" = 1;
+    "boost-mpl" = 1;
+    "boost-msm" = 1;
+    "boost-multi-array" = 1;
+    "boost-multi-index" = 1;
+    "boost-multiprecision" = 1;
+    "boost-nowide" = 1;
+    "boost-numeric-conversion" = 1;
+    "boost-odeint" = 1;
+    "boost-optional" = 1;
+    "boost-outcome" = 1;
+    "boost-parameter" = 1;
+    "boost-parameter-python" = 1;
+    "boost-pfr" = 1;
+    "boost-phoenix" = 1;
+    "boost-poly-collection" = 1;
+    "boost-polygon" = 1;
+    "boost-pool" = 1;
+    "boost-predef" = 1;
+    "boost-preprocessor" = 1;
+    "boost-process" = 1;
+    "boost-program-options" = 1;
+    "boost-property-map" = 1;
+    "boost-property-map-parallel" = 1;
+    "boost-property-tree" = 1;
+    "boost-proto" = 1;
+    "boost-ptr-container" = 1;
+    "boost-python" = 1;
+    "boost-qvm" = 1;
+    "boost-random" = 1;
+    "boost-range" = 1;
+    "boost-ratio" = 1;
+    "boost-rational" = 1;
+    "boost-regex" = 1;
+    "boost-safe-numerics" = 1;
+    "boost-scope-exit" = 1;
+    "boost-serialization" = 1;
+    "boost-signals2" = 1;
+    "boost-smart-ptr" = 1;
+    "boost-sort" = 1;
+    "boost-spirit" = 1;
+    "boost-stacktrace" = 1;
+    "boost-statechart" = 1;
+    "boost-static-assert" = 1;
+    "boost-static-string" = 1;
+    "boost-stl-interfaces" = 1;
+    "boost-system" = 1;
+    "boost-test" = 1;
+    "boost-thread" = 1;
+    "boost-throw-exception" = 1;
+    "boost-timer" = 1;
+    "boost-tokenizer" = 1;
+    "boost-tti" = 1;
+    "boost-tuple" = 1;
+    "boost-type-erasure" = 1;
+    "boost-type-index" = 1;
+    "boost-typeof" = 1;
+    "boost-type-traits" = 1;
+    "boost-ublas" = 1;
+    "boost-uninstall" = 1;
+    "boost-units" = 1;
+    "boost-unordered" = 1;
+    "boost-utility" = 1;
+    "boost-uuid" = 1;
+    "boost-variant" = 1;
+    "boost-variant2" = 1;
+    "boost-vcpkg-helpers" = 1;
+    "boost-vmd" = 1;
+    "boost-wave" = 1;
+    "boost-winapi" = 1;
+    "boost-xpressive" = 1;
+    "boost-yap" = 1;
 }
 
 $portData = @{
@@ -168,6 +312,41 @@ function GeneratePortDependency() {
     }
 }
 
+function MakePortVersionString() {
+    param (
+        [string]$PortName
+    )
+    if ($portVersions.Contains($PortName)) {
+        return $version + '#' + $portVersions[$PortName]
+    }
+    return $version
+}
+
+function AddBoostVersionConstraints() {
+    param (
+        $Dependencies = @()
+    )
+
+    $updated_dependencies = @()
+    foreach ($dependency in $Dependencies) {
+        if ($dependency.Contains("name")) {
+            if ($dependency.name.StartsWith("boost")) {
+                $dependency["version>="] = MakePortVersionString $dependency.name
+            }
+        }
+        else {
+            if ($dependency.StartsWith("boost")) {
+                $dependency = @{
+                    "name"       = $dependency
+                    "version>="  = MakePortVersionString $dependency
+                }
+            }
+        }
+        $updated_dependencies += $dependency
+    }
+    $updated_dependencies
+}
+
 function GeneratePortManifest() {
     param (
         [string]$PortName,
@@ -177,6 +356,7 @@ function GeneratePortManifest() {
         $Dependencies = @()
     )
     $manifest = @{
+        "`$comment"     = "When changing this file also update and run scripts/boost/generate-ports.ps1"
         "name"          = $PortName
         "version"       = $version
         "homepage"      = $Homepage
@@ -215,6 +395,12 @@ function GeneratePortManifest() {
                 }
             }
         }
+    }
+
+    # Add version constraints to boost dependencies
+    $manifest["dependencies"] = @(AddBoostVersionConstraints $manifest["dependencies"])
+    foreach ($feature in $manifest.features.Keys) {
+        $manifest.features.$feature["dependencies"] = @(AddBoostVersionConstraints $manifest.features.$feature["dependencies"])
     }
 
     $manifest | ConvertTo-Json -Depth 10 -Compress `

--- a/versions/b-/boost-accumulators.json
+++ b/versions/b-/boost-accumulators.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc69978ce36846187e85003e5a050ed6a0fd74bb",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b25f312085b5e73329ad76e24d11c9c1882e2ee7",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-algorithm.json
+++ b/versions/b-/boost-algorithm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb8f387ba19a3fabe9d59398185263b6448ad028",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "449cdd984b8e373b02b3b5fe727520d2bbddc64f",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-align.json
+++ b/versions/b-/boost-align.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22825c46826b39662752e10219af0c341c18d2e9",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2ba43f3bf67d3825a663dbb55e6210525de2eafd",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-any.json
+++ b/versions/b-/boost-any.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf6b746793770d578a4efef646bf95e1b029932f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c702b79eb10c68b859be09c9aedbdb1533972ede",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-array.json
+++ b/versions/b-/boost-array.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1bc925ca852177c963e12c5da7e8a0b49d51411",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d19880de99410f68c581fc1461458e502952c6d5",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-asio.json
+++ b/versions/b-/boost-asio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95a00e0e4990c9e8179a705132ce53e5f928bbb6",
+      "version": "1.80.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5ee085e21ed4445f2cb442f39fd91c77f79a80e4",
       "version": "1.80.0",
       "port-version": 1

--- a/versions/b-/boost-assert.json
+++ b/versions/b-/boost-assert.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a21b125be748deb6421054f1293be675a1dcd0f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6725be5e5074efec28c39594ca05acccc6f00389",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-assign.json
+++ b/versions/b-/boost-assign.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39a18577662b5babbdc30b9f976e6485f09a4d69",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d4ca8465c21f725287f49640fff191431b14d6d7",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-atomic.json
+++ b/versions/b-/boost-atomic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5d96b1e0077d3b92de462eff308f45327774bb5",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7981a7b10701edd0230d2aac6a058c5ba02f4acc",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-beast.json
+++ b/versions/b-/boost-beast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb8695c5f671d7837dba09787e38d260a0410056",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f6ad5168ee3dfc5e23b7a47f2919de10b4070af6",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-bimap.json
+++ b/versions/b-/boost-bimap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7dd8b2fdefbd75a34020e668f407f3d01530f1c8",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c94058be2a3f7dd8a6b7b4999be4ca799c415249",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-bind.json
+++ b/versions/b-/boost-bind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e599d532e37607322d8f2b7167469ffd197b9b5d",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8d42f0055a3147df3268da26432a64580f9bdbea",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-build.json
+++ b/versions/b-/boost-build.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f09a642cf310a83696849a628942cb40cbbbb75d",
+      "version": "1.80.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "ec5ac2fde8a696a243092c4039f4b34b68091859",
       "version": "1.80.0",
       "port-version": 1

--- a/versions/b-/boost-callable-traits.json
+++ b/versions/b-/boost-callable-traits.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b8d10d87259e5b3038dee8fb55f101387c0f0f8",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f830b72c86e472095ce7c2f86b56e8a4ef8b0585",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-chrono.json
+++ b/versions/b-/boost-chrono.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea2397905d6361f15dca29c4d550d0030fc513af",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "af0a6c6a5b473a08afeacfb8590bd4220129ed47",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-circular-buffer.json
+++ b/versions/b-/boost-circular-buffer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9eb14aa8f4e4ff2381d886468e5fda1603e96d31",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf70dc530094e3190c4d5cc945bb452807cc150b",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-compatibility.json
+++ b/versions/b-/boost-compatibility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5b998028a2b65289a32dab8998d8a0fe38d9a3f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f07e01ce42b7ea0cbecd1ee38ac2700e69a4457a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-compute.json
+++ b/versions/b-/boost-compute.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "852afd7006bc3ef2b5e162c10e80dd788024e099",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4bc892c9f1c28371c4ff1f29b02b350e06dbc8b7",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-concept-check.json
+++ b/versions/b-/boost-concept-check.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86d725b5f62ce91ca280310245072fa6a02b4e7f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0beb38f9779faecd886d454778c8824f2a1b6112",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-config.json
+++ b/versions/b-/boost-config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06e5221e416ce5e62edb12d860e3174388cf40dc",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ca3f30a318dacc3dcab0250a9eeb37dc5b6b92a5",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-container-hash.json
+++ b/versions/b-/boost-container-hash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "83795f2025ec2205c4e6db55c4450426e62f2ea9",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8dc3bdcb7719958b2c449f9d0c5a4a1fee740638",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-container.json
+++ b/versions/b-/boost-container.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "669c74604cc73bada702b35c5ae597428adb02d9",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bacf967cd20a1da8f12491d458bd833194b5c8ff",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-context.json
+++ b/versions/b-/boost-context.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6acc7fc6639406a0ec333c52403b20ac6fcd5aab",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3935b80eb6478299ca2215ec8f44bbaadb7cb097",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-contract.json
+++ b/versions/b-/boost-contract.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bcf4aee9c764ed68d69c7c7c2c5fd4a419852707",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4602cdd4b32f084e83f9c687d2aabf7aac5a7694",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-conversion.json
+++ b/versions/b-/boost-conversion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b5014e3708747964bb4613ab1937bf1772705e5a",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0eefde4b20dad197e9a868ade748b825e6ddafcd",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-convert.json
+++ b/versions/b-/boost-convert.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5caccf25e9d3a859e0fb0f9e4352805a54e4ade4",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "86c8d2de7e7f583832e134096f2c2a869f16e23d",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-core.json
+++ b/versions/b-/boost-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f49830ed564594f4f35e99c73df1d89fb2b1361",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c883ecbdff6a25a10471499fe6baa265370d8e80",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-coroutine.json
+++ b/versions/b-/boost-coroutine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ad73dc1827cbca291002b28510f60912cbf12e8",
+      "version": "1.80.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "58decd230ff2227603af8e6e95dfcf45fab3b032",
       "version": "1.80.0",
       "port-version": 1

--- a/versions/b-/boost-coroutine2.json
+++ b/versions/b-/boost-coroutine2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ae4a6556eee9c00d542a9efc6a45f342c51732b",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2b92ef8da314cedfeb9c03cccb9ed74c54464937",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-crc.json
+++ b/versions/b-/boost-crc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9477953bb7805e421b7953a86705771ba60b99e6",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f1ffdaef7352c8861f62b6a81197f8f57433e471",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-date-time.json
+++ b/versions/b-/boost-date-time.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0dcad93c43fe52b123c5e3abf8c3e94112ebe4f0",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4d59467ccd3c5545e253f0077e97237d3e89e320",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-describe.json
+++ b/versions/b-/boost-describe.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e69329263efe6a881ac4bd42a9ba24ae30da2b4d",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "91eb316df6588d70db583e6accf94f3dc79cb78b",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-detail.json
+++ b/versions/b-/boost-detail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "38ec0a4a84acceb11ec8388fe3a3da794ca91351",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4e3b1298f453e933f97c2145a1539ed0763e52b1",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-dll.json
+++ b/versions/b-/boost-dll.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e6f9ce9e7881e9c45425000cd709593784a20f9",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "58b721d72a67913e4f5001269c25b3e7b8982f93",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-dynamic-bitset.json
+++ b/versions/b-/boost-dynamic-bitset.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6959c97c0e4308db06332a09d896712492e6d23c",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "288335907a0fe3dfaccf6bf7dc796d6a4e2570e2",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-endian.json
+++ b/versions/b-/boost-endian.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7522ddb265f1755e5c6c1e121291788353e4253b",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a7e23bb3fd93937ab37715ea481e5ed84b51f37e",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-exception.json
+++ b/versions/b-/boost-exception.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd131b74e6a6bf14aaf31aef22be644b4fa57a3a",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "fd7bd1fcdb784fea657d9a4f068253b5d95ca333",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-fiber.json
+++ b/versions/b-/boost-fiber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f4bc44fe6c4a0c24f2b5245f555fe9b24c3c23e",
+      "version": "1.80.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "6f4c9240d299fe5785433544a022cf4521fe942e",
       "version": "1.80.0",
       "port-version": 1

--- a/versions/b-/boost-filesystem.json
+++ b/versions/b-/boost-filesystem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "253643753293f6813c1bcc874cd28a6f3cc9ab2d",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "77d8b1f9dff7eec868e4c8007c399bb123d80a97",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-flyweight.json
+++ b/versions/b-/boost-flyweight.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6769685902151b1d6e393cc08bf5af3d13d298d4",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "65fcde6f347e7f0100ef071d6f943d5e1f05790b",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-foreach.json
+++ b/versions/b-/boost-foreach.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79898d070e211f5e82883529d4b2827409d31b43",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7b86b0bc008ecde19a6e4c83aa2365a197dc214e",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-format.json
+++ b/versions/b-/boost-format.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8deeaabce25837a416a49e0ed89f9ba7785a5609",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8b8465c0970d28814c1162b864c02f685e471482",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-function-types.json
+++ b/versions/b-/boost-function-types.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4562bcffbb698917249d0155ce70c9598311cd8",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d09eff712efc437ebb49cc7dbf5644a641be3b31",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-function.json
+++ b/versions/b-/boost-function.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b3d421112777238fe9150fd401d81e7578d70f36",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4a3017f165de9e889e161ab353dda4439cea8169",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-functional.json
+++ b/versions/b-/boost-functional.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c8d615fe6316c17e838de35cae546196767b26f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "43e00a8e09e0b0fd501b8a7b8dacc2a189a0c587",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-fusion.json
+++ b/versions/b-/boost-fusion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ec6b28fe668dae192e851b799e9cd5b7d1c21690",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4e5e11a2bdcfb620804b47dd24f09145d67892e0",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-geometry.json
+++ b/versions/b-/boost-geometry.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c2cf914316e5568a4765a8656e338b476b6e149a",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "22ed5ea6012738b12286b239ddf1cc9606e3130a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-gil.json
+++ b/versions/b-/boost-gil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "87ff21e8f7a36871221406d9ed84c59832680567",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2bec2e61c5e01a16e3cd4ca47449aa15382931c6",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-graph-parallel.json
+++ b/versions/b-/boost-graph-parallel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eba27831af655f97947aac5806f4659943ca9c5f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2246b1dab26eb279a95fe40b6d6f225b2469d8cf",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-graph.json
+++ b/versions/b-/boost-graph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "133fb1954fafd50e84cdda7e7e5ce08a1ef34403",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d7fd5ed599b799127c74238c346fbca9be455009",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-hana.json
+++ b/versions/b-/boost-hana.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb5ffe4a8f02f762efed5aa2fbbc9227455263b0",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "dd068f8c4347e0ed41005a78ee39f98ecf79c441",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-heap.json
+++ b/versions/b-/boost-heap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2bfb87607aa7a01941233e4fe118381417327e04",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "02f31ba7775130e875051cd5f5cbdb76066ff0bd",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-histogram.json
+++ b/versions/b-/boost-histogram.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dab5adb258a540b70e4e32762cb119a3449e096c",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "70a6aaca30a05b7f234b62988f1bd8f53421710a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-hof.json
+++ b/versions/b-/boost-hof.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60797dbac318098253cd607c0e3cb5fa04a36d9f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "40ecf7b9f806bed59a911028354f0f471b5e1beb",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-icl.json
+++ b/versions/b-/boost-icl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3b1aa6aa1a9190a0270d208ce1832bf8c0deca2",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "061544233c810a2a3e04cca99364bb2fe3edcbb2",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-integer.json
+++ b/versions/b-/boost-integer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "524f6107bc7ae49cd24a04b94ed8886604ee3e2c",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f980326e208e00560547b76cbb13759357e74598",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-interprocess.json
+++ b/versions/b-/boost-interprocess.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c82814fdaafa13305c7aa4c29340f025544285ca",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c9830784da99cc5088750233a568961dfe6701c0",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-interval.json
+++ b/versions/b-/boost-interval.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9dd8339312f4b410207cb01118937eb38df2ac3d",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cc4c8e51cac9fa083d9f181e9da090a65fe62779",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-intrusive.json
+++ b/versions/b-/boost-intrusive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85a69fe7a9157a957545c6c3233586715d18c9ae",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "538ebc32732429b15db300664e07bab697c2e5e2",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-io.json
+++ b/versions/b-/boost-io.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef9f00355277eacf410b5661b306991f21cf82bd",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cfe6645cfe18cc173a5101310bc86dbb5fc5532a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-iostreams.json
+++ b/versions/b-/boost-iostreams.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3576e6c1d93316cde685ff4f9c2c054aa00cb4c",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "37de3e0e0107aaeb4eb8bc2ee29457131145bb36",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-iterator.json
+++ b/versions/b-/boost-iterator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67993642b285e3448abef01738372590a4795044",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d5df6fffeb95a0cdd702d8471696ca31a45f1600",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-json.json
+++ b/versions/b-/boost-json.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20921eed92d9e5a1083d8eb83fb642a401e55a64",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e00f0980f7fc5a06bf3c559b6a1052e068d5de96",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-lambda.json
+++ b/versions/b-/boost-lambda.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7204e1ed786f4b70c34119c3eb233bccfe7ce375",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e96e65ee098d0846218e7df13156804051aadd23",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-lambda2.json
+++ b/versions/b-/boost-lambda2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fee0b83871eaf93b97a052e4612aab52f2d8b271",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ea6068a8cd06ecf372e93ec9967af05735e0e64a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-leaf.json
+++ b/versions/b-/boost-leaf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd906879bdcd0656df06ac52b059295cfabd5e65",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "151ee4285909980fe5008aaf36d65ffc636e654a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-lexical-cast.json
+++ b/versions/b-/boost-lexical-cast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f68712a48e0aefc65866fe43edc152e1afd5e94",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a1c65d88dc4dd33ee2308e6dffa9ff580b3ad0e8",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-local-function.json
+++ b/versions/b-/boost-local-function.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f63b725031f3fba9235568d39523b33eb1c1185",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0c1a73008438d7a613f4fbb3a8d12c33276ae584",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-locale.json
+++ b/versions/b-/boost-locale.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5f8a6a2c2f766dace9c3a7887b3732c5fa7b4b3",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f76509b5e99db09e81179f9168a3da090c581c0b",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-lockfree.json
+++ b/versions/b-/boost-lockfree.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2aab84f6f6ce1cbde92ae48e80aff99f25ff2dc",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c1e9c0f8ac538167c8425f199e49c771c132d1f9",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-log.json
+++ b/versions/b-/boost-log.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "421d4a05c15c9e6e8b2ce014f896713703eb40aa",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3c2e069e10107dd06749bf7fadf7d086799ab91a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-logic.json
+++ b/versions/b-/boost-logic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9536411e1f225383e6d8ff8f58bcfb0454ce4fd6",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "588f889d8da686230f6f610141d8110562504312",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-math.json
+++ b/versions/b-/boost-math.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e646999339a79fdfb234566e4f8efcfe51c850af",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c3f7257d4b3a7b8d94e00348149051d37eb75921",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-metaparse.json
+++ b/versions/b-/boost-metaparse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cd8f72d5142bd7b0d34945ee840ff709d4155ee8",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d49c84675e49cb7998be2c9efb382044f5bfcd39",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c01b4620588f657e9e4005fa5f9d9a649a8feba9",
+      "version": "1.80.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "3cfe5562e40b1ef219b3d36054e1235508c41037",
       "version": "1.80.0",
       "port-version": 1

--- a/versions/b-/boost-move.json
+++ b/versions/b-/boost-move.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eaa3532f107240627f18023ee2d4453e7c15082b",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a892eef83cda1beff03d4a7dc11481b153fadfa0",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-mp11.json
+++ b/versions/b-/boost-mp11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a63b1a2c7dc6e115b98d788fcca72f5611dc9655",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cf20115432a67132df2313b6ad134276595cd886",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-mpi.json
+++ b/versions/b-/boost-mpi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "825b89feccc1de3c5fc21923da8cf24f3c67985c",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "87dd60df15aacd026d27193cc0efd1b5323dcde9",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-mpl.json
+++ b/versions/b-/boost-mpl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3bb30cd9de09091f89f9dc089849942977321c3a",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c213f7c4b3d93700c4cfa30498138df314619c98",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-msm.json
+++ b/versions/b-/boost-msm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab4b1d65ab603bb1cd6a31938a6a09b32932cb59",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5b4b10c39ed7937f0cd9539a22f7af1bfc5a3a08",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-multi-array.json
+++ b/versions/b-/boost-multi-array.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b11ed52164da13a94121b0d801c49dcf8b49177",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9f1e6f3a8453417be928e6f603986ca0937d6365",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-multi-index.json
+++ b/versions/b-/boost-multi-index.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e0d5d944725d59bfd052a45a1fa6359160bba5e",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e217e3de385a4953c622960e326d5ae354822f19",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-multiprecision.json
+++ b/versions/b-/boost-multiprecision.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4117ddf70595a1d908d386b26a7d04ef6d9b5410",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5e2eb2ccd2df8fe19e09aeb8b2c23cb1142c649b",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-nowide.json
+++ b/versions/b-/boost-nowide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d16fe18d5e02726b147f738299dcfc9ae091415c",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a5bf7c703090e7a83527aef14901df5e26668240",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-numeric-conversion.json
+++ b/versions/b-/boost-numeric-conversion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ef5bee24ba2306792e90eadeb29513d3b39257f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d472eba74f6936b736a2759ae9e0be3c96a7d4b7",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-odeint.json
+++ b/versions/b-/boost-odeint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "271376a4dc38558bd9c8fbe66c7dc07548d20f2f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f08d713ac19958a488cba507887bc2e7beea1a2e",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-optional.json
+++ b/versions/b-/boost-optional.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a028094bf6e20c3ec659fc2b4fcd1b9d6ea1502",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f25e73c7f9e4db6d27692ece6b2db2269bbd3a72",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-outcome.json
+++ b/versions/b-/boost-outcome.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e75e2e921a4cb4d3adb850a0e5a2515d304d7cc",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3e67c523f8a5112b14aec2d7f931027848e9d424",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-parameter-python.json
+++ b/versions/b-/boost-parameter-python.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "65cbc2458c2ebc14c3aaa805b24f4c136cce89ae",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0f685a59fbc75e930b74189fa71a740ca2a4eb60",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-parameter.json
+++ b/versions/b-/boost-parameter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a2b7c65bfea84b3b5c4a598a45250fca5a1112d0",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "dfa271d39fd1a50822e9c72199164d383410bbe5",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-pfr.json
+++ b/versions/b-/boost-pfr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2129988348177a6896a03c6144f20f5c562ff87e",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5d050fa2a0189cd8ff8625e9ee6b6199b3a28785",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-phoenix.json
+++ b/versions/b-/boost-phoenix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd5461d6cb0ea1e05a378d912383fbef50e8ec25",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c69ac60adcb765d3b35a18b2be37dd7ea21fa711",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-poly-collection.json
+++ b/versions/b-/boost-poly-collection.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "481eb4011dd911ddef930551a61840f880f121c5",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4be3065ec0871a76272899ff58c1e55aa9e387c1",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-polygon.json
+++ b/versions/b-/boost-polygon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d173c6e24ed272a57506ec4f3094e35f94b61a5",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c77b533b461ca02f57c02480d0b49175fcd33305",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-pool.json
+++ b/versions/b-/boost-pool.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32fda1e57ec88d8316456aa218e2bcc6c5ea3798",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "72126937ced48f11d0b1bd0417b55c0bbbff80d0",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-predef.json
+++ b/versions/b-/boost-predef.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "655098bc9822d731faeee6bbf1b1247488e3e86f",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "aba63dc45c18c5b2486a1597c57a8c8bc8c4332e",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-preprocessor.json
+++ b/versions/b-/boost-preprocessor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c48eda62428e1821b43a16e58be0c1e5a19333bc",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ecc094cbf773842dc012128b15a0a8b33655a48a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-process.json
+++ b/versions/b-/boost-process.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0158e11fa88f33081d0b1f076ec789a834c00253",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf4118e63efe0bc19f98f3639916e3dc565884ba",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-program-options.json
+++ b/versions/b-/boost-program-options.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0e5c05478f63ed0efe14f961fae87d913b06b81",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "306ab169b6f177e71d82cb08c77a8629337a1b6a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-property-map-parallel.json
+++ b/versions/b-/boost-property-map-parallel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60e15d78a331d327d131bba2cdaa5be5351610e1",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "addcd2668a3f5f1ce1dcd5f3b548077cd9c3a16c",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-property-map.json
+++ b/versions/b-/boost-property-map.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5921bb73cf27346ab03121a94efd62dc275b86d4",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6a784463d4425f1b9f97d5e469a27a8223f5f0b0",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-property-tree.json
+++ b/versions/b-/boost-property-tree.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80c63c4b5522c88fffe94fb9ce2ae2fbba68e866",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0993baf1328cd41a1f980b4e1147a38e44b7c23d",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-proto.json
+++ b/versions/b-/boost-proto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8068ac7d4e5792c081ad1d0e56a46414ab4e6bf0",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "df51ae90d5540b775b1f14bf796bd7e4f4b6529e",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-ptr-container.json
+++ b/versions/b-/boost-ptr-container.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8fcbe89c6181b32292c07084bfcfb19863b846d",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "81b98fdaf0c11a4b157b220a98d050fabead9e06",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-python.json
+++ b/versions/b-/boost-python.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a040e012e71e5fe4338ba4bc23bdb827348aeb0e",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "37c146ee0ddbf30f5372bf434bca80f97d1a653e",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-qvm.json
+++ b/versions/b-/boost-qvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43b7947d031f7dc90e89e5ab20a942307bce299c",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b341b99d2ab5ebdd7722ee83fe57c5cad255a2ef",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-random.json
+++ b/versions/b-/boost-random.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7df4d79fdeece9481a89f53c6b0d80ac42f7e4b",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6372fd79a4e213f92ebe9e71be03fdf71b77d532",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-range.json
+++ b/versions/b-/boost-range.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7436352f0a4c6248fc5ddd3dbdf54cf745ae39e3",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8c39bc84eb02172bd336ad4c310a181ce983eae5",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-ratio.json
+++ b/versions/b-/boost-ratio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f47c052da4ae6392cff38664fea7fa27503e5ffc",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9474d4e6541e03de3c1636305bf1dbcbc46ac971",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-rational.json
+++ b/versions/b-/boost-rational.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a001714b6712c22b24b1c3234a1c78f7f18e43cb",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5ebe5bd52b65623fca07154f8dd993ae9bf7522f",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-regex.json
+++ b/versions/b-/boost-regex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9988f582a655bfd7d3d88dbaa771ec575784a750",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8ca14abfbb7f576ae870202425068b603e48452f",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-safe-numerics.json
+++ b/versions/b-/boost-safe-numerics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02216f2a6df2143071e9a0e994d8458bb6f42d1b",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "50e0e90565017dfa188314c53df5119c8fa3e5ce",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-scope-exit.json
+++ b/versions/b-/boost-scope-exit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "157b0ac2b97473baa320c3a436d3952ec556ce58",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9d6f15ab55ce24e64b53a1004d5286a2a6af1ba1",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-serialization.json
+++ b/versions/b-/boost-serialization.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf0c163ebd43ebc46c07dddab43c65b3c751fd41",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "566a672aaf52abdc07527d293f88772b3e28e079",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-signals2.json
+++ b/versions/b-/boost-signals2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d2651cc0faabbb473973110a28cc699be1e239b",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d7846d029daf05be0a560dad09ac64a64850a297",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-smart-ptr.json
+++ b/versions/b-/boost-smart-ptr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d091ad74677a0e52d40ccd2fba29bd00ba5fbfd",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b7b255db01f37243bdc87ffabeaf493dcb9de474",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-sort.json
+++ b/versions/b-/boost-sort.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf35201f0de023dd7a287ad5476a363805642a39",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "be28a0d59e37787052758401bd5ab59a0f70d9ca",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-spirit.json
+++ b/versions/b-/boost-spirit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "957991a8081ca1c3be811fd21e1da58cc0b0428b",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "74f1c93e41e9b732a47afc259b396c0812f266de",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-stacktrace.json
+++ b/versions/b-/boost-stacktrace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be2886a710a14f41b5272e48d48cfecac21a650a",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d2168810ccbabcae3d538f8679181ae300b815ac",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-statechart.json
+++ b/versions/b-/boost-statechart.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6397499d13e7ab3fcbbfb156613668570bfe6222",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "41d7af8a2e26fd1f41dae61d62cb8484ea978884",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-static-assert.json
+++ b/versions/b-/boost-static-assert.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1d473e4761320293cb036a6dd2f00ebdcff169e",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "55582331cbe3fc0e46ca145196d341140511edad",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-static-string.json
+++ b/versions/b-/boost-static-string.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce625ddf570552c9fb62006d8e20a8ba70613dd1",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b58ce47fd0d910a9b436540cf87e0b06a1767fa3",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-stl-interfaces.json
+++ b/versions/b-/boost-stl-interfaces.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19154572a3a78e70a7b43d0eb17579fecdaf75fa",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0b82eb711e6d0b9a580b7fd149b1bd4b95d9c9d1",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-system.json
+++ b/versions/b-/boost-system.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a6e70bad5ea38a9e78b3068ce0bc9237d4ad413",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "198bd87002215340f09b4269e8d80dbb7f314c7e",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-test.json
+++ b/versions/b-/boost-test.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7322867adec8f2f81a99e227202805a3f291fba2",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7324e419ee3fa4d7871aae2cac389cb3eb2dda94",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-thread.json
+++ b/versions/b-/boost-thread.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68aa268b4f5054150b946af87cf73a58ddd46281",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "010869a933ea4108c7cfb6ebc10d86ff823a1073",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-throw-exception.json
+++ b/versions/b-/boost-throw-exception.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1bdea74428f14ec2c9906cfda12610ffd0b53187",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7ff821c116eab19736c1549d09245fbac968c7ec",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-timer.json
+++ b/versions/b-/boost-timer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fdfece6a14ea383eabe8f147c1672c7b0791ffed",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "dc5dca14265350c93bafac78b73c1305d514a9ea",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-tokenizer.json
+++ b/versions/b-/boost-tokenizer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ebdbeabd169a5242203d56538a4112559da6e4c8",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "860575e6cabb9769a64a55d67b8734decfc0dc25",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-tti.json
+++ b/versions/b-/boost-tti.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d64d8aaf865a3992837a4cab0fb398b124daca3d",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "845aab372d2f165939e1554598fcb6d7963119e8",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-tuple.json
+++ b/versions/b-/boost-tuple.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d08e7b23a8644fefd924b2cd21af2c99b6ffa7e6",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e4941b65ae10c7111efc790716e7ab44108718c0",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-type-erasure.json
+++ b/versions/b-/boost-type-erasure.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c2806659e6ec0ea290162c209f8f64c004b3a77",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "dabde40cb34f79fba07538d0dfe27e001fdd022d",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-type-index.json
+++ b/versions/b-/boost-type-index.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d48eb1cefa16768fe1eaf570744b37a954f75a74",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "139ead6a2f009c871512ff2313970a7ced6ba19a",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-type-traits.json
+++ b/versions/b-/boost-type-traits.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06c7db2dbd9d4fe6a6d4b74b120e16ad6cb25b8e",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "64116e3dd1e586ab99b4f39786b73fc6bf433565",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-typeof.json
+++ b/versions/b-/boost-typeof.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c195f9b7d65f84db84ea3f27ab2179b22c60fe48",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7157d86a4332212ca5da2d3e4bcb980f59373c1f",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-ublas.json
+++ b/versions/b-/boost-ublas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c7cdeb18adddbbb7c307d97553370029099111a",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1fe638c91ec64ab61220e4ece208a9d70ad9557f",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-uninstall.json
+++ b/versions/b-/boost-uninstall.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb6551ecfc9d94c9bfe131d7bcdcec0a0b33f5f1",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9eb27209522fff06b9aad5e4443312888cf680ce",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-units.json
+++ b/versions/b-/boost-units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "deb1621e5cb52697de1be40a555e5415263743dc",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "94d24c25122f4aee516ae8df34e60450dc7a9dad",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-unordered.json
+++ b/versions/b-/boost-unordered.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf2c66f63c1859c8a271beb4b09b56d2e28a3ce0",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a64980c42d17c231e1164e6dcd7f55361cf6bbca",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-utility.json
+++ b/versions/b-/boost-utility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85e74c765fe5aa059a93dc20c29626a7533054c8",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9544b25d2474879b1dc04879bf6d48ac20b8ae1d",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-uuid.json
+++ b/versions/b-/boost-uuid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5f37dcea4cd579491232822504725da49a25f66",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "346b3215925506cde0a4d8f2558434f812572094",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-variant.json
+++ b/versions/b-/boost-variant.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c54a1945bc717ef69676421820eb5bf6b503ca9",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "052552e2ffe5c387e6dfd6800509379143747b93",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-variant2.json
+++ b/versions/b-/boost-variant2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46508a1c16f583aef59468ec4ca9dd51fbe01c66",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0bc906a591673c127a85b38092dac0ab850931e5",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-vcpkg-helpers.json
+++ b/versions/b-/boost-vcpkg-helpers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5243d77112bcebbfbe67c57a96e0077eb0921a4a",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "244bfc6425dfb6e1c0c8b556f6ab8786e394c246",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-vmd.json
+++ b/versions/b-/boost-vmd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2325791b07ed7cbaf2252ff61a2afd7e1e38f0dd",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7f1ce668d0b408886328f3602b4ba2dcdc6e0f34",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-wave.json
+++ b/versions/b-/boost-wave.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e7a7b136b4f7ec5badd9969bca100fa4bede6b5",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3b3867b5b587bc385e9c185e669651610af7ee0e",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-winapi.json
+++ b/versions/b-/boost-winapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0d6af12fbd2f2efe8310394c82487686a7141c4",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "510961ace0ba15ccb5018734f6638f8af539258c",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-xpressive.json
+++ b/versions/b-/boost-xpressive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76511563b1908aa5ab663bfb67071f35bef001c0",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e226118acbf483b6f0fd12cf6037a961520140df",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost-yap.json
+++ b/versions/b-/boost-yap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be0b950a4703cff293354292f257e978552601ad",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "382723f52354a14670f68b46c89c1101c0310a4e",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/b-/boost.json
+++ b/versions/b-/boost.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fe661a6643f1b0d0acb080684d65d8b725ad108f",
+      "version": "1.80.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "dd28384ddceb935eecbc6e787b67e2a9b506aab3",
       "version": "1.80.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -558,139 +558,139 @@
     },
     "boost": {
       "baseline": "1.80.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-accumulators": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-algorithm": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-align": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-any": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-array": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-asio": {
       "baseline": "1.80.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-assert": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-assign": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-atomic": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-beast": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-bimap": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-bind": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-build": {
       "baseline": "1.80.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-callable-traits": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-chrono": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-circular-buffer": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-compatibility": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-compute": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-concept-check": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-config": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-container": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-container-hash": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-context": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-contract": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-conversion": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-convert": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-core": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-coroutine": {
       "baseline": "1.80.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-coroutine2": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-crc": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-date-time": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-describe": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-detail": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-di": {
       "baseline": "1.2.0",
@@ -698,467 +698,467 @@
     },
     "boost-dll": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-dynamic-bitset": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-endian": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-exception": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-fiber": {
       "baseline": "1.80.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-filesystem": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-flyweight": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-foreach": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-format": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-function": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-function-types": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-functional": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-fusion": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-geometry": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-gil": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-graph": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-graph-parallel": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-hana": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-heap": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-histogram": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-hof": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-icl": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-integer": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-interprocess": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-interval": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-intrusive": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-io": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-iostreams": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-iterator": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-json": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-lambda": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-lambda2": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-leaf": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-lexical-cast": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-local-function": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-locale": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-lockfree": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-log": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-logic": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-math": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-metaparse": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-modular-build-helper": {
       "baseline": "1.80.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-move": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-mp11": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-mpi": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-mpl": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-msm": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-multi-array": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-multi-index": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-multiprecision": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-nowide": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-numeric-conversion": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-odeint": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-optional": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-outcome": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-parameter": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-parameter-python": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-pfr": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-phoenix": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-poly-collection": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-polygon": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-pool": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-predef": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-preprocessor": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-process": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-program-options": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-property-map": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-property-map-parallel": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-property-tree": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-proto": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-ptr-container": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-python": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-qvm": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-random": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-range": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-ratio": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-rational": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-regex": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-safe-numerics": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-scope-exit": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-serialization": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-signals2": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-smart-ptr": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-sort": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-spirit": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-stacktrace": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-statechart": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-static-assert": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-static-string": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-stl-interfaces": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-system": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-test": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-thread": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-throw-exception": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-timer": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-tokenizer": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-tti": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-tuple": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-type-erasure": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-type-index": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-type-traits": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-typeof": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-ublas": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-uninstall": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-units": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-unordered": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-utility": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-uuid": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-variant": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-variant2": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-vcpkg-helpers": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-vmd": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-wave": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-winapi": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-xpressive": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-yap": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boringssl": {
       "baseline": "2021-06-23",


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/discussions/26582 (aka https://github.com/microsoft/vcpkg/issues/26548) by adding version constraints to boost ports.

Cc @horenmar 