### PR TITLE
[gstreamer] Fix building on linux

### DIFF
--- a/ports/gstreamer/gstreamer-disable-no-unused.patch
+++ b/ports/gstreamer/gstreamer-disable-no-unused.patch
@@ -2,14 +2,13 @@ diff --git a/meson.build b/meson.build
 index bed8c4e..772809e 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -435,8 +435,9 @@ if cc.has_header('execinfo.h')
+@@ -435,8 +435,8 @@ if cc.has_header('execinfo.h')
    endif
  endif
  
-+build_system = build_machine.system()
  gst_debug = get_option('gst_debug')
 -if not gst_debug
-+if not gst_debug and build_system != 'windows'
++if not gst_debug and cc.has_argument('-Wno-unused')
    add_project_arguments(['-Wno-unused'], language: 'c')
  endif
  

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -49,7 +49,7 @@ vcpkg_from_github(
     REF 1.19.2
     SHA512 70dcd4a36d3bd35f680eaa3c980842fbb57f55f17d1453c6a95640709b1b33a263689bf54caa367154267d281e5474686fedaa980de24094de91886a57b6547a
     HEAD_REF master
-    PATCHES ${PLUGIN_UGLY_PATCHES} fix-clang-cl-ugly.patch
+    PATCHES ${PLUGIN_UGLY_PATCHES} fix-clang-cl-ugly.patch remove_x264_define.patch
 )
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
@@ -290,9 +290,12 @@ vcpkg_install_meson()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/KHR"
                     "${CURRENT_PACKAGES_DIR}/include/GL"
 )
-file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/include/gst/gl/gstglconfig.h"
-            "${CURRENT_PACKAGES_DIR}/include/gstreamer-1.0/gst/gl/gstglconfig.h"
-)
+if(NOT VCPKG_TARGET_IS_LINUX)
+    file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/include/gst/gl/gstglconfig.h"
+                "${CURRENT_PACKAGES_DIR}/include/gstreamer-1.0/gst/gl/gstglconfig.h"
+    )
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
                     "${CURRENT_PACKAGES_DIR}/debug/libexec"
                     "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/include"
@@ -301,6 +304,14 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    # Move plugin pkg-config files
+    file(GLOB pc_files "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/pkgconfig/*")
+    file(COPY ${pc_files} DESTINATION "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(GLOB pc_files_dbg "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/pkgconfig/*")
+    file(COPY ${pc_files_dbg} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/pkgconfig/"
+                        "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/pkgconfig/")
+
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin"
                         "${CURRENT_PACKAGES_DIR}/bin"
     )

--- a/ports/gstreamer/remove_x264_define.patch
+++ b/ports/gstreamer/remove_x264_define.patch
@@ -1,0 +1,18 @@
+diff --git a/ext/x264/gstx264enc.h b/ext/x264/gstx264enc.h
+index 6cbfc5c3d..ba7845b20 100644
+--- a/ext/x264/gstx264enc.h
++++ b/ext/x264/gstx264enc.h
+@@ -31,13 +31,6 @@
+ #include <stdint.h>
+ #endif
+ 
+-/* The x264.h header says this isn't needed with MinGW, but sometimes the
+- * compiler is unable to correctly do the pointer indirection for us, which
+- * leads to a segfault when you try to dereference any const values provided
+- * by x264.dll. See: https://bugzilla.gnome.org/show_bug.cgi?id=779249 */
+-#if defined(_WIN32) && !defined(X264_API_IMPORTS)
+-# define X264_API_IMPORTS
+-#endif
+ #include <x264.h>
+ 
+ G_BEGIN_DECLS

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "gstreamer",
   "version": "1.19.2",
-  "port-version": 8,
+  "port-version": 9,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",
-  "supports": "!linux & !uwp",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "cairo",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2770,7 +2770,7 @@
     },
     "gstreamer": {
       "baseline": "1.19.2",
-      "port-version": 8
+      "port-version": 9
     },
     "gtest": {
       "baseline": "1.12.1",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50b3345068815cb82022b680689ddfee0395e6de",
+      "version": "1.19.2",
+      "port-version": 9
+    },
+    {
       "git-tree": "34e4471f1313a9d9ce220e461dde37a331c5bf47",
       "version": "1.19.2",
       "port-version": 8


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes building gstreamer on linux

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yeah

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  trust the bots