### PR TITLE
[python3] Fix compilation of built-in modules on older versions of GCC

### DIFF
--- a/ports/python3/0012-gcc-ldflags-fix.patch
+++ b/ports/python3/0012-gcc-ldflags-fix.patch
@@ -1,0 +1,42 @@
+diff --git a/Lib/distutils/unixccompiler.py b/Lib/distutils/unixccompiler.py
+index d00c48981e..b14ce8454e 100644
+--- a/Lib/distutils/unixccompiler.py
++++ b/Lib/distutils/unixccompiler.py
+@@ -13,7 +13,7 @@
+   * link shared library handled by 'cc -shared'
+ """
+ 
+-import os, sys, re
++import os, sys, re, shutil
+ 
+ from distutils import sysconfig
+ from distutils.dep_util import newer
+@@ -216,7 +216,27 @@ def library_dir_option(self, dir):
+ 
+     def _is_gcc(self, compiler_name):
+         # clang uses same syntax for rpath as gcc
+-        return any(name in compiler_name for name in ("gcc", "g++", "clang"))
++        valid_compiler_names = ("gcc", "g++", "clang")
++        is_gcc = any(name in compiler_name for name in valid_compiler_names)
++        # On Linux systems, the compiler name may be, e.g., "cc -pthread".
++        # The executable "cc" is in this case a symlink to the true compiler.
++        if not is_gcc and "cc" in compiler_name:
++            # We need to make sure that this is not another compiler with "cc"
++            # at the end of its name, like "icc". For this, it is checked
++            # whether "cc" is the first word, or separated by a space or path
++            # delimiter before the "cc" substring.
++            cc_string_location = compiler_name.find("cc")
++            if cc_string_location == 0 \
++                    or compiler_name[cc_string_location - 1] == ' ' \
++                    or compiler_name[cc_string_location - 1] == '/' \
++                    or compiler_name[cc_string_location - 1] == '\\':
++                cc_path = shutil.which("cc")
++                if cc_path is not None:
++                    real_compiler_path = os.path.realpath(cc_path)
++                    is_gcc = any(
++                        name in real_compiler_path \
++                        for name in valid_compiler_names)
++        return is_gcc
+ 
+     def runtime_library_dir_option(self, dir):
+         # XXX Hackish, at the very least.  See Python bug #445902:

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -20,6 +20,10 @@ set(PATCHES
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     list(PREPEND PATCHES 0001-static-library.patch)
 endif()
+# Fix build failures with GCC for built-in modules (https://github.com/microsoft/vcpkg/issues/26573)
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(APPEND PATCHES 0012-gcc-ldflags-fix.patch)
+endif()
 
 # Python 3.9 removed support for Windows 7. This patch re-adds support for Windows 7 and is therefore
 # required to build this port on Windows 7 itself due to Python using itself in its own build system.

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.10.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5918,7 +5918,7 @@
     },
     "python3": {
       "baseline": "3.10.5",
-      "port-version": 3
+      "port-version": 4
     },
     "qca": {
       "baseline": "2.3.4",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6bf44809eee3bfbce1b176e55d41beb54cac6f2",
+      "version": "3.10.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "03352a9860cce420c7bc069e1f62f5b1a19226ef",
       "version": "3.10.5",
       "port-version": 3


### PR DESCRIPTION
This PR fixes #26573. I can confirm that the build failures reported in this issue no longer happen with the changes from this PR.

The problem underlying this issue was that on Linux, vcpkg seems to report the used compiler to Python as `cc -pthread`, however, the compiler `cc` is not recognized by distuilts as an alias of `g++`.

I also opened a PR in the upstream project (https://github.com/python/cpython/pull/98220). I hope this fix will be included in future releases of Python, but until this is the case, vcpkg can use this PR to patch the source code of current Python releases to avoid build errors with older versions of GCC.

- #### What does your PR fix?
  Fixes #26573.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
