### PR TITLE
[restc-cpp] use modern cmake helpers

### DIFF
--- a/ports/restc-cpp/portfile.cmake
+++ b/ports/restc-cpp/portfile.cmake
@@ -18,8 +18,9 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         boost-log     RESTC_CPP_LOG_WITH_BOOST_LOG
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
     OPTIONS
         -DINSTALL_RAPIDJSON_HEADERS=OFF
         -DRESTC_CPP_WITH_EXAMPLES=OFF
@@ -28,12 +29,12 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share
-                    ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/restc-cpp/vcpkg.json
+++ b/ports/restc-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "restc-cpp",
   "version-semver": "0.10.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Modern C++ REST Client library",
   "homepage": "https://github.com/jgaa/restc-cpp",
   "license": "MIT",
@@ -15,7 +15,15 @@
     "boost-program-options",
     "boost-system",
     "boost-uuid",
-    "rapidjson"
+    "rapidjson",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "default-features": [
     "openssl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6702,7 +6702,7 @@
     },
     "restc-cpp": {
       "baseline": "0.10.0",
-      "port-version": 1
+      "port-version": 2
     },
     "restclient-cpp": {
       "baseline": "2022-02-09",

--- a/versions/r-/restc-cpp.json
+++ b/versions/r-/restc-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2e57eacc4df802951e1ae319194becc2bc3e0fb4",
+      "version-semver": "0.10.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "98f2e4aed1e4c9a84df72116c4036a59a3d59436",
       "version-semver": "0.10.0",
       "port-version": 1


### PR DESCRIPTION
Needed for #26981 because this port is special because it needs msbuild on windows 