### PR TITLE
Prevent SDL2 from detecting libdecor and causing linker errors

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -42,6 +42,7 @@ vcpkg_cmake_configure(
         -DSDL_LIBC=ON
         -DSDL_HIDAPI_JOYSTICK=ON
         -DSDL_TEST=OFF
+        -DSDL_WAYLAND_LIBDECOR=OFF
     MAYBE_UNUSED_VARIABLES
         SDL_FORCE_STATIC_VCRT
 )


### PR DESCRIPTION
Adds a flag to the SDL2 port that prevents it from detecting a system install of [libdecor](https://gitlab.gnome.org/jadahl/libdecor). If SDL2 detects libdecor, it tries to use functions from it which then cause linker errors if libdecor is not also linked. As a workaround, I updated the portfile to disable detecting libdecor in the first place.

- #### What does your PR fix?
  Fixes #25892

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Linux, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  N/A

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
