### PR TITLE
[catch2] Update to 3.2.1

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
     REF v${VERSION}
-    SHA512 983d37824a8d9e24ff107d27f11cb4f8ea53516dc2c5c9b32d4758c718f29041eecdb023d81a2776c87d283e3671722352c9f0eea02393b5bb191fa26bb12c82
+    SHA512 f9be225ca042f03ea750e77e8a0118f631100d607181ffe505e74063f3a0eda95de6ff0b7db39b7a31e8ea3ce72da5a95b408a1d34c89f57c3b9ec8a97c4fe5b
     HEAD_REF devel
     PATCHES
         fix-install-path.patch

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version-semver": "3.2.0",
+  "version-semver": "3.2.1",
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1317,7 +1317,7 @@
       "port-version": 1
     },
     "catch2": {
-      "baseline": "3.2.0",
+      "baseline": "3.2.1",
       "port-version": 0
     },
     "cccapstone": {

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43e022b806928c512e298052ad4fae210998a846",
+      "version-semver": "3.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9dd2bc1c39e6f6262dc7741b24514e76d6f1d8da",
       "version-semver": "3.2.0",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
Update Catch2 from 3.2.0 to 3.2.1 : https://github.com/catchorg/Catch2/releases/tag/v3.2.1

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
No changes

- #### Does your PR follow the [maintainer guide]
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
 Yes