### PR TITLE
[quill] Update to 2.4.2

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
-    REF v2.4.0
-    SHA512 fc15a078ac0728355805cf4a7ae43bf33bd6cb0f35db52c9beebfc34235e3fa019ce0037f3f6e935c3e7907007814d4f3352458190bdd1b5acc463cc5ac8aee3
+    REF v2.4.2
+    SHA512 d7cfb7491f447ef17142d171cd138ed4cc0a00ef7de7a06686848a07412d16b9907ca59dd0effce99c37d27a8ceac6a98dde9f4cd33d3d9dec1aed922eb90bb5
     HEAD_REF master
 )
 

--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
-    REF v2.3.3
-    SHA512 3e30c5f4f2bc1aefa6c81fa34f3449ffe713de1f9205bd72c71ffa639db35f3d798f24e1c10e2ac5586209d4e2f021d0c6dcb4197c2717c31b89d1316ca0599c
+    REF v2.4.0
+    SHA512 fc15a078ac0728355805cf4a7ae43bf33bd6cb0f35db52c9beebfc34235e3fa019ce0037f3f6e935c3e7907007814d4f3352458190bdd1b5acc463cc5ac8aee3
     HEAD_REF master
 )
 

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "C++14 Asynchronous Low Latency Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT",

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "description": "C++14 Asynchronous Low Latency Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6429,7 +6429,7 @@
       "port-version": 8
     },
     "quill": {
-      "baseline": "2.4.0",
+      "baseline": "2.4.2",
       "port-version": 0
     },
     "quirc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6429,7 +6429,7 @@
       "port-version": 8
     },
     "quill": {
-      "baseline": "2.3.3",
+      "baseline": "2.4.0",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "fa98ace5436e0d4035d84b513225c03afdc5ad94",
-      "version": "2.4.0",
+      "git-tree": "7fe7b94a1b021a83770a3ff6d4b2939804bb4bf9",
+      "version": "2.4.2",
       "port-version": 0
     },
     {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa98ace5436e0d4035d84b513225c03afdc5ad94",
+      "version": "2.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8b2ab7a8f72bd483d07a6fbafc08a4be9948e975",
       "version": "2.3.3",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
Update quill from 2.3.3 to 2.4.2 :
https://github.com/odygrd/quill/releases/tag/v2.4.0
https://github.com/odygrd/quill/releases/tag/v2.4.1
https://github.com/odygrd/quill/releases/tag/v2.4.2

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
No changes

- #### Does your PR follow the [maintainer guide]
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes
