### PR TITLE
[vcpkg] Lower the version of PowerShell to v7.2.7

### DIFF
--- a/scripts/azure-pipelines/windows/deploy-pwsh.ps1
+++ b/scripts/azure-pipelines/windows/deploy-pwsh.ps1
@@ -5,5 +5,5 @@
 
 # REPLACE WITH UTILITY-PREFIX.ps1
 
-$PwshUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.0/PowerShell-7.3.0-win-x64.msi'
+$PwshUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.7/PowerShell-7.2.7-win-x64.msi'
 InstallMSI -Url $PwshUrl -Name 'PowerShell Core'

--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -194,11 +194,11 @@
         <archiveName>ninja-freebsd-1.8.2.zip</archiveName>
     </tool>
     <tool name="powershell-core" os="windows">
-        <version>7.3.0</version>
+        <version>7.2.7</version>
         <exeRelativePath>pwsh.exe</exeRelativePath>
-        <url>https://github.com/PowerShell/PowerShell/releases/download/v7.3.0/PowerShell-7.3.0-win-x86.zip</url>
-        <sha512>da01f53bc8e3f11b99ad936c5925074ea379ff6aec9e9e4f6040e406de5fa08cd266f619913ce16aa7883b2c6a1e0e2bbf2c3521c0ec4feba2531ca2cc61f363</sha512>
-        <archiveName>PowerShell-7.3.0-win-x86.zip</archiveName>
+        <url>https://github.com/PowerShell/PowerShell/releases/download/v7.2.7/PowerShell-7.2.7-win-x86.zip</url>
+        <sha512>e17b307b66d17d4ece4d2f93080e6111265070b2ee6b77ffe3224973a470c59a14b1b17fab7445b18d370ac1720045188a9a011f0c9c8538ac56eca7673f184a</sha512>
+        <archiveName>PowerShell-7.2.7-win-x86.zip</archiveName>
     </tool>
     <tool name="node" os="windows">
         <version>16.15.1</version>


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/28020 https://github.com/microsoft/vcpkg/issues/28046

  PowerShell 7.3.0 x86 will crashes on startup on Windows 11 22H2, this is a known issue of https://github.com/PowerShell/PowerShell, and this issue has been fixed by https://github.com/PowerShell/PowerShell/pull/18547, but this fix has not been released yet, I will update PowerShell to 7.3.0 when it is released.
