### PR TITLE
[lcms] update to version 2.14

### DIFF
--- a/ports/lcms/cpp17.patch
+++ b/ports/lcms/cpp17.patch
@@ -6,8 +6,8 @@ index 7e061ce7c..5d234c4e4 100644
  #endif
  
  // Handle "register" keyword
--#if defined(CMS_NO_REGISTER_KEYWORD) && !defined(CMS_DLL) && !defined(CMS_DLL_BUILD) 
-+#if __cplusplus >= 201703L || defined(CMS_NO_REGISTER_KEYWORD) && !defined(CMS_DLL) && !defined(CMS_DLL_BUILD) 
+-#if defined(CMS_NO_REGISTER_KEYWORD)
++#if __cplusplus >= 201703L || defined(CMS_NO_REGISTER_KEYWORD)
  #  define CMSREGISTER
  #else
  #  define CMSREGISTER register

--- a/ports/lcms/portfile.cmake
+++ b/ports/lcms/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mm2/Little-CMS
-    REF 924a020d09bfe468c665467caf24aadeb41ff77c # 2.12
-    SHA512 0c2dc069878ca38a92af4800aa3fb2660203fbcdf6dccd9db60cfacb6896185e3e9222893f39ec3e132b0f4900a2932d490dd8db5b1b431519966a64d28404d2
+    REF e88d9bcad79b7ebf6b97ebd634af31ed23c1b910 # 2.14
+    SHA512 29cc2bd6b41939d424a0893c4cca5323a50ed16efd48f03e42e0e1dd27ad9144050b0c20ac56a1174e0ca0e043151f44b77a2f0181a233dd7da0aef9b51a9d41
     HEAD_REF master
     PATCHES
         remove_library_directive.patch

--- a/ports/lcms/vcpkg.json
+++ b/ports/lcms/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "lcms",
   "version": "2.14",
   "description": "Little CMS.",
+  "license": "MIT",
   "homepage": "https://github.com/mm2/Little-CMS",
   "dependencies": [
     {

--- a/ports/lcms/vcpkg.json
+++ b/ports/lcms/vcpkg.json
@@ -2,8 +2,8 @@
   "name": "lcms",
   "version": "2.14",
   "description": "Little CMS.",
-  "license": "MIT",
   "homepage": "https://github.com/mm2/Little-CMS",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/lcms/vcpkg.json
+++ b/ports/lcms/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "lcms",
-  "version": "2.12",
-  "port-version": 4,
+  "version": "2.14",
   "description": "Little CMS.",
   "homepage": "https://github.com/mm2/Little-CMS",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3501,8 +3501,8 @@
       "port-version": 5
     },
     "lcms": {
-      "baseline": "2.12",
-      "port-version": 4
+      "baseline": "2.14",
+      "port-version": 0
     },
     "leaf": {
       "baseline": "0.2.2",

--- a/versions/l-/lcms.json
+++ b/versions/l-/lcms.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e46007bfe12bd76515e23d12e6259277b9241f02",
+      "version": "2.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "220d2255b3f13ec7b0266393d65c674f5c060c2b",
       "version": "2.12",
       "port-version": 4

--- a/versions/l-/lcms.json
+++ b/versions/l-/lcms.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e46007bfe12bd76515e23d12e6259277b9241f02",
+      "git-tree": "30de9d3240fafda247e7ba9f1e7c2e2209882d77",
       "version": "2.14",
       "port-version": 0
     },


### PR DESCRIPTION
- #### What does your PR fix?
  Updates lcms to version 2.14

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
   Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes