### PR TITLE
[vcpkg scripts] [vcpkg_clean_executables_in_bin] Clean bundles

### DIFF
--- a/scripts/cmake/vcpkg_clean_executables_in_bin.cmake
+++ b/scripts/cmake/vcpkg_clean_executables_in_bin.cmake
@@ -33,6 +33,12 @@ function(vcpkg_clean_executables_in_bin)
             "${CURRENT_PACKAGES_DIR}/bin/${file_name}.pdb"
             "${CURRENT_PACKAGES_DIR}/debug/bin/${file_name}.pdb"
         )
+        if(NOT VCPKG_TARGET_BUNDLE_SUFFIX STREQUAL "")
+            file(REMOVE_RECURSE
+                "${CURRENT_PACKAGES_DIR}/bin/${file_name}${VCPKG_TARGET_BUNDLE_SUFFIX}"
+                "${CURRENT_PACKAGES_DIR}/debug/bin/${file_name}${VCPKG_TARGET_BUNDLE_SUFFIX}"
+            )
+        endif()
     endforeach()
 
     z_vcpkg_clean_executables_in_bin_remove_directory_if_empty("${CURRENT_PACKAGES_DIR}/bin")


### PR DESCRIPTION
- #### What does your PR fix?
  Ensure that macOS bundles are deleted from `/bin`, for consistency with handling of plain executables, and for consistent behavior of `vcpkg_copy_tools( ... AUTO_CLEAN)`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, but affect macOS.