### PR TITLE
[ncurses] Update to 6.4

### DIFF
--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -1,12 +1,11 @@
-set(NCURSES_VERSION_STR 6.3)
 vcpkg_download_distfile(
     ARCHIVE_PATH
     URLS
-        "https://invisible-mirror.net/archives/ncurses/ncurses-${NCURSES_VERSION_STR}.tar.gz"
-        "ftp://ftp.invisible-island.net/ncurses/ncurses-${NCURSES_VERSION_STR}.tar.gz"
-        "https://ftp.gnu.org/gnu/ncurses/ncurses-${NCURSES_VERSION_STR}.tar.gz"
-    FILENAME "ncurses-${NCURSES_VERSION_STR}.tgz"
-    SHA512 5373f228cba6b7869210384a607a2d7faecfcbfef6dbfcd7c513f4e84fbd8bcad53ac7db2e7e84b95582248c1039dcfc7c4db205a618f7da22a166db482f0105
+        "https://invisible-mirror.net/archives/ncurses/ncurses-${VERSION}.tar.gz"
+        "ftp://ftp.invisible-island.net/ncurses/ncurses-${VERSION}.tar.gz"
+        "https://ftp.gnu.org/gnu/ncurses/ncurses-${VERSION}.tar.gz"
+    FILENAME "ncurses-${VERSION}.tgz"
+    SHA512 1c2efff87a82a57e57b0c60023c87bae93f6718114c8f9dc010d4c21119a2f7576d0225dab5f0a227c2cfc6fb6bdbd62728e407f35fce5bf351bb50cf9e0fd34
 )
 
 vcpkg_extract_source_archive(
@@ -14,15 +13,8 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE_PATH}"
 )
 
-set(OPTIONS
-    --disable-db-install
-    --enable-pc-files
-    --without-ada
-    --without-manpages
-    --without-progs
-    --without-tack
-    --without-tests
-)
+vcpkg_list(SET OPTIONS)
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     list(APPEND OPTIONS
         --with-shared
@@ -45,27 +37,27 @@ if(VCPKG_TARGET_IS_MINGW)
     )
 endif()
 
-file(MAKE_DIRECTORY "${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig")
-file(MAKE_DIRECTORY "${CURRENT_INSTALLED_DIR}/lib/pkgconfig")
-
-set(OPTIONS_DEBUG
-    "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig"
-    --with-debug
-    --without-normal
-)
-set(OPTIONS_RELEASE
-    "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/lib/pkgconfig"
-    --without-debug
-    --with-normal
-)
-
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     DETERMINE_BUILD_TRIPLET
-    OPTIONS ${OPTIONS}
-    OPTIONS_DEBUG ${OPTIONS_DEBUG}
-    OPTIONS_RELEASE ${OPTIONS_RELEASE}
     NO_ADDITIONAL_PATHS
+    OPTIONS
+        ${OPTIONS}
+        --disable-db-install
+        --enable-pc-files
+        --without-ada
+        --without-manpages
+        --without-progs
+        --without-tack
+        --without-tests
+    OPTIONS_DEBUG
+        "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig"
+        --with-debug
+        --without-normal
+    OPTIONS_RELEASE
+        "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/lib/pkgconfig"
+        --without-debug
+        --with-normal
 )
 vcpkg_install_make()
 

--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -50,12 +50,11 @@ vcpkg_configure_make(
         --without-progs
         --without-tack
         --without-tests
+        --with-pkg-config-libdir=libdir
     OPTIONS_DEBUG
-        "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig"
         --with-debug
         --without-normal
     OPTIONS_RELEASE
-        "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/lib/pkgconfig"
         --without-debug
         --with-normal
 )

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ncurses",
-  "version": "6.3",
-  "port-version": 4,
+  "version": "6.4",
   "description": "Free software emulation of curses in System V Release 4.0, and more",
   "homepage": "https://invisible-island.net/ncurses/announce.html",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5253,8 +5253,8 @@
       "port-version": 0
     },
     "ncurses": {
-      "baseline": "6.3",
-      "port-version": 4
+      "baseline": "6.4",
+      "port-version": 0
     },
     "neargye-semver": {
       "baseline": "0.3.0",

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "932a2ba5483549013686858e67b2e7dab5ad85e1",
+      "git-tree": "c557b7daa2f3a87a54e037e7b984ad8a661c5903",
       "version": "6.4",
       "port-version": 0
     },

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "932a2ba5483549013686858e67b2e7dab5ad85e1",
+      "version": "6.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "83eac97c40a368314b01639191657529194d8bdc",
       "version": "6.3",
       "port-version": 4


### PR DESCRIPTION
Fixes [CVE-2022-29458](https://nvd.nist.gov/vuln/detail/CVE-2022-29458).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
