### PR TITLE
[catch2] Update vcpkg_minimum_required

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -1,7 +1,7 @@
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
-vcpkg_minimum_required(VERSION 2022-11-10)
+vcpkg_minimum_required(VERSION 2022-10-12)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "catch2",
   "version-semver": "3.2.1",
+  "port-version": 1,
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1326,7 +1326,7 @@
     },
     "catch2": {
       "baseline": "3.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "cccapstone": {
       "baseline": "9b4128ee1153e78288a1b5433e2c06a0d47a4c4e",

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ae99f1261107cb694aa46253c07c9eef8c67d2d",
+      "version-semver": "3.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "43e022b806928c512e298052ad4fae210998a846",
       "version-semver": "3.2.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #28762 
  vcpkg executable is from 2022-10-17 which is older than required by
  the caller of vcpkg_minimum_required(VERSION 2022-11-10).
  Update vcpkg_minimum_required from 2022-10-17 to 2022-11-10 build successfully.
