### PR TITLE
[stduuid] Using stduuid with non C++20 mode (with gsl::span) fails to find gsl

### DIFF
--- a/ports/stduuid/fix-gsl-polyfill.patch
+++ b/ports/stduuid/fix-gsl-polyfill.patch
@@ -27,7 +27,7 @@ index 7217b72..fb981d2 100644
      endif ()
  endif ()
  
-+if (NOT "@UUID_USING_CXX20_SPAN@")
++if (NOT @UUID_USING_CXX20_SPAN@)
 +    find_dependency(Microsoft.GSL)
 +endif ()
 +

--- a/ports/stduuid/vcpkg.json
+++ b/ports/stduuid/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "stduuid",
   "version": "1.2.2",
+  "port-version": 1,
   "description": "A C++17 cross-platform implementation for UUIDs",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7362,7 +7362,7 @@
     },
     "stduuid": {
       "baseline": "1.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "stftpitchshift": {
       "baseline": "1.4.1",

--- a/versions/s-/stduuid.json
+++ b/versions/s-/stduuid.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "08a09e972cd80c475e343f25ba92a9f5d1fa9af9",
+      "git-tree": "8f1808fd359cf984c88931fa07d40f39fde07479",
       "version": "1.2.2",
       "port-version": 1
     },

--- a/versions/s-/stduuid.json
+++ b/versions/s-/stduuid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08a09e972cd80c475e343f25ba92a9f5d1fa9af9",
+      "version": "1.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "bd235773c953e5636a7b9f6356437daef6e5010c",
       "version": "1.2.2",
       "port-version": 0


### PR DESCRIPTION
Fixes issues with stduuid when used in non C++20 mode (with gsl::span)

- #### What does your PR fix?
  Wrapping the generate variable @UUID_USING_CXX20_SPAN@ in quotes seems to be a typo that fails to trigger find_dependency(Microsoft.GSL)
The error isn't caught during the building of the port itself but when the port is used in a project

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
No

- #### Does your PR follow the [maintainer guide]
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
 I am still working on this PR

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
