### PR TITLE
[qtbase] make double-conversion a hard dependency

### DIFF
--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.4.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -22,8 +22,15 @@
       "default-features": false,
       "features": [
         "doubleconversion"
+      ]
+    },
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "thread"
       ],
-      "platform": "windows"
+      "platform": "osx"
     },
     {
       "name": "qtbase",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6270,7 +6270,7 @@
     },
     "qtbase": {
       "baseline": "6.4.1",
-      "port-version": 2
+      "port-version": 3
     },
     "qtcharts": {
       "baseline": "6.4.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f718070277a5feb4b54410d860556c980c5c6d82",
+      "version": "6.4.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "7fa87eeff71c2069b1d7e042ddcb7cec126050e8",
       "version": "6.4.1",
       "port-version": 2


### PR DESCRIPTION
double-conversion is needed at all major platforms (linux, osx, windows), otherwise the configure step will fail
