### PR TITLE
[vcpkg baseline][monkeys-audio] Fixing error C2471 and error C1090

### DIFF
--- a/ports/monkeys-audio/fix-C2471.patch
+++ b/ports/monkeys-audio/fix-C2471.patch
@@ -1,0 +1,13 @@
+diff --git a/Source/Projects/VS2019/MACDll/MACDll.vcxproj b/Source/Projects/VS2019/MACDll/MACDll.vcxproj
+index 4dfa820..7ac4bce 100644
+--- a/Source/Projects/VS2019/MACDll/MACDll.vcxproj
++++ b/Source/Projects/VS2019/MACDll/MACDll.vcxproj
+@@ -108,7 +108,7 @@
+       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
+       <PrecompiledHeader>Use</PrecompiledHeader>
+       <WarningLevel>Level3</WarningLevel>
+-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
++      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+     </ClCompile>
+     <ResourceCompile>
+       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/ports/monkeys-audio/portfile.cmake
+++ b/ports/monkeys-audio/portfile.cmake
@@ -9,18 +9,19 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 d3b5a10574dde1ea90578959378b87f8a8c94b3cc7198bc51b86f7128d66117d706c191d56a699dce0c2a53b7722e0893cb614f96f9ad725a266a871da587fd4
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     NO_REMOVE_ONE_LEVEL
     PATCHES
         fix-project-config.patch
         remove-certificate-step.patch
+        fix-C2471.patch
 )
 
 file(REMOVE_RECURSE
-    ${SOURCE_PATH}/Shared/32
-    ${SOURCE_PATH}/Shared/64
+    "${SOURCE_PATH}/Shared/32"
+    "${SOURCE_PATH}/Shared/64"
 )
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
@@ -33,39 +34,39 @@ endif()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     vcpkg_install_msbuild(
-        SOURCE_PATH ${SOURCE_PATH}
-        PROJECT_SUBPATH Source/Projects/VS2019/MACDll/MACDll.vcxproj
+        SOURCE_PATH "${SOURCE_PATH}"
+        PROJECT_SUBPATH "Source/Projects/VS2019/MACDll/MACDll.vcxproj"
         PLATFORM ${PLATFORM}
     )
 else()
     vcpkg_install_msbuild(
-        SOURCE_PATH ${SOURCE_PATH}
-        PROJECT_SUBPATH Source/Projects/VS2019/MACLib/MACLib.vcxproj
+        SOURCE_PATH "${SOURCE_PATH}"
+        PROJECT_SUBPATH "Source/Projects/VS2019/MACLib/MACLib.vcxproj"
         PLATFORM ${PLATFORM}
     )
 endif()
 
 if ("tools" IN_LIST FEATURES)
     vcpkg_install_msbuild(
-        SOURCE_PATH ${SOURCE_PATH}
-        PROJECT_SUBPATH Source/Projects/VS2019/Console/Console.vcxproj
+        SOURCE_PATH "${SOURCE_PATH}"
+        PROJECT_SUBPATH "Source/Projects/VS2019/Console/Console.vcxproj"
         PLATFORM ${PLATFORM}
     )
 
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/Console.lib ${CURRENT_PACKAGES_DIR}/debug/lib/Console.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/tools/monkeys-audio/Console.exe ${CURRENT_PACKAGES_DIR}/tools/monkeys-audio/mac.exe)
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/Console.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/Console.lib")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/tools/monkeys-audio/Console.exe" "${CURRENT_PACKAGES_DIR}/tools/monkeys-audio/mac.exe")
 
-    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 endif()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/MACLib.lib ${CURRENT_PACKAGES_DIR}/debug/lib/MACLib.lib)
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/MACLib.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/MACLib.lib")
 endif()
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/include)
-file(COPY           ${SOURCE_PATH}/Shared/
-     DESTINATION    ${CURRENT_PACKAGES_DIR}/include/monkeys-audio
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include")
+file(COPY           "${SOURCE_PATH}/Shared/"
+     DESTINATION    "${CURRENT_PACKAGES_DIR}/include/monkeys-audio"
      FILES_MATCHING PATTERN "*.h")
-file(REMOVE         ${CURRENT_PACKAGES_DIR}/include/monkeys-audio/MACDll.h)
+file(REMOVE         "${CURRENT_PACKAGES_DIR}/include/monkeys-audio/MACDll.h")
 
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/license DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${CMAKE_CURRENT_LIST_DIR}/license")

--- a/ports/monkeys-audio/portfile.cmake
+++ b/ports/monkeys-audio/portfile.cmake
@@ -55,8 +55,6 @@ if ("tools" IN_LIST FEATURES)
 
     file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/Console.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/Console.lib")
     file(RENAME "${CURRENT_PACKAGES_DIR}/tools/monkeys-audio/Console.exe" "${CURRENT_PACKAGES_DIR}/tools/monkeys-audio/mac.exe")
-
-    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 endif()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/monkeys-audio/vcpkg.json
+++ b/ports/monkeys-audio/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "monkeys-audio",
   "version": "5.70",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "Monkey's Audio is an excellent audio compression tool which has multiple advantages over traditional methods.",
     "Audio files compressed with it end with .ape extension."
   ],
   "homepage": "https://monkeysaudio.com",
+  "license": null,
   "supports": "!(uwp | osx | linux)",
   "features": {
     "tools": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4990,7 +4990,7 @@
     },
     "monkeys-audio": {
       "baseline": "5.70",
-      "port-version": 2
+      "port-version": 3
     },
     "moos-core": {
       "baseline": "10.4.0",

--- a/versions/m-/monkeys-audio.json
+++ b/versions/m-/monkeys-audio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a8d61dcf5bb65df20756ed84ca1dfe8cd9fa407",
+      "version": "5.70",
+      "port-version": 3
+    },
+    {
       "git-tree": "6dbdeec6bf1752114f81a6ad09c85d046dc2ca3b",
       "version": "5.70",
       "port-version": 2

--- a/versions/m-/monkeys-audio.json
+++ b/versions/m-/monkeys-audio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5a8d61dcf5bb65df20756ed84ca1dfe8cd9fa407",
+      "git-tree": "029d9c14ce64feb48e15e8cd11b1a3123d016c62",
       "version": "5.70",
       "port-version": 3
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  In a [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=82967&view=logs&j=878666d5-db33-5b27-9e7d-b0c7ee352005&t=dc897974-8f7e-5107-e5db-0a01be8e9d4f) testing, `monkeys-audio:x86-windows` install failed with following errors:
  ```
  14.34.31933\atlmfc\include\afx.inl : error C2471: cannot update program database 
  Windows Kits\10\Include\10.0.22000.0\um\shellapi.h : error C2471: cannot update program database
  Source\Shared\WAVInfoDialog.cpp(158,1): error C2471: cannot update program database '???'
  Windows Kits\10\Include\10.0.22000.0\um\propsys.h(803,1): fatal  error C1090: PDB API call failed, error code '23': (0x00000006)
  ```
  For fixing this issue, I used /Z7 option instead of /ZI option.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `Support !(uwp | osx | linux)`, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
