### PR TITLE
[entt, libharu, libopensp, minizip, smf, vlpp, vulkan-headers] Fix incorrect versions

### DIFF
--- a/versions/e-/entt.json
+++ b/versions/e-/entt.json
@@ -16,11 +16,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "965c440d8611528f1069a2a494f11da420110408",
-      "version": "3.10.0",
-      "port-version": 0
-    },
-    {
       "git-tree": "a871a9d0c7187960052099119854369e854c3e50",
       "version": "3.10.0",
       "port-version": 0

--- a/versions/l-/libharu.json
+++ b/versions/l-/libharu.json
@@ -16,11 +16,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "bfeaf0d13fce9156ac216daa37a2c945290fc0ed",
-      "version-date": "2017-08-15",
-      "port-version": 11
-    },
-    {
       "git-tree": "312f4b697d2f46818c218e270bd447cdeb76322c",
       "version-string": "2017-08-15",
       "port-version": 10

--- a/versions/l-/libopensp.json
+++ b/versions/l-/libopensp.json
@@ -6,7 +6,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "4b7d728266ee8b4e03f27a619cbf9efc9484cbb6",
+      "git-tree": "c52391221569480b2e639b0e07a9e809e7711320",
       "version": "1.5.2",
       "port-version": 0
     }

--- a/versions/m-/minizip.json
+++ b/versions/m-/minizip.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "65a32bfac58033a215e271db94d5e022fce816e3",
-      "version-semver": "1.2.12",
-      "port-version": 0
-    },
-    {
       "git-tree": "528703ed8d2b78aeaa55695765535efafa24540b",
       "version-semver": "1.2.11",
       "port-version": 11

--- a/versions/s-/smf.json
+++ b/versions/s-/smf.json
@@ -4,11 +4,6 @@
       "git-tree": "a3c982437f774a6d7d18552556c00d8cfb0f3a2c",
       "version": "0.1.1",
       "port-version": 0
-    },
-    {
-      "git-tree": "6cd06f8a59de4a2e89f0180c650c94cf1f739c41",
-      "version": "0.1.0",
-      "port-version": 0
     }
   ]
 }

--- a/versions/v-/vlpp.json
+++ b/versions/v-/vlpp.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "d593e711f4b1ee56e84b9cfe4fab3bcc79fc602e",
-      "version": "0.11.0.0",
-      "port-version": 4
-    },
-    {
       "git-tree": "b4f56db04c13b5bf335e4e5939617596e15e89ac",
       "version": "0.11.0.0",
       "port-version": 3

--- a/versions/v-/vulkan-headers.json
+++ b/versions/v-/vulkan-headers.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "210cfaec79a27c7f7f4da9664b4f994ca388e89d",
-      "version": "1.3.233",
-      "port-version": 0
-    },
-    {
       "git-tree": "91d99bf9fe3492ffda0fbb13befda47b00ae388a",
       "version": "1.3.224",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  While working on [vcpkg.link](https://vcpkg.link/), I realized that some ports' versions point to invalid git trees. Therefore, this PR fixes these different issues.

  In order to find these invalid git trees, it is possible to check the output of the `git ls-tree` command. For example, the duplicate `sdl2` `3.10.0#0` has a git tree of `965c440d8611528f1069a2a494f11da420110408` and running the command produces the following output:
  
  ```bash
  $ git ls-tree 965c440d8611528f1069a2a494f11da420110408
  fatal: not a tree object
  ```

  This is incorrect as we should be able to retrieve the git tree containing all the files as the working `3.10.0#0` version entry:
  
  ```bash
  $ git ls-tree a871a9d0c7187960052099119854369e854c3e50
  100644 blob 63ba1818e98160d2f040c801aa16d0453d40e010	portfile.cmake
  100644 blob 92b5a87baee9670140ba5bcb032453d399405d16	vcpkg.json
  ```

  It is also possible to directly see the content of a file in a given tree by using `git show`
  
  ```bash
  $ git show a871a9d0c7187960052099119854369e854c3e50:vcpkg.json
  ```

  When updating git refs, since `./vcpkg x-ci-verify-versions --verify-git-trees` validates that it links to a matching manifest or control file with the given package version and port version, we have to either find an existing tree with the right version or remove the invalid entry. In this PR, it was only possible to reverse the changes for `libopensp` and invalid versions has been removed for `entt`, `libharu`, `minizip`, `smf`, `vlpp` and `vulkan-headers`.
 
  Semi-related to this PR, https://github.com/microsoft/vcpkg/issues/27451 suggests using `git blame` in order to get the history of a port. While changing the file would alter this history, using `git blame` already doesn't provide any data before the introduction of the versions files. In other words, vcpkg does not and should not rely on `git blame` for simulating this functionality.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Support was not changed in this PR

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  N/A

  The output of `./vcpkg x-ci-verify-versions --verify-git-trees` now only show unknown errors (https://github.com/microsoft/vcpkg/pull/24277)
  - FAIL: abseil
  ```
  Error: While reading versions for port abseil from file: ./vcpkg/versions/a-/abseil.json
       While validating version: 2020-03-03#7.
       While trying to load port from: 28fa609b06eec70bb06e61891e94b94f35f7d06e:vcpkg.json
       Found the following error(s):
  ```
  - FAIL: blend2d
  ```
  Error: While reading versions for port blend2d from file: ./vcpkg/versions/b-/blend2d.json
       While validating version: beta_2020-07-31.
       While trying to load port from: ffce764b880d8cc24e3b00328aa3861f15bae91d:vcpkg.json
       Found the following error(s):
  ```
  - FAIL: libwebp
  ```
  Error: While reading versions for port libwebp from file: ./vcpkg/versions/l-/libwebp.json
       While validating version: 1.1.0.
       While trying to load port from: a05e0de81085231df86f6902aba1e0a364e2ca7b:CONTROL
       Found the following error(s):
          a05e0de81085231df86f6902aba1e0a364e2ca7b:CONTROL:1:94: error: invalid character in feature name (must be lowercase, digits, '-', or '*')
       on expression: libwebp[anim, gif2webp, img2webp, info, mux, nearlossless, simd, cwebp, dwebp], libwebp[vwebp_sdl] (!osx), libwebp[extras] (!osx)
   ```
