### PR TITLE
[vcpkg] Fix VS can still be IntelliSense after disabling vcpkg

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -71,7 +71,7 @@
 
     <_ZVcpkgConfigSubdir Condition="'$(_ZVcpkgNormalizedConfiguration)' == 'Debug'">debug\</_ZVcpkgConfigSubdir>
     <_ZVcpkgExecutable>$(_ZVcpkgRoot)vcpkg.exe</_ZVcpkgExecutable>
-    <ExternalIncludePath>$(ExternalIncludePath);$(_ZVcpkgCurrentInstalledDir)include</ExternalIncludePath>
+    <ExternalIncludePath Condition="'$(VcpkgEnabled)' == 'true'">$(ExternalIncludePath);$(_ZVcpkgCurrentInstalledDir)include</ExternalIncludePath>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/28200
Note: 
After setting `Use Vcpkg`  to `No`, the header path of vcpkg installed ports will not be deleted in the `External Include Directories`. 
This is due to the regression triggered by the PR https://github.com/microsoft/vcpkg/pull/21544 without setting conditions.
Problems caused:
The IntelliSense in the VS can still sense the library provided by the currently integrated vcpkg.

![image](https://user-images.githubusercontent.com/68489543/205891312-fd2b742c-c555-4d55-9cf7-615ec23d8165.png)
![image](https://user-images.githubusercontent.com/68489543/205891325-816a577e-f1b0-42de-afd7-3704ca7b335b.png)
