### PR TITLE
[fastcdr] Update to 1.0.26

### DIFF
--- a/ports/fastcdr/portfile.cmake
+++ b/ports/fastcdr/portfile.cmake
@@ -22,4 +22,9 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/lib/fastcdr ${CURRENT_PACKAGES_DIR}/debug/lib/fastcdr)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fastcdr/eProsima_auto_link.h" "(defined(_DLL) || defined(_RTLDLL)) && defined(EPROSIMA_DYN_LINK)" "1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fastcdr/fastcdr_dll.h" "defined(FASTCDR_DYN_LINK)" "1")
+endif()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fastcdr/portfile.cmake
+++ b/ports/fastcdr/portfile.cmake
@@ -1,8 +1,10 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-CDR
-    REF v1.0.25
-    SHA512 6a20e8ba61fb516fce35bb27f02db8fb45f287bfd49574dcb39e149e6edde0b4d0598f00399a4d0557ca1f6133d96a6701d6475cbd9039879cddb5089b0ef447
+    REF v${VERSION}
+    SHA512 6b31e9ba2f7fe719eb4ac7af59a34cdff1c0d13ed40340d8bea8bfa477c0ffe080f4d6c73096add62f3b20af5fbf8ee8bde288dd9074bfb094b5b355016184f2
     HEAD_REF master
     PATCHES
         pdb-file.patch
@@ -20,10 +22,4 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/lib/fastcdr ${CURRENT_PACKAGES_DIR}/debug/lib/fastcdr)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fastcdr/eProsima_auto_link.h" "#define EPROSIMA_LIB_PREFIX \"lib\"" "#define EPROSIMA_LIB_PREFIX")
-else()
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fastcdr/config.h" "#define _FASTCDR_CONFIG_H_" "#define _FASTCDR_CONFIG_H_\r\n#define FASTCDR_DYN_LINK")
-endif()
-
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fastcdr/vcpkg.json
+++ b/ports/fastcdr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastcdr",
-  "version-semver": "1.0.25",
+  "version-semver": "1.0.26",
   "description": "eProsima FastCDR is a C++ library that provides two serialization mechanisms. One is the standard CDR serialization mechanism, while the other is a faster implementation that modifies the standard.",
   "homepage": "https://github.com/eProsima/Fast-CDR",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2285,7 +2285,7 @@
       "port-version": 0
     },
     "fastcdr": {
-      "baseline": "1.0.25",
+      "baseline": "1.0.26",
       "port-version": 0
     },
     "fastcgi": {

--- a/versions/f-/fastcdr.json
+++ b/versions/f-/fastcdr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2ac6b7f69d7a9db5fcb43b83cf834a5c7008dc14",
+      "git-tree": "8ac25a2de2fa721da695d61b5346f05e93a51bf7",
       "version-semver": "1.0.26",
       "port-version": 0
     },

--- a/versions/f-/fastcdr.json
+++ b/versions/f-/fastcdr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ac6b7f69d7a9db5fcb43b83cf834a5c7008dc14",
+      "version-semver": "1.0.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "770f5d0a255b922f7f1ef8c375ef4f13b0111252",
       "version-semver": "1.0.25",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Update fastcdr to 1.0.26

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes