### PR TITLE
[libical] Fix CMake option with berkeleydb

### DIFF
--- a/ports/libical/portfile.cmake
+++ b/ports/libical/portfile.cmake
@@ -23,7 +23,7 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DCMAKE_DISABLE_FIND_PACKAGE_BDB=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_BerkeleyDB=ON
         -DUSE_BUILTIN_TZDATA=ON
         -DICAL_GLIB=OFF
         -DICAL_BUILD_DOCS=OFF

--- a/ports/libical/vcpkg.json
+++ b/ports/libical/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libical",
   "version": "3.0.16",
+  "port-version": 1,
   "description": "Reference implementation of the iCalendar data type and serialization format",
   "homepage": "https://github.com/libical/libical",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3818,7 +3818,7 @@
     },
     "libical": {
       "baseline": "3.0.16",
-      "port-version": 0
+      "port-version": 1
     },
     "libice": {
       "baseline": "1.0.10",

--- a/versions/l-/libical.json
+++ b/versions/l-/libical.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86f667b283c1e7d92dd68a3733d80d2e074db342",
+      "version": "3.0.16",
+      "port-version": 1
+    },
+    {
       "git-tree": "1b43ddbc68adc33c4d442851a313d655840a7893",
       "version": "3.0.16",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #27356, change incorrect option `CMAKE_DISABLE_FIND_PACKAGE_BDB` to `CMAKE_DISABLE_FIND_PACKAGE_BerkeleyDB`, fix failure building with berkeleydb.
  The related upstream issue: https://github.com/libical/libical/issues/617