### PR TITLE
python3: libcrypt doesn't need to be a dependency of libpython

### DIFF
--- a/ports/python3/0013-configure-no-libcrypt.patch
+++ b/ports/python3/0013-configure-no-libcrypt.patch
@@ -1,0 +1,42 @@
+diff --git a/configure b/configure
+index 15c7c54b0953..70f28b0c7064 100755
+--- a/configure
++++ b/configure
+@@ -13227,6 +13227,8 @@ done
+ 
+ # We search for both crypt and crypt_r as one or the other may be defined
+ # This gets us our -lcrypt in LIBS when required on the target platform.
++# Save/restore LIBS to avoid linking libpython with libcrypt.
++LIBS_SAVE=$LIBS
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing crypt" >&5
+ $as_echo_n "checking for library containing crypt... " >&6; }
+ if ${ac_cv_search_crypt+:} false; then :
+@@ -13368,6 +13370,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ 
+ fi
+ 
++LIBS=$LIBS_SAVE
+ 
+ for ac_func in clock_gettime
+ do :
+diff --git a/configure.ac b/configure.ac
+index 6c65b2914bf6..afdc68363cea 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4085,6 +4085,8 @@ AC_CHECK_FUNCS(setpgrp,
+ 
+ # We search for both crypt and crypt_r as one or the other may be defined
+ # This gets us our -lcrypt in LIBS when required on the target platform.
++# Save/restore LIBS to avoid linking libpython with libcrypt.
++LIBS_SAVE=$LIBS
+ AC_SEARCH_LIBS(crypt, crypt)
+ AC_SEARCH_LIBS(crypt_r, crypt)
+ 
+@@ -4099,6 +4101,7 @@ char *r = crypt_r("", "", &d);
+     [AC_DEFINE(HAVE_CRYPT_R, 1, [Define if you have the crypt_r() function.])],
+     [])
+ )
++LIBS=$LIBS_SAVE
+ 
+ AC_CHECK_FUNCS(clock_gettime, [], [
+     AC_CHECK_LIB(rt, clock_gettime, [

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -17,6 +17,7 @@ set(PATCHES
     0009-bz2d.patch
     0010-dont-skip-rpath.patch
     0012-force-disable-curses.patch
+    0013-configure-no-libcrypt.patch  # https://github.com/python/cpython/pull/28881
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.10.7",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6122,7 +6122,7 @@
     },
     "python3": {
       "baseline": "3.10.7",
-      "port-version": 4
+      "port-version": 5
     },
     "qca": {
       "baseline": "2.3.4",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43e3e2453968d19d674b96aea99718541c96d852",
+      "version": "3.10.7",
+      "port-version": 5
+    },
+    {
       "git-tree": "13185f7c713eeb0ec50990488e9ea2eef9a9a276",
       "version": "3.10.7",
       "port-version": 4


### PR DESCRIPTION
- #### What does your PR fix?

vcpkg's Python3 `libpython3.10.so` currently depends on libcrypt (as a system dependency), but it doesn't need to - it uses no symbols from the library. libcrypt is different on Linux between RH-based and Debian-based distros too, which makes it annoying.

This is [fixed upstream in Python3.11](https://github.com/python/cpython/issues/89596). Backport the upstream change here.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

all (x64-linux-dynamic)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes
