### PR TITLE
[catch2] build static lib on WIN32

### DIFF
--- a/ports/catch2/build-static-lib.patch
+++ b/ports/catch2/build-static-lib.patch
@@ -1,0 +1,22 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 94f2dc8..9ea9d28 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -286,7 +286,7 @@ set(REPORTER_SOURCES
+ )
+ set(REPORTER_FILES ${REPORTER_HEADERS} ${REPORTER_SOURCES})
+ 
+-add_library(Catch2
++add_library(Catch2 STATIC
+   ${REPORTER_FILES}
+   ${INTERNAL_FILES}
+   ${BENCHMARK_HEADERS}
+@@ -339,7 +339,7 @@ target_include_directories(Catch2
+ )
+ 
+ 
+-add_library(Catch2WithMain
++add_library(Catch2WithMain STATIC
+     ${SOURCES_DIR}/internal/catch_main.cpp
+ )
+ add_build_reproducibility_settings(Catch2WithMain)

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -1,3 +1,8 @@
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND PATCHES build-static-lib.patch)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
@@ -7,6 +12,7 @@ vcpkg_from_github(
     PATCHES
         fix-install-path.patch
         fix-uwp-build.patch
+        ${PATCHES}
 )
 
 vcpkg_cmake_configure(

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "catch2",
   "version-semver": "3.1.0",
-  "port-version": "1",
+  "port-version": 1,
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "catch2",
   "version-semver": "3.1.0",
+  "port-version": "1",
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1306,7 +1306,7 @@
     },
     "catch2": {
       "baseline": "3.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cccapstone": {
       "baseline": "9b4128ee1153e78288a1b5433e2c06a0d47a4c4e",

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d72b649d08bbc3a7480d67c30258982f3c41b335",
+      "version-semver": "3.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "414a5ef901a6f05c85b4f19ff2d0d216933a65b1",
       "version-semver": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
Fix #26880 

[catch2] enables dynamic builds after version 3.10, but on windows it fails to provide exported symbols.

Error:
````
1>------ Build started: Project: tests, Configuration: Debug x64 ------
1>tests.cpp
1>tests.obj : error LNK2001: unresolved external symbol "public: static int Catch::StringMaker<double,void>::precision" (?precision@?$StringMaker@NX@Catch@@2HA)
1>C:\ubuntu\temp\msvc-sln\Debug\tests.exe : fatal error LNK1120: 1 unresolved externals
1>Done building project "tests.vcxproj" -- FAILED.
````