### PR TITLE
[gdal] ios compatibility

### DIFF
--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.5.2",
+  "port-version": 1,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,
@@ -82,7 +83,7 @@
             "hdf5",
             "netcdf"
           ],
-          "platform": "!uwp & !(windows & arm64) & !android"
+          "platform": "!uwp & !(windows & arm64) & !android & !ios"
         },
         "giflib",
         "libiconv",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2534,7 +2534,7 @@
     },
     "gdal": {
       "baseline": "3.5.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gdcm": {
       "baseline": "3.0.12",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e3314fa33861c06a566a2727e443b8fabeef022f",
+      "version-semver": "3.5.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "f88341b75df68d585c06df3ed7b7b0a5412ae986",
       "version-semver": "3.5.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes gdal for ios. hdf5 and netcdf are not supported

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`
