### PR TITLE
[libsrtp] Fix DLL destination and mingw

### DIFF
--- a/ports/libsrtp/cmake-project-include.cmake
+++ b/ports/libsrtp/cmake-project-include.cmake
@@ -1,0 +1,3 @@
+if(MSVC)
+    string(APPEND CMAKE_CFLAGS " /wd4703")
+endif()

--- a/ports/libsrtp/fix-runtime-destination.patch
+++ b/ports/libsrtp/fix-runtime-destination.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d548e78..4a839e2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -262,6 +262,7 @@ endif()
+ 
+ install(TARGETS srtp2 DESTINATION lib
+   EXPORT libSRTPTargets
++  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+ )
+ 
+ install(FILES include/srtp.h crypto/include/auth.h

--- a/ports/libsrtp/portfile.cmake
+++ b/ports/libsrtp/portfile.cmake
@@ -9,16 +9,15 @@ vcpkg_from_github(
     REPO cisco/libsrtp
     REF v2.4.2
     SHA512 6E4805E6D34B2050A6F68F629B0B42356B1D27F2CBAA6CC6166E56957609C3D9AA6B723DCC674E5C74180D122D27BADD2F9496639CCB1E0C210B9E1F7949D0E2
-    PATCHES ${CMAKE_PR_PATCH}
+    PATCHES 
+        ${CMAKE_PR_PATCH}
+        fix-runtime-destination.patch
 )
-
-if (VCPKG_TARGET_IS_WINDOWS)
-    set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} /wd4703")
-    set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} /wd4703")
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DCMAKE_PROJECT_INCLUDE=${CMAKE_CURRENT_LIST_DIR}/cmake-project-include.cmake"
 )
 
 vcpkg_cmake_install()
@@ -28,14 +27,5 @@ vcpkg_cmake_config_fixup(
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/srtp2.dll")
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/lib/srtp2.dll" "${CURRENT_PACKAGES_DIR}/bin/srtp2.dll")
-endif()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/srtp2.dll")
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/srtp2.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/srtp2.dll")
-endif()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libsrtp" RENAME copyright)

--- a/ports/libsrtp/vcpkg.json
+++ b/ports/libsrtp/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libsrtp",
   "version": "2.4.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "This package provides an implementation of the Secure Real-time Transport Protocol (SRTP), the Universal Security Transform (UST), and a supporting cryptographic kernel.",
+  "homepage": "https://github.com/cisco/libsrtp/",
   "license": null,
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4230,7 +4230,7 @@
     },
     "libsrtp": {
       "baseline": "2.4.2",
-      "port-version": 2
+      "port-version": 3
     },
     "libssh": {
       "baseline": "0.10.4",

--- a/versions/l-/libsrtp.json
+++ b/versions/l-/libsrtp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d66d808ef040f2802ffa00ec6c4728d5603e76f9",
+      "version": "2.4.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "7c935c9b1559cab3460f928c2a6abb25271cfb65",
       "version": "2.4.2",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/27538. Should fix https://github.com/microsoft/vcpkg/issues/20721.
  Replaces https://github.com/microsoft/vcpkg/pull/27296 by @FrankXie05 .

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  fixes mingw, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes