### PR TITLE
[tiff] Add patches from Debian

### DIFF
--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -1,10 +1,10 @@
-set(LIBTIFF_VERSION 4.4.0)
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.com
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtiff/libtiff
-    REF v${LIBTIFF_VERSION}
+    REF "v${VERSION}"
     SHA512 93955a2b802cf243e41d49048499da73862b5d3ffc005e3eddf0bf948a8bd1537f7c9e7f112e72d082549b4c49e256b9da9a3b6d8039ad8fc5c09a941b7e75d7
     HEAD_REF master
     PATCHES
@@ -64,10 +64,9 @@ file(REMOVE_RECURSE
 )
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
-file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 if ("tools" IN_LIST FEATURES)
-    set(_tools
+    set(tools
         fax2ps
         fax2tiff
         pal2rgb
@@ -87,9 +86,11 @@ if ("tools" IN_LIST FEATURES)
         tiffset
         tiffsplit
     )
-    vcpkg_copy_tools(TOOL_NAMES ${_tools} AUTO_CLEAN)
+    vcpkg_copy_tools(TOOL_NAMES ${tools} AUTO_CLEAN)
 elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
 vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -1,5 +1,20 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
+set(tiff_debian_archive_name "tiff_4.4.0-6.debian.tar.xz")
+vcpkg_download_distfile(
+    tiff_debian_archive
+    URLS "https://deb.debian.org/debian/pool/main/t/tiff/${tiff_debian_archive_name}"
+         "https://snapshot.debian.org/archive/debian/20221124T210835Z/pool/main/t/tiff/${tiff_debian_archive_name}"
+    FILENAME "${tiff_debian_archive_name}"
+    SHA512 a806debc92e8dac573f1e603a91eabb8fa1ab493404d0be62ca926e35f97df2d4514c58bdb93317a91d7f98abb18e9ff91ad51ff0f796a4f94f8b90195c4fdcf
+)
+vcpkg_extract_source_archive(tiff_debian
+    ARCHIVE "${tiff_debian_archive}"
+    SOURCE_BASE "debian"
+)
+file(STRINGS "${tiff_debian}/patches/series" cve_patches REGEX "^CVE-")
+list(TRANSFORM cve_patches PREPEND "${tiff_debian}/patches/")
+
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.com
     OUT_SOURCE_PATH SOURCE_PATH
@@ -11,6 +26,7 @@ vcpkg_from_gitlab(
         cmakelists.patch
         FindCMath.patch
         android-libm.patch
+        ${cve_patches}
 )
 
 set(EXTRA_OPTIONS "")

--- a/ports/tiff/vcpkg.json
+++ b/ports/tiff/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "tiff",
   "version": "4.4.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library that supports the manipulation of TIFF image files",
   "homepage": "https://libtiff.gitlab.io/libtiff/",
-  "license": null,
+  "license": "libtiff",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7426,7 +7426,7 @@
     },
     "tiff": {
       "baseline": "4.4.0",
-      "port-version": 1
+      "port-version": 2
     },
     "tinkerforge": {
       "baseline": "2.1.25",

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "995bf067680005c3fe50299cfe62cc2e8de61d47",
+      "version": "4.4.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "7d5e9083d0072a4370b44f434cd4dac7b3bee7bc",
       "version": "4.4.0",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes several CVEs for tiff 4.4.0, based on the patches collected by the Debian maintainers. Some patches "only" affect the tools, but others touch the library itself.
  This is a temporary solution until a new tiff patch release is available.

  The particular Debian changes tarball should be available from the official servers until Debian maintainers do another patch release for tiff, and from the snapshot servers with no particular time limit.
  According to the included `copyright` file, the original licenses also applies to the debian files. (Only the authors differ.)
  Browse the current debian files online at:
  https://sources.debian.org/src/tiff/4.4.0-6/debian/

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes