### PR TITLE
[7-Zip] update to 22.01

### DIFF
--- a/ports/7zip/portfile.cmake
+++ b/ports/7zip/portfile.cmake
@@ -28,3 +28,5 @@ file(
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     RENAME copyright
 )
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/7zip/portfile.cmake
+++ b/ports/7zip/portfile.cmake
@@ -1,8 +1,8 @@
-set(7ZIP_VERSION "2200")
+set(7ZIP_VERSION "2201")
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.7-zip.org/a/7z${7ZIP_VERSION}-src.7z"
     FILENAME "7z${7ZIP_VERSION}-src.7z"
-    SHA512 ff5bab0ad5c16dee84208b42df27ab1df34499365d934b33f61cd8c79b2a946e8875b1524540c1306381a51d6b24535bbcaf92819bf5331814d6c14cf12d3b07
+    SHA512 c37cede4b7253b8dc4372e9e011ef0fee0c1cd53cf9705bf106672a455e7ce1e5a0a288c763d73d3c28b2a41fb860c9bacb702b01d9192eed810787c7da1e0d8
 )
 
 vcpkg_extract_source_archive(
@@ -28,5 +28,3 @@ file(
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     RENAME copyright
 )
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "7zip",
-  "version": "22.0",
-  "port-version": 1,
+  "version-string": "22.01",
   "description": "Library for archiving file with a high compression ratio.",
   "homepage": "https://www.7-zip.org",
   "license": "LGPL-2.1-or-later",

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6efff14786dba7c8e8bc1010fbebf50986e8f9c4",
+      "version-string": "22.01",
+      "port-version": 0
+    },
+    {
       "git-tree": "3cbbaee3c546a24fc68b37759c9a5fc62b683ff0",
       "version": "22.0",
       "port-version": 1

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6efff14786dba7c8e8bc1010fbebf50986e8f9c4",
+      "git-tree": "e28ef5008a5e93e67db2904c72586f4a667ef5ed",
       "version-string": "22.01",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5,8 +5,8 @@
       "port-version": 2
     },
     "7zip": {
-      "baseline": "22.0",
-      "port-version": 1
+      "baseline": "22.01",
+      "port-version": 0
     },
     "ableton": {
       "baseline": "3.0.5",


### PR DESCRIPTION
Fix #27993 

Update 7zip to the latest version 22.01

Note: no feature need to test.