### PR TITLE
[discordcoreapi] Fix compilation with ffmpeg.

### DIFF
--- a/ports/discordcoreapi/0001-Add-extern-C-to-avcodec.patch
+++ b/ports/discordcoreapi/0001-Add-extern-C-to-avcodec.patch
@@ -1,0 +1,14 @@
+diff --git a/Source/AudioDecoder.cpp b/Source/AudioDecoder.cpp
+index 42bd4543..ff210878 100644
+--- a/Source/AudioDecoder.cpp
++++ b/Source/AudioDecoder.cpp
+@@ -25,7 +25,9 @@
+ 
+ #include <discordcoreapi/Utilities.hpp>
+ #include <discordcoreapi/AudioDecoder.hpp>
++extern "C" {
+ #include <libavcodec/avcodec.h>
++}
+ 
+ namespace DiscordCoreInternal {
+ 

--- a/ports/discordcoreapi/portfile.cmake
+++ b/ports/discordcoreapi/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
 	REF c8591ab721b76a7649cb5b45944fab1c5c798242
 	SHA512 943d2a77dc3d297b4ec84d6b4808554aec9a89c33a242e5f6401a9831f674ff948f53d3e877737a40517a393b3b2a9bd873c6007a193892743c88c2fdb58341a
 	HEAD_REF main
+    PATCHES
+        0001-Add-extern-C-to-avcodec.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/discordcoreapi/vcpkg.json
+++ b/ports/discordcoreapi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "discordcoreapi",
   "version-date": "2022-12-04",
+  "port-version": 1,
   "description": "A Discord bot library written in C++ using custom asynchronous coroutines.",
   "homepage": "https://discordcoreapi.com",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1978,7 +1978,7 @@
     },
     "discordcoreapi": {
       "baseline": "2022-12-04",
-      "port-version": 0
+      "port-version": 1
     },
     "discount": {
       "baseline": "2.2.6",

--- a/versions/d-/discordcoreapi.json
+++ b/versions/d-/discordcoreapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d73e8f486425465e5ea3fe24db81e36cfaf4ac3b",
+      "version-date": "2022-12-04",
+      "port-version": 1
+    },
+    {
       "git-tree": "0832ba20725a822358548dab0fd9c561bf4a78fa",
       "version-date": "2022-12-04",
       "port-version": 0


### PR DESCRIPTION
The current version of discordcoreapi includes a C header from ffmpeg into a C++ source file without correctly marking it as `extern "C"`. This causes compilation errors depending on the ffmpeg version used.

This is required to support using newer versions of ffmpeg (5.0+)

See PR [#23312](https://github.com/microsoft/vcpkg/pull/23312)