### PR TITLE
[ode] Fix error C3861

### DIFF
--- a/ports/ode/fix-error-C3861.patch
+++ b/ports/ode/fix-error-C3861.patch
@@ -1,0 +1,20 @@
+diff --git a/ou/include/ou/atomic.h b/ou/include/ou/atomic.h
+index 2f90a70..33e0ab9 100644
+--- a/ou/include/ou/atomic.h
++++ b/ou/include/ou/atomic.h
+@@ -397,6 +397,7 @@ END_NAMESPACE_OU();
+ 
+ #include <windows.h>
+ #include <stddef.h>
++#include <intrin.h>
+ 
+ 
+ BEGIN_NAMESPACE_OU();
+@@ -574,7 +575,6 @@ static _OU_ALWAYSINLINE bool _OU_CONVENTION_API
+ 
+ #define __OU_ATOMIC_READREORDERBARRIER_FUNCTION_DEFINED
+ 
+-#include <intrin.h>
+ 
+ static _OU_ALWAYSINLINE void _OU_CONVENTION_API 
+ /*void */AtomicReadReorderBarrier()

--- a/ports/ode/portfile.cmake
+++ b/ports/ode/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_bitbucket(
     REF 0.16.1
     SHA512 04429cae1b8fc703e53880c5de78293cee46fe4855c96ca7006bd5848255a0df004b75716a6b30ff5176df004e2bec29b2a31d4af8e7ac59da18f0af2eed8396
     HEAD_REF master
+    PATCHES fix-error-C3861.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/ode/portfile.cmake
+++ b/ports/ode/portfile.cmake
@@ -4,12 +4,15 @@ vcpkg_from_bitbucket(
     REF 0.16.1
     SHA512 04429cae1b8fc703e53880c5de78293cee46fe4855c96ca7006bd5848255a0df004b75716a6b30ff5176df004e2bec29b2a31d4af8e7ac59da18f0af2eed8396
     HEAD_REF master
-    PATCHES fix-error-C3861.patch
+    PATCHES
+        fix-error-C3861.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS -DODE_WITH_DEMOS=0 -DODE_WITH_TESTS=0
+    OPTIONS
+        -DODE_WITH_DEMOS=0
+        -DODE_WITH_TESTS=0
 )
 
 vcpkg_cmake_install()

--- a/ports/ode/vcpkg.json
+++ b/ports/ode/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "0.16.1",
   "port-version": 4,
   "description": "Open Dynamics Engine",
-  "homepage": "https://bitbucket.org/odedevs/ode/src/default/",
+  "homepage": "https://bitbucket.org/odedevs/ode/src/master/",
   "license": "BSD-3-Clause OR LGPL-2.1-or-later",
   "dependencies": [
     {

--- a/ports/ode/vcpkg.json
+++ b/ports/ode/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "ode",
   "version": "0.16.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Open Dynamics Engine",
   "homepage": "https://bitbucket.org/odedevs/ode/src/default/",
+  "license": "BSD-3-Clause OR LGPL-2.1-or-later",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5314,7 +5314,7 @@
     },
     "ode": {
       "baseline": "0.16.1",
-      "port-version": 3
+      "port-version": 4
     },
     "offscale-libetcd-cpp": {
       "baseline": "2019-07-10",

--- a/versions/o-/ode.json
+++ b/versions/o-/ode.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f78f16bb5953f1d0b796d678797123a79ad31bab",
+      "git-tree": "205b8fbadd2afe4fb17b6f161ead18ec7dd0e735",
       "version": "0.16.1",
       "port-version": 4
     },

--- a/versions/o-/ode.json
+++ b/versions/o-/ode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f78f16bb5953f1d0b796d678797123a79ad31bab",
+      "version": "0.16.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "8bc51447289df2b0693e433dace17ac0facbeba9",
       "version": "0.16.1",
       "port-version": 3


### PR DESCRIPTION
In an internal version of Visual Studio, `ode` install failed with following error:
```
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1433~1.316\bin\Hostx64\x64\cl.exe   /TP -DCCD_IDEDOUBLE -DODE_DLL -DODE_EXPORTS -D_CRT_SECURE_NO_DEPRECATE -D_OU_FEATURE_SET=_OU_FEATURE_SET_ATOMICS -D_OU_NAMESPACE=odeou -D_OU_TARGET_OS=_OU_TARGET_OS_WINDOWS -D_SCL_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES -DdATOMICS_ENABLED -DdBUILTIN_THREADING_IMPL_ENABLED -DdIDEDOUBLE -DdOU_ENABLED -DdTRIMESH_ENABLED -DdTRIMESH_OPCODE -IF:\Lily\1017\buildtrees\ode\x64-windows-dbg\include -IF:\Lily\1017\buildtrees\ode\x64-windows-dbg\ode\src -IF:\Lily\1017\buildtrees\ode\src\0.16.1-4fa7add51b.clean\include -IF:\Lily\1017\buildtrees\ode\src\0.16.1-4fa7add51b.clean\ode\src -IF:\Lily\1017\buildtrees\ode\src\0.16.1-4fa7add51b.clean\ode\src\joints -IF:\Lily\1017\buildtrees\ode\src\0.16.1-4fa7add51b.clean\ou\include -IF:\Lily\1017\buildtrees\ode\src\0.16.1-4fa7add51b.clean\OPCODE -IF:\Lily\1017\buildtrees\ode\src\0.16.1-4fa7add51b.clean\OPCODE\Ice /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1 /showIncludes /FoCMakeFiles\ODE.dir\ode\src\fastldltfactor.cpp.obj /FdCMakeFiles\ODE.dir\ /FS -c F:\Lily\1017\buildtrees\ode\src\0.16.1-4fa7add51b.clean\ode\src\fastldltfactor.cpp
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\include\__msvc_int128.hpp(115): error C3861: '_addcarry_u64': identifier not found
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\include\__msvc_int128.hpp(129): error C3861: '_subborrow_u64': identifier not found
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\include\__msvc_int128.hpp(247): error C3861: '_udiv128': identifier not found
```
This error is caused by `atomic.h` is including MSVC's `<intrin.h>` in a namespace. This ends up declaring `_addcarry_u64` etc. within `namespace odeou`, so later when `<__msvc_int128.hpp>` tries to use those intrinsics, they can't be found (in the global namespace where they should be). This error will be fixed by moving `#include <intrin.h>` from Line 577 to Line 400 in file _[SOURCE_PATH]/ou/include/ou/atomic.h_
I have submitted an issue on upstream: https://bitbucket.org/odedevs/ode/issues/78/ode-build-failed-with-error-c3861-in-msvc