### PR TITLE
[vcpkg baseline] [libproxy] Fix build error on Linux

### DIFF
--- a/ports/libproxy/portfile.cmake
+++ b/ports/libproxy/portfile.cmake
@@ -30,12 +30,14 @@ vcpkg_cmake_configure(
         -DWITH_WEBKIT3=OFF
         -DWITH_KDE=${VCPKG_TARGET_IS_LINUX}
         -DMSVC_STATIC=${STATICCRT}
+        -DWITH_GNOME3=OFF
     MAYBE_UNUSED_VARIABLES
         WITH_DOTNET
         WITH_PERL
         WITH_PYTHON2
         WITH_PYTHON3
         WITH_VALA
+        MSVC_STATIC
 )
 
 vcpkg_cmake_install()

--- a/ports/libproxy/vcpkg.json
+++ b/ports/libproxy/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libproxy",
   "version": "0.4.18",
+  "port-version": 1,
   "description": "libproxy is a library that provides automatic proxy configuration management.",
   "homepage": "https://github.com/libproxy/libproxy",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -83,7 +83,7 @@
     "amd-amf": {
       "baseline": "1.4.26",
       "port-version": 0
-    }, 
+    },
     "ampl-asl": {
       "baseline": "2020-11-11",
       "port-version": 3
@@ -4134,7 +4134,7 @@
     },
     "libproxy": {
       "baseline": "0.4.18",
-      "port-version": 0
+      "port-version": 1
     },
     "libqcow": {
       "baseline": "20210419",

--- a/versions/l-/libproxy.json
+++ b/versions/l-/libproxy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74ecff4623774abaa9333489e644bdbc881e268f",
+      "version": "0.4.18",
+      "port-version": 1
+    },
+    {
       "git-tree": "1e70cf451a9b90297ce32751eb17760a31c0b394",
       "version": "0.4.18",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes build error on Linux.
```
[13/22] : && /usr/bin/c++ -fvisibility=hidden -fPIC -g  libproxy/CMakeFiles/pxgsettings.dir/modules/pxgsettings.cpp.o -o libproxy/pxgsettings -L/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../lib -Wl,-rpath,/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../lib:  -lgio-2.0  -lresolv  -lgmodule-2.0  -ldl  -lz  -lgobject-2.0  -lglib-2.0  -lm  -lpcre2-8  -lffi && :
FAILED: libproxy/pxgsettings 
: && /usr/bin/c++ -fvisibility=hidden -fPIC -g  libproxy/CMakeFiles/pxgsettings.dir/modules/pxgsettings.cpp.o -o libproxy/pxgsettings -L/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../lib -Wl,-rpath,/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../lib:  -lgio-2.0  -lresolv  -lgmodule-2.0  -ldl  -lz  -lgobject-2.0  -lglib-2.0  -lm  -lpcre2-8  -lffi && :
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../lib/libglib-2.0.a(gmain.c.o): in function `g_get_worker_context':
/mnt/vcpkg-ci/buildtrees/glib/x64-linux-dbg/../src/glib-2-802473e24b.clean/glib/gmain.c:6438: undefined reference to `pthread_sigmask'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/glib/x64-linux-dbg/../src/glib-2-802473e24b.clean/glib/gmain.c:6443: undefined reference to `pthread_sigmask'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../lib/libglib-2.0.a(gthread-posix.c.o): in function `g_rec_mutex_impl_new':
/mnt/vcpkg-ci/buildtrees/glib/x64-linux-dbg/../src/glib-2-802473e24b.clean/glib/gthread-posix.c:290: undefined reference to `pthread_mutexattr_init'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/glib/x64-linux-dbg/../src/glib-2-802473e24b.clean/glib/gthread-posix.c:291: undefined reference to `pthread_mutexattr_settype'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/glib/x64-linux-dbg/../src/glib-2-802473e24b.clean/glib/gthread-posix.c:293: undefined reference to `pthread_mutexattr_destroy'
```

