### PR TITLE
[physx] Fix macOS arm64 build

### DIFF
--- a/ports/physx/portfile.cmake
+++ b/ports/physx/portfile.cmake
@@ -12,6 +12,13 @@ vcpkg_download_distfile(
     SHA512 4eb7630db1cb10b2372220c3706dfe255075f466c6b2b12654c9fbc3b17c4df69d7b91e6f0d798c92a4cb8806e1c34b66bb52b46d9358d643ca62ec0de321fd2
 )
 
+vcpkg_download_distfile(
+    patch3
+    URLS "https://github.com/NVIDIAGameWorks/PhysX/commit/cdbfc0f1283829c71b07e332ddd6ce2e5aa7d467.patch"
+    FILENAME "physx-PR569-cdbfc0f.patch"
+    SHA512 2d9d4d30d923b0e006ae1a5c413993325bb4ce5c130fe655242611e87dab945cb220776f112b6cf96b1f06c83a6cec475314a11649bf03304083f5068e282ef2
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NVIDIAGameWorks/PhysX
@@ -22,6 +29,7 @@ vcpkg_from_github(
         fix-compiler-flag.patch
         "${patch1}"
         "${patch2}"
+        "${patch3}"
         remove-werror.patch
 )
 

--- a/ports/physx/vcpkg.json
+++ b/ports/physx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "physx",
   "version": "4.1.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The NVIDIA PhysX SDK is a scalable multi-platform physics solution supporting a wide range of devices, from smartphones to high-end multicore CPUs and GPUs",
   "homepage": "https://github.com/NVIDIAGameWorks/PhysX",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5798,7 +5798,7 @@
     },
     "physx": {
       "baseline": "4.1.2",
-      "port-version": 4
+      "port-version": 5
     },
     "picojson": {
       "baseline": "1.3.0",

--- a/versions/p-/physx.json
+++ b/versions/p-/physx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b081926dc46f3fadf1696719e4b708f4cd136f25",
+      "version": "4.1.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "ebfd4955bdff06becb259bc91575143bc9866dcc",
       "version": "4.1.2",
       "port-version": 4


### PR DESCRIPTION
- #### What does your PR fix?
  Something changed in newer Xcode compilers that was causing error when compiling `vdupq_lane_f32` with a variable integer. This includes a patch to replace the variable with an explicit switch statement for all 4 possible values.
  
  Patch is based on this commit: https://github.com/dpogue/PhysX/commit/cdbfc0f1283829c71b07e332ddd6ce2e5aa7d467

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Add support for community triplet arm64-osx. No change to other triplets.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
   Yes