### PR TITLE
[workflow] Update version to 0.10.5

### DIFF
--- a/ports/workflow/portfile.cmake
+++ b/ports/workflow/portfile.cmake
@@ -2,16 +2,16 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO sogou/workflow
-        REF v0.9.7-win
-        SHA512 c23b8c1910c4ca5d57fa732e3084f56e17fdfead5561a8eab7be469d8f6081d830555365b2cf74e27956ffa88a6fb284dbde4654b23b130da9fbb4eb404686bd
+        REF v0.10.5-win
+        SHA512 4299b2c8bc545676b5437086c666a7b0955524aae758a8753719439697b3dd4d5b46c0a8eba9dba80c0daa9ee9c4188e46fd085f0d2f68f61b33fad1f903c4c2
         HEAD_REF windows
     )
 else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO sogou/workflow
-        REF v0.9.7
-        SHA512 4866d9cfe2d9ba30f2f7866819ee8f425b91082d7f86994c1194a6b4406e8ee99e22ce6b0bafeb22c5f098f7da30029fb6b12895c2ac45810d33c28d4bfad006
+        REF v0.10.5
+        SHA512 696e82a1f6a7e6c339fbabb7b1f98ffe40f5f5ee7e77f4c947c0c1532817409e7a61f020c6238a32acd9eb3e06cf3e522e6d67beda32d5bbb08ea1080c20277d
         HEAD_REF master
     )
 endif()

--- a/ports/workflow/vcpkg.json
+++ b/ports/workflow/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.9.7",
-  "port-version": 1,
+  "version": "0.10.5",
   "description": "About C++ Parallel Computing and Asynchronous Networking Engine",
   "homepage": "https://github.com/sogou/workflow",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8189,8 +8189,8 @@
       "port-version": 1
     },
     "workflow": {
-      "baseline": "0.9.7",
-      "port-version": 1
+      "baseline": "0.10.5",
+      "port-version": 0
     },
     "wpilib": {
       "baseline": "2020-03-02",

--- a/versions/w-/workflow.json
+++ b/versions/w-/workflow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a4bdf3d2e4afdb3e5f67b416ccfd511532d74eba",
+      "version": "0.10.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "2e673ba0fd8857c0d13f6137e32b3ce5cfda65d9",
       "version": "0.9.7",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
