### PR TITLE
[ctpg] Fix portfile

### DIFF
--- a/ports/ctpg/portfile.cmake
+++ b/ports/ctpg/portfile.cmake
@@ -18,10 +18,6 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(GLOB files "${CURRENT_PACKAGES_DIR}/share/${PORT}/cmake/*")
-file(COPY ${files} DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/cmake/")
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/ctpg/portfile.cmake
+++ b/ports/ctpg/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/${PORT}/cmake)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 

--- a/ports/ctpg/vcpkg.json
+++ b/ports/ctpg/vcpkg.json
@@ -1,13 +1,17 @@
 {
   "name": "ctpg",
   "version": "1.3.7",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Compile Time Parser Generator is a C++ single header library which takes a language description as a C++ code and turns it into a LR1 table parser with a deterministic finite automaton lexical analyzer, all in compile time.",
   "homepage": "https://github.com/peter-winter/ctpg",
   "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/ports/ctpg/vcpkg.json
+++ b/ports/ctpg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ctpg",
   "version": "1.3.7",
-  "port-version": 3,
+  "port-version": 2,
   "description": "Compile Time Parser Generator is a C++ single header library which takes a language description as a C++ code and turns it into a LR1 table parser with a deterministic finite automaton lexical analyzer, all in compile time.",
   "homepage": "https://github.com/peter-winter/ctpg",
   "license": "MIT",

--- a/ports/ctpg/vcpkg.json
+++ b/ports/ctpg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ctpg",
   "version": "1.3.7",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Compile Time Parser Generator is a C++ single header library which takes a language description as a C++ code and turns it into a LR1 table parser with a deterministic finite automaton lexical analyzer, all in compile time.",
   "homepage": "https://github.com/peter-winter/ctpg",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1798,7 +1798,7 @@
     },
     "ctpg": {
       "baseline": "1.3.7",
-      "port-version": 2
+      "port-version": 3
     },
     "ctre": {
       "baseline": "3.7.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1798,7 +1798,7 @@
     },
     "ctpg": {
       "baseline": "1.3.7",
-      "port-version": 3
+      "port-version": 2
     },
     "ctre": {
       "baseline": "3.7.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1798,7 +1798,7 @@
     },
     "ctpg": {
       "baseline": "1.3.7",
-      "port-version": 1
+      "port-version": 2
     },
     "ctre": {
       "baseline": "3.7.1",

--- a/versions/c-/ctpg.json
+++ b/versions/c-/ctpg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce005721070c743c453fed6b2dcd3b2f2d351ba9",
+      "version": "1.3.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "3cbcbbd2011b26de3ddec2aca13ee915c838021a",
       "version": "1.3.7",
       "port-version": 1

--- a/versions/c-/ctpg.json
+++ b/versions/c-/ctpg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59a666ff9f67ea79c9eca77d981b2ceecad89d0a",
+      "version": "1.3.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "3cbcbbd2011b26de3ddec2aca13ee915c838021a",
       "version": "1.3.7",
       "port-version": 1

--- a/versions/c-/ctpg.json
+++ b/versions/c-/ctpg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9e422634e91620aeb44013c59d7c0e7731f3ba4",
+      "version": "1.3.7",
+      "port-version": 3
+    },
+    {
       "git-tree": "59a666ff9f67ea79c9eca77d981b2ceecad89d0a",
       "version": "1.3.7",
       "port-version": 2

--- a/versions/c-/ctpg.json
+++ b/versions/c-/ctpg.json
@@ -1,16 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "e9e422634e91620aeb44013c59d7c0e7731f3ba4",
-      "version": "1.3.7",
-      "port-version": 3
-    },
-    {
-      "git-tree": "59a666ff9f67ea79c9eca77d981b2ceecad89d0a",
-      "version": "1.3.7",
-      "port-version": 2
-    },
-    {
       "git-tree": "3cbcbbd2011b26de3ddec2aca13ee915c838021a",
       "version": "1.3.7",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
  Removes three lines from `ports/ctpg/portfile.cmake`, that copy the `share` from the `debug` directory into the main directory. `ctpg` is header-only so the files aren't needed, and they end up using an invalid include path, which made the library unusable. (Tested on `x64-windows`.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Same as before, everything. No.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes.
