### PR TITLE
[`wayland`,`wayland-protocols`] Add `force-build` feature 💪

### DIFF
--- a/ports/wayland-protocols/portfile.cmake
+++ b/ports/wayland-protocols/portfile.cmake
@@ -1,10 +1,19 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
-if(NOT X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "force-build" FORCE_BUILD
+)
+
+if(NOT X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS AND NOT FORCE_BUILD)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 else()
+
+if (NOT FORCE_BUILD OR NOT X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES)
+    message(FATAL_ERROR "To build wayland libraries the `force-build` feature must be enabled and the X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES triplet variable must be set.")
+endif()
 
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org

--- a/ports/wayland-protocols/vcpkg.json
+++ b/ports/wayland-protocols/vcpkg.json
@@ -1,10 +1,27 @@
 {
   "name": "wayland-protocols",
   "version": "1.31",
+  "port-version": 1,
   "description": "wayland-protocols contains Wayland protocols that add functionality not available in the Wayland core protocol.",
   "homepage": "https://wayland.freedesktop.org",
   "license": "MIT",
   "dependencies": [
     "wayland"
-  ]
+  ],
+  "features": {
+    "force-build": {
+      "description": [
+        "Build wayland libraries instead of depending on system ones.",
+        "Requires triplet variable X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES to be set."
+      ],
+      "dependencies": [
+        {
+          "name": "wayland",
+          "features": [
+            "force-build"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/ports/wayland/portfile.cmake
+++ b/ports/wayland/portfile.cmake
@@ -3,6 +3,15 @@ if(NOT X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 else()
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "force-build" FORCE_BUILD
+)
+
+if (NOT FORCE_BUILD OR NOT X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES)
+    message(FATAL_ERROR "To build wayland libraries the `force-build` feature must be enabled and the X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES triplet variable must be set.")
+endif()
+
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/wayland/portfile.cmake
+++ b/ports/wayland/portfile.cmake
@@ -1,12 +1,13 @@
-if(NOT X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
-    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES")
-    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
-
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         "force-build" FORCE_BUILD
 )
+
+if(NOT X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS AND NOT FORCE_BUILD)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
 
 if (NOT FORCE_BUILD OR NOT X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES)
     message(FATAL_ERROR "To build wayland libraries the `force-build` feature must be enabled and the X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES triplet variable must be set.")

--- a/ports/wayland/vcpkg.json
+++ b/ports/wayland/vcpkg.json
@@ -1,17 +1,26 @@
 {
   "name": "wayland",
   "version": "1.21.0",
+  "port-version": 1,
   "description": "Core Wayland window system code and protocol",
   "homepage": "https://wayland.freedesktop.org",
   "license": "MIT",
   "supports": "!(windows | osx)",
-  "dependencies": [
-    "expat",
-    "libffi",
-    "libxml2",
-    {
-      "name": "vcpkg-tool-meson",
-      "host": true
+  "features": {
+    "force-build": {
+      "description": [
+        "Build wayland libraries instead of depending on system ones.",
+        "Requires triplet variable X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES to be set."
+      ],
+      "dependencies": [
+        "expat",
+        "libffi",
+        "libxml2",
+        {
+          "name": "vcpkg-tool-meson",
+          "host": true
+        }
+      ]
     }
-  ]
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8006,7 +8006,7 @@
     },
     "wayland": {
       "baseline": "1.21.0",
-      "port-version": 0
+      "port-version": 1
     },
     "wayland-protocols": {
       "baseline": "1.31",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8010,7 +8010,7 @@
     },
     "wayland-protocols": {
       "baseline": "1.31",
-      "port-version": 0
+      "port-version": 1
     },
     "websocketpp": {
       "baseline": "0.8.2",

--- a/versions/w-/wayland-protocols.json
+++ b/versions/w-/wayland-protocols.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f541a93fca9beb61d50adbcfc375b746997cd7c",
+      "version": "1.31",
+      "port-version": 1
+    },
+    {
       "git-tree": "a47f6381ef380391595319d483f3e81098fce826",
       "version": "1.31",
       "port-version": 0

--- a/versions/w-/wayland.json
+++ b/versions/w-/wayland.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1878d131f42b67b0d337d8dd30243f90da9dfb48",
+      "git-tree": "7a320b0e7a8409b2a369eaf7b613bfc738835cc5",
       "version": "1.21.0",
       "port-version": 1
     },

--- a/versions/w-/wayland.json
+++ b/versions/w-/wayland.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1878d131f42b67b0d337d8dd30243f90da9dfb48",
+      "version": "1.21.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "638381423adec9c24b18a622ef02d1f75f102428",
       "version": "1.21.0",
       "port-version": 0


### PR DESCRIPTION
This PR removes `wayland`'s dependencies on the empty-package path. 

In order to force the wayland libraries to be built the `force-build` feature must be enabled in addition to the `X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES` triplet variable.