### PR TITLE
[libunistring] Improve build parallelization

### DIFF
--- a/ports/libunistring/parallelize-symbol-collection.patch
+++ b/ports/libunistring/parallelize-symbol-collection.patch
@@ -1,0 +1,46 @@
+diff --git a/lib/Makefile.am b/lib/Makefile.am
+index 382d2bc..d9f0144 100644
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -274,6 +274,25 @@ endif
+ # But don't hide symbols that start with "libintl_locale", for the reason
+ # stated in localename-table.h.
+ all check install: config.h
++%_exported:
++	@d=`echo "$@" | sed -e 's,/[^/]*$$,,'`; \
++	test "$$d" = "$@" || mkdir -p "$$d" ; \
++	true >"$@" || exit 1 ; \
++	f=`echo "$@" | sed -e 's,_exported$$,,'`; \
++	case $$f in \
++	  *.res.lo ) ;; \
++	  *.c | *.$(OBJEXT) | *.lo ) \
++	    sf=`echo "$$f" | sed -e 's,\\.[^.]*$$,,'`.c; \
++	    test -f $$sf || sf=$(srcdir)/$$sf; \
++	    of=`echo "$$f" | sed -e 's,^.*/,,' -e 's,\\.[^.]*$$,,'`.$(OBJEXT); \
++	    echo "$(COMPILE) -c $$sf && sh ./exported.sh $$of 1>>$@" ; \
++	    $(COMPILE) -c $$sf || exit 1; \
++	    sh ./exported.sh $$of 1>>"$@"; \
++	    rm -f $$of `echo "$$of" | sed -e 's,\\.$(OBJEXT)$$,.lo,'`; \
++	    ;; \
++	esac
++libunistring_la_EXPORTED = $(libunistring_la_SOURCES:%=%_exported) $(libunistring_la_LIBADD:%=%_exported)
++exported: $(libunistring_la_EXPORTED)
+ config.h: $(BUILT_SOURCES) $(srcdir)/libunistring.sym
+ 	{ echo '/* DO NOT EDIT! GENERATED AUTOMATICALLY! */'; \
+ 	  : "Avoid double inclusion, to avoid a warning about redefinitions."; \
+@@ -285,10 +304,14 @@ config.h: $(BUILT_SOURCES) $(srcdir)/libunistring.sym
+ 	  echo '#endif /* UNISTRING_CONFIG_H */'; \
+ 	} > config.h && \
+ 	if test -n "$(NAMESPACING)" && test -n "$(HAVE_GLOBAL_SYMBOL_PIPE)"; then \
++	  echo "Collecting symbols to be renamed"; \
++	  $(MAKE) exported && \
+ 	  { \
+ 	    { \
+-	      for f in $(libunistring_la_SOURCES) $(libunistring_la_LIBADD); do \
++	      for f in $(libunistring_la_EXPORTED); do \
+ 	        case $$f in \
++	          *_exported ) cat $$f 1>&5; ;; \
++	          * ) ;; \
+ 	          *.res.lo ) ;; \
+ 	          *.c | *.$(OBJEXT) | *.lo ) \
+ 	            sf=`echo "$$f" | sed -e 's,\\.[^.]*$$,,'`.c; \

--- a/ports/libunistring/portfile.cmake
+++ b/ports/libunistring/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     PATCHES
         disable-gnulib-fetch.patch
         disable-subdirs.patch
+        parallelize-symbol-collection.patch
 )
 
 vcpkg_configure_make(

--- a/ports/libunistring/vcpkg.json
+++ b/ports/libunistring/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libunistring",
   "version": "1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GNU libunistring provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.",
   "homepage": "https://www.gnu.org/software/libunistring/",
   "license": "LGPL-3.0-or-later OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4314,7 +4314,7 @@
     },
     "libunistring": {
       "baseline": "1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "liburing": {
       "baseline": "2.2",

--- a/versions/l-/libunistring.json
+++ b/versions/l-/libunistring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8bcb2f939ea16732abab03352b951cf12713bc54",
+      "version": "1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "a5511958230904a505b18af4043c5b51512d8684",
       "version": "1.1",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes slow building.
  The package compiles gnulib and processes source files in order to find their symbols and to define renaming. This PR parallelizes the expensive per-source-file part, collecting intermediate results in additional files.
  For x64-linux locally, the generated `lib/config.h` was checked to be identical, and build time is down from 2 min to 1.5 min.
  For x64-windows CI, build time is down from 14 min to 9 min.
  For x64-osx CI, build time is down from 7.7 min to 5.5 min.
  Credits: IIRC this idea was presented before by another contributor.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes