### PR TITLE
[folly] Fix incorrect option of zlib from PR 27728

### DIFF
--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -38,23 +38,15 @@ endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        "zlib" CMAKE_REQUIRE_FIND_PACKAGE_ZLIB
+        "zlib"       CMAKE_REQUIRE_FIND_PACKAGE_ZLIB
+    INVERTED_FEATURES
+        "bzip2"      CMAKE_DISABLE_FIND_PACKAGE_BZip2
+        "lzma"       CMAKE_DISABLE_FIND_PACKAGE_LibLZMA
+        "lz4"        CMAKE_DISABLE_FIND_PACKAGE_LZ4
+        "zstd"       CMAKE_DISABLE_FIND_PACKAGE_Zstd
+        "snappy"     CMAKE_DISABLE_FIND_PACKAGE_Snappy
+        "libsodium"  CMAKE_DISABLE_FIND_PACKAGE_unofficial-sodium
 )
-
-macro(feature FEATURENAME PACKAGENAME)
-    if("${FEATURENAME}" IN_LIST FEATURES)
-        list(APPEND FEATURE_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_${PACKAGENAME}=OFF)
-    else()
-        list(APPEND FEATURE_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_${PACKAGENAME}=ON)
-    endif()
-endmacro()
-
-feature(bzip2 BZip2)
-feature(lzma LibLZMA)
-feature(lz4 LZ4)
-feature(zstd Zstd)
-feature(snappy Snappy)
-feature(libsodium unofficial-sodium)
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -36,7 +36,10 @@ else()
     set(MSVC_USE_STATIC_RUNTIME OFF)
 endif()
 
-set(FEATURE_OPTIONS)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "zlib" CMAKE_REQUIRE_FIND_PACKAGE_ZLIB
+)
 
 macro(feature FEATURENAME PACKAGENAME)
     if("${FEATURENAME}" IN_LIST FEATURES)
@@ -46,7 +49,6 @@ macro(feature FEATURENAME PACKAGENAME)
     endif()
 endmacro()
 
-feature(zlib ZLIB)
 feature(bzip2 BZip2)
 feature(lzma LibLZMA)
 feature(lz4 LZ4)

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "folly",
   "version-string": "2022.10.31.00",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2382,7 +2382,7 @@
     },
     "folly": {
       "baseline": "2022.10.31.00",
-      "port-version": 1
+      "port-version": 2
     },
     "font-chef": {
       "baseline": "1.1.0",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "791733ce6ee29dfd3d0c9a48cbf3d9421070ec27",
+      "version-string": "2022.10.31.00",
+      "port-version": 2
+    },
+    {
       "git-tree": "93e3787e5d3b5f22d58c029919d3654f9c6b1500",
       "version-string": "2022.10.31.00",
       "port-version": 1

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "791733ce6ee29dfd3d0c9a48cbf3d9421070ec27",
+      "git-tree": "fe39202619449823918182d7eb34a7eab60e1f59",
       "version-string": "2022.10.31.00",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Change the incorrect feature option of `zlib` in folly's portfile.cmake. The related comment: https://github.com/microsoft/vcpkg/pull/27728#issuecomment-1317990671
