### PR TITLE
[qtmultimedia] Reintroduce alsa

### DIFF
--- a/ports/alsa/ALSAConfig.cmake
+++ b/ports/alsa/ALSAConfig.cmake
@@ -1,0 +1,1 @@
+pkg_check_modules(ALSA alsa)

--- a/ports/alsa/portfile.cmake
+++ b/ports/alsa/portfile.cmake
@@ -38,3 +38,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/tools/alsa/debug")
 
 configure_file("${SOURCE_PATH}/COPYING" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+configure_file("${SOURCE_PATH}/ALSAConfig.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/ALSAConfig.cmake" COPYONLY)

--- a/ports/qtmultimedia/portfile.cmake
+++ b/ports/qtmultimedia/portfile.cmake
@@ -38,8 +38,12 @@ else()
     list(APPEND FEATURE_OPTIONS "-DINPUT_gstreamer='no'")
 endif()
 
-# alsa is not ready
-list(APPEND FEATURE_OPTIONS "-DFEATURE_alsa=OFF")
+if(VCPKG_TARGET_IS_LINUX)
+    list(APPEND FEATURE_OPTIONS "-DFEATURE_alsa=ON")
+    list(APPEND FEATURE_OPTIONS "-DCMAKE_REQUIRE_FIND_PACKAGE_ALSA=ON")
+else()
+    list(APPEND FEATURE_OPTIONS "-DCMAKE_DISABLE_FIND_PACKAGE_ALSA=ON")
+endif()
 
 qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
                      CONFIGURE_OPTIONS ${FEATURE_OPTIONS}

--- a/ports/qtmultimedia/vcpkg.json
+++ b/ports/qtmultimedia/vcpkg.json
@@ -6,6 +6,10 @@
   "license": null,
   "dependencies": [
     {
+      "name": "alsa",
+      "platform": "linux"
+    },
+    {
       "name": "qtbase",
       "default-features": false,
       "features": [


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  In #26000 alsa support was removed from qtmultimedia, leaving it with no backend on linux, which leads to an immediate runtime error (dear qt, why do you not just fail at build time in that case? /rant off)
  It will probably fail, it seems the alsa integration with Qt is broken in Qt 6.3.2, at least I cannot see how it's supposed to work if a pure virtual method is not implemented.

```
buildtrees/qtmultimedia/src/here-src-6-2b3feb2b27.clean/src/multimedia/platform/qplatformmediaintegration_p.h:90:39: note:     ‘virtual QPlatformMediaFormatInfo* QPlatformMediaIntegration::formatInfo()’
   90 |     virtual QPlatformMediaFormatInfo *formatInfo() = 0;
      |                                       ^~~~~~~~~~
```

With Qt 6.4.0 the whole backend stuff has been reorganized, I hope that has been fixed there. Untested.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  no