### PR TITLE
[libical] update to 3.0.15

### DIFF
--- a/ports/libical/portfile.cmake
+++ b/ports/libical/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libical/libical
-    REF v3.0.11
-    SHA512 cdee86c50edc2373ab2024d7d4ae26dd4b9a728dbc13083472c4923c67f61ff3cef7d43edca762c6a11979d2040fc1576a033eaa23a19e58af8f14a7d67fc139
+    REF 408c598eea3d40c728df4e7dfd78dcdcc132c377 #v3.0.15
+    SHA512 7b25f3eab1b81621eb4704943bf9c69f5bb37a3d1489f84e95febb69073fa583877649a3d1109679962175f57f953547601e02349f034eb95b5eda8cfcec6f71
 )
 
 vcpkg_find_acquire_program(PERL)

--- a/ports/libical/vcpkg.json
+++ b/ports/libical/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "libical",
-  "version": "3.0.11",
-  "port-version": 1,
+  "version": "3.0.15",
   "description": "Reference implementation of the iCalendar data type and serialization format",
   "homepage": "https://github.com/libical/libical",
+  "license": "MPL-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3797,8 +3797,8 @@
       "port-version": 0
     },
     "libical": {
-      "baseline": "3.0.11",
-      "port-version": 1
+      "baseline": "3.0.15",
+      "port-version": 0
     },
     "libice": {
       "baseline": "1.0.10",

--- a/versions/l-/libical.json
+++ b/versions/l-/libical.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ebb6d5999a0382ec8845da8fc473fa794a4f5aee",
+      "version": "3.0.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "409bb4044895d73c1af9720e1d77f8ef46eafb73",
       "version": "3.0.11",
       "port-version": 1


### PR DESCRIPTION
Fixes #27122. 
Update version to 3.0.15. 
  
Feature `rscale` is tested successfully in the following triplet: 


- x86-windows
- x64-windows