### PR TITLE
[llfio,outcome,ned14-internal-quickcpplib] Fix minor nits

### DIFF
--- a/ports/llfio/portfile.cmake
+++ b/ports/llfio/portfile.cmake
@@ -63,6 +63,8 @@ vcpkg_cmake_configure(
         -DLLFIO_FORCE_OPENSSL_OFF=ON
         -DLLFIO_ENABLE_DEPENDENCY_SMOKE_TEST=ON  # Leave this always on to test everything compiles
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
+        -DCXX_CONCEPTS_FLAGS=
+        -DCXX_COROUTINES_FLAGS=
         ${extra_config}
 )
 

--- a/ports/llfio/portfile.cmake
+++ b/ports/llfio/portfile.cmake
@@ -8,8 +8,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ned14/llfio
-    REF ae7f9c5a92879285ad5100c89efc47ce1cb0031b
-    SHA512 aa8563e4e78e4355ae1041bd8d2984e33e8c8b7634a6eac029e4716dff564a9616ba1826504709f428f789103e8f4ab90447208e66583536ad692400e51eec60
+    REF 6c8e3e10a2919b4da754d0f3db54b3c616e1dd56
+    SHA512 9265d722a6d9e4a9a0605fc071c5053bd71188f6d5500cfa4e64ef9ee33be364d3a1289d011863b64a4f3bdfc3a54fa9bfc6ee69ff1a93995584605c58e79f62
     HEAD_REF develop
     PATCHES
 )
@@ -60,6 +60,7 @@ vcpkg_cmake_configure(
         -DPROJECT_IS_DEPENDENCY=On
         -Dquickcpplib_DIR=${CURRENT_INSTALLED_DIR}/share/quickcpplib
         ${LLFIO_FEATURE_OPTIONS}
+        -DLLFIO_FORCE_OPENSSL_OFF=ON
         -DLLFIO_ENABLE_DEPENDENCY_SMOKE_TEST=ON  # Leave this always on to test everything compiles
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
         ${extra_config}

--- a/ports/llfio/vcpkg.json
+++ b/ports/llfio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "llfio",
-  "version-date": "2022-09-08",
+  "version-date": "2022-09-18",
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/ports/ned14-internal-quickcpplib/portfile.cmake
+++ b/ports/ned14-internal-quickcpplib/portfile.cmake
@@ -69,7 +69,7 @@ vcpkg_cmake_configure(
         -DPROJECT_IS_DEPENDENCY=On
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
-        -DCMAKE_INSTALL_DATADIR=${CURRENT_PACKAGES_DIR}/share/ned14-internal-quickcpplib
+        "-DCMAKE_INSTALL_DATADIR=${CURRENT_PACKAGES_DIR}/share/ned14-internal-quickcpplib"
         ${FEATURE_OPTIONS}
     MAYBE_UNUSED_VARIABLES
         CMAKE_DISABLE_FIND_PACKAGE_Doxygen

--- a/ports/ned14-internal-quickcpplib/vcpkg.json
+++ b/ports/ned14-internal-quickcpplib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ned14-internal-quickcpplib",
   "version-date": "2022-09-08",
+  "port-version": 1,
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/ports/outcome/portfile.cmake
+++ b/ports/outcome/portfile.cmake
@@ -45,6 +45,7 @@ vcpkg_cmake_configure(
         -Dstatus-code_DIR=${CURRENT_INSTALLED_DIR}/share/status-code
         -DOUTCOME_ENABLE_DEPENDENCY_SMOKE_TEST=ON  # Leave this always on to test everything compiles
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
+        -DCXX_CONCEPTS_FLAGS=
 )
 
 if("run-tests" IN_LIST FEATURES)

--- a/ports/outcome/vcpkg.json
+++ b/ports/outcome/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "outcome",
   "version": "2.2.4",
+  "port-version": 1,
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4417,7 +4417,7 @@
       "port-version": 0
     },
     "llfio": {
-      "baseline": "2022-09-08",
+      "baseline": "2022-09-18",
       "port-version": 0
     },
     "llgl": {
@@ -4994,7 +4994,7 @@
     },
     "ned14-internal-quickcpplib": {
       "baseline": "2022-09-08",
-      "port-version": 0
+      "port-version": 1
     },
     "neon2sse": {
       "baseline": "2021-09-16",
@@ -5466,7 +5466,7 @@
     },
     "outcome": {
       "baseline": "2.2.4",
-      "port-version": 0
+      "port-version": 1
     },
     "p-ranav-csv": {
       "baseline": "2019-07-11",

--- a/versions/l-/llfio.json
+++ b/versions/l-/llfio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75a5c6e3170c65d747e5103b292f5da55ec2aa0a",
+      "version-date": "2022-09-18",
+      "port-version": 0
+    },
+    {
       "git-tree": "7974159a11b2a1a1f5aed7b6c500eae3fa54481f",
       "version-date": "2022-09-08",
       "port-version": 0

--- a/versions/n-/ned14-internal-quickcpplib.json
+++ b/versions/n-/ned14-internal-quickcpplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9c41d87d7d3dc77a9d7dfaddef8571574721f0d",
+      "version-date": "2022-09-08",
+      "port-version": 1
+    },
+    {
       "git-tree": "89d5a8630a97d2e3a7cae1a56253de75014a0738",
       "version-date": "2022-09-08",
       "port-version": 0

--- a/versions/o-/outcome.json
+++ b/versions/o-/outcome.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "504177d3c3f3d1a063db2ce6d12292141e874d37",
+      "version": "2.2.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "9e3ec2f8aff33b12210dc924ff285b3cf23abb2a",
       "version": "2.2.4",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  It prevents the llfio and outcome buildsystems from trying to enable concepts and coroutine support on older standard versions (via `-fconcepts` and such).
  Disable llfio's `OpenSSL` support (which has been recently implemented) until someone properly upgrades this port with a corresponding feature (I won't).
  Properly escapes a path option in the quickcpplib port.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
