### PR TITLE
[geogram] does not work on arm osx

### DIFF
--- a/ports/geogram/portfile.cmake
+++ b/ports/geogram/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
         use-arm64-intrinsics.patch
 )
 
-file(COPY ${CURRENT_PORT_DIR}/Config.cmake.in DESTINATION ${SOURCE_PATH}/cmake)
+file(COPY "${CURRENT_PORT_DIR}/Config.cmake.in" DESTINATION "${SOURCE_PATH}/cmake")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -48,10 +48,10 @@ else()
     endif()
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     # Geogram cannot be built with ninja because it embeds $(Configuration) in some of the generated paths. These require MSBuild in order to be evaluated.
-    #PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    WINDOWS_USE_MSBUILD
     OPTIONS
         -DVORPALINE_BUILD_DYNAMIC=${VORPALINE_BUILD_DYNAMIC}
         -DGEOGRAM_LIB_ONLY=ON
@@ -61,22 +61,22 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/doc)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/doc)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_replace_string(
-    ${CURRENT_PACKAGES_DIR}/share/geogram/GeogramTargets.cmake
+    "${CURRENT_PACKAGES_DIR}/share/geogram/GeogramTargets.cmake"
     [[INTERFACE_INCLUDE_DIRECTORIES "/src/lib;${_IMPORT_PREFIX}/include"]]
     [[INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"]]
     )
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/doc/devkit/license.dox DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/doc/devkit/license.dox" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_fixup_pkgconfig()

--- a/ports/geogram/vcpkg.json
+++ b/ports/geogram/vcpkg.json
@@ -1,13 +1,22 @@
 {
   "name": "geogram",
   "version": "1.7.6",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Geogram is a programming library of geometric algorithms.",
   "homepage": "https://gforge.inria.fr/projects/geogram/",
-  "supports": "!uwp",
+  "license": "BSD-3-Clause",
+  "supports": "!uwp & !(osx & arm64)",
   "dependencies": [
     "blas",
-    "lapack"
+    "lapack",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "features": {
     "graphics": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2550,7 +2550,7 @@
     },
     "geogram": {
       "baseline": "1.7.6",
-      "port-version": 3
+      "port-version": 4
     },
     "geographiclib": {
       "baseline": "2.1.1",

--- a/versions/g-/geogram.json
+++ b/versions/g-/geogram.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "902027c917fa8e2047dd0655721a753305432010",
+      "version": "1.7.6",
+      "port-version": 4
+    },
+    {
       "git-tree": "2be512adda374e08c638f617f81f86b3dc3099a0",
       "version": "1.7.6",
       "port-version": 3


### PR DESCRIPTION
You get errors like
```
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/geogram/src/5296ce80d3-9df1bba3f7.clean/src/lib/geogram/basic/process_unix.cpp:75:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
```