### PR TITLE
[sdl2-mixer] Fix building on Android by not building samples

### DIFF
--- a/ports/sdl2-mixer/portfile.cmake
+++ b/ports/sdl2-mixer/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         -DSDL2MIXER_VENDORED=OFF
+        -DSDL2MIXER_SAMPLES=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/sdl2-mixer/vcpkg.json
+++ b/ports/sdl2-mixer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2-mixer",
   "version": "2.6.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Multi-channel audio mixer library for SDL.",
   "homepage": "https://github.com/libsdl-org/SDL_mixer",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6698,7 +6698,7 @@
     },
     "sdl2-mixer": {
       "baseline": "2.6.1",
-      "port-version": 1
+      "port-version": 2
     },
     "sdl2-net": {
       "baseline": "2.0.1",

--- a/versions/s-/sdl2-mixer.json
+++ b/versions/s-/sdl2-mixer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6994c429d80fd95894a448a6bb55260563cc3946",
+      "version": "2.6.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "c06711b92dfd4c048f6a56c0236697012094a6e5",
       "version": "2.6.1",
       "port-version": 1


### PR DESCRIPTION
The PR disables building the SDL2_mixer sample projects. Those probably build fine on most systems but fail when using community triplet arm64-android (and other android triplets).

- #### What does your PR fix?
  Fixes #26667

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All previously supported triplets, and now `*-android`, No (needed?)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
