### PR TITLE
[quill] Update to 2.3.0

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
-    REF v2.2.0
-    SHA512 cf9ef0f45f6afad38aebcfb7884dc52207d09416cc42c01710b6bbb9ade9ff1cb0d58d7dd8b09a9e08457fbeeddcccb73a75316c1c80dc4241652b2b7786ebb6
+    REF v2.3.0
+    SHA512 6f3e905ea04adcf2d93e51b2065749523bc5a5c47400273c7f21049c6178d4e74e6541d8785bd1e5f81b7eafda301a5ebf8f19c989ca296c31a4568435364457
     HEAD_REF master
 )
 

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "C++14 Asynchronous Low Latency Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6381,7 +6381,7 @@
       "port-version": 8
     },
     "quill": {
-      "baseline": "2.2.0",
+      "baseline": "2.3.0",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "970b5bf8d060f0cd51048c922226b755c21ac4b8",
+      "version": "2.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a49ab25dd1b0c7287b11f8ca4c0ba4a0117658cc",
       "version": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Update Quill port from 2.2.0 to 2.3.0 : https://github.com/odygrd/quill/releases/tag/v2.3.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Unchanged

- #### Does your PR follow the [maintainer guide]
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes
