### PR TITLE
[jxrlib] Fix mingw build

### DIFF
--- a/ports/jxrlib/CMakeLists.txt
+++ b/ports/jxrlib/CMakeLists.txt
@@ -18,9 +18,11 @@ macro(JXR_MAKE_OBJ SET_NAME)
   endforeach()
 endmacro()
 
-if(NOT MSVC)
+if(NOT WIN32)
   add_definitions(-D__ANSI__)
-  add_compile_options(-Wno-error=implicit-function-declaration)
+endif()
+if(NOT MSVC)
+  add_compile_options(-Wno-error=implicit-function-declaration -Wno-endif-labels)
 endif()
 
 include(TestBigEndian)

--- a/ports/jxrlib/fix-mingw.patch
+++ b/ports/jxrlib/fix-mingw.patch
@@ -1,0 +1,51 @@
+diff --git a/common/include/wmspecstrings_adt.h b/common/include/wmspecstrings_adt.h
+index ca7f25f..d5eb028 100644
+--- a/common/include/wmspecstrings_adt.h
++++ b/common/include/wmspecstrings_adt.h
+@@ -36,6 +36,10 @@
+         __type_has_adt_prop(compname,valid_schars) \
+         __type_has_adt_prop(compname,correct_len) \
+         __nullterminated
++#ifdef __MINGW32__
++#undef __$compname_props
++#define __$compname_props
++#endif
+ #if defined(UNICODE) || defined(_UNICODE)
+ #define  __$TCHAR unsigned short
+ #else
+diff --git a/image/sys/strcodec.h b/image/sys/strcodec.h
+index 695a454..9fad5b6 100644
+--- a/image/sys/strcodec.h
++++ b/image/sys/strcodec.h
+@@ -59,7 +59,7 @@
+ //#ifdef WIN32
+ #if defined(WIN32) && !defined(UNDER_CE)   // WIN32 seems to be defined always in VS2005 for ARM platform
+ #define PLATFORM_X86
+-#include "..\x86\x86.h"
++#include "../x86/x86.h"
+ #endif
+ 
+ #ifndef UNREFERENCED_PARAMETER
+diff --git a/jxrgluelib/JXRMeta.h b/jxrgluelib/JXRMeta.h
+index b7b5880..7c9d653 100644
+--- a/jxrgluelib/JXRMeta.h
++++ b/jxrgluelib/JXRMeta.h
+@@ -111,6 +111,18 @@
+ #define __out_win   __out
+ #endif
+ 
++#ifndef __in
++#define __in
++#endif
++#ifndef __out
++#define __out
++#endif
++#ifndef __in_ecount
++#define __in_ecount(x)
++#endif
++#ifndef __out_ecount
++#define __out_ecount(x)
++#endif
+ 
+ //================================================================
+ 

--- a/ports/jxrlib/guiddef.patch
+++ b/ports/jxrlib/guiddef.patch
@@ -1,0 +1,20 @@
+diff --git a/common/include/guiddef.h b/common/include/jxrguiddef.h
+similarity index 100%
+rename from common/include/guiddef.h
+rename to common/include/jxrguiddef.h
+diff --git a/jxrgluelib/JXRGlue.h b/jxrgluelib/JXRGlue.h
+index d0b219c..c3e5d2b 100644
+--- a/jxrgluelib/JXRGlue.h
++++ b/jxrgluelib/JXRGlue.h
+@@ -32,7 +32,11 @@ extern "C" {
+ #endif
+ 
+ #include <JXRMeta.h>
++#ifdef _WIN32
+ #include <guiddef.h>
++#else
++#include <jxrguiddef.h>
++#endif
+ 
+ //================================================================
+ #define WMP_SDK_VERSION 0x0101

--- a/ports/jxrlib/portfile.cmake
+++ b/ports/jxrlib/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
         fix-mingw.patch
 )
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 if(NOT VCPKG_CMAKE_SYSTEM_NAME MATCHES Darwin AND NOT VCPKG_CMAKE_SYSTEM_NAME MATCHES Linux AND NOT VCPKG_CMAKE_SYSTEM_NAME MATCHES iOS)
     # The file guiddef.h is part of the Windows SDK,
@@ -19,18 +19,16 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME MATCHES Darwin AND NOT VCPKG_CMAKE_SYSTEM_NAME MA
 endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-#install FindJXR.cmake file
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/FindJXR.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/jxr")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/jxr")
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/jxr")
 
-# Handle copyright
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/jxr")
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/jxrlib/portfile.cmake
+++ b/ports/jxrlib/portfile.cmake
@@ -7,16 +7,11 @@ vcpkg_from_github(
     SHA512 f5617cbe73b6b905cc6bba181e6a3efedd59584f7a8c90e0f34db580cfdad4239a2ab753df4e221f26a5c0db51475b021052e3b9e3ab3673573573b1d57f3fdb
     HEAD_REF master
     PATCHES
+        guiddef.patch
         fix-mingw.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
-
-if(NOT VCPKG_CMAKE_SYSTEM_NAME MATCHES Darwin AND NOT VCPKG_CMAKE_SYSTEM_NAME MATCHES Linux AND NOT VCPKG_CMAKE_SYSTEM_NAME MATCHES iOS)
-    # The file guiddef.h is part of the Windows SDK,
-    # we then remove the local copy shipped with jxrlib
-    file(REMOVE "${SOURCE_PATH}/common/include/guiddef.h")
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/jxrlib/portfile.cmake
+++ b/ports/jxrlib/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF f7521879862b9085318e814c6157490dd9dbbdb4
     SHA512 f5617cbe73b6b905cc6bba181e6a3efedd59584f7a8c90e0f34db580cfdad4239a2ab753df4e221f26a5c0db51475b021052e3b9e3ab3673573573b1d57f3fdb
     HEAD_REF master
+    PATCHES
+        fix-mingw.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION ${SOURCE_PATH})

--- a/ports/jxrlib/vcpkg.json
+++ b/ports/jxrlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "jxrlib",
   "version": "2019.10.9",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Open source implementation of the jpegxr image format standard.",
   "homepage": "https://github.com/4creators/jxrlib",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3206,7 +3206,7 @@
     },
     "jxrlib": {
       "baseline": "2019.10.9",
-      "port-version": 4
+      "port-version": 5
     },
     "kangaru": {
       "baseline": "4.3.1",

--- a/versions/j-/jxrlib.json
+++ b/versions/j-/jxrlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e303b910797ec21313839eac286cf6baaf31c5a",
+      "version": "2019.10.9",
+      "port-version": 5
+    },
+    {
       "git-tree": "faadd72c2d406fce9c076c025285aa692995a8b5",
       "version": "2019.10.9",
       "port-version": 4


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes #18294 (mingw), for native builds (MSYS2) and for cross builds (Ubuntu 18.04).
  Minor cleanup.
  Add proper patch for guiddef header selection by preprocessor. Fixes a source tree modification which wasn't hashed for the source dir name.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Fixes mingw, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes