### PR TITLE
[libosmium] Trim dependencies

### DIFF
--- a/ports/libosmium/vcpkg.json
+++ b/ports/libosmium/vcpkg.json
@@ -1,17 +1,17 @@
 {
   "name": "libosmium",
   "version-semver": "2.18.0",
+  "port-version": 1,
   "description": "A fast and flexible C++ library for working with OpenStreetMap data",
   "homepage": "https://osmcode.org/libosmium/",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost",
+    "boost-crc",
+    "boost-variant",
     "bzip2",
     "expat",
     "lz4",
-    "proj",
     "protozero",
-    "utfcpp",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4146,7 +4146,7 @@
     },
     "libosmium": {
       "baseline": "2.18.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libosmscout": {
       "baseline": "1.1.1",

--- a/versions/l-/libosmium.json
+++ b/versions/l-/libosmium.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4f1daf8d87c98ec46d720ff10449e520614b677",
+      "version-semver": "2.18.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2336c0db38fce27c033ff77a649645a1eb508e33",
       "version-semver": "2.18.0",
       "port-version": 0


### PR DESCRIPTION
Cf. https://osmcode.org/libosmium/manual.html#dependencies 
The deprecated PROJ support needs `proj_api.h`, removed in PROJ 8.0. 
utfcpp was used before libosmium 2.15.0.
