### PR TITLE
[ignition-common3] Update to 3.14.1.

### DIFF
--- a/ports/ignition-cmake2/add-pkgconfig-and-remove-privatefor-limit.patch
+++ b/ports/ignition-cmake2/add-pkgconfig-and-remove-privatefor-limit.patch
@@ -2,16 +2,16 @@ diff --git a/cmake/IgnUtils.cmake b/cmake/IgnUtils.cmake
 index bc6dbdc..1e8adbb 100644
 --- a/cmake/IgnUtils.cmake
 +++ b/cmake/IgnUtils.cmake
-@@ -138,7 +138,7 @@ macro(ign_find_package PACKAGE_NAME)
+@@ -142,7 +142,7 @@ macro(ign_find_package PACKAGE_NAME)
    #------------------------------------
    # Define the expected arguments
-   set(options REQUIRED PRIVATE EXACT QUIET BUILD_ONLY PKGCONFIG_IGNORE)
+   set(options REQUIRED PRIVATE EXACT QUIET CONFIG BUILD_ONLY PKGCONFIG_IGNORE)
 -  set(oneValueArgs VERSION PRETTY PURPOSE EXTRA_ARGS PKGCONFIG PKGCONFIG_LIB PKGCONFIG_VER_COMPARISON)
 +  set(oneValueArgs VERSION PRETTY PURPOSE EXTRA_ARGS PKGCONFIG PKGCONFIG_LIB PKGCONFIG_VER_COMPARISON BY_PKGCONFIG)
    set(multiValueArgs REQUIRED_BY PRIVATE_FOR COMPONENTS OPTIONAL_COMPONENTS)
  
    #------------------------------------
-@@ -183,9 +183,15 @@ macro(ign_find_package PACKAGE_NAME)
+@@ -191,9 +191,15 @@ macro(ign_find_package PACKAGE_NAME)
    endif()
  
  
@@ -27,7 +27,7 @@ index bc6dbdc..1e8adbb 100644
  
    if(${PACKAGE_NAME}_FOUND)
  
-@@ -300,17 +306,11 @@ macro(ign_find_package PACKAGE_NAME)
+@@ -319,17 +325,11 @@ macro(ign_find_package PACKAGE_NAME)
      endif()
  
      if(ign_find_package_REQUIRED_BY)

--- a/ports/ignition-cmake2/portfile.cmake
+++ b/ports/ignition-cmake2/portfile.cmake
@@ -1,10 +1,9 @@
-set(PACKAGE_VERSION "2.5.0")
+set(PACKAGE_VERSION "2.16.0")
 
 ignition_modular_library(NAME cmake
                          VERSION ${PACKAGE_VERSION}
-                         SHA512 e39ed44ae6f7ccc338412f466f1257f88989e0818bee801ddbe09350e906cd9ce709be24356310fdbfde22d1b5b5846fed0aa794c06dcf7caf82748a07b428d6
+                         SHA512 6ee64ff6c82c657678188be459c50a4255fd3881d758906d93361425702d04854a13a46124b20e058069f314077ba7e6c15a058153b615b3245084f066d1cbae
                          PATCHES
-                            FindGTS.patch
                             add-pkgconfig-and-remove-privatefor-limit.patch)
 
 # Install custom usage

--- a/ports/ignition-cmake2/vcpkg.json
+++ b/ports/ignition-cmake2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ignition-cmake2",
-  "version": "2.5.0",
-  "port-version": 3,
+  "version": "2.16.0",
   "description": "CMake helper functions for building robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/cmake",
   "license": null,

--- a/ports/ignition-common3/portfile.cmake
+++ b/ports/ignition-common3/portfile.cmake
@@ -1,6 +1,6 @@
 ignition_modular_library(NAME common
-                         VERSION "3.9.0"
-                         SHA512 1bae86efd7da10ac517d67a75ad1b612ea2046128eb75e0f0a134ffff7cc76431e850a9b46fdb7dc6603e2acb044f4204fdedaf38fc7bff82883db3f36830fb9
+                         VERSION "3.14.1"
+                         SHA512 5f83685b67cb0b8e295136f74a681e2ca5f00a730b0a221f0c00cab5f9049c84692185fb5924ab29cd07cbdf85450e81dfcdc984fc8af4ed4cc549b2fe2f9a6e
                          OPTIONS -DUSE_EXTERNAL_TINYXML2=ON
                          PATCHES fix-dependencies.patch)
 

--- a/ports/ignition-common3/vcpkg.json
+++ b/ports/ignition-common3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ignition-common3",
-  "version": "3.9.0",
-  "port-version": 4,
+  "version": "3.14.1",
   "description": "Common libraries for robotics applications",
   "homepage": "https://ignitionrobotics.org/libs/common",
   "license": null,

--- a/ports/ignition-math6/portfile.cmake
+++ b/ports/ignition-math6/portfile.cmake
@@ -1,4 +1,4 @@
 ignition_modular_library(NAME math
-                         VERSION "6.6.0"
-                         SHA512 6c0a6e7098f31b3dc9abbcd8714808669eca10e385748d4c1b44aa06dcfa5701906bea0277a99c3132fdd1a8c9a8e9c593099ac0eedfe5dec370018b2b63bfec
-                         PATCHES fix-isspace.patch)
+                         VERSION "6.9.2"
+                         SHA512 87fe43f745a2337e1b4c92abdb98180d55cf6034f9b85e93e42ab1c6e0af645912b9a246589115f919ca1fe7ecb38090fe76cdd0d6726315ffb0f090626c0634
+                         )

--- a/ports/ignition-math6/vcpkg.json
+++ b/ports/ignition-math6/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ignition-math6",
-  "version": "6.6.0",
-  "port-version": 3,
+  "version": "6.9.2",
   "description": "Math API for robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/math",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2997,16 +2997,16 @@
       "port-version": 4
     },
     "ignition-cmake2": {
-      "baseline": "2.5.0",
-      "port-version": 3
+      "baseline": "2.16.0",
+      "port-version": 0
     },
     "ignition-common1": {
       "baseline": "1.1.1",
       "port-version": 3
     },
     "ignition-common3": {
-      "baseline": "3.9.0",
-      "port-version": 4
+      "baseline": "3.14.1",
+      "port-version": 0
     },
     "ignition-fuel-tools1": {
       "baseline": "1.2.0",
@@ -3021,8 +3021,8 @@
       "port-version": 3
     },
     "ignition-math6": {
-      "baseline": "6.6.0",
-      "port-version": 3
+      "baseline": "6.9.2",
+      "port-version": 0
     },
     "ignition-modularscripts": {
       "baseline": "2022-05-11",

--- a/versions/i-/ignition-cmake2.json
+++ b/versions/i-/ignition-cmake2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e94a4739cf0e6197a67fbd5770cbff1afcf5f51",
+      "version": "2.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "04ad74fe00ed7c2030aec3e27fc0beaaf2c90bf8",
       "version": "2.5.0",
       "port-version": 3

--- a/versions/i-/ignition-common3.json
+++ b/versions/i-/ignition-common3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f63b7872dccdd6f71e0a075ea4bbf677c679a9d8",
+      "version": "3.14.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6dc33f01d43ba86ec811a09138434f76815a40c8",
       "version": "3.9.0",
       "port-version": 4

--- a/versions/i-/ignition-math6.json
+++ b/versions/i-/ignition-math6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ba12e1d6fbb4b7b72e209a4dad9b3bf0ec83879",
+      "version": "6.9.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "eb148027e8b1f6b1c6a47500140fa02467911e26",
       "version": "6.6.0",
       "port-version": 3


### PR DESCRIPTION
[ignition-cmake2] Update to 2.16.

[ignition-math6] Update to 6.9.2.

[ignition-common] Update to 3.14.1.

This is required to support using newer versions of ffmpeg (5.0+)

See PR [#23312](https://github.com/microsoft/vcpkg/pull/23312)