### PR TITLE
Add -static suffix to non-empty triplet if static libraries are enabled

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -39,6 +39,8 @@
     <_ZVcpkgLinkage />
     <_ZVcpkgLinkage Condition="'$(VcpkgUseStatic)' == 'true'">-static</_ZVcpkgLinkage>
     <VcpkgTriplet Condition="'$(VcpkgTriplet)' == ''">$(VcpkgPlatformTarget)-$(VcpkgOSTarget)$(_ZVcpkgLinkage)</VcpkgTriplet>
+    <VcpkgTriplet Condition="'$(VcpkgTriplet)' != '' and !$(VcpkgTriplet.EndsWith('-static'))">$(VcpkgTriplet)$(_ZVcpkgLinkage)</VcpkgTriplet>
+    <VcpkgTriplet Condition="'$(VcpkgTriplet)' != '' and $(VcpkgTriplet.EndsWith('-static'))">$(VcpkgTriplet)</VcpkgTriplet>
   </PropertyGroup>
 
   <!-- Include the triplet in ProjectStateLine to force VS2017 and later to fully rebuild if the user changes it.  -->


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes #28009 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `All`, `No`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `No`