### PR TITLE
[pngpp] Fix strerror_r not found error on windows

### DIFF
--- a/ports/pngpp/fix-stderror-win.patch
+++ b/ports/pngpp/fix-stderror-win.patch
@@ -1,0 +1,13 @@
+diff --git a/error.hpp b/error.hpp
+index 31e1801..d4b4655 100644
+--- a/error.hpp
++++ b/error.hpp
+@@ -32,7 +32,7 @@
+ #define PNGPP_ERROR_HPP_INCLUDED
+ 
+ /* check if we have strerror_s or strerror_r, prefer the former which is C11 std */
+-#ifdef __STDC_LIB_EXT1__
++#if defined(__STDC_LIB_EXT1__) || defined(_WIN32)
+ #define __STDC_WANT_LIB_EXT1__ 1
+ #include <string.h>
+ 

--- a/ports/pngpp/portfile.cmake
+++ b/ports/pngpp/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
+    PATCHES
+        fix-stderror-win.patch
 )
 
 file(GLOB HEADER_FILES ${SOURCE_PATH}/*.hpp)

--- a/ports/pngpp/vcpkg.json
+++ b/ports/pngpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pngpp",
-  "version-string": "0.2.10",
+  "version": "0.2.10",
   "port-version": 1,
   "description": "A C++ wrapper for libpng library.",
   "dependencies": [

--- a/ports/pngpp/vcpkg.json
+++ b/ports/pngpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pngpp",
   "version-string": "0.2.10",
+  "port-version": 1,
   "description": "A C++ wrapper for libpng library.",
   "dependencies": [
     "libpng"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5730,7 +5730,7 @@
     },
     "pngpp": {
       "baseline": "0.2.10",
-      "port-version": 0
+      "port-version": 1
     },
     "pngwriter": {
       "baseline": "0.7.0",

--- a/versions/p-/pngpp.json
+++ b/versions/p-/pngpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7cd27b8baf6398928dcc6f2bd4277cd7ef567b6b",
+      "git-tree": "088d8489ba3b0778d1612d59682ea0b6b3c2eb88",
       "version": "0.2.10",
       "port-version": 1
     },

--- a/versions/p-/pngpp.json
+++ b/versions/p-/pngpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7cd27b8baf6398928dcc6f2bd4277cd7ef567b6b",
+      "version": "0.2.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "4c162ef0d91f9415a77e44bd02f9bd3abf3684e1",
       "version-string": "0.2.10",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes strerror_r not found error when including the library on windows.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `All`/`No`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `Yes`

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
