### PR TITLE
[xsimd] Update version to 9.0.1

### DIFF
--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -3,13 +3,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xsimd
-    REF 8.1.0
-    SHA512 539f7b565b45e8225c6476ca1becc8243a84ae7fb51b45a584231e7d36aee10a09d7d30fb87d89cb77813fb063a7b7617bcf01fdf996f59d99e8d474d2a044ee
+    REF 9.0.1
+    SHA512 ed56287f608ccdf5bc5d5fc2918e313e7c4cecdd9ef2c9993a72ea900d9ff662c57ac5326c7a809eb11505c6f39d4599f3f161b97b6e03c65783b824b8d700d2
     HEAD_REF master
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    xcomplex ENABLE_XTL_COMPLEX
+    FEATURES
+        xcomplex ENABLE_XTL_COMPLEX
 )
 
 vcpkg_cmake_configure(
@@ -19,6 +20,8 @@ vcpkg_cmake_configure(
         -DBUILD_TESTS=OFF
         -DDOWNLOAD_GTEST=OFF
         ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        ENABLE_FALLBACK
 )
 
 vcpkg_cmake_install()

--- a/ports/xsimd/vcpkg.json
+++ b/ports/xsimd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xsimd",
-  "version": "8.1.0",
+  "version": "9.0.1",
   "description": "Modern, portable C++ wrappers for SIMD intrinsics",
   "homepage": "https://github.com/xtensor-stack/xsimd",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8117,7 +8117,7 @@
       "port-version": 1
     },
     "xsimd": {
-      "baseline": "8.1.0",
+      "baseline": "9.0.1",
       "port-version": 0
     },
     "xtensor": {

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "759475a9304ef56ad21c8c3300aa89404e7a1b83",
+      "version": "9.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d7f059f0f9d91da33b87a09615ef7f7f84cc76a",
       "version": "8.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixed #27621 

Update [xsimd] version to 9.0.1

All features are tested successfully in the following triplet:

- x86-windows
- x64-windows
- x64-windows-stataic