### PR TITLE
[bext-ut] remove `ut-1.1.9/include` from header install path

### DIFF
--- a/ports/bext-ut/portfile.cmake
+++ b/ports/bext-ut/portfile.cmake
@@ -1,10 +1,3 @@
-# See https://github.com/boost-ext/ut/pull/521
-vcpkg_download_distfile(PR_521_PATCH_PATH
-    URLS "https://github.com/boost-ext/ut/pull/521.diff"
-    FILENAME bext-ut-pr-521.patch
-    SHA512 32eaf8beee3792927a3a7b1ce8dc5fd32b910819e65a544471bbfab2135a9e4e3b1be9b7f186cf8b93362978afc5cac8c1f4462ffe475d5cb621aa29e359ccd3
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO boost-ext/ut
@@ -13,7 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         avoid-cpm.patch
-        ${PR_521_PATCH_PATH}
+        pr-521.patch # See https://github.com/boost-ext/ut/pull/521
 )
 
 vcpkg_cmake_configure(
@@ -22,7 +15,7 @@ vcpkg_cmake_configure(
         -DBOOST_UT_BUILD_BENCHMARKS=OFF
         -DBOOST_UT_BUILD_EXAMPLES=OFF
         -DBOOST_UT_BUILD_TESTS=OFF
-        -DINCLUDE_INSTALL_DIR="include"
+        -DINCLUDE_INSTALL_DIR=include
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/bext-ut/portfile.cmake
+++ b/ports/bext-ut/portfile.cmake
@@ -1,3 +1,10 @@
+# See https://github.com/boost-ext/ut/pull/521
+vcpkg_download_distfile(PR_521_PATCH_PATH
+    URLS "https://github.com/boost-ext/ut/pull/521.diff"
+    FILENAME bext-ut-pr-521.patch
+    SHA512 32eaf8beee3792927a3a7b1ce8dc5fd32b910819e65a544471bbfab2135a9e4e3b1be9b7f186cf8b93362978afc5cac8c1f4462ffe475d5cb621aa29e359ccd3
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO boost-ext/ut
@@ -6,6 +13,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         avoid-cpm.patch
+        ${PR_521_PATCH_PATH}
 )
 
 vcpkg_cmake_configure(
@@ -14,6 +22,7 @@ vcpkg_cmake_configure(
         -DBOOST_UT_BUILD_BENCHMARKS=OFF
         -DBOOST_UT_BUILD_EXAMPLES=OFF
         -DBOOST_UT_BUILD_TESTS=OFF
+        -DINCLUDE_INSTALL_DIR="include"
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/bext-ut/pr-521.patch
+++ b/ports/bext-ut/pr-521.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea96425..a8ce453 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,7 +52,9 @@ endif()
+ 
+ add_library(ut INTERFACE)
+ 
+-set(INCLUDE_INSTALL_DIR include/${PROJECT_NAME}-${PROJECT_VERSION}/include)
++if(NOT DEFINED INCLUDE_INSTALL_DIR)
++  set(INCLUDE_INSTALL_DIR include/${PROJECT_NAME}-${PROJECT_VERSION}/include)
++endif()
+ # XXX variant: set(INCLUDE_INSTALL_DIR include)
+ target_include_directories(ut INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>)
+ if(APPLE)

--- a/ports/bext-ut/vcpkg.json
+++ b/ports/bext-ut/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "bext-ut",
   "version": "1.1.9",
+  "port-version": 1,
   "description": "UT: C++20 μ(micro)/Unit Testing Framework",
   "homepage": "https://boost-ext.github.io/ut/",
   "license": "BSL-1.0",

--- a/versions/b-/bext-ut.json
+++ b/versions/b-/bext-ut.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23650052a61a780b59e4d2e34bdd250c513c3c4b",
+      "version": "1.1.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "ea37a3905161a060e837b30d42868792d50029f8",
       "version": "1.1.9",
       "port-version": 0

--- a/versions/b-/bext-ut.json
+++ b/versions/b-/bext-ut.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "23650052a61a780b59e4d2e34bdd250c513c3c4b",
+      "git-tree": "c80b6f438634bb91f77d03f18bcafe5486f8aaab",
       "version": "1.1.9",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -466,7 +466,7 @@
     },
     "bext-ut": {
       "baseline": "1.1.9",
-      "port-version": 0
+      "port-version": 1
     },
     "bext-wintls": {
       "baseline": "0.9.5",


### PR DESCRIPTION
### What does your PR fix?

See Also https://github.com/boost-ext/ut/pull/521
Support `find_path`  like other header-only libraries

```cmake
find_path(ut_INCLUDE_DIR "boost/ut.hpp" REQUIRED)
```

### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

This is a header-only library. All triplets should be OK.

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.
