### PR TITLE
[boost-fiber] Enable x64-osx

### DIFF
--- a/ports/boost-fiber/vcpkg.json
+++ b/ports/boost-fiber/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "boost-fiber",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Boost fiber module",
   "homepage": "https://github.com/boostorg/fiber",
   "license": "BSL-1.0",
-  "supports": "!osx & !uwp & !arm & !emscripten",
+  "supports": "!uwp & !arm & !emscripten",
   "dependencies": [
     "boost-algorithm",
     "boost-assert",

--- a/scripts/boost/generate-ports.ps1
+++ b/scripts/boost/generate-ports.ps1
@@ -45,7 +45,7 @@ $portData = @{
     };
     "boost-beast"            = @{ "supports" = "!emscripten" };
     "boost-fiber"            = @{
-        "supports" = "!osx & !uwp & !arm & !emscripten";
+        "supports" = "!uwp & !arm & !emscripten";
         "features" = @{
             "numa" = @{
                 "description" = "Enable NUMA support";

--- a/scripts/boost/generate-ports.ps1
+++ b/scripts/boost/generate-ports.ps1
@@ -24,6 +24,7 @@ else {
 # Clear this array when moving to a new boost version
 $portVersions = @{
     #e.g. "boost-asio" = 1;
+    "boost-fiber" = 1;
 }
 
 $portData = @{

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1263,6 +1263,7 @@ vcpkg-ci-arrow:x64-windows-static-md=pass
 vcpkg-ci-arrow:x64-osx=pass
 vcpkg-ci-arrow:x64-linux=pass
 vcpkg-ci-boost:x64-linux=pass
+vcpkg-ci-boost:x64-osx=pass
 vcpkg-ci-boost:x64-windows-static-md=pass
 vcpkg-ci-boost:x64-windows-static=pass
 vcpkg-ci-boost:x64-windows=pass

--- a/versions/b-/boost-fiber.json
+++ b/versions/b-/boost-fiber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f4c9240d299fe5785433544a022cf4521fe942e",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "624a28b01820a368ad83f7e3bb6442706e1dfcb6",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -706,7 +706,7 @@
     },
     "boost-fiber": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-filesystem": {
       "baseline": "1.80.0",


### PR DESCRIPTION
- #### What does your PR fix?
  Enables x64-osx support for the boost-fiber port.
  In turn, this allows requiring vcpkg-ci-boost to pass for x64-osx.

  Disclaimer: I'm unaware of actual particularities of macOS support in this port. I see that people build it outside vcpkg, and I didn't find a reason for disabling it in the port history or upstream.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Enabled x64-osx. Require vcpkg-ci-boost:x64-osx to pass.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
