### PR TITLE
[g3log] Update g3log to 2.1

### DIFF
--- a/ports/g3log/portfile.cmake
+++ b/ports/g3log/portfile.cmake
@@ -1,3 +1,4 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KjellKod/g3log
@@ -9,11 +10,8 @@ vcpkg_from_github(
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" G3_SHARED_LIB)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" G3_SHARED_RUNTIME)
 
-# https://github.com/KjellKod/g3log#prerequisites
-set(VERSION "2.1")
-
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DG3_SHARED_LIB=${G3_SHARED_LIB} # Options.cmake
         -DG3_SHARED_RUNTIME=${G3_SHARED_RUNTIME} # Options.cmake

--- a/ports/g3log/portfile.cmake
+++ b/ports/g3log/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KjellKod/g3log
-    REF 2fca06ff6da5c67465b591f4d45e8fd14d531142 #v1.3.4
-    SHA512 8dba89e5a08e44d585478470725e25e37486685d8fe4d3cb5e97c81013389c95d96bdde658244e425008169bc8a9fc2d34a065b83b110c62e73d3ccab9b2b9e1
+    REF 6f6da0ed2a8b42b8a5d1a416fe1646fe45e45c99
+    SHA512 65d966e0cb35ae6903619349520f12abf473c98ce6c9ffcb9b196b0be5d2b75ee5b716eeec8285ddc909f65049d8feab9389347c28be376b46cdb0d9246ffbbd
     HEAD_REF master
 )
 
@@ -10,11 +10,10 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" G3_SHARED_LIB)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" G3_SHARED_RUNTIME)
 
 # https://github.com/KjellKod/g3log#prerequisites
-set(VERSION "1.3.4")
+set(VERSION "2.1")
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DG3_SHARED_LIB=${G3_SHARED_LIB} # Options.cmake
         -DG3_SHARED_RUNTIME=${G3_SHARED_RUNTIME} # Options.cmake
@@ -24,11 +23,11 @@ vcpkg_configure_cmake(
         -DVERSION=${VERSION}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/g3log)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/g3log)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/g3log/vcpkg.json
+++ b/ports/g3log/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "2.1",
   "description": "Asynchronous logger with Dynamic Sinks",
   "homepage": "https://github.com/KjellKod/g3log",
+  "license": "Unlicense",
   "supports": "!(arm | uwp)",
   "dependencies": [
     {

--- a/ports/g3log/vcpkg.json
+++ b/ports/g3log/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Asynchronous logger with Dynamic Sinks",
   "homepage": "https://github.com/KjellKod/g3log",
   "license": "Unlicense",
-  "supports": "!(arm | uwp)",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/g3log/vcpkg.json
+++ b/ports/g3log/vcpkg.json
@@ -1,8 +1,17 @@
 {
   "name": "g3log",
-  "version": "1.3.4",
-  "port-version": 2,
+  "version": "2.1",
   "description": "Asynchronous logger with Dynamic Sinks",
   "homepage": "https://github.com/KjellKod/g3log",
-  "supports": "!(arm | uwp)"
+  "supports": "!(arm | uwp)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2509,8 +2509,8 @@
       "port-version": 2
     },
     "g3log": {
-      "baseline": "1.3.4",
-      "port-version": 2
+      "baseline": "2.1",
+      "port-version": 0
     },
     "gainput": {
       "baseline": "1.0.0",

--- a/versions/g-/g3log.json
+++ b/versions/g-/g3log.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c8fdfbf4c71b76bdc8c22827cf3d8bef60a3591d",
+      "git-tree": "ce2eee87993ff26684fad107624adebc23e64737",
       "version": "2.1",
       "port-version": 0
     },

--- a/versions/g-/g3log.json
+++ b/versions/g-/g3log.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66d6e92bbb0af1ad4cd9a659cdc804cdf97e9b5a",
+      "version": "2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b97c6fdba216caec4a83323a693a871cb57968fd",
       "version": "1.3.4",
       "port-version": 2

--- a/versions/g-/g3log.json
+++ b/versions/g-/g3log.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "66d6e92bbb0af1ad4cd9a659cdc804cdf97e9b5a",
+      "git-tree": "c8fdfbf4c71b76bdc8c22827cf3d8bef60a3591d",
       "version": "2.1",
       "port-version": 0
     },


### PR DESCRIPTION
Updates g3log to version 2.1, I also updated the cmake commands as written in the mainter guide and updated the json deps.

- #### What does your PR fix?
//

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
 I personally tested it with x64-windows theorically it should work on all platforms that g3log supports.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I think yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes
