### PR TITLE
[strong-type] add port

### DIFF
--- a/ports/strong-type/portfile.cmake
+++ b/ports/strong-type/portfile.cmake
@@ -1,0 +1,12 @@
+vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
+    REPO "rollbear/strong_type"
+    REF "v8"
+    SHA512 "d9bd43c090aac6d36183f70f6cc066484357e997b1b2081114ecb459f80cd990ad31c9141948bf2a9d12ac504da77331a470f2f0eaadc57fbfc9bec6c4de6464"
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "strong_type" CONFIG_PATH "lib/cmake/strong_type")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")

--- a/ports/strong-type/vcpkg.json
+++ b/ports/strong-type/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "strong-type",
+  "version": "8",
+  "description": "An additive strong typedef library for C++14/17/20",
+  "homepage": "https://github.com/rollbear/strong_type",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7400,6 +7400,10 @@
       "baseline": "1.6.0",
       "port-version": 0
     },
+    "strong-type": {
+      "baseline": "8",
+      "port-version": 0
+    },
     "stronk": {
       "baseline": "0.3.1",
       "port-version": 0

--- a/versions/s-/strong-type.json
+++ b/versions/s-/strong-type.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "017b73a108f38fb46a32be946809985a6b1ab96c",
+      "version": "8",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Hello, this PR adds a new port, https://github.com/rollbear/strong_type.

It describes itself as "An additive strong typedef library for C++14/17/20".

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
All supported AFAIK.  No CI changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes!

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
I did forgot, thanks for the reminder.
