### PR TITLE
[boost-vcpkg-helpers] update license to BSL-1.0

### DIFF
--- a/ports/boost-vcpkg-helpers/vcpkg.json
+++ b/ports/boost-vcpkg-helpers/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "boost-vcpkg-helpers",
   "version": "1.80.0",
+  "port-version": 1,
   "description": "Internal vcpkg port used to modularize Boost",
-  "license": "MIT",
+  "license": "BSL-1.0",
   "dependencies": [
     "boost-uninstall"
   ]

--- a/versions/b-/boost-vcpkg-helpers.json
+++ b/versions/b-/boost-vcpkg-helpers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8295019a06342be9804a7d25857f67035c3ef0e",
+      "version": "1.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "244bfc6425dfb6e1c0c8b556f6ab8786e394c246",
       "version": "1.80.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1138,7 +1138,7 @@
     },
     "boost-vcpkg-helpers": {
       "baseline": "1.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-vmd": {
       "baseline": "1.80.0",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #27067. 
  Update boost-vcpkg-helpers license to BSL-1.0 . 