### PR TITLE
[glib] Update and cleanup

### DIFF
--- a/ports/glib/libintl.patch
+++ b/ports/glib/libintl.patch
@@ -2,46 +2,16 @@ diff --git a/meson.build b/meson.build
 index f44fa2d4e..d465253af 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2090,37 +2090,10 @@ libz_dep = dependency('zlib')
+@@ -2090,9 +2090,9 @@ libz_dep = dependency('zlib')
  # proxy-libintl subproject.
  # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
  # implementations. This could be extended if issues are found in some platforms.
 -libintl_deps = []
 -libintl = dependency('intl', required: false)
 -if libintl.found()
--  # libintl supports different threading APIs, which may not
--  # require additional flags, but it defaults to using pthreads if
--  # found. Meson's "threads" dependency does not allow you to
--  # prefer pthreads. We may not be using pthreads for glib itself
--  # either so just link the library to satisfy libintl rather than
--  # also defining the macros with the -pthread flag.
--  #
--  # Meson's builtin dependency lookup as of 0.60.0 doesn't check for
--  # pthread, so we do this manually here.
--  if cc.has_function('ngettext', dependencies : libintl)
--    libintl_deps += [libintl]
--  else
--    libintl_pthread = cc.find_library('pthread', required : false)
--    if libintl_pthread.found() and cc.has_function('ngettext', dependencies : [libintl, libintl_pthread])
--      libintl_deps += [libintl, libintl_pthread]
--    else
--      libintl = disabler()
--    endif
--  endif
--endif
--
--if libintl.found()
--  have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset', dependencies: libintl_deps)
--else
--  libintl = subproject('proxy-libintl').get_variable('intl_dep')
--  libintl_deps = [libintl]
--  have_bind_textdomain_codeset = true  # proxy-libintl supports it
--endif
 +libintl = dependency('Intl', method:'cmake', required : true)
 +libintl_deps = [libintl]
-+have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset',
-+                                                   dependencies : libintl_deps)
- 
- glib_conf.set('HAVE_BIND_TEXTDOMAIN_CODESET', have_bind_textdomain_codeset)
- 
-
++if false
+   # libintl supports different threading APIs, which may not
+   # require additional flags, but it defaults to using pthreads if
+   # found. Meson's "threads" dependency does not allow you to

--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -1,23 +1,23 @@
-set(GLIB_MAJOR_MINOR 2.74)
-set(GLIB_PATCH 0)
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
+string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIB_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIB_ARCHIVE
-    URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${GLIB_MAJOR_MINOR}.${GLIB_PATCH}.tar.xz"
-    FILENAME "glib-${GLIB_MAJOR_MINOR}.${GLIB_PATCH}.tar.xz"
-    SHA512 5cdadd2f4568c0c3d45083b4d39699abf651e42e020f7bc880cce3ff33d28943118388d17a0632777e843f48009c1f97d5634fde3cb8c69c7c7f35b278ac8225
+    URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${VERSION}.tar.xz"
+    FILENAME "glib-${VERSION}.tar.xz"
+    SHA512 21176cb95fcab49a781d02789bf21191a96a34a6391f066699b3c20b414b3169c958bd86623deb34ca55912083862885f7a7d12b67cc041467da2ba94d9e83c3
 )
 
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE ${GLIB_ARCHIVE}
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${GLIB_ARCHIVE}"
     PATCHES
         use-libiconv-on-windows.patch
         libintl.patch
 )
 
+vcpkg_list(SET OPTIONS)
 if (selinux IN_LIST FEATURES)
-    if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT EXISTS "/usr/include/selinux")
-        message("Selinux was not found in its typical system location. Your build may fail. You can install Selinux with \"apt-get install selinux libselinux1-dev\".")
+    if(NOT EXISTS "/usr/include/selinux")
+        message(WARNING "SELinux was not found in its typical system location. Your build may fail. You can install SELinux with \"apt-get install selinux libselinux1-dev\".")
     endif()
     list(APPEND OPTIONS -Dselinux=enabled)
 else()
@@ -37,75 +37,64 @@ endif()
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -Dinstalled_tests=false
         ${OPTIONS}
+        -Dgtk_doc=false
+        -Dinstalled_tests=false
+        -Dlibelf=disabled
+        -Dman=false
         -Dtests=false
         -Dxattr=false
-        -Dlibelf=disabled
 )
-
 vcpkg_install_meson(ADD_BIN_TO_PATH)
-
 vcpkg_copy_pdbs()
 
-set(GLIB_TOOLS gdbus
-               gio
-               gio-querymodules
-               glib-compile-resources
-               glib-compile-schemas
-               gobject-query
-               gresource
-               gsettings
-               )
-
-if(NOT VCPKG_TARGET_IS_WINDOWS)
-    if(NOT VCPKG_TARGET_IS_OSX)
-        list(APPEND GLIB_TOOLS gapplication)
-    endif()
-    list(APPEND GLIB_TOOLS glib-gettextize gtester)
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+set(GLIB_SCRIPTS
+    gdbus-codegen
+    glib-genmarshal
+    glib-gettextize
+    glib-mkenums
+    gtester-report
+)
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    list(REMOVE_ITEM GLIB_SCRIPTS glib-gettextize)
 endif()
-set(GLIB_SCRIPTS gdbus-codegen glib-genmarshal glib-mkenums gtester-report)
-
-
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "x64|arm64")
-    list(APPEND GLIB_TOOLS  gspawn-win64-helper${VCPKG_EXECUTABLE_SUFFIX}
-                            gspawn-win64-helper-console${VCPKG_EXECUTABLE_SUFFIX})
-elseif(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-    list(APPEND GLIB_TOOLS  gspawn-win32-helper${VCPKG_EXECUTABLE_SUFFIX}
-                            gspawn-win32-helper-console${VCPKG_EXECUTABLE_SUFFIX})
-endif()
-vcpkg_copy_tools(TOOL_NAMES ${GLIB_TOOLS} AUTO_CLEAN)
 foreach(script IN LISTS GLIB_SCRIPTS)
     file(RENAME "${CURRENT_PACKAGES_DIR}/bin/${script}" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/${script}")
     file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${script}")
 endforeach()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+set(GLIB_TOOLS
+    gapplication
+    gdbus
+    gio
+    gio-querymodules
+    glib-compile-resources
+    glib-compile-schemas
+    gobject-query
+    gresource
+    gsettings
+    gtester
+)
+if(VCPKG_TARGET_IS_WINDOWS)
+    list(REMOVE_ITEM GLIB_TOOLS gapplication gtester)
+    if(VCPKG_TARGET_ARCHITECTURE MATCHES "x64|arm64")
+        list(APPEND GLIB_TOOLS gspawn-win64-helper gspawn-win64-helper-console)
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+        list(APPEND GLIB_TOOLS gspawn-win32-helper gspawn-win32-helper-console)
+    endif()
+elseif(VCPKG_TARGET_IS_OSX)
+    list(REMOVE_ITEM GLIB_TOOLS gapplication)
 endif()
+vcpkg_copy_tools(TOOL_NAMES ${GLIB_TOOLS} AUTO_CLEAN)
 
-IF(VCPKG_TARGET_IS_WINDOWS)
-    set(SYSTEM_LIBRARIES dnsapi iphlpapi winmm lshlwapi)
-else()
-    set(SYSTEM_LIBRARIES resolv mount blkid selinux)
-endif()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gio-2.0.pc")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gio-2.0.pc" "\${bindir}" "\${prefix}/tools/${PORT}")
-endif()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gio-2.0.pc")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gio-2.0.pc" "\${bindir}" "\${prefix}/tools/${PORT}")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/glib-2.0.pc" "\${bindir}" "\${prefix}/tools/${PORT}")
+if(NOT VCPKG_BUILD_TYPE)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gio-2.0.pc" "\${bindir}" "\${prefix}/../tools/${PORT}")
-endif()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/glib-2.0.pc")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/glib-2.0.pc" "\${bindir}" "\${prefix}/tools/${PORT}")
-endif()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/glib-2.0.pc")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/glib-2.0.pc" "\${bindir}" "\${prefix}/../tools/${PORT}")
 endif()
-vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES})
-
-file(INSTALL "${SOURCE_PATH}/LICENSES/LGPL-2.1-or-later.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_fixup_pkgconfig()
 
 # Fix python scripts
 set(_file "${CURRENT_PACKAGES_DIR}/tools/${PORT}/gdbus-codegen")
@@ -114,10 +103,16 @@ string(REPLACE "elif os.path.basename(filedir) == 'bin':" "elif os.path.basename
 string(REPLACE "path = os.path.join(filedir, '..', 'share', 'glib-2.0')" "path = os.path.join(filedir, '../..', 'share', 'glib-2.0')" _contents "${_contents}")
 string(REPLACE "path = os.path.join(filedir, '..')" "path = os.path.join(filedir, '../../share/glib-2.0')" _contents "${_contents}")
 string(REPLACE "path = os.path.join('${CURRENT_PACKAGES_DIR}/share', 'glib-2.0')" "path = os.path.join('unuseable/share', 'glib-2.0')" _contents "${_contents}")
-
 file(WRITE "${_file}" "${_contents}")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/gdb")
-if(EXISTS "${CURRENT_PACKAGES_DIR}/tools/glib/glib-gettextize")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/glib/glib-gettextize" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../..")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/tools/${PORT}/glib-gettextize")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/glib-gettextize" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../..")
 endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/gdb"
+)
+
+file(INSTALL "${SOURCE_PATH}/LICENSES/LGPL-2.1-or-later.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "glib",
-  "version": "2.74.0",
+  "version": "2.74.1",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
-  "license": "LGPL-2.1-only",
+  "license": "LGPL-2.1-or-later",
   "supports": "!uwp",
   "dependencies": [
     "dirent",
@@ -26,7 +26,8 @@
       ]
     },
     "selinux": {
-      "description": "Build with selinux support."
+      "description": "Build with selinux support.",
+      "supports": "linux"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2649,7 +2649,7 @@
       "port-version": 0
     },
     "glib": {
-      "baseline": "2.74.0",
+      "baseline": "2.74.1",
       "port-version": 0
     },
     "glibmm": {

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "62e6236281de8dd6bd983d4d51721374e5559c7c",
+      "version": "2.74.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "97fc41e084d04073610421cbdf4bfae0e89fb99c",
       "version": "2.74.0",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Updates glib to 2.74.1. Fixes #27409.
  Portfile cleanup.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no
  Tested mingw on linux.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes