### PR TITLE
[scripts|world rebuild] Retry 'make install' in non-parallel mode

### DIFF
--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -51,6 +51,7 @@ function(vcpkg_build_make)
         string(REPLACE " " [[\ ]] vcpkg_package_prefix "${CURRENT_PACKAGES_DIR}")
         string(REGEX REPLACE [[([a-zA-Z]):/]] [[/\1/]] vcpkg_package_prefix "${vcpkg_package_prefix}")
         vcpkg_list(SET install_opts -j ${VCPKG_CONCURRENCY} --trace -f ${arg_MAKEFILE} ${arg_INSTALL_TARGET} DESTDIR=${vcpkg_package_prefix})
+        vcpkg_list(SET no_parallel_install_opts -j 1 --trace -f ${arg_MAKEFILE} ${arg_INSTALL_TARGET} DESTDIR=${vcpkg_package_prefix})
         #TODO: optimize for install-data (release) and install-exec (release/debug)
 
     else()
@@ -63,6 +64,7 @@ function(vcpkg_build_make)
         vcpkg_list(SET make_opts ${arg_MAKE_OPTIONS} V=1 -j ${VCPKG_CONCURRENCY} -f ${arg_MAKEFILE} ${arg_BUILD_TARGET})
         vcpkg_list(SET no_parallel_make_opts ${arg_MAKE_OPTIONS} V=1 -j 1 -f ${arg_MAKEFILE} ${arg_BUILD_TARGET})
         vcpkg_list(SET install_opts -j ${VCPKG_CONCURRENCY} -f ${arg_MAKEFILE} ${arg_INSTALL_TARGET} DESTDIR=${CURRENT_PACKAGES_DIR})
+        vcpkg_list(SET no_parallel_install_opts -j 1 -f ${arg_MAKEFILE} ${arg_INSTALL_TARGET} DESTDIR=${CURRENT_PACKAGES_DIR})
     endif()
 
     # Since includes are buildtype independent those are setup by vcpkg_configure_make
@@ -160,8 +162,10 @@ function(vcpkg_build_make)
             if (arg_ENABLE_INSTALL)
                 message(STATUS "Installing ${TARGET_TRIPLET}${short_buildtype}")
                 vcpkg_list(SET make_cmd_line ${make_command} ${install_opts})
+                vcpkg_list(SET no_parallel_make_cmd_line ${make_command} ${no_parallel_install_opts})
                 vcpkg_execute_build_process(
                     COMMAND ${make_cmd_line}
+                    NO_PARALLEL_COMMAND ${no_parallel_make_cmd_line}
                     WORKING_DIRECTORY "${working_directory}"
                     LOGNAME "install-${TARGET_TRIPLET}${short_buildtype}"
                 )

--- a/scripts/cmake/vcpkg_execute_build_process.cmake
+++ b/scripts/cmake/vcpkg_execute_build_process.cmake
@@ -12,6 +12,8 @@ set(Z_VCPKG_EXECUTE_BUILD_PROCESS_RETRY_ERROR_MESSAGES
     "Cannot write file"
     # Multiple threads caused the wrong order of creating folders and creating files in folders
     "Can't open"
+    # `make install` may stumble over concurrency, in particular with `mkdir` on osx.
+    "mkdir [^:]*: File exists"
 )
 list(JOIN Z_VCPKG_EXECUTE_BUILD_PROCESS_RETRY_ERROR_MESSAGES "|" Z_VCPKG_EXECUTE_BUILD_PROCESS_RETRY_ERROR_MESSAGES)
 


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes spurious (CI) errors when parallel `make install` stumbles over directory creation order.
  Past incidents: https://github.com/microsoft/vcpkg/pull/26617#issuecomment-1267373372, https://github.com/microsoft/vcpkg/pull/25959#issuecomment-1196324733, https://github.com/microsoft/vcpkg/issues/17375#issue-861795164, https://github.com/microsoft/vcpkg/issues/17039#issue-849202887, https://github.com/microsoft/vcpkg/pull/12738#issuecomment-675282218

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes