### PR TITLE
[live555] Update to 2022-12-01

### DIFF
--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -6,9 +6,9 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 bb5dc80b5b1621e04fb8a100bd3deff190efb757da10e6cfc652d6eaa878f6a3e063b2f2219d5d83d6fb6892b55be55eafe2dd43f42a559e1f931130b45584b1
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE} 
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}" 
     PATCHES
         fix-RTSPClient.patch
 )
@@ -29,6 +29,6 @@ file(GLOB HEADERS
 )
 
 file(COPY ${HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_copy_pdbs()

--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY) 
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.live555.com/liveMedia/public/live.2022.07.14.tar.gz"
-    FILENAME "live.2022.07.14.tar.gz"
-    SHA512 382544d9d9fe200699669a1f3301efb4ccec0193499c95b532ea923c380b1ec6fa721a4118d36a447ba9df08575f185498f244293c66bbe97cff0482eab033c7
+    URLS "http://www.live555.com/liveMedia/public/live.2022.12.01.tar.gz"
+    FILENAME "live.2022.12.01.tar.gz"
+    SHA512 bb5dc80b5b1621e04fb8a100bd3deff190efb757da10e6cfc652d6eaa878f6a3e063b2f2219d5d83d6fb6892b55be55eafe2dd43f42a559e1f931130b45584b1
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "live555",
-  "version-date": "2022-07-14",
+  "version-date": "2022-12-01",
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4569,7 +4569,7 @@
       "port-version": 0
     },
     "live555": {
-      "baseline": "2022-07-14",
+      "baseline": "2022-12-01",
       "port-version": 0
     },
     "llfio": {

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3eee4a32779504666e21804b89bc3569f729e043",
+      "git-tree": "7c55bad3936e67fe4e56228533acc22e6bae2572",
       "version-date": "2022-12-01",
       "port-version": 0
     },

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3eee4a32779504666e21804b89bc3569f729e043",
+      "version-date": "2022-12-01",
+      "port-version": 0
+    },
+    {
       "git-tree": "6f99761c9c260c5b654cd1028610b2edaa3036e0",
       "version-date": "2022-07-14",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  The upstream updated their version and remove the old version (again).
  Fixes https://github.com/microsoft/vcpkg/issues/28152

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
