### PR TITLE
[rocksdb] update to 7.9.2

### DIFF
--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb
-  REF bf2c335184de16a3cc1787fa97ef9f22f7114238 # v7.8.3
-  SHA512 436ab1f16ddc931267d45a49449efd25cd9e11b340fa8bdb1c89f9a269b0e2479e3c9cfebdf35c0acf7bc60d090d23c8d131a74769891fe4192cfcdabe0563a1
+  REF 444b3f4845dd01b0d127c4b420fdd3b50ad56682 # v7.9.2
+  SHA512 a987abbedcc74d0633977ef3953c50824e1f1afdb2deb52db078a63ce9f0c39d5980fbc5127bbd9d7b6aebdc5268ab0f52b5b476d6cff47fb469a8c567ae70a1
   HEAD_REF main
   PATCHES
     0002-only-build-one-flavor.patch

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rocksdb",
-  "version": "7.8.3",
+  "version": "7.9.2",
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6765,7 +6765,7 @@
       "port-version": 0
     },
     "rocksdb": {
-      "baseline": "7.8.3",
+      "baseline": "7.9.2",
       "port-version": 0
     },
     "rpclib": {

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9ab4b0ca16f88be2bcddaab354944e2650a33b77",
+      "version": "7.9.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "216ddcf58e82ef42dd259ee9f60a63c6e2c38324",
       "version": "7.8.3",
       "port-version": 0


### PR DESCRIPTION
- Update the rocksdb port to new upstream release 7.9.2

Includes upstream PR https://github.com/facebook/rocksdb/pull/10667 which restores the use of SIMD-optimized crc32c to PORTABLE builds on MSVC triplets.
