### PR TITLE
[eve] Fix export usage

### DIFF
--- a/ports/eve/fix-export-usage.patch
+++ b/ports/eve/fix-export-usage.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/config/eve-install.cmake b/cmake/config/eve-install.cmake
+index ff909a2..4a4b6a8 100644
+--- a/cmake/config/eve-install.cmake
++++ b/cmake/config/eve-install.cmake
+@@ -4,7 +4,7 @@
+ ##  SPDX-License-Identifier: BSL-1.0
+ ##==================================================================================================
+ include(GNUInstallDirs)
+-set(MAIN_DEST     "${CMAKE_INSTALL_LIBDIR}/eve-${PROJECT_VERSION}")
++set(MAIN_DEST     "share/eve")
+ set(INSTALL_DEST  "${CMAKE_INSTALL_INCLUDEDIR}/eve-${PROJECT_VERSION}")
+ set(DOC_DEST      "${CMAKE_INSTALL_DOCDIR}-${PROJECT_VERSION}")
+ 

--- a/ports/eve/portfile.cmake
+++ b/ports/eve/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v2022.09.0
     SHA512 ab5be8c897955e08e1aa192ac9dd90e310b2786a2f295b0d5a5d309fa8e621b66673668b9dbe2f683a5e2596d291b0521d80a8bb80f493ecb12e86ab5d830c7b
     HEAD_REF main
+    PATCHES
+        fix-export-usage.patch
 )
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")

--- a/ports/eve/vcpkg.json
+++ b/ports/eve/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "eve",
   "version-date": "2022-09-20",
+  "port-version": 1,
   "description": "EVE - the Expressive Vector Engine",
   "homepage": "https://github.com/jfalcou/eve",
   "documentation": "https://jfalcou.github.io/eve/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2182,7 +2182,7 @@
     },
     "eve": {
       "baseline": "2022-09-20",
-      "port-version": 0
+      "port-version": 1
     },
     "eventpp": {
       "baseline": "0.1.2",

--- a/versions/e-/eve.json
+++ b/versions/e-/eve.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ae762e5ae173137a2e4666ac403be49bfa5427d",
+      "version-date": "2022-09-20",
+      "port-version": 1
+    },
+    {
       "git-tree": "3b6a47336d9cf0e99ea0dffc7c0c41bb04dfff5a",
       "version-date": "2022-09-20",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/27989
  Note: Export `eve` cmake configuration to the correct file location.
  The usage has been tested successfully.
  ```
  eve provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(eve CONFIG REQUIRED)
    target_link_libraries(main PRIVATE eve::eve)
  ```
