### PR TITLE
[rappture] fix wasm build by setting explicitly to build library with c++11 standard

### DIFF
--- a/ports/rappture/CMakeLists.txt
+++ b/ports/rappture/CMakeLists.txt
@@ -80,23 +80,25 @@ set(HEADERS
 
 add_library(rappture ${SRC_RAPPTURE_CORE} ${HEADERS})
 
-target_include_directories(rappture PUBLIC 
-                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/core/> 
+set_property(TARGET rappture PROPERTY CXX_STANDARD 11)
+
+target_include_directories(rappture PUBLIC
+                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/core/>
                             $<INSTALL_INTERFACE:include>
 )
 
 find_package(expat CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 
-target_compile_definitions(rappture PUBLIC 
-                            -D_CRT_SECURE_NO_WARNINGS 
-                            -DRAPPTURE_VERSION=1.9 
-                            -DSVN_VERSION=6713 
+target_compile_definitions(rappture PUBLIC
+                            -D_CRT_SECURE_NO_WARNINGS
+                            -DRAPPTURE_VERSION=1.9
+                            -DSVN_VERSION=6713
                             -D_USE_MATH_DEFINES
 )
 
-target_link_libraries(rappture PRIVATE 
-                        expat::expat 
+target_link_libraries(rappture PRIVATE
+                        expat::expat
                         ZLIB::ZLIB
 )
 

--- a/ports/rappture/vcpkg.json
+++ b/ports/rappture/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "rappture",
   "version": "1.9",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Rappture is a toolkit supporting Rapid application infrastructure, making it quick and easy to develop powerful scientific applications.",
+  "license": null,
   "dependencies": [
     "expat",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6458,7 +6458,7 @@
     },
     "rappture": {
       "baseline": "1.9",
-      "port-version": 1
+      "port-version": 2
     },
     "raylib": {
       "baseline": "4.2.0",

--- a/versions/r-/rappture.json
+++ b/versions/r-/rappture.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a477ff69e89f147d8d51545dce1eaf309401bc2",
+      "version": "1.9",
+      "port-version": 2
+    },
+    {
       "git-tree": "46511874b74e433c10e518d592ae43a475bb7aaf",
       "version": "1.9",
       "port-version": 1


### PR DESCRIPTION
Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
