### PR TITLE
[protobuf] update to v3.21.6 release

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,10 +1,10 @@
-set(version 3.21.4)
+set(version 3.21.6)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF c9869dc7803eb0a21d7e589c40ff4f9288cd34ae #v3.21.4
-    SHA512 99f90020bfc21f717341cf88b43950ede4ba4bd75357397eb2517cb4f6699ae88dcabd65e666df7321b9ba5203b18603fa1c4e97d924aa7978b1ba6b63216fbb
+    REF v3.21.6
+    SHA512 31506c777d30c7ff0d510a4cfa56d5b352e3c299dbaf8ab6c623220dbead96ff8d3cd5819d28d9f9fe742e31fa5e260c68be7074dae6412860195ab3b6aec5d0
     HEAD_REF master
     PATCHES
         fix-static-build.patch

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf",
-  "version": "3.21.4",
+  "version": "3.21.6",
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5801,7 +5801,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "3.21.4",
+      "baseline": "3.21.6",
       "port-version": 0
     },
     "protobuf-c": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d2c32252e568decb813b1109f1d86e6023af6dd",
+      "version": "3.21.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "b66573195da9e32b3396e253b520ad498617405b",
       "version": "3.21.4",
       "port-version": 0


### PR DESCRIPTION
Updates `protobuf` to the latest release (v3.21.6)

- #### What does your PR fix?

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes.
