### PR TITLE
[libpng] Fix libpng for android

### DIFF
--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -55,10 +55,10 @@ endif()
 vcpkg_list(SET LD_VERSION_SCRIPT_OPTION)
 if(VCPKG_TARGET_IS_ANDROID)
     vcpkg_list(APPEND LD_VERSION_SCRIPT_OPTION "-Dld-version-script=OFF")
-    # for armeabi-v7a, check whether NEON is available
-    vcpkg_list(APPEND LIBPNG_HARDWARE_OPTIMIZATIONS_OPTION "-DPNG_ARM_NEON=check")
-else()
-    vcpkg_list(APPEND LIBPNG_HARDWARE_OPTIMIZATIONS_OPTION "-DPNG_ARM_NEON=on")
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+        # for armeabi-v7a, check whether NEON is available
+        vcpkg_list(APPEND LIBPNG_HARDWARE_OPTIMIZATIONS_OPTION "-DPNG_ARM_NEON=check")
+    endif()
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/libpng/vcpkg.json
+++ b/ports/libpng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpng",
   "version": "1.6.38",
+  "port-version": 1,
   "description": "libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files",
   "homepage": "https://github.com/glennrp/libpng",
   "license": "libpng-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4094,7 +4094,7 @@
     },
     "libpng": {
       "baseline": "1.6.38",
-      "port-version": 0
+      "port-version": 1
     },
     "libpopt": {
       "baseline": "1.16",

--- a/versions/l-/libpng.json
+++ b/versions/l-/libpng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f53e65c25d240846146641165cff9d572f9a7992",
+      "version": "1.6.38",
+      "port-version": 1
+    },
+    {
       "git-tree": "923c99cca2e5f79dfc04e9432ac1146ee6da5b11",
       "version": "1.6.38",
       "port-version": 0


### PR DESCRIPTION
**Describe the problem**

`check` is only a valid value for arm architectures.

On `arm64` this errors with

```
CMake Error at CMakeLists.txt:108 (message):
  PNG_ARM_NEON must be one of [on;off]
```

**Describe the pull request**

Only use `check` on `arm`