### PR TITLE
[geos] Update version to 3.11.1

### DIFF
--- a/ports/geos/fix-dll-builds.patch
+++ b/ports/geos/fix-dll-builds.patch
@@ -1,90 +1,67 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 074986f38..bb092ed13 100644
+index 074986f..bb5ab3a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -184,12 +184,16 @@ target_compile_features(geos_cxx_flags INTERFACE cxx_std_11)
- #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98207
- #-----------------------------------------------------------------------------
- 
-+if(MSVC)
-+target_compile_options(geos_cxx_flags INTERFACE
-+    /fp:precise /wd4996
-+	)
-+else()
+@@ -187,7 +187,7 @@ target_compile_features(geos_cxx_flags INTERFACE cxx_std_11)
  target_compile_options(geos_cxx_flags INTERFACE
  	"$<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-ffp-contract=off>"
  	"$<$<CXX_COMPILER_ID:GNU>:-ffp-contract=off>"
 -	$<$<CXX_COMPILER_ID:MSVC>:/fp:precise /wd4996>
++  "$<$<BOOL:${MSVC}>:/fp:precise /wd4996>"
  	)
--
-+endif()
- # Use -ffloat-store for 32-bit builds (needed to make some tests pass)
- target_compile_options(geos_cxx_flags INTERFACE
-   $<$<AND:$<CXX_COMPILER_ID:GNU>,$<EQUAL:4,${CMAKE_SIZEOF_VOID_P}>>:-ffloat-store>
-@@ -225,13 +229,14 @@ target_compile_definitions(geos_cxx_flags
-   INTERFACE
-     USE_UNSTABLE_GEOS_CPP_API)
  
-+if(MSVC)
+ # Use -ffloat-store for 32-bit builds (needed to make some tests pass)
+@@ -227,10 +227,10 @@ target_compile_definitions(geos_cxx_flags
+ 
  target_compile_definitions(geos_developer_cxx_flags
    INTERFACE
 -    $<$<CXX_COMPILER_ID:MSVC>:_CRT_NONSTDC_NO_DEPRECATE>
 -    $<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_DEPRECATE>
 -    $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
 -    $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
--
-+    _CRT_NONSTDC_NO_DEPRECATE
-+    _SCL_SECURE_NO_DEPRECATE
-+    _CRT_SECURE_NO_WARNINGS
-+    NOMINMAX)
-+endif()
++    "$<$<BOOL:${MSVC}>:_CRT_NONSTDC_NO_DEPRECATE>"
++    "$<$<BOOL:${MSVC}>:_SCL_SECURE_NO_DEPRECATE>"
++    "$<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>"
++    "$<$<BOOL:${WIN32}>:NOMINMAX>")
+ 
  target_compile_options(geos_developer_cxx_flags
    INTERFACE
-     $<$<CXX_COMPILER_ID:MSVC>:-W4>
-@@ -268,9 +273,10 @@ add_subdirectory(src)
- option(VERSION_MINGW_SHARED_LIBS "Add version suffix to MinGW shared libraries" OFF)
+@@ -269,7 +269,7 @@ option(VERSION_MINGW_SHARED_LIBS "Add version suffix to MinGW shared libraries"
  
  if(BUILD_SHARED_LIBS)
--  target_compile_definitions(geos
+   target_compile_definitions(geos
 -    PRIVATE $<IF:$<CXX_COMPILER_ID:MSVC>,GEOS_DLL_EXPORT,DLL_EXPORT>)
--
-+  if(MSVC)
-+    target_compile_definitions(geos
-+        PRIVATE GEOS_DLL_EXPORT DLL_EXPORT)
-+  endif()
++    PRIVATE $<$<BOOL:${WIN32}>:GEOS_DLL_EXPORT>)
+ 
    set_target_properties(geos PROPERTIES VERSION ${GEOS_VERSION_NOPATCH})
    set_target_properties(geos PROPERTIES SOVERSION ${GEOS_VERSION_NOPATCH})
-   if(MINGW AND VERSION_MINGW_SHARED_LIBS)
-@@ -286,8 +292,10 @@ add_library(GEOS::geos_c ALIAS geos_c)
- target_link_libraries(geos_c PRIVATE geos)
+@@ -287,7 +287,7 @@ target_link_libraries(geos_c PRIVATE geos)
  
  if(BUILD_SHARED_LIBS)
-+  if(MSVC)
    target_compile_definitions(geos_c
 -    PRIVATE $<IF:$<CXX_COMPILER_ID:MSVC>,GEOS_DLL_EXPORT,DLL_EXPORT>)
-+    PRIVATE GEOS_DLL_EXPORT DLL_EXPORT)
-+  endif()
++    PRIVATE $<$<BOOL:${WIN32}>:GEOS_DLL_EXPORT>)
  
    set_target_properties(geos_c PROPERTIES VERSION ${CAPI_VERSION})
    if(NOT WIN32 OR MINGW)
 diff --git a/include/geos/algorithm/locate/IndexedPointInAreaLocator.h b/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
-index 7a647e461..73da77942 100644
+index 7a647e4..52a29c9 100644
 --- a/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
 +++ b/include/geos/algorithm/locate/IndexedPointInAreaLocator.h
-@@ -119,7 +119,7 @@ public:
-      * @param p the point to test
-      * @return the location of the point in the geometry
-      */
--    geom::Location locate(const geom::Coordinate* /*const*/ p) override;
-+    GEOS_DLL geom::Location locate(const geom::Coordinate* /*const*/ p) override;
- 
- };
- 
+@@ -51,7 +51,7 @@ namespace locate { // geos::algorithm::locate
+  * The index is lazy-loaded, which allows creating instances even if they are not used.
+  *
+  */
+-class IndexedPointInAreaLocator : public PointOnGeometryLocator {
++class GEOS_DLL IndexedPointInAreaLocator : public PointOnGeometryLocator {
+ private:
+     struct SegmentView {
+         SegmentView(const geom::Coordinate* p_p0, const geom::Coordinate* p_p1) : m_p0(p_p0) {
 diff --git a/include/geos/export.h b/include/geos/export.h
-index 1a26f8c7a..ba89e0f82 100644
+index 1a26f8c..997fb4c 100644
 --- a/include/geos/export.h
 +++ b/include/geos/export.h
-@@ -19,9 +19,9 @@
+@@ -19,7 +19,7 @@
  #  if defined(GEOS_DLL_EXPORT)
  #    define GEOS_DLL   __declspec(dllexport)
  #  elif defined(GEOS_DLL_IMPORT)
@@ -93,5 +70,3 @@ index 1a26f8c7a..ba89e0f82 100644
  #  else
  #    define GEOS_DLL
  #  endif
- #else
- #  define GEOS_DLL

--- a/ports/geos/fix-exported-config.patch
+++ b/ports/geos/fix-exported-config.patch
@@ -54,7 +54,7 @@ index 6eff1eb14..8827f6ac6 100644
  usage()
  {
 @@ -47,16 +49,16 @@ while test $# -gt 0; do
-       echo -L${libdir} -lgeos-@VERSION_RELEASE@
+       echo -L${libdir} -lgeos
        ;;
      --clibs)
 -      echo -L${libdir} -lgeos_c

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -13,11 +13,6 @@ vcpkg_extract_source_archive(SOURCE_PATH
         fix-dll-builds.patch
 )
 
-vcpkg_list(SET EXTRA_OPTIONS)
-if(VCPKG_TARGET_IS_MINGW)
-    vcpkg_list(APPEND EXTRA_OPTIONS "-DDISABLE_GEOS_INLINE=ON")
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -26,7 +21,6 @@ vcpkg_cmake_configure(
         -DBUILD_GEOSOP=OFF
         -DBUILD_TESTING=OFF
         -DBUILD_BENCHMARKS=OFF
-        ${EXTRA_OPTIONS}
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/GEOS)

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,14 +1,12 @@
-set(GEOS_VERSION 3.11.0)
-
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2"
-    FILENAME "geos-${GEOS_VERSION}.tar.bz2"
-    SHA512 40c7553bbb93673c231ddd0131b73bf43b3f50524bc5bd9e6934c068d2c09632f388b7429254ae15d9641da2d15e3a626b430438854e98d9e7419ad04e535189
+    URLS "https://download.osgeo.org/geos/geos-${VERSION}.tar.bz2"
+    FILENAME "geos-${VERSION}.tar.bz2"
+    SHA512 708500aba9b04208ee46a531d55ddf63a213dfaa2922dae937b524300b2b46c95143ed6cd3ff1414e9099f2be95e5df5a2e0b49df43acf93a9478215259f20d3
 )
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
+vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
-    REF "${GEOS_VERSION}"
+    SOURCE_BASE "v${VERSION}"
     PATCHES
         disable-warning-4996.patch
         fix-exported-config.patch

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     PATCHES
         disable-warning-4996.patch
         fix-exported-config.patch
-        fix_clang-cl.patch
+        fix-dll-builds.patch
 )
 
 vcpkg_list(SET EXTRA_OPTIONS)

--- a/ports/geos/vcpkg.json
+++ b/ports/geos/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "geos",
-  "version": "3.11.0",
-  "port-version": 1,
+  "version": "3.11.1",
   "description": "Geometry Engine Open Source",
   "homepage": "https://libgeos.org/",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2573,8 +2573,8 @@
       "port-version": 0
     },
     "geos": {
-      "baseline": "3.11.0",
-      "port-version": 1
+      "baseline": "3.11.1",
+      "port-version": 0
     },
     "geotrans": {
       "baseline": "3.8",

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b07718e8986bb5f0502b324ee9465bcbf7a03754",
+      "git-tree": "1f2b8b7ba62c8e0ca9e17f7ac5a2312c559eb547",
       "version": "3.11.1",
       "port-version": 0
     },

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b07718e8986bb5f0502b324ee9465bcbf7a03754",
+      "version": "3.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9bf5a546e53664298e8d1f843600013cd0d94ae5",
       "version": "3.11.0",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
  Updates geos.
  Revises the clang-cl build (CC @Neumann-A): Size reduction. Adaption for mingw: Mingw geos (C++) import lib is reduced by one third.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes