### PR TITLE
[stb] Bump version and remove downloading stb_perlin separately since that patent is expired

### DIFF
--- a/ports/stb/portfile.cmake
+++ b/ports/stb/portfile.cmake
@@ -1,24 +1,16 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nothings/stb
-    REF af1a5bc352164740c1cc1354942b1c6b72eacb8a # committed on 2021-09-10
-    SHA512 5937baa1a9b7342ddc0e41c37ba0ea6b0c878f670a81b55bb124681e6b5e381fdc1d9557c96637e3ba082d6d968ed67a78b47f16aa5555c1c43394d1f9e57f2d
+    REF 8b5f1f37b5b75829fc72d38e7b5d4bcbf8a26d55 # committed on 2022-09-09
+    SHA512 76e0ed7536146aac71f89d6246235221c1dc0bd035ae4b33d496213acf5be95413cae4455a3f1419f84113320f7bd662dc50b47788cbdc8e7208bbbbcfd23f98
     HEAD_REF master
 )
 
-# originally deleted due to patent US6867776, but it has expired and it has yet to be restored
-# see https://github.com/nothings/stb/commit/59e7dec3e8bb0a8d4050d03c2dc32cf71ffa87c6
-vcpkg_download_distfile(
-    STB_PERLIN_H
-    URLS "https://raw.githubusercontent.com/nothings/stb/2bb4a0accd4003c1db4c24533981e01b1adfd656/stb_perlin.h"
-    FILENAME stb_perlin.h
-    SHA512 9dbc77a530ea368a47988393c7228ffaa8622ce5ffd83770306eaa6282bf289f7f6e55f4a4a5c746798e8c8a49e180344fd8837983ec734664abf9077e37d39f
-)
-
 file(GLOB HEADER_FILES "${SOURCE_PATH}/*.h")
-file(COPY ${HEADER_FILES} "${STB_PERLIN_H}" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/FindStb.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/stb/usage
+++ b/ports/stb/usage
@@ -1,0 +1,4 @@
+The package stb provides CMake targets:
+
+    find_package(Stb REQUIRED)
+    target_include_directories(main PRIVATE ${Stb_INCLUDE_DIR})

--- a/ports/stb/vcpkg.json
+++ b/ports/stb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "stb",
-  "version-date": "2021-09-10",
-  "port-version": 1,
+  "version-date": "2022-09-09",
   "description": "public domain header-only libraries",
   "homepage": "https://github.com/nothings/stb",
   "license": "MIT OR CC-PDDC"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7369,8 +7369,8 @@
       "port-version": 1
     },
     "stb": {
-      "baseline": "2021-09-10",
-      "port-version": 1
+      "baseline": "2022-09-09",
+      "port-version": 0
     },
     "stduuid": {
       "baseline": "1.2.2",

--- a/versions/s-/stb.json
+++ b/versions/s-/stb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "259df7e67a205697472aa4a3ff0326ac6fa60aa2",
+      "version-date": "2022-09-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ebadca0be90431f35a8d20b44f40b07285eb33d",
       "version-date": "2021-09-10",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
1. Bump to latest version
2. Remove downloading stb_perlin separately since that patent is expired
3. Add usage