### PR TITLE
[function2] Update to version 4.2.2

### DIFF
--- a/ports/function2/portfile.cmake
+++ b/ports/function2/portfile.cmake
@@ -1,27 +1,23 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Naios/function2
-    REF 02ca99831de59c7c3a4b834789260253cace0ced # 4.2.0
-    SHA512 5b14d95584586c7365119f5171c86c7556ce402ae3c5db09e4e54e1225fc71e40f88ab77188986ecf9dac5eecbfd6330c5a7ecfe0375cb37773d007ebef1ba93
+    REF 2d3a878ef19dd5d2fb188898513610fac0a48621 # 4.2.2
+    SHA512 e59c6fe7f4b68d4d70d1b0ccb3677ee5529e08431ee642933a4de1b217390d3a91f6501f06d0da080af85a5cb55da5b48c6de92818779ac25c6f56166a5b59fd
     HEAD_REF master
     PATCHES
         disable-testing.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
-
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
-
-file(REMOVE ${CURRENT_PACKAGES_DIR}/Readme.md)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
-
-# Put the installed licence file where vcpkg expects it
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(RENAME ${CURRENT_PACKAGES_DIR}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
-
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+
+file(REMOVE "${CURRENT_PACKAGES_DIR}/LICENSE.txt" "${CURRENT_PACKAGES_DIR}/Readme.md")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/function2/vcpkg.json
+++ b/ports/function2/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "function2",
-  "version-string": "4.2.0",
-  "port-version": 1,
+  "version-semver": "4.2.2",
   "description": "Improved drop-in replacement to std::function",
-  "homepage": "https://github.com/Naios/function2"
+  "homepage": "https://github.com/Naios/function2",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2481,8 +2481,8 @@
       "port-version": 0
     },
     "function2": {
-      "baseline": "4.2.0",
-      "port-version": 1
+      "baseline": "4.2.2",
+      "port-version": 0
     },
     "functions-framework-cpp": {
       "baseline": "1.1.0",

--- a/versions/f-/function2.json
+++ b/versions/f-/function2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afa334fcb26a441121e2426e39e879c6574db698",
+      "version-semver": "4.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "98e16b513e6457caf3edc8ac5dc1db7e62255797",
       "version-string": "4.2.0",
       "port-version": 1


### PR DESCRIPTION
Update to function2 4.2.2 and modernize portfile.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Same as before, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
