### PR TITLE
[ngtcp2] new port

### DIFF
--- a/ports/ngtcp2/export-unofficical-target.patch
+++ b/ports/ngtcp2/export-unofficical-target.patch
@@ -1,13 +1,16 @@
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index d98747f..e9dc1e6 100644
+index d98747f..f7e3385 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
-@@ -80,12 +80,17 @@ if(ENABLE_SHARED_LIB)
+@@ -80,12 +80,20 @@ if(ENABLE_SHARED_LIB)
      C_VISIBILITY_PRESET hidden
      POSITION_INDEPENDENT_CODE ON
    )
 -  target_include_directories(ngtcp2 PUBLIC ${ngtcp2_INCLUDE_DIRS})
-+  target_include_directories(ngtcp2 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes> $<INSTALL_INTERFACE:include>)
++  target_include_directories(ngtcp2 PUBLIC 
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes> 
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/includes> 
++    $<INSTALL_INTERFACE:include>)
  
 -  install(TARGETS ngtcp2
 +  install(TARGETS ngtcp2 EXPORT unofficial-ngtcp2-config
@@ -17,17 +20,20 @@ index d98747f..e9dc1e6 100644
 +  install(
 +    EXPORT unofficial-ngtcp2-config
 +    FILE unofficial-ngtcp2-config.cmake
-+    NAMESPACE unofficial::
++    NAMESPACE unofficial::ngtcp2::
 +    DESTINATION share/unofficial-ngtcp2)
  endif()
  
  if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
-@@ -97,12 +102,18 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
+@@ -97,12 +105,21 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
      C_VISIBILITY_PRESET hidden
    )
    target_compile_definitions(ngtcp2_static PUBLIC "-DNGTCP2_STATICLIB")
 -  target_include_directories(ngtcp2_static PUBLIC ${ngtcp2_INCLUDE_DIRS})
-+  target_include_directories(ngtcp2_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes> $<INSTALL_INTERFACE:include>)
++  target_include_directories(ngtcp2_static PUBLIC 
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes> 
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/includes>
++  $<INSTALL_INTERFACE:include>)
    if(ENABLE_STATIC_LIB)
 -    install(TARGETS ngtcp2_static
 +  
@@ -36,7 +42,7 @@ index d98747f..e9dc1e6 100644
 +    install(
 +      EXPORT unofficial-ngtcp2_static-config
 +      FILE unofficial-ngtcp2_static-config.cmake
-+      NAMESPACE unofficial::
++      NAMESPACE unofficial::ngtcp2::
 +      DESTINATION share/unofficial-ngtcp2_static)
    endif()
  endif()

--- a/ports/ngtcp2/export-unofficical-target.patch
+++ b/ports/ngtcp2/export-unofficical-target.patch
@@ -1,56 +1,43 @@
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index d98747f..f7e3385 100644
+index d98747f..7a590ef 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
-@@ -80,12 +80,20 @@ if(ENABLE_SHARED_LIB)
+@@ -80,12 +80,15 @@ if(ENABLE_SHARED_LIB)
      C_VISIBILITY_PRESET hidden
      POSITION_INDEPENDENT_CODE ON
    )
 -  target_include_directories(ngtcp2 PUBLIC ${ngtcp2_INCLUDE_DIRS})
-+  target_include_directories(ngtcp2 PUBLIC 
-+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes> 
-+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/includes> 
-+    $<INSTALL_INTERFACE:include>)
- 
+-
 -  install(TARGETS ngtcp2
++  target_include_directories(ngtcp2 PRIVATE ${ngtcp2_INCLUDE_DIRS})
 +  install(TARGETS ngtcp2 EXPORT unofficial-ngtcp2-config
      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 +  install(
 +    EXPORT unofficial-ngtcp2-config
-+    FILE unofficial-ngtcp2-config.cmake
 +    NAMESPACE unofficial::ngtcp2::
 +    DESTINATION share/unofficial-ngtcp2)
  endif()
  
  if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
-@@ -97,12 +105,21 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
+@@ -97,10 +100,14 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
      C_VISIBILITY_PRESET hidden
    )
    target_compile_definitions(ngtcp2_static PUBLIC "-DNGTCP2_STATICLIB")
 -  target_include_directories(ngtcp2_static PUBLIC ${ngtcp2_INCLUDE_DIRS})
-+  target_include_directories(ngtcp2_static PUBLIC 
-+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes> 
-+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/includes>
-+  $<INSTALL_INTERFACE:include>)
++  target_include_directories(ngtcp2_static PRIVATE ${ngtcp2_INCLUDE_DIRS})
    if(ENABLE_STATIC_LIB)
 -    install(TARGETS ngtcp2_static
-+  
 +    install(TARGETS ngtcp2_static EXPORT unofficial-ngtcp2_static-config
        DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 +    install(
 +      EXPORT unofficial-ngtcp2_static-config
-+      FILE unofficial-ngtcp2_static-config.cmake
-+      NAMESPACE unofficial::ngtcp2::
++      NAMESPACE unofficial::ngtcp2_static::
 +      DESTINATION share/unofficial-ngtcp2_static)
    endif()
  endif()
  
- install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libngtcp2.pc"
--  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-\ No newline at end of file
 diff --git a/lib/includes/CMakeLists.txt b/lib/includes/CMakeLists.txt
 index 5eabf73..78bb715 100644
 --- a/lib/includes/CMakeLists.txt

--- a/ports/ngtcp2/export-unofficical-target.patch
+++ b/ports/ngtcp2/export-unofficical-target.patch
@@ -45,13 +45,3 @@ index d98747f..e9dc1e6 100644
 -  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 +  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 \ No newline at end of file
-diff --git a/lib/includes/CMakeLists.txt b/lib/includes/CMakeLists.txt
-index 5eabf73..7a11b5f 100644
---- a/lib/includes/CMakeLists.txt
-+++ b/lib/includes/CMakeLists.txt
-@@ -1,3 +1,5 @@
-+configure_file("${CMAKE_CURRENT_LIST_DIR}/ngtcp2/version.h.in" "${CMAKE_CURRENT_LIST_DIR}/ngtcp2/version.h")
-+
- install(FILES
-     ngtcp2/ngtcp2.h
-     "${CMAKE_CURRENT_BINARY_DIR}/ngtcp2/version.h"

--- a/ports/ngtcp2/export-unofficical-target.patch
+++ b/ports/ngtcp2/export-unofficical-target.patch
@@ -1,0 +1,57 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index d98747f..e9dc1e6 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -80,12 +80,17 @@ if(ENABLE_SHARED_LIB)
+     C_VISIBILITY_PRESET hidden
+     POSITION_INDEPENDENT_CODE ON
+   )
+-  target_include_directories(ngtcp2 PUBLIC ${ngtcp2_INCLUDE_DIRS})
++  target_include_directories(ngtcp2 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes> $<INSTALL_INTERFACE:include>)
+ 
+-  install(TARGETS ngtcp2
++  install(TARGETS ngtcp2 EXPORT unofficial-ngtcp2-config
+     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
++  install(
++    EXPORT unofficial-ngtcp2-config
++    FILE unofficial-ngtcp2-config.cmake
++    NAMESPACE unofficial::
++    DESTINATION share/unofficial-ngtcp2)
+ endif()
+ 
+ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
+@@ -97,12 +102,18 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
+     C_VISIBILITY_PRESET hidden
+   )
+   target_compile_definitions(ngtcp2_static PUBLIC "-DNGTCP2_STATICLIB")
+-  target_include_directories(ngtcp2_static PUBLIC ${ngtcp2_INCLUDE_DIRS})
++  target_include_directories(ngtcp2_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes> $<INSTALL_INTERFACE:include>)
+   if(ENABLE_STATIC_LIB)
+-    install(TARGETS ngtcp2_static
++  
++    install(TARGETS ngtcp2_static EXPORT unofficial-ngtcp2_static-config
+       DESTINATION "${CMAKE_INSTALL_LIBDIR}")
++    install(
++      EXPORT unofficial-ngtcp2_static-config
++      FILE unofficial-ngtcp2_static-config.cmake
++      NAMESPACE unofficial::
++      DESTINATION share/unofficial-ngtcp2_static)
+   endif()
+ endif()
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libngtcp2.pc"
+-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+\ No newline at end of file
+diff --git a/lib/includes/CMakeLists.txt b/lib/includes/CMakeLists.txt
+index 5eabf73..7a11b5f 100644
+--- a/lib/includes/CMakeLists.txt
++++ b/lib/includes/CMakeLists.txt
+@@ -1,3 +1,5 @@
++configure_file("${CMAKE_CURRENT_LIST_DIR}/ngtcp2/version.h.in" "${CMAKE_CURRENT_LIST_DIR}/ngtcp2/version.h")
++
+ install(FILES
+     ngtcp2/ngtcp2.h
+     "${CMAKE_CURRENT_BINARY_DIR}/ngtcp2/version.h"

--- a/ports/ngtcp2/export-unofficical-target.patch
+++ b/ports/ngtcp2/export-unofficical-target.patch
@@ -45,3 +45,12 @@ index d98747f..e9dc1e6 100644
 -  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 +  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 \ No newline at end of file
+diff --git a/lib/includes/CMakeLists.txt b/lib/includes/CMakeLists.txt
+index 5eabf73..78bb715 100644
+--- a/lib/includes/CMakeLists.txt
++++ b/lib/includes/CMakeLists.txt
+@@ -1,3 +1,4 @@
++configure_file("${CMAKE_CURRENT_LIST_DIR}/ngtcp2/version.h.in" "${CMAKE_CURRENT_BINARY_DIR}/ngtcp2/version.h")
+ install(FILES
+     ngtcp2/ngtcp2.h
+     "${CMAKE_CURRENT_BINARY_DIR}/ngtcp2/version.h"

--- a/ports/ngtcp2/export-unofficical-target.patch
+++ b/ports/ngtcp2/export-unofficical-target.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index d98747f..7a590ef 100644
+index d98747f..2bc20d0 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
 @@ -80,12 +80,15 @@ if(ENABLE_SHARED_LIB)
@@ -34,7 +34,7 @@ index d98747f..7a590ef 100644
 +    install(
 +      EXPORT unofficial-ngtcp2_static-config
 +      NAMESPACE unofficial::ngtcp2_static::
-+      DESTINATION share/unofficial-ngtcp2_static)
++      DESTINATION share/unofficial-ngtcp2)
    endif()
  endif()
  

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -20,16 +20,12 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/unofficial-ngtcp2")
 
 # Clean
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    vcpkg_cmake_config_fixup(CONFIG_PATH "share/unofficial-ngtcp2")
-endif()
-
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
-    vcpkg_cmake_config_fixup(CONFIG_PATH "share/unofficial-ngtcp2_static")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/doc")

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -1,0 +1,38 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ngtcp2/ngtcp2
+    REF v0.9.0
+    SHA512 ed4a6e79bb5a07753d73f85eecee042a7c34a110a32a27d5af730dc115df7a8ae861ecef969e391d512681326e8e560fbe4f30bf3f3ceb745b980f1d33076bba
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC_LIB)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED_LIB)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DENABLE_STATIC_LIB=${ENABLE_STATIC_LIB}"
+        "-DENABLE_SHARED_LIB=${ENABLE_SHARED_LIB}"
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/man"
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+    file(APPEND "${CURRENT_PACKAGES_DIR}/include/ngtcp2/version.h" [[
+]])
+endif()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v0.9.0
     SHA512 ed4a6e79bb5a07753d73f85eecee042a7c34a110a32a27d5af730dc115df7a8ae861ecef969e391d512681326e8e560fbe4f30bf3f3ceb745b980f1d33076bba
     HEAD_REF master
+    PATCHES
+      export-unofficical-target.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC_LIB)

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -21,20 +21,20 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/share"
-    "${CURRENT_PACKAGES_DIR}/share/man"
-    "${CURRENT_PACKAGES_DIR}/share/doc"
-)
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE
-        "${CURRENT_PACKAGES_DIR}/bin"
-        "${CURRENT_PACKAGES_DIR}/debug/bin"
-    )
-    file(APPEND "${CURRENT_PACKAGES_DIR}/include/ngtcp2/version.h" [[
-]])
+# Clean
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "share/unofficial-ngtcp2")
 endif()
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "share/unofficial-ngtcp2_static")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+#License
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ngtcp2/ngtcp2
-    REF v0.9.0
-    SHA512 ed4a6e79bb5a07753d73f85eecee042a7c34a110a32a27d5af730dc115df7a8ae861ecef969e391d512681326e8e560fbe4f30bf3f3ceb745b980f1d33076bba
+    REF v0.11.0
+    SHA512 e15296c7ffd85e85c32db3bcd109fb473ca6af9b0c03b0d0559ae29c0938da59163ad45968a27cc020f56929732edbb42755c9bc83a2b1c5bdb396b69650d936
     HEAD_REF master
     PATCHES
       export-unofficical-target.patch

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -9,6 +9,10 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "ngtcp2",
+  "version": "0.9.0",
+  "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
+  "homepage": "https://github.com/ngtcp2/ngtcp2",
+  "license": "MIT",
+  "supports": "!(arm & uwp)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ngtcp2",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5064,6 +5064,10 @@
       "baseline": "37",
       "port-version": 0
     },
+    "ngtcp2": {
+      "baseline": "0.9.0",
+      "port-version": 0
+    },
     "nifly": {
       "baseline": "1.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5065,7 +5065,7 @@
       "port-version": 0
     },
     "ngtcp2": {
-      "baseline": "0.9.0",
+      "baseline": "0.11.0",
       "port-version": 0
     },
     "nifly": {

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9f872ef2fa7b6defcfc80f60720f3db3db51bce",
+      "git-tree": "1ff059d0f9042d07cacb4053392fe271d6d2ffe6",
       "version": "0.9.0",
       "port-version": 0
     }

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7187660240bce186fca7b9c32b5db7212a564855",
+      "git-tree": "3c0abb910cbb03d7ed4f0f237f278db4f34eb689",
       "version": "0.9.0",
       "port-version": 0
     }

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f49a456ae63e3959fbecf32e79a4fb1f55fc8d13",
+      "git-tree": "a284ece306ad245f677961fa98332f852032e722",
       "version": "0.9.0",
       "port-version": 0
     }

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a284ece306ad245f677961fa98332f852032e722",
+      "git-tree": "b9f872ef2fa7b6defcfc80f60720f3db3db51bce",
       "version": "0.9.0",
       "port-version": 0
     }

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1ff059d0f9042d07cacb4053392fe271d6d2ffe6",
+      "git-tree": "7187660240bce186fca7b9c32b5db7212a564855",
       "version": "0.9.0",
       "port-version": 0
     }

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f89267eac28ec14cc7face5f19f6da949fa9c4b5",
+      "git-tree": "f49a456ae63e3959fbecf32e79a4fb1f55fc8d13",
       "version": "0.9.0",
       "port-version": 0
     }

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f89267eac28ec14cc7face5f19f6da949fa9c4b5",
+      "version": "0.9.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,9 +1,4 @@
 {
   "versions": [
-    {
-      "git-tree": "3c0abb910cbb03d7ed4f0f237f278db4f34eb689",
-      "version": "0.9.0",
-      "port-version": 0
-    }
   ]
 }

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,4 +1,9 @@
 {
   "versions": [
+    {
+      "git-tree": "84ab1e937c8536276a0dbd41ef161818f3227a27",
+      "version": "0.11.0",
+      "port-version": 0
+    }
   ]
 }


### PR DESCRIPTION
**Describe the pull request**
Add new port: ngtcp2 to compile curl with http3.


- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
