### PR TITLE
[vulkan-headers] Update to v1.3.239

### DIFF
--- a/ports/vulkan-headers/portfile.cmake
+++ b/ports/vulkan-headers/portfile.cmake
@@ -1,20 +1,16 @@
-# header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/Vulkan-Headers
-    REF 00671c64ba5c488ade22ad572a0ef81d5e64c803
-    SHA512 e740688d0d2abd5c82b5bda1606e24edd87674ec7bd72ed4220c4d2d5bab30b8c993251c0b96a4c59d9e3190ddda7cb0cbf1e160aa404ef6e3c4aff23864d535
-    HEAD_REF v1.3.238
+    REF 2bb0a23104ceffd9a28d5b7401f2cee7dae35bb8
+    SHA512 06eaf7cddf2d8c9487244f3c3adee0a2ebed7f8d53a34409cc19d91847e9b5110cbd9af6b71379ae3e4c310db341cff38fc6978af713aa000e6789f1afec4b03
+    HEAD_REF v1.3.239
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_cmake_install()
 
-# Cleanup
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/vulkan-headers/vcpkg.json
+++ b/ports/vulkan-headers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vulkan-headers",
-  "version": "1.3.238",
+  "version": "1.3.239",
   "description": "Vulkan header files and API registry",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Headers",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8057,7 +8057,7 @@
       "port-version": 2
     },
     "vulkan-headers": {
-      "baseline": "1.3.238",
+      "baseline": "1.3.239",
       "port-version": 0
     },
     "vulkan-hpp": {

--- a/versions/v-/vulkan-headers.json
+++ b/versions/v-/vulkan-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7ca3a0cb7523e883530931e29520c17d42352e9",
+      "version": "1.3.239",
+      "port-version": 0
+    },
+    {
       "git-tree": "7d23bba2a37b43eab6af9748934187d6d7ebebf6",
       "version": "1.3.238",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
 Update to v1.3.239

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  I haven't update the baseline.txt since nothing has changed in terms of support.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
