### PR TITLE
[boringssl] Add pkg-config file so it still works with gRPC

### DIFF
--- a/ports/boringssl/install-pc-files.cmake
+++ b/ports/boringssl/install-pc-files.cmake
@@ -1,0 +1,39 @@
+function(install_pc_file name pc_data)
+    # fix platform-specific details
+    if(NOT VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)
+        string(REPLACE "-llibssl" "-lssl" pc_data "${pc_data}")
+        string(REPLACE "-llibcrypt" "-lcrypto" pc_data "${pc_data}")
+        string(REPLACE "-lcrypt32" "" pc_data "${pc_data}")
+        string(REPLACE "-lws2_32" "" pc_data "${pc_data}")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        configure_file("${CMAKE_CURRENT_LIST_DIR}/openssl.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${name}.pc" @ONLY)
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        configure_file("${CMAKE_CURRENT_LIST_DIR}/openssl.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${name}.pc" @ONLY)
+    endif()
+endfunction()
+
+install_pc_file(openssl [[
+Name: BoringSSL
+Description: Secure Sockets Layer and cryptography libraries and tools
+Requires: libssl libcrypto
+]])
+
+install_pc_file(libssl [[
+Name: BoringSSL-libssl
+Description: Secure Sockets Layer and cryptography libraries
+Libs: -L"${libdir}" -llibssl
+Requires: libcrypto
+Cflags: -I"${includedir}"
+]])
+
+install_pc_file(libcrypto [[
+Name: BoringSSL-libcrypto
+Description: OpenSSL cryptography library
+Libs: -L"${libdir}" -llibcrypto
+Libs.private: -lcrypt32 -lws2_32
+Cflags: -I"${includedir}"
+]])
+
+vcpkg_fixup_pkgconfig()

--- a/ports/boringssl/openssl.pc.in
+++ b/ports/boringssl/openssl.pc.in
@@ -1,0 +1,6 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+Version: @OPENSSL_VERSION@
+@pc_data@

--- a/ports/boringssl/portfile.cmake
+++ b/ports/boringssl/portfile.cmake
@@ -41,6 +41,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+include("${CMAKE_CURRENT_LIST_DIR}/install-pc-files.cmake")
+
 if(IS_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/boringssl)
   vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/boringssl")
 endif()

--- a/ports/boringssl/vcpkg.json
+++ b/ports/boringssl/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "boringssl",
   "version-date": "2021-06-23",
-  "port-version": 2,
-  "description": "BoringSSl is a fork of OpenSSL developed by Google",
+  "port-version": 3,
+  "description": "BoringSSL is a fork of OpenSSL developed by Google",
   "homepage": "https://boringssl.googlesource.com/boringssl",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/b-/boringssl.json
+++ b/versions/b-/boringssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb83700b7bf53177773421dfb803fb8478e6a72d",
+      "version-date": "2021-06-23",
+      "port-version": 3
+    },
+    {
       "git-tree": "8d28c72d322cf2245e69075deef73c5edefee0b5",
       "version-date": "2021-06-23",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1162,7 +1162,7 @@
     },
     "boringssl": {
       "baseline": "2021-06-23",
-      "port-version": 2
+      "port-version": 3
     },
     "botan": {
       "baseline": "2.19.1",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Fixes failure to be able to build gRPC against boringssl (after adjusting the grpc dependencies). This used to work before a recent gRPC update in vcpkg, this makes it work again.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Have only tested on Linux but it should work on Windows too. Did not update CI baseline

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes

