### PR TITLE
[baseline][libssh] Update to latest commit

### DIFF
--- a/ports/libssh/0001-export-pkgconfig-file.patch
+++ b/ports/libssh/0001-export-pkgconfig-file.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7bc3331..5c7275d 100644
+index 741dc61..42f0e8f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -124,8 +124,28 @@ add_subdirectory(include)
@@ -7,7 +7,7 @@ index 7bc3331..5c7275d 100644
  
  # pkg-config file
 -if (UNIX OR MINGW)
- configure_file(libssh.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc)
+ configure_file(libssh.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc @ONLY)
 +  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc "Requires:")
 +  if (WITH_ZLIB)
 +    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc " zlib")

--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://git.libssh.org/projects/libssh.git
-    REF e8322817a9e5aaef0698d779ddd467a209a85d85 # REFERENCE VERSION 0.10.4
+    REF 0fa215e2acdf08482708199eeb258efbc8e6aeae # Latest commit on 2022-11-22
     PATCHES
         0001-export-pkgconfig-file.patch
         0002-mingw_for_Android.patch
@@ -15,9 +15,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 if (VCPKG_TARGET_IS_ANDROID)
-	set(EXTRA_ARGS "-DWITH_SERVER=FALSE"
-			"-DWITH_PCAP=FALSE"
-			)
+    set(EXTRA_ARGS "-DWITH_SERVER=FALSE"
+                   "-DWITH_PCAP=FALSE")
 endif ()
 
 vcpkg_cmake_configure(
@@ -48,18 +47,18 @@ vcpkg_fixup_pkgconfig()
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
     vcpkg_replace_string(
-	    "${CURRENT_PACKAGES_DIR}/include/libssh/libssh.h"
-	    "#ifdef LIBSSH_STATIC"
-	    "#if 1"
-	)
+        "${CURRENT_PACKAGES_DIR}/include/libssh/libssh.h"
+        "#ifdef LIBSSH_STATIC"
+        "#if 1"
+    )
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string(
-	    "${CURRENT_PACKAGES_DIR}/share/libssh/libssh-config.cmake"
-	    ".dll"
-	    ".lib"
-	)
+        "${CURRENT_PACKAGES_DIR}/share/libssh/libssh-config.cmake"
+        ".dll"
+        ".lib"
+    )
 endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -2,6 +2,7 @@ vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://git.libssh.org/projects/libssh.git
     REF 9941e89f307e73352d887cac14e4e26b481a0a82 # Latest commit on 2022-11-23
+    FETCH_REF master
     PATCHES
         0001-export-pkgconfig-file.patch
         0002-mingw_for_Android.patch

--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://git.libssh.org/projects/libssh.git
-    REF 0fa215e2acdf08482708199eeb258efbc8e6aeae # Latest commit on 2022-11-22
+    REF 9941e89f307e73352d887cac14e4e26b481a0a82 # Latest commit on 2022-11-23
     PATCHES
         0001-export-pkgconfig-file.patch
         0002-mingw_for_Android.patch

--- a/ports/libssh/vcpkg.json
+++ b/ports/libssh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libssh",
-  "version-date": "2022-11-22",
+  "version-string": "0.10.4+20221122",
   "description": "libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side",
   "homepage": "https://www.libssh.org/",
   "license": "LGPL-2.1-only",

--- a/ports/libssh/vcpkg.json
+++ b/ports/libssh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libssh",
-  "version": "0.10.4",
+  "version-date": "2022-11-22",
   "description": "libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side",
   "homepage": "https://www.libssh.org/",
   "license": "LGPL-2.1-only",

--- a/ports/libssh/vcpkg.json
+++ b/ports/libssh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libssh",
-  "version": "0.10.4+20221122",
+  "version": "0.10.4+20221123",
   "description": "libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side",
   "homepage": "https://www.libssh.org/",
   "license": "LGPL-2.1-only",

--- a/ports/libssh/vcpkg.json
+++ b/ports/libssh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libssh",
-  "version-string": "0.10.4+20221122",
+  "version": "0.10.4+20221122",
   "description": "libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side",
   "homepage": "https://www.libssh.org/",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4249,7 +4249,7 @@
       "port-version": 3
     },
     "libssh": {
-      "baseline": "2022-11-22",
+      "baseline": "0.10.4+20221122",
       "port-version": 0
     },
     "libssh2": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4249,7 +4249,7 @@
       "port-version": 3
     },
     "libssh": {
-      "baseline": "0.10.4",
+      "baseline": "2022-11-22",
       "port-version": 0
     },
     "libssh2": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4249,7 +4249,7 @@
       "port-version": 3
     },
     "libssh": {
-      "baseline": "0.10.4+20221122",
+      "baseline": "0.10.4+20221123",
       "port-version": 0
     },
     "libssh2": {

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d5d8ac831eaa593dd35fa7002a07dcf6afe876e",
+      "version-date": "2022-11-22",
+      "port-version": 0
+    },
+    {
       "git-tree": "6de85714bb1e12c5e87284700f832fd08523e10d",
       "version": "0.10.4",
       "port-version": 0

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "93b66302f7c1cc061a0559a1ca0bc6abdc5f6e9c",
-      "version": "0.10.4+20221122",
+      "git-tree": "b7aa17d0963b6185180977dfd20c43d59a2a369d",
+      "version": "0.10.4+20221123",
       "port-version": 0
     },
     {

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "4d5d8ac831eaa593dd35fa7002a07dcf6afe876e",
-      "version-date": "2022-11-22",
-      "port-version": 0
-    },
-    {
       "git-tree": "6de85714bb1e12c5e87284700f832fd08523e10d",
       "version": "0.10.4",
       "port-version": 0

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b7aa17d0963b6185180977dfd20c43d59a2a369d",
+      "git-tree": "fc1f60a58c33279b187a474890dd1a54cdc17062",
       "version": "0.10.4+20221123",
       "port-version": 0
     },

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93b66302f7c1cc061a0559a1ca0bc6abdc5f6e9c",
+      "version": "0.10.4+20221122",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d5d8ac831eaa593dd35fa7002a07dcf6afe876e",
       "version-date": "2022-11-22",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Update `libssh` to latest commit, fix `libssh` fetch error on Linux.
```
/usr/bin/git fetch https://git.libssh.org/projects/libssh.git e8322817a9e5aaef0698d779ddd467a209a85d85 --depth 1 -n
error: Server does not allow request for unadvertised object e8322817a9e5aaef0698d779ddd467a209a85d85
```
All features test pass on x64-windows.