### PR TITLE
[eve] Update and fixes

### DIFF
--- a/ports/eve/portfile.cmake
+++ b/ports/eve/portfile.cmake
@@ -1,15 +1,29 @@
-message(WARNING "EVE requires a C++ 20 compliant compiler. GCC-11 and clang-12 are known to work.")
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
+string(REGEX REPLACE "^(v[0-9]+)[.]([0-9])[.]([0-9]+)\$" "\\1.0\\2.\\3" git_ref "v${VERSION}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jfalcou/eve
-    REF v2022.09.0
-    SHA512 ab5be8c897955e08e1aa192ac9dd90e310b2786a2f295b0d5a5d309fa8e621b66673668b9dbe2f683a5e2596d291b0521d80a8bb80f493ecb12e86ab5d830c7b
+    REF "${git_ref}"
+    SHA512 5623587de77c3e321555ca99326829928f69c5ac499d2abedfb18860e8c2a4c7dd5b408afef3ae2f8681cb363ffbfbc869dbf28c90e62e2b0abca62e03d08d12
     HEAD_REF main
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/eve" RENAME copyright)
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/eve-${VERSION}")
+if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/share/eve/eve-config.cmake")
+    message(FATAL_ERROR "CMake config is missing")
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/lib"
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/eve/usage
+++ b/ports/eve/usage
@@ -1,0 +1,7 @@
+eve provides CMake targets:
+
+    find_package(eve CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE eve::eve)
+
+Using eve requires a C++20 compliant compiler.
+GCC-11 and clang-12 are known to work.

--- a/ports/eve/vcpkg.json
+++ b/ports/eve/vcpkg.json
@@ -1,11 +1,14 @@
 {
   "name": "eve",
-  "version-date": "2022-09-20",
-  "description": "EVE - the Expressive Vector Engine",
+  "version": "2022.9.1",
+  "description": [
+    "EVE - the Expressive Vector Engine",
+    "A header-only C++20 and onward implementation of a type based wrapper around SIMD extensions sets for most current architectures."
+  ],
   "homepage": "https://github.com/jfalcou/eve",
   "documentation": "https://jfalcou.github.io/eve/",
   "license": "BSL-1.0",
-  "supports": "!windows",
+  "supports": "!windows, mingw",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2181,7 +2181,7 @@
       "port-version": 1
     },
     "eve": {
-      "baseline": "2022-09-20",
+      "baseline": "2022.9.1",
       "port-version": 0
     },
     "eventpp": {

--- a/versions/e-/eve.json
+++ b/versions/e-/eve.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "701ec863d463d1a8c570336d3c5bd672f540793c",
+      "version": "2022.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b6a47336d9cf0e99ea0dffc7c0c41bb04dfff5a",
       "version-date": "2022-09-20",
       "port-version": 0


### PR DESCRIPTION
Alternative to #28198, without patching. CC @FrankXie05 

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/27989. 
  Updates even to 2022.09.1. In the manifest, the chosen scheme is `"version": "2022.9.1"`, to support version order with a good match to upstream version identifiers (which diverge from release dates) and with the version in exported CMake config. 
  Skips the pointless debug build.
  Enables mingw builds.
  Moves the C++20 compiler message from port build to usage.