### PR TITLE
[glog] Add feature WITH_CUSTOM_PREFIX

### DIFF
--- a/ports/glog/portfile.cmake
+++ b/ports/glog/portfile.cmake
@@ -12,7 +12,8 @@ vcpkg_from_github(
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    unwind     WITH_UNWIND
+    unwind          WITH_UNWIND
+    customprefix    WITH_CUSTOM_PREFIX
 )
 file(REMOVE "${SOURCE_PATH}/glog-modules.cmake.in")
 

--- a/ports/glog/vcpkg.json
+++ b/ports/glog/vcpkg.json
@@ -17,12 +17,12 @@
     }
   ],
   "features": {
+    "customprefix": {
+      "description": "Enable support for user-generated message prefixes"
+    },
     "unwind": {
       "description": "Enable libunwind support",
       "supports": "linux"
-    },
-    "customprefix": {
-      "description": "Enable support for user-generated message prefixes"
     }
   }
 }

--- a/ports/glog/vcpkg.json
+++ b/ports/glog/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glog",
   "version": "0.6.0",
+  "port-version": 1,
   "description": "C++ implementation of the Google logging module",
   "homepage": "https://github.com/google/glog",
   "license": "BSD-3-Clause",
@@ -19,6 +20,9 @@
     "unwind": {
       "description": "Enable libunwind support",
       "supports": "linux"
+    },
+    "customprefix": {
+      "description": "Enable support for user-generated message prefixes"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2658,7 +2658,7 @@
     },
     "glog": {
       "baseline": "0.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "gloo": {
       "baseline": "20201203",

--- a/versions/g-/glog.json
+++ b/versions/g-/glog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1fceaa6733361ea635af35ec1ce9b3caf47e0ffc",
+      "version": "0.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b1be508a55f3c9cbd8d78b40ac3739365ff301b7",
       "version": "0.6.0",
       "port-version": 0


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vcpkg/issues/24459

Add feature `customprefix `to enable support for user-generated message prefixes.

Tested feature on the following triplets:

- x64-windows
- x86-windows
- x64-windows-static