### PR TITLE
[openmvg] does not support arm64 osx

### DIFF
--- a/ports/openmvg/vcpkg.json
+++ b/ports/openmvg/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "openmvg",
   "version": "2.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "open Multiple View Geometry library. Basis for 3D computer vision and Structure from Motion.",
   "license": "MPL-2.0-no-copyleft-exception",
+  "supports": "!(osx & arm64)",
   "dependencies": [
     "cereal",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5458,7 +5458,7 @@
     },
     "openmvg": {
       "baseline": "2.0",
-      "port-version": 4
+      "port-version": 5
     },
     "openmvs": {
       "baseline": "2.0.1",

--- a/versions/o-/openmvg.json
+++ b/versions/o-/openmvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "884daf253c53c86a780f1a75907d0c0f28e352de",
+      "version": "2.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "7a97e175386e994ff24a45911a373450d17fe516",
       "version": "2.0",
       "port-version": 4


### PR DESCRIPTION
```
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/openmvg/src/1047522df9-bc12641d25.clean/src/openMVG/matching/metric_simd.hpp:20:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/immintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
```
