### PR TITLE
[cmakerc] Add usage text.

### DIFF
--- a/ports/cmakerc/portfile.cmake
+++ b/ports/cmakerc/portfile.cmake
@@ -9,6 +9,5 @@ vcpkg_from_github(
 )
 
 file(INSTALL "${SOURCE_PATH}/CMakeRC.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME cmakerc-config.cmake)
-
-# Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cmakerc/usage
+++ b/ports/cmakerc/usage
@@ -1,0 +1,7 @@
+The package cmakerc provides additional cmake functions:
+
+    find_package(CMakeRC CONFIG REQUIRED)
+    cmrc_add_resource_library(foo-resources ALIAS foo::rc NAMESPACE foo  ...)
+    target_link_libraries(main PRIVATE foo::rc)
+
+See https://github.com/vector-of-bool/cmrc/blob/master/README.md

--- a/ports/cmakerc/vcpkg.json
+++ b/ports/cmakerc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cmakerc",
   "version-date": "2021-08-27",
+  "port-version": 1,
   "description": "A Resource Compiler in a Single CMake Script",
   "homepage": "https://github.com/vector-of-bool/cmrc",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1490,7 +1490,7 @@
     },
     "cmakerc": {
       "baseline": "2021-08-27",
-      "port-version": 0
+      "port-version": 1
     },
     "cmark": {
       "baseline": "0.30.1",

--- a/versions/c-/cmakerc.json
+++ b/versions/c-/cmakerc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2fd3d5a7ba3648e56e111691ea6fa938cbc4ed9",
+      "version-date": "2021-08-27",
+      "port-version": 1
+    },
+    {
       "git-tree": "740fd9bb83e79eba29ccd69546d2b3105d719d5d",
       "version-date": "2021-08-27",
       "port-version": 0


### PR DESCRIPTION
Previously we generated not very helpful usage text:

```
cmakerc provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(cmakerc CONFIG REQUIRED)
    target_link_libraries(main PRIVATE " cmrc-base cmrc::base)
```