### PR TITLE
[rapidfuzz] new port

### DIFF
--- a/ports/rapidfuzz/portfile.cmake
+++ b/ports/rapidfuzz/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO maxbachmann/rapidfuzz-cpp
+    REF 87ee0dd61289fa6d7d0d2b5716f5363ee6b38fb7 # rapidfuzz-1.8.0
+    SHA512 c1d7c69a291e381453ccad4053353c75fa94288e850183f0b133f617e2b77cae80c9989753fed236e196eb445d821af5dd7e329acbe4994d5a96ab1318af9cf9
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rapidfuzz/vcpkg.json
+++ b/ports/rapidfuzz/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "rapidfuzz",
+  "version": "1.8.0",
+  "description": "Rapid fuzzy string matching library for C++17 using the Levenshtein Distance.",
+  "homepage": "https://github.com/maxbachmann/rapidfuzz-cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6364,6 +6364,10 @@
       "baseline": "8.64",
       "port-version": 0
     },
+    "rapidfuzz": {
+      "baseline": "1.8.0",
+      "port-version": 0
+    },
     "rapidjson": {
       "baseline": "2022-06-28",
       "port-version": 3

--- a/versions/r-/rapidfuzz.json
+++ b/versions/r-/rapidfuzz.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e4ccc785af13a54ced4b4333612323f98a85b68b",
+      "version": "1.8.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- #### What does your PR fix?

It adds a new port, rapidfuzz.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

It is a header-only library, so it should support all.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

yeah

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

yes

