### PR TITLE
[modp-base64] Add missing header files

### DIFF
--- a/ports/modp-base64/CMakeLists.txt
+++ b/ports/modp-base64/CMakeLists.txt
@@ -19,8 +19,9 @@ install(
 )
 
 if(NOT DISABLE_INSTALL_HEADERS)
+  file(GLOB HEADERS "${SOURCE_PATH}/src/*.h") 
   install(
-    FILES ${SOURCE_PATH}/src/modp_b64.h
+    FILES ${HEADERS}
     DESTINATION include
   )
 endif()

--- a/ports/modp-base64/CMakeLists.txt
+++ b/ports/modp-base64/CMakeLists.txt
@@ -19,7 +19,6 @@ install(
 )
 
 if(NOT DISABLE_INSTALL_HEADERS)
-
   install(
     FILES
       "${SOURCE_PATH}/src/extern_c_begin.h"
@@ -28,5 +27,4 @@ if(NOT DISABLE_INSTALL_HEADERS)
       "${SOURCE_PATH}/src/modp_stdint.h"
     DESTINATION include
   )
-  
 endif()

--- a/ports/modp-base64/CMakeLists.txt
+++ b/ports/modp-base64/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(libmodpbase64 C)
 
 if(MSVC)
-  add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
+  add_compile_options(/wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 configure_file(config.h.cmake config.h @ONLY)
@@ -19,9 +19,14 @@ install(
 )
 
 if(NOT DISABLE_INSTALL_HEADERS)
-  file(GLOB HEADERS "${SOURCE_PATH}/src/*.h") 
+
   install(
-    FILES ${HEADERS}
+    FILES
+      "${SOURCE_PATH}/src/extern_c_begin.h"
+      "${SOURCE_PATH}/src/extern_c_end.h"
+      "${SOURCE_PATH}/src/modp_b64.h"
+      "${SOURCE_PATH}/src/modp_stdint.h"
     DESTINATION include
   )
+  
 endif()

--- a/ports/modp-base64/portfile.cmake
+++ b/ports/modp-base64/portfile.cmake
@@ -6,14 +6,13 @@ vcpkg_from_github(
   HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-  SOURCE_PATH ${CMAKE_CURRENT_LIST_DIR}
-  PREFER_NINJA
+vcpkg_cmake_configure(
+  SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}"
   OPTIONS -DSOURCE_PATH=${SOURCE_PATH}
   OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/modp-base64/vcpkg.json
+++ b/ports/modp-base64/vcpkg.json
@@ -1,6 +1,13 @@
 {
   "name": "modp-base64",
   "version-string": "2020-09-26",
-  "port-version": 1,
-  "description": "High performance base64 encoder/decoder"
+  "port-version": 2,
+  "description": "High performance base64 encoder/decoder",
+  "homepage": "https://github.com/client9/stringencoders",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/ports/modp-base64/vcpkg.json
+++ b/ports/modp-base64/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "modp-base64",
-  "version-string": "2020-09-26",
+  "version-date": "2020-09-26",
   "port-version": 2,
   "description": "High performance base64 encoder/decoder",
   "homepage": "https://github.com/client9/stringencoders",

--- a/ports/modp-base64/vcpkg.json
+++ b/ports/modp-base64/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 2,
   "description": "High performance base64 encoder/decoder",
   "homepage": "https://github.com/client9/stringencoders",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5026,7 +5026,7 @@
     },
     "modp-base64": {
       "baseline": "2020-09-26",
-      "port-version": 1
+      "port-version": 2
     },
     "mongo-c-driver": {
       "baseline": "1.22.2",

--- a/versions/m-/modp-base64.json
+++ b/versions/m-/modp-base64.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aac736b7f95fe749e7492e5b4faf540fcc543bdc",
+      "git-tree": "7e0a47b0147b38d5b2e408a16bfbe9d1ffcb2fce",
       "version-date": "2020-09-26",
       "port-version": 2
     },

--- a/versions/m-/modp-base64.json
+++ b/versions/m-/modp-base64.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aac736b7f95fe749e7492e5b4faf540fcc543bdc",
+      "version-date": "2020-09-26",
+      "port-version": 2
+    },
+    {
       "git-tree": "8e39629dc5108d0e7dac7c91bea6e7fbdeaeee14",
       "version-string": "2020-09-26",
       "port-version": 1

--- a/versions/m-/modp-base64.json
+++ b/versions/m-/modp-base64.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cea2b40c04c45acdd097d0bca4d2ff519c7184b1",
+      "git-tree": "85f2a557b0fdca31efb6e9e6c769309d583ea2a3",
       "version-date": "2020-09-26",
       "port-version": 2
     },

--- a/versions/m-/modp-base64.json
+++ b/versions/m-/modp-base64.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7e0a47b0147b38d5b2e408a16bfbe9d1ffcb2fce",
+      "git-tree": "cea2b40c04c45acdd097d0bca4d2ff519c7184b1",
       "version-date": "2020-09-26",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #28499

After modp-base6 install, only one header file https://github.com/microsoft/vcpkg/blob/b295670e4bab14debe88d92cd5364b21ce26232c/ports/modp-base64/CMakeLists.txt#L23 is included. When using it, if #include <modp_b64. h> will report an error:
````
Compiler error: modp_b64.h(33,10): fatal error C1083: Cannot open include file: 'extern_c_begin.h': No such file or directory
````
I installed all the .h files in the "${SOURCE_PATH}/src/" directory to the include directory in CMakeLists.txt to fix this problem and successfully tested locally.