### PR TITLE
[ffmpeg ] Fix build errors

### DIFF
--- a/ports/ffmpeg/0022-fix-cl-path-format.patch
+++ b/ports/ffmpeg/0022-fix-cl-path-format.patch
@@ -1,0 +1,40 @@
+diff --git a/configure b/configure
+index 1f9f35e..5c70fe6 100644
+--- a/configure
++++ b/configure
+@@ -1025,7 +1025,10 @@ test_cc(){
+     log test_cc "$@"
+     cat > $TMPC
+     log_file $TMPC
+-    test_cmd $cc $CPPFLAGS $CFLAGS "$@" $CC_C $(cc_o $TMPO) $TMPC
++    tmpc_=$TMPC
++    tmpo_=$TMPO
++    [ -x "$(command -v cygpath)" ] && tmpc_=$(cygpath -w $tmpc_) && tmpo_=$(cygpath -w $tmpo_)
++    test_cmd $cc $CPPFLAGS $CFLAGS "$@" $CC_C $(cc_o $tmpo_) $tmpc_
+ }
+ 
+ test_cxx(){
+@@ -1070,7 +1073,10 @@ test_cpp(){
+     log test_cpp "$@"
+     cat > $TMPC
+     log_file $TMPC
+-    test_cmd $cc $CPPFLAGS $CFLAGS "$@" $(cc_e $TMPO) $TMPC
++    tmpc_=$TMPC
++    tmpo_=$TMPO
++    [ -x "$(command -v cygpath)" ] && tmpc_=$(cygpath -w $tmpc_) && tmpo_=$(cygpath -w $tmpo_)
++    test_cmd $cc $CPPFLAGS $CFLAGS "$@" $(cc_e $tmpo_) $tmpc_
+ }
+ 
+ test_as(){
+@@ -1160,7 +1166,10 @@ test_ld(){
+     test_$type $($cflags_filter $flags) || return
+     flags=$($ldflags_filter $flags)
+     libs=$($ldflags_filter $libs)
+-    test_cmd $ld $LDFLAGS $LDEXEFLAGS $flags $(ld_o $TMPE) $TMPO $libs $extralibs
++    tmpe_=$TMPE
++    tmpo_=$TMPO
++    [ -x "$(command -v cygpath)" ] && tmpe_=$(cygpath -w $tmpe_) && tmpo_=$(cygpath -w $tmpo_)
++    test_cmd $ld $LDFLAGS $LDEXEFLAGS $flags $(ld_o $tmpe_) $tmpo_ $libs $extralibs
+ }
+ 
+ check_ld(){

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -26,12 +26,12 @@ vcpkg_from_github(
         0019-libx264-Do-not-explicitly-set-X264_API_IMPORTS.patch
         0020-fix-aarch64-libswscale.patch
         0021-fix-sdl2-version-check.patch
+        0022-fix-cl-path-format.patch
 )
 
 if (SOURCE_PATH MATCHES " ")
     message(FATAL_ERROR "Error: ffmpeg will not build with spaces in the path. Please use a directory with no spaces")
 endif()
-
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     # ffmpeg nasm build gives link error on x86, so fall back to yasm
@@ -45,6 +45,10 @@ else()
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    set(FFMPEG_MSVC TRUE)
+endif()
+
+if(FFMPEG_MSVC)
     #We're assuming that if we're building for Windows we're using MSVC
     set(INCLUDE_VAR "INCLUDE")
     set(LIB_PATH_VAR "LIB")
@@ -92,7 +96,7 @@ endif()
 vcpkg_cmake_get_vars(cmake_vars_file)
 include("${cmake_vars_file}")
 
-if(VCPKG_DETECTED_MSVC)
+if(FFMPEG_MSVC)
     set(OPTIONS "--toolchain=msvc ${OPTIONS}")
     # This is required because ffmpeg depends upon optimizations to link correctly
     string(APPEND VCPKG_COMBINED_C_FLAGS_DEBUG " -O2")
@@ -526,7 +530,7 @@ if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
     set(ENV{CFLAGS} "@${crsp}")
     # All tools except the msvc arm{,64} assembler accept @... as response file syntax.
     # For that assembler, there is no known way to pass in flags. We must hope that not passing flags will work acceptably.
-    if(NOT VCPKG_DETECTED_MSVC OR NOT VCPKG_TARGET_ARCHITECTURE MATCHES "^arm")
+    if(NOT FFMPEG_MSVC OR NOT VCPKG_TARGET_ARCHITECTURE MATCHES "^arm")
         set(ENV{ASFLAGS} "@${crsp}")
     endif()
     set(ENV{LDFLAGS} "@${ldrsp}")
@@ -557,7 +561,7 @@ if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     set(ldrsp "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/ldflags.rsp")
     file(WRITE "${ldrsp}" "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_DEBUG}")
     set(ENV{CFLAGS} "@${crsp}")
-    if(NOT VCPKG_DETECTED_MSVC OR NOT VCPKG_TARGET_ARCHITECTURE MATCHES "^arm")
+    if(NOT FFMPEG_MSVC OR NOT VCPKG_TARGET_ARCHITECTURE MATCHES "^arm")
         set(ENV{ASFLAGS} "@${crsp}")
     endif()
     set(ENV{LDFLAGS} "@${ldrsp}")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.1",
-  "port-version": 22,
+  "port-version": 23,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2298,7 +2298,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.1",
-      "port-version": 22
+      "port-version": 23
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a8fea3809f306eb9d356b9e79e710f74886f0420",
+      "version": "4.4.1",
+      "port-version": 23
+    },
+    {
       "git-tree": "1a56131c12116cc5ee8b86c329ee6e815ec2c17e",
       "version": "4.4.1",
       "port-version": 22


### PR DESCRIPTION
Fix a couple of errors when buliding ffmpeg:

1. Add conversion of Unix-style paths of test program files (test.o and test.o) to Windows-style paths inside in the `configure` script, so that `cl.exe` can recognize these paths as valid. Chang functions `test_cc`, `test_cpp`, `test_ld` to use `cygpath` similar to how it was previously done by someone else for `test_nvcc`.
2. Remove the use of undeclared variable `VCPKG_DETECTED_MSVC` to properly pass `--toolchain=msvc` option to `configure`.

- #### What does your PR fix?
  Fixes #27046

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  windows, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
