### PR TITLE
Fix qt incorrectly detecting an android build on non-android targets.

### DIFF
--- a/ports/qtbase/cmake/qt_install_submodule.cmake
+++ b/ports/qtbase/cmake/qt_install_submodule.cmake
@@ -60,7 +60,7 @@ function(qt_cmake_configure)
     cmake_parse_arguments(PARSE_ARGV 0 "_qarg" "DISABLE_NINJA;DISABLE_PARALLEL_CONFIGURE"
                       ""
                       "TOOL_NAMES;OPTIONS;OPTIONS_DEBUG;OPTIONS_RELEASE;OPTIONS_MAYBE_UNUSED")
-    
+
     vcpkg_find_acquire_program(PERL) # Perl is probably required by all qt ports for syncqt
     get_filename_component(PERL_PATH ${PERL} DIRECTORY)
     vcpkg_add_to_path(${PERL_PATH})
@@ -79,7 +79,7 @@ function(qt_cmake_configure)
     if(_qarg_DISABLE_NINJA)
         set(ninja_option WINDOWS_USE_MSBUILD)
     endif()
-    
+
     set(disable_parallel "")
     if(_qarg_DISABLE_PARALLEL_CONFIGURE)
         set(disable_parallel DISABLE_PARALLEL_CONFIGURE)
@@ -97,13 +97,17 @@ function(qt_cmake_configure)
     string(REGEX MATCHALL "CMAKE_REQUIRE_FIND_PACKAGE_[^:=]+(:BOOL)?=OFF" require_find_package "${_qarg_OPTIONS}")
     list(TRANSFORM require_find_package REPLACE "(:BOOL)?=OFF" "")
     list(APPEND _qarg_OPTIONS_MAYBE_UNUSED ${require_find_package})
-    
-    # Disable unused warnings for disabled features. Qt might decide to not emit the feature variables if other features are deactivated. 
+
+    # Disable unused warnings for disabled features. Qt might decide to not emit the feature variables if other features are deactivated.
     string(REGEX MATCHALL "(QT_)?FEATURE_[^:=]+(:BOOL)?=OFF" disabled_features "${_qarg_OPTIONS}")
     list(TRANSFORM disabled_features REPLACE "(:BOOL)?=OFF" "")
     list(APPEND _qarg_OPTIONS_MAYBE_UNUSED ${disabled_features})
 
     list(APPEND _qarg_OPTIONS "-DQT_NO_FORCE_SET_CMAKE_BUILD_TYPE:BOOL=ON")
+
+    if(VCPKG_TARGET_IS_ANDROID)
+        list(APPEND _qarg_OPTIONS "-DANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}")
+    endif()
 
     if(NOT PORT MATCHES "qtbase")
         list(APPEND _qarg_OPTIONS "-DQT_MKSPECS_DIR:PATH=${CURRENT_HOST_INSTALLED_DIR}/share/Qt6/mkspecs")
@@ -113,8 +117,8 @@ function(qt_cmake_configure)
         SOURCE_PATH "${SOURCE_PATH}"
         ${ninja_option}
         ${disable_parallel}
-        OPTIONS 
-            -DQT_USE_DEFAULT_CMAKE_OPTIMIZATION_FLAGS:BOOL=ON # We don't want Qt to screw with users toolchain settings. 
+        OPTIONS
+            -DQT_USE_DEFAULT_CMAKE_OPTIMIZATION_FLAGS:BOOL=ON # We don't want Qt to screw with users toolchain settings.
             #-DQT_HOST_PATH=<somepath> # For crosscompiling
             #-DQT_PLATFORM_DEFINITION_DIR=mkspecs/win32-msvc
             #-DQT_QMAKE_TARGET_MKSPEC=win32-msvc
@@ -127,7 +131,6 @@ function(qt_cmake_configure)
             -DINSTALL_LIBEXECDIR:STRING=bin
             -DINSTALL_PLUGINSDIR:STRING=${qt_plugindir}
             -DINSTALL_QMLDIR:STRING=${qt_qmldir}
-            -DANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}
             ${_qarg_OPTIONS}
         OPTIONS_RELEASE
             ${_qarg_OPTIONS_RELEASE}
@@ -188,7 +191,7 @@ function(qt_fixup_and_cleanup)
     ## Handle PRL files
     qt_fix_prl_files()
 
-    ## Handle CMake files. 
+    ## Handle CMake files.
     set(COMPONENTS)
     file(GLOB COMPONENTS_OR_FILES LIST_DIRECTORIES true "${CURRENT_PACKAGES_DIR}/share/Qt6*")
     list(REMOVE_ITEM COMPONENTS_OR_FILES "${CURRENT_PACKAGES_DIR}/share/Qt6")
@@ -203,7 +206,7 @@ function(qt_fixup_and_cleanup)
     foreach(_comp IN LISTS COMPONENTS)
         if(EXISTS "${CURRENT_PACKAGES_DIR}/share/Qt6${_comp}")
             vcpkg_cmake_config_fixup(PACKAGE_NAME "Qt6${_comp}" CONFIG_PATH "share/Qt6${_comp}" TOOLS_PATH "tools/Qt6/bin")
-            # Would rather put it into share/cmake as before but the import_prefix correction in vcpkg_cmake_config_fixup is working against that. 
+            # Would rather put it into share/cmake as before but the import_prefix correction in vcpkg_cmake_config_fixup is working against that.
         else()
             message(STATUS "WARNING: Qt component ${_comp} not found/built!")
         endif()
@@ -220,7 +223,7 @@ function(qt_fixup_and_cleanup)
         file(GLOB_RECURSE STATIC_CMAKE_TARGETS "${CURRENT_PACKAGES_DIR}/share/Qt6Qml/QmlPlugins/*.cmake")
         foreach(_plugin_target IN LISTS STATIC_CMAKE_TARGETS)
             # restore a single get_filename_component which was remove by vcpkg_cmake_config_fixup
-            vcpkg_replace_string("${_plugin_target}" 
+            vcpkg_replace_string("${_plugin_target}"
                                  [[get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)]]
                                  "get_filename_component(_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)\nget_filename_component(_IMPORT_PREFIX \"\${_IMPORT_PREFIX}\" PATH)")
         endforeach()
@@ -275,7 +278,7 @@ function(qt_fixup_and_cleanup)
         file(GLOB_RECURSE _bin_files "${CURRENT_PACKAGES_DIR}/bin/*")
         if(NOT _bin_files STREQUAL "")
             message(STATUS "Remaining files in bin: '${_bin_files}'")
-        else() # Only clean if empty otherwise let vcpkg throw and error. 
+        else() # Only clean if empty otherwise let vcpkg throw and error.
             file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin/" "${CURRENT_PACKAGES_DIR}/debug/bin/")
         endif()
     endif()
@@ -295,7 +298,7 @@ function(qt_install_submodule)
     if(_qis_DISABLE_NINJA)
         set(_opt DISABLE_NINJA)
     endif()
-    qt_cmake_configure(${_opt} 
+    qt_cmake_configure(${_opt}
                        OPTIONS ${_qis_CONFIGURE_OPTIONS}
                        OPTIONS_DEBUG ${_qis_CONFIGURE_OPTIONS_DEBUG}
                        OPTIONS_RELEASE ${_qis_CONFIGURE_OPTIONS_RELEASE}

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.3.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6218,7 +6218,7 @@
     },
     "qtbase": {
       "baseline": "6.3.2",
-      "port-version": 2
+      "port-version": 3
     },
     "qtcharts": {
       "baseline": "6.3.2",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e279c6fed17e9d572a061c482ee73906ffd3e54e",
+      "version": "6.3.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "fdd5dc4e0a94cae2b27acd08ea0c4a7453a6519d",
       "version": "6.3.2",
       "port-version": 2


### PR DESCRIPTION
Probably introduced in https://github.com/microsoft/vcpkg/pull/27421 , shows up as a baseline issue in https://github.com/microsoft/vcpkg/pull/27598/
