### PR TITLE
[binlog] Add new port

### DIFF
--- a/ports/binlog/portfile.cmake
+++ b/ports/binlog/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO morganstanley/binlog
+    REF 3fef8846f5ef98e64211e7982c2ead67e0b185a6
+    SHA512 106da76da3fc229211f8754306156bb7456d828678bfab18a0ad24f713ce1101debab4a75fe12bf7686bfab2f3f26eef66b57642447d7ddfb7de343f3ad8279d
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBINLOG_BUILD_BREAD=OFF
+        -DBINLOG_BUILD_BRECOVERY=OFF
+        -DBINLOG_BUILD_EXAMPLES=OFF
+        -DBINLOG_BUILD_UNIT_TESTS=OFF
+        -DBINLOG_BUILD_INTEGRATION_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/binlog")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_copy_pdbs()

--- a/ports/binlog/vcpkg.json
+++ b/ports/binlog/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "binlog",
+  "version-date": "2021-04-16",
+  "description": "Binlog is a high performance C++ log library to produce structured binary logs.",
+  "homepage": "http://opensource.morganstanley.com/binlog/",
+  "license": "Apache-2.0",
+  "supports": "!uwp & !(arm64 & windows)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/b-/binlog.json
+++ b/versions/b-/binlog.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "eb0ae943fc2b0c1c19ad62308d1f321439967fd4",
+      "version-date": "2021-04-16",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -520,6 +520,10 @@
       "baseline": "2010.04.30",
       "port-version": 7
     },
+    "binlog": {
+      "baseline": "2021-04-16",
+      "port-version": 0
+    },
     "binn": {
       "baseline": "3.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

Add binlog, a high performance C++ log library to produce structured binary logs.

- #### What does your PR fix?
  New port.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All except UWP and Windows ARM, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Hopefully?

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
