### PR TITLE
[gdal] Move dependencies into separate features

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -21,37 +21,37 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         cfitsio          GDAL_USE_CFITSIO
         curl             GDAL_USE_CURL
-        recommended-features GDAL_USE_EXPAT
+        expat            GDAL_USE_EXPAT
         freexl           GDAL_USE_FREEXL
         geos             GDAL_USE_GEOS
         core             GDAL_USE_GEOTIFF
-        default-features GDAL_USE_GIF
+        gif              GDAL_USE_GIF
         hdf5             GDAL_USE_HDF5
-        default-features GDAL_USE_ICONV
-        default-features GDAL_USE_JPEG
+        iconv            GDAL_USE_ICONV
+        jpeg             GDAL_USE_JPEG
         core             GDAL_USE_JSONC
         lerc             GDAL_USE_LERC
         libkml           GDAL_USE_LIBKML  # TODO, needs policy patches to FindLibKML.cmake
-        default-features GDAL_USE_LIBLZMA
-        default-features GDAL_USE_LIBXML2
+        lzma             GDAL_USE_LIBLZMA
+        libxml2          GDAL_USE_LIBXML2
         mysql-libmariadb GDAL_USE_MYSQL 
         netcdf           GDAL_USE_NETCDF
         odbc             GDAL_USE_ODBC
-        default-features GDAL_USE_OPENJPEG
-        default-features GDAL_USE_OPENSSL
-        default-features GDAL_USE_PCRE2
-        default-features GDAL_USE_PNG
+        openjpeg         GDAL_USE_OPENJPEG
+        openssl          GDAL_USE_OPENSSL
+        pcre2            GDAL_USE_PCRE2
+        png              GDAL_USE_PNG
         poppler          GDAL_USE_POPPLER
         postgresql       GDAL_USE_POSTGRESQL
-        default-features GDAL_USE_QHULL
+        qhull            GDAL_USE_QHULL
         #core             GDAL_USE_SHAPELIB  # https://github.com/OSGeo/gdal/issues/5711, https://github.com/microsoft/vcpkg/issues/16041
         core             GDAL_USE_SHAPELIB_INTERNAL
         libspatialite    GDAL_USE_SPATIALITE
-        recommended-features GDAL_USE_SQLITE3
+        sqlite3          GDAL_USE_SQLITE3
         core             GDAL_USE_TIFF
-        default-features GDAL_USE_WEBP
+        webp             GDAL_USE_WEBP
         core             GDAL_USE_ZLIB
-        default-features GDAL_USE_ZSTD
+        zstd             GDAL_USE_ZSTD
         tools            BUILD_APPS
 )
 if(GDAL_USE_ICONV AND VCPKG_TARGET_IS_WINDOWS)

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.5.3",
+  "port-version": 1,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,
@@ -56,14 +57,20 @@
     "default-features": {
       "description": "Default set of features, including recommended features",
       "dependencies": [
-        "expat",
         {
           "name": "gdal",
           "default-features": false,
           "features": [
-            "curl",
-            "geos",
-            "recommended-features"
+            "gif",
+            "iconv",
+            "libxml2",
+            "lzma",
+            "openjpeg",
+            "openssl",
+            "pcre2",
+            "recommended-features",
+            "webp",
+            "zstd"
           ]
         },
         {
@@ -83,19 +90,13 @@
             "netcdf"
           ],
           "platform": "!uwp & !(windows & arm64) & !android & !ios"
-        },
-        "giflib",
-        "libiconv",
-        "libjpeg-turbo",
-        "liblzma",
-        "libpng",
-        "libwebp",
-        "libxml2",
-        "openjpeg",
-        "openssl",
-        "pcre2",
-        "qhull",
-        "zstd"
+        }
+      ]
+    },
+    "expat": {
+      "description": "Use EXPAT library",
+      "dependencies": [
+        "expat"
       ]
     },
     "freexl": {
@@ -110,6 +111,12 @@
         "geos"
       ]
     },
+    "gif": {
+      "description": "Enable GIF support",
+      "dependencies": [
+        "giflib"
+      ]
+    },
     "hdf5": {
       "description": "Enable HDF5 support",
       "dependencies": [
@@ -122,6 +129,18 @@
         }
       ]
     },
+    "iconv": {
+      "description": "Use iconv library",
+      "dependencies": [
+        "libiconv"
+      ]
+    },
+    "jpeg": {
+      "description": "Use JPEG compression library",
+      "dependencies": [
+        "libjpeg-turbo"
+      ]
+    },
     "lerc": {
       "description": "Enable LERC support",
       "dependencies": [
@@ -132,6 +151,18 @@
       "description": "Create or update SpatiaLite databases using libspatialite",
       "dependencies": [
         "libspatialite"
+      ]
+    },
+    "libxml2": {
+      "description": "Use LibXML2 library",
+      "dependencies": [
+        "libxml2"
+      ]
+    },
+    "lzma": {
+      "description": "Use LZMA library",
+      "dependencies": [
+        "liblzma"
       ]
     },
     "mysql-libmariadb": {
@@ -147,6 +178,30 @@
           "name": "netcdf-c",
           "default-features": false
         }
+      ]
+    },
+    "openjpeg": {
+      "description": "Use OpenJPEG library",
+      "dependencies": [
+        "openjpeg"
+      ]
+    },
+    "openssl": {
+      "description": "Use OpenSSL library",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "pcre2": {
+      "description": "Enable PCRE2 support for sqlite3",
+      "dependencies": [
+        "pcre2"
+      ]
+    },
+    "png": {
+      "description": "Use PNG compression library",
+      "dependencies": [
+        "libpng"
       ]
     },
     "poppler": {
@@ -167,10 +222,34 @@
         "libpq"
       ]
     },
+    "qhull": {
+      "description": "Use QHULL library",
+      "dependencies": [
+        "qhull"
+      ]
+    },
     "recommended-features": {
       "description": "Features that are explicity marked as recommended by GDAL.",
       "dependencies": [
-        "expat",
+        {
+          "name": "gdal",
+          "default-features": false,
+          "features": [
+            "curl",
+            "expat",
+            "geos",
+            "jpeg",
+            "lerc",
+            "png",
+            "qhull",
+            "sqlite3"
+          ]
+        }
+      ]
+    },
+    "sqlite3": {
+      "description": "Enable SQLite3 support",
+      "dependencies": [
         {
           "name": "sqlite3",
           "features": [
@@ -196,6 +275,18 @@
     },
     "tools": {
       "description": "Builds gdal and ogr executables"
+    },
+    "webp": {
+      "description": "Enable WEBP support",
+      "dependencies": [
+        "libwebp"
+      ]
+    },
+    "zstd": {
+      "description": "Use ZSTD library",
+      "dependencies": [
+        "zstd"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2538,7 +2538,7 @@
     },
     "gdal": {
       "baseline": "3.5.3",
-      "port-version": 0
+      "port-version": 1
     },
     "gdcm": {
       "baseline": "3.0.12",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8523d8bd85ac0b7646be51eb0498ebd51f8e2804",
+      "version-semver": "3.5.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "7d27d35c37e48b554b8276dbba52b75646ae4748",
       "version-semver": "3.5.3",
       "port-version": 0


### PR DESCRIPTION
Make gdal port more modular by moving dependencies into separate features. My main goal was to be able to use `iconv` without having to pull a lot of other dependencies like `libpq`.
Also update `recommended-features` feature to reflect upstream decisions (https://github.com/OSGeo/gdal/blob/master/cmake/helpers/CheckDependentLibraries.cmake).

Cc @dg0yt 