### PR TITLE
[opentelemetry-cpp] Turn off preview OTel metrics and remove the macro

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -44,7 +44,6 @@ vcpkg_cmake_configure(
     OPTIONS
         -DBUILD_TESTING=OFF
         -DWITH_EXAMPLES=OFF
-        -DWITH_METRICS_PREVIEW=ON
         -DWITH_LOGS_PREVIEW=ON
         ${FEATURE_OPTIONS}
 )

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.7.0",
+  "port-version": 1,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5558,7 +5558,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opentracing": {
       "baseline": "1.6.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e36a0cf804de37cd2fbdeb92b6ff77b5e03ed1b",
+      "version-semver": "1.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "454e8d6c9d7b195d7e923e8f29486ecb08966e41",
       "version-semver": "1.7.0",
       "port-version": 0

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6e36a0cf804de37cd2fbdeb92b6ff77b5e03ed1b",
+      "git-tree": "047e485793a6f8d4c86d887f76f5418ea90baee0",
       "version-semver": "1.7.0",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
OpenTelemetry C++ provided preview version of metrics which is outdated as the stable version of metrics released in v1.7.0 (v1.7.0 is the current version in vcpkg, see [here](https://github.com/microsoft/vcpkg/blob/master/ports/opentelemetry-cpp/vcpkg.json#L4)). This PR removes setting `WITH_PREVIEW_METRICS=ON` which turns off the preview version of metrics, and back to the new metrics implementation in this version which is the expected behavior.

BTW, the setting `WITH_PREVIEW_METRICS` was completely removed in https://github.com/open-telemetry/opentelemetry-cpp/pull/1735/files.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
