### PR TITLE
[pystring] Update to v1.1.4

### DIFF
--- a/ports/pystring/portfile.cmake
+++ b/ports/pystring/portfile.cmake
@@ -1,10 +1,12 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO imageworks/pystring
-  REF v1.1.3
-  SHA512 a46bb2e96d6eb351a4a8097cde46ac2877d28e88f9e57e0ac36c42e8fc8543517c4be70306a01e2f88a891fc53c612494aeb37f47a200d94b8e1b050ed16eff6
+  REF v${VERSION}
+  SHA512 9c0460fea67885492f9b0d29a9ba312d960fd5e43577cdcfd47faf04397ff4b7e456ed68f1948b923d2f63f9922d576b93e4ca1a27376bcb6d29c683828acb01
   HEAD_REF master
 )
 
@@ -19,4 +21,4 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/pystring/vcpkg.json
+++ b/ports/pystring/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "pystring",
-  "version-semver": "1.1.3",
-  "port-version": 5,
+  "version": "1.1.4",
   "description": "Pystring is a collection of C++ functions which match the interface and behavior of python's string class methods using std::string",
   "homepage": "https://github.com/imageworks/pystring",
-  "license": "LGPL-2.1-only",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6069,8 +6069,8 @@
       "port-version": 1
     },
     "pystring": {
-      "baseline": "1.1.3",
-      "port-version": 5
+      "baseline": "1.1.4",
+      "port-version": 0
     },
     "python2": {
       "baseline": "2.7.18",

--- a/versions/p-/pystring.json
+++ b/versions/p-/pystring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09efd652931d6b9129dafea6f06386f0be44e8d7",
+      "version": "1.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "b0b08ff66f53aeb63ab3797212c667a822c88a3e",
       "version-semver": "1.1.3",
       "port-version": 5


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/28757. 
Update `pystring` to v1.1.4.