### PR TITLE
[hunspell] Remove deprecated minimal rebuild switch.

### DIFF
--- a/ports/hunspell/0006-remove-gm.patch
+++ b/ports/hunspell/0006-remove-gm.patch
@@ -1,0 +1,12 @@
+diff --git a/msvc/hunspell.vcxproj b/msvc/hunspell.vcxproj
+index 660a082..e1757db 100644
+--- a/msvc/hunspell.vcxproj
++++ b/msvc/hunspell.vcxproj
+@@ -122,7 +122,6 @@
+       <Optimization>Disabled</Optimization>
+       <AdditionalIncludeDirectories>..\src\hunspell;..\src\parsers;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+       <PreprocessorDefinitions>W32;WIN32;_DEBUG;_CONSOLE;HUNSPELL_STATIC;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-      <MinimalRebuild>true</MinimalRebuild>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+       <PrecompiledHeader />

--- a/ports/hunspell/portfile.cmake
+++ b/ports/hunspell/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         0003-fix-win-build.patch
         0004-add-win-arm64.patch
         0005-autotools-subdirs.patch
+        0006-remove-gm.patch # https://github.com/hunspell/hunspell/pull/890
 )
 
 file(REMOVE "${SOURCE_PATH}/README") #README is a symlink

--- a/ports/hunspell/vcpkg.json
+++ b/ports/hunspell/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "hunspell",
   "version": "1.7.1",
+  "port-version": 1,
   "description": "The most popular spellchecking library.",
   "homepage": "https://github.com/hunspell/hunspell",
   "license": "MPL-1.1 OR LGPL-2.1-or-later OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2938,7 +2938,7 @@
     },
     "hunspell": {
       "baseline": "1.7.1",
-      "port-version": 0
+      "port-version": 1
     },
     "hwloc": {
       "baseline": "2.7.1",

--- a/versions/h-/hunspell.json
+++ b/versions/h-/hunspell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b41e3a543323f9a28cfa2fc9e93c8d3fc31a2597",
+      "version": "1.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "3adb7d5162395e281e90173a290f16303c977f3b",
       "version": "1.7.1",
       "port-version": 0


### PR DESCRIPTION
Fixes build break first detected in: https://github.com/microsoft/vcpkg/pull/27718

Submitted upstream as: https://github.com/hunspell/hunspell/pull/890
