### PR TITLE
[baseline] Remove mfl from ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -595,12 +595,6 @@ mesa:x64-windows-static=fail
 # Missing dependent libraries.
 mesa:x64-linux=fail
 mesa:x64-osx=fail
-# Triggers an ICE
-mfl:x64-windows-static=fail
-mfl:x64-windows-static-md=fail
-mfl:x64-linux=skip
-mfl:x64-osx=skip
-mfl:arm64-osx=skip
 milerius-sfml-imgui:x64-windows-static=fail
 minifb:arm-uwp=fail
 minifb:x64-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -595,6 +595,9 @@ mesa:x64-windows-static=fail
 # Missing dependent libraries.
 mesa:x64-linux=fail
 mesa:x64-osx=fail
+mfl:x64-linux=skip
+mfl:x64-osx=skip
+mfl:arm64-osx=skip
 milerius-sfml-imgui:x64-windows-static=fail
 minifb:arm-uwp=fail
 minifb:x64-uwp=fail


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  The ICE of `mfl` has been fixed by PR https://github.com/microsoft/vcpkg/pull/26951, `mfl:x64-windows-static` and `mfl:x64-windows-static-md` can install succeed now, so remove the records of mfl from ci.baseline.txt
