### PR TITLE
[mp3lame] Use list append for setting options

### DIFF
--- a/ports/mp3lame/portfile.cmake
+++ b/ports/mp3lame/portfile.cmake
@@ -98,7 +98,7 @@ else()
     endif()
 
     if(NOT VCPKG_TARGET_IS_MINGW)
-        string(APPEND OPTIONS --with-pic=yes)
+        list(APPEND OPTIONS --with-pic=yes)
     endif()
 
     vcpkg_configure_make(

--- a/ports/mp3lame/vcpkg.json
+++ b/ports/mp3lame/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mp3lame",
   "version": "3.100",
-  "port-version": 9,
+  "port-version": 10,
   "description": "LAME is a high quality MPEG Audio Layer III (MP3) encoder licensed under the LGPL.",
   "homepage": "https://sourceforge.net/projects/lame",
   "license": "LGPL-2.0-only"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4886,7 +4886,7 @@
     },
     "mp3lame": {
       "baseline": "3.100",
-      "port-version": 9
+      "port-version": 10
     },
     "mpark-variant": {
       "baseline": "1.4.0",

--- a/versions/m-/mp3lame.json
+++ b/versions/m-/mp3lame.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86d297de90265851ff47145e3aeb48738139a4d9",
+      "version": "3.100",
+      "port-version": 10
+    },
+    {
       "git-tree": "e24c300cc7a378ed1355ca4edba742a11d0d7a7a",
       "version": "3.100",
       "port-version": 9


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Uses `list(APPEND ...)` instead of `string(APPEND ...)` for appending options, since the former is less fragile and not prone to e.g. concatenating flags without a space inbetween.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes