### PR TITLE
[baseline][kf5solid] Explicitly disable imobile backend

### DIFF
--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -44,6 +44,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DBUILD_DEVICE_BACKEND_imobile=OFF
         -DBUILD_TESTING=OFF
         -DKDE_INSTALL_QMLDIR=qml
 )

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5solid",
   "version": "5.98.0",
+  "port-version": 1,
   "description": "Desktop hardware abstraction",
   "homepage": "https://api.kde.org/frameworks/solid/html/index.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3398,7 +3398,7 @@
     },
     "kf5solid": {
       "baseline": "5.98.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5sonnet": {
       "baseline": "5.98.0",

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b532dd98f6da51797e2f14681dfc859fb02d8de",
+      "version": "5.98.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "908096648c32dd9d82a9d2be78b63355f8c9361f",
       "version": "5.98.0",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes a baseline regression introduced by the last kf5 update.
  IMO the backend can be enabled when the libimobiledevice family of ports uses genuine upstream and supports !windows.
