### PR TITLE
[ffmpeg] fixed build on Windows ARM

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -72,16 +72,16 @@ if(VCPKG_TARGET_IS_WINDOWS)
                 # Required for "cpp.exe" preprocessor
                 "https://repo.msys2.org/msys/x86_64/gcc-11.3.0-2-x86_64.pkg.tar.zst"
                 1efc34aa8312eb5a8fef02c7c903d9ed98c4d50b13b8cf9679df1d545847eb9e0e9a42a810b2e085c6f938796a2a9846cb8b515e9380fdd6bec8ae4a1a131d9e
-                "https://repo.msys2.org/msys/x86_64/isl-0.22.1-1-x86_64.pkg.tar.xz"
-                f4db50d00bad0fa0abc6b9ad965b0262d936d437a9faa35308fa79a7ee500a474178120e487b2db2259caf51524320f619e18d92acf4f0b970b5cbe5cc0f63a2
-                "https://repo.msys2.org/msys/x86_64/zlib-1.2.11-1-x86_64.pkg.tar.xz"
-                b607da40d3388b440f2a09e154f21966cd55ad77e02d47805f78a9dee5de40226225bf0b8335fdfd4b83f25ead3098e9cb974d4f202f28827f8468e30e3b790d
-                "https://repo.msys2.org/msys/x86_64/mpc-1.1.0-1-x86_64.pkg.tar.xz"
-                7d0715c41c27fdbf91e6dcc73d6b8c02ee62c252e027f0a17fa4bfb974be8a74d8e3a327ef31c2460721902299ef69a7ef3c7fce52c8f02ce1cb47f0b6e073e9
+                "https://repo.msys2.org/msys/x86_64/isl-0.25-2-x86_64.pkg.tar.zst"
+                9fcf50d18694ba983a1223f46312128bcdde700f72d3dc7b905acf1a8c167e5343ebf7957468fa943ad6f66259c316e437fc60c2456e18617e1ae1990eaf226b
+                "https://repo.msys2.org/msys/x86_64/zlib-1.2.12-2-x86_64.pkg.tar.zst"
+                5470a5da1acaf1e5639c5c1f396ca5dfdef58cb652168b04291c6c1a6cd90c6427f7d5b8e6620ad110e2c8ad1fe0d62a94e385a8d60bf41022754994b9bf39eb
+                "https://repo.msys2.org/msys/x86_64/mpc-1.2.1-1-x86_64.pkg.tar.zst"
+                31d9cd84bbd0b83ffc77ff0b0356d2c1e3dd8880e9f73f09c5140442c1ed17b93af08804038bd3cd1f90ac1e4cfe52bfeac1fe0b349ed5699088b7aa8420e550
                 "https://repo.msys2.org/msys/x86_64/mpfr-4.1.0-1-x86_64.pkg.tar.zst"
                 d64fa60e188124591d41fc097d7eb51d7ea4940bac05cdcf5eafde951ed1eaa174468f5ede03e61106e1633e3428964b34c96de76321ed8853b398fbe8c4d072
-                "https://repo.msys2.org/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz"
-                1389a443e775bb255d905665dd577bef7ed71d51a8c24d118097f8119c08c4dfe67505e88ddd1e9a3764dd1d50ed8b84fa34abefa797d257e90586f0cbf54de8
+                "https://repo.msys2.org/msys/x86_64/gmp-6.2.1-2-x86_64.pkg.tar.zst"
+                b2df273243ba08ed2b1117d2b4826900706859c51c1c39ca6e47df2b44b006b2512f7db801738fdbb9411594bc8bc67d308cf205f7fa1aab179863844218e513
         )
     else()
         vcpkg_acquire_msys(MSYS_ROOT)

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.1",
-  "port-version": 20,
+  "port-version": 21,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2294,7 +2294,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.1",
-      "port-version": 20
+      "port-version": 21
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8429893dd135ce02c91222b8280f2d5e224c2706",
+      "version": "4.4.1",
+      "port-version": 21
+    },
+    {
       "git-tree": "a4a2ee724ee276834d3f5715bac6bf6ec179c31b",
       "version": "4.4.1",
       "port-version": 20


### PR DESCRIPTION
Currently build fails with the error:
```
Building ffmpeg[avcodec,avdevice,avfilter,avformat,core,swresample,swscale]:arm64-windows...
-- Using cached ffmpeg-ffmpeg-n4.4.1.tar.gz.
-- Cleaning sources at C:/projects/synfig-arm/vcpkg/buildtrees/ffmpeg/src/n4.4.1-9dd22c1484.clean. Use --editable to skip cleaning for the packages you specify.
-- Extracting source C:/projects/synfig-arm/vcpkg/downloads/ffmpeg-ffmpeg-n4.4.1.tar.gz
-- Applying patch 0001-create-lib-libraries.patch
...
-- Downloading https://repo.msys2.org/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz;https://www2.futureware.at/~nickoe/msys2-mirror/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz;https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz;https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz;https://mirrors.ustc.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz;https://mirror.bit.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz;https://mirror.selfnet.de/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz;https://mirrors.sjtug.sjtu.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz -> msys-gmp-6.2.0-1-x86_64.pkg.tar.xz...
[DEBUG] To include the environment variables in debug output, pass --debug-env
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'manifests' = off
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] Downloading https://repo.msys2.org/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz
[DEBUG] Downloading https://www2.futureware.at/~nickoe/msys2-mirror/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz
[DEBUG] Downloading https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz
[DEBUG] Downloading https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz
[DEBUG] Downloading https://mirrors.ustc.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz
[DEBUG] Downloading https://mirror.bit.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz
[DEBUG] Download failed -- retrying after 1000 ms.
[DEBUG] Download failed -- retrying after 2000 ms.
[DEBUG] Download failed -- retrying after 4000 ms.
[DEBUG] Downloading https://mirror.selfnet.de/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz
[DEBUG] Downloading https://mirrors.sjtug.sjtu.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz
[DEBUG] Download failed -- retrying after 1000 ms.
[DEBUG] Download failed -- retrying after 2000 ms.
[DEBUG] Download failed -- retrying after 4000 ms.
Error: Failed to download from mirror set:
https://repo.msys2.org/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: failed: status code 404
https://www2.futureware.at/~nickoe/msys2-mirror/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: failed: status code 404
https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: failed: status code 404
https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: failed: status code 404
https://mirrors.ustc.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: failed: status code 404
https://mirror.bit.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: WinHttpSendRequest() failed: 12007
https://mirror.bit.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: WinHttpSendRequest() failed: 12007
https://mirror.bit.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: WinHttpSendRequest() failed: 12007
https://mirror.bit.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: WinHttpSendRequest() failed: 12007
https://mirror.selfnet.de/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: failed: status code 404
https://mirrors.sjtug.sjtu.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: WinHttpSendRequest() failed: 12029
https://mirrors.sjtug.sjtu.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: WinHttpSendRequest() failed: 12029
https://mirrors.sjtug.sjtu.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: WinHttpSendRequest() failed: 12029
https://mirrors.sjtug.sjtu.edu.cn/msys2/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz: WinHttpSendRequest() failed: 12029
```

This happens because MSYS2 has switched to zstd compression and
https://repo.msys2.org/msys/x86_64/gmp-6.2.0-1-x86_64.pkg.tar.xz
already removed from the MSYS2 repository.

Also I bumped other dependencies too.