### PR TITLE
[flatbuffers] update to 23.1.4

### DIFF
--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/flatbuffers
-    REF 203241ed3275625c8a25c4a1e7b86e3c0289c488 #v22.10.26
-    SHA512 b2c889aa97d039f0044133daea6c68361ab4d4bb80bd6c67d3e1f6ffd1b4175fc36a21b1ab3a75d83b0296c83d98f6e42756e01fc1193ba19a77c3e896cba212
+    REF af9ceabeef1a10c1004e2741f8c0c090ca59e5af #v23.1.4
+    SHA512 63220e37743b868b4c7c7894a8f64cbb80545feda5d7afb1223d316d9aa6c0c25670563a988971e853db68d98efb692c7d8dd402df7bff7d95db844baba57820
     HEAD_REF master
     PATCHES
         fix-uwp-build.patch

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "flatbuffers",
-  "version": "22.10.26",
-  "port-version": 1,
+  "version": "23.1.4",
   "description": [
     "Memory Efficient Serialization Library",
     "FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2377,8 +2377,8 @@
       "port-version": 0
     },
     "flatbuffers": {
-      "baseline": "22.10.26",
-      "port-version": 1
+      "baseline": "23.1.4",
+      "port-version": 0
     },
     "flecs": {
       "baseline": "3.1.0",
@@ -6060,6 +6060,10 @@
       "baseline": "2021-02-21",
       "port-version": 0
     },
+    "ptc-print": {
+      "baseline": "1.4.0",
+      "port-version": 0
+    },
     "ptex": {
       "baseline": "2.3.2",
       "port-version": 4
@@ -8431,10 +8435,6 @@
     "zziplib": {
       "baseline": "0.13.72",
       "port-version": 3
-    },
-    "ptc-print": {
-      "baseline": "1.4.0",
-      "port-version": 0
     }
   }
 }

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea66df31df93dca4ac16469f5655ac91cdd8e024",
+      "version": "23.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "fe5da09bde98af97c3c3edf1d70f4d986629fdb9",
       "version": "22.10.26",
       "port-version": 1


### PR DESCRIPTION
Fix #28659 

Update flatbuffers to the latest version 23.1.4

Note: no feature need to test