### PR TITLE
[snappy] fix correct lib name in snappy.pc file

### DIFF
--- a/ports/snappy/snappy.pc.in
+++ b/ports/snappy/snappy.pc.in
@@ -6,5 +6,5 @@ includedir=${prefix}/include
 Name: @name@
 Description: @description@
 Version: @version@
-Libs: -L${libdir} -l@libname@
+Libs: -L${libdir} -l@name@
 Cflags: -I${includedir}

--- a/ports/snappy/vcpkg.json
+++ b/ports/snappy/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "snappy",
   "version": "1.1.9",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A fast compressor/decompressor.",
   "homepage": "https://github.com/google/snappy",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7066,7 +7066,7 @@
     },
     "snappy": {
       "baseline": "1.1.9",
-      "port-version": 3
+      "port-version": 4
     },
     "sndfile": {
       "baseline": "0",

--- a/versions/s-/snappy.json
+++ b/versions/s-/snappy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e0221e0b55bab4a662ff8ba9e3fa1f792f01724",
+      "version": "1.1.9",
+      "port-version": 4
+    },
+    {
       "git-tree": "00bd59377f162448da6b19382a7ca392b1761f22",
       "version": "1.1.9",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/28675
  Note: The lib name generated by the port is `snappy.lib`, fix the wrong lib name in the pc file.
  https://github.com/microsoft/vcpkg/blob/0f719b3fdfc36f8dd45229370a0df180fdbf68f6/ports/snappy/snappy.pc.in#L9
  
  No feature needs to test.