### PR TITLE
[sentry-native] Add features 'backend' and 'transport'

### DIFF
--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -6,23 +6,25 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
     NO_REMOVE_ONE_LEVEL
     PATCHES
         fix-warningC5105.patch
         fix-config-cmake.patch
 )
+file(REMOVE_RECURSE "${SOURCE_PATH}/external/crashpad/third_party/zlib")
 
-if (NOT DEFINED SENTRY_BACKEND)
-    if(MSVC AND CMAKE_GENERATOR_TOOLSET MATCHES "_xp$")
-        set(SENTRY_BACKEND "breakpad")
-    elseif(APPLE OR WIN32)
-        set(SENTRY_BACKEND "crashpad") # needs zlib
-    elseif(LINUX)
-        set(SENTRY_BACKEND "breakpad")
-    else()
-        set(SENTRY_BACKEND "inproc")
-    endif()
+vcpkg_list(SET options)
+
+if(NOT "backend" IN_LIST FEATURES)
+    vcpkg_list(APPEND options "-DSENTRY_BACKEND=none")
+elseif(DEFINED SENTRY_BACKEND)
+    # Legacy, possible override from triplet, but cannot handle dependencies
+    vcpkg_list(APPEND options "-DSENTRY_BACKEND=${SENTRY_BACKEND}")
+endif()
+
+if(NOT "transport" IN_LIST FEATURES)
+    vcpkg_list(APPEND options "-DSENTRY_TRANSPORT=none")
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
@@ -33,9 +35,9 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${options}
         -DSENTRY_BUILD_TESTS=OFF
         -DSENTRY_BUILD_EXAMPLES=OFF
-        -DSENTRY_BACKEND=${SENTRY_BACKEND}
         -DCRASHPAD_ZLIB_SYSTEM=ON
     MAYBE_UNUSED_VARIABLES
         CRASHPAD_ZLIB_SYSTEM
@@ -49,19 +51,8 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME sentry CONFIG_PATH lib/cmake/sentry)
 
-if (SENTRY_BACKEND STREQUAL "crashpad")
-    vcpkg_copy_tools(
-        TOOL_NAMES crashpad_handler
-        AUTO_CLEAN
-    )
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/crashpad_handler${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+    vcpkg_copy_tools(TOOL_NAMES crashpad_handler AUTO_CLEAN)
 endif()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
-
-file(
-    INSTALL "${SOURCE_PATH}/LICENSE"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-    RENAME copyright
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_extract_source_archive(
         fix-warningC5105.patch
         fix-config-cmake.patch
 )
-file(REMOVE_RECURSE "${SOURCE_PATH}/external/crashpad/third_party/zlib")
+file(REMOVE_RECURSE "${SOURCE_PATH}/external/crashpad/third_party/zlib/zlib")
 
 vcpkg_list(SET options)
 

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,16 +1,12 @@
 {
   "name": "sentry-native",
   "version": "0.5.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",
   "supports": "osx | (!arm & !uwp)",
   "dependencies": [
-    {
-      "name": "curl",
-      "platform": "!windows"
-    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -18,10 +14,40 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "zlib",
-      "platform": "ios | osx | windows"
     }
-  ]
+  ],
+  "default-features": [
+    "backend",
+    "transport"
+  ],
+  "features": {
+    "backend": {
+      "description": [
+        "Enables the platform-specific backend.",
+        "This feature does nothing for some platforms.",
+        "Cf. https://github.com/getsentry/sentry-native#compile-time-options"
+      ],
+      "dependencies": [
+        {
+          "$comment": "zlib is used by the crashpad backend.",
+          "name": "zlib",
+          "platform": "!android & !ios"
+        }
+      ]
+    },
+    "transport": {
+      "description": [
+        "Enables the platform-specific network transport.",
+        "This feature does nothing for some platforms.",
+        "Cf. https://github.com/getsentry/sentry-native#compile-time-options"
+      ],
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false,
+          "platform": "!windows"
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6978,7 +6978,7 @@
     },
     "sentry-native": {
       "baseline": "0.5.3",
-      "port-version": 1
+      "port-version": 2
     },
     "septag-dmon": {
       "baseline": "2022-02-08",

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff396629404d78a1099662104d9bf28c6606605e",
+      "version": "0.5.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "5ac3f218a83c74fd1479bb64ae8fd07e04a7309e",
       "version": "0.5.3",
       "port-version": 1

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff396629404d78a1099662104d9bf28c6606605e",
+      "git-tree": "10a861c0b8f25d9243ce5136b508ef30c9eb126d",
       "version": "0.5.3",
       "port-version": 2
     },


### PR DESCRIPTION
- Moves choice between alternative specific backends from the portfile to upstream's buildsystem.
- Enables opt-out from the default backend/transport, explicitly selecting the 'none' backend/transport in this case.
- Resolves #27696 wrt to choosing the 'none' backend. Alternative to #27770, implementing proper additive, default features. CC @FrankXie05.

