### PR TITLE
[pixman] build fix for arm-windows and arm-uwp

### DIFF
--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -29,6 +29,12 @@ elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "mips")
             -Dssse3=disabled)
 endif()
 
+if(VCPKG_TARGET_IS_UWP AND VCPKG_TARGET_ARCHITECTURE MATCHES "arm")
+   list(APPEND OPTIONS
+               -Darm-simd=disabled
+               -Dneon=disabled)
+endif()
+
 set(PIXMAN_VERSION 0.40.0)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.cairographics.org/releases/pixman-${PIXMAN_VERSION}.tar.gz"

--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -29,7 +29,7 @@ elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "mips")
             -Dssse3=disabled)
 endif()
 
-if(VCPKG_TARGET_IS_UWP AND VCPKG_TARGET_ARCHITECTURE MATCHES "arm")
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "arm")
    list(APPEND OPTIONS
                -Darm-simd=disabled
                -Dneon=disabled)

--- a/ports/pixman/vcpkg.json
+++ b/ports/pixman/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pixman",
   "version": "0.40.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.",
   "homepage": "https://www.cairographics.org/releases",
   "license": "MIT",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -799,7 +799,6 @@ pfring:arm64-osx=fail
 # pfring on Linux currently fails because its build scripts enable warnings as
 # errors, and warnings trigger with the Linux kernel headers in the Azure images.
 pfring:x64-linux=fail
-pixman:arm-uwp=fail
 platform-folders:arm-uwp=fail
 platform-folders:x64-uwp=fail
 plibsys:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5794,7 +5794,7 @@
     },
     "pixman": {
       "baseline": "0.40.0",
-      "port-version": 4
+      "port-version": 5
     },
     "pkgconf": {
       "baseline": "1.8.0",

--- a/versions/p-/pixman.json
+++ b/versions/p-/pixman.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f26230558cb33582de396b799e90a9046672b151",
+      "version": "0.40.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "d0209cb23d5ca18cd74fa4a67e7ca80f7e81c0cd",
       "version": "0.40.0",
       "port-version": 4


### PR DESCRIPTION
This PR disables arm-simd and neon pixman options for both arm-windows and arm-uwp, to correctly build these triplets.

- #### What does your PR fix?
  Fixes #28021 

- #### Which triplets are supported? 
  arm-windows
  arm-uwp

- #### Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

