### PR TITLE
[bgfx] Add bgfx port

### DIFF
--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -1,0 +1,85 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/bkaradzic/bgfx.cmake/archive/refs/tags/v1.118.8384-362.tar.gz"
+    FILENAME "v1.118.8384-362.tar.gz"
+    SHA512 56203c40a724cd9e225d1c3142a30f8dd2e2f8cfc869a19cfa512bc69f0f62cd9460d016f1345a21bae9ef81323571d30dc588fde53f0fd0ba8628f7bbbab563
+)
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH_BX
+  REPO "bkaradzic/bx"
+  HEAD_REF master
+  REF aed1086c48884b1b4f1c2f9af34c5198624263f6
+  SHA512 63bc5c6358f6a760bd5d8d056ef6fc6de175dcf8b940d5490225f13dfdd791c6b1d6bd2087d5d48a34955649bc12cbcc92f5221188ba0df5eb5c5d00eb389e94
+)
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH_BIMG
+  REPO "bkaradzic/bimg"
+  HEAD_REF master
+  REF 85109d7cdbe775a0ab72cf38510df525d5e8d3da
+  SHA512 b3e082cd249e802e6d209ed45a552843604713a06597277b2855d1fa1c39b3d5136d5589599a85126eda218ccfee0ce6177f004cb5dccb912fe64ea7e07af2a8
+)
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH_BGFX
+  REPO "bkaradzic/bgfx"
+  HEAD_REF master
+  REF 66de825e6f9de21890b336994141ab5dbc214dec
+  SHA512 16ee1d3897dce5fcee7e658f793e078a1f3547b5d3512ebb860819d5105df99f87e4389ee1c66c1d24df04e0e589b6842cf36a52581e21732164017098f36f60
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES tools BGFX_BUILD_TOOLS multithreaded BGFX_CONFIG_MULTITHREADED
+)
+
+if (BGFX_BUILD_TOOLS AND TARGET_TRIPLET MATCHES "(windows|uwp)")
+  # bgfx doesn't apply __declspec(dllexport) which prevents dynamic linking for tools
+  set(BGFX_LIBRARY_TYPE "STATIC")
+elseif (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+  set(BGFX_LIBRARY_TYPE "SHARED")
+else ()
+  set(BGFX_LIBRARY_TYPE "STATIC")
+endif ()
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS -DBX_DIR=${SOURCE_PATH_BX}
+          -DBIMG_DIR=${SOURCE_PATH_BIMG}
+          -DBGFX_DIR=${SOURCE_PATH_BGFX}
+          -DBGFX_LIBRARY_TYPE=${BGFX_LIBRARY_TYPE}
+          -DBX_AMALGAMATED=ON
+          -DBGFX_AMALGAMATED=ON
+          -DBGFX_BUILD_EXAMPLES=OFF
+          -DBGFX_OPENGLES_VERSION=30
+          ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_copy_pdbs()
+
+if (BGFX_BUILD_TOOLS)
+  vcpkg_copy_tools(
+    TOOL_NAMES shaderc geometryc geometryv texturec texturev AUTO_CLEAN
+  )
+endif ()
+
+# Handle copyright
+file(
+  INSTALL "${CURRENT_PACKAGES_DIR}/share/licences/${PORT}/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/licences"
+     "${CURRENT_PACKAGES_DIR}/debug/include"
+     "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "name": "bgfx",
+  "version": "1.118.8384-362",
+  "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
+  "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
+  "homepage": "https://bkaradzic.github.io/bgfx/overview.html",
+  "documentation": "https://bkaradzic.github.io/bgfx",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "multithreaded"
+  ],
+  "features": {
+    "multithreaded": {
+      "description": "Encode and render on different threads"
+    },
+    "tools": {
+      "$comment": "Use '\"host\": true' in dependencies of vcpkg.json to prevent cross compiling the tools.",
+      "description": "Shader, Texture and Geometry compilers for bgfx."
+    }
+  }
+}

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6554186755cae40eef0b34bf0c447861d6e6dd7a",
+      "version": "1.118.8384-362",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -484,6 +484,10 @@
       "baseline": "1.6",
       "port-version": 0
     },
+    "bgfx": {
+      "baseline": "1.118.8384-362",
+      "port-version": 0
+    },
     "bigint": {
       "baseline": "2010.04.30",
       "port-version": 7


### PR DESCRIPTION
**Describe the pull request**

Add the bgfx graphics library. We've been using this a local config package for about a year. There have been attempts to port this in the past that ended up being abandoned by the authors.

The cmake config come from https://github.com/bkaradzic/bgfx.cmake which are maintained by the bgfx author with the help of myself and a few other users.

There are tools and multithreaded features to configure usage.
* tools: Include tools to compile shaders and format textures and geometry. These take longer to compile but can be used inside cmake config for usages like compiling a shader into a header for another target. You wouldn't want to use this on android for example, you'd do this on the cross-compile host.
* multithreaded: bgfx is easier to debug in single threaded mode and some usages such as OpenXR might require single threaded mode. Platforms such as webasm also have limited multithreading capabilities.

I chose not to split the package into bx, bimg and bgfx as they are pretty tied together. The reason for this is to closely mirror the configuration of the bgfx.cmake repository.

bgfx makes use of code in spirv-opt and spirv-cross among others that are in its source/3rdparty. The author uses local copies in order to control the supported versions and to apply changes and fixes to these libraries in their use within bgfx. For this reason, the package doesn't depend on them.

We use this configuration in https://github.com/openblack/openblack and test it on vcpkg+ninja on x64-linux, x86-windows, x64-windows, x64-osx, arm64-android, arm-android, x64-android, x86-android, wasm32-emscripten (experimental)

- #### What does your PR fix?
  Closes #14955, a highly requested port.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

