### PR TITLE
[docs] Correct vcpkg_check_features examples

### DIFF
--- a/docs/maintainers/vcpkg_check_features.md
+++ b/docs/maintainers/vcpkg_check_features.md
@@ -57,7 +57,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         # Expands to "-DMI_SEE_ASM=ON;-DMI_OVERRIDE=OFF;-DMI_SECURE=ON"
         ${FEATURE_OPTIONS}
@@ -70,14 +70,14 @@ vcpkg_cmake_configure(
 $ ./vcpkg install cpprestsdk[websockets]
 
 # ports/cpprestsdk/portfile.cmake
-vcpkg_check_features(
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     INVERTED_FEATURES
         brotli      CPPREST_EXCLUDE_BROTLI
         websockets  CPPREST_EXCLUDE_WEBSOCKETS
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         # Expands to "-DCPPREST_EXCLUDE_BROTLI=ON;-DCPPREST_EXCLUDE_WEBSOCKETS=OFF"
         ${FEATURE_OPTIONS}
@@ -90,7 +90,7 @@ vcpkg_cmake_configure(
 $ ./vcpkg install pcl[cuda]
 
 # ports/pcl/portfile.cmake
-vcpkg_check_features(
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         cuda  WITH_CUDA
         cuda  BUILD_CUDA
@@ -98,7 +98,7 @@ vcpkg_check_features(
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         # Expands to "-DWITH_CUDA=ON;-DBUILD_CUDA=ON;-DBUILD_GPU=ON"
         ${FEATURE_OPTIONS}
@@ -111,7 +111,7 @@ vcpkg_cmake_configure(
 $ ./vcpkg install rocksdb[tbb]
 
 # ports/rocksdb/portfile.cmake
-vcpkg_check_features(
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         tbb   WITH_TBB
     INVERTED_FEATURES
@@ -119,7 +119,7 @@ vcpkg_check_features(
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         # Expands to "-DWITH_TBB=ON;-DROCKSDB_IGNORE_PACKAGE_TBB=OFF"
         ${FEATURE_OPTIONS}


### PR DESCRIPTION
`OUT_FEATURE_OPTIONS` is mandatory in `vcpkg_check_features`.
Also added quotes around `${SOURCE_PATH}` so that copy-pasted code automatically follows guidelines.