### PR TITLE
[expat] Fix build failure.

### DIFF
--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -1,6 +1,5 @@
 vcpkg_minimum_required(VERSION 2022-10-12)
-string(REPLACE "." "_" REF "${VERSION}")
-string(PREPEND REF "R_")
+string(REPLACE "." "_" REF "R_${VERSION}")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -27,7 +26,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/expat-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/expat-${VERSION}")
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -1,7 +1,11 @@
+set(VERSION_MAJOR 2)
+set(VERSION_MINOR 5)
+set(VERSION_PATCH 0)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libexpat/libexpat
-    REF R_2_5_0
+    REF R_${VERSION_MAJOR}_${VERSION_MINOR}_${VERSION_PATCH}
     SHA512 779f0d0f3f2d8b33db0fd044864ab5ab1a40f20501f792fe90ad0d18de536c4765c3749f120e21fec11a0e6c89af1dc576d1fe261c871ca44a594f7b61fd1d9e
     HEAD_REF master
 )
@@ -23,7 +27,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/expat-${VERSION}")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/expat-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -1,11 +1,11 @@
-set(VERSION_MAJOR 2)
-set(VERSION_MINOR 5)
-set(VERSION_PATCH 0)
+vcpkg_minimum_required(VERSION 2022-10-12)
+string(REPLACE "." "_" REF "${VERSION}")
+string(PREPEND REF "R_")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libexpat/libexpat
-    REF R_${VERSION_MAJOR}_${VERSION_MINOR}_${VERSION_PATCH}
+    REF "${REF}"
     SHA512 779f0d0f3f2d8b33db0fd044864ab5ab1a40f20501f792fe90ad0d18de536c4765c3749f120e21fec11a0e6c89af1dc576d1fe261c871ca44a594f7b61fd1d9e
     HEAD_REF master
 )

--- a/ports/expat/vcpkg.json
+++ b/ports/expat/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "expat",
   "version": "2.5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "XML parser library written in C",
   "homepage": "https://github.com/libexpat/libexpat",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2206,7 +2206,7 @@
     },
     "expat": {
       "baseline": "2.5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "expected-lite": {
       "baseline": "0.6.2",

--- a/versions/e-/expat.json
+++ b/versions/e-/expat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "699df182ede7b9402382fd84dc05ea18723514db",
+      "version": "2.5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5da852ba8ea975e8f950bf766129724327232861",
       "version": "2.5.0",
       "port-version": 1

--- a/versions/e-/expat.json
+++ b/versions/e-/expat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "699df182ede7b9402382fd84dc05ea18723514db",
+      "git-tree": "9e83fcee33ad4bce7db7381799ad9068b766b2f4",
       "version": "2.5.0",
       "port-version": 2
     },

--- a/versions/e-/expat.json
+++ b/versions/e-/expat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9e83fcee33ad4bce7db7381799ad9068b766b2f4",
+      "git-tree": "fcad5bc870991726ccb6cc02760d2a5422257bbd",
       "version": "2.5.0",
       "port-version": 2
     },


### PR DESCRIPTION
This fixes a build failure in the expat port due to `VERSION` no longer being set in the portfile. This was broken by #27547. I elected to hardwire the version numbers instead of reading vcpkg.json because vcpkg.json can have versions that are not expat versions, eg `version-date`.

- #### What does your PR fix?
  Fixes
```
CMake Error at D:/Plasma/CyanWorlds.comEngine/build/vc++2022-x64/vcpkg_installed/x64-windows-plasma/share/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake:36 (message):

  
  'D:/Plasma/CyanWorlds.comEngine/vcpkg/packages/expat_x64-windows-plasma/debug/lib/cmake/expat-'
  does not exist.
Call Stack (most recent call first):
  ports/expat/portfile.cmake:26 (vcpkg_cmake_config_fixup)
  scripts/ports.cmake:147 (include)



error: building expat:x64-windows-plasma failed with: BUILD_FAILED
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
