### PR TITLE
[tbb] Enable iOS builds for TBB

### DIFF
--- a/ports/tbb/vcpkg.json
+++ b/ports/tbb/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "tbb",
   "version": "2021.5.0",
+  "port-version": 1,
   "description": "Intel's Threading Building Blocks.",
   "homepage": "https://github.com/01org/tbb",
   "license": "Apache-2.0",
-  "supports": "(windows & !uwp) | linux | osx",
+  "supports": "(windows & !uwp) | linux | osx | ios",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7258,7 +7258,7 @@
     },
     "tbb": {
       "baseline": "2021.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tcb-span": {
       "baseline": "2021-12-15",

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22900b5a0b9c5114e5dc9452b088028ce6c6afc3",
+      "version": "2021.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e2d94c971f648a21fa3068485c590b70bfa8b716",
       "version": "2021.5.0",
       "port-version": 0


### PR DESCRIPTION
This PR enables TBB for iOS. It works at least on iOS 13+ for arm64.

- #### What does your PR fix?
  TBB 2021.5 switched to CMake for building, which fixed various problem with compiling for iOS. It now "just works".

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  This PR doesn't change the existing ports.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes