### PR TITLE
[geos] Fix broken patch.

### DIFF
--- a/ports/geos/disable-warning-4996.patch
+++ b/ports/geos/disable-warning-4996.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e758b5dc8..074986f38 100644
+index e758b5dc8..1cfedb630 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -187,7 +187,7 @@ target_compile_features(geos_cxx_flags INTERFACE cxx_std_11)
@@ -7,7 +7,7 @@ index e758b5dc8..074986f38 100644
  	"$<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-ffp-contract=off>"
  	"$<$<CXX_COMPILER_ID:GNU>:-ffp-contract=off>"
 -	"$<$<CXX_COMPILER_ID:MSVC>:/fp:precise>"
-+	$<$<CXX_COMPILER_ID:MSVC>:/fp:precise /wd4996>
++	"$<$<CXX_COMPILER_ID:MSVC>:/fp:precise /wd4996>"
  	)
  
  # Use -ffloat-store for 32-bit builds (needed to make some tests pass)


### PR DESCRIPTION
**Describe the pull request**

The patch file got broken [here](https://github.com/microsoft/vcpkg/blob/6adca01a3fadca0cc0b80f03ec57c7c3a0be5c02/ports/geos/disable-warning-4996.patch#L10).
With Ninja I get incorrect `compile_commands.json` files. That will produce the following warning in MSVS:
`Command line warning D9002: ignoring unknown option '/fp:precise /wd4996'`

- #### What does your PR fix?
  I'm fixing the patch. 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
 Should be fine everywhere. 

- #### Does your PR follow the [maintainer guide] 
 It does

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  I have not updated the port. Only updated the patch files. 

