### PR TITLE
[ffmpeg] Install the usage file

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -1,7 +1,9 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ffmpeg/ffmpeg
-    REF n5.0.2
+    REF n${VERSION}
     SHA512 76f892f15b65574c01a98eb6e8e0fa8a6c9febd9419f3f2a91bbd275762934d65bd809c6dbe67e047a475e1c8510b3e8d503fb0016e979a52edb7a02722788ca
     HEAD_REF master
     PATCHES
@@ -868,4 +870,5 @@ endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/FindFFMPEG.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/FindFFMPEG.cmake" @ONLY)
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/${LICENSE_FILE}" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/${LICENSE_FILE}")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "5.0.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2338,7 +2338,7 @@
     },
     "ffmpeg": {
       "baseline": "5.0.2",
-      "port-version": 1
+      "port-version": 2
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02b374be0e9ee8609f53d8247a74653805f82f98",
+      "version": "5.0.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "8caa5e4f23e22c213044d4d2322a1504076dea7a",
       "version": "5.0.2",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/28881.
Install the `usage` file, the problem comes from https://github.com/microsoft/vcpkg/pull/17284, it provides the `usage` file but does not install to the specified location.