### PR TITLE
[sqlite3] Fix typo for the Windows build

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -112,7 +112,7 @@ if(WITH_JSON1)
 endif()
 
 if (WIN32)
-    string(APPEND PKGCONFIG_DEFINES " -DQLITE_OS_WIN=1")
+    string(APPEND PKGCONFIG_DEFINES " -DSQLITE_OS_WIN=1")
     target_compile_definitions(sqlite3 PUBLIC -DSQLITE_OS_WIN=1)
     
     string(APPEND PKGCONFIG_DEFINES " -DSQLITE_ENABLE_COLUMN_METADATA=1")

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlite3",
   "version": "3.40.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://github.com/sqlite/sqlite",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7314,7 +7314,7 @@
     },
     "sqlite3": {
       "baseline": "3.40.0",
-      "port-version": 1
+      "port-version": 2
     },
     "sqlitecpp": {
       "baseline": "3.2.0",

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c8847911865e9de25af862637764ce514feaf36",
+      "version": "3.40.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "822fbc846fb73d1906929b6843ee939c1bb78cc5",
       "version": "3.40.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes a small (but critical?) typo in sqlite build script

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  no change to support status, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  sure

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
