### PR TITLE
[libspatialindex] modernize

### DIFF
--- a/ports/libspatialindex/portfile.cmake
+++ b/ports/libspatialindex/portfile.cmake
@@ -9,19 +9,20 @@ vcpkg_from_github(
         mingw.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
     OPTIONS
         -DCMAKE_DEBUG_POSTFIX=d
         -DSIDX_BUILD_TESTS:BOOL=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
 #Debug
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libspatialindex/vcpkg.json
+++ b/ports/libspatialindex/vcpkg.json
@@ -1,10 +1,15 @@
 {
   "name": "libspatialindex",
   "version": "1.9.3",
-  "port-version": 1,
+  "port-version": 3,
   "description": "C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API.",
   "homepage": "http://libspatialindex.github.com",
+  "license": "MIT",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
     "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4246,7 +4246,7 @@
     },
     "libspatialindex": {
       "baseline": "1.9.3",
-      "port-version": 1
+      "port-version": 3
     },
     "libspatialite": {
       "baseline": "5.0.1",

--- a/versions/l-/libspatialindex.json
+++ b/versions/l-/libspatialindex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "97b36055483a86131a19e83cde29ec1fbd0e87c3",
+      "version": "1.9.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "48179f2e21bb0918129f0f2d02cacb39f88ab347",
       "version": "1.9.3",
       "port-version": 1


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/pull/26981. The port needs `WINDOWS_USE_MSBUILD` which is not inserted by default 