### PR TITLE
[cpptoml] Add cmake config to the installation

### DIFF
--- a/ports/cpptoml/portfile.cmake
+++ b/ports/cpptoml/portfile.cmake
@@ -1,14 +1,23 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO skystrife/cpptoml
-	
+
 	REF fededad7169e538ca47e11a9ee9251bc361a9a65
-	SHA512 2ec50f4585bca33bb343170470048a7d7e7902f1ffa5709cf84ddf9f53a899ff1cc9ffa49e059f6dad93d13823c4d2661bc8109e4356078cdbdfef1a2be6a622 
-	
+	SHA512 2ec50f4585bca33bb343170470048a7d7e7902f1ffa5709cf84ddf9f53a899ff1cc9ffa49e059f6dad93d13823c4d2661bc8109e4356078cdbdfef1a2be6a622
+
     HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR} FILES_MATCHING PATTERN "*.h")
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCPPTOML_BUILD_EXAMPLES=OFF
+)
 
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/cpptoml RENAME copyright)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cpptoml/vcpkg.json
+++ b/ports/cpptoml/vcpkg.json
@@ -3,6 +3,7 @@
   "version-string": "v0.1.1",
   "port-version": 2,
   "description": "A header-only library for parsing TOML configuration files.",
+  "homepage": "https://github.com/skystrife/cpptoml",
   "license": "MIT",
   "dependencies": [
     {

--- a/ports/cpptoml/vcpkg.json
+++ b/ports/cpptoml/vcpkg.json
@@ -1,6 +1,17 @@
 {
   "name": "cpptoml",
   "version-string": "v0.1.1",
-  "port-version": 1,
-  "description": "A header-only library for parsing TOML configuration files."
+  "port-version": 2,
+  "description": "A header-only library for parsing TOML configuration files.",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1694,7 +1694,7 @@
     },
     "cpptoml": {
       "baseline": "v0.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "cppunit": {
       "baseline": "1.15.1",

--- a/versions/c-/cpptoml.json
+++ b/versions/c-/cpptoml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aa55a22d74b28a95fa0130a7629e2b2a6a353621",
+      "git-tree": "56b510542b03ac901331cc1d074c140ff7aaaad1",
       "version-string": "v0.1.1",
       "port-version": 2
     },

--- a/versions/c-/cpptoml.json
+++ b/versions/c-/cpptoml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa55a22d74b28a95fa0130a7629e2b2a6a353621",
+      "version-string": "v0.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "f99a8c54489e45f171c05fa68d75f8cf5f6103cb",
       "version-string": "v0.1.1",
       "port-version": 1


### PR DESCRIPTION
There is no cmake configuration included in the current cpptoml package. This PR fixes the problem.

- #### What does your PR fix?
  This fix adds cmake configuration to the installation

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
