### PR TITLE
[omplapp] no absolute paths

### DIFF
--- a/ports/omplapp/portfile.cmake
+++ b/ports/omplapp/portfile.cmake
@@ -77,5 +77,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/omplapp/vcpkg.json
+++ b/ports/omplapp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "omplapp",
   "version": "1.5.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Use OMPL for reading meshes and performing collision checking",
   "homepage": "https://ompl.kavrakilab.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5462,7 +5462,7 @@
     },
     "omplapp": {
       "baseline": "1.5.1",
-      "port-version": 4
+      "port-version": 5
     },
     "onednn": {
       "baseline": "2.6.1",

--- a/versions/o-/omplapp.json
+++ b/versions/o-/omplapp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c7e3d29552841ecf363e9f222c6bc554be4b91e",
+      "version": "1.5.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "f3fba6a92711a359d5418b5568c973b69ff7fdda",
       "version": "1.5.1",
       "port-version": 4


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/issues/20469

the pkgconfig files are only installed for the opengl feature and are broken 