### PR TITLE
[wil] Update to v1.0.220914.1

### DIFF
--- a/ports/wil/portfile.cmake
+++ b/ports/wil/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/wil
-    REF f9284c19c9873664978b873b8858d7dfacc6af1e
-    SHA512 df81e7f12f15f8e382f537f783c33c9833bb83c4d86d571bd47503e7400698686f51a8a50efd2224c95a5409ab8ef719186d806afbfc4ea2af8d4fd7f8dce024
+    REF 5f4caba4e7a9017816e47becdd918fcc872039ba
+    SHA512 46b0ceb0d2681c76ead9e6626557facf82622b6c22376d26225016d116f6d5b1528401635022f79c2dde97177264442be849ab7c0cbac4a43c0d46e0e3e9e6e5
     HEAD_REF master
 )
 
@@ -20,4 +20,8 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/WIL)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+# Install natvis files
+file(INSTALL "${SOURCE_PATH}/natvis/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/natvis")
+
+# Install copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/wil/vcpkg.json
+++ b/ports/wil/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "wil",
-  "version-date": "2021-12-25",
+  "version-date": "2022-09-23",
   "description": "The Windows Implementation Libraries (WIL) is a header-only C++ library created to make life easier for developers on Windows through readable type-safe C++ interfaces for common Windows coding patterns.",
   "homepage": "https://github.com/microsoft/wil",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7813,7 +7813,7 @@
       "port-version": 1
     },
     "wil": {
-      "baseline": "2022-07-23",
+      "baseline": "2022-09-23",
       "port-version": 0
     },
     "wildmidi": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7813,7 +7813,7 @@
       "port-version": 1
     },
     "wil": {
-      "baseline": "2021-12-25",
+      "baseline": "2022-07-23",
       "port-version": 0
     },
     "wildmidi": {

--- a/versions/w-/wil.json
+++ b/versions/w-/wil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1481b7907b914288a49773105eeeabaa9b4a6385",
+      "version-date": "2022-09-23",
+      "port-version": 0
+    },
+    {
       "git-tree": "c918f3ae742f41c096f5758afd5af98fe7a194b5",
       "version-date": "2021-12-25",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Updates WIL to https://github.com/microsoft/wil/releases/tag/v1.0.220914.1. Also adds natvis installation as WIL added one recently, and updates the copyright installation to use a "modern" function.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  triplets unchanged, baseline not modified

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
