### PR TITLE
[directxmath] updated port to DirectXMath 3.18 release

### DIFF
--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -23,7 +23,7 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
 
     file(INSTALL
       ${DOWNLOADS}/sal.h
-      DESTINATION ${CURRENT_PACKAGES_DIR}/include/DirectXMath)
+      DESTINATION ${CURRENT_PACKAGES_DIR}/include/directxmath)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMath
-    REF may2022
-    SHA512 685e5a0cdd1bc66a5df628f864eae0959d5d5abdcc7e9242ea7af1d5b011cb0705447c366bacd456db96e39dac8cf0e0618a6e055a7db821cdcfa20a1ad08868
+    REF dec2022
+    SHA512 61da5464e4a6b0e405307496b0b925fc52e3f7acd3841527c5f8e86d5188865767dd44d4277f034c46b0088d1ee52da72f747c5965cd37411600418b605d4702
     HEAD_REF main
 )
 
@@ -11,7 +11,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/directxmath/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxmath)
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_download_distfile(

--- a/ports/directxmath/vcpkg.json
+++ b/ports/directxmath/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmath",
-  "version-date": "2022-05-18",
+  "version-date": "2022-12-12",
   "description": "DirectXMath SIMD C++ math library",
   "homepage": "https://github.com/Microsoft/DirectXMath",
   "documentation": "https://docs.microsoft.com/windows/win32/dxmath/directxmath-portal",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1929,7 +1929,7 @@
       "port-version": 0
     },
     "directxmath": {
-      "baseline": "2022-05-18",
+      "baseline": "2022-12-12",
       "port-version": 0
     },
     "directxmesh": {

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad8c9305615a648d48549c3f4bd8a9a2d2085d2e",
+      "version-date": "2022-12-12",
+      "port-version": 0
+    },
+    {
       "git-tree": "383135431007008f6d04e2cfbe55988b06054f15",
       "version-date": "2022-05-18",
       "port-version": 0

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad8c9305615a648d48549c3f4bd8a9a2d2085d2e",
+      "git-tree": "ecd21e108091a293a27869c9c093ad558ffcdc42",
       "version-date": "2022-12-12",
       "port-version": 0
     },


### PR DESCRIPTION
Upstream release on GitHub and NuGet. Updated vcpkg port to match.

* C++20 spaceship operators for XMFLOAT2, XMFLOAT3, etc. when building with ``/std:c++20 /Zc:_cplusplus``
* Improved conformance for ARM64 when using `/Zc:arm64-aliased-neon-types-`
* Minor code review
* CMake project updated to require 3.20 or later

