### PR TITLE
[gstreamer] Update to version 1.20.5

### DIFF
--- a/ports/gst-rtsp-server/portfile.cmake
+++ b/ports/gst-rtsp-server/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gstreamer/gstreamer
-    REF 1.20.4
-    SHA512 bd2e3812f719c530027513f1ac6715e093c4fb3c56553e4ad82506dfc5fd81616777ee08489723809faee693e68f010abf716cc23c82a7d17490b6942ce5cac4
+    REF 1.20.5
+    SHA512 2a996d8ac0f70c34dbbc02c875026df6e89346f0844fbaa25475075bcb6e57c81ceb7d71e729c3259eace851e3d7222cb3fe395e375d93eb45b1262a6ede1fdb
     HEAD_REF master
 )
 

--- a/ports/gst-rtsp-server/vcpkg.json
+++ b/ports/gst-rtsp-server/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gst-rtsp-server",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "description": "gst-rtsp-server is a library on top of GStreamer for building an RTSP server",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.1-only",

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -8,8 +8,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gstreamer/gstreamer
-    REF 1.20.4
-    SHA512 bd2e3812f719c530027513f1ac6715e093c4fb3c56553e4ad82506dfc5fd81616777ee08489723809faee693e68f010abf716cc23c82a7d17490b6942ce5cac4
+    REF 1.20.5
+    SHA512 2a996d8ac0f70c34dbbc02c875026df6e89346f0844fbaa25475075bcb6e57c81ceb7d71e729c3259eace851e3d7222cb3fe395e375d93eb45b1262a6ede1fdb
     HEAD_REF master
     PATCHES
         fix-clang-cl.patch

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gstreamer",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2797,11 +2797,11 @@
       "port-version": 1
     },
     "gst-rtsp-server": {
-      "baseline": "1.20.4",
+      "baseline": "1.20.5",
       "port-version": 0
     },
     "gstreamer": {
-      "baseline": "1.20.4",
+      "baseline": "1.20.5",
       "port-version": 0
     },
     "gtest": {

--- a/versions/g-/gst-rtsp-server.json
+++ b/versions/g-/gst-rtsp-server.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6bde18badd06f4466ca4cb75b83aa98b1f24f3bd",
+      "version": "1.20.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "167d04773dc90f37d577ae302276e6b5a5f05911",
       "version": "1.20.4",
       "port-version": 0

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e790c6925b367f31a0d7311288aada1c8d045e56",
+      "version": "1.20.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "b7afb1aa90258b95521b94bd290a343502705f5c",
       "version": "1.20.4",
       "port-version": 0


### PR DESCRIPTION
Updates gstreamer and gst-rtsp-server to version 1.20.5

- #### What does your PR fix?
None

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes