### PR TITLE
[glog] fix not work on windows cuda nvcc compiler.

### DIFF
--- a/ports/glog/fix_cplusplus_macro.patch
+++ b/ports/glog/fix_cplusplus_macro.patch
@@ -1,14 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d145517..681b791 100644
+index d145517..fc6d80d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -669,6 +669,10 @@ if (CYGWIN OR WIN32)
+@@ -669,6 +669,8 @@ if (CYGWIN OR WIN32)
    target_compile_definitions (glog PUBLIC GLOG_NO_ABBREVIATED_SEVERITIES)
  endif (CYGWIN OR WIN32)
  
-+if ((MSVC) AND (MSVC_VERSION GREATER_EQUAL 1914))
-+    target_compile_options(glog INTERFACE "/Zc:__cplusplus")
-+endif()
++target_compile_options(glog INTERFACE $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus>>)
 +
  if (WITH_CUSTOM_PREFIX)
    target_compile_definitions (glog PUBLIC GLOG_CUSTOM_PREFIX_SUPPORT)

--- a/ports/glog/vcpkg.json
+++ b/ports/glog/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glog",
   "version": "0.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ implementation of the Google logging module",
   "homepage": "https://github.com/google/glog",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2670,7 +2670,7 @@
     },
     "glog": {
       "baseline": "0.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "gloo": {
       "baseline": "20201203",

--- a/versions/g-/glog.json
+++ b/versions/g-/glog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48a4b620854cc76925bfbebca8985b95cf99b5b9",
+      "version": "0.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "1fceaa6733361ea635af35ec1ce9b3caf47e0ffc",
       "version": "0.6.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes  not work on on windows cuda nvcc compiler. #27899

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  <all>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
