### PR TITLE
[geogram] Add arm64-windows support

### DIFF
--- a/ports/geogram/portfile.cmake
+++ b/ports/geogram/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 0ec0deded92c8d5d100b6e77f8cfbbbaf7b744c230e10abd0b86861960cda9713ff65209575fdc09034afcb0e9137428a20c00d399c09fd58ce541fed2105a2d
     PATCHES
         fix-vcpkg-install.patch
+        use-arm64-intrinsics.patch
 )
 
 file(COPY ${CURRENT_PORT_DIR}/Config.cmake.in DESTINATION ${SOURCE_PATH}/cmake)

--- a/ports/geogram/use-arm64-intrinsics.patch
+++ b/ports/geogram/use-arm64-intrinsics.patch
@@ -1,0 +1,16 @@
+diff --git a/src/lib/geogram/delaunay/periodic_delaunay_3d.cpp b/src/lib/geogram/delaunay/periodic_delaunay_3d.cpp
+index 352ea76..34e73e2 100644
+--- a/src/lib/geogram/delaunay/periodic_delaunay_3d.cpp
++++ b/src/lib/geogram/delaunay/periodic_delaunay_3d.cpp
+@@ -122,7 +122,11 @@ namespace {
+ #if defined(GEO_COMPILER_GCC_FAMILY)
+ 	return GEO::index_t(Numeric::uint32(__builtin_popcount(x)));
+ #elif defined(GEO_COMPILER_MSVC)
++    #if defined(_M_ARM64)
++	return GEO::index_t(_CountOneBits(x));
++    #else
+ 	return GEO::index_t(__popcnt(x));
++    #endif
+ #else
+ 	int result = 0;
+ 	for(int b=0; b<32; ++b) {

--- a/ports/geogram/vcpkg.json
+++ b/ports/geogram/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "geogram",
   "version": "1.7.6",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Geogram is a programming library of geometric algorithms.",
   "homepage": "https://gforge.inria.fr/projects/geogram/",
   "supports": "!uwp",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -284,7 +284,6 @@ gsoap:x86-windows        = skip
 gsoap:x64-windows-static = skip
 gsoap:x64-windows-static-md = skip
 
-geogram:arm64-windows=fail
 # Port geotrans source ftp://ftp.nga.mil server
 # extremely slow may take several hours to download
 geotrans:x64-linux           = skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2538,7 +2538,7 @@
     },
     "geogram": {
       "baseline": "1.7.6",
-      "port-version": 2
+      "port-version": 3
     },
     "geographiclib": {
       "baseline": "2.1.1",

--- a/versions/g-/geogram.json
+++ b/versions/g-/geogram.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2be512adda374e08c638f617f81f86b3dc3099a0",
+      "version": "1.7.6",
+      "port-version": 3
+    },
+    {
       "git-tree": "d68db6c8078b7598e5bed6550a911f791ae63ab3",
       "version": "1.7.6",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?
  Adds arm64-windows support by fixing the usage of popcount intrinsics.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  !uwp, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
