### PR TITLE
[poly2tri] Set policy CMP0063 to NEW

### DIFF
--- a/ports/poly2tri/CMakeLists.txt
+++ b/ports/poly2tri/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
 
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+
 project(poly2tri LANGUAGES C CXX)
 
 set(INSTALL_BIN_DIR      "bin"                     CACHE PATH "Path where exe and dll will be installed")

--- a/ports/poly2tri/CMakeLists.txt
+++ b/ports/poly2tri/CMakeLists.txt
@@ -4,6 +4,9 @@ if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)
 endif()
 
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
+
 project(poly2tri LANGUAGES C CXX)
 
 set(INSTALL_BIN_DIR      "bin"                     CACHE PATH "Path where exe and dll will be installed")

--- a/ports/poly2tri/vcpkg.json
+++ b/ports/poly2tri/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "poly2tri",
   "version-string": "2020-07-21",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Clipper library performs clipping and offsetting for both lines and polygons. All four boolean clipping operations are supported - intersection, union, difference and exclusive-or. Polygons can be of any shape including self-intersecting polygons.",
   "homepage": "https://github.com/greenm01/poly2tri",
   "supports": "!uwp",

--- a/ports/poly2tri/vcpkg.json
+++ b/ports/poly2tri/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "poly2tri",
-  "version-string": "2020-07-21",
+  "version-date": "2020-07-21",
   "port-version": 3,
   "description": "The Clipper library performs clipping and offsetting for both lines and polygons. All four boolean clipping operations are supported - intersection, union, difference and exclusive-or. Polygons can be of any shape including self-intersecting polygons.",
   "homepage": "https://github.com/greenm01/poly2tri",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5798,7 +5798,7 @@
     },
     "poly2tri": {
       "baseline": "2020-07-21",
-      "port-version": 2
+      "port-version": 3
     },
     "polyclipping": {
       "baseline": "6.4.2",

--- a/versions/p-/poly2tri.json
+++ b/versions/p-/poly2tri.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "89645297df5f0af1fc040ac33ac243f42caa49fb",
-      "version-string": "2020-07-21",
+      "git-tree": "6f490bcfed9bb8b55036006a4389bfa7e94c73ff",
+      "version-date": "2020-07-21",
       "port-version": 3
     },
     {

--- a/versions/p-/poly2tri.json
+++ b/versions/p-/poly2tri.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89645297df5f0af1fc040ac33ac243f42caa49fb",
+      "version-string": "2020-07-21",
+      "port-version": 3
+    },
+    {
       "git-tree": "03cdd793a8f279b18df99f74bf4eef1e24ad5809",
       "version-string": "2020-07-21",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Linker warnings about conflicting visibility settings if `poly2tri`, which is built as a static library, is pulled into a build as an indirect dependency of a shared library. An example of such a configuration is `assimp`, which depends on `poly2tri`, and can be built as a dynamic library on macOS.

Policy `CMP0063` enables CMake to set the symbol visibility of static libraries to avoid this problem.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes, to the best of my knowledge.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
 No, the maintainer guide says to do that only when updating multiple ports at the same time.

