### PR TITLE
[cppzmq] Fix can't be found with "ZeroMQ"

### DIFF
--- a/ports/cppzmq/vcpkg.json
+++ b/ports/cppzmq/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "cppzmq",
   "version": "4.8.1",
-  "description": "lightweight messaging kernel, C++ bindings",
+  "port-version": 1,
+  "description": "Header-only C++ binding for ZeroMQ",
   "homepage": "https://github.com/zeromq/cppzmq",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1702,7 +1702,7 @@
     },
     "cppzmq": {
       "baseline": "4.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "cpr": {
       "baseline": "1.9.2",

--- a/versions/c-/cppzmq.json
+++ b/versions/c-/cppzmq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f419d44bd1ecfd65a17218ff840cb6717efc94f3",
+      "version": "4.8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "79921528ad838f11245ebfb6b3f2fe9dc4bdca26",
       "version": "4.8.1",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Fix that the description of `cppzmq` doesn't include "ZeroMQ", so it can't be found with "ZeroMQ". No code changes included.
