### PR TITLE
[immer] Update to v0.8.0

### DIFF
--- a/ports/immer/portfile.cmake
+++ b/ports/immer/portfile.cmake
@@ -1,10 +1,11 @@
 # header-only library
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO arximboldi/immer
-    REF a1271fa712342f5c6dfad876820da17e10c28214
-    SHA512 7ea544c88b7a3742ebeedabe5ff7ba78178b3523c1c8564b5c0daae4044dda22340b0531e1382618557d1c118222da4a7ce06dde02e4bc05833514dde1cf2dd1
+    REF v${VERSION}
+    SHA512 fc34242d36efdb9faa1f22ccc7591c1ace34c2b383e1266a290346baedc154e3d4a682d6dd5094460b75e123347194710072e996d19165cc5fd23c922fdfc4e8
     HEAD_REF master
 )
 
@@ -31,4 +32,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Immer)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/immer/vcpkg.json
+++ b/ports/immer/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "immer",
-  "version-date": "2022-02-12",
+  "version": "0.8.0",
   "description": "Postmodern immutable and persistent data structures for C++",
   "homepage": "https://sinusoid.es/immer/",
+  "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3125,7 +3125,7 @@
       "port-version": 0
     },
     "immer": {
-      "baseline": "2022-02-12",
+      "baseline": "0.8.0",
       "port-version": 0
     },
     "implot": {

--- a/versions/i-/immer.json
+++ b/versions/i-/immer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e996304abce149829a2d0db1156bcf34c9e51c8",
+      "version": "0.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "37adfac25bfa3c7df3718c1cb0c9be295eb34cb3",
       "version-date": "2022-02-12",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/28796. 
Update `immer` to v0.8.0 and replace `version-date` in `vcpkg.json` with `version`.

Feature `docs` is tested successfully in the following triplet:
x86-windows
x64-windows
x64-windows-static