### PR TITLE
[crashpad] Include common lib target in output

### DIFF
--- a/ports/crashpad/crashpadConfig.cmake.in
+++ b/ports/crashpad/crashpadConfig.cmake.in
@@ -9,7 +9,7 @@ endif()
 add_library(crashpad INTERFACE)
 add_library(crashpad::crashpad ALIAS crashpad)
 
-set(CRASHPAD_LIBRARIES client util base)
+set(CRASHPAD_LIBRARIES client util base common)
 
 if(WIN32)
 	target_compile_definitions(crashpad INTERFACE NOMINMAX)

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -98,7 +98,7 @@ vcpkg_configure_gn(
 
 vcpkg_install_gn(
     SOURCE_PATH "${SOURCE_PATH}"
-    TARGETS client util third_party/mini_chromium/mini_chromium/base handler:crashpad_handler
+    TARGETS client client:common util third_party/mini_chromium/mini_chromium/base handler:crashpad_handler
 )
 
 message(STATUS "Installing headers...")

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2022-09-05",
+  "port-version": 1,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1726,7 +1726,7 @@
     },
     "crashpad": {
       "baseline": "2022-09-05",
-      "port-version": 0
+      "port-version": 1
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7ead3d493577856543add942c07776fe60ded9e",
+      "version-date": "2022-09-05",
+      "port-version": 1
+    },
+    {
       "git-tree": "6d39be1cd402a6147c057802a84ffdc1715d6384",
       "version-date": "2022-09-05",
       "port-version": 0


### PR DESCRIPTION
**Include common.lib in the output of crashpad**

- #### What does your PR fix?
When looking at the [tutorial for bugsplat](https://docs.bugsplat.com/introduction/getting-started/integrations/cross-platform/crashpad/how-to-build-google-crashpad), we can read the following:

> At a minimum, Windows applications need to be linked with **out\Default\obj\client\common.lib**, out\Default\obj\client\client.lib, out\Default\obj\util\util.lib, and out\Default\obj\third_party\mini_chromium\mini_chromium\base\base.lib.

However, crashpad, when built as a vcpkg package, does not actually copy common.lib to the output. So, while very basic usage of crashpad *does* work with the vcpkg version, features such as automatic uploading to bugsplat would not work.

This PR attempts to fix that, by copying the required libs to the output, and linking against them when using the CMake target.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
