### PR TITLE
[tracy] Fix imgui search path for Linux build

### DIFF
--- a/ports/tracy/003-fix-imgui-path.patch
+++ b/ports/tracy/003-fix-imgui-path.patch
@@ -1,0 +1,13 @@
+diff --git a/profiler/build/unix/build.mk b/profiler/build/unix/build.mk
+index 24765f1a..dc2923c8 100644
+--- a/profiler/build/unix/build.mk
++++ b/profiler/build/unix/build.mk
+@@ -1,7 +1,7 @@
+ CFLAGS +=
+ CXXFLAGS := $(CFLAGS) -std=c++17
+ DEFINES += -DIMGUI_ENABLE_FREETYPE
+-INCLUDES := $(shell pkg-config --cflags glfw3 freetype2 capstone) -I../../../imgui
++INCLUDES := -I../../../imgui $(shell pkg-config --cflags glfw3 freetype2 capstone)
+ LIBS := $(shell pkg-config --libs glfw3 freetype2 capstone) -lpthread -ldl
+ 
+ PROJECT := Tracy

--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
     PATCHES
         001-fix-vcxproj-vcpkg.patch
         002-fix-capstone-5.patch
+        003-fix-imgui-path.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tracy",
   "version-semver": "0.9.0",
+  "port-version": 1,
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7630,7 +7630,7 @@
     },
     "tracy": {
       "baseline": "0.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "transwarp": {
       "baseline": "2.2.2",

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed78af871d0cb41933e62e1daf455ca02453139d",
+      "version-semver": "0.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d7c6276fc6867dd978b2e49047027da3466d7ef3",
       "version-semver": "0.9.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**
Tracy package has its own copy of imgui library, which version can be different from the imgui version available as vcpkg port; in case when we build Tracy on Linux with gui-tools feature enabled and imgui is already installed through vcpkg, include path to vcpkg version of imgui appears earlier than include path to tracy-local copy, and this leads to multiple compilation errors. The proposed solution is to patch ordering of include paths.

- #### What does your PR fix?
  Fixes linux build of tracy package with gui-tools feature enabled

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Linux, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  N/A

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
