### PR TITLE
[scripts|nmake] Add `jom` option, add language control

### DIFF
--- a/docs/maintainers/vcpkg_build_nmake.md
+++ b/docs/maintainers/vcpkg_build_nmake.md
@@ -8,18 +8,20 @@ Build a msvc makefile project.
 ```cmake
 vcpkg_build_nmake(
     SOURCE_PATH <${SOURCE_PATH}>
-    [NO_DEBUG]
-    [ENABLE_INSTALL]
-    [TARGET <all>]
     [PROJECT_SUBPATH <${SUBPATH}>]
     [PROJECT_NAME <${MAKEFILE_NAME}>]
+    [LOGFILE_ROOT <prefix>]
+    [CL_LANGUAGE <language-name>]
+    [PREFER_JOM]
     [PRERUN_SHELL <${SHELL_PATH}>]
     [PRERUN_SHELL_DEBUG <${SHELL_PATH}>]
     [PRERUN_SHELL_RELEASE <${SHELL_PATH}>]
     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
     [OPTIONS_RELEASE <-DOPTIMIZE=1>...]
     [OPTIONS_DEBUG <-DDEBUGGABLE=1>...]
-    [TARGET <target>])
+    [TARGET <all>...]
+    [ENABLE_INSTALL]
+)
 ```
 
 ## Parameters
@@ -28,45 +30,60 @@ Specifies the directory containing the source files.
 By convention, this is usually set in the portfile as the variable `SOURCE_PATH`.
 
 ### PROJECT_SUBPATH
-Specifies the sub directory containing the `makefile.vc`/`makefile.mak`/`makefile.msvc` or other msvc makefile.
+Specifies the sub directory containing the makefile.
 
 ### PROJECT_NAME
-Specifies the name of msvc makefile name.
+Specifies the name of the makefile.
 Default is `makefile.vc`
 
-### ENABLE_INSTALL
-Install binaries after build.
+### LOGFILE_ROOT
+Specifies a log file prefix.
+
+### CL_LANGUAGE
+Specifies the language for setting up flags in the `_CL_` environment variable.
+The default language is `CXX`.
+To disable the modification of `_CL_`, use `NONE`.
+
+### PREFER_JOM
+Specifies that a parallel build with `jom` should be attempted.
+This is useful for faster builds of makefiles which process many independent targets
+and which cannot benefit from the `/MP` cl option.
+To mitigate issues with concurrency-unaware makefiles, a normal `nmake` build is run after `jom` errors.
 
 ### PRERUN_SHELL
-Script that needs to be called before build
+Script that needs to be called before build.
 
 ### PRERUN_SHELL_DEBUG
-Script that needs to be called before debug build
+Script that needs to be called before debug build.
 
 ### PRERUN_SHELL_RELEASE
-Script that needs to be called before release build
+Script that needs to be called before release build.
 
 ### OPTIONS
-Additional options passed to generate during the generation.
+Additional options passed to the build command.
 
 ### OPTIONS_RELEASE
-Additional options passed to generate during the Release generation. These are in addition to `OPTIONS`.
+Additional options passed to the build command for the release build. These are in addition to `OPTIONS`.
 
 ### OPTIONS_DEBUG
-Additional options passed to generate during the Debug generation. These are in addition to `OPTIONS`.
+Additional options passed to the build command for the debug build. These are in addition to `OPTIONS`.
 
 ### TARGET
-The target passed to the nmake build command (`nmake/nmake install`). If not specified, no target will
-be passed.
+The list of targets passed to the build command.
+If not specified, target `all` will be passed.
+
+### ENABLE_INSTALL
+Adds `install` to the list of targets passed to the build command,
+and passes the install prefix in the `INSTALLDIR` makefile variable.
 
 ## Notes:
 You can use the alias [`vcpkg_install_nmake()`](vcpkg_install_nmake.md) function if your makefile supports the
-"install" target
+"install" target.
 
 ## Examples
 
