### PR TITLE
[sse2neon] Fix sse2neon header install path

### DIFF
--- a/ports/sse2neon/portfile.cmake
+++ b/ports/sse2neon/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
 )
 
 # Copy header file
-file(COPY "${SOURCE_PATH}/sse2neon.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/sse2neon/sse2neon.h")
+file(COPY "${SOURCE_PATH}/sse2neon.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/sse2neon/")
 
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sse2neon/vcpkg.json
+++ b/ports/sse2neon/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sse2neon",
   "version-semver": "1.5.1",
+  "port-version": 1,
   "description": "A translator from Intel SSE intrinsics to Arm/Aarch64 NEON implementation",
   "homepage": "https://github.com/DLTcollab/sse2neon",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7230,7 +7230,7 @@
     },
     "sse2neon": {
       "baseline": "1.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "starlink-ast": {
       "baseline": "9.2.7",

--- a/versions/s-/sse2neon.json
+++ b/versions/s-/sse2neon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a4bda251b90a7bd189f57588bf9148cb294e0d5",
+      "version-semver": "1.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e00a052f2ef1408866bdb2c216d84e239f9bd11c",
       "version-semver": "1.5.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  The `DESTINATION` parameter of [`file(COPY ...`](https://cmake.org/cmake/help/v3.10/command/file.html) accepts a path. However, in the current portfile it was used as if it was the destination file location. This results in the final installed file location being:
```
installed/arm64-osx/include/sse2neon/sse2neon.h/sse2neon.h
```
Instead of what I assume to be the desired:
```
installed/arm64-osx/include/sse2neon/sse2neon.h
```

I updated the `file(COPY ...` call to install the header to the expected location.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  no change, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
