### PR TITLE
[xaudio2redist] allow static CRT

### DIFF
--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -1,5 +1,5 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.XAudio2.Redist/${VERSION}"
@@ -19,12 +19,14 @@ file(INSTALL ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT
 file(INSTALL "${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 file(INSTALL "${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
 
-if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
+if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
    file(INSTALL "${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist_md.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
    file(INSTALL "${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist_md.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+   set(lib_suffix "_md")
 else()
    file(INSTALL "${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
    file(INSTALL "${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+   set(lib_suffix "")
 endif()
 
 file(COPY "${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
@@ -32,4 +34,4 @@ file(COPY "${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/x
 
 file(INSTALL "${PACKAGE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
-configure_file("${CMAKE_CURRENT_LIST_DIR}/xaudio2redist-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" COPYONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/xaudio2redist-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" @ONLY)

--- a/ports/xaudio2redist/vcpkg.json
+++ b/ports/xaudio2redist/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "xaudio2redist",
   "version": "1.2.10",
+  "port-version": 1,
   "description": "Redistributable version of XAudio 2.9 for Windows 7 SP1 or later",
   "homepage": "https://aka.ms/XAudio2Redist",
   "documentation": "https://aka.ms/XAudio2Redist",
   "license": null,
-  "supports": "windows & !arm & !uwp & !staticcrt"
+  "supports": "windows & !arm & !uwp"
 }

--- a/ports/xaudio2redist/xaudio2redist-config.cmake.in
+++ b/ports/xaudio2redist/xaudio2redist-config.cmake.in
@@ -18,8 +18,8 @@ if (EXISTS "${_xaudio2_root_lib}")
 
    add_library(Microsoft::XApoBase STATIC IMPORTED)
    set_target_properties(Microsoft::XApoBase PROPERTIES
-      IMPORTED_LOCATION_RELEASE            "${_xaudio2_root}/lib/xapobaseredist_md.lib"
-      IMPORTED_LOCATION_DEBUG              "${_xaudio2_root}/debug/lib/xapobaseredist_md.lib"
+      IMPORTED_LOCATION_RELEASE            "${_xaudio2_root}/lib/xapobaseredist@lib_suffix@.lib"
+      IMPORTED_LOCATION_DEBUG              "${_xaudio2_root}/debug/lib/xapobaseredist@lib_suffix@.lib"
       INTERFACE_INCLUDE_DIRECTORIES        "${_xaudio2_root}/include/xaudio2redist"
       IMPORTED_CONFIGURATIONS              "Debug;Release")
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8150,7 +8150,7 @@
     },
     "xaudio2redist": {
       "baseline": "1.2.10",
-      "port-version": 0
+      "port-version": 1
     },
     "xbitmaps": {
       "baseline": "1.1.2",

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bbabce07404d10a9eec61bc9ed7115683be8a0b0",
+      "version": "1.2.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "105a0337f2d46d0c4fa55970f5da88918d818ba9",
       "version": "1.2.10",
       "port-version": 0


### PR DESCRIPTION
`vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)` was invalid since the DLL this redist bundles is build against dynamic CRT. 
Since it bundles a static library with static CRT linkage static CRT linkage is obviously allowed. 