### PR TITLE
[fltk] Disable obsolete math.h polyfill

### DIFF
--- a/ports/fltk/math-h-polyfill.patch
+++ b/ports/fltk/math-h-polyfill.patch
@@ -1,0 +1,13 @@
+diff --git a/FL/math.h b/FL/math.h
+index b574000..216a2ad 100644
+--- a/FL/math.h
++++ b/FL/math.h
+@@ -47,7 +47,7 @@
+ #    define M_SQRT1_2       0.70710678118654752440
+ #  endif // !M_SQRT2
+ 
+-#  if (defined(WIN32) || defined(CRAY)) && !defined(__MINGW32__) && !defined(__MWERKS__)
++#  if defined(FLTK_ENABLE_MATH_H_POLYFILL)
+ 
+ inline double rint(double v) {return floor(v+.5);}
+ inline double copysign(double a, double b) {return b<0 ? -a : a;}

--- a/ports/fltk/portfile.cmake
+++ b/ports/fltk/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         config-path.patch
         include.patch
         fix-system-link.patch
+        math-h-polyfill.patch
 )
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/jpeg"

--- a/ports/fltk/vcpkg.json
+++ b/ports/fltk/vcpkg.json
@@ -9,7 +9,8 @@
   "dependencies": [
     {
       "name": "fltk",
-      "host": true
+      "host": true,
+      "default-features": false
     },
     {
       "name": "fontconfig",

--- a/ports/fltk/vcpkg.json
+++ b/ports/fltk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fltk",
   "version": "1.3.8",
-  "port-version": 3,
+  "port-version": 4,
   "description": "FLTK (pronounced fulltick) is a cross-platform C++ GUI toolkit for UNIX/Linux (X11), Microsoft Windows, and MacOS X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL and its built-in GLUT emulation.",
   "homepage": "https://www.fltk.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2374,7 +2374,7 @@
     },
     "fltk": {
       "baseline": "1.3.8",
-      "port-version": 3
+      "port-version": 4
     },
     "fluidlite": {
       "baseline": "2020-08-27",

--- a/versions/f-/fltk.json
+++ b/versions/f-/fltk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "149b0f939eca23de263cab90db1de98e17d22343",
+      "version": "1.3.8",
+      "port-version": 4
+    },
+    {
       "git-tree": "f9c84b6995e5d327678ce90845e994854555e849",
       "version": "1.3.8",
       "port-version": 3

--- a/versions/f-/fltk.json
+++ b/versions/f-/fltk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "149b0f939eca23de263cab90db1de98e17d22343",
+      "git-tree": "20def1217e8d9ac6306e900f9bdc5662bf593d82",
       "version": "1.3.8",
       "port-version": 4
     },


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes duplicate symbols with Windows UCRT.
  (Detected in / pulled out of #28311.)
  Fixes opting out of `opengl` feature for host build.

FTR `copysign` isn't used at all.
