### PR TITLE
[vcpkg baseline][forge] Remove from ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -243,7 +243,6 @@ fontconfig:arm-uwp=fail
 foonathan-memory:arm64-windows=fail
 foonathan-memory:arm-uwp=fail
 foonathan-memory:x64-uwp=fail
-forge:x86-windows=fail
 freeglut:arm-uwp=fail
 freeglut:x64-uwp=fail
 freeglut:x64-osx=fail


### PR DESCRIPTION
Remove `forge:x86-windows=fail` from ci.baseline.txt, because it has been fixed in PR https://github.com/microsoft/vcpkg/pull/28972.