### PR TITLE
[libtheora] Fix non-MSVC x86 builds / triplets

### DIFF
--- a/ports/libtheora/CMakeLists.txt
+++ b/ports/libtheora/CMakeLists.txt
@@ -11,6 +11,25 @@ file(GLOB HEADERS
   "include/theora/theoraenc.h"
 )
 
+if(MSVC)
+  set(LIBTHEORA_COMMON_X86
+    "lib/x86_vc/mmxfrag.c"
+    "lib/x86_vc/mmxidct.c"
+    "lib/x86_vc/mmxstate.c"
+    "lib/x86_vc/x86cpu.c"
+    "lib/x86_vc/x86state.c"
+  )
+else()
+  set(LIBTHEORA_COMMON_X86
+    "lib/x86/mmxfrag.c"
+    "lib/x86/mmxidct.c"
+    "lib/x86/mmxstate.c"
+    "lib/x86/sse2idct.c"
+    "lib/x86/x86cpu.c"
+    "lib/x86/x86state.c"
+  )
+endif()
+
 set(LIBTHEORA_COMMON
   "lib/apiwrapper.c"
   "lib/bitpack.c"
@@ -22,12 +41,24 @@ set(LIBTHEORA_COMMON
   "lib/state.c"
   "lib/quant.c"
 
-  "lib/x86_vc/mmxfrag.c"
-  "lib/x86_vc/mmxidct.c"
-  "lib/x86_vc/mmxstate.c"
-  "lib/x86_vc/x86cpu.c"
-  "lib/x86_vc/x86state.c"
+  ${LIBTHEORA_COMMON_X86}
 )
+
+if(MSVC)
+  set(LIBTHEORA_ENC_X86
+    "lib/x86_vc/mmxencfrag.c"
+    "lib/x86_vc/mmxfdct.c"
+    "lib/x86_vc/x86enc.c"
+  )
+else()
+  set(LIBTHEORA_ENC_X86
+    "lib/x86/mmxencfrag.c"
+    "lib/x86/mmxfdct.c"
+    "lib/x86/x86enc.c"
+    "lib/x86/x86enquant.c"
+    "lib/x86/sse2encfrag.c"
+  )
+endif()
 
 set(LIBTHEORA_ENC
   "lib/analyze.c"
@@ -43,9 +74,7 @@ set(LIBTHEORA_ENC
   "lib/rate.c"
   "lib/tokenize.c"
 
-  "lib/x86_vc/mmxencfrag.c"
-  "lib/x86_vc/mmxfdct.c"
-  "lib/x86_vc/x86enc.c"
+  ${LIBTHEORA_ENC_X86}
 )
 
 set(LIBTHEORA_DEC

--- a/ports/libtheora/vcpkg.json
+++ b/ports/libtheora/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtheora",
   "version-string": "1.2.0alpha1-20170719",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Theora is a free and open video compression format from the Xiph.org Foundation.",
   "homepage": "https://github.com/xiph/theora",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4270,7 +4270,7 @@
     },
     "libtheora": {
       "baseline": "1.2.0alpha1-20170719",
-      "port-version": 4
+      "port-version": 5
     },
     "libtins": {
       "baseline": "4.3",

--- a/versions/l-/libtheora.json
+++ b/versions/l-/libtheora.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee3ae063e330da252b75c91b2b8a4a9392fc8a46",
+      "version-string": "1.2.0alpha1-20170719",
+      "port-version": 5
+    },
+    {
       "git-tree": "77e6aad4fc7e821831290f3e17d368ea17609117",
       "version-string": "1.2.0alpha1-20170719",
       "port-version": 4


### PR DESCRIPTION
Properly use the MSVC-specific or non-MSVC x86 files.

- #### What does your PR fix?
  Fixes x86 builds on non-MSVC compilers (example: x86-mingw triplets)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, Not needed

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes