### PR TITLE
[zziplib] fix build for Android triplets running on Windows host

### DIFF
--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -11,6 +11,11 @@ vcpkg_from_github(
 string(COMPARE EQUAL VCPKG_CRT_LINKAGE "static" MSVC_STATIC_RUNTIME)
 string(COMPARE EQUAL VCPKG_LIBRARY_LINKAGE "static" BUILD_STATIC_LIBS)
 
+# on Windows hosts, the UnixCommands are not available; disable options that use them
+if(VCPKG_HOST_IS_WINDOWS)
+    set(ZZIPLIB_OPTIONS "-DZZIP_COMPAT=OFF;-DZZIP_PKGCONFIG=OFF")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -24,6 +29,7 @@ vcpkg_cmake_configure(
         -DZZIPBINS=OFF
         -DZZIPTEST=OFF
         -DZZIPDOCS=OFF
+        ${ZZIPLIB_OPTIONS}
 )
 vcpkg_cmake_install()
 

--- a/ports/zziplib/vcpkg.json
+++ b/ports/zziplib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zziplib",
   "version": "0.13.72",
-  "port-version": 2,
+  "port-version": 3,
   "description": "library providing read access on ZIP-archives",
   "homepage": "https://github.com/gdraheim/zziplib",
   "license": "LGPL-2.0-or-later OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8166,7 +8166,7 @@
     },
     "zziplib": {
       "baseline": "0.13.72",
-      "port-version": 2
+      "port-version": 3
     }
   }
 }

--- a/versions/z-/zziplib.json
+++ b/versions/z-/zziplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4408845ee5c914b49838db10b1e7dec234ee5981",
+      "version": "0.13.72",
+      "port-version": 3
+    },
+    {
       "git-tree": "ba836047fca40d155c24a986af7cf5283692a4d6",
       "version": "0.13.72",
       "port-version": 2


### PR DESCRIPTION
This PR is fixing building zziplib for the Android triplets (or actually any target systems that CMake considers as UNIX). zziplib has two switches, `ZZIP_COMPAT` and `ZZIP_PKGCONFIG` that lead to `find_package(UnixCommands)`, which is unavailable when building on a Windows host. The PR switches off these options in the `portfile.cmake` file.

- #### What does your PR fix?
  Fixes #25187

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All triplets are supported, and now the Android triplets when building on Windows; ci.baseline.txt was not updated.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes