### PR TITLE
[tl-expected, tl-optional, tl-ranges] Fix CMake config location

### DIFF
--- a/ports/tl-expected/portfile.cmake
+++ b/ports/tl-expected/portfile.cmake
@@ -1,31 +1,23 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO TartanLlama/expected
-    REF v1.0.0
-    SHA512 747ea34b5540dfcf595896332851f10c52a823ab8ba3fc8152478b0a9e8ca01f0f26827348407249827f4106ff577bd6e697ea6f749c1f21bd1f0913a621075d
+    REF b74fecd4448a1a5549402d17ddc51e39faa5020c # 2022-11-24
+    SHA512 d59d7a63dc0f7244cd0a65971ed2b51e2d01de8658b043673aacb83c7bcefb90009f2d5792a49943c9d5e80f9f5811f5db3db1bb11f8429c9e732c872b91ae66
     HEAD_REF master
 )
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH TL_CMAKE_SOURCE_DIR
-    REPO TartanLlama/tl-cmake
-    REF 284c6a3f0f61823cc3871b0f193e8df699e2c4ce
-    SHA512 f611326d75d6e87e58cb05e91f9506b1d83e6fd3b214fe311c4c15604feabfb7a18bbf9c4b4c389a39d615eb468b1f4b15802ab9f44f334a12310cb183fa77a7
-    HEAD_REF master
-)
-
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
-        -DFETCHCONTENT_SOURCE_DIR_TL_CMAKE=${TL_CMAKE_SOURCE_DIR}
-        -DEXPECTED_ENABLE_TESTS=OFF
+        -DEXPECTED_BUILD_TESTS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/tl-expected)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/cmake")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/tl-expected RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/tl-expected/vcpkg.json
+++ b/ports/tl-expected/vcpkg.json
@@ -2,8 +2,8 @@
   "name": "tl-expected",
   "version-date": "2022-11-24",
   "description": "C++11/14/17 std::expected implementation with functional-style extensions",
-  "documentation": "https://tl.tartanllama.xyz/en/latest/api/expected.html",
   "homepage": "https://github.com/TartanLlama/expected",
+  "documentation": "https://tl.tartanllama.xyz/en/latest/api/expected.html",
   "license": "CC0-1.0",
   "dependencies": [
     {

--- a/ports/tl-expected/vcpkg.json
+++ b/ports/tl-expected/vcpkg.json
@@ -1,6 +1,18 @@
 {
   "name": "tl-expected",
-  "version-string": "1.0.0",
-  "port-version": 2,
-  "description": "C++11/14/17 std::expected implementation with functional-style extensions"
+  "version-date": "2022-11-24",
+  "description": "C++11/14/17 std::expected implementation with functional-style extensions",
+  "documentation": "https://tl.tartanllama.xyz/en/latest/api/expected.html",
+  "homepage": "https://github.com/TartanLlama/expected",
+  "license": "CC0-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/tl-optional/portfile.cmake
+++ b/ports/tl-optional/portfile.cmake
@@ -1,31 +1,23 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO TartanLlama/optional
-    REF v1.0.0
-    SHA512 6e5020808650ec312f5cdf4bc92be9067dc214c2e02d635511e99b325d34c360ce360cf93e67287dba4b9c0d674f3cbae96a75b83b13374fbb1291d2bb0f078a
+    REF c28fcf74d207fc667c4ed3dbae4c251ea551c8c1 # 2021-05-02
+    SHA512 e5d5a6878903cb6641980f0fc68c4d94a59e3a8b0ad6a7f87abcc79ad7033e540045ce5ccd0e641ee924d43ba6df99e2b4ce2b04e1164ca9f47c660b8c2b2d48
     HEAD_REF master
 )
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH TL_CMAKE_SOURCE_DIR
-    REPO TartanLlama/tl-cmake
-    REF 284c6a3f0f61823cc3871b0f193e8df699e2c4ce
-    SHA512 f611326d75d6e87e58cb05e91f9506b1d83e6fd3b214fe311c4c15604feabfb7a18bbf9c4b4c389a39d615eb468b1f4b15802ab9f44f334a12310cb183fa77a7
-    HEAD_REF master
-)
-
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
-        -DFETCHCONTENT_SOURCE_DIR_TL_CMAKE=${TL_CMAKE_SOURCE_DIR}
-        -DOPTIONAL_ENABLE_TESTS=OFF
+        -DOPTIONAL_BUILD_TESTS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/tl-optional)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/cmake")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/tl-optional RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/tl-optional/vcpkg.json
+++ b/ports/tl-optional/vcpkg.json
@@ -1,6 +1,18 @@
 {
   "name": "tl-optional",
-  "version-string": "1.0.0",
-  "port-version": 2,
-  "description": "C++11/14/17 std::optional implementation with functional-style extensions"
+  "version-date": "2021-05-02",
+  "description": "C++11/14/17 std::optional implementation with functional-style extensions",
+  "documentation": "https://tl.tartanllama.xyz/en/latest/api/optional.html",
+  "homepage": "https://github.com/TartanLlama/optional",
+  "license": "CC0-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/tl-optional/vcpkg.json
+++ b/ports/tl-optional/vcpkg.json
@@ -2,8 +2,8 @@
   "name": "tl-optional",
   "version-date": "2021-05-02",
   "description": "C++11/14/17 std::optional implementation with functional-style extensions",
-  "documentation": "https://tl.tartanllama.xyz/en/latest/api/optional.html",
   "homepage": "https://github.com/TartanLlama/optional",
+  "documentation": "https://tl.tartanllama.xyz/en/latest/api/optional.html",
   "license": "CC0-1.0",
   "dependencies": [
     {

--- a/ports/tl-ranges/portfile.cmake
+++ b/ports/tl-ranges/portfile.cmake
@@ -14,5 +14,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/tl-ranges)
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/cmake")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/tl-ranges/vcpkg.json
+++ b/ports/tl-ranges/vcpkg.json
@@ -3,8 +3,8 @@
   "version-date": "2022-12-07",
   "port-version": 1,
   "description": "Ranges that didn't make C++20",
-  "documentation": "https://tl.tartanllama.xyz/en/latest/api/ranges/index.html",
   "homepage": "https://github.com/TartanLlama/ranges",
+  "documentation": "https://tl.tartanllama.xyz/en/latest/api/ranges/index.html",
   "license": "CC0-1.0",
   "dependencies": [
     {

--- a/ports/tl-ranges/vcpkg.json
+++ b/ports/tl-ranges/vcpkg.json
@@ -1,12 +1,18 @@
 {
   "name": "tl-ranges",
   "version-date": "2022-12-07",
+  "port-version": 1,
   "description": "Ranges that didn't make C++20",
-  "homepage": "https://tl.tartanllama.xyz",
+  "documentation": "https://tl.tartanllama.xyz/en/latest/api/ranges/index.html",
+  "homepage": "https://github.com/TartanLlama/ranges",
   "license": "CC0-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7529,8 +7529,8 @@
       "port-version": 2
     },
     "tl-expected": {
-      "baseline": "1.0.0",
-      "port-version": 2
+      "baseline": "2022-11-24",
+      "port-version": 0
     },
     "tl-function-ref": {
       "baseline": "1.0.0",
@@ -7541,12 +7541,12 @@
       "port-version": 0
     },
     "tl-optional": {
-      "baseline": "1.0.0",
-      "port-version": 2
+      "baseline": "2021-05-02",
+      "port-version": 0
     },
     "tl-ranges": {
       "baseline": "2022-12-07",
-      "port-version": 0
+      "port-version": 1
     },
     "tlx": {
       "baseline": "0.5.20191212",

--- a/versions/t-/tl-expected.json
+++ b/versions/t-/tl-expected.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b521818cf86910000788131a556006c5141116d",
+      "version-date": "2022-11-24",
+      "port-version": 0
+    },
+    {
       "git-tree": "952f8ebe25660f2bf6a7091c338e4113691279dd",
       "version-string": "1.0.0",
       "port-version": 2

--- a/versions/t-/tl-optional.json
+++ b/versions/t-/tl-optional.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb9c03ff3152ce00751b8a63fd8e8a808a802a47",
+      "version-date": "2021-05-02",
+      "port-version": 0
+    },
+    {
       "git-tree": "a88a1a6074c36dd4c7872c7a439c839da2a1e99d",
       "version-string": "1.0.0",
       "port-version": 2

--- a/versions/t-/tl-ranges.json
+++ b/versions/t-/tl-ranges.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2f06b8ba757a38aae977b3c96dedfa102844f36",
+      "version-date": "2022-12-07",
+      "port-version": 1
+    },
+    {
       "git-tree": "d98b8af62d474ab0328d33cc20be629f9257452f",
       "version-date": "2022-12-07",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Each of those ports did not use `vcpkg_cmake_config_fixup()`. This caused config files to be in the wrong directory (`share/cmake/${PORT}`). Furthermore, not using `vcpkg_cmake_config_fixup()` is almost always an issue.
  `tl-expected` and `tl-optional` no longer need to download 2 GitHub repos.

/cc: @TartanLlama