### PR TITLE
[qtwebengine] Remove duplicate dependency

### DIFF
--- a/ports/qtwebengine/vcpkg.json
+++ b/ports/qtwebengine/vcpkg.json
@@ -86,10 +86,6 @@
       "default-features": false
     },
     {
-      "name": "qtdeclarative",
-      "default-features": false
-    },
-    {
       "name": "qttools",
       "default-features": false
     },


### PR DESCRIPTION
`qtdeclarative` is listed twice for some reason.

- #### What does your PR fix?
  None.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  No

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  I do not believe it's necessary for this change.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
