### PR TITLE
[boost-modular-build-helper] Don't set target architecture for emscripten boost

### DIFF
--- a/ports/boost-modular-build-helper/CMakeLists.txt
+++ b/ports/boost-modular-build-helper/CMakeLists.txt
@@ -44,7 +44,7 @@ elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "mips64")
     list(APPEND B2_OPTIONS architecture=mips64)
 elseif("arm64" IN_LIST VCPKG_TARGET_ARCHITECTURE AND "x86_64" IN_LIST VCPKG_TARGET_ARCHITECTURE)
     list(APPEND B2_OPTIONS architecture=arm+x86)
-else()
+elseif(NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Emscripten") # Emscripten doesn't require an architecture to be set here, architecture gets set by Emscripten SDK
     list(APPEND B2_OPTIONS architecture=x86)
 endif()
 


### PR DESCRIPTION
Fixes #27641

**Describe the pull request**

- #### What does your PR fix?
  Fixes #27641 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes (I think)

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
No (I will do that later)

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
