### PR TITLE
[angle] Improve UX for unofficial CMake package

### DIFF
--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -742,7 +742,8 @@ else()
     )
 endif()
 
-install(EXPORT ANGLEExport FILE unofficial-angle-config.cmake NAMESPACE unofficial::angle:: DESTINATION share/unofficial-angle)
+install(EXPORT ANGLEExport FILE unofficial-angle-targets.cmake NAMESPACE unofficial::angle:: DESTINATION share/unofficial-angle)
+install(FILES unofficial-angle-config.cmake DESTINATION share/unofficial-angle)
 
 if(NOT DISABLE_INSTALL_HEADERS)
     install(

--- a/ports/angle/portfile.cmake
+++ b/ports/angle/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_from_github(
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-angle-config.cmake" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/angle_commit.h" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/angle_commit.h" DESTINATION "${SOURCE_PATH}/src/common")
 

--- a/ports/angle/unofficial-angle-config.cmake
+++ b/ports/angle/unofficial-angle-config.cmake
@@ -1,0 +1,7 @@
+include(CMakeFindDependencyMacro)
+find_dependency(ZLIB)
+if(UNIX AND NOT APPLE)
+  find_dependency(X11 COMPONENTS Xext Xi)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-angle-targets.cmake")

--- a/ports/angle/usage
+++ b/ports/angle/usage
@@ -1,0 +1,8 @@
+The package angle provides unofficial CMake targets:
+
+    find_package(unofficial-angle REQUIRED CONFIG)
+    target_link_libraries(main PRIVATE unofficial::angle::libGLESv2)
+
+    # Or use the EGL target
+    find_package(unofficial-angle REQUIRED CONFIG)
+    target_link_libraries(main PRIVATE unofficial::angle::libEGL)

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "angle",
   "version-string": "chromium_4472",
-  "port-version": 6,
+  "port-version": 7,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."
   ],
   "homepage": "https://github.com/google/angle",
+  "license": "BSD-3-Clause",
   "dependencies": [
     "egl-registry",
     {

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "10d893d25d50a449f8aa0592007b973516f325a7",
+      "git-tree": "96213b303b5b0804d7c8e9b6b94aa3cd3cc90660",
       "version-string": "chromium_4472",
       "port-version": 7
     },

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "10d893d25d50a449f8aa0592007b973516f325a7",
+      "version-string": "chromium_4472",
+      "port-version": 7
+    },
+    {
       "git-tree": "d48bbcf1eba07a4156e745140be81caff95b8757",
       "version-string": "chromium_4472",
       "port-version": 6

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -106,7 +106,7 @@
     },
     "angle": {
       "baseline": "chromium_4472",
-      "port-version": 6
+      "port-version": 7
     },
     "antlr4": {
       "baseline": "4.11.1",


### PR DESCRIPTION
This PR adds a config script to the unofficial CMake package that properly propagates transitive dependencies and usage info for the unofficial CMake package to avoid vcpkg barfing almost all the targets in it.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
