### PR TITLE
[openmpi] Enable parallel build

### DIFF
--- a/ports/openmpi/portfile.cmake
+++ b/ports/openmpi/portfile.cmake
@@ -31,7 +31,7 @@ vcpkg_configure_make(
             --enable-debug
 )
 
-vcpkg_install_make(DISABLE_PARALLEL)
+vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/openmpi/vcpkg.json
+++ b/ports/openmpi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openmpi",
   "version": "4.1.3",
+  "port-version": 1,
   "description": "The Open MPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.",
   "homepage": "https://www.open-mpi.org/",
   "supports": "!(windows | uwp)"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5626,7 +5626,7 @@
     },
     "openmpi": {
       "baseline": "4.1.3",
-      "port-version": 0
+      "port-version": 1
     },
     "openmvg": {
       "baseline": "2.0",

--- a/versions/o-/openmpi.json
+++ b/versions/o-/openmpi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c24d22620b08b5839cf13480633e6a736fb5a038",
+      "version": "4.1.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "bcbf51e64ac3e140af58a4279f34fb0e096b27e7",
       "version": "4.1.3",
       "port-version": 0


### PR DESCRIPTION
(Re-)enable parallel build of the openmpi port to fix slow build time. Parallel build of openmpi seems to be officially supported, see https://www.open-mpi.org/faq/?category=building#vpath-parallel-build
Looking at the vcpkg history, parallel build of openmpi was disabled in #12975 (@JackBoosY). The attached error messages are looking like the problem was compiling Fortran files, but meanwhile Fortran bindings seems to be disabled in the port (#20300).
What I'm not able to test is if this was maybe an OSX specific problem back then or there are more errors than the ones attached in #12975, but parallel build at least runs perfectly fine on several different linux machines.

- #### What does your PR fix?
  Slow build times of the openmpi port due to disabled parallel build.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
