### PR TITLE
[OpenSSL] Update to 3.0.7.

### DIFF
--- a/ports/boringssl/openssl.pc.in
+++ b/ports/boringssl/openssl.pc.in
@@ -2,5 +2,5 @@ prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
-Version: @OPENSSL_VERSION@
+Version: @VERSION@
 @pc_data@

--- a/ports/boringssl/openssl.pc.in
+++ b/ports/boringssl/openssl.pc.in
@@ -2,5 +2,5 @@ prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
-Version: @VERSION@
+Version: @OPENSSL_VERSION@
 @pc_data@

--- a/ports/openssl/openssl.pc.in
+++ b/ports/openssl/openssl.pc.in
@@ -2,5 +2,5 @@ prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
-Version: @OPENSSL_VERSION@
+Version: @VERSION@
 @pc_data@

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -11,19 +11,31 @@ It can be installed on alpine systems via apk add linux-headers.]]
     )
 endif()
 
-set(OPENSSL_VERSION 3.0.5)
-
 if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_UWP)
     set(OPENSSL_PATCHES "${CMAKE_CURRENT_LIST_DIR}/windows/flags.patch")
 endif()
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO openssl/openssl
-    REF openssl-${OPENSSL_VERSION}
-    SHA512 e426f2d48dcd87ad938b246cea69988710198c3ed2f5bb9065aa9e74492161b056336f5b1f29be64e70dfd86a77808fe727ebb46eae10331c76f1ff08e341133
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS
+        https://www.openssl.org/source/openssl-3.0.7.tar.gz
+    FILENAME openssl-3.0.7.tar.gz
+    SHA512 6c2bcd1cd4b499e074e006150dda906980df505679d8e9d988ae93aa61ee6f8c23c0fa369e2edc1e1a743d7bec133044af11d5ed57633b631ae479feb59e3424
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES ${OPENSSL_PATCHES}
 )
+
+# vcpkg_from_github(
+#     OUT_SOURCE_PATH SOURCE_PATH
+#     REPO openssl/openssl
+#     REF openssl-${VERSION}
+#     SHA512 0
+#     PATCHES ${OPENSSL_PATCHES}
+# )
 
 vcpkg_find_acquire_program(PERL)
 get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -1,3 +1,4 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 if(EXISTS "${CURRENT_INSTALLED_DIR}/share/libressl/copyright"
     OR EXISTS "${CURRENT_INSTALLED_DIR}/share/boringssl/copyright")
     message(FATAL_ERROR "Can't build openssl if libressl/boringssl is installed. Please remove libressl/boringssl, and try install openssl again if you need it.")
@@ -15,27 +16,13 @@ if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_UWP)
     set(OPENSSL_PATCHES "${CMAKE_CURRENT_LIST_DIR}/windows/flags.patch")
 endif()
 
-vcpkg_download_distfile(
-    ARCHIVE
-    URLS
-        https://www.openssl.org/source/openssl-3.0.7.tar.gz
-    FILENAME openssl-3.0.7.tar.gz
-    SHA512 6c2bcd1cd4b499e074e006150dda906980df505679d8e9d988ae93aa61ee6f8c23c0fa369e2edc1e1a743d7bec133044af11d5ed57633b631ae479feb59e3424
-)
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO openssl/openssl
+    REF openssl-${VERSION}
+    SHA512 27dd3ef0c1827a74ec880d20232acb818c7d05e004ad7389c355e200a01e899f1b1ba5c34dcce44ecf7c8767c5e1bfbb2c795e3fa5461346087e7e3b95c8a51f
     PATCHES ${OPENSSL_PATCHES}
 )
-
-# vcpkg_from_github(
-#     OUT_SOURCE_PATH SOURCE_PATH
-#     REPO openssl/openssl
-#     REF openssl-${VERSION}
-#     SHA512 0
-#     PATCHES ${OPENSSL_PATCHES}
-# )
 
 vcpkg_find_acquire_program(PERL)
 get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openssl",
-  "version": "3.0.5",
-  "port-version": 5,
+  "version": "3.0.7",
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/ports/openssl/windows/flags.patch
+++ b/ports/openssl/windows/flags.patch
@@ -1,16 +1,3 @@
-diff --git a/Configurations/10-main.conf b/Configurations/10-main.conf
-index 66bc81d..2364633 100644
---- a/Configurations/10-main.conf
-+++ b/Configurations/10-main.conf
-@@ -1302,7 +1302,7 @@ my %targets = (
-         inherit_from     => [ "BASE_Windows" ],
-         template         => 1,
-         CC               => "cl",
--        CPP              => '"$(CC)" /EP /C',
-+        CPP              => '$(CC) /EP /C',
-         CFLAGS           => "/W3 /wd4090 /nologo",
-         coutflag         => "/Fo",
-         LD               => "link",
 diff --git a/Configure b/Configure
 index 8b234f6..e031768 100644
 --- a/Configure

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5497,8 +5497,8 @@
       "port-version": 4
     },
     "openssl": {
-      "baseline": "3.0.5",
-      "port-version": 5
+      "baseline": "3.0.7",
+      "port-version": 0
     },
     "openssl-unix": {
       "baseline": "deprecated",
@@ -6832,6 +6832,10 @@
       "baseline": "1.3.1",
       "port-version": 0
     },
+    "shader-slang": {
+      "baseline": "0.23.13",
+      "port-version": 0
+    },
     "shaderc": {
       "baseline": "2021.1",
       "port-version": 3
@@ -6915,10 +6919,6 @@
     "skyr-url": {
       "baseline": "1.13.0",
       "port-version": 2
-    },
-    "shader-slang": {
-      "baseline": "0.23.13",
-      "port-version": 0
     },
     "sleef": {
       "baseline": "3.5.1",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7042c058a51fe655c219d8ccf6d0461100ecf4d8",
+      "version": "3.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "067a790dfd1559e77d5a199ccbe982322882d667",
       "version": "3.0.5",
       "port-version": 5

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7042c058a51fe655c219d8ccf6d0461100ecf4d8",
+      "git-tree": "09701bf7506bd0d161bf671eff1c7f5b3d73e3a9",
       "version": "3.0.7",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes 2 high security vulnerabilities https://www.openssl.org/news/secadv/20221101.txt (formerly known as https://twitter.com/iamamoose/status/1584908434855628800 )

flags.patch part already applied by upstream in 3.0.6 removed.

