### PR TITLE
[vk-bootstrap] Disable build tests and example

### DIFF
--- a/ports/vk-bootstrap/portfile.cmake
+++ b/ports/vk-bootstrap/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_PROJECT_NAME=
 )
 
 vcpkg_cmake_install()
@@ -17,6 +19,6 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/${PORT}-config.cmake" "${CMAKE_CURRENT_LIST_DIR}/${PORT}-targets-release.cmake" "${CMAKE_CURRENT_LIST_DIR}/${PORT}-targets-debug.cmake" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/${PORT}-config.cmake" "${CMAKE_CURRENT_LIST_DIR}/${PORT}-targets-release.cmake" "${CMAKE_CURRENT_LIST_DIR}/${PORT}-targets-debug.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-configure_file("${SOURCE_PATH}/LICENSE.txt" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/vk-bootstrap/portfile.cmake
+++ b/ports/vk-bootstrap/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        # This option will disable build tests and example, and next release this option need to change as -DVK_BOOTSTRAP_TEST=OFF. The related upstream commit: https://github.com/charles-lunarg/vk-bootstrap/commit/4ae9513ff9182b9c519504a73435ed575a821300.
         -DCMAKE_PROJECT_NAME=
 )
 

--- a/ports/vk-bootstrap/vcpkg.json
+++ b/ports/vk-bootstrap/vcpkg.json
@@ -1,7 +1,10 @@
 {
   "name": "vk-bootstrap",
   "version": "0.5",
+  "port-version": 1,
   "description": "Vulkan bootstraping library",
+  "homepage": "https://github.com/charles-lunarg/vk-bootstrap",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7986,7 +7986,7 @@
     },
     "vk-bootstrap": {
       "baseline": "0.5",
-      "port-version": 0
+      "port-version": 1
     },
     "vkfft": {
       "baseline": "1.2.17",

--- a/versions/v-/vk-bootstrap.json
+++ b/versions/v-/vk-bootstrap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c2a75ef2dfe2acc1dec28e475e224bd241c9e8b",
+      "version": "0.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "c882b9c4c2adf3ea8e63dae9d4ab03b4d34a4dc1",
       "version": "0.5",
       "port-version": 0

--- a/versions/v-/vk-bootstrap.json
+++ b/versions/v-/vk-bootstrap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4c2a75ef2dfe2acc1dec28e475e224bd241c9e8b",
+      "git-tree": "5b4e562582567c73a3bad2120a3b23e0b6b32dde",
       "version": "0.5",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #28844, fixes https://github.com/microsoft/vcpkg/issues/28654.
  Setting `CMAKE_PROJECT_NAME` is empty to disable build tests and example in **CMakeLists.txt**. The following codes are related codes in **CMakeLists.txt**.
```
if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR VK_BOOTSTRAP_TEST)

    add_subdirectory(ext)
    add_subdirectory(tests)
    add_subdirectory(example)
endif ()
```