### PR TITLE
[qhull] Disable tools install on iOS

### DIFF
--- a/ports/qhull/disable-tools-install.patch
+++ b/ports/qhull/disable-tools-install.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f50b187..ff654c3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -342,7 +342,7 @@ set(qhull_SHAREDR qhull_r)
+ set(qhull_SHARED libqhull)  # Temporarily avoid name conflict with qhull executable
+ set(qhull_SHAREDP qhull_p)  # libqhull and qhull_p are deprecated, use qhull_r instead
+ 
+-set(qhull_TARGETS_APPLICATIONS qhull rbox qconvex qdelaunay qvoronoi qhalf)
++set(qhull_TARGETS_APPLICATIONS )
+ set(qhull_TARGETS_STATIC ${qhull_CPP} ${qhull_STATIC} ${qhull_STATICR})
+ set(qhull_TARGETS_SHARED ${qhull_CPP} ${qhull_SHAREDR})
+ 

--- a/ports/qhull/portfile.cmake
+++ b/ports/qhull/portfile.cmake
@@ -1,12 +1,20 @@
+set(patches
+    "include-qhullcpp-shared.patch"
+    "fix-missing-symbols.patch" # upstream https://github.com/qhull/qhull/pull/93
+)
+
+# The iOS tools are not usable and cause problems with the install.
+if (VCPKG_TARGET_IS_IOS)
+    list(APPEND patches "disable-tools-install.patch")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO qhull/qhull
     REF 613debeaea72ee66626dace9ba1a2eff11b5d37d
     SHA512 5b8ff9665ba73621a9859a6e86717b980b67f8d79d6c78cbf5672bce66aed671f7d64fcbec457bca79eef2e17e105f136017afdf442bb430b9f4a059d7cb93c3
     HEAD_REF master
-    PATCHES 
-        include-qhullcpp-shared.patch
-        fix-missing-symbols.patch # upstream https://github.com/qhull/qhull/pull/93
+    PATCHES ${patches}
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC_LIBS)
@@ -53,15 +61,17 @@ if(NOT DEFINED VCPKG_BUILD_TYPE)
 endif()
 vcpkg_fixup_pkgconfig()
 
-vcpkg_copy_tools(TOOL_NAMES
-    qconvex
-    qdelaunay
-    qhalf
-    qhull
-    qvoronoi
-    rbox
-    AUTO_CLEAN
-)
+if(NOT VCPKG_TARGET_IS_IOS)
+    vcpkg_copy_tools(TOOL_NAMES
+        qconvex
+        qdelaunay
+        qhalf
+        qhull
+        qvoronoi
+        rbox
+        AUTO_CLEAN
+    )
+endif()
 
 file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME usage)
 file(INSTALL "${SOURCE_PATH}/COPYING.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/qhull/vcpkg.json
+++ b/ports/qhull/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qhull",
   "version": "8.0.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "computes the convex hull, Delaunay triangulation, Voronoi diagram",
   "homepage": "https://github.com/qhull/qhull",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5994,7 +5994,7 @@
     },
     "qhull": {
       "baseline": "8.0.2",
-      "port-version": 3
+      "port-version": 4
     },
     "qnnpack": {
       "baseline": "2021-02-26",

--- a/versions/q-/qhull.json
+++ b/versions/q-/qhull.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a58de4d2daad726db897a0add7171714cbedb39",
+      "version": "8.0.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "afe7d7f235d72db1da52a99ebe085cafd21577b3",
       "version": "8.0.2",
       "port-version": 3


### PR DESCRIPTION
CMake doesn't generate usable tool executables when cross-compiling to iOS, and the install step is broken due to invalid paths in the targets file.

- #### What does your PR fix?
  Skip installing the iOS tools, they don't run and there's no real use for them anyway.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes