### PR TITLE
[openssl-unix, openssl-uwp, openssl-windows] Change version to deprecated

### DIFF
--- a/ports/openssl-unix/portfile.cmake
+++ b/ports/openssl-unix/portfile.cmake
@@ -1,1 +1,2 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+message(WARNING "${PORT} is deprecated. Please use port openssl instead.")

--- a/ports/openssl-unix/vcpkg.json
+++ b/ports/openssl-unix/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "openssl-unix",
-  "version-string": "1.1.1h",
-  "port-version": 2,
-  "description": "Deprecated OpenSSL port",
-  "supports": "!(windows | uwp)",
+  "version-string": "deprecated",
+  "description": "Deprecated OpenSSL port. Use port openssl instead.",
+  "supports": "!windows",
   "dependencies": [
     "openssl"
   ]

--- a/ports/openssl-uwp/portfile.cmake
+++ b/ports/openssl-uwp/portfile.cmake
@@ -1,1 +1,2 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+message(WARNING "${PORT} is deprecated. Please use port openssl instead.")

--- a/ports/openssl-uwp/vcpkg.json
+++ b/ports/openssl-uwp/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "openssl-uwp",
-  "version-string": "1.1.1h",
-  "port-version": 2,
-  "description": "Deprecated OpenSSL port",
+  "version-string": "deprecated",
+  "description": "Deprecated OpenSSL port. Use port openssl instead.",
   "supports": "uwp",
   "dependencies": [
     "openssl"

--- a/ports/openssl-windows/portfile.cmake
+++ b/ports/openssl-windows/portfile.cmake
@@ -1,1 +1,2 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+message(WARNING "${PORT} is deprecated. Please use port openssl instead.")

--- a/ports/openssl-windows/vcpkg.json
+++ b/ports/openssl-windows/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "openssl-windows",
-  "version-string": "1.1.1h",
-  "port-version": 2,
-  "description": "Deprecated OpenSSL port",
-  "supports": "windows",
+  "version-string": "deprecated",
+  "description": "Deprecated OpenSSL port. Use port openssl instead.",
+  "supports": "windows & !uwp",
   "dependencies": [
     "openssl"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5469,16 +5469,16 @@
       "port-version": 5
     },
     "openssl-unix": {
-      "baseline": "1.1.1h",
-      "port-version": 2
+      "baseline": "deprecated",
+      "port-version": 0
     },
     "openssl-uwp": {
-      "baseline": "1.1.1h",
-      "port-version": 2
+      "baseline": "deprecated",
+      "port-version": 0
     },
     "openssl-windows": {
-      "baseline": "1.1.1h",
-      "port-version": 2
+      "baseline": "deprecated",
+      "port-version": 0
     },
     "opensubdiv": {
       "baseline": "3.4.4",

--- a/versions/o-/openssl-unix.json
+++ b/versions/o-/openssl-unix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e410c3651975a5eeb7c13f6013ab23b727be116",
+      "version-string": "deprecated",
+      "port-version": 0
+    },
+    {
       "git-tree": "6084ac3842ee1641284254bffc3f01706a372eac",
       "version-string": "1.1.1h",
       "port-version": 2

--- a/versions/o-/openssl-unix.json
+++ b/versions/o-/openssl-unix.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3e410c3651975a5eeb7c13f6013ab23b727be116",
+      "git-tree": "a974b962f0ceb2af70639e1a9dcf08ff690d49f8",
       "version-string": "deprecated",
       "port-version": 0
     },

--- a/versions/o-/openssl-uwp.json
+++ b/versions/o-/openssl-uwp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6a2b3a3b9eab22b596cc6581a29872c728872394",
+      "git-tree": "312a6b6d7401200193aaeb960a678b85085c777d",
       "version-string": "deprecated",
       "port-version": 0
     },

--- a/versions/o-/openssl-uwp.json
+++ b/versions/o-/openssl-uwp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a2b3a3b9eab22b596cc6581a29872c728872394",
+      "version-string": "deprecated",
+      "port-version": 0
+    },
+    {
       "git-tree": "1a51fbd29a373e9c57ed233d581112359109a234",
       "version-string": "1.1.1h",
       "port-version": 2

--- a/versions/o-/openssl-windows.json
+++ b/versions/o-/openssl-windows.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4433689cef00d5a32e5bbc44d2fffeb7027fb7a2",
+      "version-string": "deprecated",
+      "port-version": 0
+    },
+    {
       "git-tree": "8a169239b58831cf291de837dc26a357585136d9",
       "version-string": "1.1.1h",
       "port-version": 2

--- a/versions/o-/openssl-windows.json
+++ b/versions/o-/openssl-windows.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4433689cef00d5a32e5bbc44d2fffeb7027fb7a2",
+      "git-tree": "dc90f49befe5f19295f8004024d3830a5f571195",
       "version-string": "deprecated",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Some people are confused that those ports have version `1.1.1h` and think that vcpkg still supports openssl 1.1.1 on master. See for example #27275. The version `deprecated` expresses that the ports themselves are deprecated and not upstream's openssl 1.1.1.

People that still need openssl 1.1.1 should consider migrating their software to support openssl 3, use the [versioning feature](https://github.com/microsoft/vcpkg/blob/master/docs/users/versioning.md) to pin an old version of openssl or create an [overlay port](https://github.com/microsoft/vcpkg/blob/master/docs/specifications/ports-overlay.md) to update to a newer version of openssl 1.1.1.