### PR TITLE
[spdlog] Fix the non-Windows build issue by scoping the define to Windows targets.

### DIFF
--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -50,7 +50,7 @@ vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/tweakme.h
     "// #define SPDLOG_FMT_EXTERNAL"
     "#ifndef SPDLOG_FMT_EXTERNAL\n#define SPDLOG_FMT_EXTERNAL\n#endif"
 )
-if(SPDLOG_WCHAR_SUPPORT)
+if(SPDLOG_WCHAR_SUPPORT AND VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/tweakme.h
         "// #define SPDLOG_WCHAR_TO_UTF8_SUPPORT"
         "#ifndef SPDLOG_WCHAR_TO_UTF8_SUPPORT\n#define SPDLOG_WCHAR_TO_UTF8_SUPPORT\n#endif"

--- a/ports/spdlog/vcpkg.json
+++ b/ports/spdlog/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "spdlog",
   "version-semver": "1.10.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Very fast, header only, C++ logging library",
   "homepage": "https://github.com/gabime/spdlog",
   "license": "MIT",
@@ -24,7 +24,8 @@
       ]
     },
     "wchar": {
-      "description": "Build with wchar_t (Windows only)"
+      "description": "Build with wchar_t (Windows only)",
+      "supports": "windows"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7062,7 +7062,7 @@
     },
     "spdlog": {
       "baseline": "1.10.0",
-      "port-version": 1
+      "port-version": 2
     },
     "spectra": {
       "baseline": "1.0.1",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7ad0e9d934ce7401fb68968f5392fddc7dd4e3a",
+      "version-semver": "1.10.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "3256ea88cc375fda2f977a2eb18435e23d498572",
       "version-semver": "1.10.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  The previous portfile update (https://github.com/microsoft/vcpkg/commit/840f701d83d5019aa5033c9d) broke non-Windows builds when the `wchar` feature is enabled. The feature is allowed for non-Windows systems, just getting ignored in that case. But the change that adds the `#define SPDLOG_WCHAR_TO_UTF8_SUPPORT` is not scoped to Windows, and having that define in a non-Windows build triggers an #error:
```
build/vcpkg_installed/x64-linux/include/spdlog/common.h:182:10: error: #error SPDLOG_WCHAR_TO_UTF8_SUPPORT only supported on windows
```
This PR fixes the non-Windows build issue by scoping the define to Windows targets.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
