### PR TITLE
[pango] Fix the dependency type name of freetype

### DIFF
--- a/ports/pango/fix-pangoft2PC.patch
+++ b/ports/pango/fix-pangoft2PC.patch
@@ -7,7 +7,7 @@ index 4e796ec..9693dc7 100644
                            fallback: ['freetype2', 'freetype_dep'])
  
 -if freetype_dep.found() and freetype_dep.type_name() == 'pkgconfig'
-+if freetype_dep.found() and freetype_dep.type_name() == 'cmake'
++if freetype_dep.found()
    freetype2_pc = 'freetype2'
  endif
  

--- a/ports/pango/fix-pangoft2PC.patch
+++ b/ports/pango/fix-pangoft2PC.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 4e796ec..9693dc7 100644
+--- a/meson.build
++++ b/meson.build
+@@ -345,7 +345,7 @@ freetype_dep = dependency(freetype_package_name,
+                           required: freetype_option,
+                           fallback: ['freetype2', 'freetype_dep'])
+ 
+-if freetype_dep.found() and freetype_dep.type_name() == 'pkgconfig'
++if freetype_dep.found() and freetype_dep.type_name() == 'cmake'
+   freetype2_pc = 'freetype2'
+ endif
+ 

--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -22,8 +22,6 @@ vcpkg_configure_meson(
         -Dgtk_doc=false #Build API reference for Pango using GTK-Doc
     ADDITIONAL_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
                         glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
-                        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-                        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
 )
 
 vcpkg_install_meson()

--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -5,10 +5,12 @@ vcpkg_from_gitlab(
     REF  eabdbd54ee38fa658be574c4fa4574a05c755f16 #v1.50.11
     SHA512 06077e3cda5f1f5cda1fa37958e981b462715ac119af42e48e78f33807d082c31e903c2e4e753624e5fbf9759f0a66ee1dda055286b11a9e3d8698d5d8dffcb7
     HEAD_REF master # branch name
+    PATCHES
+        fix-pangoft2PC.patch
 ) 
 
 vcpkg_configure_meson(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -Dintrospection=disabled # Build the GObject introspection data for Pango
         -Dfontconfig=enabled # Build with FontConfig support.
@@ -18,10 +20,10 @@ vcpkg_configure_meson(
         -Dxft=disabled # Build with xft support
         -Dfreetype=enabled # Build with freetype support
         -Dgtk_doc=false #Build API reference for Pango using GTK-Doc
-    ADDITIONAL_NATIVE_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-                               glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
-    ADDITIONAL_CROSS_BINARIES  glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-                               glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+    ADDITIONAL_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+                        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+                        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+                        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
 )
 
 vcpkg_install_meson()
@@ -30,7 +32,7 @@ vcpkg_copy_pdbs()
 
 vcpkg_copy_tools(TOOL_NAMES pango-view pango-list pango-segmentation AUTO_CLEAN)
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 set(_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/pango.pc")
 if(EXISTS "${_file}")

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pango",
   "version": "1.50.11",
+  "port-version": 1,
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "license": "LGPL-2.0-only",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -794,8 +794,6 @@ opusfile:arm-uwp=fail
 opusfile:x64-uwp=fail
 paho-mqtt:arm-uwp=fail
 paho-mqtt:x64-uwp=fail
-pango:x64-windows-static=fail
-pango:x64-windows-static-md=fail
 pfring:x64-osx=fail
 pfring:arm64-osx=fail
 # pfring on Linux currently fails because its build scripts enable warnings as

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5654,7 +5654,7 @@
     },
     "pango": {
       "baseline": "1.50.11",
-      "port-version": 0
+      "port-version": 1
     },
     "pangolin": {
       "baseline": "0.6",

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "13370c6e795170f1c6734f3b1b59a71c846274ab",
+      "git-tree": "637afc61eebb86f29206c8c237e1b6059da41c8c",
       "version": "1.50.11",
       "port-version": 1
     },

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39feb6c61a55632c47828cb6b79ebd0939d392fc",
+      "version": "1.50.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "603dfcd1767e9e61cff29bf3552cda854a225329",
       "version": "1.50.11",
       "port-version": 0

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39feb6c61a55632c47828cb6b79ebd0939d392fc",
+      "git-tree": "13370c6e795170f1c6734f3b1b59a71c846274ab",
       "version": "1.50.11",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #27801, change `freetype_dep.type_name()` to cmake, add `freetype2` to `Requires` in **pangoft2.pc**, and fix the build error:
```
ENV{PKG_CONFIG_PATH}: "T:/Dev/test/vcpkg/packages/pango_x64-windows-static/lib/pkgconfig;T:/Dev/test/vcpkg/packages/pango_x64-windows-static/share/pkgconfig;T:/Dev/test/vcpkg/installed/x64-windows-static/lib/pkgconfig;T:/Dev/test/vcpkg/installed/x64-windows-static/share/pkgconfig"
output: Empty package name in Requires or Conflicts in file 'T:/Dev/test/vcpkg/packages/pango_x64-windows-static/lib/pkgconfig\pangoft2.pc'
```
The original `Requires` content is as below, about `freetype` is empty.
x64-windows:
```
Requires: pango, , fontconfig >=  2.13.0
Requires.private: glib-2.0 >=  2.62, gobject-2.0 >=  2.62, gio-2.0 >=  2.62, fribidi >=  1.0.6, harfbuzz >=  2.6.0, cairo >=  1.12.10
```
x64-windows-static:
```
Requires: pango, glib-2.0 >=  2.62, gobject-2.0 >=  2.62, gio-2.0 >=  2.62, fribidi >=  1.0.6, harfbuzz >=  2.6.0, fontconfig >=  2.13.0, cairo >=  1.12.10, 
```

