### PR TITLE
[osgearth] Fix find_path regression

### DIFF
--- a/ports/osgearth/fix-osgearth-config.patch
+++ b/ports/osgearth/fix-osgearth-config.patch
@@ -1,5 +1,5 @@
 diff --git a/osgEarthConfig.cmake.in b/osgEarthConfig.cmake.in
-index 3f27dffe9..4141ff939 100644
+index 3f27dffe9..c787e7668 100644
 --- a/osgEarthConfig.cmake.in
 +++ b/osgEarthConfig.cmake.in
 @@ -6,52 +6,54 @@ set(XPREFIX OSGEARTH)
@@ -15,8 +15,9 @@ index 3f27dffe9..4141ff939 100644
 +set(osgEarth_DEFINITIONS ${${XPREFIX}_CFLAGS})
  
 -find_path(osgearth_INCLUDE_DIR
+-    NAMES OSGEARTH/RTREE.H
 +find_path(osgEarth_INCLUDE_DIR
-     NAMES OSGEARTH/RTREE.H
++    NAMES osgEarth/rtree.h
      HINTS ${${XPREFIX}_INCLUDE_DIRS}
  )
  

--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osgearth",
   "version": "3.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2021 Pelican Mapping.",
   "homepage": "https://github.com/gwaldron/osgearth",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5586,7 +5586,7 @@
     },
     "osgearth": {
       "baseline": "3.3",
-      "port-version": 3
+      "port-version": 4
     },
     "osi": {
       "baseline": "0.108.6",

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "208b0c23a8e79910067bb0b8a6dc589da7307de5",
+      "version": "3.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "6c024ede3cf289475ceeeccc91045868db965c02",
       "version": "3.3",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes a regression (introduced in 5d6bbf3da3f6c67408f3fcf5e07df9a3e185adb0) in a patch to osgEarthConfig.cmake.in, which causes CMake configuration to fail on non-Windows platforms.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, No.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
