### PR TITLE
[getopt-win32] Allow use as a CMake package

### DIFF
--- a/ports/getopt-win32/CMakeLists.txt
+++ b/ports/getopt-win32/CMakeLists.txt
@@ -7,5 +7,20 @@ if(BUILD_SHARED_LIBS)
 else()
     add_definitions(-DSTATIC_GETOPT)
 endif()
+
 add_library(getopt getopt.c)
-install(TARGETS getopt)
+
+install(
+    TARGETS getopt
+    EXPORT unofficial-getopt-win32
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(
+    EXPORT unofficial-getopt-win32
+    NAMESPACE unofficial::getopt-win32::
+    DESTINATION share/unofficial-getopt-win32
+    FILE unofficial-getopt-win32-config.cmake
+)

--- a/ports/getopt-win32/portfile.cmake
+++ b/ports/getopt-win32/portfile.cmake
@@ -7,28 +7,28 @@ vcpkg_from_github(
     PATCHES getopt.h.patch
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
 
-file(COPY ${SOURCE_PATH}/getopt.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY "${SOURCE_PATH}/getopt.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string(
-        ${CURRENT_PACKAGES_DIR}/include/getopt.h
+        "${CURRENT_PACKAGES_DIR}/include/getopt.h"
         "	#define __GETOPT_H_"
         "	#define __GETOPT_H_\n	#define STATIC_GETOPT"
     )
 endif()
 
 vcpkg_cmake_config_fixup(
-    CONFIG_PATH  share/unofficial-getopt-win32
-    PACKAGE_NAME unofficial-getopt-win32
+    CONFIG_PATH  "share/unofficial-getopt-win32"
+    PACKAGE_NAME "unofficial-getopt-win32"
 )
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
-set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS enabled)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS "enabled")

--- a/ports/getopt-win32/portfile.cmake
+++ b/ports/getopt-win32/portfile.cmake
@@ -7,17 +7,28 @@ vcpkg_from_github(
     PATCHES getopt.h.patch
 )
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
 
-file(COPY "${SOURCE_PATH}/getopt.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/")
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/getopt.h"
-        "	#define __GETOPT_H_" "	#define __GETOPT_H_\n	#define STATIC_GETOPT"
+file(COPY ${SOURCE_PATH}/getopt.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_replace_string(
+        ${CURRENT_PACKAGES_DIR}/include/getopt.h
+        "	#define __GETOPT_H_"
+        "	#define __GETOPT_H_\n	#define STATIC_GETOPT"
     )
 endif()
 
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH  share/unofficial-getopt-win32
+    PACKAGE_NAME unofficial-getopt-win32
+)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
 set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS enabled)

--- a/ports/getopt-win32/usage
+++ b/ports/getopt-win32/usage
@@ -1,0 +1,4 @@
+getopt-win32 provides CMake targets:
+
+    find_package(unofficial-getopt-win32 REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::getopt-win32::getopt)

--- a/ports/getopt-win32/vcpkg.json
+++ b/ports/getopt-win32/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "getopt-win32",
   "version": "0.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "An implementation of getopt.",
   "homepage": "https://github.com/libimobiledevice-win32/getopt",
   "license": "LGPL-3.0-only",
@@ -9,6 +9,10 @@
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2594,7 +2594,7 @@
     },
     "getopt-win32": {
       "baseline": "0.1",
-      "port-version": 4
+      "port-version": 5
     },
     "gettext": {
       "baseline": "0.21",

--- a/versions/g-/getopt-win32.json
+++ b/versions/g-/getopt-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ea837a30494764ce03d258c672bc1bf6514db1c",
+      "version": "0.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "a655b35c38424570406603859dcfbb70d25bc0b9",
       "version": "0.1",
       "port-version": 4

--- a/versions/g-/getopt-win32.json
+++ b/versions/g-/getopt-win32.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8ea837a30494764ce03d258c672bc1bf6514db1c",
+      "git-tree": "e20f1829d379f402502feedd978738b06b3f17ad",
       "version": "0.1",
       "port-version": 5
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  This PR allows using getopt-win32 as a package using `find_package(unnoficial-getopt-win32 REQUIRED)`, and then using its target using `target_link_libraries(main PRIVATE unofficial::getopt-win32::getopt)`, for example. It correctly selects the `Release` or `Debug` library, allowing developers not to bother with it, like previously with `find_library`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  As long as I know, yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
