### PR TITLE
[freeimage] Set default symbol visibility to hidden

### DIFF
--- a/ports/freeimage/CMakeLists.txt
+++ b/ports/freeimage/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.4)
 
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
+
 include(GNUInstallDirs)
 
 project(FreeImage C CXX)

--- a/ports/freeimage/vcpkg.json
+++ b/ports/freeimage/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "freeimage",
   "version": "3.18.0",
-  "port-version": 24,
+  "port-version": 25,
   "description": "Support library for graphics image formats",
   "homepage": "https://sourceforge.net/projects/freeimage/",
   "license": "GPL-2.0-only OR GPL-3.0-only OR FreeImage",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2430,7 +2430,7 @@
     },
     "freeimage": {
       "baseline": "3.18.0",
-      "port-version": 24
+      "port-version": 25
     },
     "freeopcua": {
       "baseline": "20190125",
@@ -7740,6 +7740,10 @@
       "baseline": "2022-05-10",
       "port-version": 1
     },
+    "vcpkg-tool-bazel": {
+      "baseline": "5.2.0",
+      "port-version": 0
+    },
     "vcpkg-tool-gn": {
       "baseline": "2022-04-16",
       "port-version": 0
@@ -7770,10 +7774,6 @@
     },
     "vcpkg-tool-python2": {
       "baseline": "2.7.18",
-      "port-version": 0
-    },
-    "vcpkg-tool-bazel": {
-      "baseline": "5.2.0",
       "port-version": 0
     },
     "vectorclass": {

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1814be19922bfdbb69b6fadf0627908ca7300485",
+      "version": "3.18.0",
+      "port-version": 25
+    },
+    {
       "git-tree": "b72eaa94f12facf42b2180bf49ff9121d9477eaa",
       "version": "3.18.0",
       "port-version": 24


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?

Fixes linker warnings when linking against `freeimage` with inconsistent visibility settings (main project has symbols hidden, linked library has symbols visible). `freeimage` is already set up correctly to export symbols for public functions etc. on all platforms it supports, so this should not break existing projects.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
   yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  I have run `vcpkg x-add-version freeimage` since this PR only affects one port.
