### PR TITLE
[vcpkg baseline][ideviceinstaller] Remove ideviceinstaller:x64-windows-static-md=fail from CI.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -335,7 +335,6 @@ healpix:arm-uwp=fail
 healpix:x64-osx=fail
 hpx:x64-windows-static=fail
 hpx:arm64-windows=fail
-ideviceinstaller:x64-windows-static-md=fail
 idevicerestore:x64-linux=fail
 idevicerestore:x64-osx=fail
 ignition-common1:x64-linux=fail


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fix [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=83341&view=results) issue PASSING, REMOVE FROM FAIL LIST: ideviceinstaller:x64-windows-static-md.
  `ideviceinstaller:x64-windows-static-md=fail` was added into the `ci.baseline.txt` by PR https://github.com/microsoft/vcpkg/pull/15788
 This issue has been fixed by https://github.com/microsoft/vcpkg/pull/28718, https://github.com/microsoft/vcpkg/pull/28459 and https://github.com/microsoft/vcpkg/pull/28382, so remove the record from `ci.baseline.txt`.
