### PR TITLE
[b64] Update vcpkg schema URL

### DIFF
--- a/ports/b64/vcpkg.json
+++ b/ports/b64/vcpkg.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "b64",
   "version": "2.0.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libb64 is a library of ANSI C routines for fast encoding/decoding data into and from a base64-encoded format",
   "license": null,
   "dependencies": [

--- a/versions/b-/b64.json
+++ b/versions/b-/b64.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7be7da91f5c6bbeb5bfb10bafcb4072bf3df5127",
+      "version": "2.0.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "aeaf7d2076e25b321032c4fc88c22cbb46002a90",
       "version": "2.0.0.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -422,7 +422,7 @@
     },
     "b64": {
       "baseline": "2.0.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "basisu": {
       "baseline": "1.11",


### PR DESCRIPTION
The JSON schema has been moved to the vcpkg-tool repo.