### PR TITLE
[magic-enum] update port to v0.8.2

### DIFF
--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/magic_enum
-    REF v0.8.1
-    SHA512 97b14ddfa2fec4b582f4658cea96f61510b3eb1f367d770a642136ffbaf7e5d87e6a8c950f7ac6af47cc605899d0ff8e2b9c71a19a28ad1dfaa724f003339edc
+    REF v0.8.2
+    SHA512 849c426484156faf91dde3f32f6c755c7698879b16dd83e13fb86b299b53ec9bbe4d55267581386302c8acb93d80ec044cc248371fdc8608cdd8f4ab12099f0a
     HEAD_REF master
 )
 

--- a/ports/magic-enum/vcpkg.json
+++ b/ports/magic-enum/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-enum",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.",
   "homepage": "https://github.com/Neargye/magic_enum",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4433,7 +4433,7 @@
       "port-version": 0
     },
     "magic-enum": {
-      "baseline": "0.8.1",
+      "baseline": "0.8.2",
       "port-version": 0
     },
     "magic-get": {

--- a/versions/m-/magic-enum.json
+++ b/versions/m-/magic-enum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "579c97b898c772c488b1de1fef924cb8c767c511",
+      "version": "0.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c67da42e72855b5d2d5d72d570fafb3a1149fa01",
       "version": "0.8.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

Updates the [magic-enum] port to v0.8.2

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Triplet support should be unchanged.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Think so

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
 Yes
