### PR TITLE
[vcpkg baseline][mchehab-zbar] Fix build error on x64-windows-static

### DIFF
--- a/ports/mchehab-zbar/portfile.cmake
+++ b/ports/mchehab-zbar/portfile.cmake
@@ -27,6 +27,7 @@ vcpkg_configure_make(
         --without-java
         --without-python
         --without-qt
+        --without-xv
 )
 
 vcpkg_install_make()

--- a/ports/mchehab-zbar/vcpkg.json
+++ b/ports/mchehab-zbar/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mchehab-zbar",
   "version": "0.23.90",
+  "port-version": 1,
   "description": "ZBar is an open source software suite for reading bar codes from various sources, including webcams. This fork is actively maintained.",
   "homepage": "https://github.com/mchehab/zbar",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4734,7 +4734,7 @@
     },
     "mchehab-zbar": {
       "baseline": "0.23.90",
-      "port-version": 0
+      "port-version": 1
     },
     "mcpp": {
       "baseline": "2.7.2.14",

--- a/versions/m-/mchehab-zbar.json
+++ b/versions/m-/mchehab-zbar.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "545ecda77fa95f46216d944ca8ab1f7e12378930",
+      "version": "0.23.90",
+      "port-version": 1
+    },
+    {
       "git-tree": "7c066057a5c24bbea65e26e9e7519db938a2932e",
       "version": "0.23.90",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes [baseline](https://dev.azure.com/vcpkg/public/_build/results?buildId=79790&view=results) build error on `x64-windows-static` and `x64-windows-static-md`:
```
checking for XvQueryExtension in -lXv... no
configure: error: in `/d/buildtrees/mchehab-zbar/x64-windows-static-dbg':
configure: error: unable to find XvQueryExtension in -lXv!
specify XV_LIBS or configure --without-xv to disable the extension
```

cc @Ulysses1337
