### PR TITLE
[sdl2] Disable X11 feature and make it and Wayland defaults

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -14,7 +14,7 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         vulkan   SDL_VULKAN
-        x11      SDL_X11_SHARED
+        x11      SDL_X11
         wayland  SDL_WAYLAND
 )
 
@@ -37,7 +37,6 @@ vcpkg_cmake_configure(
         -DSDL_SHARED=${SDL_SHARED}
         -DSDL_FORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
         -DSDL_LIBC=ON
-        -DSDL_HIDAPI_JOYSTICK=ON
         -DSDL_TEST=OFF
         -DSDL_IBUS=OFF
         -DSDL_INSTALL_CMAKEDIR="cmake"

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.26.1",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",
@@ -14,7 +15,24 @@
       "host": true
     }
   ],
+  "default-features": [
+    "base"
+  ],
   "features": {
+    "base": {
+      "description": "Base functionality for SDL",
+      "dependencies": [
+        {
+          "name": "sdl2",
+          "default-features": false,
+          "features": [
+            "wayland",
+            "x11"
+          ],
+          "platform": "linux"
+        }
+      ]
+    },
     "vulkan": {
       "description": "Vulkan functionality for SDL"
     },
@@ -23,7 +41,7 @@
       "supports": "linux"
     },
     "x11": {
-      "description": "Dynamically load X11 support",
+      "description": "Build with X11 support",
       "supports": "!windows"
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6818,7 +6818,7 @@
     },
     "sdl2": {
       "baseline": "2.26.1",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61ecd58c79e5522e8a23f842936e24b2b6f08c75",
+      "version": "2.26.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "323de63997d074a6076426bcc5f90fb2a183d534",
       "version": "2.26.1",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?

\- Disabling the X11 feature now correctly disables the X11 backend
\- Make `x11` and `wayland` features the default on Linux, because that's what you usually always want.
\- SDL_HIDAPI_JOYSTICK is set to ON by default, so no need to pass it explicitly

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

Linux

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

yeah
