### PR TITLE
[entt] Update to 3.11.0

### DIFF
--- a/ports/entt/portfile.cmake
+++ b/ports/entt/portfile.cmake
@@ -8,8 +8,8 @@ else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO skypjack/entt
-        REF v3.10.1
-        SHA512 ce611f8892626d8df2d6be6a0e7c0218683899bae5665b4466f149c6a5b6a4d184b390370262faa3ea822a399ac71a92f4780e9a22438d4a7a14ca5f554e94c4
+        REF v3.11.0
+        SHA512 aca15f0c59fcb700ae69a9bb451fd1d9a44613931c870d91a4696a376f70b35aaf5c7e8918119a194a8e33438e0354e1dcc22fe6294e3bf3a9511cb807c3135a
         HEAD_REF master
     )
 endif()

--- a/ports/entt/vcpkg.json
+++ b/ports/entt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "entt",
-  "version": "3.10.1",
+  "version": "3.11.0",
   "port-version": 1,
   "description": "Gaming meets modern C++ - a fast and reliable entity-component system and much more",
   "homepage": "https://github.com/skypjack/entt",

--- a/ports/entt/vcpkg.json
+++ b/ports/entt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "entt",
   "version": "3.11.0",
-  "port-version": 1,
   "description": "Gaming meets modern C++ - a fast and reliable entity-component system and much more",
   "homepage": "https://github.com/skypjack/entt",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2161,7 +2161,7 @@
       "port-version": 3
     },
     "entt": {
-      "baseline": "3.10.1",
+      "baseline": "3.11.0",
       "port-version": 1
     },
     "epsilon": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2162,7 +2162,7 @@
     },
     "entt": {
       "baseline": "3.11.0",
-      "port-version": 1
+      "port-version": 0
     },
     "epsilon": {
       "baseline": "0.9.2",

--- a/versions/e-/entt.json
+++ b/versions/e-/entt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1bbb72320031821b14b973f3df4fe1555ac467dc",
+      "version": "3.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b10833e0c192da3fe85fbe23fc843fc0593a33a",
       "version": "3.11.0",
       "port-version": 1

--- a/versions/e-/entt.json
+++ b/versions/e-/entt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b10833e0c192da3fe85fbe23fc843fc0593a33a",
+      "version": "3.11.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ac258cd82d39f21b9a55ec179f02517f29802cdb",
       "version": "3.10.1",
       "port-version": 1

--- a/versions/e-/entt.json
+++ b/versions/e-/entt.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "3b10833e0c192da3fe85fbe23fc843fc0593a33a",
-      "version": "3.11.0",
-      "port-version": 1
-    },
-    {
       "git-tree": "ac258cd82d39f21b9a55ec179f02517f29802cdb",
       "version": "3.10.1",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?

Updates EnTT to 3.11.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No change to triplet support, tested on x64-windows

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes
