### PR TITLE
[vcpkg baseline][pangolin] Fix regressions

### DIFF
--- a/ports/pangolin/devendor-palsigslot.patch
+++ b/ports/pangolin/devendor-palsigslot.patch
@@ -1,0 +1,26 @@
+diff --git a/cmake/PangolinConfig.cmake.in b/cmake/PangolinConfig.cmake.in
+index f891e34..6fbfc7d 100644
+--- a/cmake/PangolinConfig.cmake.in
++++ b/cmake/PangolinConfig.cmake.in
+@@ -12,6 +12,7 @@ SET( Pangolin_LIBRARY      "${Pangolin_LIBRARIES}" )
+ 
+ include(CMakeFindDependencyMacro)
+ find_dependency(Eigen3)
++find_dependency(PalSigslot CONFIG)
+ 
+ if (UNIX)
+   find_dependency(Threads)
+diff --git a/components/pango_core/CMakeLists.txt b/components/pango_core/CMakeLists.txt
+index 315913d..1d1a1d0 100644
+--- a/components/pango_core/CMakeLists.txt
++++ b/components/pango_core/CMakeLists.txt
+@@ -44,6 +44,9 @@ install(DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/include"
+   DESTINATION ${CMAKE_INSTALL_PREFIX}
+ )
+ 
++find_package(PalSigslot CONFIG REQUIRED)
++target_link_libraries(${COMPONENT} PUBLIC Pal::Sigslot)
++
+ find_package(Threads QUIET)
+ if(Threads_FOUND)
+     target_link_libraries(${COMPONENT} PUBLIC Threads::Threads)

--- a/ports/pangolin/portfile.cmake
+++ b/ports/pangolin/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
     REF v0.8
     SHA512 d4ca405097e8c439a4f74495f374bc5d5e4febafcf59ee88d985a8764ed36da1753ca4a3a73476dfb74c7d92df31a99242df6e1b47c648e860eee835a6f4f434
     HEAD_REF master
+    PATCHES
+        devendor-palsigslot.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -31,6 +33,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 file(REMOVE "${SOURCE_PATH}/CMakeModules/FindGLEW.cmake")
 file(REMOVE "${SOURCE_PATH}/CMakeModules/FindFFMPEG.cmake")
+file(REMOVE_RECURSE "${SOURCE_PATH}/components/pango_core/include/sigslot")
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" MSVC_USE_STATIC_CRT)
 

--- a/ports/pangolin/portfile.cmake
+++ b/ports/pangolin/portfile.cmake
@@ -59,7 +59,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Pangolin)
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/pangolin/PangolinConfig.cmake" "SET( Pangolin_CMAKEMODULES ${SOURCE_PATH}/src/../CMakeModules )" "")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/pangolin/PangolinConfig.cmake" "Pangolin_CMAKEMODULES ${SOURCE_PATH}/" "Pangolin_CMAKEMODULES \${CMAKE_CURRENT_LIST_DIR}/")
 
 vcpkg_copy_pdbs()
 

--- a/ports/pangolin/usage
+++ b/ports/pangolin/usage
@@ -1,5 +1,4 @@
-The package pangolin is compatible with built-in CMake targets:
+pangolin provides CMake targets:
 
     find_package(Pangolin CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE pangolin)
-    target_include_directories(main PRIVATE ${Pangolin_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE ${Pangolin_LIBRARIES})

--- a/ports/pangolin/vcpkg.json
+++ b/ports/pangolin/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pangolin",
   "version": "0.8",
+  "port-version": 1,
   "description": "Lightweight GUI Library",
   "homepage": "https://github.com/stevenlovegrove/Pangolin",
   "license": "MIT",
@@ -8,6 +9,7 @@
   "dependencies": [
     "eigen3",
     "glew",
+    "palsigslot",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5718,7 +5718,7 @@
     },
     "pangolin": {
       "baseline": "0.8",
-      "port-version": 0
+      "port-version": 1
     },
     "pangomm": {
       "baseline": "2.50.1",

--- a/versions/p-/pangolin.json
+++ b/versions/p-/pangolin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b6465120255800b1cb8df8fb0a47eff4970a2b47",
+      "version": "0.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "94c1e44cce955d8e29658ed7f1db982a3a695cc3",
       "version": "0.8",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes a baseline regression due to conflict caused by vendored copy of palsigslot.
  Fixes a regression in fixup of absolute paths.
  Rectifies the usage doc.
