### PR TITLE
Roll back PowerShell to 7.2.x to restore support for Win7.

### DIFF
--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -194,11 +194,11 @@
         <archiveName>ninja-freebsd-1.8.2.zip</archiveName>
     </tool>
     <tool name="powershell-core" os="windows">
-        <version>7.3.1</version>
+        <version>7.2.8</version>
         <exeRelativePath>pwsh.exe</exeRelativePath>
-        <url>https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win-x86.zip</url>
-        <sha512>0a2324a668b448271f3f4f74034d4e3ac636c50e4c228a3ddad3472d97b149016855f3bce96f96a04cb74dd3d8c1ee23e9bccbdc4396b15a8039f87fb212d832</sha512>
-        <archiveName>PowerShell-7.3.1-win-x86.zip</archiveName>
+        <url>https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/PowerShell-7.2.8-win-x86.zip</url>
+        <sha512>b91ad901837099b34f689ae654b238a1171141adce8be6fc52f48373a7e79117072e84ab38e427c1ac66647dd86a19f1c6c6cba2b8e365d656c65c8447069c72</sha512>
+        <archiveName>PowerShell-7.2.8-win-x86.zip</archiveName>
     </tool>
     <tool name="node" os="windows">
         <version>16.15.1</version>


### PR DESCRIPTION
Note that we will still be installing the latest powershell in the build labs, but we will leave the tool accepting 7.2.

Resolves https://github.com/microsoft/vcpkg/issues/29008
