### PR TITLE
[libssh] fix json file

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -503,7 +503,6 @@ libsoundio:arm-uwp=fail
 libsoundio:x64-uwp=fail
 libspatialite:arm-uwp=fail
 libspatialite:x64-uwp=fail
-libssh:arm64-windows=fail
 libssh:arm-uwp=fail
 libssh:x64-uwp=fail
 libtins:arm-uwp=fail

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc1f60a58c33279b187a474890dd1a54cdc17062",
+      "version": "0.10.4+20221123",
+      "port-version": 0
+    },
+    {
       "git-tree": "6de85714bb1e12c5e87284700f832fd08523e10d",
       "version": "0.10.4",
       "port-version": 0

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-	{
+    {
       "git-tree": "baa8d88a9e8de14901a3d6d59bab61220774854d",
       "version": "0.10.4+20221123",
       "port-version": 1

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,16 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "baa8d88a9e8de14901a3d6d59bab61220774854d",
-      "version": "0.10.4+20221123",
-      "port-version": 1
-    },
-    {
-      "git-tree": "68659ea5eb32e7c3f1b594fa7c6179a745efbb5e",
-      "version": "0.10.4",
-      "port-version": 1
-    },
-    {
       "git-tree": "6de85714bb1e12c5e87284700f832fd08523e10d",
       "version": "0.10.4",
       "port-version": 0

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,5 +1,10 @@
 {
   "versions": [
+	{
+      "git-tree": "baa8d88a9e8de14901a3d6d59bab61220774854d",
+      "version": "0.10.4+20221123",
+      "port-version": 1
+    },
     {
       "git-tree": "fc1f60a58c33279b187a474890dd1a54cdc17062",
       "version": "0.10.4+20221123",


### PR DESCRIPTION
Fix json issue from https://github.com/microsoft/vcpkg/pull/28031, related: https://github.com/microsoft/vcpkg/pull/27973. 

Remove `libssh:arm64-windows=fail` in `scripts/ci.baseline.txt`, because from https://github.com/microsoft/vcpkg/pull/28031, started working on arm. The first addition comes from https://github.com/microsoft/vcpkg/pull/9203.