### PR TITLE
[baseline][bitserializer, tbb] Remove from ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -519,6 +519,7 @@ libtins:x64-uwp=fail
 libtomcrypt:arm64-windows=fail
 libtomcrypt:arm-uwp=fail
 libui:arm-uwp=fail
+libui:x64-linux=fail
 libui:x64-uwp=fail
 libusb:arm-uwp=fail
 libusb:x64-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -38,7 +38,6 @@
 apr:arm64-windows=fail
 # broken when `python` is python3, https://github.com/microsoft/vcpkg/issues/18937
 bde:x64-linux=fail
-bitserializer:x64-osx=fail
 bitserializer:arm64-osx=fail
 blitz:x64-uwp=fail
 blitz:arm64-windows=fail
@@ -520,7 +519,6 @@ libtins:x64-uwp=fail
 libtomcrypt:arm64-windows=fail
 libtomcrypt:arm-uwp=fail
 libui:arm-uwp=fail
-libui:x64-linux=fail
 libui:x64-uwp=fail
 libusb:arm-uwp=fail
 libusb:x64-uwp=fail
@@ -1079,9 +1077,6 @@ symengine:arm-uwp=fail
 systemc:arm64-windows=fail
 systemc:arm-uwp=fail
 systemc:x64-uwp=fail
-tbb:arm64-windows=fail
-tbb:arm-uwp=fail
-tbb:x64-uwp=fail
 tcl:arm-uwp=fail
 tcl:arm64-windows=fail
 tcl:x64-uwp=fail


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  `bitserializer:x64-osx` and `tbb:arm64-windows` can install succeed, remove them from **ci.baseline.txt**.

  -   `tbb:arm64-windows` should be fixed in PR https://github.com/microsoft/vcpkg/pull/26284

  -    `bitserializer:x64-osx` was added to **ci.baseline.txt** by PR https://github.com/microsoft/vcpkg/pull/20053

  `tbb` has `supports: (windows & !uwp)` in vcpkg.json, so remove `tbb:arm-uwp=fail` and `tbb:x64-uwp=fail` from **ci.baseline.txt**.