### PR TITLE
[tensorflow-common] fix regex pattern of static link script

### DIFF
--- a/ports/tensorflow-common/generate_static_link_cmd_macos.py
+++ b/ports/tensorflow-common/generate_static_link_cmd_macos.py
@@ -10,7 +10,7 @@ with open(sys.argv[1], "r") as f_in:
     with open("static_link.sh", "w") as f_out:
         if os.path.isfile(f"{params_path}/libtensorflow_framework.{version}.dylib-2.params"):
             p_cd = re.compile(r"^\((cd .*) && \\$")
-            p_linker = re.compile(fr"^\s*.+cc_wrapper.sh.+(@bazel-out\S+libtensorflow{lib_suffix}\.\d\.\d\.\d\.dylib-2\.params).*")
+            p_linker = re.compile(fr"^\s*.+cc_wrapper.sh.+(@bazel-out\S+libtensorflow{lib_suffix}\.\d+\.\d+\.\d+\.dylib-2\.params).*")
             f_out.write("#!/bin/bash\n# note: ar/binutils version 2.27 required to support output files > 4GB\n")
             env = []
             for line in f_in:
@@ -29,8 +29,8 @@ with open(sys.argv[1], "r") as f_in:
         else:
             # old behaviour (still on some platforms): inline all parameters instead of using -2.params file
             p_cd = re.compile(r"^\((cd .*) && \\$")
-            p_linker1 = re.compile(fr"^.*cc_wrapper.sh.+-shared.+-o (bazel-out\S+libtensorflow{lib_suffix}\.\d\.\d\.\d\.dylib)")
-            p_linker2 = re.compile("^.*cc_wrapper.sh.+-shared.+-o (bazel-out\\S+libtensorflow_framework\\.\\d\\.\\d\\.\\d\\.dylib)")
+            p_linker1 = re.compile(fr"^.*cc_wrapper.sh.+-shared.+-o (bazel-out\S+libtensorflow{lib_suffix}\.\d+\.\d+\.\d+\.dylib)")
+            p_linker2 = re.compile("^.*cc_wrapper.sh.+-shared.+-o (bazel-out\\S+libtensorflow_framework\\.\\d+\\.\\d+\\.\\d+\\.dylib)")
             f_out.write("#!/bin/bash\n# note: ar/binutils version 2.27 required to support output files > 4GB\n")
             env = []
             parts = None

--- a/ports/tensorflow-common/vcpkg.json
+++ b/ports/tensorflow-common/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tensorflow-common",
   "version-semver": "2.10.0",
+  "port-version": 1,
   "description": "This meta package holds common files for the C [tensorflow] and the C++ [tensorflow-cc] API version of TensorFlow but is not installable on its own.",
   "homepage": "https://github.com/tensorflow/tensorflow",
   "license": "Apache-2.0"

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1059,9 +1059,6 @@ tensorflow-cc:x64-windows=fail
 tensorflow-cc:x64-windows-static=fail
 tensorflow-cc:x64-windows-static-md=fail
 
-tensorflow:x64-osx=fail
-tensorflow-cc:x64-osx=fail
-
 theia:arm64-windows      = skip
 theia:arm-uwp            = skip
 theia:x64-uwp            = skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7334,7 +7334,7 @@
     },
     "tensorflow-common": {
       "baseline": "2.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tensorpipe": {
       "baseline": "2022-03-16",

--- a/versions/t-/tensorflow-common.json
+++ b/versions/t-/tensorflow-common.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "958295999ce648940c11c6671f0897f38944841a",
+      "git-tree": "0c6c288cabee4b8f5b260c2af84c534ece1285d8",
+      "version-semver": "2.10.0",
+      "port-version": 1
+    },
+    {
+      "git-tree": "6f2b166291c2d1c9b37a06acf83d40d91d128eb5",
       "version-semver": "2.10.0",
       "port-version": 0
     },

--- a/versions/t-/tensorflow-common.json
+++ b/versions/t-/tensorflow-common.json
@@ -6,7 +6,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "6f2b166291c2d1c9b37a06acf83d40d91d128eb5",
+      "git-tree": "958295999ce648940c11c6671f0897f38944841a",
       "version-semver": "2.10.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fix regular expression for static link pattern script.

Pattern `r"\.\d\.\d\.\d"` cannot match string `2.10.0`, changed it to `r"\.\d+\.\d+\.\d+"`.

Without this modification, we can't generate static-linked library (.a) correctly in osx.

reference issue: https://github.com/microsoft/vcpkg/issues/27411