### PR TITLE
[alpaka] Fix Boost version constraints

### DIFF
--- a/ports/alpaka/vcpkg.json
+++ b/ports/alpaka/vcpkg.json
@@ -1,17 +1,18 @@
 {
   "name": "alpaka",
   "version": "0.9.0",
+  "port-version": 1,
   "description": "The alpaka library is a header-only abstraction library for accelerator development",
   "homepage": "https://github.com/alpaka-group/alpaka",
   "license": "MPL-2.0",
   "dependencies": [
     {
       "name": "boost-core",
-      "version>=": "1.74"
+      "version>=": "1.74.0"
     },
     {
       "name": "boost-predef",
-      "version>=": "1.74"
+      "version>=": "1.74.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/a-/alpaka.json
+++ b/versions/a-/alpaka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7149b432a8cfdb7406ce5979d11c11c5caa8fe3f",
+      "version": "0.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "fa2a5d53283561fed784514fd0063badc589eb39",
       "version": "0.9.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -74,7 +74,7 @@
     },
     "alpaka": {
       "baseline": "0.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "alsa": {
       "baseline": "1.2.6.1",


### PR DESCRIPTION
When I proposed to include the alpaka library in #26812 I added version constraints for alpaka's Boost dependencies. However, it seems that the format for the version I entered was not correct. At least, if I use `alpaka` as a dependency in a project in manifest mode, I get the following error:

```
$ cmake -DCMAKE_TOOLCHAIN_FILE=~/dev/vcpkg/scripts/buildsystems/vcpkg.cmake ..
-- Running vcpkg install
Error: No version entry for boost-core at version 1.74. This may be fixed by updating vcpkg to the latest master via `git pull`.
Available versions:
    1.80.0#1
    1.80.0
    1.79.0
    1.78.0
    1.77.0
    1.76.0
    1.75.0
    1.74.0
    1.73.0
    1.72.0
    1.71.0
    1.70.0
    1.69.0
    1.68.0
    1.67.0
    1.66.0

See `vcpkg help versioning` for more information.
```
Notice that vcpkg says that there is no version `1.74` but the version `1.74.0` is available.

- #### What does your PR fix?

It (tries to) fix the version constraints for Boost in the alpaka port. Please tell me if it is correct now!

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes