### PR TITLE
[openssl] add OPENSSL_NO_SEED definition

### DIFF
--- a/ports/openssl/vcpkg-cmake-wrapper.cmake.in
+++ b/ports/openssl/vcpkg-cmake-wrapper.cmake.in
@@ -47,6 +47,9 @@ if(DEFINED OPENSSL_USE_STATIC_LIBS_BAK)
     unset(OPENSSL_USE_STATIC_LIBS_BAK)
 endif()
 
+# add option like ./Configure command 
+add_definition(-DOPENSSL_NO_SEED)
+
 if(OPENSSL_FOUND AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
     if(WIN32)
         list(APPEND OPENSSL_LIBRARIES crypt32 ws2_32)


### PR DESCRIPTION
Some code use the EVP_seed_ecb, EVP_seed_cbc, EVP_seed_cfb128, EVP_seed_ofb function with openssl. This code need the OPENSSL_NO_SSED option with openssl build.

(cherry picked from commit f5403846deffcaaa1e61f41391ad7f32d04d0083)

**Describe the pull request**

- #### What does your PR fix?
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
