### PR TITLE
[sqlite3] update to 3.40.0

### DIFF
--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -1,7 +1,7 @@
 # Be sure to update both of these versions together.
-set(SQLITE_VERSION 3390200)
-set(PKGCONFIG_VERSION 3.39.2)
-set(SQLITE_HASH a8fb7903cdc985d17b421035d6affe16795382085d7eb70428bdbbb4abc7ea6674aa251d4e532b531733c195e8867bfbd3c5556824c76cf321f8bc617bad6a32)
+set(SQLITE_VERSION 3400000)
+set(PKGCONFIG_VERSION 3.40.0)
+set(SQLITE_HASH db099793e05ac0f37355c9bd41173fb63cfe20fe4eea49de227d06f6d22064ded38bb8369c495ce06a1ef1e687d41169d93d74359367333622c6893720f3c1f0)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2022/sqlite-amalgamation-${SQLITE_VERSION}.zip"

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -11,8 +11,7 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    REF ${SQLITE_VERSION}
+    ARCHIVE "${ARCHIVE}"
     PATCHES fix-arm-uwp.patch
 )
 

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -9,8 +9,8 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 ${SQLITE_HASH}
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
+vcpkg_extract_source_archive(
+    SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     REF ${SQLITE_VERSION}
     PATCHES fix-arm-uwp.patch

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.39.2",
+  "version": "3.40.0",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://github.com/sqlite/sqlite",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7157,7 +7157,7 @@
       "port-version": 0
     },
     "sqlite3": {
-      "baseline": "3.39.2",
+      "baseline": "3.40.0",
       "port-version": 0
     },
     "sqlitecpp": {

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "06f595be5f6a254456b354b05bc67ccccda36cb2",
+      "git-tree": "29726ec54ab7d17bbfbffcc2ff9448201334e6ea",
       "version": "3.40.0",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "29726ec54ab7d17bbfbffcc2ff9448201334e6ea",
+      "git-tree": "2a4aa5dd4dce8b1852a367c9e6ded10e4ca00006",
       "version": "3.40.0",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06f595be5f6a254456b354b05bc67ccccda36cb2",
+      "version": "3.40.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b673cfda60055677c42fe66cdd0655ad4a1110dd",
       "version": "3.39.2",
       "port-version": 0


### PR DESCRIPTION
Fix #27866 

Update sqlite3 to the latest version 3.40.0

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static