### PR TITLE
[minizip-ng] update to 3.0.7

### DIFF
--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/minizip-ng
-    REF 3.0.5
-    SHA512 da0c230951caafd986331300b840d09a4c27a677183174f8b1782c2515209b51cf00133dd5fc5f9fc88a349134db7f93d3daa7c05b7d0270be99b9cf85a6c133
+    REF 241428886216f0f0efd6926efcaaaa13794e51bd #v3.0.7
+    SHA512 779a53fafe63b64f5f703448262871c323f5753cbb58001dd0d0ef10de8d3bd7bb6055db4e763e664ccb5b781ce8dd06bf7c3e6b38eca019de835322a833fa06
     HEAD_REF master
     PATCHES 
         Modify-header-file-path.patch

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "3.0.7",
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
-  "license": "MIT",
+  "license": "Zlib",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "minizip-ng",
-  "version": "3.0.5",
+  "version": "3.0.7",
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
+  "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4829,7 +4829,7 @@
       "port-version": 11
     },
     "minizip-ng": {
-      "baseline": "3.0.5",
+      "baseline": "3.0.7",
       "port-version": 0
     },
     "mio": {

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6078437093ef4c059be7c67bf412148688612c74",
+      "version": "3.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "36ef459c57047fcfc0ddbfc97d7360d7307acb24",
       "version": "3.0.5",
       "port-version": 0

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6078437093ef4c059be7c67bf412148688612c74",
+      "git-tree": "e97e41aa57defe3c82bebab5941a4e4320f5a704",
       "version": "3.0.7",
       "port-version": 0
     },


### PR DESCRIPTION
Fix #27264 

Update minizip-ng to the latest version 3.0.7

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static