### PR TITLE
[vcpkg baseline][ideviceinstaller] Fix LNK2019 in static triplet

### DIFF
--- a/ports/ideviceinstaller/Add-missing-lib.patch
+++ b/ports/ideviceinstaller/Add-missing-lib.patch
@@ -1,0 +1,40 @@
+diff --git a/ideviceinstaller.vcxproj b/ideviceinstaller.vcxproj
+index dd8d483..4b15d7e 100644
+--- a/ideviceinstaller.vcxproj
++++ b/ideviceinstaller.vcxproj
+@@ -112,7 +112,7 @@
+     <Link>
+       <SubSystem>Console</SubSystem>
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
++      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+     </Link>
+   </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+@@ -126,7 +126,7 @@
+     <Link>
+       <SubSystem>Console</SubSystem>
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
++      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+     </Link>
+   </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+@@ -144,7 +144,7 @@
+       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+       <OptimizeReferences>true</OptimizeReferences>
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
++      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+     </Link>
+   </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+@@ -162,7 +162,7 @@
+       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+       <OptimizeReferences>true</OptimizeReferences>
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
++      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+     </Link>
+   </ItemDefinitionGroup>
+   <ItemDefinitionGroup>

--- a/ports/ideviceinstaller/portfile.cmake
+++ b/ports/ideviceinstaller/portfile.cmake
@@ -1,13 +1,16 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libimobiledevice-win32/ideviceinstaller
-    REF 1.1.2.23
+    REF ${VERSION}
     SHA512 d0801b3a38eb02206a6f06e05cc19b794c69a87c06895165f64522c61e07030046499c5f0e436981682f9e17f91eae87913cca091e2e039a74ee35a5136100d4
     HEAD_REF msvc-master
+    PATCHES Add-missing-lib.patch
 )
 
 vcpkg_install_msbuild(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     PROJECT_SUBPATH ideviceinstaller.vcxproj
     LICENSE_SUBPATH COPYING
     USE_VCPKG_INTEGRATION

--- a/ports/ideviceinstaller/vcpkg.json
+++ b/ports/ideviceinstaller/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "ideviceinstaller",
   "version": "1.1.2.23",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Manage apps of iOS devices",
+  "homepage": "https://libimobiledevice.org/",
   "license": "LGPL-2.1-only",
   "supports": "windows & !arm64",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -83,7 +83,7 @@
     "amd-amf": {
       "baseline": "1.4.26",
       "port-version": 0
-    }, 
+    },
     "ampl-asl": {
       "baseline": "2020-11-11",
       "port-version": 3
@@ -2974,7 +2974,7 @@
     },
     "ideviceinstaller": {
       "baseline": "1.1.2.23",
-      "port-version": 4
+      "port-version": 5
     },
     "idevicerestore": {
       "baseline": "1.0.12",

--- a/versions/i-/ideviceinstaller.json
+++ b/versions/i-/ideviceinstaller.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12d1a6edf7ea5af4aa326371f2b1e269b00bd26f",
+      "version": "1.1.2.23",
+      "port-version": 5
+    },
+    {
       "git-tree": "82bc629affc514c34b77216d2a00cfbbcf1f2220",
       "version": "1.1.2.23",
       "port-version": 4

--- a/versions/i-/ideviceinstaller.json
+++ b/versions/i-/ideviceinstaller.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "12d1a6edf7ea5af4aa326371f2b1e269b00bd26f",
+      "git-tree": "3e54543ef504b74edb836a2c47abb3845b83b7c3",
       "version": "1.1.2.23",
       "port-version": 5
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes ideviceinstaller install failed with below errors in static triplet:
```
  imobiledevice-1.0.lib(socket.c.obj) : error LNK2019: unresolved external symbol __imp_accept referenced in function socket_accept
  libcrypto.lib(libcrypto-lib-e_capi.obj) : error LNK2019: unresolved external symbol __imp_CertOpenStore referenced in function capi_open_store
```
  
