### PR TITLE
[vcpkg baseline][usbmuxd] Add "!static" to the port.

### DIFF
--- a/ports/usbmuxd/vcpkg.json
+++ b/ports/usbmuxd/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "usbmuxd",
   "version": "1.2.235",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A socket daemon to multiplex connections from and to iOS devices",
   "homepage": "http://www.libimobiledevice.org",
   "license": "LGPL-2.1-only",
-  "supports": "windows & !arm64",
+  "supports": "windows & !arm64 & !static",
   "dependencies": [
     "libimobiledevice",
     "libusb",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -83,7 +83,7 @@
     "amd-amf": {
       "baseline": "1.4.26",
       "port-version": 0
-    }, 
+    },
     "ampl-asl": {
       "baseline": "2020-11-11",
       "port-version": 3
@@ -7734,7 +7734,7 @@
     },
     "usbmuxd": {
       "baseline": "1.2.235",
-      "port-version": 2
+      "port-version": 3
     },
     "usd": {
       "baseline": "20.08",

--- a/versions/u-/usbmuxd.json
+++ b/versions/u-/usbmuxd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b3f2cea522d35497750ecfd9446e29bf034b4d21",
+      "version": "1.2.235",
+      "port-version": 3
+    },
+    {
       "git-tree": "53c6e0e8c2a4f5db93d2a41d51d2aa8ba68b8e7e",
       "version": "1.2.235",
       "port-version": 2


### PR DESCRIPTION
The `usbmuxd` [installation fails](https://dev.azure.com/vcpkg/public/_build/results?buildId=82385&view=logs&j=3859ca13-59fe-57bd-13f9-449df7d191a6&t=fd8b99e7-4eca-52cb-a612-b91f191f402c&l=46970) with the following error in the static triple:
```
     1>imobiledevice-1.0.lib(idevice.c.obj) : error LNK2005: DllMain already defined in libusb0.lib(windows.c.obj) [D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]
     1>imobiledevice-1.0.lib(utils.c.obj) : error LNK2005: buffer_read_from_filename already defined in utils.obj [D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]
     1>imobiledevice-1.0.lib(utils.c.obj) : error LNK2005: buffer_write_to_filename already defined in utils.obj [D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]
     1>imobiledevice-1.0.lib(utils.c.obj) : error LNK2005: plist_read_from_filename already defined in utils.obj [D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]
     1>imobiledevice-1.0.lib(utils.c.obj) : error LNK2005: plist_write_to_filename already defined in utils.obj [D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]
     1>imobiledevice-1.0.lib(utils.c.obj) : error LNK2005: stpcpy already defined in utils.obj [D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]
     1>imobiledevice-1.0.lib(utils.c.obj) : error LNK2005: string_concat already defined in utils.obj [D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]
            Creating library D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\x64\Release\usbmuxd.lib and object D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\x64\Release\usbmuxd.exp
     1>LINK : warning LNK4098: defaultlib 'LIBCMT' conflicts with use of other libs; use /NODEFAULTLIB:library [D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]
     1>D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\x64\Release\usbmuxd.exe : fatal error LNK1169: one or more multiply defined symbols found [D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]
     1>Done Building Project "D:\buildtrees\usbmuxd\x64-windows-static-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj" (Rebuild target(s)) -- FAILED.
```

In order to avoid blocking other ports, I added `!static` to `support`, which is not a real fix.