### PR TITLE
[vcpkg baseline][ideviceinstaller] Fixing error LNK2005: optind already defined in darknet.lib

### DIFF
--- a/ports/darknet/fix-dependence-getopt.patch
+++ b/ports/darknet/fix-dependence-getopt.patch
@@ -1,0 +1,61 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d34b8f8..a8488c6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -203,6 +203,7 @@ if(MSVC AND USE_INTEGRATED_LIBS)
+   find_package(PThreads4W REQUIRED)
+ elseif(MSVC)
+   find_package(pthreads REQUIRED)
++  find_package(unofficial-getopt-win32 REQUIRED)
+ endif()
+ if(ENABLE_OPENCV)
+   find_package(OpenCV REQUIRED)
+@@ -371,9 +372,9 @@ list(APPEND headers
+ if(NOT MSVC)
+   list(REMOVE_ITEM headers
+     ${CMAKE_CURRENT_LIST_DIR}/src/gettimeofday.h
+-    ${CMAKE_CURRENT_LIST_DIR}/src/getopt.h
+   )
+ endif()
++
+ #set(exported_headers ${headers})
+ 
+ #look for all *.c files in src folder
+@@ -391,10 +392,13 @@ list(REMOVE_ITEM sources
+ if(NOT MSVC)
+   list(REMOVE_ITEM sources
+     ${CMAKE_CURRENT_LIST_DIR}/src/gettimeofday.c
+-    ${CMAKE_CURRENT_LIST_DIR}/src/getopt.c
+   )
+ endif()
+ 
++#remove local getopt files
++list(REMOVE_ITEM headers ${CMAKE_CURRENT_LIST_DIR}/src/getopt.h)
++list(REMOVE_ITEM sources ${CMAKE_CURRENT_LIST_DIR}/src/getopt.c)
++
+ if(ENABLE_CUDA)
+   file(GLOB cuda_sources "${CMAKE_CURRENT_LIST_DIR}/src/*.cu")
+ endif()
+@@ -478,6 +482,7 @@ endif()
+ if(MSVC)
+   target_link_libraries(darknet PRIVATE PThreads_windows::PThreads_windows)
+   target_link_libraries(darknet PRIVATE wsock32)
++  target_link_libraries(dark PRIVATE unofficial::getopt-win32::getopt)
+   target_link_libraries(dark PUBLIC PThreads_windows::PThreads_windows)
+   target_link_libraries(dark PUBLIC wsock32)
+   target_link_libraries(uselib PRIVATE PThreads_windows::PThreads_windows)
+diff --git a/DarknetConfig.cmake.in b/DarknetConfig.cmake.in
+index 1221206..6bdff49 100644
+--- a/DarknetConfig.cmake.in
++++ b/DarknetConfig.cmake.in
+@@ -9,6 +9,10 @@ if(@OpenCV_FOUND@)
+   find_dependency(OpenCV)
+ endif()
+ 
++if(@unofficial-getopt-win32_FOUND@)
++  find_dependency(unofficial-getopt-win32)
++endif()
++
+ if(@ENABLE_CUDA@)
+   include(CheckLanguage)
+   check_language(CUDA)

--- a/ports/darknet/portfile.cmake
+++ b/ports/darknet/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
   REF 8a0bf84c19e38214219dbd3345f04ce778426c57
   SHA512 6253d5b498f4f6eba7fc539d5a4b4e163139f4841623f11d84760bcf1ffabe6519f85e98e3d4aeac6846313fea3b98451407134b6b6f5b91137c62d1647109d9
   HEAD_REF master
+  PATCHES fix-dependence-getopt.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -58,4 +59,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${SOURCE_PATH}/scripts/download_weights.ps1" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/scripts")
 message(STATUS "To download weight files, please go to ${CURRENT_INSTALLED_DIR}/tools/${PORT}/scripts and run ./download_weights.ps1")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/darknet/vcpkg.json
+++ b/ports/darknet/vcpkg.json
@@ -1,13 +1,17 @@
 {
   "name": "darknet",
   "version-date": "2022-03-06",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Darknet is an open source neural network framework written in C and CUDA. You only look once (YOLO) is a state-of-the-art, real-time object detection system, best example of darknet functionalities.",
   "homepage": "https://github.com/alexeyab/darknet",
   "license": null,
   "dependencies": [
     "pthreads",
     "stb",
+    {
+      "name": "getopt",
+      "platform": "windows & !mingw"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/darknet/vcpkg.json
+++ b/ports/darknet/vcpkg.json
@@ -6,12 +6,12 @@
   "homepage": "https://github.com/alexeyab/darknet",
   "license": null,
   "dependencies": [
-    "pthreads",
-    "stb",
     {
       "name": "getopt",
       "platform": "windows & !mingw"
     },
+    "pthreads",
+    "stb",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1850,7 +1850,7 @@
     },
     "darknet": {
       "baseline": "2022-03-06",
-      "port-version": 1
+      "port-version": 2
     },
     "darts-clone": {
       "baseline": "1767ab87cffe",

--- a/versions/d-/darknet.json
+++ b/versions/d-/darknet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "979891799df34103a8312038f12bb6e6b73301d5",
+      "version-date": "2022-03-06",
+      "port-version": 2
+    },
+    {
       "git-tree": "0e4e40d483fe8ff2bade4fe1b10996cf71f3089b",
       "version-date": "2022-03-06",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes `ideviceinstaller:x64-windows-static` install failed with error LNK2005: optind already defined in darknet.lib.

  This issue is a CI baseline issue from https://dev.azure.com/vcpkg/public/_build/results?buildId=83095&view=results
