### PR TITLE
[cppwinrt] Update port for 2.0.220929.3 release

### DIFF
--- a/ports/cppwinrt/portfile.cmake
+++ b/ports/cppwinrt/portfile.cmake
@@ -1,9 +1,9 @@
-set(CPPWINRT_VERSION 2.0.220418.1)
+set(CPPWINRT_VERSION 2.0.220929.3)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Windows.CppWinRT/${CPPWINRT_VERSION}"
     FILENAME "cppwinrt.${CPPWINRT_VERSION}.zip"
-    SHA512 67738587f7b1ca98a7c2c2c0733dd09612deb5ef6bcfa788ca0bcccbbfde2c706a675316085a41e79ab2c8796a0dd3bdba87d5c996dc0b6f76b438b5d75d2567
+    SHA512 be15d8aab83ee56b4ae45782c87f5e38af6e07c2b468aea157e32b8b5289c1084e955f4d8237f8d9f1ebb4e36564be913b274210f535056fa6d773c8e0cb986b
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/cppwinrt/vcpkg.json
+++ b/ports/cppwinrt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppwinrt",
-  "version": "2.0.220418.1",
+  "version": "2.0.220929.3",
   "description": "C++/WinRT is a standard C++ language projection for the Windows Runtime.",
   "homepage": "https://github.com/microsoft/cppwinrt",
   "documentation": "https://docs.microsoft.com/windows/uwp/cpp-and-winrt-apis/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1693,7 +1693,7 @@
       "port-version": 2
     },
     "cppwinrt": {
-      "baseline": "2.0.220418.1",
+      "baseline": "2.0.220929.3",
       "port-version": 0
     },
     "cppxaml": {

--- a/versions/c-/cppwinrt.json
+++ b/versions/c-/cppwinrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba79ee15a44c311721836b535804423506cbcf5d",
+      "version": "2.0.220929.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "18d6860cc0a36639fe348d27ab4cb763dfc0e879",
       "version": "2.0.220418.1",
       "port-version": 0


### PR DESCRIPTION
Update port for changes to cppwinrt.exe compiler on NuGet since April 2022.

https://github.com/microsoft/cppwinrt/releases/tag/2.0.220929.3

https://github.com/microsoft/cppwinrt/releases/tag/2.0.220912.1

https://github.com/microsoft/cppwinrt/releases/tag/2.0.220608.4

https://github.com/microsoft/cppwinrt/releases/tag/2.0.220607.4

https://github.com/microsoft/cppwinrt/releases/tag/2.0.220531.1