### PR TITLE
[uriparser] update to 0.9.7

### DIFF
--- a/ports/uriparser/portfile.cmake
+++ b/ports/uriparser/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uriparser/uriparser
-    REF 1ebc4811d2a986d68142587eca2256837be0da85 # uriparser-0.9.6
-    SHA512 fda7a92afddf12362691718a220ff23363c9684d0f2b500362f7060abd04440a8baaad1cd3d3ba6ab7e94a16e29763ca67c415aa66c284102bea6b80a8058045
+    REF 634b678fa858abf1d1ebc0634e96e9e29596e92a # uriparser-0.9.7
+    SHA512 124d1b772b365af3c603146c65986698a94e839e5499da6391694d7958d73bfad38d59f967836270c2a190a1c8d2309fb5ad6068543ce40e4847523e55ca26b9
     HEAD_REF master
 )
 
@@ -36,7 +36,7 @@ endif()
 
 set(_package_version_re "#define[ ]+PACKAGE_VERSION[ ]+\"([0-9]+.[0-9]+.[0-9]+)\"")
 file(STRINGS
-    "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/config.h"
+	"${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/UriConfig.h"
     _package_version_define REGEX "${_package_version_re}"
 )
 string(REGEX REPLACE "${_package_version_re}" "\\1" _package_version ${_package_version_define})
@@ -54,5 +54,6 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/uriparser/usage
+++ b/ports/uriparser/usage
@@ -1,0 +1,4 @@
+The package uriparser provides CMake targets:
+
+    find_package(uriparser CONFIG REQUIRED char wchar_t)
+    target_link_libraries(main PUBLIC uriparser::uriparser)

--- a/ports/uriparser/vcpkg.json
+++ b/ports/uriparser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uriparser",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Strictly RFC 3986 compliant URI parsing and handling library written in C89.",
   "homepage": "https://uriparser.github.io/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7637,7 +7637,7 @@
       "port-version": 2
     },
     "uriparser": {
-      "baseline": "0.9.6",
+      "baseline": "0.9.7",
       "port-version": 0
     },
     "usbmuxd": {

--- a/versions/u-/uriparser.json
+++ b/versions/u-/uriparser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "975fead9dd72eb7261d36b7fa2c0c2aeb7b79f43",
+      "version": "0.9.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "9f9aef4f8260430170711fecac6c383bb259f034",
       "version": "0.9.6",
       "port-version": 0


### PR DESCRIPTION
## Description

- update https://github.com/uriparser/uriparser to 0.9.7
- add recommended usage based on https://github.com/uriparser/uriparser#example-use-from-an-existing-cmake-project
