### PR TITLE
[libpqxx] Don't use default features for libpq

### DIFF
--- a/ports/libpqxx/vcpkg.json
+++ b/ports/libpqxx/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "libpqxx",
   "version": "7.7.3",
+  "port-version": 1,
   "description": "The official C++ client API for PostgreSQL",
   "homepage": "https://www.postgresql.org/",
   "license": "BSD-3-Clause",
   "dependencies": [
-    "libpq",
+    {
+      "name": "libpq",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4082,7 +4082,7 @@
     },
     "libpqxx": {
       "baseline": "7.7.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libprotobuf-mutator": {
       "baseline": "1.0",

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80df17c2607ce1c8e29014ae165b64c495be1f5c",
+      "version": "7.7.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "da2e393b9844105fa00c800afb44bc93541dcb00",
       "version": "7.7.3",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  libpqxx enables all default features of libpq, but it doesn't need them. It's should be up to the user what features are required.