### PR TITLE
[opengl-registry,vcpkg-spdx] Get missing license info from SPDX

### DIFF
--- a/ports/opengl-registry/portfile.cmake
+++ b/ports/opengl-registry/portfile.cmake
@@ -19,13 +19,6 @@ file(COPY
   DESTINATION "${CURRENT_PACKAGES_DIR}/share/opengl"
 )
 
-# Using the Makefile because it is the smallest file with a complete copy of the license text
-file(
-  INSTALL "${SOURCE_PATH}/xml/Makefile"
-  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-  RENAME copyright
-)
-
 # pc layout from cygwin (consumed in xserver!)
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/pkgconfig/khronos-opengl-registry.pc" [=[
 prefix=${pcfiledir}/../..
@@ -35,3 +28,16 @@ Name: khronos-opengl-registry
 Description: Khronos OpenGL registry
 Version: git4594c03239fb76580bc5d5a13acb2a8f563f0158
 ]=])
+
+# grep -R -B1 "SPDX-License-Identifier: " packages/opengl-registry_<TRIPLET>
+vcpkg_spdx_license_file(MIT)
+vcpkg_spdx_license_file(Apache-2.0)
+vcpkg_install_copyright(FILE_LIST "${MIT}" "${Apache-2.0}" COMMENT [[
+Most headers are
+Copyright 2013-2020 The Khronos Group Inc.
+SPDX-License-Identifier: MIT
+
+Some headers are
+Copyright 2008-2020 The Khronos Group Inc.
+SPDX-License-Identifier: Apache-2.0
+]])

--- a/ports/opengl-registry/vcpkg.json
+++ b/ports/opengl-registry/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 1,
   "description": "the API and Extension registries for the OpenGL family APIs",
   "homepage": "https://github.com/KhronosGroup/OpenGL-Registry",
+  "license": "MIT AND Apache-2.0",
   "dependencies": [
     "egl-registry",
     {

--- a/ports/opengl-registry/vcpkg.json
+++ b/ports/opengl-registry/vcpkg.json
@@ -1,9 +1,14 @@
 {
   "name": "opengl-registry",
   "version-date": "2022-09-29",
+  "port-version": 1,
   "description": "the API and Extension registries for the OpenGL family APIs",
   "homepage": "https://github.com/KhronosGroup/OpenGL-Registry",
   "dependencies": [
-    "egl-registry"
+    "egl-registry",
+    {
+      "name": "vcpkg-spdx",
+      "host": true
+    }
   ]
 }

--- a/ports/vcpkg-spdx/portfile.cmake
+++ b/ports/vcpkg-spdx/portfile.cmake
@@ -1,0 +1,10 @@
+set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg_spdx_license_file.cmake"
+             "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/vcpkg_spdx_license_file.cmake")
+vcpkg_spdx_license_file(MIT)
+vcpkg_install_copyright(FILE_LIST "${MIT}")

--- a/ports/vcpkg-spdx/vcpkg-port-config.cmake
+++ b/ports/vcpkg-spdx/vcpkg-port-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/vcpkg_spdx_license_file.cmake")

--- a/ports/vcpkg-spdx/vcpkg.json
+++ b/ports/vcpkg-spdx/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "vcpkg-spdx",
+  "version": "3.19",
+  "description": "Port maintainer function for accessing SPDX License List data.",
+  "license": "MIT",
+  "supports": "native"
+}

--- a/ports/vcpkg-spdx/vcpkg_spdx_license_file.cmake
+++ b/ports/vcpkg-spdx/vcpkg_spdx_license_file.cmake
@@ -1,0 +1,45 @@
+include_guard(GLOBAL)
+
+function(z_vcpkg_spdx_license_list_data out_var)
+    set(data_version v3.19)
+    set(data_dir "${DOWNLOADS}/tools/spdx_license-list-data_${data_version}")
+    if(NOT EXISTS "${data_dir}")
+        vcpkg_download_distfile(data_archive
+            URLS "https://github.com/spdx/license-list-data/archive/refs/tags/v3.19.tar.gz"
+            FILENAME "spdx_license-list-data_${data_version}.tar.gz"
+            SHA512 23d90eece2f164a00ad710c84c3f3194bf54830b4c2b5c2739c4bf713c95ab161697850eecb20d1c3dfbdad24aa795a75bf11f9473982824fc9fe885962b7433
+        )
+        vcpkg_extract_source_archive(source_path
+            ARCHIVE "${data_archive}"
+            WORKING_DIRECTORY "${DOWNLOADS}/tools"
+        )
+        file(RENAME "${source_path}" "${data_dir}")
+    endif()
+    set("${out_var}" "${data_dir}" PARENT_SCOPE)
+endfunction()
+
+function(vcpkg_spdx_license_file out_var)
+    cmake_parse_arguments(PARSE_ARGV 1 "arg" "" "FORMAT" "NAMES")
+    if("${arg_NAMES}" STREQUAL "")
+        set(arg_NAMES "${ARGV0}")
+    endif()
+    if("${arg_FORMAT}" STREQUAL "")
+        set(arg_FORMAT "text")
+    endif()
+    set(extension_html ".html")
+    set(extension_json ".json")
+    set(extension_jsonld ".jsonld")
+    set(extension_rdfa ".html")
+    set(extension_rdfnt ".nt")
+    set(extension_rdfturtle ".ttl")
+    set(extension_rdfxml ".rdf")
+    set(extension_text ".txt")
+    if(NOT DEFINED "extension_${arg_FORMAT}")
+        message(FATAL_ERROR "Invalid format '${arg_FORMAT}'")
+    endif()
+
+    z_vcpkg_spdx_license_list_data(data_dir)
+    list(TRANSFORM arg_NAMES APPEND "${extension_${arg_FORMAT}}" OUTPUT_VARIABLE filenames)
+    find_file(file NAMES ${filenames} PATHS "${data_dir}/${arg_FORMAT}" PATH_SUFFIXES "details" "exceptions" NO_DEFAULT_PATH NO_CACHE REQUIRED)
+    set("${out_var}" "${file}" PARENT_SCOPE)
+endfunction()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5542,7 +5542,7 @@
     },
     "opengl-registry": {
       "baseline": "2022-09-29",
-      "port-version": 0
+      "port-version": 1
     },
     "openh264": {
       "baseline": "2021-03-16",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7876,6 +7876,10 @@
       "baseline": "2022-11-16",
       "port-version": 0
     },
+    "vcpkg-spdx": {
+      "baseline": "3.19",
+      "port-version": 0
+    },
     "vcpkg-tool-bazel": {
       "baseline": "5.2.0",
       "port-version": 0

--- a/versions/o-/opengl-registry.json
+++ b/versions/o-/opengl-registry.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "88eb228a1424e588036938c491f9b933c1575379",
+      "git-tree": "e241e81d2d4bd723875f9024579e1cd08227d95b",
       "version-date": "2022-09-29",
       "port-version": 1
     },

--- a/versions/o-/opengl-registry.json
+++ b/versions/o-/opengl-registry.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88eb228a1424e588036938c491f9b933c1575379",
+      "version-date": "2022-09-29",
+      "port-version": 1
+    },
+    {
       "git-tree": "3456b7358048ad983b423973eca86e19d7939bd4",
       "version-date": "2022-09-29",
       "port-version": 0

--- a/versions/v-/vcpkg-spdx.json
+++ b/versions/v-/vcpkg-spdx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0f9cee904a90fcc1518a5b26c38f69d2ad23391b",
+      "version": "3.19",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes improper `copyright` in `opengl-registry`.
  For this purpose, adds a script port / maintainer function which gives access to the SPDX license list data.
