### PR TITLE
[dstorage] update port to make sure DLLs are part of TARGET_RUNTIME_DLLS

### DIFF
--- a/ports/dstorage/dstorage-config.cmake.in
+++ b/ports/dstorage/dstorage-config.cmake.in
@@ -13,7 +13,15 @@ if (EXISTS "${_dstorage_root_lib}")
       INTERFACE_INCLUDE_DIRECTORIES        "${_dstorage_root}/include"
       IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
-    set(dstorage_FOUND TRUE)
+   add_library(Microsoft::DirectStorageCore SHARED IMPORTED)
+   set_target_properties(Microsoft::DirectStorageCore PROPERTIES
+      IMPORTED_LOCATION                    "${_dstorage_root}/bin/dstoragecore.dll"
+      IMPORTED_IMPLIB                      "${_dstorage_root_lib}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+
+   target_link_libraries(Microsoft::DirectStorage INTERFACE Microsoft::DirectStorageCore)
+
+   set(dstorage_FOUND TRUE)
 
 else()
 

--- a/ports/dstorage/vcpkg.json
+++ b/ports/dstorage/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dstorage",
   "version": "1.1.0",
+  "port-version": 1,
   "description": "DirectStorage for Windows",
   "homepage": "https://aka.ms/directstorage/",
   "documentation": "https://github.com/microsoft/DirectStorage",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2026,7 +2026,7 @@
     },
     "dstorage": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "dtl": {
       "baseline": "1.20",

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e85e5404767b7d1564fc9e6d3f8b47c3ecbc5218",
+      "version": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "aba352546f75fec5058f075a5c7162c9865ef774",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
The DirectStorage API actually requires two DLLs to be present at runtime: ``DSTORAGE.DLL`` and ``DSTORAGECORE.DLL``.

When using the Cmake 3.21 solution, you only ended up with ``DSTORAGE.DLL``:

```
if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
   add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
      COMMAND ${CMAKE_COMMAND} -E copy
      $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> $<TARGET_FILE_DIR:${PROJECT_NAME}>
      COMMAND_EXPAND_LISTS
      )
endif()
```

This port update fixes this by adding a second SHARED IMPORT definition and have a dependency on it.