### PR TITLE
[google-cloud-cpp] update to latest release (v2.3.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v2.2.0
-    SHA512 7f51f993464ff72e34a39ba0095774ba71b51203aba82953aaedf9c6eb610efe00d1e798f848575e7e526cf1e5de512bf2024adce50506bab429ac765429159c
+    REF v2.3.0
+    SHA512 094b8607aab0fc69a0999f63c4f4ed0d23a3658215192229968dfcf24ae3c9610821dc0e9b0da61edf192fcbf554e23cd4f9979c57ff6103011251012fb28596
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.2.0",
-  "port-version": 1,
+  "version": "2.3.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -392,6 +391,18 @@
         }
       ]
     },
+    "edgecontainer": {
+      "description": "Distributed Cloud Edge Container API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "eventarc": {
       "description": "Eventarc API C++ Client Library",
       "dependencies": [
@@ -602,6 +613,18 @@
     },
     "monitoring": {
       "description": "Cloud Monitoring API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "networkconnectivity": {
+      "description": "Network Connectivity API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2689,8 +2689,8 @@
       "port-version": 1
     },
     "google-cloud-cpp": {
-      "baseline": "2.2.0",
-      "port-version": 1
+      "baseline": "2.3.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "653d6d11f8a3dade7985f982ae09471dc34b9d7d",
+      "version": "2.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1787308d659051c50c95298d855cd7ad5308d8b4",
       "version": "2.2.0",
       "port-version": 1


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v2.3.0).
Add new features included in this release.

- #### What does your PR fix?
N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes.

Tested on `x64-linux` with `google-cloud-cpp[core,edgecontainer]`, `google-cloud-cpp[core,networkconnectivity]` and `google-cloud-cpp[*]`.
