### PR TITLE
[redis-plus-plus] update to <1.3.7>

### DIFF
--- a/ports/redis-plus-plus/portfile.cmake
+++ b/ports/redis-plus-plus/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sewenew/redis-plus-plus
-    REF 39f5a515d048cc5ef897aaf319ddffb54ae9427c # 1.3.6
-    SHA512 f02fd77e9c8964cb0503e1a99edeaa793f4cf9365ef20b25ebf10001c1ed1fa9a6e90314092d9fb545a60168eb5bade161d57b17bb74068bdd52d356e484a505
+    REF f3b19a8a1f609d1a1b79002802e5cf8c336dc262 # 1.3.7
+    SHA512 c99a4506be06224ebc4adaa29d5eeff0f6efae8b99e48ac02c26cec4a86fb46237a7d380ddb89eddc3d2e75c0c567e9b68610bcf271a0c708bca8ca6a5641075
     HEAD_REF master
     PATCHES
         fix-conversion.patch

--- a/ports/redis-plus-plus/vcpkg.json
+++ b/ports/redis-plus-plus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-plus-plus",
-  "version-semver": "1.3.6",
+  "version-semver": "1.3.7",
   "description": "This is a C++ client for Redis. It's based on hiredis, and written in C++ 11",
   "homepage": "https://github.com/sewenew/redis-plus-plus",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6665,7 +6665,7 @@
       "port-version": 0
     },
     "redis-plus-plus": {
-      "baseline": "1.3.6",
+      "baseline": "1.3.7",
       "port-version": 0
     },
     "refl-cpp": {

--- a/versions/r-/redis-plus-plus.json
+++ b/versions/r-/redis-plus-plus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a48ccb1b618d7dedeeb50bde2ecc413b63c3742",
+      "version-semver": "1.3.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff28095e328281a0f0bba9ad251fb0881f08f5a2",
       "version-semver": "1.3.6",
       "port-version": 0


### PR DESCRIPTION
Fix #28865

Update redis-plus-plus to the latest version 1.3.7

All features are tested successfully in the following triplet:
> x86-windows
> x64-windows
> x64-windows-static