### PR TITLE
[nethost] Update to 7.0.0

### DIFF
--- a/ports/nethost/0001-nethost-cmakelists.patch
+++ b/ports/nethost/0001-nethost-cmakelists.patch
@@ -1,15 +1,3 @@
-diff --git a/eng/native/version/copy_version_files.sh b/eng/native/version/copy_version_files.sh
-index d60ed4715b5..3508b585727 100755
---- a/eng/native/version/copy_version_files.sh
-+++ b/eng/native/version/copy_version_files.sh
-@@ -29,6 +29,7 @@ for path in "${__VersionFolder}/"*{.h,.c}; do
-             echo "$version_file_contents" > "$version_file_destination"
-         fi
-     elif [[ ! -e "$__RepoRoot/artifacts/obj/$(basename "$path")" ]]; then
-+        mkdir -p "$__RepoRoot/artifacts/obj/"
-         cp "$path" "$__RepoRoot/artifacts/obj/"
-     fi
- done
 diff --git a/src/native/corehost/nethost/CMakeLists.txt b/src/native/corehost/nethost/CMakeLists.txt
 index 5ae3f76e8fe..9c0209ba9bc 100644
 --- a/src/native/corehost/nethost/CMakeLists.txt

--- a/ports/nethost/0001-nethost-cmakelists.patch
+++ b/ports/nethost/0001-nethost-cmakelists.patch
@@ -1,5 +1,17 @@
+diff --git a/eng/native/version/copy_version_files.sh b/eng/native/version/copy_version_files.sh
+index d60ed4715b5..3508b585727 100755
+--- a/eng/native/version/copy_version_files.sh
++++ b/eng/native/version/copy_version_files.sh
+@@ -29,6 +29,7 @@ for path in "${__VersionFolder}/"*{.h,.c}; do
+             echo "$version_file_contents" > "$version_file_destination"
+         fi
+     elif [[ ! -e "$__RepoRoot/artifacts/obj/$(basename "$path")" ]]; then
++        mkdir -p "$__RepoRoot/artifacts/obj/"
+         cp "$path" "$__RepoRoot/artifacts/obj/"
+     fi
+ done
 diff --git a/src/native/corehost/nethost/CMakeLists.txt b/src/native/corehost/nethost/CMakeLists.txt
-index a9f44e720..0f24d4458 100644
+index 5ae3f76e8fe..9c0209ba9bc 100644
 --- a/src/native/corehost/nethost/CMakeLists.txt
 +++ b/src/native/corehost/nethost/CMakeLists.txt
 @@ -1,11 +1,14 @@
@@ -41,7 +53,7 @@ index a9f44e720..0f24d4458 100644
  # Copy static lib PDB to the project output directory
  if (WIN32)
      set_target_properties(libnethost PROPERTIES
-@@ -32,15 +46,18 @@ if (WIN32)
+@@ -32,12 +46,17 @@ if (WIN32)
          COMPILE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
      )
  endif(WIN32)
@@ -59,13 +71,22 @@ index a9f44e720..0f24d4458 100644
 +    RUNTIME DESTINATION bin
 +)
  
++if(NOT BUILD_SHARED_LIBS)
+ if (MSVC)
+     # We ship libnethost.lib as a static library for external consumption, so
+     # LTCG must be disabled to ensure that non-MSVC toolchains can work with it.
+@@ -47,10 +66,10 @@ if (MSVC)
+     string(REPLACE "/LTCG" "" CMAKE_STATIC_LINKER_FLAGS_RELEASE ${CMAKE_STATIC_LINKER_FLAGS_RELEASE})
+     string(REPLACE "/LTCG" "" CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO ${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO})
+ endif()
++endif()
+ 
 -# Only Windows creates a symbols file for static libs.
 -if (WIN32)
 -    install_with_stripped_symbols(libnethost TARGETS corehost)
 -else()
 -    install(TARGETS libnethost DESTINATION corehost)
 -endif(WIN32)
-\ No newline at end of file
 +install(EXPORT unofficial-nethost-config
 +    DESTINATION share/unofficial-nethost
 +    FILE unofficial-nethost-config.cmake

--- a/ports/nethost/portfile.cmake
+++ b/ports/nethost/portfile.cmake
@@ -12,14 +12,16 @@ vcpkg_from_github(
 
 set(PRODUCT_VERSION "7.0.0")
 
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+  execute_process(COMMAND sh -c "mkdir -p ${SOURCE_PATH}/artifacts/obj && ${SOURCE_PATH}/eng/native/version/copy_version_files.sh")
+endif()
+
 if(VCPKG_TARGET_IS_WINDOWS)
   set(RID_PLAT "win")
 elseif(VCPKG_TARGET_IS_OSX)
   set(RID_PLAT "osx")
-  execute_process(COMMAND sh -c "${SOURCE_PATH}/eng/native/version/copy_version_files.sh")
-  elseif(VCPKG_TARGET_IS_LINUX)
+elseif(VCPKG_TARGET_IS_LINUX)
   set(RID_PLAT "linux")
-  execute_process(COMMAND sh -c "${SOURCE_PATH}/eng/native/version/copy_version_files.sh")
 else()
   message(FATAL_ERROR "Unsupported platform")
 endif()

--- a/ports/nethost/portfile.cmake
+++ b/ports/nethost/portfile.cmake
@@ -1,23 +1,25 @@
-set(COMMIT_HASH v6.0.5)
+set(COMMIT_HASH v7.0.0)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dotnet/runtime
     REF ${COMMIT_HASH}
-    SHA512 ccf4865bd9ea63c525fc11b0008774052d51f9247427fc28a91e3836e8e8d157569565bdac17326fe44a446d98a3e4b74a55779d01bede596f2458f4ec86f3aa
+    SHA512 59210df1d9541018a21a7e89e0f552ad35c849f49be31cf47e2a85086363cdabd2bf8ce652d2024479977ae059d658c3bd18de3bdaeb8cb3ddd71f2413f266bc
     HEAD_REF master
     PATCHES
         0001-nethost-cmakelists.patch
 )
 
-set(PRODUCT_VERSION "6.0.5")
+set(PRODUCT_VERSION "7.0.0")
 
 if(VCPKG_TARGET_IS_WINDOWS)
   set(RID_PLAT "win")
 elseif(VCPKG_TARGET_IS_OSX)
   set(RID_PLAT "osx")
-elseif(VCPKG_TARGET_IS_LINUX)
+  execute_process(COMMAND sh -c "${SOURCE_PATH}/eng/native/version/copy_version_files.sh")
+  elseif(VCPKG_TARGET_IS_LINUX)
   set(RID_PLAT "linux")
+  execute_process(COMMAND sh -c "${SOURCE_PATH}/eng/native/version/copy_version_files.sh")
 else()
   message(FATAL_ERROR "Unsupported platform")
 endif()

--- a/ports/nethost/vcpkg.json
+++ b/ports/nethost/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Provides a set of APIs that can be used to host .NET Core (dotnet)",
   "homepage": "https://github.com/dotnet/runtime/tree/main/src/native/corehost/nethost",
   "license": "MIT",
-  "supports": "!uwp",
+  "supports": "(windows & !uwp), (linux, osx)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/nethost/vcpkg.json
+++ b/ports/nethost/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "nethost",
-  "version": "6.0.5",
+  "version": "7.0.0",
   "description": "Provides a set of APIs that can be used to host .NET Core (dotnet)",
-  "homepage": "https://github.com/dotnet/runtime/tree/master/src/installer/corehost/cli/nethost",
+  "homepage": "https://github.com/dotnet/runtime/tree/main/src/native/corehost/nethost",
+  "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5209,7 +5209,7 @@
       "port-version": 3
     },
     "nethost": {
-      "baseline": "6.0.5",
+      "baseline": "7.0.0",
       "port-version": 0
     },
     "nettle": {

--- a/versions/n-/nethost.json
+++ b/versions/n-/nethost.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05ce5b76fc9cc70680c72f9cec8870aa176b2c6f",
+      "version": "7.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "267a7f140709e65c5d692a7f3add885021764c25",
       "version": "6.0.5",
       "port-version": 0

--- a/versions/n-/nethost.json
+++ b/versions/n-/nethost.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "05ce5b76fc9cc70680c72f9cec8870aa176b2c6f",
+      "git-tree": "d0dbe0f8de11978aea0148c9474377cdc8e88aaf",
       "version": "7.0.0",
       "port-version": 0
     },


### PR DESCRIPTION
Update the nethost port to v7.0.0 following the latest .NET 7 release announcement: https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/

- #### What does your PR fix?
N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Same as previous version

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes, I've used `vcpkg x-add-version nethost`
