### PR TITLE
[DPP] Bump to version 10.0.21

### DIFF
--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO brainboxdotcc/DPP
-    REF cb591768ee009be2c935847d087fc935ef075ce7
-    SHA512  18832c99f208aba4fe44b4fd68fa7132518b16f2535af1323c274282f3128ad7ddb250b5d6c34a87558adf33ba7000561c8abf3be735f221baf978971b4d943d
+    REF cee27e000166b7aa5fce63f6c8ef25ded2f8bf27
+    SHA512  38716a2fcbfab43df34fc213c1901f077d4a5e1b9013027826b1d1c40ea5aa736a7f43c2a75773bd3c3b1ce5d3255526956becc469df93588b7ea4005f9f6d23
     HEAD_REF master
     PATCHES
         make-pkgconfig-required.patch

--- a/ports/dpp/vcpkg.json
+++ b/ports/dpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dpp",
-  "version": "10.0.20",
+  "version": "10.0.21",
   "description": "D++ Extremely Lightweight C++ Discord Library.",
   "homepage": "https://dpp.dev/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2009,7 +2009,7 @@
       "port-version": 1
     },
     "dpp": {
-      "baseline": "10.0.20",
+      "baseline": "10.0.21",
       "port-version": 0
     },
     "draco": {
@@ -6832,6 +6832,10 @@
       "baseline": "1.3.1",
       "port-version": 0
     },
+    "shader-slang": {
+      "baseline": "0.23.13",
+      "port-version": 0
+    },
     "shaderc": {
       "baseline": "2021.1",
       "port-version": 3
@@ -6915,10 +6919,6 @@
     "skyr-url": {
       "baseline": "1.13.0",
       "port-version": 2
-    },
-    "shader-slang": {
-      "baseline": "0.23.13",
-      "port-version": 0
     },
     "sleef": {
       "baseline": "3.5.1",

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "464ce638a24ff77d86e3c0649cffbf599d13a9b2",
+      "version": "10.0.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "5d961ae0b2739368c053459b3f6d53ecce397a6f",
       "version": "10.0.20",
       "port-version": 0


### PR DESCRIPTION
**This PR updates DPP package to 10.0.21**

Our vcpkg update is built from our CI actions.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `Triplets are unchanged, baseline not updated.`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `Yes`


