### PR TITLE
[zint] use support expression

### DIFF
--- a/ports/zint/vcpkg.json
+++ b/ports/zint/vcpkg.json
@@ -1,9 +1,11 @@
 {
   "name": "zint",
   "version": "2.12.0",
+  "port-version": 1,
   "description": "A barcode encoding library supporting over 50 symbologies",
   "homepage": "https://github.com/zint/zint",
   "license": null,
+  "supports": "!osx",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1126,7 +1126,6 @@ yara:arm-uwp=fail
 yara:x64-uwp=fail
 z3:arm-uwp=fail
 z3:x64-uwp=fail
-zint:x64-osx=fail
 
 # clapack is replaced by lapack-reference on the platforms lapack-reference supports
 clapack:x64-linux=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8394,7 +8394,7 @@
     },
     "zint": {
       "baseline": "2.12.0",
-      "port-version": 0
+      "port-version": 1
     },
     "zkpp": {
       "baseline": "0.2.3",

--- a/versions/z-/zint.json
+++ b/versions/z-/zint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b46eb328f75102f1d27eea28fd0e910040046e3",
+      "version": "2.12.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "70662dabd6b07aaa376385d94a20fb2b979f8ae0",
       "version": "2.12.0",
       "port-version": 0


### PR DESCRIPTION
It always fails on osx and not only in the ci