### PR TITLE
[liblsquic] Remove spurious duplicated install line.

### DIFF
--- a/ports/liblsquic/portfile.cmake
+++ b/ports/liblsquic/portfile.cmake
@@ -69,8 +69,6 @@ vcpkg_install_copyright(FILE_LIST
   "${SOURCE_PATH}/LICENSE.chrome"
 )
 
-file(INSTALL "${CURRENT_BUILDTREES_DIR}/copyright" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
 # Remove duplicated include directory
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/liblsquic/vcpkg.json
+++ b/ports/liblsquic/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "liblsquic",
   "version": "3.1.1",
+  "port-version": 1,
   "description": "An implementation of the QUIC and HTTP/3 protocols.",
   "homepage": "https://github.com/litespeedtech/lsquic",
   "license": "MIT AND BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3874,7 +3874,7 @@
     },
     "liblsquic": {
       "baseline": "3.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "liblzma": {
       "baseline": "5.2.5",

--- a/versions/l-/liblsquic.json
+++ b/versions/l-/liblsquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a2383de53efd9458419db7bd82db49b342023da",
+      "version": "3.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "f6f4593aba81acc749f3223d0fd3987d5920b164",
       "version": "3.1.1",
       "port-version": 0


### PR DESCRIPTION
Got left behind when the new helper usage was added before merging the original PR

- #### What does your PR fix?
Fixing installing the liblsquic port, which I believe doesn't get tested by CI because it needs boringssl.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Tested on Linux, but should apply equally on all platforms.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes.  Fixed what the bot wanted fixed too.
