### PR TITLE
 [c9y] Bump to 0.5.0

### DIFF
--- a/ports/c9y/portfile.cmake
+++ b/ports/c9y/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rioki/c9y
-    REF v0.4.0
-    SHA512 496466a639fa1f4111583363ce13ce4f2c1d6a56763fd12f45acc2cb791f379a6d81545536186e8f0f72f19a9b5689d16fd0561345411ca1cb98a16447141114
+    REF v0.5.0
+    SHA512 596bf99e031a44997ab114831a720667d4988ff20af1abb43a17f92f18cf820dfe5f7ad8d91b6a77db2fa7d12b29bc5afd5fb6654381c2c687d8fecb297b32f6
     )
 
 vcpkg_cmake_configure(
@@ -12,5 +12,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/c9y/vcpkg.json
+++ b/ports/c9y/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c9y",
-  "version-semver": "0.4.0",
+  "version-semver": "0.5.0",
   "description": "Concurency",
   "homepage": "https://github.com/rioki/c9y",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1257,7 +1257,7 @@
       "port-version": 1
     },
     "c9y": {
-      "baseline": "0.4.0",
+      "baseline": "0.5.0",
       "port-version": 0
     },
     "caf": {

--- a/versions/c-/c9y.json
+++ b/versions/c-/c9y.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8903a62bc2476fb4e7e1a74081cd80661ebebc95",
+      "version-semver": "0.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7664032e69d86b58605c20e353af75d9961d10d8",
       "version-semver": "0.4.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?

  Update c9y to 0.5.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  
 unchanged: all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

  To the best of my knowledge, yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

  yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
