### PR TITLE
[ffmpeg] add android support 

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -48,14 +48,22 @@ endif()
 
 set(OPTIONS "--enable-pic --disable-doc --enable-debug --enable-runtime-cpudetect --disable-autodetect")
 
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
-  set(OPTIONS "${OPTIONS} --disable-asm --disable-x86asm")
-endif()
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-  set(OPTIONS "${OPTIONS} --enable-asm --disable-x86asm")
-endif()
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-  set(OPTIONS "${OPTIONS} --enable-asm --enable-x86asm")
+if(VCPKG_TARGET_IS_ANDROID)
+    # Disable asm and x86asm on all android targets because they trigger build failures:
+    # arm64 Android build fails with 'relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol ff_cos_32; recompile with -fPIC'
+    # x86 Android build fails with 'error: inline assembly requires more registers than available'.
+    # x64 Android build fails with 'relocation R_X86_64_PC32 cannot be used against symbol ff_h264_cabac_tables; recompile with -fPIC'
+    set(OPTIONS "${OPTIONS} --disable-asm --disable-x86asm")
+else()
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+        set(OPTIONS "${OPTIONS} --disable-asm --disable-x86asm")
+    endif()
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        set(OPTIONS "${OPTIONS} --enable-asm --disable-x86asm")
+    endif()
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        set(OPTIONS "${OPTIONS} --enable-asm --enable-x86asm")
+    endif()
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "5.0.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2342,7 +2342,7 @@
     },
     "ffmpeg": {
       "baseline": "5.0.2",
-      "port-version": 2
+      "port-version": 3
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4da48cc8448d8b126b8558bf6ddf5f2a380bf51",
+      "version": "5.0.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "02b374be0e9ee8609f53d8247a74653805f82f98",
       "version": "5.0.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
