### PR TITLE
[opentelemetry-cpp] Update vcpkg schema URL

### DIFF
--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -1,7 +1,8 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.8.1",
+  "port-version": 1,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5586,7 +5586,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "opentracing": {
       "baseline": "1.6.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a2a7c47fdf502e1345d3ba742ded612ba0506764",
+      "version-semver": "1.8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e843a5826f9147538a9f50194eebfcb5002a8f7b",
       "version-semver": "1.8.1",
       "port-version": 0


### PR DESCRIPTION
The JSON schema has been moved to the vcpkg-tool repo.