### PR TITLE
[cppwinrt] update to 2.0.221121.5

### DIFF
--- a/ports/cppwinrt/portfile.cmake
+++ b/ports/cppwinrt/portfile.cmake
@@ -1,8 +1,8 @@
-set(CPPWINRT_VERSION 2.0.221121.5)
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.nuget.org/api/v2/package/Microsoft.Windows.CppWinRT/${CPPWINRT_VERSION}"
-    FILENAME "cppwinrt.${CPPWINRT_VERSION}.zip"
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.Windows.CppWinRT/${VERSION}"
+    FILENAME "cppwinrt.${VERSION}.zip"
     SHA512 0a5a46bf2508ee396861b810a2196e694f351385700c267cb6637dcbb966a4017703020378289aebb50c508cf082c9be9b7f4c756fd757d177ebd74480b7d13e
 )
 

--- a/ports/cppwinrt/portfile.cmake
+++ b/ports/cppwinrt/portfile.cmake
@@ -1,9 +1,9 @@
-set(CPPWINRT_VERSION 2.0.220929.3)
+set(CPPWINRT_VERSION 2.0.221121.5)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Windows.CppWinRT/${CPPWINRT_VERSION}"
     FILENAME "cppwinrt.${CPPWINRT_VERSION}.zip"
-    SHA512 be15d8aab83ee56b4ae45782c87f5e38af6e07c2b468aea157e32b8b5289c1084e955f4d8237f8d9f1ebb4e36564be913b274210f535056fa6d773c8e0cb986b
+    SHA512 0a5a46bf2508ee396861b810a2196e694f351385700c267cb6637dcbb966a4017703020378289aebb50c508cf082c9be9b7f4c756fd757d177ebd74480b7d13e
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/cppwinrt/portfile.cmake
+++ b/ports/cppwinrt/portfile.cmake
@@ -6,9 +6,9 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 0a5a46bf2508ee396861b810a2196e694f351385700c267cb6637dcbb966a4017703020378289aebb50c508cf082c9be9b7f4c756fd757d177ebd74480b7d13e
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH src
-    ARCHIVE ${ARCHIVE}
+vcpkg_extract_source_archive(
+    src
+    ARCHIVE "${ARCHIVE}"
     NO_REMOVE_ONE_LEVEL
 )
 

--- a/ports/cppwinrt/vcpkg.json
+++ b/ports/cppwinrt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppwinrt",
-  "version": "2.0.220929.3",
+  "version": "2.0.221121.5",
   "description": "C++/WinRT is a standard C++ language projection for the Windows Runtime.",
   "homepage": "https://github.com/microsoft/cppwinrt",
   "documentation": "https://docs.microsoft.com/windows/uwp/cpp-and-winrt-apis/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1705,7 +1705,7 @@
       "port-version": 3
     },
     "cppwinrt": {
-      "baseline": "2.0.220929.3",
+      "baseline": "2.0.221121.5",
       "port-version": 0
     },
     "cppxaml": {

--- a/versions/c-/cppwinrt.json
+++ b/versions/c-/cppwinrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "075b55fa107d8fa25e46be03a38d0edc74e6c432",
+      "version": "2.0.221121.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "ba79ee15a44c311721836b535804423506cbcf5d",
       "version": "2.0.220929.3",
       "port-version": 0

--- a/versions/c-/cppwinrt.json
+++ b/versions/c-/cppwinrt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "075b55fa107d8fa25e46be03a38d0edc74e6c432",
+      "git-tree": "f3ad6ba947b35fd22a9be24e98b919033f365a45",
       "version": "2.0.221121.5",
       "port-version": 0
     },

--- a/versions/c-/cppwinrt.json
+++ b/versions/c-/cppwinrt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3ad6ba947b35fd22a9be24e98b919033f365a45",
+      "git-tree": "1d3deb9b47938422fb8f885f19a677ff51a4b6bc",
       "version": "2.0.221121.5",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/23249
  Note: Since PR https://github.com/microsoft/vcpkg/pull/24967, port `cppwinrt` is no longer an empty port. So, start updating to the latest version `2.0.221121.5` https://www.nuget.org/packages/Microsoft.Windows.CppWinRT

No feature needs to test.