### PR TITLE
[etl] Add port v20.35.4

### DIFF
--- a/ports/etl/portfile.cmake
+++ b/ports/etl/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ETLCPP/etl
+    REF 20.35.4
+    SHA512 04c68b50cbd7d1052f7253170806b0b67e2b9f78d57da2405284bf84695eb20c81be104b93a07f4d4a97fe14f5a1d3882aa7d96f418d6fbaec67db44375b7b75
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/etl/portfile.cmake
+++ b/ports/etl/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/etl/vcpkg.json
+++ b/ports/etl/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "20.35.4",
   "description": "A C++ template library for embedded applications",
   "homepage": "https://www.etlcpp.com",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/etl/vcpkg.json
+++ b/ports/etl/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "etl",
+  "version": "20.35.4",
+  "description": "A C++ template library for embedded applications",
+  "homepage": "https://www.etlcpp.com",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2180,6 +2180,10 @@
       "baseline": "ca7cb332011ec37",
       "port-version": 1
     },
+    "etl": {
+      "baseline": "20.35.4",
+      "port-version": 0
+    },
     "eve": {
       "baseline": "2022-09-20",
       "port-version": 0

--- a/versions/e-/etl.json
+++ b/versions/e-/etl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fecca8937b9d0a77e30845c3cd8775496c97135c",
+      "version": "20.35.4",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/e-/etl.json
+++ b/versions/e-/etl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fecca8937b9d0a77e30845c3cd8775496c97135c",
+      "git-tree": "4c71341c1081f0135ba14fcc8e1f5007264cdf92",
       "version": "20.35.4",
       "port-version": 0
     }


### PR DESCRIPTION
Created new port for https://github.com/ETLCPP/etl
related to issue https://github.com/microsoft/vcpkg/issues/4063

- #### What does your PR fix?
  Add new port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
