### PR TITLE
[sleef] does not supports arm64-osx

### DIFF
--- a/ports/sleef/vcpkg.json
+++ b/ports/sleef/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "sleef",
   "version": "3.5.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "SIMD Library for Evaluating Elementary Functions, vectorized libm and DFT",
   "homepage": "https://sleef.org/",
   "license": "BSL-1.0",
-  "supports": "!uwp & !(arm & windows)",
+  "supports": "!uwp & !(arm & windows) & !(arm64 & osx)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6918,7 +6918,7 @@
     },
     "sleef": {
       "baseline": "3.5.1",
-      "port-version": 2
+      "port-version": 3
     },
     "sleepy-discord": {
       "baseline": "2022-02-05",

--- a/versions/s-/sleef.json
+++ b/versions/s-/sleef.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd282d0004a477385c5e6487aabc83bab31059ec",
+      "version": "3.5.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "24d704091e9827b6e0192fb51f0798422da9707e",
       "version": "3.5.1",
       "port-version": 2


### PR DESCRIPTION
You get
```
[25/64] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DDORENAME=1 -DENABLE_BUILTIN_MATH=1 -DENABLE_NEON32VFPV4=1 -DSLEEF_STATIC_LIBS=1 -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/common -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/arch -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/arm64-osx-dbg/src/libm/include -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/libm -fPIC -Wall -Wno-unused -Wno-attributes -Wno-unused-result -ffp-contract=off -fno-math-errno -fno-trapping-math -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -march=armv7-a -mfpu=neon-vfpv4 -std=gnu99 -MD -MT src/libm/CMakeFiles/sleefneon32vfpv4.dir/sleefsimdsp.c.o -MF src/libm/CMakeFiles/sleefneon32vfpv4.dir/sleefsimdsp.c.o.d -o src/libm/CMakeFiles/sleefneon32vfpv4.dir/sleefsimdsp.c.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/libm/sleefsimdsp.c
FAILED: src/libm/CMakeFiles/sleefneon32vfpv4.dir/sleefsimdsp.c.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DDORENAME=1 -DENABLE_BUILTIN_MATH=1 -DENABLE_NEON32VFPV4=1 -DSLEEF_STATIC_LIBS=1 -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/common -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/arch -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/arm64-osx-dbg/src/libm/include -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/libm -fPIC -Wall -Wno-unused -Wno-attributes -Wno-unused-result -ffp-contract=off -fno-math-errno -fno-trapping-math -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -march=armv7-a -mfpu=neon-vfpv4 -std=gnu99 -MD -MT src/libm/CMakeFiles/sleefneon32vfpv4.dir/sleefsimdsp.c.o -MF src/libm/CMakeFiles/sleefneon32vfpv4.dir/sleefsimdsp.c.o.d -o src/libm/CMakeFiles/sleefneon32vfpv4.dir/sleefsimdsp.c.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/libm/sleefsimdsp.c
clang: error: the clang compiler does not support '-march=armv7-a'
```
Because arm64 is detected as arm32. I tried to fix that, but that seems to be a bigger problem. 