### PR TITLE
[google-cloud-cpp] update to latest release (v2.6.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v2.5.0
-    SHA512 e4ead5aa91d542a81ac6405597726f2ee0c96278db2a974784110d1fb3ab4574ae3d5ae42e46a91e25f4b25bddc42395876db3406beb8ce40a9dd17e9647e7d5
+    REF v2.6.0
+    SHA512 13a3ca1ecc6e0839b3e6a7a84638270ffb0a5e013b86a5b23d58c96717e5e245c79ef13128caabe68ed646ba5db82c44436ce62a3a8960bea5a37655be515673
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.5.0",
-  "port-version": 1,
+  "version": "2.6.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2733,8 +2733,8 @@
       "port-version": 1
     },
     "google-cloud-cpp": {
-      "baseline": "2.5.0",
-      "port-version": 1
+      "baseline": "2.6.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3cf693b6f222dfea1458f2a576f6e4ff270efac2",
+      "version": "2.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c30065de0805a0b44a0f913541b4824286a053a",
       "version": "2.5.0",
       "port-version": 1


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release.

- #### What does your PR fix?
N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
N/A

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes
