### PR TITLE
[osi] do not force static linkage

### DIFF
--- a/ports/osi/portfile.cmake
+++ b/ports/osi/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/Osi

--- a/ports/osi/vcpkg.json
+++ b/ports/osi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osi",
   "version-string": "0.108.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Osi (Open Solver Interface) provides an abstract base class to a generic linear programming (LP) solver, along with derived classes for specific solvers. Many applications may be able to use the Osi to insulate themselves from a specific LP solver.",
   "dependencies": [
     "coinutils"


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
I reach the limit of 65535 objects in a library in debug when using some vcpkg libraries: osi, coinutils and clp.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]


- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?


- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
I am still working on this PR
