### PR TITLE
[vcpkg_configure_cmake] Partially revert #26959

### DIFF
--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -242,7 +242,6 @@ function(vcpkg_configure_cmake)
         "-DZ_VCPKG_ROOT_DIR=${VCPKG_ROOT_DIR}"
         "-D_VCPKG_INSTALLED_DIR=${_VCPKG_INSTALLED_DIR}"
         "-DVCPKG_MANIFEST_INSTALL=OFF"
-        "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
     )
 
     if(NOT "${generator_arch}" STREQUAL "")


### PR DESCRIPTION
We must avoid significant breaking changes to the sets of scripts coupled to the vcpkg tool version.

- #### What does your PR fix?

Partially addresses https://github.com/microsoft/vcpkg/issues/28386. @craigscott-crascit has identified this as a breaking change which is not permissible in the helper scripts bundled with the tool.
