### PR TITLE
[hunspell] Update hunspell in ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -335,7 +335,6 @@ healpix:arm-uwp=fail
 healpix:x64-osx=fail
 hpx:x64-windows-static=fail
 hpx:arm64-windows=fail
-hunspell:x64-windows-static-md=fail
 ideviceinstaller:x64-windows-static-md=fail
 idevicerestore:x64-linux=fail
 idevicerestore:x64-osx=fail


### PR DESCRIPTION
`hunspell:x64-windows-static-md=fail` was added by https://github.com/microsoft/vcpkg/pull/18037 due to the following post-check problem:
```
-- Performing post-build validation
Invalid crt linkage. Expected Debug,Dynamic, but the following libs had:

    E:\vcpkg\packages\hunspell_x64-windows-static-md\debug\lib\libhunspell.lib: Debug,Static

To inspect the lib files, use:
    dumpbin.exe /directives mylibfile.lib
Invalid crt linkage. Expected Release,Dynamic, but the following libs had:

    E:\vcpkg\packages\hunspell_x64-windows-static-md\lib\libhunspell.lib: Release,Static

To inspect the lib files, use:
    dumpbin.exe /directives mylibfile.lib
Found 2 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile:
    E:\vcpkg\ports\hunspell\portfile.cmake
-- Performing post-build validation done
```

Now this post-build error is fixed by https://github.com/microsoft/vcpkg/pull/28607.

The purpose of this PR is to remove `hunspell:x64-windows-static-md=fail` in `ci.baseline.txt`.