### PR TITLE
[avcpp] Update to version 2.1.0

### DIFF
--- a/ports/avcpp/portfile.cmake
+++ b/ports/avcpp/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO h4tr3d/avcpp
-    REF fa9a1ef70bbf9e9f3963fbaa4540e8aac4ad8daa
-    SHA512 e0821d8e01e0fdb28d58564c87cafa7f9349b1b31dc90d4f2ea4c22c51fc16555f4a01f30d7575798138067921a011faa10e4d2ac2ac02acdf224546724e0338
+    REF v2.1.0
+    SHA512 1e66afcf9a1f1085001aab9eb270cbbc6930cc42e60567300676d220120c421c44d24c7aeccb0b5c3ebd9de574ca1efbc67a29c681e3e11a796c32cc370069e4
     HEAD_REF master
     PATCHES
         0002-av_init_packet_deprecation.patch
@@ -14,6 +14,10 @@ vcpkg_from_github(
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" AVCPP_ENABLE_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" AVCPP_ENABLE_SHARED)
+
+if(NOT HOST_TRIPLET STREQUAL TARGET_TRIPLET)
+    vcpkg_add_to_path(${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf)
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/avcpp/portfile.cmake
+++ b/ports/avcpp/portfile.cmake
@@ -1,6 +1,8 @@
 # avcpp doesn't export any symbols
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO h4tr3d/avcpp

--- a/ports/avcpp/portfile.cmake
+++ b/ports/avcpp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO h4tr3d/avcpp
-    REF v2.1.0
+    REF "v${VERSION}"
     SHA512 1e66afcf9a1f1085001aab9eb270cbbc6930cc42e60567300676d220120c421c44d24c7aeccb0b5c3ebd9de574ca1efbc67a29c681e3e11a796c32cc370069e4
     HEAD_REF master
     PATCHES

--- a/ports/avcpp/vcpkg.json
+++ b/ports/avcpp/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "avcpp",
-  "version-date": "2021-06-14",
-  "port-version": 1,
+  "version": "2.1.0",
   "description": "Wrapper for the FFmpeg that simplify usage it from C++ projects.",
   "homepage": "https://github.com/h4tr3d/avcpp",
+  "license": "LGPL-2.1-only OR BSD-3-Clause",
   "dependencies": [
     {
       "name": "ffmpeg",
@@ -17,6 +17,10 @@
         "swresample",
         "swscale"
       ]
+    },
+    {
+      "name": "pkgconf",
+      "host": true
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/a-/avcpp.json
+++ b/versions/a-/avcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89ce0f88456eeb494453591d129e62bc3ef3096d",
+      "git-tree": "7227fc33d6f65475816f10bffcdbedd6d2485298",
       "version": "2.1.0",
       "port-version": 0
     },

--- a/versions/a-/avcpp.json
+++ b/versions/a-/avcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89ce0f88456eeb494453591d129e62bc3ef3096d",
+      "version": "2.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "caf5460d5bfca1d608b7c7eab2bd2872080bf0d8",
       "version-date": "2021-06-14",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -273,8 +273,8 @@
       "port-version": 0
     },
     "avcpp": {
-      "baseline": "2021-06-14",
-      "port-version": 1
+      "baseline": "2.1.0",
+      "port-version": 0
     },
     "avisynthplus": {
       "baseline": "3.7.2",


### PR DESCRIPTION
Updates to latest tag version.

This is required to support using newer versions of ffmpeg (5.0+)

See PR [#23312](https://github.com/microsoft/vcpkg/pull/23312)