### PR TITLE
[quill] Update to 2.2.0

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
-    REF v2.1.0
-    SHA512 377e765d455cff729e8b5df6a1fcb28335c20259d8ff1b4ef3327f8640a7c69467147e39a9eab1c92097e04db3f732b9906e55167d5c9fd334e054b5eb5d320c
+    REF v2.2.0
+    SHA512 cf9ef0f45f6afad38aebcfb7884dc52207d09416cc42c01710b6bbb9ade9ff1cb0d58d7dd8b09a9e08457fbeeddcccb73a75316c1c80dc4241652b2b7786ebb6
     HEAD_REF master
 )
 

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "C++14 Asynchronous Low Latency Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6349,7 +6349,7 @@
       "port-version": 8
     },
     "quill": {
-      "baseline": "2.1.0",
+      "baseline": "2.2.0",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a49ab25dd1b0c7287b11f8ca4c0ba4a0117658cc",
+      "version": "2.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cf93531e147436f75761409a5148fbd6cc1969f8",
       "version": "2.1.0",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
Update quill from 2.1.0 to 2.2.0 : https://github.com/odygrd/quill/releases/tag/v2.2.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Unchanged, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes