### PR TITLE
[ableton] no werror et al

### DIFF
--- a/ports/ableton/no-werror.patch
+++ b/ports/ableton/no-werror.patch
@@ -1,0 +1,28 @@
+diff --git a/cmake_include/ConfigureCompileFlags.cmake b/cmake_include/ConfigureCompileFlags.cmake
+index 63bdfec..80879f9 100644
+--- a/cmake_include/ConfigureCompileFlags.cmake
++++ b/cmake_include/ConfigureCompileFlags.cmake
+@@ -25,7 +25,6 @@ if(UNIX)
+     set(build_flags_COMMON_LIST
+       ${build_flags_COMMON_LIST}
+       "-Weverything"
+-      "-Werror"
+       "-Wno-c++98-compat"
+       "-Wno-c++98-compat-pedantic"
+       "-Wno-deprecated"
+@@ -44,7 +43,6 @@ if(UNIX)
+   elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+     set(build_flags_COMMON_LIST
+       ${build_flags_COMMON_LIST}
+-      "-Werror"
+       "-Wno-multichar"
+     )
+   endif()
+@@ -87,7 +85,6 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+     ${build_flags_COMMON_LIST}
+     "/MP"
+     "/Wall"
+-    "/WX"
+     "/EHsc"
+ 
+     #############################

--- a/ports/ableton/portfile.cmake
+++ b/ports/ableton/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         replace_local_asiostandalone_by_vcpkg_asio.patch
         replace_asiosdk_download_by_vcpkg_asiosdk.patch
         replace_local_catch_by_vcpkg_catch2.patch
+        no-werror.patch
 )
 # Note that the dependencies ASIO and ASIOSDK are completely different things:
 # -ASIO (ASyncronous IO) is a cross-platform C++ library for network and low-level I/O programming

--- a/ports/ableton/vcpkg.json
+++ b/ports/ableton/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ableton",
   "version": "3.0.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Ableton Link, a technology that synchronizes musical beat, tempo, and phase across multiple applications running on one or more devices.",
   "homepage": "https://www.ableton.com/en/link/",
   "documentation": "http://ableton.github.io/link/",

--- a/versions/a-/ableton.json
+++ b/versions/a-/ableton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d688b97174372d4d7d73278cece5bdc5a64b4136",
+      "version": "3.0.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "70d81e7e966f983af654d779a02817d89eacea3b",
       "version": "3.0.5",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10,7 +10,7 @@
     },
     "ableton": {
       "baseline": "3.0.5",
-      "port-version": 1
+      "port-version": 2
     },
     "abseil": {
       "baseline": "20220623.1",


### PR DESCRIPTION
Fixes the build of windows for me
```
[4/7] C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1434~1.319\bin\Hostx64\x64\cl.exe   /TP -DLINKHUT_AUDIO_PLATFORM_ASIO=1 -DLINK_BUILD_VLD=0 -DLINK_PLATFORM_WINDOWS=1 -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -IG:\vcpkg\vcpkg_installed\x64-windows\include\asiosdk\common -IG:\vcpkg\vcpkg_installed\x64-windows\include\asiosdk\host -IG:\vcpkg\vcpkg_installed\x64-windows\include\asiosdk\host\pc -IG:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\examples\linkaudio -external:IG:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\include -external:IG:\vcpkg\vcpkg_installed\x64-windows\share\asio\..\..\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MP /Wall /WX /EHsc /wd4061 /wd4265 /wd4350 /wd4355 /wd4365 /wd4371 /wd4503 /wd4510 /wd4512 /wd4514 /wd4571 /wd4610 /wd4625 /wd4626 /wd4628 /wd4640 /wd4710 /wd4711 /wd4723 /wd4738 /wd4820 /wd4996 /wd5045 /wd5204 /wd4464 /wd4548 /wd4623 /wd4868 /wd5026 /wd5027 /wd4987 /wd4774 /wd5039 /wd4127 /wd4242 /wd4619 /wd4668 /wd4702 /wd4946 /wd4267 /wd4477 /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1  /DDEBUG=1 /showIncludes /Foexamples\CMakeFiles\LinkHut.dir\linkaudio\AudioEngine.cpp.obj /Fdexamples\CMakeFiles\LinkHut.dir\ /FS -c G:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\examples\linkaudio\AudioEngine.cpp
FAILED: examples/CMakeFiles/LinkHut.dir/linkaudio/AudioEngine.cpp.obj 
C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1434~1.319\bin\Hostx64\x64\cl.exe   /TP -DLINKHUT_AUDIO_PLATFORM_ASIO=1 -DLINK_BUILD_VLD=0 -DLINK_PLATFORM_WINDOWS=1 -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -IG:\vcpkg\vcpkg_installed\x64-windows\include\asiosdk\common -IG:\vcpkg\vcpkg_installed\x64-windows\include\asiosdk\host -IG:\vcpkg\vcpkg_installed\x64-windows\include\asiosdk\host\pc -IG:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\examples\linkaudio -external:IG:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\include -external:IG:\vcpkg\vcpkg_installed\x64-windows\share\asio\..\..\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MP /Wall /WX /EHsc /wd4061 /wd4265 /wd4350 /wd4355 /wd4365 /wd4371 /wd4503 /wd4510 /wd4512 /wd4514 /wd4571 /wd4610 /wd4625 /wd4626 /wd4628 /wd4640 /wd4710 /wd4711 /wd4723 /wd4738 /wd4820 /wd4996 /wd5045 /wd5204 /wd4464 /wd4548 /wd4623 /wd4868 /wd5026 /wd5027 /wd4987 /wd4774 /wd5039 /wd4127 /wd4242 /wd4619 /wd4668 /wd4702 /wd4946 /wd4267 /wd4477 /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1  /DDEBUG=1 /showIncludes /Foexamples\CMakeFiles\LinkHut.dir\linkaudio\AudioEngine.cpp.obj /Fdexamples\CMakeFiles\LinkHut.dir\ /FS -c G:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\examples\linkaudio\AudioEngine.cpp
G:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\examples\linkaudio\AudioEngine.cpp(140): error C2220: the following warning is treated as an error
G:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\examples\linkaudio\AudioEngine.cpp(140): warning C5264: 'double const `private: void __cdecl ableton::linkaudio::AudioEngine::renderMetronomeIntoBuffer(ableton::BasicLink<ableton::platforms::windows::Clock>::SessionState,double,std::chrono::duration<__int64,std::ratio<1,1000000> >,unsigned __int64)'::`2'::lowTone': 'const' variable is not used
G:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\examples\linkaudio\AudioEngine.cpp(140): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
G:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\examples\linkaudio\AudioEngine.cpp(139): warning C5264: 'double const `private: void __cdecl ableton::linkaudio::AudioEngine::renderMetronomeIntoBuffer(ableton::BasicLink<ableton::platforms::windows::Clock>::SessionState,double,std::chrono::duration<__int64,std::ratio<1,1000000> >,unsigned __int64)'::`2'::highTone': 'const' variable is not used
G:\vcpkg\buildtrees\ableton\src\825333bd28-828085aa86.clean\examples\linkaudio\AudioEngine.cpp(139): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
```