### PR TITLE
[getopt-win32] Missing include directory in package

### DIFF
--- a/ports/getopt-win32/CMakeLists.txt
+++ b/ports/getopt-win32/CMakeLists.txt
@@ -16,6 +16,7 @@ install(
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
+    INCLUDES DESTINATION include
 )
 
 install(

--- a/ports/getopt-win32/vcpkg.json
+++ b/ports/getopt-win32/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "getopt-win32",
   "version": "0.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "An implementation of getopt.",
   "homepage": "https://github.com/libimobiledevice-win32/getopt",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -83,7 +83,7 @@
     "amd-amf": {
       "baseline": "1.4.26",
       "port-version": 0
-    }, 
+    },
     "ampl-asl": {
       "baseline": "2020-11-11",
       "port-version": 3
@@ -2602,7 +2602,7 @@
     },
     "getopt-win32": {
       "baseline": "0.1",
-      "port-version": 5
+      "port-version": 6
     },
     "gettext": {
       "baseline": "0.21",

--- a/versions/g-/getopt-win32.json
+++ b/versions/g-/getopt-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2e91ce0684f0a2daa95adc45c9c32e61ae40a7e",
+      "version": "0.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "e20f1829d379f402502feedd978738b06b3f17ad",
       "version": "0.1",
       "port-version": 5


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  unofficial-getopt-win32 package is missing the include directory, requiring you to add it manually. This PR fixes it.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
