### PR TITLE
[dcmtk] re-enable support on arm64-osx

### DIFF
--- a/ports/dcmtk/vcpkg.json
+++ b/ports/dcmtk/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "dcmtk",
   "version": "3.6.7",
-  "port-version": 2,
+  "port-version": 3,
   "description": "This DICOM ToolKit (DCMTK) package consists of source code, documentation and installation instructions for a set of software libraries and applications implementing part of the DICOM/MEDICOM Standard.",
   "homepage": "https://github.com/DCMTK/dcmtk",
   "license": "BSD-3-Clause OR BSD-2-Clause OR libtiff OR MIT OR Zlib OR Libpng",
-  "supports": "!arm",
+  "supports": "!(windows & arm)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1894,7 +1894,7 @@
     },
     "dcmtk": {
       "baseline": "3.6.7",
-      "port-version": 2
+      "port-version": 3
     },
     "debug-assert": {
       "baseline": "1.3.3",

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39b7057f1236e5a218c8cda2f56c5409d067681a",
+      "version": "3.6.7",
+      "port-version": 3
+    },
+    {
       "git-tree": "cbfc85b6b840eb68b947c8b9bd69988c938198d3",
       "version": "3.6.7",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Re-enables dcmtk build on arm64-osx

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  arm64-osx is a community triplet and not applicable to ci.baseline.txt from what I can tell.
  arm64-windows and arm-uwp still fail in CI, so support has been excluded for those in the port file
  arm[64]-{android,ios,linux,mingw} etc. are untested, I might be able to test crosscompilation for arm[64]-linux if that is necessary
  Since  [#23034](https://github.com/microsoft/vcpkg/pull/23034) explicitly references arm mac, I think this should be ok.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
