### PR TITLE
[libevent] Fix android build

### DIFF
--- a/ports/libevent/fix-android-threads.patch
+++ b/ports/libevent/fix-android-threads.patch
@@ -1,0 +1,30 @@
+From 5698ab6de0720f4da078423aa1676ad6a1c6d7ff Mon Sep 17 00:00:00 2001
+From: Ryan Pavlik <ryan.pavlik@collabora.com>
+Date: Mon, 3 Oct 2022 09:31:10 -0500
+Subject: [PATCH] cmake: Fix Android build.
+
+Android/Bionic C library needs no special flags to have threading support.
+Found when trying to build with vcpkg.
+---
+ CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 20bdc92e..4efe834e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -556,6 +556,11 @@ endif()
+ if (NOT EVENT__DISABLE_THREAD_SUPPORT)
+     if (WIN32)
+         list(APPEND SRC_CORE evthread_win32.c)
++    elseif(ANDROID)
++        # pthreads is built in to bionic
++        set(EVENT__HAVE_PTHREADS 1)
++        CHECK_TYPE_SIZE(pthread_t EVENT__SIZEOF_PTHREAD_T)
++        list(APPEND SYMBOLS_TO_CHECK pthread_mutexattr_setprotocol)
+     else()
+         find_package(Threads REQUIRED)
+         if (NOT CMAKE_USE_PTHREADS_INIT)
+-- 
+2.34.1
+

--- a/ports/libevent/portfile.cmake
+++ b/ports/libevent/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
         fix-file_path.patch
         fix-LibeventConfig_cmake_in_path.patch
         fix-usage.patch
+        fix-android-threads.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libevent/vcpkg.json
+++ b/ports/libevent/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libevent",
   "version": "2.1.12",
-  "port-version": 6,
+  "port-version": 7,
   "description": "An event notification library",
   "homepage": "https://github.com/libevent/libevent",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3662,7 +3662,7 @@
     },
     "libevent": {
       "baseline": "2.1.12",
-      "port-version": 6
+      "port-version": 7
     },
     "libevhtp": {
       "baseline": "1.2.18",

--- a/versions/l-/libevent.json
+++ b/versions/l-/libevent.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49a66da074def8806e42235e6c64af567987498f",
+      "version": "2.1.12",
+      "port-version": 7
+    },
+    {
       "git-tree": "c1fbaddea4a9b98b61cba0d785441115c161d24f",
       "version": "2.1.12",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Fixes build on Android: no special flags are needed for threading support.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Only affects Android, have not updated CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes, submitted upstream: https://github.com/libevent/libevent/pull/1353

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes
