### PR TITLE
[dlfcn-win32] Fix install failure when build type is set to release

### DIFF
--- a/ports/dlfcn-win32/portfile.cmake
+++ b/ports/dlfcn-win32/portfile.cmake
@@ -14,17 +14,12 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-if(NOT VCPKG_BUILD_TYPE STREQUAL release)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/share/${PORT}/${PORT}-targets-debug.cmake" "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug")
-    file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}/${PORT}-targets-debug.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_fixup_cmake_targets()
 
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
 
 set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS enabled)

--- a/ports/dlfcn-win32/portfile.cmake
+++ b/ports/dlfcn-win32/portfile.cmake
@@ -14,12 +14,13 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(READ "${CURRENT_PACKAGES_DIR}/debug/share/dlfcn-win32/dlfcn-win32-targets-debug.cmake" dlfcn-win32_DEBUG_MODULE)
-string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" dlfcn-win32_DEBUG_MODULE "${dlfcn-win32_DEBUG_MODULE}")
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/dlfcn-win32/dlfcn-win32-targets-debug.cmake" "${dlfcn-win32_DEBUG_MODULE}")
+if(NOT VCPKG_BUILD_TYPE STREQUAL release)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/share/${PORT}/${PORT}-targets-debug.cmake" "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug")
+    file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}/${PORT}-targets-debug.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+endif()
 
 vcpkg_copy_pdbs()
 

--- a/ports/dlfcn-win32/portfile.cmake
+++ b/ports/dlfcn-win32/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/dlfcn-win32/vcpkg.json
+++ b/ports/dlfcn-win32/vcpkg.json
@@ -10,6 +10,10 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/ports/dlfcn-win32/vcpkg.json
+++ b/ports/dlfcn-win32/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dlfcn-win32",
   "version": "1.3.1",
+  "port-version": 1,
   "description": "dlfcn-win32 is an implementation of dlfcn for Windows.",
   "homepage": "https://github.com/dlfcn-win32/dlfcn-win32",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1982,7 +1982,7 @@
     },
     "dlfcn-win32": {
       "baseline": "1.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "dlib": {
       "baseline": "19.24",

--- a/versions/d-/dlfcn-win32.json
+++ b/versions/d-/dlfcn-win32.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e38cb58b6b9a8fa8efb86d0651133dd7e421faf3",
+      "git-tree": "39fcef74b0e249a6e49b28eb8b4be8d1f6bc3d54",
       "version": "1.3.1",
       "port-version": 1
     },

--- a/versions/d-/dlfcn-win32.json
+++ b/versions/d-/dlfcn-win32.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "54d2f07f1d63a5723edb2bddc4d03f3af916c873",
+      "git-tree": "e38cb58b6b9a8fa8efb86d0651133dd7e421faf3",
       "version": "1.3.1",
       "port-version": 1
     },

--- a/versions/d-/dlfcn-win32.json
+++ b/versions/d-/dlfcn-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54d2f07f1d63a5723edb2bddc4d03f3af916c873",
+      "version": "1.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "eefd0e5c4b4d59e8bfb88842e9562115cb77d078",
       "version": "1.3.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
if `VCPKG_BUILD_TYPE` is set to `release`, installing dlfcn-win32 will fail. This PR fixes it.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
All, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes (as long as I am aknowledged to it).

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
