### PR TITLE
[vcpkg baseline][embree3] Add supports field `!arm`

### DIFF
--- a/ports/embree3/portfile.cmake
+++ b/ports/embree3/portfile.cmake
@@ -47,10 +47,9 @@ Only set feature avx automaticlly.
     endif()
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    PREFER_NINJA
     OPTIONS ${FEATURE_OPTIONS}
         -DEMBREE_ISPC_SUPPORT=OFF
         -DEMBREE_TUTORIALS=OFF
@@ -58,9 +57,9 @@ vcpkg_configure_cmake(
         -DEMBREE_STATIC_LIB=${EMBREE_STATIC_LIB}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/embree TARGET_PATH share/embree)
+vcpkg_cmake_config_fixup(PACKAGE_NAME embree)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/embree3/vcpkg.json
+++ b/ports/embree3/vcpkg.json
@@ -1,11 +1,21 @@
 {
   "name": "embree3",
   "version-semver": "3.12.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "High Performance Ray Tracing Kernels.",
   "homepage": "https://github.com/embree/embree",
+  "license": "Apache-2.0",
+  "supports": "!arm",
   "dependencies": [
-    "tbb"
+    "tbb",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "default-features": [
     "avx",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2130,7 +2130,7 @@
     },
     "embree3": {
       "baseline": "3.12.2",
-      "port-version": 2
+      "port-version": 3
     },
     "enet": {
       "baseline": "1.3.17",

--- a/versions/e-/embree3.json
+++ b/versions/e-/embree3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "36abe72d0c102d1abb828db85701450b8bfab9e7",
+      "version-semver": "3.12.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "04c9ff8d31137bc08cd37662050a41dd5f1d8ecf",
       "version-semver": "3.12.2",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fix `embree3:arm64-windows` install failed with error: 
  `MSVC\14.33.31629\include\immintrin.h(15): fatal error C1189: #error:  This header is specific to X86 and X64 targets`
  
  One of port `embree3` dependency port `tbb` was added support arm in PR [#26284](https://github.com/microsoft/vcpkg/pull/26284) but triggered `embree3:arm64-windows`to be tested, that caused this regression.

  After checking on the upstream, the latest resources of this port on the upstream only support `Neon ARM` and this issue is not completely fixed, so I added the `"supports": "!arm"` field to this port.

  The following is the relevant information on upstream:
  https://github.com/embree/embree/issues/351
  https://github.com/embree/embree/blob/master/common/sys/intrinsics.h

  Related: https://dev.azure.com/vcpkg/public/_build/results?buildId=78539&view=results