### PR TITLE
[vcpkg baseline][gdk-pixbuf] Fix build issues, license, cleanup

### DIFF
--- a/ports/gdk-pixbuf/loaders-cache.patch
+++ b/ports/gdk-pixbuf/loaders-cache.patch
@@ -1,0 +1,20 @@
+diff --git a/gdk-pixbuf/meson.build b/gdk-pixbuf/meson.build
+index 54ff9dd..27f8512 100644
+--- a/gdk-pixbuf/meson.build
++++ b/gdk-pixbuf/meson.build
+@@ -348,7 +348,14 @@ foreach bin: gdkpixbuf_bin
+   set_variable(bin_name.underscorify(), bin)
+ endforeach
+ 
+-if not meson.is_cross_build()
++if dynamic_loaders.length() == 0
++  # skip tool invocation
++  cmake = find_program('cmake', required : true)
++  loaders_cache = custom_target('loaders.cache', output: 'loaders.cache', capture: true,
++                                command: [ cmake, '-E', 'echo', '# No dynamic loaders enabled at build time' ],
++                                build_by_default: true)
++  loaders_dep = declare_dependency(sources: [ loaders_cache ])
++elif not meson.is_cross_build()
+   # The 'loaders.cache' used for testing, so we don't accidentally
+   # load the installed cache; we always build it by default
+   loaders_cache = custom_target('loaders.cache',

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_gitlab(
     HEAD_REF master
     PATCHES
         fix_build_error_windows.patch
+        loaders-cache.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -41,20 +41,12 @@ if(NOT VCPKG_BUILD_TYPE)
 endif()
 vcpkg_fixup_pkgconfig()
 
-set(TOOL_NAMES gdk-pixbuf-csource gdk-pixbuf-pixdata gdk-pixbuf-query-loaders gdk-pixbuf-thumbnailer)
-
+set(TOOL_NAMES gdk-pixbuf-csource gdk-pixbuf-pixdata gdk-pixbuf-query-loaders)
 # gdk-pixbuf-thumbnailer is not compiled for cross-compiling 
-set(IS_NEED_REMOVE_THUMBNAILER ${VCPKG_CROSSCOMPILING})
-# This adjusting logic might be place in vcpkg_common_definitions.cmake.
-if(VCPKG_TARGET_IS_WINDOWS)
-    if(VCPKG_TARGET_ARCHITECTURE MATCHES "(x|X)86" OR VCPKG_TARGET_ARCHITECTURE MATCHES "(amd|AMD|x|X)64")
-        set(IS_NEED_REMOVE_THUMBNAILER false)
-    endif()
+# vcpkg-meson cross-build configuration differs from VCPKG_CROSSCOMPILING
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/gdk-pixbuf-thumbnailer${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+    list(APPEND TOOL_NAMES gdk-pixbuf-thumbnailer)
 endif()
-if(IS_NEED_REMOVE_THUMBNAILER)
-    list(REMOVE_ITEM TOOL_NAMES gdk-pixbuf-thumbnailer)
-endif()
-
 vcpkg_copy_pdbs()
 vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)
 

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -1,11 +1,8 @@
-set(GDK_PIXBUF_VERSION 2.42)
-set(GDK_PIXBUF_PATCH 9)
-
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.gnome.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/gdk-pixbuf
-    REF "${GDK_PIXBUF_VERSION}.${GDK_PIXBUF_PATCH}"
+    REF "${VERSION}"
     SHA512 3406f47b413fe3860df410a0cc0076ce47d10605b39347105690c85616739e67e5dfd0804efcad758614b0c8d1369e410b9efaa704a234bfd19686b82595b9e1
     HEAD_REF master
     PATCHES
@@ -31,29 +28,16 @@ vcpkg_configure_meson(
         -Dgio_sniffing=false        # Perform file type detection using GIO (Unused on MacOS and Windows)
         -Dbuiltin_loaders=all       # since it is unclear where loadable plugins should be located;
                                     # Comma-separated list of loaders to build into gdk-pixbuf, or "none", or "all" to build all buildable loaders into gdk-pixbuf
-    ADDITIONAL_NATIVE_BINARIES glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources'
-                               glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-                               glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
-    ADDITIONAL_CROSS_BINARIES  glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources'
-                               glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-                               glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
-        )
+    ADDITIONAL_BINARIES glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources'
+                        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+                        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+)
 vcpkg_install_meson(ADD_BIN_TO_PATH)
 
-# Fix paths in pc file.
-set(_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gdk-pixbuf-2.0.pc")
-if(EXISTS "${_file}")
-    file(READ "${_file}" _contents)
-    string(REPLACE [[${bindir}]] "\${prefix}/../tools/${PORT}" _contents "${_contents}")
-    file(WRITE "${_file}" "${_contents}")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gdk-pixbuf-2.0.pc" [[${bindir}]] "\${prefix}/tools/${PORT}")
+if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gdk-pixbuf-2.0.pc" [[${bindir}]] "\${prefix}/../tools/${PORT}")
 endif()
-set(_file "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gdk-pixbuf-2.0.pc")
-if(EXISTS "${_file}")
-    file(READ "${_file}" _contents)
-    string(REPLACE [[${bindir}]] "\${prefix}/tools/${PORT}" _contents "${_contents}")
-    file(WRITE "${_file}" "${_contents}")
-endif()
-
 vcpkg_fixup_pkgconfig()
 
 set(TOOL_NAMES gdk-pixbuf-csource gdk-pixbuf-pixdata gdk-pixbuf-query-loaders gdk-pixbuf-thumbnailer)
@@ -73,6 +57,6 @@ endif()
 vcpkg_copy_pdbs()
 vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.9",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
-  "license": "LGPL-2.1-only",
+  "license": "LGPL-2.1-or-later",
   "dependencies": [
     "gettext",
     "glib",
@@ -13,7 +13,10 @@
       "host": true
     },
     "libpng",
-    "tiff",
+    {
+      "name": "tiff",
+      "default-features": false
+    },
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2550,7 +2550,7 @@
     },
     "gdk-pixbuf": {
       "baseline": "2.42.9",
-      "port-version": 1
+      "port-version": 2
     },
     "gemmlowp": {
       "baseline": "2021-09-28",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b42054b8e96faa6387ef8df5870276df1b0902e1",
+      "version": "2.42.9",
+      "port-version": 2
+    },
+    {
       "git-tree": "ec4e9442f7771435547892134cde77081fd013d7",
       "version": "2.42.9",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes mingw cross build.
  Mitigates flaky CI results on windows by shortcutting the generation of `loaders.cache` during the build: the port configures all loaders to be built-in, so that generated file contained nothing but comment lines. But running a generated tool during the *build* [sometimes failed](https://dev.azure.com/vcpkg/public/_build/results?buildId=79644&view=logs&j=3859ca13-59fe-57bd-13f9-449df7d191a6) without clear message (oh, meson):
  ~~~
  [65/67] "D:\downloads\tools\python\python-3.10.5-x64\python.exe" "D:\installed\x64-windows\tools\meson\meson.py" "--internal" "exe" "--unpickle" "D:\buildtrees\gdk-pixbuf\x64-windows-static-dbg\meson-private\meson_exe_gdk-pixbuf-query-loaders_f7db632f23937c8e4c75e41d639308a05a9a9507.dat"
  FAILED: gdk-pixbuf/loaders.cache 
  "D:\downloads\tools\python\python-3.10.5-x64\python.exe" "D:\installed\x64-windows\tools\meson\meson.py" "--internal" "exe" "--unpickle" "D:\buildtrees\gdk-pixbuf\x64-windows-static-dbg\meson-private\meson_exe_gdk-pixbuf-query-loaders_f7db632f23937c8e4c75e41d639308a05a9a9507.dat"
  while executing ['D:\\buildtrees\\gdk-pixbuf\\x64-windows-static-dbg\\gdk-pixbuf\\gdk-pixbuf-query-loaders.exe']
  --- stderr ---
  
  ninja: build stopped: subcommand failed.
  ~~~
  Note that there is a similar *post-install* step which is not modified yet. So the installed `loaders.cache` is still generated as designed upstream.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes