### PR TITLE
[libgpg-error] Fix crossbuilds, control gettext

### DIFF
--- a/ports/libgpg-error/cross-tools.patch
+++ b/ports/libgpg-error/cross-tools.patch
@@ -1,0 +1,36 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 9a86251..00cc2fd 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -17,6 +17,7 @@
+ # License along with this program; if not, see <https://www.gnu.org/licenses/>.
+ # SPDX-License-Identifier: LGPL-2.1+
+ 
++HOST_TOOLS_PREFIX ?= .
+ 
+ #
+ # We distribute the generated sources err-sources.h and err-codes.h,
+@@ -290,8 +291,8 @@ mkw32errmap$(EXEEXT_FOR_BUILD): mkw32errmap.c mkw32errmap.tab.h Makefile
+ 	$(CPPFLAGS_FOR_BUILD) -I. -I$(srcdir) -o $@ $(srcdir)/mkw32errmap.c
+ endif
+ 
+-code-from-errno.h: mkerrcodes$(EXEEXT_FOR_BUILD) Makefile
+-	./mkerrcodes$(EXEEXT_FOR_BUILD) | $(AWK) -f $(srcdir)/mkerrcodes2.awk >$@
++code-from-errno.h: $(HOST_TOOLS_PREFIX)/mkerrcodes$(EXEEXT_FOR_BUILD) Makefile
++	$(HOST_TOOLS_PREFIX)/mkerrcodes$(EXEEXT_FOR_BUILD) | $(AWK) -f $(srcdir)/mkerrcodes2.awk >$@
+ 
+ errnos-sym.h: Makefile mkstrtable.awk errnos.in
+ 	$(AWK) -f $(srcdir)/mkstrtable.awk -v textidx=2 -v nogettext=1 \
+@@ -336,10 +337,10 @@ endif
+ 
+ # We also depend on versioninfo.rc because that is build by
+ # config.status and thus has up-to-date version numbers.
+-gpg-error.h: Makefile mkheader$(EXEEXT_FOR_BUILD) $(parts_of_gpg_error_h) \
++gpg-error.h: Makefile $(HOST_TOOLS_PREFIX)/mkheader$(EXEEXT_FOR_BUILD) $(parts_of_gpg_error_h) \
+              versioninfo.rc ../config.h
+ 	$(pre_mkheader_cmds)
+-	./mkheader$(EXEEXT_FOR_BUILD) $(mkheader_opts)       \
++	$(HOST_TOOLS_PREFIX)/mkheader$(EXEEXT_FOR_BUILD) $(mkheader_opts)       \
+                    $(host_triplet)  $(srcdir)/gpg-error.h.in \
+                    ../config.h $(PACKAGE_VERSION) $(VERSION_NUMBER) >$@
+ 

--- a/ports/libgpg-error/pkgconfig-libintl.patch
+++ b/ports/libgpg-error/pkgconfig-libintl.patch
@@ -1,0 +1,11 @@
+diff --git a/src/gpg-error.pc.in b/src/gpg-error.pc.in
+index 970bb6c..a51c9d3 100644
+--- a/src/gpg-error.pc.in
++++ b/src/gpg-error.pc.in
+@@ -11,5 +11,5 @@ Description: GPG Runtime
+ Version: @PACKAGE_VERSION@
+ Cflags: @GPG_ERROR_CONFIG_CFLAGS@
+ Libs: @GPG_ERROR_CONFIG_LIBS@
+-Libs.private: @GPG_ERROR_CONFIG_LIBS_PRIVATE@
++Libs.private: @GPG_ERROR_CONFIG_LIBS_PRIVATE@ @LIBINTL@
+ URL: https://www.gnupg.org/software/libgpg-error/index.html

--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
-if(VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     message(WARNING "libgpg-error on Windows uses a fork managed by the ShiftMediaProject: https://shiftmediaproject.github.io/")
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -80,10 +80,19 @@ else()
             add_cflags_to_tools.patch
     )
 
+    vcpkg_list(SET options)
+    if("nls" IN_LIST FEATURES)
+        vcpkg_list(APPEND options "--enable-nls")
+    else()
+        set(ENV{AUTOPOINT} true) # true, the program
+        vcpkg_list(APPEND options "--disable-nls")
+    endif()
+
     vcpkg_configure_make(
         AUTOCONFIG
         SOURCE_PATH "${SOURCE_PATH}"
         OPTIONS
+            ${options}
             --disable-tests
             --disable-doc
             --disable-silent-rules

--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -122,6 +122,10 @@ else()
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/debug/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../../..")
     endif()
 
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/locale" "${CURRENT_PACKAGES_DIR}/debug/share")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+    if(NOT "nls" IN_LIST FEATURES)
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/locale")
+    endif()
+
     file(INSTALL "${SOURCE_PATH}/COPYING.LIB" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 endif()

--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -117,11 +117,8 @@ else()
         )
     endif()
 	
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../..")
-    endif()
-
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../..")
+    if(NOT VCPKG_BUILD_TYPE)
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/debug/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../../..")
     endif()
 

--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -78,6 +78,7 @@ else()
         HEAD_REF master
         PATCHES
             add_cflags_to_tools.patch
+            pkgconfig-libintl.patch
     )
 
     vcpkg_list(SET options)

--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -1,11 +1,11 @@
-set (PACKAGE_VERSION 1.42)
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
 if(VCPKG_TARGET_IS_WINDOWS)
     message(WARNING "libgpg-error on Windows uses a fork managed by the ShiftMediaProject: https://shiftmediaproject.github.io/")
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ShiftMediaProject/libgpg-error
-        REF libgpg-error-${PACKAGE_VERSION}
+        REF libgpg-error-${VERSION}
         SHA512 2dbf41e28196f4b99d641a430e6e77566ae2d389bbe9d6f6e310d56a5ca90de9b9ae225a3eee979fe4606d36878d3db6f777162d697de717b4748151dd3525d0
         HEAD_REF master
         PATCHES 
@@ -73,7 +73,7 @@ else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO gpg/libgpg-error
-        REF libgpg-error-${PACKAGE_VERSION}
+        REF libgpg-error-${VERSION}
         SHA512 f5a1c1874ac1dee36ee01504f1ab0146506aa7af810879e192eac17a31ec81945fe850953ea1c57188590c023ce3ff195c7cab62af486b731fa1534546d66ba3
         HEAD_REF master
         PATCHES

--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -78,6 +78,7 @@ else()
         HEAD_REF master
         PATCHES
             add_cflags_to_tools.patch
+            cross-tools.patch
             pkgconfig-libintl.patch
     )
 
@@ -87,6 +88,10 @@ else()
     else()
         set(ENV{AUTOPOINT} true) # true, the program
         vcpkg_list(APPEND options "--disable-nls")
+    endif()
+
+    if(VCPKG_CROSSCOMPILING)
+        set(ENV{HOST_TOOLS_PREFIX} "${CURRENT_HOST_INSTALLED_DIR}/tools/libgpg-error/bin")
     endif()
 
     vcpkg_configure_make(
@@ -102,6 +107,15 @@ else()
     vcpkg_install_make()
     vcpkg_fixup_pkgconfig() 
     vcpkg_copy_pdbs()
+
+    if("build-tools" IN_LIST FEATURES)
+        file(INSTALL
+                "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/mkerrcodes${VCPKG_TARGET_SUFFIX}"
+                "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/mkheader${VCPKG_TARGET_SUFFIX}"
+            DESTINATION "${CURRENT_PACKAGES_DIR}/tools/libgpg-error/bin"
+            USE_SOURCE_PERMISSIONS
+        )
+    endif()
 	
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../..")

--- a/ports/libgpg-error/vcpkg.json
+++ b/ports/libgpg-error/vcpkg.json
@@ -4,5 +4,21 @@
   "port-version": 5,
   "description": "A common dependency of all GnuPG components",
   "homepage": "https://gnupg.org/software/libgpg-error/index.html",
-  "supports": "!(windows & (arm | arm64))"
+  "supports": "!(windows & (arm | arm64))",
+  "features": {
+    "nls": {
+      "description": "Enable native language support",
+      "supports": "!windows | mingw",
+      "dependencies": [
+        "gettext",
+        {
+          "name": "gettext",
+          "host": true,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/ports/libgpg-error/vcpkg.json
+++ b/ports/libgpg-error/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libgpg-error",
   "version": "1.42",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A common dependency of all GnuPG components",
   "homepage": "https://gnupg.org/software/libgpg-error/index.html",
   "supports": "!(windows & (arm | arm64))"

--- a/ports/libgpg-error/vcpkg.json
+++ b/ports/libgpg-error/vcpkg.json
@@ -5,7 +5,22 @@
   "description": "A common dependency of all GnuPG components",
   "homepage": "https://gnupg.org/software/libgpg-error/index.html",
   "supports": "!(windows & (arm | arm64))",
+  "dependencies": [
+    {
+      "name": "libgpg-error",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "build-tools"
+      ],
+      "platform": "!native"
+    }
+  ],
   "features": {
+    "build-tools": {
+      "description": "Build-time tools, needed for cross builds",
+      "supports": "native"
+    },
     "nls": {
       "description": "Enable native language support",
       "supports": "!windows | mingw",

--- a/ports/libgpg-error/vcpkg.json
+++ b/ports/libgpg-error/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 5,
   "description": "A common dependency of all GnuPG components",
   "homepage": "https://gnupg.org/software/libgpg-error/index.html",
+  "license": "LGPL-2.1-or-later",
   "supports": "!(windows & (arm | arm64))",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3770,7 +3770,7 @@
     },
     "libgpg-error": {
       "baseline": "1.42",
-      "port-version": 4
+      "port-version": 5
     },
     "libgpiod": {
       "baseline": "1.6.3",

--- a/versions/l-/libgpg-error.json
+++ b/versions/l-/libgpg-error.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e9cc549c3cd80b8f37c7f3635e3a95fa9ba87f5",
+      "version": "1.42",
+      "port-version": 5
+    },
+    {
       "git-tree": "728a8999d1083dc72eae0612669f0c34075a3f01",
       "version": "1.42",
       "port-version": 4

--- a/versions/l-/libgpg-error.json
+++ b/versions/l-/libgpg-error.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e9cc549c3cd80b8f37c7f3635e3a95fa9ba87f5",
+      "git-tree": "e3ddb32fcdabf15633f8ab591d0e02212e353880",
       "version": "1.42",
       "port-version": 5
     },


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes exported pkgconfig for musl libc (external libintl). Fixes #27592 (untested).
  Adds feature `nls` to control gettext dependency.
  Fixes mingw builds.
  Fixes cross builds

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged.
  Built for arm64-linux and x64-mingw-static on x64-linux

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes