### PR TITLE
[glbinding] Fix CMake warnings

### DIFF
--- a/ports/glbinding/portfile.cmake
+++ b/ports/glbinding/portfile.cmake
@@ -18,9 +18,10 @@ vcpkg_cmake_configure(
         -DOPTION_BUILD_TOOLS=OFF
         -DOPTION_BUILD_EXAMPLES=OFF
         -DGIT_REV=0
+        -DCMAKE_DISABLE_FIND_PACKAGE_cpplocate=ON
         -DOPTION_BUILD_EXAMPLES=OFF
     MAYBE_UNUSED_VARIABLES
-        -DCMAKE_DISABLE_FIND_PACKAGE_cpplocate=ON
+        CMAKE_DISABLE_FIND_PACKAGE_cpplocate
 )
 
 vcpkg_cmake_install()

--- a/ports/glbinding/portfile.cmake
+++ b/ports/glbinding/portfile.cmake
@@ -11,21 +11,20 @@ vcpkg_from_github(
         0004_fix-config-expected-paths.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DOPTION_BUILD_TESTS=OFF
-        -DOPTION_BUILD_GPU_TESTS=OFF
         -DOPTION_BUILD_TOOLS=OFF
         -DOPTION_BUILD_EXAMPLES=OFF
         -DGIT_REV=0
-        -DCMAKE_DISABLE_FIND_PACKAGE_cpplocate=ON
         -DOPTION_BUILD_EXAMPLES=OFF
+    MAYBE_UNUSED_VARIABLES
+        -DCMAKE_DISABLE_FIND_PACKAGE_cpplocate=ON
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/glbinding)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
 vcpkg_copy_pdbs()
 
 ## _IMPORT_PREFIX needs to go up one extra level in the directory tree.
@@ -48,12 +47,12 @@ get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
     file(WRITE ${TARGET_CMAKE} "${_contents}")
 endforeach()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Remove files already published by egl-registry
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/KHR)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/KHR")
 
 # Handle copyright
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/glbinding/LICENSE ${CURRENT_PACKAGES_DIR}/share/glbinding/copyright)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/glbinding/usage @ONLY)
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)

--- a/ports/glbinding/vcpkg.json
+++ b/ports/glbinding/vcpkg.json
@@ -1,10 +1,19 @@
 {
   "name": "glbinding",
   "version-string": "3.1.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "glbinding is an MIT licensed, cross-platform C++ binding for the OpenGL API",
   "homepage": "https://github.com/cginternals/glbinding",
+  "license": "MIT",
   "dependencies": [
-    "egl-registry"
+    "egl-registry",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/glbinding/vcpkg.json
+++ b/ports/glbinding/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glbinding",
-  "version-string": "3.1.0",
+  "version": "3.1.0",
   "port-version": 4,
   "description": "glbinding is an MIT licensed, cross-platform C++ binding for the OpenGL API",
   "homepage": "https://github.com/cginternals/glbinding",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2634,7 +2634,7 @@
     },
     "glbinding": {
       "baseline": "3.1.0",
-      "port-version": 3
+      "port-version": 4
     },
     "glew": {
       "baseline": "2.2.0",

--- a/versions/g-/glbinding.json
+++ b/versions/g-/glbinding.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "263ca20312a93de0c46928a2f1861e91c2a01a2f",
+      "git-tree": "5932f5a201e721aa59a787380b9448e1018bb4b3",
       "version": "3.1.0",
       "port-version": 4
     },

--- a/versions/g-/glbinding.json
+++ b/versions/g-/glbinding.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "263ca20312a93de0c46928a2f1861e91c2a01a2f",
+      "version": "3.1.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "6feb489ecd418b013262401ff4911eccf5c03deb",
       "version-string": "3.1.0",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/27418 
  
  Remove `OPTION_BUILD_GPU_TESTS` because it has been removed in upstream by https://github.com/cginternals/glbinding/commit/52e1b5786ea3874d7f8c3a7878f76a4002cd5748
  Add `CMAKE_DISABLE_FIND_PACKAGE_cpplocate` into the `MAYBE_UNUSED_VARIABLES`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
