### PR TITLE
[sqlite3] Re-set option SQLITE_ENABLE_COLUMN_METADATA to 1

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -39,7 +39,6 @@ target_compile_definitions(
         $<$<CONFIG:Debug>:SQLITE_ENABLE_WHERETRACE>
         ${SQLITE_API}
         -DSQLITE_ENABLE_UNLOCK_NOTIFY
-        -DSQLITE_ENABLE_COLUMN_METADATA
 )
 
 if (BUILD_SHARED_LIBS)
@@ -115,12 +114,18 @@ endif()
 if (WIN32)
     string(APPEND PKGCONFIG_DEFINES " -DQLITE_OS_WIN=1")
     target_compile_definitions(sqlite3 PUBLIC -DSQLITE_OS_WIN=1)
-
+    
+    string(APPEND PKGCONFIG_DEFINES " -DSQLITE_ENABLE_COLUMN_METADATA=1")
+    target_compile_definitions(sqlite3 PUBLIC -DSQLITE_ENABLE_COLUMN_METADATA=1)
+    
     if(CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
         string(APPEND PKGCONFIG_DEFINES " -DSQLITE_OS_WINRT=1")
         target_compile_definitions(sqlite3 PUBLIC -DSQLITE_OS_WINRT=1)
     endif()
 else()
+    string(APPEND PKGCONFIG_DEFINES " -DSQLITE_ENABLE_COLUMN_METADATA=1")
+    target_compile_definitions(sqlite3 PUBLIC -DSQLITE_ENABLE_COLUMN_METADATA=1)
+    
     string(APPEND PKGCONFIG_DEFINES " -DSQLITE_OS_UNIX=1")
     target_compile_definitions(sqlite3 PUBLIC -DSQLITE_OS_UNIX=1)
 endif()

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sqlite3",
   "version": "3.40.0",
+  "port-version": 1,
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://github.com/sqlite/sqlite",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7170,7 +7170,7 @@
     },
     "sqlite3": {
       "baseline": "3.40.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sqlitecpp": {
       "baseline": "3.2.0",

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "822fbc846fb73d1906929b6843ee939c1bb78cc5",
+      "version": "3.40.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2a4aa5dd4dce8b1852a367c9e6ded10e4ca00006",
       "version": "3.40.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/27923
  Note: set `SQLITE_ENABLE_COLUMN_METADATA` to 1. Upstream behavior：https://github.com/sqlite/sqlite/commit/66f9de030e7428da1745d6544133235b7b01340a

  ````
  Error: UnsatisfiedLink Error looking up function 'sqlite3_column_table_name': The specified procedure could not be found.
  ````
  

