### PR TITLE
[aws-crt-cpp] no werror et al

### DIFF
--- a/ports/aws-crt-cpp/no-werror.patch
+++ b/ports/aws-crt-cpp/no-werror.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a1a7964..7a5b1a5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -293,9 +293,9 @@ if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
+     target_compile_definitions(${PROJECT_NAME} PRIVATE "-DDEBUG_BUILD")
+     #set extra warning flags for debug build
+     if (MSVC)
+-        target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX /wd4068)
++        target_compile_options(${PROJECT_NAME} PRIVATE /W4 /wd4068)
+     else ()
+-        target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-long-long -pedantic -Werror)
++        target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-long-long -pedantic)
+     endif ()
+ endif ()
+ 

--- a/ports/aws-crt-cpp/portfile.cmake
+++ b/ports/aws-crt-cpp/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     PATCHES
         fix-cmake-target-path.patch
         fix-ios-build.patch
+        no-werror.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_CRT)

--- a/ports/aws-crt-cpp/vcpkg.json
+++ b/ports/aws-crt-cpp/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "aws-crt-cpp",
   "version": "0.15.1",
-  "port-version": 3,
-  "description": "Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient SW implementations.",
+  "port-version": 4,
+  "description": "C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Protocols and SSL/TLS implementations for C++.",
   "homepage": "https://github.com/awslabs/aws-crt-cpp",
+  "license": "Apache-2.0",
   "supports": "!(windows & arm) & !uwp",
   "dependencies": [
     "aws-c-auth",

--- a/versions/a-/aws-crt-cpp.json
+++ b/versions/a-/aws-crt-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2247bebb1109b41b4a27e18d2c91812d23dfe55d",
+      "version": "0.15.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "e542ffdad6392c75909a3235d33c2a22c939c980",
       "version": "0.15.1",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -330,7 +330,7 @@
     },
     "aws-crt-cpp": {
       "baseline": "0.15.1",
-      "port-version": 3
+      "port-version": 4
     },
     "aws-lambda-cpp": {
       "baseline": "0.2.7",


### PR DESCRIPTION
Otherwise it fails with:
```
[2/28] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DAWS_MQTT_WITH_WEBSOCKETS -DAWS_USE_KQUEUE -DCJSON_HIDE_SYMBOLS -DDEBUG_BUILD -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/aws-crt-cpp/src/c763da6810-766cf92b91.clean/include -isystem /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg_installed/arm64-osx/include -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk -Wall -Wno-long-long -pedantic -Werror -std=gnu++11 -MD -MT CMakeFiles/aws-crt-cpp.dir/source/external/cJSON.cpp.o -MF CMakeFiles/aws-crt-cpp.dir/source/external/cJSON.cpp.o.d -o CMakeFiles/aws-crt-cpp.dir/source/external/cJSON.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/aws-crt-cpp/src/c763da6810-766cf92b91.clean/source/external/cJSON.cpp
FAILED: CMakeFiles/aws-crt-cpp.dir/source/external/cJSON.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DAWS_MQTT_WITH_WEBSOCKETS -DAWS_USE_KQUEUE -DCJSON_HIDE_SYMBOLS -DDEBUG_BUILD -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/aws-crt-cpp/src/c763da6810-766cf92b91.clean/include -isystem /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg_installed/arm64-osx/include -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk -Wall -Wno-long-long -pedantic -Werror -std=gnu++11 -MD -MT CMakeFiles/aws-crt-cpp.dir/source/external/cJSON.cpp.o -MF CMakeFiles/aws-crt-cpp.dir/source/external/cJSON.cpp.o.d -o CMakeFiles/aws-crt-cpp.dir/source/external/cJSON.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/aws-crt-cpp/src/c763da6810-766cf92b91.clean/source/external/cJSON.cpp
/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/aws-crt-cpp/src/c763da6810-766cf92b91.clean/source/external/cJSON.cpp:146:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
    sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
    ^
```