### PR TITLE
[cmake-user] format-manifest

### DIFF
--- a/scripts/test_ports/cmake-user/vcpkg.json
+++ b/scripts/test_ports/cmake-user/vcpkg.json
@@ -58,13 +58,16 @@
           "platform": "!mingw & !uwp"
         },
         {
+          "$comment": "CMake 3.13 for debug postfix support",
+          "$package": "GLUT",
+          "$since": "3.13",
+          "name": "freeglut",
+          "platform": "!uwp & !osx"
+        },
+        {
           "$package": "Freetype",
           "name": "freetype",
           "default-features": false
-        },
-        {
-          "$package": "Intl",
-          "name": "gettext"
         },
         {
           "$comment": "CMake 3.9 for find_dependency forwarding extra arguments",
@@ -75,20 +78,22 @@
           "platform": "!uwp"
         },
         {
-          "$package": "GIF",
-          "name": "giflib"
+          "$package": "Intl",
+          "name": "gettext"
         },
         {
-          "$comment": "CMake 3.13 for debug postfix support",
-          "$package": "GLUT",
-          "$since": "3.13",
-          "name": "freeglut",
-          "platform": "!uwp & !osx"
+          "$package": "GIF",
+          "name": "giflib"
         },
         {
           "$package": "ICU",
           "name": "icu",
           "platform": "!uwp"
+        },
+        {
+          "$package": "LAPACK",
+          "name": "lapack",
+          "platform": "!(uwp & arm)"
         },
         {
           "$package": "Iconv",
@@ -98,11 +103,6 @@
         {
           "$package": "JPEG",
           "name": "libjpeg-turbo"
-        },
-        {
-          "$package": "LAPACK",
-          "name": "lapack",
-          "platform": "!(uwp & arm)"
         },
         {
           "$package": "LibLZMA",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
