### PR TITLE
[mp3lame] allow universal macos builds

### DIFF
--- a/ports/mp3lame/add-macos-universal-config.patch
+++ b/ports/mp3lame/add-macos-universal-config.patch
@@ -1,0 +1,12 @@
+diff --git a/config.sub b/config.sub
+index 3580aaf..bf099fc 100755
+--- a/config.sub
++++ b/config.sub
+@@ -439,6 +439,7 @@ case $basic_machine in
+        | tile*-* \
+        | tron-* \
+        | ubicom32-* \
++       | universal-* \
+        | v850-* | v850e-* | v850e1-* | v850es-* | v850e2-* | v850e2v3-* \
+        | vax-* \
+        | visium-* \

--- a/ports/mp3lame/portfile.cmake
+++ b/ports/mp3lame/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_sourceforge(
     PATCHES
         00001-msvc-upgrade-solution-up-to-vc11.patch
         remove_lame_init_old_from_symbol_list.patch # deprecated https://github.com/zlargon/lame/blob/master/include/lame.h#L169
+        add-macos-universal-config.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/mp3lame/vcpkg.json
+++ b/ports/mp3lame/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mp3lame",
   "version": "3.100",
-  "port-version": 8,
+  "port-version": 9,
   "description": "LAME is a high quality MPEG Audio Layer III (MP3) encoder licensed under the LGPL.",
   "homepage": "https://sourceforge.net/projects/lame",
   "license": "LGPL-2.0-only"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4798,7 +4798,7 @@
     },
     "mp3lame": {
       "baseline": "3.100",
-      "port-version": 8
+      "port-version": 9
     },
     "mpark-variant": {
       "baseline": "1.4.0",

--- a/versions/m-/mp3lame.json
+++ b/versions/m-/mp3lame.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e24c300cc7a378ed1355ca4edba742a11d0d7a7a",
+      "version": "3.100",
+      "port-version": 9
+    },
+    {
       "git-tree": "bd7f2793ec89d5ce9c00b4b9848a80905eb7ab67",
       "version": "3.100",
       "port-version": 8


### PR DESCRIPTION


- #### What does your PR fix?
  Fixes #26759

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All (including a custom triplet `x64-arm64-osx-release`), No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes, I believe so

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

