### PR TITLE
[tinyxml2]: do not force export the symbols when building statically

### DIFF
--- a/ports/tinyxml2/0001-fix-do-not-force-export-the-symbols-when-building-st.patch
+++ b/ports/tinyxml2/0001-fix-do-not-force-export-the-symbols-when-building-st.patch
@@ -1,0 +1,45 @@
+From a512d312db5604efe803a6fe088e7d582e04533f Mon Sep 17 00:00:00 2001
+From: Amin Yahyaabadi <aminyahyaabadi74@gmail.com>
+Date: Wed, 26 Oct 2022 18:21:29 -0700
+Subject: [PATCH] fix: do not force export the symbols when building statically
+
+---
+ CMakeLists.txt | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8802fb8..87cda90 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,8 +16,10 @@ endif ()
+ ## Main library build
+ ##
+ 
+-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+-set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
++if (BUILD_SHARED_LIBS)
++    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
++    set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
++endif()
+ 
+ add_library(tinyxml2 tinyxml2.cpp tinyxml2.h)
+ add_library(tinyxml2::tinyxml2 ALIAS tinyxml2)
+@@ -36,11 +38,14 @@ target_compile_definitions(
+ set_target_properties(
+     tinyxml2
+     PROPERTIES
+-    DEFINE_SYMBOL "TINYXML2_EXPORT"
+     VERSION "${tinyxml2_VERSION}"
+     SOVERSION "${tinyxml2_VERSION_MAJOR}"
+ )
+ 
++if(BUILD_SHARED_LIBS)
++    target_compile_definitions(tinyxml2 PRIVATE "TINYXML2_EXPORT")
++endif()
++
+ if (tinyxml2_BUILD_TESTING)
+     add_executable(xmltest xmltest.cpp)
+     target_link_libraries(xmltest PRIVATE tinyxml2::tinyxml2)
+-- 
+2.37.3.windows.1
+

--- a/ports/tinyxml2/0002-fix-check-for-TINYXML2_EXPORT-on-non-windows.patch
+++ b/ports/tinyxml2/0002-fix-check-for-TINYXML2_EXPORT-on-non-windows.patch
@@ -1,0 +1,26 @@
+From 632c311b18015d194151489bb0773a28eed9c2e1 Mon Sep 17 00:00:00 2001
+From: Amin Yahyaabadi <aminyahyaabadi74@gmail.com>
+Date: Thu, 27 Oct 2022 19:06:52 -0700
+Subject: [PATCH 2/2] fix: check for TINYXML2_EXPORT on non windows
+
+---
+ tinyxml2.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tinyxml2.h b/tinyxml2.h
+index cfb1053..a56251c 100755
+--- a/tinyxml2.h
++++ b/tinyxml2.h
+@@ -72,7 +72,8 @@ distribution.
+ #   else
+ #       define TINYXML2_LIB
+ #   endif
+-#elif __GNUC__ >= 4
++#endif
++#if defined(TINYXML2_EXPORT) && __GNUC__ >= 4
+ #   define TINYXML2_LIB __attribute__((visibility("default")))
+ #else
+ #   define TINYXML2_LIB
+-- 
+2.37.3.windows.1
+

--- a/ports/tinyxml2/0002-fix-check-for-TINYXML2_EXPORT-on-non-windows.patch
+++ b/ports/tinyxml2/0002-fix-check-for-TINYXML2_EXPORT-on-non-windows.patch
@@ -1,23 +1,22 @@
-From 632c311b18015d194151489bb0773a28eed9c2e1 Mon Sep 17 00:00:00 2001
+From 4beabf9fe05a049577e3923327804851d6a05f24 Mon Sep 17 00:00:00 2001
 From: Amin Yahyaabadi <aminyahyaabadi74@gmail.com>
 Date: Thu, 27 Oct 2022 19:06:52 -0700
-Subject: [PATCH 2/2] fix: check for TINYXML2_EXPORT on non windows
+Subject: [PATCH] fix: check for TINYXML2_EXPORT on non windows
 
 ---
- tinyxml2.h | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ tinyxml2.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/tinyxml2.h b/tinyxml2.h
-index cfb1053..a56251c 100755
+index cfb1053..5a36901 100755
 --- a/tinyxml2.h
 +++ b/tinyxml2.h
-@@ -72,7 +72,8 @@ distribution.
+@@ -72,7 +72,7 @@ distribution.
  #   else
  #       define TINYXML2_LIB
  #   endif
 -#elif __GNUC__ >= 4
-+#endif
-+#if defined(TINYXML2_EXPORT) && __GNUC__ >= 4
++#elif defined(TINYXML2_EXPORT) && __GNUC__ >= 4
  #   define TINYXML2_LIB __attribute__((visibility("default")))
  #else
  #   define TINYXML2_LIB

--- a/ports/tinyxml2/portfile.cmake
+++ b/ports/tinyxml2/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 9.0.0
     SHA512 9C5CE8131984690DF302CA3E32314573B137180ED522C92FD631692979C942372A28F697FDB3D5E56BCF2D3DC596262B724D088153F3E1D721C9536F2A883367
     HEAD_REF master
+    PATCHES
+        0001-fix-do-not-force-export-the-symbols-when-building-st.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/tinyxml2/portfile.cmake
+++ b/ports/tinyxml2/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         0001-fix-do-not-force-export-the-symbols-when-building-st.patch
+        0002-fix-check-for-TINYXML2_EXPORT-on-non-windows.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/tinyxml2/vcpkg.json
+++ b/ports/tinyxml2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyxml2",
   "version-semver": "9.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A simple, small, efficient, C++ XML parser",
   "homepage": "https://github.com/leethomason/tinyxml2",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7438,7 +7438,7 @@
     },
     "tinyxml2": {
       "baseline": "9.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "tl-expected": {
       "baseline": "1.0.0",

--- a/versions/t-/tinyxml2.json
+++ b/versions/t-/tinyxml2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "29c1c3aaa87957356e4c83b54767b80e3dd89fa2",
+      "git-tree": "fca8e408ee125d30e546ba42bd9caf4955ab7430",
       "version-semver": "9.0.0",
       "port-version": 2
     },

--- a/versions/t-/tinyxml2.json
+++ b/versions/t-/tinyxml2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fca8e408ee125d30e546ba42bd9caf4955ab7430",
+      "git-tree": "c88f30e7ca28b2de522a19a7c7b6d318664e3860",
       "version-semver": "9.0.0",
       "port-version": 2
     },

--- a/versions/t-/tinyxml2.json
+++ b/versions/t-/tinyxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29c1c3aaa87957356e4c83b54767b80e3dd89fa2",
+      "version-semver": "9.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5ef0e856167ad66665f51776d78fcffb1fcc1cb1",
       "version-semver": "9.0.0",
       "port-version": 1


### PR DESCRIPTION

**Describe the pull request**

- #### What does your PR fix?
See https://github.com/leethomason/tinyxml2/pull/922


- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
 all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
