### PR TITLE
[chakracore] Avoid race condition on generated headers.

### DIFF
--- a/ports/chakracore/add-missing-reference.patch
+++ b/ports/chakracore/add-missing-reference.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/SCACore/Chakra.SCACore.vcxproj b/lib/SCACore/Chakra.SCACore.vcxproj
+index 1b13cea..57b066b 100644
+--- a/lib/SCACore/Chakra.SCACore.vcxproj
++++ b/lib/SCACore/Chakra.SCACore.vcxproj
+@@ -60,6 +60,9 @@
+     <ClInclude Include="StreamReader.h" />
+     <ClInclude Include="StreamWriter.h" />
+   </ItemGroup>
++  <ItemGroup>
++    <ProjectReference Include="$(MSBuildThisFileDirectory)../../manifests/CoreManifests.vcxproj" />
++  </ItemGroup>
+   <Import Project="$(BuildConfigPropsPath)Chakra.Build.targets" Condition="exists('$(BuildConfigPropsPath)Chakra.Build.targets')" />
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+ </Project>
+\ No newline at end of file

--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-debug-linux-build.patch
+        add-missing-reference.patch # https://github.com/chakra-core/ChakraCore/pull/6862
 )
 
 if(WIN32)

--- a/ports/chakracore/vcpkg.json
+++ b/ports/chakracore/vcpkg.json
@@ -4,5 +4,6 @@
   "port-version": 3,
   "description": "Core part of the Chakra Javascript engine",
   "homepage": "https://github.com/Microsoft/ChakraCore",
+  "license": "MIT",
   "supports": "!osx & !uwp & (linux | (!static & !staticcrt))"
 }

--- a/ports/chakracore/vcpkg.json
+++ b/ports/chakracore/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "chakracore",
   "version-date": "2021-04-22",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Core part of the Chakra Javascript engine",
   "homepage": "https://github.com/Microsoft/ChakraCore",
   "supports": "!osx & !uwp & (linux | (!static & !staticcrt))"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1382,7 +1382,7 @@
     },
     "chakracore": {
       "baseline": "2021-04-22",
-      "port-version": 2
+      "port-version": 3
     },
     "charls": {
       "baseline": "2.3.4",

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "64d31d7d085515a56e803d2a67b9491bc3398078",
+      "git-tree": "b1fb3c3a83f78bfa4191c376d026a7768257c9db",
       "version-date": "2021-04-22",
       "port-version": 3
     },

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64d31d7d085515a56e803d2a67b9491bc3398078",
+      "version-date": "2021-04-22",
+      "port-version": 3
+    },
+    {
       "git-tree": "614248322cae7f18cd412cc90848a9f140ec9f60",
       "version-date": "2021-04-22",
       "port-version": 2


### PR DESCRIPTION
This build race was observed in attempting to do the November VM update: https://dev.azure.com/vcpkg/public/_build/results?buildId=80997

Filed upstream as https://github.com/chakra-core/ChakraCore/pull/6862