### PR TITLE
[asio] add target guard for target `asio::asio`

### DIFF
--- a/ports/asio/asio-config.cmake
+++ b/ports/asio/asio-config.cmake
@@ -1,8 +1,8 @@
 include ("${CMAKE_CURRENT_LIST_DIR}/asio-targets.cmake")
 
 if(NOT TARGET asio::asio)
-	add_library(asio::asio INTERFACE IMPORTED)
-	target_link_libraries(asio::asio INTERFACE asio)
+    add_library(asio::asio INTERFACE IMPORTED)
+    target_link_libraries(asio::asio INTERFACE asio)
 endif()
 
 get_target_property(_ASIO_INCLUDE_DIR asio INTERFACE_INCLUDE_DIRECTORIES)

--- a/ports/asio/asio-config.cmake
+++ b/ports/asio/asio-config.cmake
@@ -1,6 +1,9 @@
 include ("${CMAKE_CURRENT_LIST_DIR}/asio-targets.cmake")
-add_library(asio::asio INTERFACE IMPORTED)
-target_link_libraries(asio::asio INTERFACE asio)
+
+if(NOT TARGET asio::asio)
+	add_library(asio::asio INTERFACE IMPORTED)
+	target_link_libraries(asio::asio INTERFACE asio)
+endif()
 
 get_target_property(_ASIO_INCLUDE_DIR asio INTERFACE_INCLUDE_DIRECTORIES)
 set(ASIO_INCLUDE_DIR "${_ASIO_INCLUDE_DIR}")

--- a/ports/asio/vcpkg.json
+++ b/ports/asio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "asio",
   "version": "1.24.0",
+  "port-version": 1,
   "description": "Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach.",
   "homepage": "https://github.com/chriskohlhoff/asio",
   "documentation": "https://think-async.com/Asio/asio-1.24.0/doc/",

--- a/versions/a-/asio.json
+++ b/versions/a-/asio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b134a3e21a2ef661aa5e3802cefc22386c095aaa",
+      "version": "1.24.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bba8740d419878e427c71f076d569f8a26833c6b",
       "version": "1.24.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -198,7 +198,7 @@
     },
     "asio": {
       "baseline": "1.24.0",
-      "port-version": 0
+      "port-version": 1
     },
     "asio-grpc": {
       "baseline": "2.3.0",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #28298 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  I am still working on this PR

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
