### PR TITLE
[boost-vcpkg-helpers] Fix incorrect license

### DIFF
--- a/ports/boost-vcpkg-helpers/LICENSE.txt
+++ b/ports/boost-vcpkg-helpers/LICENSE.txt
@@ -1,0 +1,23 @@
+Copyright (c) Microsoft Corporation
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ports/boost-vcpkg-helpers/boost-modular-headers.cmake
+++ b/ports/boost-vcpkg-helpers/boost-modular-headers.cmake
@@ -7,14 +7,19 @@ function(boost_modular_headers)
 
     message(STATUS "Copying headers")
     file(
-        COPY ${_bm_SOURCE_PATH}/include/boost
-        DESTINATION ${CURRENT_PACKAGES_DIR}/include
+        COPY "${_bm_SOURCE_PATH}/include/boost"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/include"
     )
     message(STATUS "Copying headers done")
 
     file(INSTALL
-        ${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/usage
-        ${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/copyright
-        DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+        "${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/usage"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+    )
+    
+    file(INSTALL
+        "${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/boost_LICENSE_1_0.txt"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+        RENAME copyright
     )
 endfunction()

--- a/ports/boost-vcpkg-helpers/portfile.cmake
+++ b/ports/boost-vcpkg-helpers/portfile.cmake
@@ -1,17 +1,17 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-
-set(BOOST_VERSION 1.81.0)
-
-file(INSTALL
-    ${CMAKE_CURRENT_LIST_DIR}/boost-modular-headers.cmake
-    ${CMAKE_CURRENT_LIST_DIR}/usage
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
-)
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
 vcpkg_download_distfile(LICENSE
-    URLS "https://raw.githubusercontent.com/boostorg/boost/boost-${BOOST_VERSION}/LICENSE_1_0.txt"
+    URLS "https://raw.githubusercontent.com/boostorg/boost/boost-${VERSION}/LICENSE_1_0.txt"
     FILENAME "boost_LICENSE_1_0.txt"
     SHA512 d6078467835dba8932314c1c1e945569a64b065474d7aced27c9a7acc391d52e9f234138ed9f1aa9cd576f25f12f557e0b733c14891d42c16ecdc4a7bd4d60b8
 )
 
-file(INSTALL ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL
+    "${CMAKE_CURRENT_LIST_DIR}/boost-modular-headers.cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/usage"
+    "${LICENSE}"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+vcpkg_install_copyright(FILE_LIST "${CMAKE_CURRENT_LIST_DIR}/LICENSE.txt")

--- a/ports/boost-vcpkg-helpers/vcpkg.json
+++ b/ports/boost-vcpkg-helpers/vcpkg.json
@@ -2,6 +2,7 @@
   "$comment": "When changing this file also update and run scripts/boost/generate-ports.ps1",
   "name": "boost-vcpkg-helpers",
   "version": "1.81.0",
+  "port-version": 1,
   "description": "Internal vcpkg port used to modularize Boost",
   "license": "MIT",
   "dependencies": [

--- a/versions/b-/boost-vcpkg-helpers.json
+++ b/versions/b-/boost-vcpkg-helpers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a92c9cc61d9cb949caea1880309fcb3d1d79a7c",
+      "version": "1.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b753df924076c5013c5fd5298a05995bc2fd5ce9",
       "version": "1.81.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1150,7 +1150,7 @@
     },
     "boost-vcpkg-helpers": {
       "baseline": "1.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-vmd": {
       "baseline": "1.81.0",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #27067, add MIT license file for `boost-vcpkg-helpers`.