### PR TITLE
[kddockwidgets2] add v2 port

### DIFF
--- a/ports/kddockwidgets2/portfile.cmake
+++ b/ports/kddockwidgets2/portfile.cmake
@@ -1,0 +1,43 @@
+if(EXISTS "${CURRENT_INSTALLED_DIR}/share/kddockwidgets/copyright")
+  message(FATAL_ERROR "'${PORT}' conflicts with 'kddockwidgets'. Please remove kddockwidgets:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDAB/KDDockWidgets
+    REF 73ebd9d50643a0176f7912918e0989562cccc0f4
+    SHA512 43d75d0701d24210af4e077f594654b0d87f2b777f89f9eae0420ca8b455e3d6b44ac2953f65bc2003a460c768938fefa409e5e2bb753d60298b9324eb33bb0f
+    HEAD_REF 2.0
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" KD_STATIC)
+
+if(VCPKG_CROSSCOMPILING)
+    list(APPEND _qarg_OPTIONS -DQT_HOST_PATH=${CURRENT_HOST_INSTALLED_DIR})
+    list(APPEND _qarg_OPTIONS -DQT_HOST_PATH_CMAKE_DIR:PATH=${CURRENT_HOST_INSTALLED_DIR}/share)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${_qarg_OPTIONS}
+        -DKDDockWidgets_QT6=ON
+        -DKDDockWidgets_STATIC=${KD_STATIC}
+        -DKDDockWidgets_QTQUICK=ON
+        -DKDDockWidgets_PYTHON_BINDINGS=OFF
+        -DKDDockWidgets_EXAMPLES=OFF
+    MAYBE_UNUSED_VARIABLES
+        KDDockWidgets_QTQUICK
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/KDDockWidgets-qt6" PACKAGE_NAME "KDDockWidgets-qt6")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/kddockwidgets2/vcpkg.json
+++ b/ports/kddockwidgets2/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "kddockwidgets2",
+  "version": "2.0.0",
+  "description": "KDAB's Dock Widget Framework for Qt, v2 with better QtQuick support",
+  "homepage": "https://www.kdab.com/development-resources/qt-tools/kddockwidgets/",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "widgets"
+      ]
+    },
+    "qtdeclarative",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1259,3 +1259,13 @@ vcpkg-ci-wxwidgets:x64-windows-static-md=pass
 vcpkg-ci-wxwidgets:x64-windows-static=pass
 vcpkg-ci-wxwidgets:x64-windows=pass
 vcpkg-ci-wxwidgets:x86-windows=pass
+
+# conflicts with kddockwidgets
+kddockwidgets2:x86-windows=skip
+kddockwidgets2:x64-windows=skip
+kddockwidgets2:x64-windows-static=skip
+kddockwidgets2:x64-uwp=skip
+kddockwidgets2:arm64-windows=skip
+kddockwidgets2:x64-linux=skip
+kddockwidgets2:x64-osx=skip
+kddockwidgets2:x64-windows-static-md=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3296,6 +3296,10 @@
       "baseline": "1.5.0",
       "port-version": 0
     },
+    "kddockwidgets2": {
+      "baseline": "2.0.0",
+      "port-version": 0
+    },
     "kealib": {
       "baseline": "1.4.14",
       "port-version": 0

--- a/versions/k-/kddockwidgets2.json
+++ b/versions/k-/kddockwidgets2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "27bb2bd423624f137813e996e131e9637e023f36",
+      "version": "2.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Adds a v2 port for KDDockWidgets (https://github.com/KDAB/KDDockWidgets). The 2.0 branch is still somewhat unstable, but has better support for QtQuick/QML, so I think it's better to have both a v1 and a v2 port in vcpkg.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes