### PR TITLE
[graphqlparser] needs python2

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -321,6 +321,7 @@ graphicsmagick:x86-windows=fail
 graphicsmagick:x64-windows=fail
 graphicsmagick:x64-windows-static=fail
 graphicsmagick:x64-windows-static-md=fail
+graphqlparser:arm64-osx=fail # python2 required
 gstreamer:x64-osx=fail
 gstreamer:arm64-osx=fail
 gtk:x64-windows-static=fail


### PR DESCRIPTION
And there is no python2 on arm64-osx machines 