### PR TITLE
[plog] Update to 1.1.9

### DIFF
--- a/ports/plog/portfile.cmake
+++ b/ports/plog/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SergiusTheBest/plog
-    REF 1.1.8
-    SHA512 09bf6e0cae7f20c1b42e68a174b4cd6a2fb8751db9758efb87449cbff48375708e43c147c72b7ed17fb9334acaf7802441f61578356284a8ed337fd886a45e79
+    REF 1.1.9
+    SHA512 d979fdf0011ef9bb94a2271da5d17058dbab5bc47438a13769d084fdebe5e169e7c05a043d69acceb752896df7cdae4433f32bfbcc81e055dffd9c701be88003
     HEAD_REF master
 )
 
@@ -17,4 +17,4 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
 file(COPY "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # Put the licence file where vcpkg expects it
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/plog/vcpkg.json
+++ b/ports/plog/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "plog",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Portable, simple and extensible C++ logging library.",
   "homepage": "https://github.com/SergiusTheBest/plog",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5869,7 +5869,7 @@
       "port-version": 6
     },
     "plog": {
-      "baseline": "1.1.8",
+      "baseline": "1.1.9",
       "port-version": 0
     },
     "plplot": {

--- a/versions/p-/plog.json
+++ b/versions/p-/plog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8123d0f93ad451c1bbf9cb25b57ea290f4124030",
+      "version": "1.1.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "b16507d8b9cbf419b2923d55de7ddfdf013f0267",
       "version": "1.1.8",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
Updates plog to 1.1.9.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
 Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes