### PR TITLE
[libunistring] Enable uwp

### DIFF
--- a/ports/libidn2/portfile.cmake
+++ b/ports/libidn2/portfile.cmake
@@ -29,13 +29,6 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_list(APPEND options "CPPFLAGS=\$CPPFLAGS -DIDN2_STATIC")
 endif()
 
-vcpkg_list(SET options_release)
-vcpkg_list(SET options_debug)
-if(NOT VCPKG_TARGET_IS_UWP)
-    vcpkg_list(APPEND options_release "--with-libunistring-prefix=${CURRENT_INSTALLED_DIR}")
-    vcpkg_list(APPEND options_debug "--with-libunistring-prefix=${CURRENT_INSTALLED_DIR}/debug")
-endif()
-
 set(ENV{GTKDOCIZE} true)
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -48,11 +41,11 @@ vcpkg_configure_make(
         --disable-doc
         --disable-gcc-warnings
     OPTIONS_RELEASE
-        ${options_release}
         "--with-libiconv-prefix=${CURRENT_INSTALLED_DIR}"
+        "--with-libunistring-prefix=${CURRENT_INSTALLED_DIR}"
     OPTIONS_DEBUG
-        ${options_debug}
         "--with-libiconv-prefix=${CURRENT_INSTALLED_DIR}/debug"
+        "--with-libunistring-prefix=${CURRENT_INSTALLED_DIR}/debug"
         "CFLAGS=\$CFLAGS -I${CURRENT_INSTALLED_DIR}/include"
 )
 

--- a/ports/libidn2/vcpkg.json
+++ b/ports/libidn2/vcpkg.json
@@ -1,15 +1,13 @@
 {
   "name": "libidn2",
   "version": "2.3.4",
+  "port-version": 1,
   "description": "GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.",
   "homepage": "https://www.gnu.org/software/libidn/",
   "license": null,
   "dependencies": [
     "libiconv",
-    {
-      "name": "libunistring",
-      "platform": "!uwp"
-    }
+    "libunistring"
   ],
   "features": {
     "nls": {

--- a/ports/libunistring/vcpkg.json
+++ b/ports/libunistring/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "libunistring",
   "version": "1.1",
+  "port-version": 1,
   "description": "GNU libunistring provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.",
   "homepage": "https://www.gnu.org/software/libunistring/",
   "license": "LGPL-3.0-or-later OR GPL-2.0-or-later",
-  "supports": "!uwp",
   "dependencies": [
     "libiconv"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4314,7 +4314,7 @@
     },
     "libunistring": {
       "baseline": "1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "liburing": {
       "baseline": "2.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3842,7 +3842,7 @@
     },
     "libidn2": {
       "baseline": "2.3.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libigl": {
       "baseline": "2.3.0",

--- a/versions/l-/libidn2.json
+++ b/versions/l-/libidn2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "111b9ff4af9664333f73344385dfbbfa40d9bc20",
+      "version": "2.3.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "35fb9b986592d348551ac34f20353c8f3e4bd187",
       "version": "2.3.4",
       "port-version": 0

--- a/versions/l-/libunistring.json
+++ b/versions/l-/libunistring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5511958230904a505b18af4043c5b51512d8684",
+      "version": "1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6ebb68b893ecddce91b3370a72e5575b8895a7df",
       "version": "1.1",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Enables uwp for libunistring.
  Enables uniform usage of libunistring in libidn2.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Adding uwp to supported.
 
- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
