### PR TITLE
[tinyexr] update to 1.0.1 and fix compiling with clang on android

### DIFF
--- a/ports/tinyexr/fixtargets.patch
+++ b/ports/tinyexr/fixtargets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6d03e7e..9d2bc7f 100644
+index 6d03e7e..be416f5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -7,6 +7,20 @@ set(SAMPLE_TARGET "test_tinyexr")
@@ -37,6 +37,15 @@ index 6d03e7e..9d2bc7f 100644
  endif()
  
  add_library(${BUILD_TARGET} ${TINYEXR_SOURCES} ${TINYEXR_DEP_SOURCES})
+@@ -43,7 +54,7 @@ target_link_libraries(${BUILD_TARGET} ${TINYEXR_EXT_LIBRARIES} ${CMAKE_DL_LIBS})
+ 
+ # Increase warning level for clang.
+ IF (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-  set_source_files_properties(${TINYEXR_SOURCES} PROPERTIES COMPILE_FLAGS "-Weverything -Werror -Wno-padded -Wno-c++98-compat-pedantic -Wno-documentation -Wno-unused-member-function")
++  set_source_files_properties(${TINYEXR_SOURCES} PROPERTIES COMPILE_FLAGS "-Weverything -Wno-padded -Wno-c++98-compat-pedantic -Wno-documentation -Wno-unused-member-function")
+ ENDIF ()
+ 
+ if (TINYEXR_BUILD_SAMPLE)
 @@ -72,3 +83,32 @@ if (TINYEXR_BUILD_SAMPLE)
    endif(WIN32)
  

--- a/ports/tinyexr/fixtargets.patch
+++ b/ports/tinyexr/fixtargets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3613642..93fb6c1 100644
+index 6d03e7e..9d2bc7f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -7,6 +7,20 @@ set(SAMPLE_TARGET "test_tinyexr")
@@ -22,8 +22,22 @@ index 3613642..93fb6c1 100644
 +
  # options
  option(TINYEXR_BUILD_SAMPLE "Build a sample" ON)
+ option(TINYEXR_USE_MINIZ "Use miniz" ON)
+@@ -28,11 +42,8 @@ set(TINYEXR_SOURCES
+     )
  
-@@ -60,3 +74,20 @@ if (TINYEXR_BUILD_SAMPLE)
+ if(TINYEXR_USE_MINIZ)
+-  enable_language(C)
+-  add_library(miniz STATIC deps/miniz/miniz.c)
+-  target_include_directories(miniz PUBLIC deps/miniz)
+-  set_target_properties(miniz PROPERTIES FOLDER "deps")
+-  list(APPEND TINYEXR_EXT_LIBRARIES miniz)
++  find_package(miniz CONFIG REQUIRED)
++  list(APPEND TINYEXR_EXT_LIBRARIES miniz::miniz)
+ endif()
+ 
+ add_library(${BUILD_TARGET} ${TINYEXR_SOURCES} ${TINYEXR_DEP_SOURCES})
+@@ -72,3 +83,32 @@ if (TINYEXR_BUILD_SAMPLE)
    endif(WIN32)
  
  endif (TINYEXR_BUILD_SAMPLE)
@@ -40,7 +54,31 @@ index 3613642..93fb6c1 100644
 +)
 +
 +install(EXPORT ${BUILD_TARGET}Targets
-+  FILE ${BUILD_TARGET}Config.cmake
++  FILE ${BUILD_TARGET}Targets.cmake
 +  NAMESPACE unofficial::${BUILD_TARGET}::
 +  DESTINATION "${INSTALL_CMAKE_DIR}"
 +)
++
++include(CMakePackageConfigHelpers)
++configure_package_config_file(
++  ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
++  ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_TARGET}Config.cmake
++  INSTALL_DESTINATION "${INSTALL_CMAKE_DIR}"
++)
++
++install(
++  FILES ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_TARGET}Config.cmake
++  DESTINATION "${INSTALL_CMAKE_DIR}"
++)
+diff --git a/Config.cmake.in b/Config.cmake.in
+new file mode 100644
+index 0000000..2e33c1d
+--- /dev/null
++++ b/Config.cmake.in
+@@ -0,0 +1,6 @@
++@PACKAGE_INIT@
++
++include(CMakeFindDependencyMacro)
++find_dependency(miniz CONFIG REQUIRED)
++
++include("${CMAKE_CURRENT_LIST_DIR}/@BUILD_TARGET@Targets.cmake")

