### PR TITLE
[c9y] update to 0.6.0

### DIFF
--- a/ports/c9y/portfile.cmake
+++ b/ports/c9y/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rioki/c9y
-    REF v0.5.1
-    SHA512 d8ccd9a61521e3cbe1881129bcdb4817cad6b80c8bebb67024c799be790bd4abecf9427f0ba62f991c156a979742aa7a8fdfb477a7619524615e2a2aed6e774f
+    REF v0.6.0
+    SHA512 20203771ca88c69a8f77010ad79ac5fe90b9e60457cb3a037106241622fd7b6c1ef409055c969dddbe7575816947d95cbe5e7c291bad557c358cc43d0db17c2d
     )
 
 vcpkg_cmake_configure(

--- a/ports/c9y/vcpkg.json
+++ b/ports/c9y/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c9y",
-  "version-semver": "0.5.1",
+  "version-semver": "0.6.0",
   "description": "Concurency",
   "homepage": "https://github.com/rioki/c9y",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1269,7 +1269,7 @@
       "port-version": 1
     },
     "c9y": {
-      "baseline": "0.5.1",
+      "baseline": "0.6.0",
       "port-version": 0
     },
     "caf": {

--- a/versions/c-/c9y.json
+++ b/versions/c-/c9y.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "637d6fd46798e96161b162117eaed37afef1a875",
+      "version-semver": "0.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0b7986fbff4e61263ed1bf9962eb6642f8f14cd8",
       "version-semver": "0.5.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  
  Updates c9y to version 0.6.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  
  all, unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  
  To the best of my knowledge, yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
   
  yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
