### PR TITLE
[ncurses] Add compiler option "enable-mixed-case" to supports mixed case file names

### DIFF
--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -30,12 +30,18 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         --without-normal
     )
 endif()
+
+if(NOT VCPKG_TARGET_IS_MINGW)
+    list(APPEND OPTIONS
+        --enable-mixed-case
+    )
+endif()
+
 if(VCPKG_TARGET_IS_MINGW)
     list(APPEND OPTIONS
         --disable-home-terminfo
         --enable-term-driver
         --disable-termcap
-        --enable-mixed-case
     )
 endif()
 

--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_extract_source_archive(
 set(OPTIONS
     --disable-db-install
     --enable-pc-files
+    --enable-mixed-case
     --without-ada
     --without-manpages
     --without-progs

--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -17,7 +17,6 @@ vcpkg_extract_source_archive(
 set(OPTIONS
     --disable-db-install
     --enable-pc-files
-    --enable-mixed-case
     --without-ada
     --without-manpages
     --without-progs
@@ -36,6 +35,7 @@ if(VCPKG_TARGET_IS_MINGW)
         --disable-home-terminfo
         --enable-term-driver
         --disable-termcap
+        --enable-mixed-case
     )
 endif()
 

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ncurses",
   "version": "6.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Free software emulation of curses in System V Release 4.0, and more",
   "homepage": "https://invisible-island.net/ncurses/announce.html",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5166,7 +5166,7 @@
     },
     "ncurses": {
       "baseline": "6.3",
-      "port-version": 3
+      "port-version": 4
     },
     "neargye-semver": {
       "baseline": "0.3.0",

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b95b3a01b7f310792f54e8deec88aeb467c51eae",
+      "git-tree": "83eac97c40a368314b01639191657529194d8bdc",
       "version": "6.3",
       "port-version": 4
     },

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9fafdff636f7eecd86f779f9382564327321042d",
+      "git-tree": "b95b3a01b7f310792f54e8deec88aeb467c51eae",
       "version": "6.3",
       "port-version": 4
     },

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9fafdff636f7eecd86f779f9382564327321042d",
+      "version": "6.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "3c178c66e9a39b757a4fd10782bbd32165ef2b0e",
       "version": "6.3",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/28310
  Note: Allow port `ncurses` to read files in mixed case file name folder by adding compiler option `enable-mixed-case`:
```
--enable-mixed-case
              override   the   configure  script's  check  if  the
              filesystem   supports   mixed-case  filenames.  This
              allows one to control how the terminal database maps
              to  the  filesystem.  For  filesystems  that  do not
              support   mixed-case,   the  library  uses  generate
              2-character  (hexadecimal) codes for the lower-level
              of the filesystem terminfo database
```