--- a/ports/tinyexr/portfile.cmake
+++ b/ports/tinyexr/portfile.cmake
@@ -3,21 +3,20 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO syoyo/tinyexr
-    REF v1.0.0
-    SHA512 5c7dc7201ea57d98505ece22161dc72c284b3db1a7993e46317254dfc42b0f0e76a59227c3cc601fd8a347f0d3aedf2e5f7d7eb9434068face94f503b94711fd
+    REF v1.0.1
+    SHA512 ba3bc09e7c2a93016b260849eb365a05fe1113c55f824767a19a20e3a6ff2a09dd686aa15094dd6c4508e68915dc8eb4a0ccc9778de73d9b55354701e7820e76
     HEAD_REF master
     PATCHES
         fixtargets.patch
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DTINYEXR_BUILD_SAMPLE=OFF
 )
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/tinyexr/vcpkg.json
+++ b/ports/tinyexr/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "tinyexr",
-  "version-string": "1.0.0",
-  "port-version": 1,
+  "version": "1.0.1",
   "description": "Library to load and save OpenEXR(.exr) images",
-  "homepage": "https://github.com/syoyo/tinyexr"
+  "homepage": "https://github.com/syoyo/tinyexr",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "miniz",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7533,8 +7533,8 @@
       "port-version": 0
     },
     "tinyexr": {
-      "baseline": "1.0.0",
-      "port-version": 1
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "tinyfiledialogs": {
       "baseline": "3.8.8",

--- a/versions/t-/tinyexr.json
+++ b/versions/t-/tinyexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e39233910425f33e3682c321813f033198bbfd0f",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "81548356751317d12ff579d7c7749d073e5d0fb6",
       "version-string": "1.0.0",
       "port-version": 1

--- a/versions/t-/tinyexr.json
+++ b/versions/t-/tinyexr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e39233910425f33e3682c321813f033198bbfd0f",
+      "git-tree": "d0381d495cb1b502e1b5ccaafb2409f75c0726a3",
       "version": "1.0.1",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

Tinyexr was failing on android using the clang compiler due to upstream warnings being treated as errors. The package is also out of date so I updated it.

I also added the dependency on miniz that the new version can use.

Android warnings:
```
   Error: vcpkg/buildtrees/tinyexr/src/v1.0.0-aa9dbdfb61.clean/tinyexr.h:2196:33: error: result of comparison 'unsigned long' > 4294967295 is always false [-Werror,-Wtautological-type-limit-compare]
    if ((source_len | *pDest_len) > 0xFFFFFFFFU) return MZ_PARAM_ERROR;
        ~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~
  Error: vcpkg/buildtrees/tinyexr/src/v1.0.0-aa9dbdfb61.clean/tinyexr.h:2404:33: error: result of comparison 'unsigned long' > 4294967295 is always false [-Werror,-Wtautological-type-limit-compare]
    if ((source_len | *pDest_len) > 0xFFFFFFFFU) return MZ_PARAM_ERROR;
        ~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~
  Error: vcpkg/buildtrees/tinyexr/src/v1.0.0-aa9dbdfb61.clean/tinyexr.h:9435:47: error: implicit conversion changes signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
        (reinterpret_cast<unsigned char *>(buf) - outPtr) +
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~  ~
  Error: vcpkg/buildtrees/tinyexr/src/v1.0.0-aa9dbdfb61.clean/tinyexr.h:12516:42: error: implicit conversion changes signedness: 'unsigned int' to 'std::__wrap_iter<unsigned char *>::difference_type' (aka 'int') [-Werror,-Wsign-conversion]
                             buf.begin() + data_len);
                                         ~ ^~~~~~~~
  Error: vcpkg/buildtrees/tinyexr/src/v1.0.0-aa9dbdfb61.clean/tinyexr.h:12546:44: error: implicit conversion changes signedness: 'unsigned int' to 'std::__wrap_iter<unsigned char *>::difference_type' (aka 'int') [-Werror,-Wsign-conversion]
                             block.begin() + data_len);
                                           ~ ^~~~~~~~
  Error: vcpkg/buildtrees/tinyexr/src/v1.0.0-aa9dbdfb61.clean/tinyexr.h:12571:44: error: implicit conversion changes signedness: 'unsigned int' to 'std::__wrap_iter<unsigned char *>::difference_type' (aka 'int') [-Werror,-Wsign-conversion]
                             block.begin() + data_len);
                                           ~ ^~~~~~~~
  Error: vcpkg/buildtrees/tinyexr/src/v1.0.0-aa9dbdfb61.clean/tinyexr.h:12599:44: error: implicit conversion changes signedness: 'unsigned int' to 'std::__wrap_iter<unsigned char *>::difference_type' (aka 'int') [-Werror,-Wsign-conversion]
                             block.begin() + data_len);
                                           ~ ^~~~~~~~
```

- #### What does your PR fix?
  Updates tinyexr to 1.0.1 and fixes compilation on android.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
