### PR TITLE
[python3] build python3.dll for stable ABI usage

### DIFF
--- a/ports/python3/0001-static-library.patch
+++ b/ports/python3/0001-static-library.patch
@@ -72,6 +72,19 @@ index ac49f7867a..f3583345ff 100644
  #endif
  #ifdef ABIFLAGS
      SET_SYS_FROM_STRING("abiflags", ABIFLAGS);
+diff --git a/PCbuild/pcbuild.proj b/PCbuild/pcbuild.proj
+index 70c336a9d3..ba797e8afd 100644
+--- a/PCbuild/pcbuild.proj
++++ b/PCbuild/pcbuild.proj
+@@ -45,7 +45,7 @@
+       <BuildInParallel>false</BuildInParallel>
+     </Projects>
+     <!-- python3.dll -->
+-    <Projects Include="python3dll.vcxproj" />
++    <Projects Include="python3dll.vcxproj" Condition="false" />
+     <!-- py[w].exe -->
+     <Projects Include="pylauncher.vcxproj;pywlauncher.vcxproj" />
+     <!-- pyshellext.dll -->
 -- 
 2.28.0.windows.1
 

--- a/ports/python3/0005-only-build-required-projects.patch
+++ b/ports/python3/0005-only-build-required-projects.patch
@@ -26,12 +26,7 @@ diff --git a/PCbuild/pcbuild.proj b/PCbuild/pcbuild.proj
 index 4d416c589e..ede9868a8f 100644
 --- a/PCbuild/pcbuild.proj
 +++ b/PCbuild/pcbuild.proj
-@@ -45,21 +45,21 @@
-       <BuildInParallel>false</BuildInParallel>
-     </Projects>
-     <!-- python3.dll -->
--    <Projects Include="python3dll.vcxproj" />
-+    <Projects Include="python3dll.vcxproj" Condition="false" />
+@@ -49,17 +49,17 @@
      <!-- py[w].exe -->
 -    <Projects Include="pylauncher.vcxproj;pywlauncher.vcxproj" />
 +    <Projects Include="pylauncher.vcxproj;pywlauncher.vcxproj" Condition="false" />

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.10.5",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5870,7 +5870,7 @@
     },
     "python3": {
       "baseline": "3.10.5",
-      "port-version": 2
+      "port-version": 3
     },
     "qca": {
       "baseline": "2.3.4",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03352a9860cce420c7bc069e1f62f5b1a19226ef",
+      "version": "3.10.5",
+      "port-version": 3
+    },
+    {
       "git-tree": "6e7ddcd01a8341a906d5dde6b3d221c955571684",
       "version": "3.10.5",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Build and install python3.dll when building python3.

  Python3.dll is used for building extensions that use python Stable ABI (e.g. shiboken2).

  Official references is here:  https://github.com/python/cpython/blob/main/Doc/c-api/stable.rst

  >On Windows, extensions that use the Stable ABI should be linked against **python3.dll* rather than a version-specific library such as python39.dll.


This is also a workaround for #25635
