### PR TITLE
[libffi] update to 3.4.4

### DIFF
--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT CMAKE_SYSTEM_PROCESSOR)
 endif()
 
 # config variables for ffi.h.in
-set(VERSION 3.4.2)
+set(VERSION 3.4.4)
 
 set(KNOWN_PROCESSORS x86 x86_64 amd64 arm arm64 i386 i686 armv7l armv7-a aarch64 mips64el)
 

--- a/ports/libffi/fficonfig.h
+++ b/ports/libffi/fficonfig.h
@@ -25,10 +25,10 @@
 #define PACKAGE "libffi"
 #define PACKAGE_BUGREPORT "http://github.com/libffi/libffi/issues"
 #define PACKAGE_NAME "libffi"
-#define PACKAGE_STRING "libffi 3.4.2"
+#define PACKAGE_STRING "libffi 3.4.4"
 #define PACKAGE_TARNAME "libffi"
 #define PACKAGE_URL ""
-#define PACKAGE_VERSION "3.4.2"
+#define PACKAGE_VERSION "3.4.4"
 #define SIZEOF_DOUBLE 8
 #define SIZEOF_LONG_DOUBLE 8
 #ifndef _WIN64
@@ -42,7 +42,7 @@
 #define SYMBOL_UNDERSCORE 1
 #endif
 #endif
-#define VERSION "3.4.2"
+#define VERSION "3.4.4"
 #if defined AC_APPLE_UNIVERSAL_BUILD
 # if defined __BIG_ENDIAN__
 #  define WORDS_BIGENDIAN 1

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -1,10 +1,10 @@
-set(VERSION 3.4.2)
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libffi/libffi
     REF "v${VERSION}"
-    SHA512 d399319efcca375fe901b05722e25eca31d11a4261c6a5d5079480bbc552d4e4b42de2026912689d3b2f886ebb3c8bebbea47102e38a2f6acbc526b8d5bba388
+    SHA512 e3b261a7900cec61225c768ebd443884465669e0904db3f523aaaeeed74b4c03dbe23d74ff8bb69554791a798e25894a5fcbe2b13b883d3ee38aeff4c1e16a49
     HEAD_REF master
 )
 

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libffi",
-  "version": "3.4.2",
-  "port-version": 6,
+  "version": "3.4.4",
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3725,8 +3725,8 @@
       "port-version": 1
     },
     "libffi": {
-      "baseline": "3.4.2",
-      "port-version": 6
+      "baseline": "3.4.4",
+      "port-version": 0
     },
     "libfido2": {
       "baseline": "1.10.0",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6552925531e923480b50d806c7d4538c1ff15481",
+      "version": "3.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "9d484f79a6c1e9cd25a8a4791af0c9a40fc26b51",
       "version": "3.4.2",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**

Update libffi to 3.4.4 (from 3.4.2)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
All?, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
To the best of my recollection...

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes