### PR TITLE
[dxut] port updated for October 2022 release

### DIFF
--- a/ports/dxut/portfile.cmake
+++ b/ports/dxut/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/DXUT
-    REF aug2022
-    SHA512 33552c4ced7a2e5653e3af9eda19dc48e3794c67e02b1588a96f2b964e552137930f5b6a9ff26b9377074137a743cbf7bd654b3d17bca442a7b667eff6d9eff8
+    REF oct2022
+    SHA512 3d6a56421b51012a33caf19c8f28319cfccf52d32f264f02ea72ad32ec208eaf94491f768ca2cbb3bee2c187d04559c48c291b04f9a41fb4763f68ac5b21d5f5
     HEAD_REF main
 )
 
@@ -25,3 +25,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/dxut)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+

--- a/ports/dxut/vcpkg.json
+++ b/ports/dxut/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dxut",
-  "version": "11.28",
+  "version": "11.29",
   "description": "A \"GLUT\"-like framework for Direct3D 11.x Win32 desktop applications",
   "homepage": "https://github.com/Microsoft/DXUT",
   "documentation": "https://github.com/microsoft/DXUT/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2057,7 +2057,7 @@
       "port-version": 4
     },
     "dxut": {
-      "baseline": "11.28",
+      "baseline": "11.29",
       "port-version": 0
     },
     "eabase": {

--- a/versions/d-/dxut.json
+++ b/versions/d-/dxut.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fa94b0dfe6b9fabe7953ee06880f764f461821a",
+      "version": "11.29",
+      "port-version": 0
+    },
+    {
       "git-tree": "6b3dc36eb04da0286e4e2c5515a07cf7dbda4c03",
       "version": "11.28",
       "port-version": 0


### PR DESCRIPTION
I recently updated my MinGW test pipelines to GNUC 12.2, and I encountered a build `-Wnarrowing` error with this library.  Since this was fatal instead of a warning, I fixed it [upstream](https://github.com/microsoft/DXUT/commit/f9ef692dedad07e710f6ac3c2064f7fa8d673ce2).
