### PR TITLE
[glslang] Make building binaries optional

### DIFF
--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON_PATH ${PYTHON3} DIRECTORY)
 vcpkg_add_to_path("${PYTHON_PATH}")
 
-if("binaries" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_IOS)
+if("tools" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_IOS)
   set(BUILD_BINARIES ON)
 else()
   # this case will report error since all executable will require BUNDLE DESTINATION

--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -14,11 +14,11 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON_PATH ${PYTHON3} DIRECTORY)
 vcpkg_add_to_path("${PYTHON_PATH}")
 
-if(VCPKG_TARGET_IS_IOS)
+if("binaries" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_IOS)
+  set(BUILD_BINARIES ON)
+else()
   # this case will report error since all executable will require BUNDLE DESTINATION
   set(BUILD_BINARIES OFF)
-else()
-  set(BUILD_BINARIES ON)  
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glslang",
   "version": "11.11.0",
+  "port-version": 1,
   "description": "Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator",
   "homepage": "https://github.com/KhronosGroup/glslang",
   "dependencies": [
@@ -12,5 +13,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "binaries"
+  ],
+  "features": {
+    "binaries": {
+      "description": "Build the glslangValidator and spv-remap binaries"
+    }
+  }
 }

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -15,11 +15,11 @@
     }
   ],
   "default-features": [
-    "binaries"
+    "tools"
   ],
   "features": {
-    "binaries": {
-      "description": "Build the glslangValidator and spv-remap binaries"
+    "tools": {
+      "description": "Build the glslangValidator and spirv-remap binaries"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2674,7 +2674,7 @@
     },
     "glslang": {
       "baseline": "11.11.0",
-      "port-version": 0
+      "port-version": 1
     },
     "glui": {
       "baseline": "2019-11-30",

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a07bac9ffbeb49c48c6dfeb8a7d5ae0c9c918f55",
+      "git-tree": "b468ee3d588ae97ba2d03a4723751cac81c80443",
       "version": "11.11.0",
       "port-version": 1
     },

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a07bac9ffbeb49c48c6dfeb8a7d5ae0c9c918f55",
+      "version": "11.11.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "15f0fd6fda1d1a10fb5e605b3e38cb66ec7b5011",
       "version": "11.11.0",
       "port-version": 0


### PR DESCRIPTION
This PR makes building the glslang binaries an optional feature, as projects that use the package for the library features don't need the binaries.

- #### What does your PR fix?
  Makes the glslang binaries an optional feature.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
   No changes to triplet support.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Mostly. The guide mentions that things like binaries should be disabled by default, but for backwards compatibility reasons the features is enabled by default as it was before.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes, ran `vcpkg x-add-version glslang`
