### PR TITLE
[ptc-print] Switch to official usage

### DIFF
--- a/ports/ptc-print/portfile.cmake
+++ b/ports/ptc-print/portfile.cmake
@@ -1,3 +1,5 @@
+# header-only library
+
 # Github config
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -23,6 +25,9 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
                     "${CURRENT_PACKAGES_DIR}/debug/lib" 
                     "${CURRENT_PACKAGES_DIR}/lib"
                     "${CURRENT_PACKAGES_DIR}/debug")
+
+# Usage
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
 
 # Install license
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/ptc-print" RENAME copyright)

--- a/ports/ptc-print/portfile.cmake
+++ b/ports/ptc-print/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 # Move cmake configs
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ptcprint)
+vcpkg_cmake_config_fixup(PACKAGE_NAME ptcprint CONFIG_PATH lib/cmake/ptcprint)
 
 # Remove duplicate files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
@@ -30,4 +30,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
 
 # Install license
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/ptc-print" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ptc-print/portfile.cmake
+++ b/ports/ptc-print/portfile.cmake
@@ -27,4 +27,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
                     "${CURRENT_PACKAGES_DIR}/debug")
 
 # Install license
-vcpkg_install_copyright(FILE_LIST"${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ptc-print/portfile.cmake
+++ b/ports/ptc-print/portfile.cmake
@@ -26,8 +26,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
                     "${CURRENT_PACKAGES_DIR}/lib"
                     "${CURRENT_PACKAGES_DIR}/debug")
 
-# Usage
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
-
 # Install license
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST"${SOURCE_PATH}/LICENSE")

--- a/ports/ptc-print/usage
+++ b/ports/ptc-print/usage
@@ -1,5 +1,5 @@
-ptc-print provides CMake targets:
+The package ptc-print can be used from CMake via:
 
-    find_package(ptcprint)
-    target_link_libraries(main PRIVATE ptcprint::ptcprint)
+    find_path(PTC_INCLUDE_DIRS "ptc/print.hpp")
+    target_include_directories(main PRIVATE ${PTC_INCLUDE_DIRS})
     

--- a/ports/ptc-print/usage
+++ b/ports/ptc-print/usage
@@ -1,5 +1,6 @@
-The package ptc-print can be used from CMake via:
 
-    find_path(PTC_INCLUDE_DIRS "ptc/print.hpp")
-    target_include_directories(main PRIVATE ${PTC_INCLUDE_DIRS})
+ptc-print provides CMake targets:
+
+    find_package(ptcprint CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE ptcprint::ptcprint)
     

--- a/ports/ptc-print/usage
+++ b/ports/ptc-print/usage
@@ -1,6 +1,0 @@
-
-ptc-print provides CMake targets:
-
-    find_package(ptcprint CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE ptcprint::ptcprint)
-    

--- a/ports/ptc-print/vcpkg.json
+++ b/ports/ptc-print/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ptc-print",
   "version": "1.4.0",
+  "port-version": 1,
   "description": "A single-header library for custom printing to the output stream.",
   "homepage": "https://github.com/JustWhit3/ptc-print",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6062,7 +6062,7 @@
     },
     "ptc-print": {
       "baseline": "1.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ptex": {
       "baseline": "2.3.2",

--- a/versions/p-/ptc-print.json
+++ b/versions/p-/ptc-print.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8767d025bc945a4a451c00fa2aaef54584bf3283",
+      "git-tree": "da8040a93ed25a329f75d842c798ad78ba457b37",
       "version": "1.4.0",
       "port-version": 1
     },

--- a/versions/p-/ptc-print.json
+++ b/versions/p-/ptc-print.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8767d025bc945a4a451c00fa2aaef54584bf3283",
+      "version": "1.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f397412b082c666b7b130ca2f808b0e7badcdf0e",
       "version": "1.4.0",
       "port-version": 0

--- a/versions/p-/ptc-print.json
+++ b/versions/p-/ptc-print.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "da8040a93ed25a329f75d842c798ad78ba457b37",
+      "git-tree": "91143be6f1ef3c424c1f061adbea52e523173076",
       "version": "1.4.0",
       "port-version": 1
     },

--- a/versions/p-/ptc-print.json
+++ b/versions/p-/ptc-print.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "91143be6f1ef3c424c1f061adbea52e523173076",
+      "git-tree": "03f588ecdd3b7638a92dd2c61ea3ca0adaa28eb6",
       "version": "1.4.0",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/pull/28332/
  Note: fix the wrong usage and the current port is `head-only`, so use `find_path()` instead of `find_package`.
  ```
  Could not find a package configuration file provided by "ptcprint" with any
  of the following names:

    ptcprintConfig.cmake
    ptcprint-config.cmake

  Add the installation prefix of "ptcprint" to CMAKE_PREFIX_PATH or set
  "ptcprint_DIR" to a directory containing one of the above files.  If
  "ptcprint" provides a separate development package or SDK, be sure it has been installed.
```
 CMake Error at CMakeLists.txt:5 (target_link_libraries):
  Target "main" links to:

    ptcprint::ptcprint

   but the target was not found.  Possible reasons include:

   * There is a typo in the target name.
   * A find_package call is missing for an IMPORTED target.
   * An ALIAS target is missing.
  ```