### PR TITLE
[kaitai-struct-cpp-stl-runtime] Added kaitai-struct-cpp-stl-runtime

### DIFF
--- a/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
+++ b/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
@@ -8,7 +8,16 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+set(STRING_ENCODING_TYPE "NONE")
+if ("iconv" IN_LIST FEATURES)
+    set(STRING_ENCODING_TYPE "ICONV")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS    
+        -DSTRING_ENCODING_TYPE=${STRING_ENCODING_TYPE}
+)
 
 vcpkg_cmake_install()
 

--- a/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
+++ b/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
@@ -1,0 +1,15 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kaitai-io/kaitai_struct_cpp_stl_runtime
+    REF 0.10
+    SHA512 27a0975edffe40a68784a3f5c639937fe70f634d97b7f3aae7d47db31ab4a81442c0707db562ac0775cf28012dc4172af52cc97bd02f2edecf713c57038f5b6d
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
+++ b/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kaitai-io/kaitai_struct_cpp_stl_runtime

--- a/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
+++ b/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "kaitai-struct-cpp-stl-runtime",
+  "version": "0.10",
+  "description": "Kaitai Struct is a declarative language used for describe various binary data structures, laid out in files or in memory. This library implements Kaitai Struct API for C++ using STL",
+  "homepage": "http://kaitai.io/",
+  "documentation": "https://doc.kaitai.io/lang_cpp_stl.html",
+  "license": "MIT",
+  "dependencies": [
+    "libiconv",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ]
+}

--- a/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
+++ b/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
@@ -5,6 +5,7 @@
   "homepage": "http://kaitai.io/",
   "documentation": "https://doc.kaitai.io/lang_cpp_stl.html",
   "license": "MIT",
+  "supports": "!staticcrt",
   "dependencies": [
     "libiconv",
     {

--- a/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
+++ b/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
@@ -7,7 +7,6 @@
   "license": "MIT",
   "supports": "!staticcrt",
   "dependencies": [
-    "libiconv",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -17,5 +16,16 @@
       "host": true
     },
     "zlib"
-  ]
+  ],
+  "default-features": [
+    "iconv"
+  ],
+  "features": {
+    "iconv": {
+      "description": "Set the way strings have to be encoded to ICONV",
+      "dependencies": [
+        "libiconv"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3292,6 +3292,10 @@
       "baseline": "2019.10.9",
       "port-version": 5
     },
+    "kaitai-struct-cpp-stl-runtime": {
+      "baseline": "0.10",
+      "port-version": 0
+    },
     "kangaru": {
       "baseline": "4.3.1",
       "port-version": 0

--- a/versions/k-/kaitai-struct-cpp-stl-runtime.json
+++ b/versions/k-/kaitai-struct-cpp-stl-runtime.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "186ce217982c57fd673a944edded61387f269fcf",
+      "version": "0.10",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/k-/kaitai-struct-cpp-stl-runtime.json
+++ b/versions/k-/kaitai-struct-cpp-stl-runtime.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f9529fdfa6f584d969ab440cc9e3fcfb3841eb0a",
+      "git-tree": "217ac9f83467405995c7d1356604661f0edf9970",
       "version": "0.10",
       "port-version": 0
     }

--- a/versions/k-/kaitai-struct-cpp-stl-runtime.json
+++ b/versions/k-/kaitai-struct-cpp-stl-runtime.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "186ce217982c57fd673a944edded61387f269fcf",
+      "git-tree": "f9529fdfa6f584d969ab440cc9e3fcfb3841eb0a",
       "version": "0.10",
       "port-version": 0
     }


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  It adds a new port of the C++ runtime lib of kaitaistruct

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Static linked triplets are not supported. Tested locally on Windows11. 

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
