### PR TITLE
[FFmpeg] Fix build on ARM64

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -70,8 +70,8 @@ if(VCPKG_TARGET_IS_WINDOWS)
         vcpkg_acquire_msys(MSYS_ROOT
             DIRECT_PACKAGES
                 # Required for "cpp.exe" preprocessor
-                "https://repo.msys2.org/msys/x86_64/gcc-9.3.0-1-x86_64.pkg.tar.xz"
-                76af0192a092278e6b26814b2d92815a2c519902a3fec056b057faec19623b1770ac928a59a39402db23cfc23b0d7601b7f88b367b27269361748c69d08654b2
+                "https://repo.msys2.org/msys/x86_64/gcc-11.3.0-2-x86_64.pkg.tar.zst"
+                1efc34aa8312eb5a8fef02c7c903d9ed98c4d50b13b8cf9679df1d545847eb9e0e9a42a810b2e085c6f938796a2a9846cb8b515e9380fdd6bec8ae4a1a131d9e
                 "https://repo.msys2.org/msys/x86_64/isl-0.22.1-1-x86_64.pkg.tar.xz"
                 f4db50d00bad0fa0abc6b9ad965b0262d936d437a9faa35308fa79a7ee500a474178120e487b2db2259caf51524320f619e18d92acf4f0b970b5cbe5cc0f63a2
                 "https://repo.msys2.org/msys/x86_64/zlib-1.2.11-1-x86_64.pkg.tar.xz"

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.1",
-  "port-version": 19,
+  "port-version": 20,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2290,7 +2290,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.1",
-      "port-version": 19
+      "port-version": 20
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a4a2ee724ee276834d3f5715bac6bf6ec179c31b",
+      "version": "4.4.1",
+      "port-version": 20
+    },
+    {
       "git-tree": "42edfcee5ee9a8884b7c1733c6b560092cad9576",
       "version": "4.4.1",
       "port-version": 19


### PR DESCRIPTION
I tried to build FFmpeg for ARM64 but I got an error. The problem happens because portfile.cmake uses gcc-9.3.0 but it has been removed from repository.
See:

https://repo.msys2.org/msys/x86_64/

![Immagine](https://user-images.githubusercontent.com/30959007/195133229-df2b8dad-e878-4841-99f0-22e0ec683db4.png)

So, it is just needed to update that file to the newer updated version and you will be able to build FFmpeg for ARM64 again.
Since only a link to a download has been updated, I think that all needed guidelines should be satisfied.
