### PR TITLE
[cryptopp] Allow disabling Crypto++ ASM using a triplet file

### DIFF
--- a/ports/cryptopp/portfile.cmake
+++ b/ports/cryptopp/portfile.cmake
@@ -41,7 +41,7 @@ endif()
 # disable assembly on ARM Windows to fix broken build
 if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "^arm")
     set(CRYPTOPP_DISABLE_ASM "ON")
-else()
+elseif(NOT DEFINED CRYPTOPP_DISABLE_ASM) # Allow disabling using a triplet file
     set(CRYPTOPP_DISABLE_ASM "OFF")
 endif()
 
@@ -59,6 +59,8 @@ vcpkg_cmake_configure(
         -DBUILD_TESTING=OFF
         -DBUILD_DOCUMENTATION=OFF
         -DDISABLE_ASM=${CRYPTOPP_DISABLE_ASM}
+        -DUSE_INTERMEDIATE_OBJECTS_TARGET=OFF # Not required when we build static only
+        -DCMAKE_POLICY_DEFAULT_CMP0063=NEW # Honor "<LANG>_VISIBILITY_PRESET" properties
 )
 
 vcpkg_cmake_install ()

--- a/ports/cryptopp/vcpkg.json
+++ b/ports/cryptopp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cryptopp",
   "version": "8.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Crypto++ is a free C++ class library of cryptographic schemes.",
   "homepage": "https://github.com/weidai11/cryptopp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1754,7 +1754,7 @@
     },
     "cryptopp": {
       "baseline": "8.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "cserialport": {
       "baseline": "4.1.1",

--- a/versions/c-/cryptopp.json
+++ b/versions/c-/cryptopp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1aecd97d5b5c29bc51bab7892b15035a8e24002d",
+      "version": "8.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "9d23fcfb280c3508aabac1d7e0f83440dcb8627f",
       "version": "8.6.0",
       "port-version": 1


### PR DESCRIPTION
Crypto++ checks the host machine instead of the target machine when deciding which harware extensions it can use. This breaks cross-compilation in most cases. For example compiling x64 binaries on Apple Silicon doesn't work.

This change allows users to disable hardware specific instructions using triplet files if they're trying to cross-compile, by adding

```
if(PORT STREQUAL "cryptopp")
    set(CRYPTOPP_DISABLE_ASM "ON")
endif()
```

- #### What does your PR fix?
  Fixes cross-compilation for Crypto++ and some CMake warnings

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes