### PR TITLE
[lerc] Update to 4.0.0

### DIFF
--- a/ports/lerc/create_package.patch
+++ b/ports/lerc/create_package.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index e90fcdd..17c79e8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -26,9 +26,16 @@ add_library(LercLib ${SOURCES})
+@@ -26,12 +26,19 @@ add_library(LercLib ${SOURCES})
  endif()
  
  install(
@@ -19,3 +19,6 @@ index e90fcdd..17c79e8 100644
 +  NAMESPACE unofficial::Lerc::
 +  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/unofficial-lerc"
 +)
+ 
+ # Configure and install pkgconfig file
+ configure_file(Lerc.pc.in ${CMAKE_CURRENT_BINARY_DIR}/Lerc.pc @ONLY)

--- a/ports/lerc/portfile.cmake
+++ b/ports/lerc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Esri/lerc
-    REF  v3.0
-    SHA512 8e04d890c4d46528641b354ec3f47f2b0563e1740927ac894925a30f7de2b235cb3517ce7e477886bd3eb50ebd6c6e78f22d73d5500877e552d9e684e626293b
+    REF  v4.0.0
+    SHA512 36fe453b6e732f6bed554d1c1c5cd4668aec63593d6de11f12b659c7b9cbc059ac9aaacc6cea483b3257d522f1b07e13c299914d08b1f8aeb0bb2cde42ba47cf
     HEAD_REF master
     PATCHES
         "create_package.patch"
@@ -13,6 +13,11 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-lerc)
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/Lerc_c_api.h" "defined(LERC_STATIC)" "1")
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/lerc/vcpkg.json
+++ b/ports/lerc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lerc",
-  "version": "3.0",
+  "version": "4.0",
   "description": "An open-source image or raster format which supports rapid encoding and decoding for any pixel type",
   "homepage": "https://github.com/Esri/lerc",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3481,7 +3481,7 @@
       "port-version": 0
     },
     "lerc": {
-      "baseline": "3.0",
+      "baseline": "4.0",
       "port-version": 0
     },
     "lest": {

--- a/versions/l-/lerc.json
+++ b/versions/l-/lerc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9fce90d3d96f4afb8ffcf1b2e7484ee75aa78ed2",
+      "version": "4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3037b9fd610059bc84e89607a3e58aa13641cdd8",
       "version": "3.0",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Updates lerc from 3 to 4.
  The new release fixes static library support for windows (by no longer applying `declspec` in this config). CC @JonLiu1993 https://github.com/microsoft/vcpkg/pull/26676#issuecomment-1250624473.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes