### PR TITLE
[google-cloud-cpp] add missing dependency

### DIFF
--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,12 +1,14 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.5.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     "abseil",
+    "grpc",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2718,7 +2718,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c30065de0805a0b44a0f913541b4824286a053a",
+      "version": "2.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ca9ad64f3cb29e1d51281a0e2679d0da3468f5c8",
       "version": "2.5.0",
       "port-version": 0


### PR DESCRIPTION
Otherwise:
```
CMake Error at /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/google-cloud-cpp/arm64-osx-dbg/CMakeFiles/CMakeTmp/CMakeLists.txt:21 (target_link_libraries):
  Target "cmTC_f2859" links to:

    gRPC::grpc++

  but the target was not found. 

```