### PR TITLE
[mimalloc] build for ARM Linux, Mac

### DIFF
--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "mimalloc",
   "version": "2.0.6",
+  "port-version": 1,
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "license": "MIT",
-  "supports": "!(arm | uwp)",
+  "supports": "!((arm & windows) | uwp)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4722,7 +4722,7 @@
     },
     "mimalloc": {
       "baseline": "2.0.6",
-      "port-version": 0
+      "port-version": 1
     },
     "minc": {
       "baseline": "2.4.03",

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "057ac5484ad7a120ffa465073655fe6e10684d4a",
+      "version": "2.0.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "e5d0b88ffbb864754eb8b01ac111f84adb8a36a8",
       "version": "2.0.6",
       "port-version": 0


### PR DESCRIPTION
**Allow building mimalloc on ARM for Linux and Mac OS**

- #### What does your PR fix?
  Fixes mimalloc builds from being disabled for Linux and Mac OS on ARM. These are [tier-1 platforms](https://github.com/microsoft/mimalloc/issues/482#issuecomment-953190795) and I've verified that it works on ARM Linux.

    I'm not sure whether it actually works with Windows on ARM, but I'm not in a position to test it, so I'm leaving that disabled.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All previously supported triplets (everything besides ARM and UWP), plus all arm-* and arm64-* triplets besides arm64-windows, arm64-windows-static, arm64-windows-static-md, arm-uwp, and arm-windows.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
    Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
    Yes.

