### PR TITLE
[botan] Update botan to 2.19.3

### DIFF
--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO randombit/botan
     REF "${VERSION}"
-    SHA512 b467f8613832873b3337794d52bb46ddc77ffa78ee3498481b67aec66d35acd347d34056c7bdf68b303b836f0da18ce11ffa751b4cfbdce606780c292b417827
+    SHA512 0f99ef4026e5180dd65dc0e935ba2cabaf750862c651699294b3521053463b7e65a90847fef6f0d640eb9f9eb5efce64b13e999aa9c215310998817d13bd5332
     HEAD_REF master
     PATCHES
         fix-generate-build-path.patch

--- a/ports/botan/vcpkg.json
+++ b/ports/botan/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "botan",
-  "version": "2.19.2",
+  "version": "2.19.3",
   "description": "A cryptography library written in C++11",
   "homepage": "https://botan.randombit.net",
   "license": "BSD-2-Clause",

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ad976f3e650d7188414a0c2c62ec7290bed64e8",
+      "version": "2.19.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "50c9b636dc542dc13c62b04e09b106354e131b3d",
       "version": "2.19.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1165,7 +1165,7 @@
       "port-version": 3
     },
     "botan": {
-      "baseline": "2.19.2",
+      "baseline": "2.19.3",
       "port-version": 0
     },
     "box2d": {


### PR DESCRIPTION
- #### What does your PR fix?
  Updates botan. New releases fixes CVE-2022-43705.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes