### PR TITLE
[corrosion] add new port

### DIFF
--- a/ports/corrosion/portfile.cmake
+++ b/ports/corrosion/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO AndrewGaspar/corrosion
+    REF v0.2.2
+    SHA512 ea4b4054658e7c6f8ac0aea1c12f97965fa8101de37310df8069fa24481e221683148ec0347fd3135e35b0c10695b698429a8f57d1b22ffc1c224bb671f97465
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCORROSION_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+# corrosion is a cmake only port
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME Corrosion CONFIG_PATH lib/cmake/Corrosion)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/corrosion/vcpkg.json
+++ b/ports/corrosion/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "corrosion",
+  "version": "0.2.2",
+  "description": "Marrying Rust and CMake - Easy Rust and C/C++ Integration!",
+  "homepage": "https://github.com/AndrewGaspar/corrosion",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1604,6 +1604,10 @@
       "baseline": "2020.06",
       "port-version": 4
     },
+    "corrosion": {
+      "baseline": "0.2.2",
+      "port-version": 0
+    },
     "cpp-base64": {
       "baseline": "V2.rc.08",
       "port-version": 0

--- a/versions/c-/corrosion.json
+++ b/versions/c-/corrosion.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5cc5e50956d77aebdc8faf76bffcd7d6d7ed95dd",
+      "version": "0.2.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a new port for corrosion library (https://github.com/corrosion-rs/corrosion), which is used for enabling easy Rust and c/C++ integration via CMake.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all / no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes


