### PR TITLE
[angle] Rename libs to avoid conflict with system OpenGL.

### DIFF
--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -85,7 +85,7 @@ else()
     set(ANGLE_COMMON_PLATFORM_SOURCES )
 endif()
 
-file(GLOB ANGLE_COMMON_SOURCES 
+file(GLOB ANGLE_COMMON_SOURCES
     ${ANGLE_COMMON_PLATFORM_SOURCES}
     "src/common/*.h"
     "src/common/*.inc"
@@ -250,13 +250,13 @@ file(GLOB TRANSLATOR_GLSL_BASE_SOURCES
     "src/compiler/translator/OutputGLSLBase.cpp"
     "src/compiler/translator/OutputGLSLBase.h"
 )
-file(GLOB TRANSLATOR_GLSL_AND_VULKAN_BASE_SOURCES 
+file(GLOB TRANSLATOR_GLSL_AND_VULKAN_BASE_SOURCES
     "src/compiler/translator/BuiltinsWorkaroundGLSL.cpp"
     "src/compiler/translator/BuiltinsWorkaroundGLSL.h"
     "src/compiler/translator/OutputGLSL.cpp"
     "src/compiler/translator/OutputGLSL.h"
 )
-file(GLOB TRANSLATOR_ESSL_SOURCES 
+file(GLOB TRANSLATOR_ESSL_SOURCES
     "src/compiler/translator/OutputESSL.cpp"
     "src/compiler/translator/OutputESSL.h"
     "src/compiler/translator/TranslatorESSL.cpp"
@@ -347,12 +347,12 @@ add_library(angle::preprocessor ALIAS angle_preprocessor)
 ## OpenGL Renderer
 if(WINDOWS_DESKTOP OR LINUX OR APPLE)
     if(WINDOWS_DESKTOP)
-        set(ANGLE_RENDERER_OPENGL_PLATFORM 
+        set(ANGLE_RENDERER_OPENGL_PLATFORM
             "src/libANGLE/renderer/gl/wgl/*.cpp"
             "src/libANGLE/renderer/gl/wgl/*.h"
         )
     elseif(APPLE)
-        set(ANGLE_RENDERER_OPENGL_PLATFORM 
+        set(ANGLE_RENDERER_OPENGL_PLATFORM
             "src/libANGLE/renderer/gl/cgl/*.mm"
             "src/libANGLE/renderer/gl/cgl/*.cpp"
             "src/libANGLE/renderer/gl/cgl/*.h"
@@ -362,7 +362,7 @@ if(WINDOWS_DESKTOP OR LINUX OR APPLE)
             "gpu_info_util/SystemInfo_macos.mm"
         )
     elseif(LINUX)
-        set(ANGLE_RENDERER_OPENGL_PLATFORM 
+        set(ANGLE_RENDERER_OPENGL_PLATFORM
             "src/libANGLE/renderer/gl/glx/*.cpp"
             "src/libANGLE/renderer/gl/glx/*.h"
             "src/libANGLE/renderer/gl/egl/*.cpp"
@@ -574,9 +574,9 @@ target_link_libraries(libANGLE PRIVATE
 target_include_directories(libANGLE PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/khronos>")
 target_compile_definitions(libANGLE
     PRIVATE -DANGLE_ENABLE_NULL
-    PUBLIC 
-        -DLIBANGLE_IMPLEMENTATION 
-        ${LIBANGLE_RENDERER_COMPILEDEF} 
+    PUBLIC
+        -DLIBANGLE_IMPLEMENTATION
+        ${LIBANGLE_RENDERER_COMPILEDEF}
         -DANGLE_EXPORT=
         -DANGLE_UTIL_EXPORT=
         -DEGLAPI=
@@ -625,6 +625,7 @@ list(APPEND LIBGLESV2_SOURCES
 )
 add_library(libGLESv2 ${LIBGLESV2_SOURCES})
 target_link_libraries(libGLESv2 PRIVATE angle::common angle::libANGLE)
+set_property(TARGET libGLESv2 PROPERTY OUTPUT_NAME libGLESv2_angle)
 target_compile_definitions(libGLESv2
     PRIVATE -DLIBGLESV2_IMPLEMENTATION
     PUBLIC
@@ -669,6 +670,7 @@ add_library(libEGL
 )
 
 target_link_libraries(libEGL PRIVATE angle::common angle::libANGLE libGLESv2)
+set_property(TARGET libEGL PROPERTY OUTPUT_NAME libEGL_angle)
 target_include_directories(libEGL PUBLIC "$<INSTALL_INTERFACE:include>" "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
 target_compile_definitions(libEGL
     PRIVATE

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -625,7 +625,9 @@ list(APPEND LIBGLESV2_SOURCES
 )
 add_library(libGLESv2 ${LIBGLESV2_SOURCES})
 target_link_libraries(libGLESv2 PRIVATE angle::common angle::libANGLE)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
 set_property(TARGET libGLESv2 PROPERTY OUTPUT_NAME libGLESv2_angle)
+endif()
 target_compile_definitions(libGLESv2
     PRIVATE -DLIBGLESV2_IMPLEMENTATION
     PUBLIC
@@ -670,7 +672,9 @@ add_library(libEGL
 )
 
 target_link_libraries(libEGL PRIVATE angle::common angle::libANGLE libGLESv2)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
 set_property(TARGET libEGL PROPERTY OUTPUT_NAME libEGL_angle)
+endif()
 target_include_directories(libEGL PUBLIC "$<INSTALL_INTERFACE:include>" "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
 target_compile_definitions(libEGL
     PRIVATE

--- a/ports/angle/portfile.cmake
+++ b/ports/angle/portfile.cmake
@@ -35,7 +35,7 @@ function(checkout_in_path_with_patches PATH URL REF PATCHES)
     if(EXISTS "${PATH}")
         return()
     endif()
-    
+
     vcpkg_from_git(
         OUT_SOURCE_PATH DEP_SOURCE_PATH
         URL "${URL}"
@@ -57,7 +57,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=1
     OPTIONS
-        -D${ANGLE_CPU_BITNESS}=1
+        "-D${ANGLE_CPU_BITNESS}=1"
+        "-DVCPKG_TARGET_IS_WINDOWS=${VCPKG_TARGET_IS_WINDOWS}"
 )
 
 vcpkg_cmake_install()
@@ -69,26 +70,26 @@ vcpkg_copy_pdbs()
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 # File conflict with opengl-registry! Make sure headers are similar on Update!
-# angle defines some additional entrypoints. 
+# angle defines some additional entrypoints.
 # opengl-registry probably needs an upstream update to account for those
-# Due to that all angle headers get moved to include/angle. 
-# If you want to use those instead of the onces provided by opengl-registry make sure 
+# Due to that all angle headers get moved to include/angle.
+# If you want to use those instead of the onces provided by opengl-registry make sure
 # VCPKG_INSTALLED_DIR/include/angle is before VCPKG_INSTALLED_DIR/include
 file(GLOB_RECURSE angle_includes "${CURRENT_PACKAGES_DIR}/include")
 file(COPY ${angle_includes} DESTINATION "${CURRENT_PACKAGES_DIR}/include/angle")
 
 set(_double_files
-    include/GLES/egl.h
-    include/GLES/gl.h
-    include/GLES/glext.h
-    include/GLES/glplatform.h
-    include/GLES2/gl2.h
-    include/GLES2/gl2ext.h
-    include/GLES2/gl2platform.h
-    include/GLES3/gl3.h
-    include/GLES3/gl31.h
-    include/GLES3/gl32.h
-    include/GLES3/gl3platform.h)
+    "include/GLES/egl.h"
+    "include/GLES/gl.h"
+    "include/GLES/glext.h"
+    "include/GLES/glplatform.h"
+    "include/GLES2/gl2.h"
+    "include/GLES2/gl2ext.h"
+    "include/GLES2/gl2platform.h"
+    "include/GLES3/gl3.h"
+    "include/GLES3/gl31.h"
+    "include/GLES3/gl32.h"
+    "include/GLES3/gl3platform.h")
 foreach(_file ${_double_files})
     if(EXISTS "${CURRENT_PACKAGES_DIR}/${_file}")
         file(REMOVE "${CURRENT_PACKAGES_DIR}/${_file}")

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_4472",
-  "port-version": 5,
+  "port-version": 6,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,14 +1,11 @@
 {
   "name": "qt5-base",
   "version": "5.15.7",
+  "port-version": 1,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
   "dependencies": [
-    {
-      "name": "angle",
-      "platform": "!windows"
-    },
     "double-conversion",
     "egl-registry",
     {
@@ -23,6 +20,10 @@
     },
     "libjpeg-turbo",
     "libpng",
+    {
+      "name": "opengl",
+      "platform": "!windows"
+    },
     "openssl",
     "pcre2",
     {

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6bdb7df1dec1178b76d12cde7fadefe9206c11d1",
+      "version-string": "chromium_4472",
+      "port-version": 6
+    },
+    {
       "git-tree": "1c154e795d3d3c736dbbfec2db72a50aa37fa8f2",
       "version-string": "chromium_4472",
       "port-version": 5

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6bdb7df1dec1178b76d12cde7fadefe9206c11d1",
+      "git-tree": "d48bbcf1eba07a4156e745140be81caff95b8757",
       "version-string": "chromium_4472",
       "port-version": 6
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -102,7 +102,7 @@
     },
     "angle": {
       "baseline": "chromium_4472",
-      "port-version": 5
+      "port-version": 6
     },
     "antlr4": {
       "baseline": "4.10.1",
@@ -6046,7 +6046,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.7",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-canvas3d": {
       "baseline": "0",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03b57b46f1e3be1f7aa32cfe41ef54ace61cb87f",
+      "version": "5.15.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "e2cd525c7989b5b2a96b9ad5ebaf145c1a549218",
       "version": "5.15.7",
       "port-version": 0


### PR DESCRIPTION
Note that we already rename the headers in https://github.com/microsoft/vcpkg/blob/e6a79ac0183043994ab21a2c4e0f9cdad8a5421c/ports/angle/portfile.cmake#L77-L96

Also remove what appears to be phantom dependency in qt5-base when not Windows, @Neumann-A reports over Discord https://discord.com/channels/400588936151433218/687365466422902841/1038241263494893649 that they just need any OpenGL implementation.

This hopefully resolves build baseline issues, including but not limited to: https://dev.azure.com/vcpkg/public/_build/results?buildId=80502

```
REGRESSION: cmake:x64-linux cascaded, but it is required to pass. (/agent/_work/1/s/scripts/azure-pipelines/../ci.baseline.txt).
REGRESSION: qt:x64-linux cascaded, but it is required to pass. (/agent/_work/1/s/scripts/azure-pipelines/../ci.baseline.txt).
REGRESSION: qtbase:x64-linux failed with BUILD_FAILED. If expected, add qtbase:x64-linux=fail to /agent/_work/1/s/scripts/azure-pipelines/../ci.baseline.txt.
```

* https://github.com/microsoft/vcpkg/pull/27598
* https://github.com/microsoft/vcpkg/pull/27618
* https://github.com/microsoft/vcpkg/pull/27585
* https://github.com/microsoft/vcpkg/pull/27689
* https://github.com/microsoft/vcpkg/pull/27694
