### PR TITLE
[libepoxy] Add dependencies egl-registry and libx11-dev on Linux

### DIFF
--- a/ports/libepoxy/portfile.cmake
+++ b/ports/libepoxy/portfile.cmake
@@ -2,8 +2,8 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
-if(VCPKG_TARGET_IS_LINUX AND NOT EXISTS "/usr/share/doc/libgles2/copyright")
-    message(STATUS "libgles2-mesa-dev must be installed before libepoxy can build. Install it with \"apt-get install libgles2-mesa-dev\".")
+if (VCPKG_TARGET_IS_LINUX)
+    message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libx11-dev\n    libgles2-mesa-dev\n\nThese can be installed on Ubuntu systems via apt-get install libx11-dev libgles2-mesa-dev.")
 endif()
 
 vcpkg_from_github(

--- a/ports/libepoxy/vcpkg.json
+++ b/ports/libepoxy/vcpkg.json
@@ -1,10 +1,15 @@
 {
   "name": "libepoxy",
   "version": "1.5.10",
+  "port-version": 1,
   "description": "Epoxy is a library for handling OpenGL function pointer management for you",
   "homepage": "https://github.com/anholt/libepoxy",
   "license": "MIT",
   "dependencies": [
+    {
+      "name": "egl-registry",
+      "platform": "linux"
+    },
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3686,7 +3686,7 @@
     },
     "libepoxy": {
       "baseline": "1.5.10",
-      "port-version": 0
+      "port-version": 1
     },
     "libevent": {
       "baseline": "2.1.12",

--- a/versions/l-/libepoxy.json
+++ b/versions/l-/libepoxy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76a3ae8e21ad9736741ecc58522805647fdbb7b9",
+      "version": "1.5.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "85d5a7075e2450d79759e0a3ec618e9ebf07b0ea",
       "version": "1.5.10",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #27507, fixes #24039, add dependencies `egl-registry` and `libx11-dev` for `libepoxy`, fix the following error:
```
../src/1.5.10-92989bd778.clean/include/epoxy/glx.h:36:10: fatal error: X11/Xlib.h: No such file or directory
   36 | #include <X11/Xlib.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```
```
[7/14] /usr/bin/cc -Isrc/libepoxy.a.p -Isrc -I../src/1.5.9-fb4e410a2d.clean/src -Iinclude -I../src/1.5.9-fb4e410a2d.clean/include -Iinclude/epoxy -I/home/bdmc/Downloads/vcpkg/installed/x64-linux/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu99 -g -fPIC -g -fPIC -Wpointer-arith -Wmissing-declarations -Wformat=2 -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wbad-function-cast -Wold-style-definition -Wdeclaration-after-statement -Wunused -Wuninitialized -Wshadow -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wlogical-op -Werror=implicit -Werror=nonnull -Werror=init-self -Werror=main -Werror=missing-braces -Werror=sequence-point -Werror=return-type -Werror=trigraphs -Werror=array-bounds -Werror=write-strings -Werror=address -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -fno-strict-aliasing -Wno-int-conversion -MD -MQ src/libepoxy.a.p/dispatch_egl.c.o -MF src/libepoxy.a.p/dispatch_egl.c.o.d -o src/libepoxy.a.p/dispatch_egl.c.o -c ../src/1.5.9-fb4e410a2d.clean/src/dispatch_egl.c
FAILED: src/libepoxy.a.p/dispatch_egl.c.o
/usr/bin/cc -Isrc/libepoxy.a.p -Isrc -I../src/1.5.9-fb4e410a2d.clean/src -Iinclude -I../src/1.5.9-fb4e410a2d.clean/include -Iinclude/epoxy -I/home/bdmc/Downloads/vcpkg/installed/x64-linux/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu99 -g -fPIC -g -fPIC -Wpointer-arith -Wmissing-declarations -Wformat=2 -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wbad-function-cast -Wold-style-definition -Wdeclaration-after-statement -Wunused -Wuninitialized -Wshadow -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wlogical-op -Werror=implicit -Werror=nonnull -Werror=init-self -Werror=main -Werror=missing-braces -Werror=sequence-point -Werror=return-type -Werror=trigraphs -Werror=array-bounds -Werror=write-strings -Werror=address -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -fno-strict-aliasing -Wno-int-conversion -MD -MQ src/libepoxy.a.p/dispatch_egl.c.o -MF src/libepoxy.a.p/dispatch_egl.c.o.d -o src/libepoxy.a.p/dispatch_egl.c.o -c ../src/1.5.9-fb4e410a2d.clean/src/dispatch_egl.c
In file included from ../src/1.5.9-fb4e410a2d.clean/include/epoxy/egl.h:46,
                 from ../src/1.5.9-fb4e410a2d.clean/src/dispatch_common.h:59,
                 from ../src/1.5.9-fb4e410a2d.clean/src/dispatch_egl.c:28:
include/epoxy/egl_generated.h:11:10: fatal error: EGL/eglplatform.h: No such file or directory
   11 | #include "EGL/eglplatform.h"
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
```

