### PR TITLE
[qt5-webglplugin] Add required dependency on qt5-websockets

### DIFF
--- a/ports/qt5-webglplugin/vcpkg.json
+++ b/ports/qt5-webglplugin/vcpkg.json
@@ -1,12 +1,14 @@
 {
   "name": "qt5-webglplugin",
   "version": "5.15.7",
-  "description": "Qt5 webglplugin Module;",
+  "port-version": 1,
+  "description": "Qt5 Webglplugin Module",
   "license": null,
   "dependencies": [
     {
       "name": "qt5-base",
       "default-features": false
-    }
+    },
+    "qt5-websockets"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6230,7 +6230,7 @@
     },
     "qt5-webglplugin": {
       "baseline": "5.15.7",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-websockets": {
       "baseline": "5.15.7",

--- a/versions/q-/qt5-webglplugin.json
+++ b/versions/q-/qt5-webglplugin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20c68afa15554da137137b3fb5e8d71bd7b824f0",
+      "version": "5.15.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "7907edc6fe8f0b81dd60b6da33638ca6c2a80672",
       "version": "5.15.7",
       "port-version": 0


### PR DESCRIPTION
closes #28154.

~~Please check the file list afterwards~~

```
qt5-webglplugin:x64-windows:/debug/plugins/platforms/qwebgld.dll
qt5-webglplugin:x64-windows:/debug/plugins/platforms/qwebgld.pdb
qt5-webglplugin:x64-windows:/plugins/platforms/qwebgl.dll
qt5-webglplugin:x64-windows:/share/cmake/Qt5Gui/Qt5Gui_QWebGLIntegrationPlugin.cmake
qt5-webglplugin:x64-windows:/share/qt5-webglplugin/copyright
qt5-webglplugin:x64-windows:/share/qt5-webglplugin/vcpkg.spdx.json
qt5-webglplugin:x64-windows:/share/qt5-webglplugin/vcpkg_abi_info.txt

qt5-webglplugin:x64-linux:/debug/plugins/platforms/libqwebgl.a
qt5-webglplugin:x64-linux:/debug/plugins/platforms/libqwebgl.prl
qt5-webglplugin:x64-linux:/plugins/platforms/libqwebgl.a
qt5-webglplugin:x64-linux:/plugins/platforms/libqwebgl.prl
qt5-webglplugin:x64-linux:/share/cmake/Qt5Gui/Qt5Gui_QWebGLIntegrationPlugin.cmake
qt5-webglplugin:x64-linux:/share/cmake/Qt5Gui/Qt5Gui_QWebGLIntegrationPlugin_Import.cpp
qt5-webglplugin:x64-linux:/share/qt5-webglplugin/copyright
qt5-webglplugin:x64-linux:/share/qt5-webglplugin/vcpkg.spdx.json
qt5-webglplugin:x64-linux:/share/qt5-webglplugin/vcpkg_abi_info.txt
qt5-webglplugin:x64-linux:/tools/qt5/debug/mkspecs/modules/qt_plugin_qwebgl.pri
qt5-webglplugin:x64-linux:/tools/qt5/mkspecs/modules/qt_plugin_qwebgl.pri
```