### PR TITLE
[tesseract] Link executable to libarchive to fix linker error

### DIFF
--- a/ports/tesseract/fix-depend-libarchive.patch
+++ b/ports/tesseract/fix-depend-libarchive.patch
@@ -1,3 +1,5 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bd2649d..f63030e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -792,7 +792,8 @@ if(OpenCL_FOUND)
@@ -10,3 +12,14 @@
  endif(LibArchive_FOUND)
  if(CURL_FOUND)
    if(NOT CURL_LIBRARIES)
+@@ -858,6 +859,10 @@ target_link_libraries(tesseract libtesseract)
+ if(HAVE_TIFFIO_H AND WIN32)
+   target_link_libraries(tesseract ${TIFF_LIBRARIES})
+ endif()
++if(LibArchive_FOUND)
++  find_package(LibArchive REQUIRED)
++  target_link_libraries(tesseract LibArchive::LibArchive)
++endif(LibArchive_FOUND)
+ 
+ if(OPENMP_BUILD AND UNIX)
+   target_link_libraries(tesseract pthread)

--- a/ports/tesseract/fix-depend-libarchive.patch
+++ b/ports/tesseract/fix-depend-libarchive.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index bd2649d..f63030e 100644
+index bd2649d..c1801a6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -792,7 +792,8 @@ if(OpenCL_FOUND)
@@ -12,14 +12,12 @@ index bd2649d..f63030e 100644
  endif(LibArchive_FOUND)
  if(CURL_FOUND)
    if(NOT CURL_LIBRARIES)
-@@ -858,6 +859,10 @@ target_link_libraries(tesseract libtesseract)
+@@ -854,7 +855,7 @@ endif()
+ # ##############################################################################
+ 
+ add_executable(tesseract src/tesseract.cpp)
+-target_link_libraries(tesseract libtesseract)
++target_link_libraries(tesseract libtesseract LibArchive::LibArchive)
  if(HAVE_TIFFIO_H AND WIN32)
    target_link_libraries(tesseract ${TIFF_LIBRARIES})
  endif()
-+if(LibArchive_FOUND)
-+  find_package(LibArchive REQUIRED)
-+  target_link_libraries(tesseract LibArchive::LibArchive)
-+endif(LibArchive_FOUND)
- 
- if(OPENMP_BUILD AND UNIX)
-   target_link_libraries(tesseract pthread)

--- a/ports/tesseract/vcpkg.json
+++ b/ports/tesseract/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tesseract",
   "version": "5.2.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.",
   "homepage": "https://github.com/tesseract-ocr/tesseract",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7278,7 +7278,7 @@
     },
     "tesseract": {
       "baseline": "5.2.0",
-      "port-version": 2
+      "port-version": 3
     },
     "tfhe": {
       "baseline": "1.0.1",

--- a/versions/t-/tesseract.json
+++ b/versions/t-/tesseract.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e70171a3b58d3d96add722d577b295eaf9b6aa7",
+      "version": "5.2.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "9d9b7d5ba2e222ee4fb62d4d5f03992e9232a97d",
       "version": "5.2.0",
       "port-version": 2

--- a/versions/t-/tesseract.json
+++ b/versions/t-/tesseract.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6e70171a3b58d3d96add722d577b295eaf9b6aa7",
+      "git-tree": "106efd2adc79ebdcf63488c2cc930b035f01535d",
       "version": "5.2.0",
       "port-version": 3
     },


### PR DESCRIPTION
- [tesseract] link exe to libarchive to fix link error
- ./vcpkg x-add-version --all

**Describe the pull request**

- #### What does your PR fix?
  In master, `./vcpkg install 'tesseract:arm64-osx-dynamic'` fails with:

```
Undefined symbols for architecture arm64:
  "_archive_version_details", referenced from:
      PrintVersionInfo() in tesseract.cpp.o
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Should be all. I haven't updated the baseline

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
