### PR TITLE
[vulkan-headers] update to 1.3.238

### DIFF
--- a/ports/vulkan-headers/portfile.cmake
+++ b/ports/vulkan-headers/portfile.cmake
@@ -2,9 +2,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/Vulkan-Headers
-    REF f97f29836cb9c8c5657979f1aeac42b46d4e51d0
-    SHA512 d03ef87156e2019b8bd180ccad6c8faa1fa32b5b538143fbdfcc8134b25d2addb60ceaae6cbd42b81d6676450d242d8bef964443628fb714ead39a40d018c63a
-    HEAD_REF v1.3.234
+    REF 00671c64ba5c488ade22ad572a0ef81d5e64c803
+    SHA512 e740688d0d2abd5c82b5bda1606e24edd87674ec7bd72ed4220c4d2d5bab30b8c993251c0b96a4c59d9e3190ddda7cb0cbf1e160aa404ef6e3c4aff23864d535
+    HEAD_REF v1.3.238
 )
 
 vcpkg_cmake_configure(

--- a/ports/vulkan-headers/vcpkg.json
+++ b/ports/vulkan-headers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vulkan-headers",
-  "version": "1.3.234",
+  "version": "1.3.238",
   "description": "Vulkan header files and API registry",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Headers",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7941,7 +7941,7 @@
       "port-version": 2
     },
     "vulkan-headers": {
-      "baseline": "1.3.234",
+      "baseline": "1.3.238",
       "port-version": 0
     },
     "vulkan-hpp": {

--- a/versions/v-/vulkan-headers.json
+++ b/versions/v-/vulkan-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d23bba2a37b43eab6af9748934187d6d7ebebf6",
+      "version": "1.3.238",
+      "port-version": 0
+    },
+    {
       "git-tree": "6004a732ca5a141020fd8d7071b8ae321a25e428",
       "version": "1.3.234",
       "port-version": 0


### PR DESCRIPTION
- [vulkan-headers] Update to 1.3.238
- ./vcpkg x-add-versions --all

**Describe the pull request**

- #### What does your PR fix?
Updates vulkan-headers to latest (1.3.238)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Same as before

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes