### PR TITLE
[glib]: bump version to 2.74.0

### DIFF
--- a/ports/glib/libintl.patch
+++ b/ports/glib/libintl.patch
@@ -1,51 +1,47 @@
 diff --git a/meson.build b/meson.build
-index 7773f56..171d193 100644
+index f44fa2d4e..d465253af 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2089,42 +2089,10 @@ endif
+@@ -2090,37 +2090,10 @@ libz_dep = dependency('zlib')
+ # proxy-libintl subproject.
  # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
  # implementations. This could be extended if issues are found in some platforms.
- libintl_deps = []
--if cc.has_function('ngettext')
--  have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset')
--else
--  # First just find the bare library.
--  libintl = cc.find_library('intl', required : false)
--  # The bare library probably won't link without help if it's static.
--  if libintl.found() and not cc.has_function('ngettext', dependencies : libintl)
--     libintl_iconv = cc.find_library('iconv', required : false)
--     # libintl supports different threading APIs, which may not
--     # require additional flags, but it defaults to using pthreads if
--     # found. Meson's "threads" dependency does not allow you to
--     # prefer pthreads. We may not be using pthreads for glib itself
--     # either so just link the library to satisfy libintl rather than
--     # also defining the macros with the -pthread flag.
--     libintl_pthread = cc.find_library('pthread', required : false)
--     # Try linking with just libiconv.
--     if libintl_iconv.found() and cc.has_function('ngettext', dependencies : [libintl, libintl_iconv])
--       libintl_deps += [libintl_iconv]
--     # Then also try linking with pthreads.
--     elif libintl_iconv.found() and libintl_pthread.found() and cc.has_function('ngettext', dependencies : [libintl, libintl_iconv, libintl_pthread])
--       libintl_deps += [libintl_iconv, libintl_pthread]
--     else
--       libintl = disabler()
--     endif
--  endif
--  if not libintl.found()
--    libintl = subproject('proxy-libintl').get_variable('intl_dep')
--    libintl_deps = [libintl] + libintl_deps
--    have_bind_textdomain_codeset = true  # proxy-libintl supports it
+-libintl_deps = []
+-libintl = dependency('intl', required: false)
+-if libintl.found()
+-  # libintl supports different threading APIs, which may not
+-  # require additional flags, but it defaults to using pthreads if
+-  # found. Meson's "threads" dependency does not allow you to
+-  # prefer pthreads. We may not be using pthreads for glib itself
+-  # either so just link the library to satisfy libintl rather than
+-  # also defining the macros with the -pthread flag.
+-  #
+-  # Meson's builtin dependency lookup as of 0.60.0 doesn't check for
+-  # pthread, so we do this manually here.
+-  if cc.has_function('ngettext', dependencies : libintl)
+-    libintl_deps += [libintl]
 -  else
--    libintl_deps = [libintl] + libintl_deps
--    have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset', 
--                                                   dependencies : libintl_deps)
+-    libintl_pthread = cc.find_library('pthread', required : false)
+-    if libintl_pthread.found() and cc.has_function('ngettext', dependencies : [libintl, libintl_pthread])
+-      libintl_deps += [libintl, libintl_pthread]
+-    else
+-      libintl = disabler()
+-    endif
 -  endif
 -endif
 -
+-if libintl.found()
+-  have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset', dependencies: libintl_deps)
+-else
+-  libintl = subproject('proxy-libintl').get_variable('intl_dep')
+-  libintl_deps = [libintl]
+-  have_bind_textdomain_codeset = true  # proxy-libintl supports it
+-endif
 +libintl = dependency('Intl', method:'cmake', required : true)
-+libintl_deps += [libintl]
++libintl_deps = [libintl]
 +have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset',
-+                                                   dependencies : libintl_deps)												   
++                                                   dependencies : libintl_deps)
+ 
  glib_conf.set('HAVE_BIND_TEXTDOMAIN_CODESET', have_bind_textdomain_codeset)
  
- # We require gettext to always be present
+