-* [tcl](https://github.com/Microsoft/vcpkg/blob/master/ports/tcl/portfile.cmake)
-* [freexl](https://github.com/Microsoft/vcpkg/blob/master/ports/freexl/portfile.cmake)
+* [librttopo](https://github.com/microsoft/vcpkg/blob/master/ports/librttopo/portfile.cmake)
+* [openssl](https://github.com/microsoft/vcpkg/blob/master/ports/openssl/portfile.cmake)
 
 ## Source
 [scripts/cmake/vcpkg\_build\_nmake.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_build_nmake.cmake)

--- a/docs/maintainers/vcpkg_install_nmake.md
+++ b/docs/maintainers/vcpkg_install_nmake.md
@@ -8,16 +8,18 @@ Build and install a msvc makefile project.
 ```cmake
 vcpkg_install_nmake(
     SOURCE_PATH <${SOURCE_PATH}>
-    [NO_DEBUG]
-    [TARGET <all>]
-    PROJECT_SUBPATH <${SUBPATH}>
-    PROJECT_NAME <${MAKEFILE_NAME}>
+    [PROJECT_SUBPATH <${SUBPATH}>]
+    [PROJECT_NAME <${MAKEFILE_NAME}>]
+    [CL_LANGUAGE <language-name>]
+    [PREFER_JOM]
     [PRERUN_SHELL <${SHELL_PATH}>]
     [PRERUN_SHELL_DEBUG <${SHELL_PATH}>]
     [PRERUN_SHELL_RELEASE <${SHELL_PATH}>]
     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
     [OPTIONS_RELEASE <-DOPTIMIZE=1>...]
     [OPTIONS_DEBUG <-DDEBUGGABLE=1>...]
+    [TARGET <all>...]
+)
 ```
 
 ## Parameters
@@ -26,43 +28,52 @@ Specifies the directory containing the source files.
 By convention, this is usually set in the portfile as the variable `SOURCE_PATH`.
 
 ### PROJECT_SUBPATH
-Specifies the sub directory containing the `makefile.vc`/`makefile.mak`/`makefile.msvc` or other msvc makefile.
+Specifies the sub directory containing the makefile.
 
 ### PROJECT_NAME
-Specifies the name of msvc makefile name.
-Default is makefile.vc
+Specifies the name of the makefile.
+Default is `makefile.vc`
 
-### NO_DEBUG
-This port doesn't support debug mode.
+### CL_LANGUAGE
+Specifies the language for setting up flags in the `_CL_` environment variable.
+The default language is `CXX`.
+To disable the modification of `_CL_`, use `NONE`.
+
+### PREFER_JOM
+Specifies that a parallel build with `jom` should be attempted.
+This is useful for faster builds of makefiles which process many independent targets
+and which cannot benefit from the `/MP` cl option.
+To mitigate issues with concurrency-unaware makefiles, a normal `nmake` build is run after `jom` errors.
 
 ### PRERUN_SHELL
-Script that needs to be called before build
+Script that needs to be called before build.
 
 ### PRERUN_SHELL_DEBUG
-Script that needs to be called before debug build
+Script that needs to be called before debug build.
 
 ### PRERUN_SHELL_RELEASE
-Script that needs to be called before release build
+Script that needs to be called before release build.
 
 ### OPTIONS
-Additional options passed to generate during the generation.
+Additional options passed to the build command.
 
 ### OPTIONS_RELEASE
-Additional options passed to generate during the Release generation. These are in addition to `OPTIONS`.
+Additional options passed to the build command for the release build. These are in addition to `OPTIONS`.
 
 ### OPTIONS_DEBUG
-Additional options passed to generate during the Debug generation. These are in addition to `OPTIONS`.
+Additional options passed to the build command for the debug build. These are in addition to `OPTIONS`.
 
-## Parameters:
-See [`vcpkg_build_nmake()`](vcpkg_build_nmake.md).
+### TARGET
+The list of targets passed to the build command.
+If not specified, target `all` will be passed.
 
 ## Notes:
-This command transparently forwards to [`vcpkg_build_nmake()`](vcpkg_build_nmake.md), adding `ENABLE_INSTALL`
+This command transparently forwards to [`vcpkg_build_nmake()`](vcpkg_build_nmake.md), adding `ENABLE_INSTALL`.
 
 ## Examples
 
-* [tcl](https://github.com/Microsoft/vcpkg/blob/master/ports/tcl/portfile.cmake)
-* [freexl](https://github.com/Microsoft/vcpkg/blob/master/ports/freexl/portfile.cmake)
+* [libspatialite](https://github.com/microsoft/vcpkg/blob/master/ports/libspatialite/portfile.cmake)
+* [tcl](https://github.com/microsoft/vcpkg/blob/master/ports/tcl/portfile.cmake)
 
 ## Source
 [scripts/cmake/vcpkg\_install\_nmake.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_install_nmake.cmake)

--- a/ports/librttopo/portfile.cmake
+++ b/ports/librttopo/portfile.cmake
@@ -27,6 +27,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     vcpkg_build_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
         TARGET librttopo.lib
+        CL_LANGUAGE C
         OPTIONS
             "OPTFLAGS=${OPTFLAGS}"
             "CFLAGS=-I. -Iheaders ${OPTFLAGS}"

--- a/ports/librttopo/vcpkg.json
+++ b/ports/librttopo/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "librttopo",
   "version": "1.1.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "The RT Topology Library exposes an API to create and manage standard (ISO 13249 aka SQL/MM) topologies using user-provided data stores.",
   "homepage": "https://git.osgeo.org/gitea/rttopo/librttopo",
-  "supports": "!uwp",
   "dependencies": [
     "geos"
   ]

--- a/ports/librttopo/vcpkg.json
+++ b/ports/librttopo/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 7,
   "description": "The RT Topology Library exposes an API to create and manage standard (ISO 13249 aka SQL/MM) topologies using user-provided data stores.",
   "homepage": "https://git.osgeo.org/gitea/rttopo/librttopo",
+  "license": "GPL-2.0-or-later",
   "dependencies": [
     "geos"
   ]

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -82,6 +82,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     endif()
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
+        CL_LANGUAGE C
         OPTIONS_RELEASE
             "CL_FLAGS=${CL_FLAGS_RELEASE}"
             "INST_DIR=${INST_DIR}"

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -82,6 +82,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     endif()
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
+        PREFER_JOM
         CL_LANGUAGE C
         OPTIONS_RELEASE
             "CL_FLAGS=${CL_FLAGS_RELEASE}"

--- a/ports/libspatialite/vcpkg.json
+++ b/ports/libspatialite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libspatialite",
   "version": "5.0.1",
-  "port-version": 8,
+  "port-version": 9,
   "description": "SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.",
   "homepage": "https://www.gaia-gis.it/gaia-sins/libspatialite-sources",
   "license": null,

--- a/ports/readosm/portfile.cmake
+++ b/ports/readosm/portfile.cmake
@@ -29,6 +29,7 @@ if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
+        PREFER_JOM
         CL_LANGUAGE C
         OPTIONS_RELEASE
             "INSTDIR=${INST_DIR}"

--- a/ports/readosm/portfile.cmake
+++ b/ports/readosm/portfile.cmake
@@ -23,20 +23,19 @@ if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 
     if(VCPKG_TARGET_IS_UWP)
         set(UWP_LIBS windowsapp.lib)
-        set(UWP_LINK_FLAGS /APPCONTAINER)
     endif()
 
     file(TO_NATIVE_PATH "${CURRENT_PACKAGES_DIR}" INST_DIR)
 
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
+        CL_LANGUAGE C
         OPTIONS_RELEASE
             "INSTDIR=${INST_DIR}"
-            "LINK_FLAGS=${UWP_LINK_FLAGS}"
             "LIBS_ALL=${PKGCONFIG_LIBS_RELEASE} ${UWP_LIBS}"
         OPTIONS_DEBUG
             "INSTDIR=${INST_DIR}\\debug"
-            "LINK_FLAGS=${UWP_LINK_FLAGS} /debug"
+            "LINK_FLAGS=/debug"
             "LIBS_ALL=${PKGCONFIG_LIBS_DEBUG} ${UWP_LIBS}"
     )
 

--- a/ports/readosm/vcpkg.json
+++ b/ports/readosm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "readosm",
   "version-string": "1.1.0a",
-  "port-version": 3,
+  "port-version": 4,
   "description": "ReadOSM is an open source library to extract valid data from within an Open Street Map input file (.osm or .osm.pbf)",
   "homepage": "https://www.gaia-gis.it/gaia-sins/readosm-sources",
   "license": "MPL-1.1",

--- a/ports/readosm/vcpkg.json
+++ b/ports/readosm/vcpkg.json
@@ -5,7 +5,6 @@
   "description": "ReadOSM is an open source library to extract valid data from within an Open Street Map input file (.osm or .osm.pbf)",
   "homepage": "https://www.gaia-gis.it/gaia-sins/readosm-sources",
   "license": "MPL-1.1",
-  "supports": "!uwp",
   "dependencies": [
     "expat",
     {

--- a/ports/spatialite-tools/portfile.cmake
+++ b/ports/spatialite-tools/portfile.cmake
@@ -47,6 +47,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
 
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
+        PREFER_JOM
         CL_LANGUAGE C
         OPTIONS_RELEASE
             "INSTDIR=${INST_DIR}"

--- a/ports/spatialite-tools/portfile.cmake
+++ b/ports/spatialite-tools/portfile.cmake
@@ -47,6 +47,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
 
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
+        CL_LANGUAGE C
         OPTIONS_RELEASE
             "INSTDIR=${INST_DIR}"
             "LIBS_ALL=/link ${PKGCONFIG_LIBS_RELEASE} ${ICONV_LIBS} ${UWP_LIBS}"

--- a/ports/spatialite-tools/vcpkg.json
+++ b/ports/spatialite-tools/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "spatialite-tools",
   "version": "5.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Contains spatialite.exe and other command line tools to work with SpatiaLite databases (import, export, SQL queries)",
   "homepage": "https://www.gaia-gis.it/fossil/spatialite-tools/index",
   "dependencies": [

--- a/ports/spatialite-tools/vcpkg.json
+++ b/ports/spatialite-tools/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 2,
   "description": "Contains spatialite.exe and other command line tools to work with SpatiaLite databases (import, export, SQL queries)",
   "homepage": "https://www.gaia-gis.it/fossil/spatialite-tools/index",
+  "license": "GPL-3.0-or-later",
   "dependencies": [
     "expat",
     "libiconv",

--- a/scripts/cmake/vcpkg_build_nmake.cmake
+++ b/scripts/cmake/vcpkg_build_nmake.cmake
@@ -28,8 +28,12 @@ function(vcpkg_build_nmake)
     if(NOT DEFINED arg_PROJECT_NAME)
         set(arg_PROJECT_NAME makefile.vc)
     endif()
+
     if(NOT DEFINED arg_TARGET)
         vcpkg_list(SET arg_TARGET all)
+    endif()
+    if(arg_ENABLE_INSTALL)
+        vcpkg_list(APPEND arg_TARGET install)
     endif()
 
     if(NOT DEFINED arg_CL_LANGUAGE)
@@ -47,9 +51,6 @@ function(vcpkg_build_nmake)
     set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")
     # Set make options
     vcpkg_list(SET make_opts_base /NOLOGO /G /U /F "${arg_PROJECT_NAME}" ${arg_TARGET})
-    if(arg_ENABLE_INSTALL)
-        vcpkg_list(APPEND make_opts_base install)
-    endif()
 
     if(arg_PREFER_JOM AND VCPKG_CONCURRENCY GREATER "1")
         vcpkg_find_acquire_program(JOM)

--- a/scripts/cmake/vcpkg_install_nmake.cmake
+++ b/scripts/cmake/vcpkg_install_nmake.cmake
@@ -5,8 +5,8 @@ function(vcpkg_install_nmake)
         PRERUN_SHELL PRERUN_SHELL_DEBUG PRERUN_SHELL_RELEASE)
 
     cmake_parse_arguments(PARSE_ARGV 0 arg
-        "NO_DEBUG"
-        "SOURCE_PATH;PROJECT_SUBPATH;PROJECT_NAME"
+        "NO_DEBUG;PREFER_JOM"
+        "SOURCE_PATH;PROJECT_SUBPATH;PROJECT_NAME;CL_LANGUAGE"
         "${multi_value_args}"
     )
     if(DEFINED arg_UNPARSED_ARGUMENTS)
@@ -31,9 +31,12 @@ function(vcpkg_install_nmake)
     if(arg_NO_DEBUG)
         vcpkg_list(APPEND extra_args NO_DEBUG)
     endif()
+    if(arg_PREFER_JOM)
+        vcpkg_list(APPEND extra_args PREFER_JOM)
+    endif()
 
     # single args
-    foreach(arg IN ITEMS PROJECT_SUBPATH PROJECT_NAME)
+    foreach(arg IN ITEMS PROJECT_SUBPATH PROJECT_NAME CL_LANGUAGE)
         if(DEFINED "arg_${arg}")
             vcpkg_list(APPEND extra_args ${arg} "${arg_${arg}}")
         endif()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4122,7 +4122,7 @@
     },
     "librttopo": {
       "baseline": "1.1.0",
-      "port-version": 6
+      "port-version": 7
     },
     "libsamplerate": {
       "baseline": "0.2.2",
@@ -4190,7 +4190,7 @@
     },
     "libspatialite": {
       "baseline": "5.0.1",
-      "port-version": 8
+      "port-version": 9
     },
     "libspnav": {
       "baseline": "0.2.3",
@@ -6418,7 +6418,7 @@
     },
     "readosm": {
       "baseline": "1.1.0a",
-      "port-version": 3
+      "port-version": 4
     },
     "realsense2": {
       "baseline": "2.51.1",
@@ -6958,7 +6958,7 @@
     },
     "spatialite-tools": {
       "baseline": "5.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "spdk": {
       "baseline": "19.01.1",

--- a/versions/l-/librttopo.json
+++ b/versions/l-/librttopo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "667198cfefc2c1bed238cab8beb4ac2263825a30",
+      "version": "1.1.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "83f4858afee7a92ece5923344f556b3900894eaf",
       "version": "1.1.0",
       "port-version": 6

--- a/versions/l-/librttopo.json
+++ b/versions/l-/librttopo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "667198cfefc2c1bed238cab8beb4ac2263825a30",
+      "git-tree": "d7e9514837d372d0a952762f6e7ea600c8a625f9",
       "version": "1.1.0",
       "port-version": 7
     },

--- a/versions/l-/libspatialite.json
+++ b/versions/l-/libspatialite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b68031f4e06a096cf94f5b1c685f97b642667818",
+      "version": "5.0.1",
+      "port-version": 9
+    },
+    {
       "git-tree": "f13da82a42aca5aa182c22cf8d582cc9019e91fc",
       "version": "5.0.1",
       "port-version": 8

--- a/versions/r-/readosm.json
+++ b/versions/r-/readosm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e91f30f55adfa57ccb0b2787e57991e5f3039921",
+      "version-string": "1.1.0a",
+      "port-version": 4
+    },
+    {
       "git-tree": "e04328cccd78bf8d4ec57d70059d49501b361292",
       "version-string": "1.1.0a",
       "port-version": 3

--- a/versions/s-/spatialite-tools.json
+++ b/versions/s-/spatialite-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0e2a4868966c7f45f4015e5497e561f44a8abe5",
+      "version": "5.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "1e91990a5c6a01d86cc1b4cb84bbea812e62b450",
       "version": "5.0.1",
       "port-version": 1

--- a/versions/s-/spatialite-tools.json
+++ b/versions/s-/spatialite-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d0e2a4868966c7f45f4015e5497e561f44a8abe5",
+      "git-tree": "480ac025b9ad7cecc2cf17f935115a13c0de31a0",
       "version": "5.0.1",
       "port-version": 2
     },


### PR DESCRIPTION
Pulled out of #27150:

- #### What does your PR fix?
  Two independent contributions:
  1. Allow proper `_CL_` setup for C projects, fixing (re-enabling) uwp builds for nmake C projects.
  2. Add opt-in concurrency support via `jom` (inspired by and targeting port openssl, but also beneficial for libspatialite etc.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  windows, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes