### PR TITLE
[libusb-win32] Add "!static" to the port

### DIFF
--- a/ports/libusb-win32/portfile.cmake
+++ b/ports/libusb-win32/portfile.cmake
@@ -1,24 +1,21 @@
-set(LIBUSB_VERSION 1.2.6.0)
-set(LIBUSB_HASH 972438b7465a22882bc91a1238291240ee3cdb09f374454a027d003b150656d4c262553104f74418bb49b4a7ca2f1a4f72d20e689fa3a7728881bafc876267f4)
+vcpkg_minimum_required(VERSION 2022-10-12)
 
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb-win32/libusb-win32-releases
-    REF ${LIBUSB_VERSION}
-    FILENAME "libusb-win32-src-${LIBUSB_VERSION}.zip"
-    SHA512 ${LIBUSB_HASH}
+    REF ${VERSION}
+    FILENAME "libusb-win32-src-${VERSION}.zip"
+    SHA512 972438b7465a22882bc91a1238291240ee3cdb09f374454a027d003b150656d4c262553104f74418bb49b4a7ca2f1a4f72d20e689fa3a7728881bafc876267f4
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA)
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
+
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(COPY ${SOURCE_PATH}/COPYING_LGPL.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/libusb-win32)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libusb-win32/COPYING_LGPL.txt ${CURRENT_PACKAGES_DIR}/share/libusb-win32/copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING_LGPL.txt")

--- a/ports/libusb-win32/vcpkg.json
+++ b/ports/libusb-win32/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 9,
   "description": "Allows user space applications to access many USB device on Windows.",
   "homepage": "https://sourceforge.net/projects/libusb-win32",
-  "license": "GPL-3.0 AND LGPL-3.0",
+  "license": "LGPL-3.0-only",
   "supports": "windows & !static",
   "dependencies": [
     {

--- a/ports/libusb-win32/vcpkg.json
+++ b/ports/libusb-win32/vcpkg.json
@@ -1,8 +1,19 @@
 {
   "name": "libusb-win32",
-  "version-string": "1.2.6.0",
-  "port-version": 8,
+  "version": "1.2.6.0",
+  "port-version": 9,
   "description": "Allows user space applications to access many USB device on Windows.",
   "homepage": "https://sourceforge.net/projects/libusb-win32",
-  "supports": "windows"
+  "license": "GPL-3.0 AND LGPL-3.0",
+  "supports": "windows & !static",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -83,7 +83,7 @@
     "amd-amf": {
       "baseline": "1.4.26",
       "port-version": 0
-    }, 
+    },
     "ampl-asl": {
       "baseline": "2020-11-11",
       "port-version": 3
@@ -4358,7 +4358,7 @@
     },
     "libusb-win32": {
       "baseline": "1.2.6.0",
-      "port-version": 8
+      "port-version": 9
     },
     "libusbmuxd": {
       "baseline": "1.2.219",

--- a/versions/l-/libusb-win32.json
+++ b/versions/l-/libusb-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "16de42e3a5331bd6a89c2bb9420fc0f9dbeef522",
+      "version": "1.2.6.0",
+      "port-version": 9
+    },
+    {
       "git-tree": "fd3ac7f3d9331b546a957f651f9f911d69d7ef4f",
       "version-string": "1.2.6.0",
       "port-version": 8

--- a/versions/l-/libusb-win32.json
+++ b/versions/l-/libusb-win32.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "16de42e3a5331bd6a89c2bb9420fc0f9dbeef522",
+      "git-tree": "33a59191d5fa27f6d37b37e39dd1f100d4faed0f",
       "version": "1.2.6.0",
       "port-version": 9
     },


### PR DESCRIPTION
`libusb-win32` don't support `static` in fact.

Alert from user: [Details](https://github.com/microsoft/vcpkg/pull/28383#issuecomment-1354586414).