### PR TITLE
[protobuf] Teach about crosscompile

### DIFF
--- a/ports/protobuf/vcpkg-cmake-wrapper.cmake
+++ b/ports/protobuf/vcpkg-cmake-wrapper.cmake
@@ -11,6 +11,6 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.3)
     cmake_policy(POP)
 endif()
 
-find_program(Protobuf_PROTOC_EXECUTABLE NAMES protoc PATHS "${CMAKE_CURRENT_LIST_DIR}/../../tools/protobuf" NO_DEFAULT_PATH)
+find_program(Protobuf_PROTOC_EXECUTABLE NAMES protoc PATHS "${CMAKE_CURRENT_LIST_DIR}/../../../@HOST_TRIPLET@/tools/protobuf" NO_DEFAULT_PATH)
 
 _find_package(${ARGS})

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "protobuf",
   "version": "3.21.6",
+  "port-version": 1,
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5838,7 +5838,7 @@
     },
     "protobuf": {
       "baseline": "3.21.6",
-      "port-version": 0
+      "port-version": 1
     },
     "protobuf-c": {
       "baseline": "1.4.0",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76da95f37a73965df86c5cfc317a2dfb677e0add",
+      "version": "3.21.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "1d2c32252e568decb813b1109f1d86e6023af6dd",
       "version": "3.21.6",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Attempts to fix cross-compiling usage of protobuf (where we want the host-platform protoc)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
I've been testing with x64-android (Target) and x64-linux (host)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes
