### PR TITLE
[vcpkg baseline][zeroc-ice] Add zeroc-ice:x64-windows-static-md=fail into the ci.baseline.txt file

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1150,6 +1150,7 @@ dimcli:x64-windows-static=fail
 
 zeroc-ice:x86-windows=fail
 zeroc-ice:x64-windows=fail
+zeroc-ice:x64-windows-static-md=fail
 # ZeroC doesn't provide ARM tagets in project files.
 zeroc-ice:arm64-windows=fail
 zeroc-ice:arm-uwp=fail


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  `zeroc-ice:x64-windows-static-md` install failed with following error on CI pipeline run:
  `error MSB6006: "slice2cpp.exe" exited with code -1073741515`

  I can't reproduce this issue in my side. In order to avoid affecting the CI test of other PRs, I add `zeroc-ice:x64-windows-static-md=fail` into the `ci.baseline.txt` file as a temporary workaround.
  I will continue to investigate this issue until I can really fix it.
