### PR TITLE
[hidapi] Update hidapi to version 0.13.1

### DIFF
--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/hidapi
-    REF hidapi-0.12.0
-    SHA512 866268927698db6fa553e000ead3c0c4b8df67ea768d36acac9c71f06f0bd8283778e90eee03f81aaa930f38dbb5719391906c7d2742b74479ffa436104f5fa4
+    REF hidapi-0.13.1
+    SHA512 07b224b9b5146caf693e6d67514fed236436ed68f38a3ada98ebf8352dfaa4e175f576902affb4b79da1bb8c9b47a1ee0831a93c7d3d210e93faee24632f7d53
     HEAD_REF master
 )
 

--- a/ports/hidapi/vcpkg.json
+++ b/ports/hidapi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hidapi",
-  "version-semver": "0.12.0",
+  "version-semver": "0.13.1",
   "description": "A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac and Windows.",
   "homepage": "https://github.com/libusb/hidapi",
   "license": "BSD-3-Clause-Clear",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2941,7 +2941,7 @@
       "port-version": 0
     },
     "hidapi": {
-      "baseline": "0.12.0",
+      "baseline": "0.13.1",
       "port-version": 0
     },
     "highfive": {

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "ed5ce28c8ec653b4b27fb02b322c2e413a277b6a",
-      "version-semver": "0.13.0",
-      "port-version": 0
-    },
-    {
       "git-tree": "803a911247de97c28264c5dee2102b368137562d",
       "version-semver": "0.12.0",
       "port-version": 0

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "git-tree": "7deb8cf068244c5583ce565bf1d302b369ed622b",
+      "version-semver": "0.13.1",
+      "port-version": 0
+    },
+    {
+      "git-tree": "ed5ce28c8ec653b4b27fb02b322c2e413a277b6a",
+      "version-semver": "0.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "803a911247de97c28264c5dee2102b368137562d",
       "version-semver": "0.12.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Updates the port hidapi from 0.12.0 to 0.13.1

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes
