### PR TITLE
[vcpkg_configure_gn] Remove build dir before configure

### DIFF
--- a/scripts/cmake/vcpkg_configure_gn.cmake
+++ b/scripts/cmake/vcpkg_configure_gn.cmake
@@ -5,6 +5,7 @@ function(z_vcpkg_configure_gn_generate)
     endif()
 
     message(STATUS "Generating build (${arg_CONFIG})...")
+    file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${arg_CONFIG}")
     vcpkg_execute_required_process(
         COMMAND "${GN}" gen "${CURRENT_BUILDTREES_DIR}/${arg_CONFIG}" "${arg_ARGS}"
         WORKING_DIRECTORY "${arg_SOURCE_PATH}"


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes unexpected reuse of build artifacts in repeated build of the same port.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  not needed