### PR TITLE
[libgnutls] Update to 3.7.8

### DIFF
--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
     FILENAME "gnutls-${VERSION}.tar.xz"
-    SHA512 72c78d7fcb024393c1d15f2a1856608ae4460ba43cc5bbbb4c29b80508cae6cb822df4638029de2363437d110187e0a3cc19a7288c3b2f44b2f648399a028438
+    SHA512 4199bcf7c9e3aab2f52266aadceefc563dfe2d938d0ea1f3ec3be95d66f4a8c8e5494d3a800c03dd02ad386dec1738bd63e1fe0d8b394a2ccfc7d6c6a0cc9359
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${tarball}"
@@ -45,8 +45,11 @@ vcpkg_configure_make(
         --disable-silent-rules
         --disable-rpath
         --disable-tests
-        --without-p11-kit
-        --without-tpm
+        --with-brotli=no
+        --with-p11-kit=no
+        --with-tpm=no
+        --with-tpm2=no
+        --with-zstd=no
         ${options}
         YACC=false # false, the program - not used here
     OPTIONS_DEBUG

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgnutls",
-  "version": "3.6.16",
+  "version": "3.7.8",
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols.",
   "homepage": "https://www.gnutls.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3773,7 +3773,7 @@
       "port-version": 0
     },
     "libgnutls": {
-      "baseline": "3.6.16",
+      "baseline": "3.7.8",
       "port-version": 0
     },
     "libgo": {

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93d9f1a3a919257ac3d518297d3ef4d34b5f5e3e",
+      "version": "3.7.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "d91748a68628086b61f6da9afb2233a4d610dc4d",
       "version": "3.6.16",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Updates libgnutls to 3.7.8. Fixes CVEs.
  libgnutls documentation indicates that 3.7.x is a development branch. But it is commonly used and packaged instead of the "stable" 3.6.x branch releases. 3.6.x hasn't been updated in a while and lacks security fixes. References: 
  https://repology.org/project/gnutls/related 
  https://github.com/repology/repology-rules/pull/636

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes