### PR TITLE
Re-bootstrap vcpkg in manifest mode if updated

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -451,8 +451,8 @@ execute_process(
     ERROR_VARIABLE Z_VCPKG_MANIFEST_VERSION_LOGTEXT
     RESULT_VARIABLE Z_VCPKG_MANIFEST_VERSION_RESULT
 )
-string(REGEX MATCH "program version ([0-9][0-9][0-9][0-9]-[0-9]?[0-9]-[0-9]?[0-9])" z_vcpkg_ver_bin "${Z_VCPKG_MANIFEST_VERSION_LOGTEXT}")
-string(REPLACE "-" "." z_vcpkg_ver_bin "${CMAKE_MATCH_1}")
+string(REGEX MATCH "[0-9][0-9][0-9][0-9]-[0-9]?[0-9]-[0-9]?[0-9]" z_vcpkg_ver_bin "${Z_VCPKG_MANIFEST_VERSION_LOGTEXT}")
+string(REPLACE "-" "." z_vcpkg_ver_bin "${z_vcpkg_ver_bin}")
 message(STATUS "vcpkg binary version: '${z_vcpkg_ver_bin}'")
 
 # Read version

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -453,7 +453,6 @@ execute_process(
 )
 string(REGEX MATCH "program version ([0-9][0-9][0-9][0-9]-[0-9]?[0-9]-[0-9]?[0-9])" z_vcpkg_ver_bin "${Z_VCPKG_MANIFEST_VERSION_LOGTEXT}")
 string(REPLACE "-" "." z_vcpkg_ver_bin "${CMAKE_MATCH_1}")
-set(z_vcpkg_ver_bin "${z_vcpkg_ver_bin}" CACHE STRING "")
 message(STATUS "vcpkg binary version: '${z_vcpkg_ver_bin}'")
 
 # Read version
@@ -466,7 +465,6 @@ set(Z_VCPKG_NEEDS_BOOTSTRAP OFF)
 if(z_vcpkg_ver_bin VERSION_LESS z_vcpkg_ver_script)
     message(STATUS "vcpkg requires updating from:  '${z_vcpkg_ver_bin}' to '${z_vcpkg_ver_script}'")
     set(Z_VCPKG_NEEDS_BOOTSTRAP ON)
-    unset(z_vcpkg_ver_bin CACHE)
 endif()
 
 if(VCPKG_MANIFEST_MODE AND VCPKG_MANIFEST_INSTALL AND NOT Z_VCPKG_CMAKE_IN_TRY_COMPILE AND NOT Z_VCPKG_HAS_FATAL_ERROR)


### PR DESCRIPTION
Solves: People being annoyed manually deleting `vcpkg${CMAKE_EXECUTABLE_SUFFIX}`
Solves: Issues due to `vcpkg_minimum_required` since you will always use latest vcpkg now!

closes #27635