### PR TITLE
[zziplib] Fix exported interface include dirs

### DIFF
--- a/ports/zziplib/export-targets.patch
+++ b/ports/zziplib/export-targets.patch
@@ -7,7 +7,7 @@ index 1883272..16d4380 100644
  add_library(libzzip ${libzzip_SRCS} )
  target_link_libraries(libzzip ZLIB::ZLIB )
 -target_include_directories (libzzip PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
-+target_include_directories (libzzip PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} PUBLIC $<INSTALL_INTERFACE:include/zzip>)
++target_include_directories (libzzip PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
  
  if(ZZIPFSEEKO)
  add_library(libzzipfseeko ${libzzipfseeko_SRCS} )

--- a/ports/zziplib/vcpkg.json
+++ b/ports/zziplib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zziplib",
   "version": "0.13.72",
-  "port-version": 1,
+  "port-version": 2,
   "description": "library providing read access on ZIP-archives",
   "homepage": "https://github.com/gdraheim/zziplib",
   "license": "LGPL-2.0-or-later OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8102,7 +8102,7 @@
     },
     "zziplib": {
       "baseline": "0.13.72",
-      "port-version": 1
+      "port-version": 2
     }
   }
 }

--- a/versions/z-/zziplib.json
+++ b/versions/z-/zziplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba836047fca40d155c24a986af7cf5283692a4d6",
+      "version": "0.13.72",
+      "port-version": 2
+    },
+    {
       "git-tree": "571af9ee98bd4bf80bf21fc10a5ec5971678b954",
       "version": "0.13.72",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
  Amends #25205.
  `include/zzip` contains a header named `stdint.h`. This headers hides the compiler's `stdint.h` when a consumer links to the exported target, resulting in errors such as (cf. x64-linux in https://dev.azure.com/vcpkg/public/_build/results?buildId=78568):
  ~~~
  error: '::int8_t' has not been declared
  ~~~
  and (cf. x64-windows in https://dev.azure.com/vcpkg/public/_build/results?buildId=78568)
  ~~~
  ...\cstdint(31): error C2039: 'int_least8_t': is not a member of '`global namespace''
  ...\cstdint(31): error C2873: 'int_least8_t': symbol cannot be used in a using-d
  ~~~
  According to an upstream test file, the canonical pattern is `#include <zzip/zzip.h>`.
  Cf. https://github.com/gdraheim/zziplib/commit/6699e0fe8a0307b16dcc055eda04452e13abe63a#r84962971

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes