### PR TITLE
[many ports] Fix a warning ADDITIONAL_(NATIVE|CROSS)_BINARIES have been deprecated

### DIFF
--- a/ports/at-spi2-core/portfile.cmake
+++ b/ports/at-spi2-core/portfile.cmake
@@ -14,10 +14,7 @@ vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -Dintrospection=no
-    ADDITIONAL_NATIVE_BINARIES
-        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
-    ADDITIONAL_CROSS_BINARIES
+    ADDITIONAL_BINARIES
         glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
         glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
 )

--- a/ports/at-spi2-core/vcpkg.json
+++ b/ports/at-spi2-core/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "at-spi2-core",
   "version": "2.44.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Base DBus XML interfaces for accessibility, the accessibility registry daemon, and atspi library.",
   "homepage": "https://www.gtk.org/",
   "license": null,

--- a/ports/gobject-introspection/portfile.cmake
+++ b/ports/gobject-introspection/portfile.cmake
@@ -34,10 +34,7 @@ vcpkg_configure_meson(
         ${OPTIONS_DEBUG}
     OPTIONS_RELEASE
         ${OPTIONS_RELEASE}
-    ADDITIONAL_NATIVE_BINARIES
-        flex='${FLEX}'
-        bison='${BISON}'
-    ADDITIONAL_CROSS_BINARIES
+    ADDITIONAL_BINARIES
         flex='${FLEX}'
         bison='${BISON}'
         g-ir-annotation-tool='${CURRENT_HOST_INSTALLED_DIR}/tools/gobject-introspection/g-ir-annotation-tool'

--- a/ports/gobject-introspection/vcpkg.json
+++ b/ports/gobject-introspection/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gobject-introspection",
   "version": "1.72.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A middleware layer between C libraries (using GObject) and language bindings.",
   "homepage": "https://gi.readthedocs.io/en/latest/",
   "license": null,

--- a/ports/graphene/portfile.cmake
+++ b/ports/graphene/portfile.cmake
@@ -39,12 +39,7 @@ vcpkg_configure_meson(
         ${OPTIONS_DEBUG}
     OPTIONS_RELEASE
         ${OPTIONS_RELEASE}
-    ADDITIONAL_NATIVE_BINARIES
-        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
-        g-ir-compiler='${CURRENT_HOST_INSTALLED_DIR}/tools/gobject-introspection/g-ir-compiler${VCPKG_HOST_EXECUTABLE_SUFFIX}'
-        g-ir-scanner='${GIR_TOOL_DIR}/tools/gobject-introspection/g-ir-scanner'
-    ADDITIONAL_CROSS_BINARIES
+    ADDITIONAL_BINARIES
         glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
         glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
         g-ir-compiler='${CURRENT_HOST_INSTALLED_DIR}/tools/gobject-introspection/g-ir-compiler${VCPKG_HOST_EXECUTABLE_SUFFIX}'

--- a/ports/graphene/vcpkg.json
+++ b/ports/graphene/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "graphene",
   "version": "1.10.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A thin layer of types for graphic libraries.",
   "homepage": "https://www.gtk.org/",
   "license": "MIT",

--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -72,16 +72,7 @@ vcpkg_configure_meson(
         ${OPTIONS_DEBUG}
     OPTIONS_RELEASE
         ${OPTIONS_RELEASE}
-    ADDITIONAL_NATIVE_BINARIES
-        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
-        glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'
-        gdbus-codegen='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/gdbus-codegen'
-        glib-compile-schemas='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-schemas${VCPKG_HOST_EXECUTABLE_SUFFIX}'
-        sassc='${CURRENT_HOST_INSTALLED_DIR}/tools/sassc/bin/sassc${VCPKG_HOST_EXECUTABLE_SUFFIX}'
-        g-ir-compiler='${CURRENT_HOST_INSTALLED_DIR}/tools/gobject-introspection/g-ir-compiler${VCPKG_HOST_EXECUTABLE_SUFFIX}'
-        g-ir-scanner='${GIR_TOOL_DIR}/tools/gobject-introspection/g-ir-scanner'
-    ADDITIONAL_CROSS_BINARIES
+    ADDITIONAL_BINARIES
         glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
         glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
         glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'

--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk",
   "version": "4.6.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": "LGPL-2.0-only",

--- a/ports/gtkmm/portfile.cmake
+++ b/ports/gtkmm/portfile.cmake
@@ -15,8 +15,8 @@ vcpkg_configure_meson(
         -Dmsvc14x-parallel-installable=false # Use separate DLL and LIB filenames for Visual Studio 2017 and 2019
         -Dbuild-tests=false
         -Dbuild-demos=false
-    ADDITIONAL_NATIVE_BINARIES glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'
-    ADDITIONAL_CROSS_BINARIES  glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'
+    ADDITIONAL_BINARIES
+        glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'
 )
 
 vcpkg_install_meson()

--- a/ports/gtkmm/vcpkg.json
+++ b/ports/gtkmm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtkmm",
   "version": "4.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "gtkmm is the official C++ interface for the popular GUI library GTK+.",
   "homepage": "https://www.gtkmm.org/",
   "license": "LGPL-3.0-or-later",

--- a/ports/libsecret/portfile.cmake
+++ b/ports/libsecret/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_configure_meson(
         -Dgtk_doc=false
         -Dmanpage=false
         -Dvapi=false
-    ADDITIONAL_NATIVE_BINARIES
+    ADDITIONAL_BINARIES
          gdbus-codegen='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/gdbus-codegen'
          glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
 )

--- a/ports/libsecret/vcpkg.json
+++ b/ports/libsecret/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsecret",
   "version": "0.20.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libsecret is a GObject-based library for accessing the Secret Service API of the freedesktop.org project, a cross-desktop effort to access passwords, tokens and other types of secrets. libsecret provides a convenient wrapper for these methods so consumers do not have to call the low-level DBus methods.",
   "homepage": "https://gitlab.gnome.org/GNOME/libsecret/",
   "license": "LGPL-2.1-or-later",

--- a/ports/pangomm/portfile.cmake
+++ b/ports/pangomm/portfile.cmake
@@ -15,10 +15,9 @@ vcpkg_configure_meson(
     OPTIONS
         -Dmsvc14x-parallel-installable=false
         -Dbuild-documentation=false
-    ADDITIONAL_NATIVE_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-                               glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
-    ADDITIONAL_CROSS_BINARIES  glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-                               glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+    ADDITIONAL_BINARIES
+        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
 )
 
 vcpkg_install_meson()

--- a/ports/pangomm/vcpkg.json
+++ b/ports/pangomm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pangomm",
   "version": "2.50.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "pangomm is the official C++ interface for the Pango font layout library. See, for instance, the Pango::Layout class.",
   "homepage": "https://gitlab.gnome.org/GNOME/pangomm",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/at-spi2-core.json
+++ b/versions/a-/at-spi2-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "897df7693a8a1addc3a5ab84efabef89e4cef1d8",
+      "version": "2.44.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "72611608fcbd5e1a1b867a88e4810d75ddc94fdf",
       "version": "2.44.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -266,7 +266,7 @@
     },
     "at-spi2-core": {
       "baseline": "2.44.1",
-      "port-version": 1
+      "port-version": 2
     },
     "atk": {
       "baseline": "2.38.0",
@@ -2862,7 +2862,7 @@
     },
     "gobject-introspection": {
       "baseline": "1.72.0",
-      "port-version": 2
+      "port-version": 3
     },
     "google-cloud-cpp": {
       "baseline": "2.9.0",
@@ -2906,7 +2906,7 @@
     },
     "graphene": {
       "baseline": "1.10.8",
-      "port-version": 1
+      "port-version": 2
     },
     "graphicsmagick": {
       "baseline": "1.3.37",
@@ -2962,7 +2962,7 @@
     },
     "gtk": {
       "baseline": "4.6.8",
-      "port-version": 1
+      "port-version": 2
     },
     "gtk3": {
       "baseline": "3.24.34",
@@ -2970,7 +2970,7 @@
     },
     "gtkmm": {
       "baseline": "4.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "gtl": {
       "baseline": "1.1.5",
@@ -4434,7 +4434,7 @@
     },
     "libsecret": {
       "baseline": "0.20.4",
-      "port-version": 1
+      "port-version": 2
     },
     "libsercomm": {
       "baseline": "1.3.2",
@@ -6002,7 +6002,7 @@
     },
     "pangomm": {
       "baseline": "2.50.1",
-      "port-version": 1
+      "port-version": 2
     },
     "parallel-hashmap": {
       "baseline": "1.3.8",

--- a/versions/g-/gobject-introspection.json
+++ b/versions/g-/gobject-introspection.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47ab422de57e980b1294daf095a942d3ea36ae98",
+      "version": "1.72.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "1c57bf1b1ead704fc0899cb496732c42e5330cc4",
       "version": "1.72.0",
       "port-version": 2

--- a/versions/g-/graphene.json
+++ b/versions/g-/graphene.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "abffc31a5c8762671618bdca4bbcd620e171f6d1",
+      "version": "1.10.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "e8c7b10cc1bdcca2e09b0f42da6ad645699680a9",
       "version": "1.10.8",
       "port-version": 1

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52d572bf77d0fa30174893ca6fe1bf6c17935cb2",
+      "version": "4.6.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "cadf0f3efc6e75b1a1978f5c29126ffaf4a75c8c",
       "version": "4.6.8",
       "port-version": 1

--- a/versions/g-/gtkmm.json
+++ b/versions/g-/gtkmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c20c4893b7e0aada402db3895d38d840123ae8c5",
+      "version": "4.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "8adcadbba0b316ce33796f84c2fe878c9f2cfa94",
       "version": "4.6.0",
       "port-version": 1

--- a/versions/l-/libsecret.json
+++ b/versions/l-/libsecret.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "56f3e1a575e955fb58859b9a50695c700f527325",
+      "version": "0.20.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "a5e91b4b0043a5deb14f9ab62710b3410e969d54",
       "version": "0.20.4",
       "port-version": 1

--- a/versions/p-/pangomm.json
+++ b/versions/p-/pangomm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "359b0fe0cdacbc56edd56143da7d545633e50960",
+      "version": "2.50.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "34b3f456c3c28463b38376b91dddb715ec4a6b7c",
       "version": "2.50.1",
       "port-version": 1


### PR DESCRIPTION
```
CMake Warning at scripts/cmake/vcpkg_configure_meson.cmake:305 (message):
  Options ADDITIONAL_(NATIVE|CROSS)_BINARIES have been deprecated.  Only use
  ADDITIONAL_BINARIES!
Call Stack (most recent call first):
  ports/harfbuzz/portfile.cmake:40 (vcpkg_configure_meson)
  scripts/ports.cmake:147 (include)
```

- [x] at-spi2-core
- [x] gobject-introspection
- [x] graphene
- [x] gtk
- [x] gtkmm
- [x] libsecret
- [x] pangomm
