### PR TITLE
[clipp] Add patch to fix std::result_of deprecated in C++20

### DIFF
--- a/ports/clipp/Fix-result_of-deprecated-in-C++20.patch
+++ b/ports/clipp/Fix-result_of-deprecated-in-C++20.patch
@@ -1,0 +1,47 @@
+diff --git a/include/clipp.h b/include/clipp.h
+index d7b101e..a1bec2d 100644
+--- a/include/clipp.h
++++ b/include/clipp.h
+@@ -155,16 +155,27 @@ namespace traits {
+  * @brief function (class) signature type trait
+  *
+  *****************************************************************************/
++#if defined(__cpp_lib_is_invocable)
+ template<class Fn, class Ret, class... Args>
+ constexpr auto
+ check_is_callable(int) -> decltype(
+     std::declval<Fn>()(std::declval<Args>()...),
+     std::integral_constant<bool,
+-        std::is_same<Ret,typename std::result_of<Fn(Args...)>::type>::value>{} );
++        std::is_same<Ret,typename std::invoke_result<Fn,Args...>::type>::value>{} );
+ 
+-template<class,class,class...>
++template<class Fn, class Ret>
+ constexpr auto
+-check_is_callable(long) -> std::false_type;
++check_is_callable_without_arg(int) -> decltype(
++    std::declval<Fn>()(),
++    std::integral_constant<bool,
++        std::is_same<Ret,typename std::invoke_result<Fn>::type>::value>{} );
++#else
++template<class Fn, class Ret, class... Args>
++constexpr auto
++check_is_callable(int) -> decltype(
++    std::declval<Fn>()(std::declval<Args>()...),
++    std::integral_constant<bool,
++        std::is_same<Ret,typename std::result_of<Fn(Args...)>::type>::value>{} );
+ 
+ template<class Fn, class Ret>
+ constexpr auto
+@@ -172,6 +183,11 @@ check_is_callable_without_arg(int) -> decltype(
+     std::declval<Fn>()(),
+     std::integral_constant<bool,
+         std::is_same<Ret,typename std::result_of<Fn()>::type>::value>{} );
++#endif
++
++template<class,class,class...>
++constexpr auto
++check_is_callable(long) -> std::false_type;
+ 
+ template<class,class>
+ constexpr auto

--- a/ports/clipp/portfile.cmake
+++ b/ports/clipp/portfile.cmake
@@ -4,14 +4,14 @@ vcpkg_from_github(
     REF 2c32b2f1f7cc530b1ec1f62c92f698643bb368db
     SHA512 4645fafe85a8099ea97b85e939747a12e9b3b92213b5b8207a9c277537377b77b5daebd88a4c090ea89cfff2937a9fc155da6e8b5558574d7129227c28826e1c
     HEAD_REF master
+    PATCHES Fix-result_of-deprecated-in-C++20.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/clipp RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/clipp/portfile.cmake
+++ b/ports/clipp/portfile.cmake
@@ -4,7 +4,8 @@ vcpkg_from_github(
     REF 2c32b2f1f7cc530b1ec1f62c92f698643bb368db
     SHA512 4645fafe85a8099ea97b85e939747a12e9b3b92213b5b8207a9c277537377b77b5daebd88a4c090ea89cfff2937a9fc155da6e8b5558574d7129227c28826e1c
     HEAD_REF master
-    PATCHES Fix-result_of-deprecated-in-C++20.patch
+    PATCHES
+        Fix-result_of-deprecated-in-C++20.patch # https://github.com/muellan/clipp/pull/54
 )
 
 vcpkg_cmake_configure(

--- a/ports/clipp/vcpkg.json
+++ b/ports/clipp/vcpkg.json
@@ -1,6 +1,13 @@
 {
   "name": "clipp",
   "version-string": "2019-04-30",
-  "port-version": 1,
-  "description": "command line interfaces for modern C++"
+  "port-version": 2,
+  "description": "command line interfaces for modern C++",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/ports/clipp/vcpkg.json
+++ b/ports/clipp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clipp",
-  "version-string": "2019-04-30",
+  "version-date": "2019-04-30",
   "port-version": 2,
   "description": "command line interfaces for modern C++",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1470,7 +1470,7 @@
     },
     "clipp": {
       "baseline": "2019-04-30",
-      "port-version": 1
+      "port-version": 2
     },
     "clockutils": {
       "baseline": "1.1.1",

--- a/versions/c-/clipp.json
+++ b/versions/c-/clipp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f37fe90a8fedaefc8e040cc131c53a8c06139798",
+      "version-string": "2019-04-30",
+      "port-version": 2
+    },
+    {
       "git-tree": "d8bced062fa89719dbb806838b968639f1ffcaf6",
       "version-string": "2019-04-30",
       "port-version": 1

--- a/versions/c-/clipp.json
+++ b/versions/c-/clipp.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "f37fe90a8fedaefc8e040cc131c53a8c06139798",
-      "version-string": "2019-04-30",
+      "git-tree": "a5ceebd07fa9e44d3ef6b78ee511760bead09958",
+      "version-date": "2019-04-30",
       "port-version": 2
     },
     {

--- a/versions/c-/clipp.json
+++ b/versions/c-/clipp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a5ceebd07fa9e44d3ef6b78ee511760bead09958",
+      "git-tree": "465f1894b073fb06718c9a8110775399c279da17",
       "version-date": "2019-04-30",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/27167

  The https://github.com/muellan/clipp/pull/54 was submitted to the upstream as early as 2020/9/30, but it seems that Upstream has no one to maintain it now, this PR hasn't been merged until now. So I added the following patch to vcpkg to fix this issue.

  No feature need to test.