### PR TITLE
[mpfr] Update to 4.1.1

### DIFF
--- a/ports/mpfr/4.1.1-p1.patch
+++ b/ports/mpfr/4.1.1-p1.patch
@@ -1,0 +1,83 @@
+diff -Naurd mpfr-4.1.1-a/PATCHES mpfr-4.1.1-b/PATCHES
+--- mpfr-4.1.1-a/PATCHES	2022-11-23 11:45:26.800476079 +0000
++++ mpfr-4.1.1-b/PATCHES	2022-11-23 11:45:26.844475966 +0000
+@@ -0,0 +1 @@
++mpfr_custom_get_kind
+diff -Naurd mpfr-4.1.1-a/VERSION mpfr-4.1.1-b/VERSION
+--- mpfr-4.1.1-a/VERSION	2022-11-17 13:28:44.000000000 +0000
++++ mpfr-4.1.1-b/VERSION	2022-11-23 11:45:26.844475966 +0000
+@@ -1 +1 @@
+-4.1.1
++4.1.1-p1
+diff -Naurd mpfr-4.1.1-a/src/mpfr.h mpfr-4.1.1-b/src/mpfr.h
+--- mpfr-4.1.1-a/src/mpfr.h	2022-11-17 13:28:44.000000000 +0000
++++ mpfr-4.1.1-b/src/mpfr.h	2022-11-23 11:45:26.840475978 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 4
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 1
+-#define MPFR_VERSION_STRING "4.1.1"
++#define MPFR_VERSION_STRING "4.1.1-p1"
+
+ /* User macros:
+    MPFR_USE_FILE:        Define it to make MPFR define functions dealing
+@@ -1027,7 +1027,7 @@
+ #if __GNUC__ > 2 || __GNUC_MINOR__ >= 95
+ #define mpfr_custom_get_kind(x)                                         \
+   __extension__ ({                                                      \
+-    mpfr_ptr _x = (x);                                                  \
++    mpfr_srcptr _x = (x);                                               \
+     _x->_mpfr_exp >  __MPFR_EXP_INF ?                                   \
+       (mpfr_int) MPFR_REGULAR_KIND * MPFR_SIGN (_x)                     \
+       : _x->_mpfr_exp == __MPFR_EXP_INF ?                               \
+diff -Naurd mpfr-4.1.1-a/src/version.c mpfr-4.1.1-b/src/version.c
+--- mpfr-4.1.1-a/src/version.c	2022-11-17 13:28:44.000000000 +0000
++++ mpfr-4.1.1-b/src/version.c	2022-11-23 11:45:26.844475966 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "4.1.1";
++  return "4.1.1-p1";
+ }
+diff -Naurd mpfr-4.1.1-a/tests/tstckintc.c mpfr-4.1.1-b/tests/tstckintc.c
+--- mpfr-4.1.1-a/tests/tstckintc.c	2022-05-06 13:47:17.000000000 +0000
++++ mpfr-4.1.1-b/tests/tstckintc.c	2022-11-23 11:45:26.836475987 +0000
+@@ -295,14 +295,16 @@
+ test_nan_inf_zero (void)
+ {
+   mpfr_ptr val;
++  mpfr_srcptr sval;  /* for compilation error checking */
+   int sign;
+   int kind;
+
+   reset_stack ();
+
+   val = new_mpfr (MPFR_PREC_MIN);
++  sval = val;
+   mpfr_set_nan (val);
+-  kind = (mpfr_custom_get_kind) (val);
++  kind = (mpfr_custom_get_kind) (sval);
+   if (kind != MPFR_NAN_KIND)
+     {
+       printf ("mpfr_custom_get_kind error: ");
+@@ -380,7 +382,8 @@
+ dummy_set_si (long si)
+ {
+   mpfr_t x;
+-  long * r = dummy_new ();
++  mpfr_srcptr px;  /* for compilation error checking */
++  long *r = dummy_new ();
+   int i1, i2, i3, i4, i5;
+
+   /* Check that the type "void *" can be used, like with the function.
+@@ -405,7 +408,8 @@
+   MPFR_ASSERTN (i5 == 1);
+
+   mpfr_set_si (x, si, MPFR_RNDN);
+-  r[0] = mpfr_custom_get_kind (x);
++  px = x;
++  r[0] = mpfr_custom_get_kind (px);
+
+   /* Check that the type "void *" can be used in C, like with the function
+      (forbidden in C++). Also check side effects. */

--- a/ports/mpfr/portfile.cmake
+++ b/ports/mpfr/portfile.cmake
@@ -1,15 +1,9 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
-if(VCPKG_TARGET_IS_LINUX)
-    message(WARNING "${PORT} currently requires the following packages:\n    autoconf-archive\nThese can be installed on Ubuntu systems via\n    sudo apt-get update -y\n    sudo apt-get install -y autoconf-archive\n")
-elseif(VCPKG_TARGET_IS_OSX)
-    message(WARNING "${PORT} currently requires the following packages:\n    autoconf-archive\nIt can be installed with\n    brew install autoconf-archive\n")
-endif()
-
 vcpkg_download_distfile(ARCHIVE
     URLS "http://www.mpfr.org/mpfr-${VERSION}/mpfr-${VERSION}.tar.xz" "https://ftp.gnu.org/gnu/mpfr/mpfr-${VERSION}.tar.xz"
     FILENAME "mpfr-${VERSION}.tar.xz"
-    SHA512 1bd1c349741a6529dfa53af4f0da8d49254b164ece8a46928cdb13a99460285622d57fe6f68cef19c6727b3f9daa25ddb3d7d65c201c8f387e421c7f7bee6273
+    SHA512 be468749bd88870dec37be35e544983a8fb7bda638eb9414c37334b9d553099ea2aa067045f51ae2c8ab86d852ef833e18161d173e414af0928e9a438c9b91f1
 )
 
 vcpkg_extract_source_archive(
@@ -18,13 +12,12 @@ vcpkg_extract_source_archive(
     PATCHES
         dll.patch
         src-only.patch
+        4.1.1-p1.patch # https://www.mpfr.org/mpfr-4.1.1/#bugs
 )
-file(REMOVE_RECURSE "${SOURCE_PATH}/m4")
 
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
-    ADDITIONAL_MSYS_PACKAGES autoconf-archive
 )
 
 vcpkg_install_make()

--- a/ports/mpfr/vcpkg.json
+++ b/ports/mpfr/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mpfr",
-  "version": "4.1.0",
-  "port-version": 7,
+  "version": "4.1.1",
   "description": "The MPFR library is a C library for multiple-precision floating-point computations with correct rounding",
   "homepage": "https://www.mpfr.org",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4981,8 +4981,8 @@
       "port-version": 2
     },
     "mpfr": {
-      "baseline": "4.1.0",
-      "port-version": 7
+      "baseline": "4.1.1",
+      "port-version": 0
     },
     "mpg123": {
       "baseline": "1.29.3",

--- a/versions/m-/mpfr.json
+++ b/versions/m-/mpfr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e03248f0a54aa99977a77f1a3d7e4be91c1048ec",
+      "version": "4.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "23e0ddc3c974f7b5b6e70c6be1389ed3d6182e81",
       "version": "4.1.0",
       "port-version": 7


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Updates mpfr to 4.1.1

  Removes the warning about autoconf-archive introduced in #27634 since now the relevant files seem to be included in the upstream (https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.1.1/m4/ax_pthread.m4).

  Adds the patch for a regression introduced in 4.1.1 (https://www.mpfr.org/mpfr-4.1.1/#bugs).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**