### PR TITLE
[msdfgen] Update to 1.10

### DIFF
--- a/ports/msdfgen/portfile.cmake
+++ b/ports/msdfgen/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_check_features(
         extensions MSDFGEN_CORE_ONLY
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+if (VCPKG_CRT_LINKAGE STREQUAL dynamic)
     set(MSDFGEN_DYNAMIC_RUNTIME ON)
 else()
     set(MSDFGEN_DYNAMIC_RUNTIME OFF)

--- a/ports/msdfgen/portfile.cmake
+++ b/ports/msdfgen/portfile.cmake
@@ -1,5 +1,3 @@
-# No symbols are exported in msdfgen source
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 if ("tools" IN_LIST FEATURES AND VCPKG_TARGET_IS_UWP)
     message(FATAL_ERROR "Tools cannot be built on UWP.")
@@ -8,22 +6,37 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Chlumsky/msdfgen
-    REF v1.9.2
-    SHA512 5080a640c353fde86883946a04581a072b39d0d2111b5f3217344510d78324cea69df4e5046a380e84cf7da247d96efd4407c041991fae69e128ba435774e30f
+    REF a811ef8935354d3f6d767cff6c4eebeb683777f2 # accessed on 2023-01-20
+    SHA512 6c7fb9e9a4f4dee2502e1dca2c4612aae005697476e30664cc263f09e336b1cd0b529d75af667cdd9063ac1dd183867ce9f5bb88731e3071687c87937dab29d9
     HEAD_REF master
 )
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        tools MSDFGEN_BUILD_STANDALONE
         openmp MSDFGEN_USE_OPENMP
+        geometry-preprocessing MSDFGEN_USE_SKIA
+        tools MSDFGEN_BUILD_STANDALONE
+    INVERTED_FEATURES
+        extensions MSDFGEN_CORE_ONLY
 )
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    set(MSDFGEN_DYNAMIC_RUNTIME ON)
+else()
+    set(MSDFGEN_DYNAMIC_RUNTIME OFF)
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DMSDFGEN_USE_VCPKG=ON
+        -DMSDFGEN_VCPKG_FEATURES_SET=ON
+        -DMSDFGEN_INSTALL=ON
+        -DMSDFGEN_DYNAMIC_RUNTIME="${MSDFGEN_DYNAMIC_RUNTIME}"
         ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        MSDFGEN_VCPKG_FEATURES_SET
 )
 
 vcpkg_cmake_install()
@@ -31,7 +44,7 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/msdfgen)
 
 # move exe to tools
-if("tools" IN_LIST FEATURES AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES msdfgen AUTO_CLEAN)
 endif()
 

--- a/ports/msdfgen/vcpkg.json
+++ b/ports/msdfgen/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "msdfgen",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "Multi-channel signed distance field generator",
   "homepage": "https://github.com/Chlumsky/msdfgen",
   "license": "MIT",
   "dependencies": [
-    "freetype",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -15,12 +14,49 @@
       "host": true
     }
   ],
+  "default-features": [
+    "extensions",
+    "geometry-preprocessing"
+  ],
   "features": {
+    "extensions": {
+      "description": "Extended functionality that depends on external libraries - loading fonts and SVG files, generating PNG images.",
+      "dependencies": [
+        "freetype",
+        "libpng",
+        "tinyxml2"
+      ]
+    },
+    "geometry-preprocessing": {
+      "description": "Preprocessing of non-compliant vector geometry via the Skia library.",
+      "dependencies": [
+        {
+          "name": "msdfgen",
+          "default-features": false,
+          "features": [
+            "extensions"
+          ]
+        },
+        {
+          "name": "skia",
+          "default-features": false
+        }
+      ]
+    },
     "openmp": {
       "description": "Build with OpenMP support for multi-threaded code."
     },
     "tools": {
-      "description": "Generates an executable inside the tools folder. Not supported on UWP."
+      "description": "Generates an executable inside the tools folder. Not supported on UWP.",
+      "dependencies": [
+        {
+          "name": "msdfgen",
+          "default-features": false,
+          "features": [
+            "extensions"
+          ]
+        }
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5125,7 +5125,7 @@
       "port-version": 0
     },
     "msdfgen": {
-      "baseline": "1.9.2",
+      "baseline": "1.10.0",
       "port-version": 0
     },
     "msgpack": {

--- a/versions/m-/msdfgen.json
+++ b/versions/m-/msdfgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e7d2b74cbb69ccd03a48c5135b930f87baccf90",
+      "version": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d49eb065f4ec389be55189e28ab310178281bfe7",
       "version": "1.9.2",
       "port-version": 0

--- a/versions/m-/msdfgen.json
+++ b/versions/m-/msdfgen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7e7d2b74cbb69ccd03a48c5135b930f87baccf90",
+      "git-tree": "f03e46126dcb57f2ff08f5834eb6e84f84e14e2b",
       "version": "1.10.0",
       "port-version": 0
     },


### PR DESCRIPTION
Updates MSDFgen to version 1.10.

Since version 1.10, the project itself has its dependencies managed by vcpkg, and this update also adds two new port features:
- `extensions` - previously on by default, now the only the core of the library can be built with no dependencies
- `geometry-preprocessing` - requires Skia, previously disabled

I am also not sure what the host `vcpkg-cmake` and `vcpkg-cmake-config` dependencies are for, can they be removed?

- #### What does your PR fix?
  Old version of MSDFgen port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All that are supported by the port's dependencies, no I haven't.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
