### PR TITLE
[glslang] Bump to latest version again

### DIFF
--- a/ports/glslang/install-to-datadir.patch
+++ b/ports/glslang/install-to-datadir.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b581c84..a011686 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -375,13 +375,13 @@ if(ENABLE_GLSLANG_INSTALL)
+         include("@PACKAGE_PATH_EXPORT_TARGETS@")
+     ]=])
+     
+-    set(PATH_EXPORT_TARGETS "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake")
++    set(PATH_EXPORT_TARGETS "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake")
+     configure_package_config_file(
+         "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in"
+         "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
+         PATH_VARS
+             PATH_EXPORT_TARGETS
+-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
++        INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}
+     )
+     
+     write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/glslang-config-version.cmake"
+@@ -392,7 +392,7 @@ if(ENABLE_GLSLANG_INSTALL)
+     install(
+         EXPORT      glslang-targets
+         NAMESPACE   "glslang::"
+-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
++        DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}"
+     )
+     
+     install(
+@@ -400,6 +400,6 @@ if(ENABLE_GLSLANG_INSTALL)
+             "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
+             "${CMAKE_CURRENT_BINARY_DIR}/glslang-config-version.cmake"
+         DESTINATION
+-            "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
++            "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}"
+     )
+ endif()
+\ No newline at end of file

--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
   HEAD_REF master
   PATCHES
     ignore-crt.patch
+    install-to-datadir.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KhronosGroup/glslang
-  REF 11.11.0
-  SHA512 c018271d499efff03540e4572a9c2f1f752c81c87efe7f2e63c2631ac47cecfedffdcfee68eddaf9187603eaae8ccd9a3e5640a022ba9fd7d05950f7827bf8cd
+  REF 11.12.0
+  SHA512 fd955f9912551668056dfe52835eef11e5dc0bf0d25b2d961a31f684adbd63bc6380759944c1921cfd63d359a58c7cc3a4a4d5eea69fa1b050f58960e5101271
   HEAD_REF master
   PATCHES
     ignore-crt.patch

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glslang",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "port-version": 1,
   "description": "Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator",
   "homepage": "https://github.com/KhronosGroup/glslang",

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 1,
   "description": "Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator",
   "homepage": "https://github.com/KhronosGroup/glslang",
+  "license": "Apache-2.0 AND BSD-3-Clause AND MIT AND GPL-3.0-or-later",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/shaderc/fix-tbuiltinresource-for-glslang-11-12.patch
+++ b/ports/shaderc/fix-tbuiltinresource-for-glslang-11-12.patch
@@ -1,0 +1,20 @@
+diff --git a/libshaderc_util/src/resources.cc b/libshaderc_util/src/resources.cc
+index d64e47f..6c662d3 100644
+--- a/libshaderc_util/src/resources.cc
++++ b/libshaderc_util/src/resources.cc
+@@ -125,6 +125,15 @@ const TBuiltInResource kDefaultTBuiltInResource = {
+     /* .maxTaskWorkGroupSizeY_NV = */ 1,
+     /* .maxTaskWorkGroupSizeZ_NV = */ 1,
+     /* .maxMeshViewCountNV = */ 4,
++    /* .maxMeshOutputVerticesEXT = */ 256,
++    /* .maxMeshOutputPrimitivesEXT = */ 256,
++    /* .maxMeshWorkGroupSizeX_EXT = */ 128,
++    /* .maxMeshWorkGroupSizeY_EXT = */ 128,
++    /* .maxMeshWorkGroupSizeZ_EXT = */ 128,
++    /* .maxTaskWorkGroupSizeX_EXT = */ 128,
++    /* .maxTaskWorkGroupSizeY_EXT = */ 128,
++    /* .maxTaskWorkGroupSizeZ_EXT = */ 128,
++    /* .maxMeshViewCountEXT = */ 4,
+     /* .maxDualSourceDrawBuffersEXT = */ 1,
+     // This is the glslang TLimits structure.
+     // It defines whether or not the following features are enabled.

--- a/ports/shaderc/portfile.cmake
+++ b/ports/shaderc/portfile.cmake
@@ -12,6 +12,8 @@ vcpkg_from_github(
         fix-build-type.patch
         fix-install-shaderc_util.patch
         fix-export-cmakefiles.patch
+        # NOTE: This should be removed when shaderc gets updated to use glslang 11.12.0
+        fix-tbuiltinresource-for-glslang-11-12.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/build-version.inc" DESTINATION "${SOURCE_PATH}/glslc/src")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2677,8 +2677,8 @@
       "port-version": 0
     },
     "glslang": {
-      "baseline": "11.11.0",
-      "port-version": 1
+      "baseline": "11.12.0",
+      "port-version": 0
     },
     "glui": {
       "baseline": "2019-11-30",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2678,7 +2678,7 @@
     },
     "glslang": {
       "baseline": "11.12.0",
-      "port-version": 0
+      "port-version": 1
     },
     "glui": {
       "baseline": "2019-11-30",

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -3,7 +3,7 @@
     {
       "git-tree": "a453755cd3b3e7c8dafec89688404269b0c40690",
       "version": "11.12.0",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "b468ee3d588ae97ba2d03a4723751cac81c80443",

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a453755cd3b3e7c8dafec89688404269b0c40690",
+      "git-tree": "068b8919de1351c408446373cf5a30e52d07451b",
       "version": "11.12.0",
       "port-version": 1
     },

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "068b8919de1351c408446373cf5a30e52d07451b",
+      "git-tree": "64952d0b82498ceb8357b5fdf80abf86ec477718",
       "version": "11.12.0",
       "port-version": 1
     },

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a453755cd3b3e7c8dafec89688404269b0c40690",
+      "version": "11.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b468ee3d588ae97ba2d03a4723751cac81c80443",
       "version": "11.11.0",
       "port-version": 1

--- a/versions/s-/shaderc.json
+++ b/versions/s-/shaderc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d93e78fd464f2f378c8faf94e40e16410e1c41e0",
+      "git-tree": "b33d795ee7bc7bb9a02f904dc4d8e08e5f5f4900",
       "version": "2021.1",
       "port-version": 3
     },


### PR DESCRIPTION
Quick bump of glslang to 11.12.0

- #### What does your PR fix?
  glslang no longer out-of-date

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All the ones it supported before (I think this is all)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
