### PR TITLE
[celero] Update to v2.8.4

### DIFF
--- a/ports/celero/portfile.cmake
+++ b/ports/celero/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DigitalInBlue/Celero
-    REF v2.8.3
-    SHA512 f6774f6076bae5d37d4f5bd12153bc99b97893f43fe9253fe805b5b0c2475ffe878e32f3fc7391544ea24020e59d5ae48e44e5b3a302f7280ad15b6a6820f70b
+    REF v2.8.4
+    SHA512 99119744d908104b44edaa8dadb1b0545bfc17c79c2ceb7f0e1101dde279b28238524dbdaa1d9716ba0f07a2f16d9979dc89be916527bd45f8615f79dc95e700
     HEAD_REF master
     PATCHES
         fix-bin-install-path.patch

--- a/ports/celero/vcpkg.json
+++ b/ports/celero/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "celero",
-  "version": "2.8.3",
-  "description": "Celero is a modern cross-platform (Windows, Linux, MacOS) Microbenchmarking library for C++.",
+  "version": "2.8.4",
+  "description": "Celero is a modern cross-platform (Windows, Linux, MacOS) Microbenchmarking library for C++ 11 and later.",
   "homepage": "https://github.com/DigitalInBlue/Celero",
   "license": "Apache-2.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1349,7 +1349,7 @@
       "port-version": 3
     },
     "celero": {
-      "baseline": "2.8.3",
+      "baseline": "2.8.4",
       "port-version": 0
     },
     "cello": {

--- a/versions/c-/celero.json
+++ b/versions/c-/celero.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1d31d577b5367b83ff03617698ebadf16c25bd5",
+      "version": "2.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "a9beee7ba313a9770888b114a8146bc1a983577e",
       "version": "2.8.3",
       "port-version": 0


### PR DESCRIPTION
Update the version of Celero to v2.8.4

- #### What does your PR fix?
  Fixes invalid group names creating seg faults when specified from the command line.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
