### PR TITLE
Fix opencv-freetype build

### DIFF
--- a/ports/opencv4/0016-fix-freetype-contrib.patch
+++ b/ports/opencv4/0016-fix-freetype-contrib.patch
@@ -7,8 +7,8 @@
 -ocv_check_modules(FREETYPE freetype2)
 -ocv_check_modules(HARFBUZZ harfbuzz)
 +if(WITH_FREETYPE)
-+find_package(freetype CONFIG REQUIRED)
-+find_package(harfbuzz CONFIG REQUIRED)
++find_package(FREETYPE CONFIG REQUIRED)
++find_package(HARFBUZZ CONFIG REQUIRED)
 +endif()
 
  if(OPENCV_INITIAL_PASS)

--- a/ports/opencv4/0016-fix-freetype-contrib.patch
+++ b/ports/opencv4/0016-fix-freetype-contrib.patch
@@ -7,8 +7,8 @@
 -ocv_check_modules(FREETYPE freetype2)
 -ocv_check_modules(HARFBUZZ harfbuzz)
 +if(WITH_FREETYPE)
-+find_package(FREETYPE CONFIG REQUIRED)
-+find_package(HARFBUZZ CONFIG REQUIRED)
++find_package(freetype CONFIG REQUIRED)
++find_package(harfbuzz CONFIG REQUIRED)
 +endif()
 
  if(OPENCV_INITIAL_PASS)

--- a/ports/opencv4/0019-fix-freetype-contrib-casing.patch
+++ b/ports/opencv4/0019-fix-freetype-contrib-casing.patch
@@ -1,0 +1,28 @@
+--- a/modules/freetype/CMakeLists.txt
++++ b/modules/freetype/CMakeLists.txt
+@@ -9,20 +9,20 @@ find_package(harfbuzz CONFIG REQUIRED)
+ endif()
+
+ if(OPENCV_INITIAL_PASS)
+-  if(NOT FREETYPE_FOUND)
++  if(NOT freetype_FOUND)
+     message(STATUS "freetype2:   NO")
+   else()
+-    message(STATUS "freetype2:   YES (ver ${FREETYPE_VERSION})")
++    message(STATUS "freetype2:   YES (ver ${freetype_VERSION})")
+   endif()
+
+-  if(NOT HARFBUZZ_FOUND)
++  if(NOT harfbuzz_FOUND)
+     message(STATUS "harfbuzz:    NO")
+   else()
+-    message(STATUS "harfbuzz:    YES (ver ${HARFBUZZ_VERSION})")
++    message(STATUS "harfbuzz:    YES (ver ${harfbuzz_VERSION})")
+   endif()
+ endif()
+
+-if(FREETYPE_FOUND AND HARFBUZZ_FOUND)
++if(freetype_FOUND AND harfbuzz_FOUND)
+   ocv_define_module(freetype opencv_core opencv_imgproc WRAP python)
+   ocv_target_link_libraries(${the_module} ${FREETYPE_LIBRARIES} ${HARFBUZZ_LIBRARIES})
+   ocv_include_directories( ${FREETYPE_INCLUDE_DIRS} ${HARFBUZZ_INCLUDE_DIRS} )

--- a/ports/opencv4/0019-fix-freetype-contrib-casing.patch
+++ b/ports/opencv4/0019-fix-freetype-contrib-casing.patch
@@ -2,7 +2,7 @@
 +++ b/modules/freetype/CMakeLists.txt
 @@ -9,20 +9,20 @@ find_package(harfbuzz CONFIG REQUIRED)
  endif()
-
+ 
  if(OPENCV_INITIAL_PASS)
 -  if(NOT FREETYPE_FOUND)
 +  if(NOT freetype_FOUND)
@@ -11,7 +11,7 @@
 -    message(STATUS "freetype2:   YES (ver ${FREETYPE_VERSION})")
 +    message(STATUS "freetype2:   YES (ver ${freetype_VERSION})")
    endif()
-
+ 
 -  if(NOT HARFBUZZ_FOUND)
 +  if(NOT harfbuzz_FOUND)
      message(STATUS "harfbuzz:    NO")
@@ -20,7 +20,7 @@
 +    message(STATUS "harfbuzz:    YES (ver ${harfbuzz_VERSION})")
    endif()
  endif()
-
+ 
 -if(FREETYPE_FOUND AND HARFBUZZ_FOUND)
 +if(freetype_FOUND AND harfbuzz_FOUND)
    ocv_define_module(freetype opencv_core opencv_imgproc WRAP python)

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -180,6 +180,7 @@ if("contrib" IN_LIST FEATURES)
       0014-fix-ogre.patch
       0016-fix-freetype-contrib.patch
       0018-fix-depend-tesseract.patch
+      0019-fix-freetype-contrib-casing.patch
   )
   set(BUILD_WITH_CONTRIB_FLAG "-DOPENCV_EXTRA_MODULES_PATH=${CONTRIB_SOURCE_PATH}/modules")
 

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.6.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5402,7 +5402,7 @@
     },
     "opencv4": {
       "baseline": "4.6.0",
-      "port-version": 6
+      "port-version": 7
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "597f3e6770fb3b9d57e631c00e85f7d4b2c26caa",
+      "version": "4.6.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "9961bbcc88c934054f6137f3417bbd9cccf478d4",
       "version": "4.6.0",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #23648

After applying patch `0016-fix-freetype-contrib.patch`, the build can find freetype and harfbuzz packages. However, the casing mismatches. It generates `freetype_FOUND` and `hardbuzz_FOUND` instead of the upper casing ones used in opencv-freetype CMakeLists.txt.

https://github.com/opencv/opencv_contrib/blob/ff5da1e154ea6e41c2cc77ca98574b3b19318848/modules/freetype/CMakeLists.txt#L9-L21

Thus, this PR adds an additional patch to fix the casing in the remaining part of the CMakelists.txt file.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `all, No`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `N/A`

