### PR TITLE
[libmupdf] uses support expression

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -460,7 +460,6 @@ libmpeg2:arm-uwp=fail
 libmpeg2:x64-linux=fail
 libmpeg2:x64-osx=fail
 libmpeg2:x64-uwp=fail
-libmupdf:x64-osx=fail
 libmysql:x86-windows=fail
 libmysql:arm64-windows=fail
 libopusenc:arm-uwp=fail


### PR DESCRIPTION
There is already "!osx"