### PR TITLE
[opus] Fix arm64-mingw builds

### DIFF
--- a/ports/opus/portfile.cmake
+++ b/ports/opus/portfile.cmake
@@ -12,10 +12,15 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         avx AVX_SUPPORTED
 )
 
+set(ADDITIONAL_OPUS_OPTIONS "")
 if(VCPKG_TARGET_IS_MINGW)
     set(STACK_PROTECTOR OFF)
     string(APPEND VCPKG_C_FLAGS "-D_FORTIFY_SOURCE=0")
     string(APPEND VCPKG_CXX_FLAGS "-D_FORTIFY_SOURCE=0")
+    if(VCPKG_TARGET_ARCHITECTURE MATCHES "^(ARM|arm)64$")
+        list(APPEND ADDITIONAL_OPUS_OPTIONS "-DOPUS_USE_NEON=OFF") # for version 1.3.1 (remove for future Opus release)
+        list(APPEND ADDITIONAL_OPUS_OPTIONS "-DOPUS_DISABLE_INTRINSICS=ON") # for HEAD (and future Opus release)
+    endif()
 elseif(VCPKG_TARGET_IS_EMSCRIPTEN)
     set(STACK_PROTECTOR OFF)
 else()
@@ -31,6 +36,10 @@ vcpkg_cmake_configure(
         -DOPUS_INSTALL_CMAKE_CONFIG_MODULE=ON
         -DOPUS_BUILD_PROGRAMS=OFF
         -DOPUS_BUILD_TESTING=OFF
+        ${ADDITIONAL_OPUS_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        OPUS_USE_NEON
+        OPUS_DISABLE_INTRINSICS
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/opus/vcpkg.json
+++ b/ports/opus/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opus",
   "version": "1.3.1",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Totally open, royalty-free, highly versatile audio codec",
   "homepage": "https://github.com/xiph/opus",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5554,7 +5554,7 @@
     },
     "opus": {
       "baseline": "1.3.1",
-      "port-version": 8
+      "port-version": 9
     },
     "opusfile": {
       "baseline": "0.12",

--- a/versions/o-/opus.json
+++ b/versions/o-/opus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "969377a42b9e5887f42419aff6182d9c111f65c2",
+      "version": "1.3.1",
+      "port-version": 9
+    },
+    {
       "git-tree": "f69aedcd28796dfac85514ee0934e7f91ab05e06",
       "version": "1.3.1",
       "port-version": 8


### PR DESCRIPTION
Fix `arm64-mingw-*` triplet builds of the `opus` port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes