### PR TITLE
[ffmpeg] Remove amf encoder's trash code

### DIFF
--- a/ports/ffmpeg/0024-remove-amf-trash-code.patch
+++ b/ports/ffmpeg/0024-remove-amf-trash-code.patch
@@ -1,0 +1,45 @@
+Subject: [PATCH] remove trash
+---
+Index: libavcodec/amfenc.c
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/libavcodec/amfenc.c b/libavcodec/amfenc.c
+--- a/libavcodec/amfenc.c	(revision 4bc4cafaef8a55462138d7b6f7579c1522de26dc)
++++ b/libavcodec/amfenc.c	(revision 4bf273b7b0be19ea55ee81c7f4f5925452e44789)
+@@ -671,18 +671,8 @@
+         }
+
+         if (hw_surface) {
+-            AMFBuffer *frame_ref_storage_buffer;
+-
+             // input HW surfaces can be vertically aligned by 16; tell AMF the real size
+             surface->pVtbl->SetCrop(surface, 0, 0, frame->width, frame->height);
+-
+-            frame_ref_storage_buffer = amf_create_buffer_with_frame_ref(frame, ctx->context);
+-            AMF_RETURN_IF_FALSE(ctx, frame_ref_storage_buffer != NULL, AVERROR(ENOMEM), "create_buffer_with_frame_ref() returned NULL\n");
+-
+-            res = amf_set_property_buffer(surface, L"av_frame_ref", frame_ref_storage_buffer);
+-            AMF_RETURN_IF_FALSE(ctx, res == AMF_OK, AVERROR_UNKNOWN, "SetProperty failed for \"av_frame_ref\" with error %d\n", res);
+-            ctx->hwsurfaces_in_queue++;
+-            frame_ref_storage_buffer->pVtbl->Release(frame_ref_storage_buffer);
+         }
+
+         surface->pVtbl->SetPts(surface, frame->pts);
+@@ -729,15 +719,6 @@
+             ret = amf_copy_buffer(avctx, avpkt, buffer);
+
+             buffer->pVtbl->Release(buffer);
+-
+-            if (data->pVtbl->HasProperty(data, L"av_frame_ref")) {
+-                AMFBuffer *frame_ref_storage_buffer;
+-                res = amf_get_property_buffer(data, L"av_frame_ref", &frame_ref_storage_buffer);
+-                AMF_RETURN_IF_FALSE(ctx, res == AMF_OK, AVERROR_UNKNOWN, "GetProperty failed for \"av_frame_ref\" with error %d\n", res);
+-                amf_release_buffer_with_frame_ref(frame_ref_storage_buffer);
+-                ctx->hwsurfaces_in_queue--;
+-            }
+-
+             data->pVtbl->Release(data);
+
+             AMF_RETURN_IF_FALSE(ctx, ret >= 0, ret, "amf_copy_buffer() failed with error %d\n", ret);

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_from_github(
         0020-fix-aarch64-libswscale.patch
         0022-fix-m1-hardware-decode-nal-bits.patch # remove in next version
         0023-fix-qsv-init.patch # remove in next version (5.x)
+        0024-remove-amf-trash-code.patch # 1000% Speed up h264_amf / hevc_amf
 )
 
 if (SOURCE_PATH MATCHES " ")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2318,7 +2318,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.3",
-      "port-version": 1
+      "port-version": 2
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "24ea8b75765cf5b2e393bd4ecb875cfecf52fc6c",
+      "version": "4.4.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "e0ba585cd7dea2dd84e0c2cf8ca462b7c1e58f1e",
       "version": "4.4.3",
       "port-version": 1


### PR DESCRIPTION
This PR is introduced because ffmpeg's amf encoder has some trash code and severly impacts the performance.
After removing these code the encoding performance can be more than 20x faster than before. (10ms to 0.5ms) (In my case, D3D11 pixel format specifically, DXVA should also have this problem. In fact all hardware surface suffers.)
The removed code literally does nothing effective, and it should be safe to remove, as the output is same after removal.

More detail:
The remove code simply alloc a buffer from amf, and copies whole AVFrame to the buffer, then set the buffer as an input parameter of frame. After sending, it reads the buffer back in the encoded packet retrived from amf, and copies the data back into AVFrame, then released everything. The point is, neither AMF nor FFMPEG use any data in these procedure, so the interop overhead cost 10ms per frame and just make amf encoders unable to use at all. This might be some debugging code while development.

FFMPEG side's bug report and mailing list has been submitted, but considering even master branch still have this bug, this might take years to let this patch merged into next distribute version. 

https://trac.ffmpeg.org/ticket/10119