### PR TITLE
[qtbase] Fix a bug that will cause deploy failed on Debug profile

### DIFF
--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.4.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtbase/windeployqt.debug.bat
+++ b/ports/qtbase/windeployqt.debug.bat
@@ -5,6 +5,6 @@ set mypath=%mypath:~0,-1%
 set BAKCD=!CD!
 cd /D %mypath%\..\..\..\debug\bin
 set PATH=!CD!;%PATH%
-"%mypath%\windeployqt.exe" --qtpaths "%mypath%\qtpaths.debug.bat" %*
 cd %BAKCD%
+"%mypath%\windeployqt.exe" --qtpaths "%mypath%\qtpaths.debug.bat" %*
 endlocal

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6294,7 +6294,7 @@
     },
     "qtbase": {
       "baseline": "6.4.1",
-      "port-version": 3
+      "port-version": 4
     },
     "qtcharts": {
       "baseline": "6.4.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "daf79eff476bddb5a9ad145f012bb2f46a2172f9",
+      "version": "6.4.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "f718070277a5feb4b54410d860556c980c5c6d82",
       "version": "6.4.1",
       "port-version": 3

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "daf79eff476bddb5a9ad145f012bb2f46a2172f9",
+      "git-tree": "8898a901b80fa6e70c8942349fef53932e90ba54",
       "version": "6.4.1",
       "port-version": 4
     },


### PR DESCRIPTION
This bug will cause
```
qt_generate_deploy_app_script(
    TARGET VTSLink
    FILENAME_VARIABLE DEPLOY_SCRIPT
    NO_UNSUPPORTED_PLATFORM_ERROR
) 
install(SCRIPT ${DEPLOY_SCRIPT})
``` 
failed to deploy on Debug builds, as the working directory is switched to another place and not switching back, making input program not found. 
This fix switch back the working directory before run windeployqt.exe