### PR TITLE
[sdformat9] no osx arm

### DIFF
--- a/ports/sdformat9/vcpkg.json
+++ b/ports/sdformat9/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "sdformat9",
   "version": "9.8.0",
+  "port-version": 1,
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "license": "Apache-2.0",
-  "supports": "!uwp",
+  "supports": "!uwp & !(arm & osx)",
   "dependencies": [
     "ignition-math6",
     "tinyxml",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6662,7 +6662,7 @@
     },
     "sdformat9": {
       "baseline": "9.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl1": {
       "baseline": "1.2.15",

--- a/versions/s-/sdformat9.json
+++ b/versions/s-/sdformat9.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "693fd5dc7bdb0dfe766275719f0b3f85477994aa",
+      "version": "9.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "32a06104ef8500390db26865dbc6f887de83f1ee",
       "version": "9.8.0",
       "port-version": 0


### PR DESCRIPTION
```
CMake Error at cmake/TargetArch.cmake:101 (message):
  Invalid OS X arch name: arm64
```