--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -1,11 +1,15 @@
-set(GLIB_MAJOR_MINOR 2.72)
-set(GLIB_PATCH 3)
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.gnome.org/
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO GNOME/glib
-    REF "${GLIB_MAJOR_MINOR}.${GLIB_PATCH}"
-    SHA512 805100bdd240122e1a74b432d7be7458af5b3b0507d46ed9cb0ce2ed6facf6e7d927b1d869831c9ba21b4a40a6667989ff69fc4f661bd044cb08932184804e79
+set(GLIB_MAJOR_MINOR 2.74)
+set(GLIB_PATCH 0)
+
+vcpkg_download_distfile(GLIB_ARCHIVE
+    URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${GLIB_MAJOR_MINOR}.${GLIB_PATCH}.tar.xz"
+    FILENAME "glib-${GLIB_MAJOR_MINOR}.${GLIB_PATCH}.tar.xz"
+    SHA512 5cdadd2f4568c0c3d45083b4d39699abf651e42e020f7bc880cce3ff33d28943118388d17a0632777e843f48009c1f97d5634fde3cb8c69c7c7f35b278ac8225
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${GLIB_ARCHIVE}
     PATCHES
         use-libiconv-on-windows.patch
         libintl.patch
@@ -101,7 +105,7 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/glib-2.0.pc")
 endif()
 vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES})
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSES/LGPL-2.1-or-later.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 # Fix python scripts
 set(_file "${CURRENT_PACKAGES_DIR}/tools/${PORT}/gdbus-codegen")

--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_extract_source_archive(
 
 if (selinux IN_LIST FEATURES)
     if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT EXISTS "/usr/include/selinux")
-        message("Selinux was not found in its typical system location. Your build may fail. You can install Selinux with \"apt-get install selinux\".")
+        message("Selinux was not found in its typical system location. Your build may fail. You can install Selinux with \"apt-get install selinux libselinux1-dev\".")
     endif()
     list(APPEND OPTIONS -Dselinux=enabled)
 else()

--- a/ports/glib/use-libiconv-on-windows.patch
+++ b/ports/glib/use-libiconv-on-windows.patch
@@ -1,8 +1,8 @@
 diff --git a/glib/gconvert.c b/glib/gconvert.c
-index 3deac78..134ded9 100644
+index 829fe38de..e01ad8884 100644
 --- a/glib/gconvert.c
 +++ b/glib/gconvert.c
-@@ -30,7 +30,8 @@
+@@ -32,7 +32,8 @@
  #include <stdlib.h>
  
  #ifdef G_OS_WIN32
@@ -13,16 +13,16 @@ index 3deac78..134ded9 100644
  
  #ifdef G_PLATFORM_WIN32
 diff --git a/meson.build b/meson.build
-index d938ddf51..2ba256115 100644
+index d465253af..34ce69e4d 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1914,7 +1914,8 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
- # the built-in implementation
- iconv_opt = get_option('iconv')
+@@ -2038,7 +2038,8 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
  if host_system == 'windows'
+   # We have a #include "win_iconv.c" in gconvert.c on Windows, so we don't need
+   # any external library for it
 -  libiconv = []
 +  libiconv = [cc.find_library('iconv')]
 +  found_iconv = true
-   # We have a #include "win_iconv.c" in gconvert.c on Windows, so we don't need
-   # any external library for it
-   if iconv_opt != 'auto'
+ else
+   libiconv = dependency('iconv')
+ endif

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glib",
-  "version": "2.72.3",
-  "port-version": 3,
+  "version": "2.74.0",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-only",
@@ -11,7 +10,7 @@
     "gettext",
     "libffi",
     "libiconv",
-    "pcre",
+    "pcre2",
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/ports/lcm/glib.link.patch
+++ b/ports/lcm/glib.link.patch
@@ -15,7 +15,7 @@ index 2f1a8be45..db823b953 100644
  
  endforeach()
  
-+find_library(PCRE_LIBRARY pcre)
++find_library(PCRE_LIBRARY pcre2-8)
 +set_property(TARGET GLib2::glib APPEND PROPERTY
 +    INTERFACE_LINK_LIBRARIES ${PCRE_LIBRARY}
 +)

--- a/ports/lcm/vcpkg.json
+++ b/ports/lcm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lcm",
   "version": "1.4.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": [
     "Lightweight Communications and Marshalling (LCM)",
     "LCM is a set of libraries and tools for message passing and data marshalling, targeted at real-time systems where high-bandwidth and low latency are critical. It provides a publish/subscribe message passing model and automatic marshalling/unmarshalling code generation with bindings for applications in a variety of programming languages."

--- a/ports/libmount/portfile.cmake
+++ b/ports/libmount/portfile.cmake
@@ -14,6 +14,8 @@ vcpkg_extract_source_archive_ex(
     REF ${VERSION}
 )
 
+set(ENV{GTKDOCIZE} true)
+
 vcpkg_configure_make(
     AUTOCONFIG
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libmount/vcpkg.json
+++ b/ports/libmount/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmount",
   "version": "2.38",
+  "port-version": 1,
   "description": "Block device identification library from util-linux",
   "homepage": "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/about/",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3922,7 +3922,7 @@
     },
     "libmount": {
       "baseline": "2.38",
-      "port-version": 0
+      "port-version": 1
     },
     "libmpeg2": {
       "baseline": "0.5.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2633,8 +2633,8 @@
       "port-version": 0
     },
     "glib": {
-      "baseline": "2.72.3",
-      "port-version": 3
+      "baseline": "2.74.0",
+      "port-version": 0
     },
     "glibmm": {
       "baseline": "2.70.0",
@@ -3462,7 +3462,7 @@
     },
     "lcm": {
       "baseline": "1.4.0",
-      "port-version": 4
+      "port-version": 5
     },
     "lcms": {
       "baseline": "2.12",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "52b87ac2b4be057c665b94927a552e131e5a920c",
+      "git-tree": "97fc41e084d04073610421cbdf4bfae0e89fb99c",
       "version": "2.74.0",
       "port-version": 0
     },

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52b87ac2b4be057c665b94927a552e131e5a920c",
+      "version": "2.74.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c9fbf2ec21948d70e4b8d5e633e600344982069f",
       "version": "2.72.3",
       "port-version": 3

--- a/versions/l-/lcm.json
+++ b/versions/l-/lcm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06163d8d06a5f6b22e76ed353743da7370d73602",
+      "version": "1.4.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "4277e71373ff869df31475afceb6b2e6881e4650",
       "version": "1.4.0",
       "port-version": 4

--- a/versions/l-/libmount.json
+++ b/versions/l-/libmount.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a006357933a743ef48b94ce80a0565a1ce608769",
+      "version": "2.38",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf368ca79f716bd0b287bf1eeedd87c3529831cf",
       "version": "2.38",
       "port-version": 0

--- a/versions/l-/libmount.json
+++ b/versions/l-/libmount.json
@@ -1,12 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a006357933a743ef48b94ce80a0565a1ce608769",
-      "version": "2.38",
-      "port-version": 1
-    },
-    {
-      "git-tree": "2bbde50cef7183b080b71e42f3adc7e6940adf12",
+      "git-tree": "bf368ca79f716bd0b287bf1eeedd87c3529831cf",
       "version": "2.38",
       "port-version": 0
     },

--- a/versions/l-/libmount.json
+++ b/versions/l-/libmount.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "bf368ca79f716bd0b287bf1eeedd87c3529831cf",
+      "git-tree": "a006357933a743ef48b94ce80a0565a1ce608769",
+      "version": "2.38",
+      "port-version": 1
+    },
+    {
+      "git-tree": "2bbde50cef7183b080b71e42f3adc7e6940adf12",
       "version": "2.38",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

Update glib to 2.74.0. Glib now uses git submodules for gvdb, and `vcpkg_from_gitlab` does not fetch submodules, so I resorted to `vcpkg_download_distfile`.
I don't know of any other library that uses gvdb, so I think it's okay not to create an entire recipe for it.