### PR TITLE
[upb] Disable pointer alignment assertion in upb.h

### DIFF
--- a/ports/upb/0003-fix-pointer-alignment.patch
+++ b/ports/upb/0003-fix-pointer-alignment.patch
@@ -1,15 +1,16 @@
+ upb/upb.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/upb/upb.h b/upb/upb.h
-index 4916c7f6..3f1ba5ad 100644
+index 4916c7f6..8e1652a0 100644
 --- a/upb/upb.h
 +++ b/upb/upb.h
-@@ -199,8 +199,8 @@ UPB_INLINE size_t _upb_ArenaHas(upb_Arena* a) {
+@@ -199,7 +199,7 @@ UPB_INLINE size_t _upb_ArenaHas(upb_Arena* a) {
  UPB_INLINE void* _upb_Arena_FastMalloc(upb_Arena* a, size_t size) {
    _upb_ArenaHead* h = (_upb_ArenaHead*)a;
    void* ret = h->ptr;
 -  UPB_ASSERT(UPB_ALIGN_MALLOC((uintptr_t)ret) == (uintptr_t)ret);
--  UPB_ASSERT(UPB_ALIGN_MALLOC(size) == size);
 +  // UPB_ASSERT(UPB_ALIGN_MALLOC((uintptr_t)ret) == (uintptr_t)ret);
-+  // UPB_ASSERT(UPB_ALIGN_MALLOC(size) == size);
+   UPB_ASSERT(UPB_ALIGN_MALLOC(size) == size);
    UPB_UNPOISON_MEMORY_REGION(ret, size);
  
-   h->ptr += size;

--- a/ports/upb/0003-fix-pointer-alignment.patch
+++ b/ports/upb/0003-fix-pointer-alignment.patch
@@ -1,0 +1,15 @@
+diff --git a/upb/upb.h b/upb/upb.h
+index 4916c7f6..3f1ba5ad 100644
+--- a/upb/upb.h
++++ b/upb/upb.h
+@@ -199,8 +199,8 @@ UPB_INLINE size_t _upb_ArenaHas(upb_Arena* a) {
+ UPB_INLINE void* _upb_Arena_FastMalloc(upb_Arena* a, size_t size) {
+   _upb_ArenaHead* h = (_upb_ArenaHead*)a;
+   void* ret = h->ptr;
+-  UPB_ASSERT(UPB_ALIGN_MALLOC((uintptr_t)ret) == (uintptr_t)ret);
+-  UPB_ASSERT(UPB_ALIGN_MALLOC(size) == size);
++  // UPB_ASSERT(UPB_ALIGN_MALLOC((uintptr_t)ret) == (uintptr_t)ret);
++  // UPB_ASSERT(UPB_ALIGN_MALLOC(size) == size);
+   UPB_UNPOISON_MEMORY_REGION(ret, size);
+ 
+   h->ptr += size;

--- a/ports/upb/portfile.cmake
+++ b/ports/upb/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         0001-make-cmakelists-py.patch
         0002-fix-uwp.patch
+		0003-fix-pointer-alignment.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/upb/portfile.cmake
+++ b/ports/upb/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     PATCHES
         0001-make-cmakelists-py.patch
         0002-fix-uwp.patch
-		0003-fix-pointer-alignment.patch
+        0003-fix-pointer-alignment.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/upb/vcpkg.json
+++ b/ports/upb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "upb",
   "version-date": "2022-04-04",
+  "port-version": 1,
   "description": "μpb (often written 'upb') is a small protobuf implementation written in C.",
   "homepage": "https://github.com/protocolbuffers/upb/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7478,7 +7478,7 @@
     },
     "upb": {
       "baseline": "2022-04-04",
-      "port-version": 0
+      "port-version": 1
     },
     "urdfdom": {
       "baseline": "3.1.0",

--- a/versions/u-/upb.json
+++ b/versions/u-/upb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f65996cdf596b485746ced9283098052d5e04d6d",
+      "version-date": "2022-04-04",
+      "port-version": 1
+    },
+    {
       "git-tree": "de1d8718e4ea42428b87f4275352c4f3bbb6ac11",
       "version-date": "2022-04-04",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
 Already fixed in third-party/upb in the port `grpc`, a "misaligned" pointer in Windows will crash in upb.h. This is commented out.
The crash occurred arbitrarily during RCP calls.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Unknown/no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
 Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  n/a