### PR TITLE
[usockets] update to 0.8.3

### DIFF
--- a/ports/usockets/portfile.cmake
+++ b/ports/usockets/portfile.cmake
@@ -9,8 +9,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uNetworking/uSockets
-    REF 917ea86baad640967f62c4a92290e5211bb7966c  #v0.8.2
-    SHA512 bc7850d9e7e79a390817b7ce530d79d9dc0f04386da81abbd616f06a9108dc18f928b29f1e31ef99600fb3a18ed28e8d9815fc9c3bc6c0ea66b7fe81a2fa19ff
+    REF 760a0243c77272df2225fcd50acfc0b1d7ffff0d  #v0.8.3
+    SHA512 23b79d11ebdfc1578fd5234246ba39d5c191c4bc3c32b62cd6c18aabc160bf0033829809451f28bfb911eedde1ccd71182d4af6884eb15949dbfacda4cded259
     HEAD_REF master
 )
 

--- a/ports/usockets/vcpkg.json
+++ b/ports/usockets/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "usockets",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Miniscule cross-platform eventing, networking & crypto for async applications",
   "homepage": "https://github.com/uNetworking/uSockets",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7721,7 +7721,7 @@
       "port-version": 4
     },
     "usockets": {
-      "baseline": "0.8.2",
+      "baseline": "0.8.3",
       "port-version": 0
     },
     "usrsctp": {

--- a/versions/u-/usockets.json
+++ b/versions/u-/usockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7738ec8a752614f52d6c117bb28b4d4588e43756",
+      "version": "0.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f12cbe4a6c1d7298131fdf658e6bfbea144d58aa",
       "version": "0.8.2",
       "port-version": 0


### PR DESCRIPTION
Fix #28225

Update usockets to the latest version 0.8.3

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static