### PR TITLE
[taglib] Disable tests and examples.

### DIFF
--- a/ports/taglib/portfile.cmake
+++ b/ports/taglib/portfile.cmake
@@ -12,7 +12,10 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${WINRT_OPTIONS}
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_EXAMPLES=OFF
+        ${WINRT_OPTIONS}
 )
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()

--- a/ports/taglib/vcpkg.json
+++ b/ports/taglib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "taglib",
   "version-semver": "1.13.0",
+  "port-version": 1,
   "description": "TagLib Audio Meta-Data Library",
   "homepage": "https://taglib.org/",
   "license": "LGPL-2.1-only OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7286,7 +7286,7 @@
     },
     "taglib": {
       "baseline": "1.13.0",
-      "port-version": 0
+      "port-version": 1
     },
     "taocpp-json": {
       "baseline": "2020-09-14",

--- a/versions/t-/taglib.json
+++ b/versions/t-/taglib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3ab8e6485aab876d06d0e43ab29372b54863467",
+      "version-semver": "1.13.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a8c78ba20c6163ed9927cb6ae1fbeec80797f13f",
       "version-semver": "1.13.0",
       "port-version": 0


### PR DESCRIPTION
New build:  
https://dev.azure.com/vcpkg/public/_build/results?buildId=80953

REGRESSION: qt:x64-windows-static cascaded, but it is required to pass. (C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt).  
REGRESSION: taglib:x64-windows-static failed with BUILD_FAILED. If expected, add taglib:x64-windows-static=fail to C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt.  
REGRESSION: taglib:x64-windows-static-md failed with BUILD_FAILED. If expected, add taglib:x64-windows-static-md=fail to C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt.

Probably caused by https://github.com/microsoft/vcpkg/pull/27751 "[taglib] Update to 1.13"

We only saw in full CI run because the trigger is an optional dependency detection for cppunit being installed first:

cppunit.lib(TestResult.cpp.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in main.cpp.obj cppunit.lib(TestResult.cpp.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MT_StaticRelease' doesn't match value 'MTd_StaticDebug' in main.cpp.obj

Upstream has:

```
if(BUILD_TESTING)
  find_package(CppUnit)
  if(CppUnit_FOUND)
    add_subdirectory(tests)
  else()
    message(WARNING "BUILD_TESTING requested, but CppUnit not found, skipping tests.")
  endif()
endif()
```

upstream. Disabling.

Also checked whether cppunit was including release libs in debug, but they aren't; upstream of taglib has a broken find module for cppunit.
