### PR TITLE
[cairo] Fix missing msimg32.lib in cairo:x64-windows-static

### DIFF
--- a/ports/cairo/fix-static-missing-lib-msimg32.patch
+++ b/ports/cairo/fix-static-missing-lib-msimg32.patch
@@ -1,0 +1,15 @@
+diff --git a/src/win32/cairo-win32-private.h b/src/win32/cairo-win32-private.h
+index d457b78..0b1b4ed 100644
+--- a/src/win32/cairo-win32-private.h
++++ b/src/win32/cairo-win32-private.h
+@@ -53,6 +53,10 @@
+ 
+ #define WIN32_FONT_LOGICAL_SCALE 32
+ 
++#ifdef _MSC_VER 
++#pragma comment(lib, "MSImg32.Lib")
++#endif
++
+ CAIRO_BEGIN_DECLS
+ 
+ /* Surface DC flag values */

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -3,10 +3,6 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(PATCHES fix_clang-cl_build.patch)
 endif()
 
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    set(PATCHES fix-static-missing-lib-msimg32.patch)
-endif()
-
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
@@ -18,6 +14,7 @@ vcpkg_from_gitlab(
         cairo_static_fix.patch
         disable-atomic-ops-check.patch # See https://gitlab.freedesktop.org/cairo/cairo/-/issues/554
         mingw-dllexport.patch
+        fix-static-missing-lib-msimg32.patch
         ${PATCHES}
 )
 

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -3,6 +3,10 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(PATCHES fix_clang-cl_build.patch)
 endif()
 
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(PATCHES fix-static-missing-lib-msimg32.patch)
+endif()
+
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
@@ -86,4 +90,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
 endif()
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairo",
   "version": "1.17.6",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1290,7 +1290,7 @@
     },
     "cairo": {
       "baseline": "1.17.6",
-      "port-version": 4
+      "port-version": 5
     },
     "cairomm": {
       "baseline": "1.16.2",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54a5bac3e85b2cc058da31e27c45a10efc1b310d",
+      "version": "1.17.6",
+      "port-version": 5
+    },
+    {
       "git-tree": "eac156360b2a89a655152bafd92c3e285adc473e",
       "version": "1.17.6",
       "port-version": 4

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "54a5bac3e85b2cc058da31e27c45a10efc1b310d",
+      "git-tree": "d4e8c89704a7354fbae6bd789d5744d37021aacc",
       "version": "1.17.6",
       "port-version": 5
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/28994
  
  Feature passed with x64-windows-static triplet.