### PR TITLE
[raylib] Fix dependency on glfw for emscripten and compilation options

### DIFF
--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -14,6 +14,10 @@ if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
     set(patches fix-linkGlfw.patch)
 endif()
 
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+	set(ADDITIONAL_OPTIONS "-DPLATFORM=Web")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO raysan5/raylib
@@ -46,6 +50,7 @@ vcpkg_cmake_configure(
         -DSTATIC=${STATIC}
         -DUSE_EXTERNAL_GLFW=OFF # externl glfw3 causes build errors on Windows
         ${FEATURE_OPTIONS}
+        ${ADDITIONAL_OPTIONS}
     OPTIONS_DEBUG
         -DENABLE_ASAN=${DEBUG_ENABLE_SANITIZERS}
         -DENABLE_UBSAN=${DEBUG_ENABLE_SANITIZERS}

--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -21,8 +21,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO raysan5/raylib
-    REF bf2ad9df5fdcaa385b2a7f66fd85632eeebbadaa #v4.2.0
-    SHA512 f6b1738d96fef89059062f570f67aaa8b143ccfbee78abfe5fbb25083371a4c432f3d1d0d357e4b475b4b72a6db7823c2341b70ac947759603b033c2b0acec47
+    REF 387c06000618ef0aa3b15c5e46d1c525ba194c50 #v4.2.0
+    SHA512 df7640dcf2979128586c7b671da4f17b628bed8a4526f252469d2d25aee2c9b16695087c8766c10bfdf26a89ff1a8f7ff6005baa7c0dbf77dadc8a0c469e1217
     HEAD_REF master
     PATCHES ${patches}
 )

--- a/ports/raylib/vcpkg.json
+++ b/ports/raylib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "raylib",
   "version-semver": "4.2.0",
+  "port-version": 1,
   "description": "A simple and easy-to-use library to enjoy videogames programming",
   "homepage": "https://github.com/raysan5/raylib",
   "license": "Zlib",

--- a/ports/raylib/vcpkg.json
+++ b/ports/raylib/vcpkg.json
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "glfw3",
-      "platform": "!windows"
+      "platform": "!(windows | emscripten)"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6218,7 +6218,7 @@
     },
     "raylib": {
       "baseline": "4.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "rbdl": {
       "baseline": "3.2.0",

--- a/versions/r-/raylib.json
+++ b/versions/r-/raylib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f414adaa0cc7bb24014fb07c4f16647aa853696e",
+      "version-semver": "4.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "84270f09d9ecfed2207ea866910905fdfcf8b229",
       "version-semver": "4.2.0",
       "port-version": 0

--- a/versions/r-/raylib.json
+++ b/versions/r-/raylib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f414adaa0cc7bb24014fb07c4f16647aa853696e",
+      "git-tree": "f3416dbe0e282bf0df99b8147aa78b0c4c3c0263",
       "version-semver": "4.2.0",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #24787

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
emscripten

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Not needed
