### PR TITLE
[rocksdb] update to 7.8.3

### DIFF
--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -3,9 +3,9 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb
-  REF eb9a80fe1f18017b4d7f4084e8f2554f12234822 # v7.7.3
-  SHA512 6606a18a75c0794bc962b10c22aab9ae44e426b127972f2cb4b4d52a34f52181a0c66007fc17a5d1ee4d43de4c490b3754d805c6f7d02c280196a60d7a14dd2f
-  HEAD_REF master
+  REF bf2c335184de16a3cc1787fa97ef9f22f7114238 # v7.8.3
+  SHA512 436ab1f16ddc931267d45a49449efd25cd9e11b340fa8bdb1c89f9a269b0e2479e3c9cfebdf35c0acf7bc60d090d23c8d131a74769891fe4192cfcdabe0563a1
+  HEAD_REF main
   PATCHES
     0002-only-build-one-flavor.patch
     0003-use-find-package.patch

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rocksdb",
-  "version": "7.7.3",
-  "port-version": 1,
+  "version": "7.8.3",
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6681,8 +6681,8 @@
       "port-version": 1
     },
     "rocksdb": {
-      "baseline": "7.7.3",
-      "port-version": 1
+      "baseline": "7.8.3",
+      "port-version": 0
     },
     "rpclib": {
       "baseline": "2.3.0",

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "216ddcf58e82ef42dd259ee9f60a63c6e2c38324",
+      "version": "7.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "75a06574e71a8183f4ebce319c7cc23708cda756",
       "version": "7.7.3",
       "port-version": 1


### PR DESCRIPTION
- Update the rocksdb port to new upstream release 7.8.3.
- Update the `HEAD_REF` to main since master is now a stale branch upstream.

