### PR TITLE
[vcpkg baseline] Fix libxmu dep

### DIFF
--- a/ports/libx11/portfile.cmake
+++ b/ports/libx11/portfile.cmake
@@ -30,6 +30,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
                 --enable-loadable-i18n=no #Pointer conversion errors
                 --enable-unix-transport=no
                 --disable-thread-safety-constructor
+                ac_cv_search_dlopen=no
     )
 endif()
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/libx11/vcpkg.json
+++ b/ports/libx11/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libx11",
   "version": "1.8.1",
+  "port-version": 1,
   "description": "The X Window System is a network-transparent window system that was designed at MIT.",
   "homepage": "https://www.x.org/wiki/",
   "license": "MIT",

--- a/ports/libxmu/vcpkg.json
+++ b/ports/libxmu/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libxmu",
   "version": "1.1.3",
+  "port-version": 1,
   "description": "X miscellaneous utility routines library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxmu",
   "license": null,

--- a/ports/libxmu/vcpkg.json
+++ b/ports/libxmu/vcpkg.json
@@ -6,6 +6,7 @@
   "license": null,
   "dependencies": [
     "bzip2",
+    "libxext",
     "libxt",
     "xorg-macros"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4458,7 +4458,7 @@
     },
     "libxmu": {
       "baseline": "1.1.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libxpm": {
       "baseline": "3.5.11",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4374,7 +4374,7 @@
     },
     "libx11": {
       "baseline": "1.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libxau": {
       "baseline": "1.0.9",

--- a/versions/l-/libx11.json
+++ b/versions/l-/libx11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "990f02cb9422412f2c71e9f3b4616a7331d65fe6",
+      "version": "1.8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c316078022f4159f578146cf4871c359d5af8321",
       "version": "1.8.1",
       "port-version": 0

--- a/versions/l-/libxmu.json
+++ b/versions/l-/libxmu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "59f551a642f1c8b1c6dd02ad3f13d32231e48d4b",
+      "git-tree": "6bcf9008d8bcd44e0ec4d05f7319133f6457c011",
       "version": "1.1.3",
       "port-version": 0
     }

--- a/versions/l-/libxmu.json
+++ b/versions/l-/libxmu.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "6bcf9008d8bcd44e0ec4d05f7319133f6457c011",
+      "git-tree": "3d3fe5c3318403e642b6b1ea9e2c6d4a53547dce",
+      "version": "1.1.3",
+      "port-version": 1
+    },
+    {
+      "git-tree": "59f551a642f1c8b1c6dd02ad3f13d32231e48d4b",
       "version": "1.1.3",
       "port-version": 0
     }


### PR DESCRIPTION
missed libxext as a dependency. Thought it would be added through libxt