### PR TITLE
[bgfx] Fix tools feature and android compilation

### DIFF
--- a/ports/bgfx/fix-dependencies.patch
+++ b/ports/bgfx/fix-dependencies.patch
@@ -42,3 +42,16 @@ index 9519b3a..e4b6341 100644
  # Put in a "bgfx" folder in Visual Studio
  set_target_properties( bimg PROPERTIES FOLDER "bgfx" )
 \ No newline at end of file
+diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
+index 5b5dd5d..335112f 100644
+--- a/cmake/Config.cmake.in
++++ b/cmake/Config.cmake.in
+@@ -1,5 +1,8 @@
+ @PACKAGE_INIT@
+
++find_dependency(tinyexr CONFIG REQUIRED)
++find_dependency(unofficial-libsquish CONFIG REQUIRED)
++
+ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+ get_target_property(BGFX_INCLUDE_PATH bgfx::bgfx INTERFACE_INCLUDE_DIRECTORIES)
+ list(GET BGFX_INCLUDE_PATH 0 BGFX_INCLUDE_PATH_1) # bgfx::bgfx exports include directory twice?

--- a/ports/bgfx/fix-dependencies.patch
+++ b/ports/bgfx/fix-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 14eb13d..dad3b53 100644
+index 1b0a893..c78c684 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -149,7 +149,7 @@ if( BGFX_INSTALL )
@@ -7,37 +7,69 @@ index 14eb13d..dad3b53 100644
  	)
  	if( NOT BGFX_LIBRARY_TYPE MATCHES "SHARED" )
 -		install( TARGETS bimg bx astc-encoder edtaa3 etc1 etc2 iqa squish nvtt pvrtc tinyexr
-+		install( TARGETS bimg bx astc-encoder edtaa3 etc1 etc2 iqa pvrtc
++		install( TARGETS bimg bx astc-encoder edtaa3 etc1 etc2 iqa bgfx-nvtt pvrtc
  				 EXPORT "${TARGETS_EXPORT_NAME}"
  				 LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
  				 ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+diff --git a/bimg b/bimg
+--- a/bimg
++++ b/bimg
+@@ -1 +1 @@
+-Subproject commit 85109d7cdbe775a0ab72cf38510df525d5e8d3da
++Subproject commit 85109d7cdbe775a0ab72cf38510df525d5e8d3da-dirty
+diff --git a/cmake/3rdparty/nvtt.cmake b/cmake/3rdparty/nvtt.cmake
+index 9fd7dda..995e58c 100644
+--- a/cmake/3rdparty/nvtt.cmake
++++ b/cmake/3rdparty/nvtt.cmake
+@@ -8,7 +8,7 @@
+ # You should have received a copy of the CC0 Public Domain Dedication along with
+ # this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ 
+-if( TARGET nvtt )
++if( TARGET bgfx-nvtt )
+ 	return()
+ endif()
+ 
+@@ -27,10 +27,10 @@ file(
+ 	${BIMG_DIR}/3rdparty/nvtt/*.h
+ )
+ 
+-add_library( nvtt STATIC ${NVTT_SOURCES} )
+-target_include_directories( nvtt
++add_library( bgfx-nvtt STATIC ${NVTT_SOURCES} )
++target_include_directories( bgfx-nvtt
+ 	PUBLIC
+ 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty>
+ 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/nvtt> )
+-set_target_properties( nvtt PROPERTIES FOLDER "bgfx/3rdparty" )
+-target_link_libraries( nvtt PUBLIC bx )
+\ No newline at end of file
++set_target_properties( bgfx-nvtt PROPERTIES FOLDER "bgfx/3rdparty" )
++target_link_libraries( bgfx-nvtt PUBLIC bx )
+\ No newline at end of file
 diff --git a/cmake/bimg.cmake b/cmake/bimg.cmake
-index 9519b3a..e4b6341 100644
+index 9519b3a..367d850 100644
 --- a/cmake/bimg.cmake
 +++ b/cmake/bimg.cmake
-@@ -14,10 +14,11 @@ include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/edtaa3.cmake )
+@@ -14,10 +14,10 @@ include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/edtaa3.cmake )
  include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/etc1.cmake )
  include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/etc2.cmake )
  include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/iqa.cmake )
 -include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/libsquish.cmake )
--include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/nvtt.cmake )
+ include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/nvtt.cmake )
  include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/pvrtc.cmake )
 -include( ${CMAKE_CURRENT_LIST_DIR}/3rdparty/tinyexr.cmake )
 +find_package(tinyexr CONFIG REQUIRED)
 +find_package(unofficial-libsquish CONFIG REQUIRED)
-+find_library(NVTT_LIBRARIES NAMES nvtt libnvtt PATH_SUFFIXES static)
-+find_path(NVTT_INCLUDE_DIRS NAMES nvtt.h PATH_SUFFIXES nvtt)
  
  # Ensure the directory exists
  if( NOT IS_DIRECTORY ${BIMG_DIR} )
-@@ -38,7 +38,8 @@ add_library( bimg STATIC ${BIMG_SOURCES} )
- 		$<BUILD_INTERFACE:${BIMG_DIR}/include>
+@@ -38,7 +38,7 @@ target_include_directories( bimg
  		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
  
-+target_include_directories( bimg PRIVATE ${NVTT_INCLUDE_DIRS})
  # bimg dependencies
 -target_link_libraries( bimg PUBLIC bx PRIVATE astc-encoder edtaa3 etc1 etc2 iqa squish nvtt pvrtc tinyexr )
-+target_link_libraries( bimg PUBLIC bx PRIVATE astc-encoder edtaa3 etc1 etc2 iqa unofficial::libsquish::squish ${NVTT_LIBRARIES} pvrtc unofficial::tinyexr::tinyexr )
++target_link_libraries( bimg PUBLIC bx PRIVATE astc-encoder edtaa3 etc1 etc2 iqa unofficial::libsquish::squish bgfx-nvtt pvrtc unofficial::tinyexr::tinyexr )
  
  # Put in a "bgfx" folder in Visual Studio
  set_target_properties( bimg PROPERTIES FOLDER "bgfx" )

--- a/ports/bgfx/fix-dependencies.patch
+++ b/ports/bgfx/fix-dependencies.patch
@@ -30,12 +30,7 @@ index 9519b3a..e4b6341 100644
  
  # Ensure the directory exists
  if( NOT IS_DIRECTORY ${BIMG_DIR} )
-@@ -33,12 +34,13 @@ add_library( bimg STATIC ${BIMG_SOURCES} )
- 
- # Add include directory of bimg
- target_include_directories( bimg
--	PUBLIC
-+    PUBLIC
+@@ -38,7 +38,8 @@ add_library( bimg STATIC ${BIMG_SOURCES} )
  		$<BUILD_INTERFACE:${BIMG_DIR}/include>
  		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
  

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "bgfx",
   "version": "1.118.8384-362",
-  "port-version": 1,
+  "port-version": 2,
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -9,7 +9,6 @@
   "license": "BSD-2-Clause",
   "dependencies": [
     "libsquish",
-    "nvtt",
     "tinyexr",
     {
       "name": "vcpkg-cmake",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee427b33dccae97cdb00343234c15d706162dea2",
+      "version": "1.118.8384-362",
+      "port-version": 2
+    },
+    {
       "git-tree": "9359637243730a77d0139bd3ecdf317bd16fa38e",
       "version": "1.118.8384-362",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -490,7 +490,7 @@
     },
     "bgfx": {
       "baseline": "1.118.8384-362",
-      "port-version": 1
+      "port-version": 2
     },
     "bigint": {
       "baseline": "2010.04.30",


### PR DESCRIPTION
**Describe the pull request**

This PR fixes regressions introduced in #28377 where `libsquish`, `tinyexr` and `nvtt` were removed from 3rd party of bgfx and made to use packages in vcpkg. The changes were not tested with the `bgfx[tools]` features and the android platform which was supported previously wasn't tested either.

The biggest issue is that [bgfx's 3rd party nvtt](https://github.com/bkaradzic/bimg/blob/f0ba7cb88cdd13651ca3691230c723e0c8090c45/3rdparty/nvtt/nvtt.cpp) does not match [what's in the `nvtt` package](https://github.com/castano/nvidia-texture-tools/blob/e393b6db0483f1fc41d85a6da18ec961e83ccd82/src/bc6h/zoh.cpp). They don't provide the same functions. Bgfx's is completely stripped down and with many fixes.

The #28377 PR broke a few things:

1. Installing on android
>    Error: nvtt:arm-android@2.1.2#8 is only supported on '!uwp & !arm'

2. Configuring projects
```
CMake Error at cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-linux/share/bgfx/bgfxTargets.cmake:69 (set_target_properties):
  The link interface of target "bgfx::bimg" contains:

    unofficial::libsquish::squish

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-linux/share/bgfx/bgfxConfig.cmake:27 (include)
  vcpkg/scripts/buildsystems/vcpkg.cmake:843 (_find_package)
  CMakeLists.txt:87 (find_package)

CMake Error at cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-linux/share/bgfx/bgfxTargets.cmake:69 (set_target_properties):
  The link interface of target "bgfx::bimg" contains:

    unofficial::tinyexr::tinyexr

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-linux/share/bgfx/bgfxConfig.cmake:27 (include)
  vcpkg/scripts/buildsystems/vcpkg.cmake:843 (_find_package)
  CMakeLists.txt:87 (find_package)

```

4. Compiling with the `tools` feature
```
FAILED: texturec 
: && /usr/bin/c++ -fPIC -g -rdynamic vcpkg/buildtrees/bgfx/src/25d5e8d3da-47d8177139.clean/tools/texturec/texturec.cpp.o -o texturec  libbimg.a  libastc-encoder.a  libedtaa3.a  libetc1.a  libetc2.a  libbx.a  -lrt  libiqa.a  vcpkg_installed/x64-linux/debug/lib/libsquishd.a  vcpkg_installed/x64-linux/lib/static/libnvtt.a  libpvrtc.a  vcpkg_installed/x64-linux/share/tinyexr/../../debug/lib/libtinyexr.a  -ldl && :
/usr/bin/ld: libbimg.a(image_encode.cpp.o): in function `bimg::imageEncodeFromRgba32f(bx::AllocatorI*, void*, void const*, unsigned int, unsigned int, unsigned int, bimg::TextureFormat::Enum, bimg::Quality::Enum, bx::Error*)':
vcpkg/buildtrees/bgfx/src/25d5e8d3da-47d8177139.clean/src/image_encode.cpp:272: undefined reference to `nvtt::compressBC6H(void const*, unsigned int, unsigned int, unsigned int, void*)'
```

Even with this fix, there is still a regression for the package on android. It would seem that the `tinyexr` package fails on android. This is fixed in #28670

- #### What does your PR fix?
* Removes dependency on vcpkg's nvtt.
* Fixes some issues compiling android.
* Fixes packages missing when linking with the `bgfx` package on all platforms.
* Fixes compiling the `tools` feature.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

