### PR TITLE
[skia] Fixing usage issues

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -170,6 +170,11 @@ if("vulkan" IN_LIST FEATURES)
      list(APPEND SKIA_PUBLIC_DEFINITIONS SK_VULKAN)
  endif()
 
+checkout_in_path("${EXTERNALS}/vulkanmemoryallocator"
+    "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator"
+    "7de5cc00de50e71a3aab22dea52fbb7ff4efceb6"
+)
+
 if(CMAKE_HOST_WIN32)
    if("direct3d" IN_LIST FEATURES)
        set(OPTIONS "${OPTIONS} skia_use_direct3d=true")

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -355,17 +355,24 @@ file(RENAME "${CURRENT_PACKAGES_DIR}/include/include"
     "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 file(GLOB_RECURSE SKIA_INCLUDE_FILES LIST_DIRECTORIES false
     "${CURRENT_PACKAGES_DIR}/include/${PORT}/*")
+
+message(STATUS "Installing HACK: ${CURRENT_PACKAGES_DIR}/include/${PORT}/modules")
+file(COPY "${SOURCE_PATH}/modules/skcms/skcms.h"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/modules/skcms")
+
 foreach(file_ ${SKIA_INCLUDE_FILES})
     vcpkg_replace_string("${file_}" "#include \"include/" "#include \"${PORT}/")
+    vcpkg_replace_string("${file_}" "#include \"modules/" "#include \"${PORT}/modules/")
 endforeach()
 
 # get a list of library dependencies for TARGET
 function(gn_desc_target_libs OUTPUT BUILD_DIR TARGET)
-    z_vcpkg_install_gn_get_desc("${OUTPUT}"
+    z_vcpkg_install_gn_get_desc(OUTPUT_
         SOURCE_PATH "${SOURCE_PATH}"
         BUILD_DIR "${BUILD_DIR}"
         TARGET "${TARGET}"
         WHAT_TO_DISPLAY libs)
+    set(${OUTPUT} ${OUTPUT_} PARENT_SCOPE)
 endfunction()
 
 function(gn_desc_target_defines OUTPUT BUILD_DIR TARGET)

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "skia",
   "version": "0.36.0",
+  "port-version": 1,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6746,7 +6746,7 @@
     },
     "skia": {
       "baseline": "0.36.0",
-      "port-version": 0
+      "port-version": 1
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d9735f0917ca62982e07b538cc63454390dc983",
+      "version": "0.36.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "960a3abb9c3b4736a73b06e65a47123798bf29f9",
       "version": "0.36.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes compilation when include SkColorSpace.h. It depends on modules/skcms/skcms.h which is not available in the installed includes.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all previous supported

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
