### PR TITLE
[Python3] Revert "Python3 cross build support"

### DIFF
--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -224,18 +224,12 @@ else()
         "--without-readline"
         "--disable-test-modules"
     )
-    if (VCPKG_CROSSCOMPILING)
-        list(APPEND OPTIONS "ac_cv_file__dev_ptmx=no")
-        list(APPEND OPTIONS "ac_cv_file__dev_ptc=no")
-    endif()
-
     if(VCPKG_TARGET_IS_OSX)
         list(APPEND OPTIONS "LIBS=-liconv -lintl")
     endif()
 
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"
-        DETERMINE_BUILD_TRIPLET
         OPTIONS ${OPTIONS}
         OPTIONS_DEBUG "--with-pydebug"
     )

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.10.7",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6062,7 +6062,7 @@
     },
     "python3": {
       "baseline": "3.10.7",
-      "port-version": 2
+      "port-version": 3
     },
     "qca": {
       "baseline": "2.3.4",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34d2d172a62b2d8da14493b4c6ad9495cf2a28cb",
+      "version": "3.10.7",
+      "port-version": 3
+    },
+    {
       "git-tree": "84623885a79a6bbf45a2bc65ab3328005af389ea",
       "version": "3.10.7",
       "port-version": 2


### PR DESCRIPTION
Reverts microsoft/vcpkg#27830 because it breaks the build on arm64-osx and the cross build from arm64-osx to x64-osx. 