### PR TITLE
[cpputest] modernize

### DIFF
--- a/ports/cpputest/portfile.cmake
+++ b/ports/cpputest/portfile.cmake
@@ -10,51 +10,42 @@ vcpkg_from_github(
         fix-arm-build-error.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/CppUTest/cmake TARGET_PATH share/CppUTest)
-if (EXISTS ${CURRENT_PACKAGES_DIR}/lib/CppUTest)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/CppUTest)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/CppUTest/cmake )
+if (EXISTS "${CURRENT_PACKAGES_DIR}/lib/CppUTest")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/CppUTest")
 endif()
 
-if (EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/CppUTest)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/CppUTest)
+if (EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/CppUTest")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/CppUTest")
 endif()
 
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/lib/manual-link)
-    file(GLOB CPPUTEST_LIBS ${CURRENT_PACKAGES_DIR}/lib/*${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
-    file(COPY ${CPPUTEST_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib/manual-link)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/manual-link")
+    file(GLOB CPPUTEST_LIBS "${CURRENT_PACKAGES_DIR}/lib/*${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+    file(COPY ${CPPUTEST_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/lib/manual-link")
     file(REMOVE ${CPPUTEST_LIBS})
     
-    file(READ ${CURRENT_PACKAGES_DIR}/share/CppUTest/CppUTestTargets-release.cmake RELEASE_CONFIG)
-    # Replace CppUTestExt first
-    string(REPLACE "\${_IMPORT_PREFIX}/lib/"
-                   "\${_IMPORT_PREFIX}/lib/manual-link/" RELEASE_CONFIG "${RELEASE_CONFIG}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/share/CppUTest/CppUTestTargets-release.cmake "${RELEASE_CONFIG}")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/CppUTestTargets-release.cmake" "\${_IMPORT_PREFIX}/lib/" "\${_IMPORT_PREFIX}/lib/manual-link/")
 endif()
 
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link)
-    file(GLOB CPPUTEST_LIBS ${CURRENT_PACKAGES_DIR}/debug/lib/*${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
-    file(COPY ${CPPUTEST_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link")
+    file(GLOB CPPUTEST_LIBS "${CURRENT_PACKAGES_DIR}/debug/lib/*${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+    file(COPY ${CPPUTEST_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link")
     file(REMOVE ${CPPUTEST_LIBS})
 
-    file(READ ${CURRENT_PACKAGES_DIR}/share/CppUTest/CppUTestTargets-debug.cmake DEBUG_CONFIG)
-    # Replace CppUTestExt first
-    string(REPLACE "\${_IMPORT_PREFIX}/debug/lib/"
-                   "\${_IMPORT_PREFIX}/debug/lib/manual-link/" DEBUG_CONFIG "${DEBUG_CONFIG}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/share/CppUTest/CppUTestTargets-debug.cmake "${DEBUG_CONFIG}")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/CppUTestTargets-debug.cmake" "\${_IMPORT_PREFIX}/debug/lib/" "\${_IMPORT_PREFIX}/debug/lib/manual-link/")
 endif()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/cpputest/vcpkg.json
+++ b/ports/cpputest/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "cpputest",
-  "version-string": "2019-9-16",
-  "port-version": 2,
+  "version": "2019-9-16",
+  "port-version": 3,
   "description": "CppUTest unit testing and mocking framework for C/C++.",
-  "homepage": "https://github.com/cpputest/cpputest"
+  "homepage": "https://github.com/cpputest/cpputest",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1698,7 +1698,7 @@
     },
     "cpputest": {
       "baseline": "2019-9-16",
-      "port-version": 2
+      "port-version": 3
     },
     "cppwinrt": {
       "baseline": "2.0.220929.3",

--- a/versions/c-/cpputest.json
+++ b/versions/c-/cpputest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9db5c5203e4af2efa89f513a14314e8bde14f24a",
+      "version": "2019-9-16",
+      "port-version": 3
+    },
+    {
       "git-tree": "e476f5c4b948489a33c704cbfc42d8ca60ac29e3",
       "version-string": "2019-9-16",
       "port-version": 2


### PR DESCRIPTION
Needed for #26981 because vcpkg_cmake_config_fixup by default installs the config files to `share/cpputest` instead of the old `TARGET_PATH share/CppUTest` and we have to replace things in these files afterwards and the linux file system is case sensitive 