### PR TITLE
[baseline] Remove rabit from ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -859,7 +859,6 @@ qt5-x11extras:x64-windows-static-md=fail
 qwt:x64-osx=fail
 qwt:arm64-osx=fail
 qwt-qt6:x64-osx=fail
-rabit:x64-osx=fail
 rabit:arm64-osx=fail
 range-v3-vs2015:arm64-windows      = skip
 range-v3-vs2015:arm-uwp            = skip


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
This record was added by PR: https://github.com/microsoft/vcpkg/pull/9203 of [ras0219-msft](https://github.com/ras0219-msft)

The issue of port `rabit` failing to build on `osx` has been resolved upstream discussions: https://github.com/dmlc/xgboost/issues/5995. 

But `rabit`'s dependency `dmlc` failed to build on `osx`, so `rabit` could not build on `osx`.

Now the problem that `dmlc` fails to build on `osx` has been resolved by PR https://github.com/microsoft/vcpkg/pull/27495. This caused `rabit` to start being built on `osx`. So, this regression is triggered

So we remove the records of `rabit` from ci.baseline.txt to fix this regression.