### PR TITLE
[libphonenumber] libphonenumber works with static, removing !static

### DIFF
--- a/ports/libphonenumber/vcpkg.json
+++ b/ports/libphonenumber/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "8.13.1",
   "description": "Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.",
   "license": "Apache-2.0",
-  "supports": "!static & !linux & !osx",
+  "supports": "!linux & !osx",
   "dependencies": [
     "abseil",
     "boost-date-time",

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a8a7aedced30ba3195353fdda4103829068e299",
+      "git-tree": "47877baf472150729025e7198ad6aa6e6574ff5a",
       "version": "8.13.1",
       "port-version": 0
     }


### PR DESCRIPTION
The port libphonenumber worked with static builds after some changes in the original PR that created the port, but we didn't remove the !static, so this PR is taking out !static in the support field of vcpkg.json in order to support static builds.

- #### What does your PR fix?
  Fixes the inability to run static builds with libphonenumber

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
linux, No (Updated in CI baseline)
osx, No (Updated in CI baseline)
uwp, No (due to icu lib, so not updated in CI baseline)
x64-windows, Yes
x86-windows, Yes
arm64-windows, Yes
x64-windows-static, Yes
x64-windows-static-md, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
