### PR TITLE
[quill] Update to 2.3.3

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
-    REF v2.3.2
-    SHA512 e6926aea20d198767900df9cbd63b6533fa42a890429e5ae2065b4a247deca3177817777e79a61bbd4edc2ee5c16b9ff4de14c5fb7d845f215ac9167abd49561
+    REF v2.3.3
+    SHA512 3e30c5f4f2bc1aefa6c81fa34f3449ffe713de1f9205bd72c71ffa639db35f3d798f24e1c10e2ac5586209d4e2f021d0c6dcb4197c2717c31b89d1316ca0599c
     HEAD_REF master
 )
 

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "C++14 Asynchronous Low Latency Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT",

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "C++14 Asynchronous Low Latency Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT",
-  "supports": "!(uwp | android)",
+  "supports": "!android",
   "dependencies": [
     "fmt",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6417,7 +6417,7 @@
       "port-version": 8
     },
     "quill": {
-      "baseline": "2.3.2",
+      "baseline": "2.3.3",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "788160d56f5fb60e8b4fbf0b17257255e93ffe1a",
+      "version": "2.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "384141a2266ca5073f31307b4c1103cb532b5b65",
       "version": "2.3.2",
       "port-version": 0

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "788160d56f5fb60e8b4fbf0b17257255e93ffe1a",
+      "git-tree": "8b2ab7a8f72bd483d07a6fbafc08a4be9948e975",
       "version": "2.3.3",
       "port-version": 0
     },


### PR DESCRIPTION
- #### What does your PR fix?
Update quill from 2.3.2 to 2.3.3 : https://github.com/odygrd/quill/releases/tag/v2.3.3

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
No changes

- #### Does your PR follow the [maintainer guide]
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes