### PR TITLE
[libtcod] Update to 1.23.1

### DIFF
--- a/ports/libtcod/portfile.cmake
+++ b/ports/libtcod/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtcod/libtcod
-    REF 1.23.0
-    SHA512 efb9d1bca56268bb467ea11f640ed3807f269cd6c6cd7ea3296b3e1fb26bbe688cd8a21d3c5bb070d747a5321088e5fe4fe2a9cc52c145958a9db120d9abf878
+    REF 1.23.1
+    SHA512 d01e168b02c0540e193f65ad630180b26ac1690b9386aac039149493f436938fed4a0499ac70235f53d2675df595b7223401804b3bd2d8660917020e911f12c9
     HEAD_REF main
 )
 
@@ -10,7 +10,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     INVERTED_FEATURES
         "png" CMAKE_DISABLE_FIND_PACKAGE_lodepng-c
         "sdl" CMAKE_DISABLE_FIND_PACKAGE_SDL2
-        "sdl" CMAKE_DISABLE_FIND_PACKAGE_GLAD
         "threads" CMAKE_DISABLE_FIND_PACKAGE_Threads
         "unicode" CMAKE_DISABLE_FIND_PACKAGE_utf8proc
         "unicode" CMAKE_DISABLE_FIND_PACKAGE_unofficial-utf8proc
@@ -24,7 +23,6 @@ vcpkg_cmake_configure(
         -DCMAKE_INSTALL_INCLUDEDIR=${CURRENT_PACKAGES_DIR}/include
         -DLIBTCOD_SDL2=find_package
         -DLIBTCOD_ZLIB=find_package
-        -DLIBTCOD_GLAD=find_package
         -DLIBTCOD_LODEPNG=find_package
         -DLIBTCOD_UTF8PROC=vcpkg
         -DLIBTCOD_STB=find_package

--- a/ports/libtcod/vcpkg.json
+++ b/ports/libtcod/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtcod",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "maintainers": "Kyle Benesch <4b796c65+github@gmail.com>",
   "description": "Common algorithms and tools for roguelikes.",
   "homepage": "https://github.com/libtcod/libtcod",
@@ -31,9 +31,8 @@
       ]
     },
     "sdl": {
-      "description": "Support for SDL2 windows and events including OpenGL support and the libtcod context.",
+      "description": "Support for SDL2 windows and events with the libtcod context.",
       "dependencies": [
-        "glad",
         "sdl2"
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4261,7 +4261,7 @@
       "port-version": 0
     },
     "libtcod": {
-      "baseline": "1.23.0",
+      "baseline": "1.23.1",
       "port-version": 0
     },
     "libtess2": {

--- a/versions/l-/libtcod.json
+++ b/versions/l-/libtcod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09fe9037f9dc927b39eac5ed74cbce37dbb62f12",
+      "version": "1.23.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "43c6a88dc753dd9d7e106f8ee9c7bc26d4ed39b6",
       "version": "1.23.0",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Updates to the latest version.
  Removes `glad` as a dependency. This library no longer uses it.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, N/A

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes