### PR TITLE
[sqlite3] Update to 3.40.1, misc fixes

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -17,15 +17,8 @@ option(WITH_JSON1 "Enable JSON functionality for sqlite3" OFF)
 option(WITH_ZLIB "Build sqlite3 with zlib support" OFF)
 option(SQLITE3_SKIP_TOOLS "Disable build sqlite3 executable" OFF)
 
-if(BUILD_SHARED_LIBS)
-    if(UNIX)
-        set(SQLITE_API "-DSQLITE_API=__attribute__((visibility(\"default\")))")
-    elseif(WIN32)
-        set(SQLITE_API "-DSQLITE_API=__declspec(dllexport)")
-    else()
-        message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
-    endif()
-endif()
+set(PKGCONFIG_DEFINES "")
+set(PKGCONFIG_LIBS_PRIVATE "")
 
 add_library(sqlite3 sqlite3.c)
 
@@ -37,17 +30,17 @@ target_compile_definitions(
         $<$<CONFIG:Debug>:SQLITE_DEBUG=1>
         $<$<CONFIG:Debug>:SQLITE_ENABLE_SELECTTRACE>
         $<$<CONFIG:Debug>:SQLITE_ENABLE_WHERETRACE>
-        ${SQLITE_API}
         -DSQLITE_ENABLE_UNLOCK_NOTIFY
 )
 
 if (BUILD_SHARED_LIBS)
-    if (UNIX)
-        string(APPEND PKGCONFIG_DEFINES " -DSQLITE_API=__attribute__((visibility(\"default\")))")
-        target_compile_definitions(sqlite3 INTERFACE "SQLITE_API=__attribute__((visibility(\"default\")))")
-    elseif (WIN32)
+    if (WIN32)
         string(APPEND PKGCONFIG_DEFINES " -DSQLITE_API=__declspec(dllimport)")
+        target_compile_definitions(sqlite3 PRIVATE "SQLITE_API=__declspec(dllexport)")
         target_compile_definitions(sqlite3 INTERFACE "SQLITE_API=__declspec(dllimport)")
+    else()
+        string(APPEND PKGCONFIG_DEFINES " -DSQLITE_API=__attribute__((visibility(\"default\")))")
+        target_compile_definitions(sqlite3 PUBLIC "SQLITE_API=__attribute__((visibility(\"default\")))")
     endif()
 endif()
 
@@ -111,6 +104,11 @@ if(WITH_JSON1)
     target_compile_definitions(sqlite3 PUBLIC SQLITE_ENABLE_JSON1)
 endif()
 
+if (WITH_ZLIB)
+    find_package(ZLIB REQUIRED)
+    target_link_libraries(sqlite3 PRIVATE ZLIB::ZLIB)
+endif()
+
 if (WIN32)
     string(APPEND PKGCONFIG_DEFINES " -DSQLITE_OS_WIN=1")
     target_compile_definitions(sqlite3 PUBLIC -DSQLITE_OS_WIN=1)
@@ -128,16 +126,18 @@ else()
     
     string(APPEND PKGCONFIG_DEFINES " -DSQLITE_OS_UNIX=1")
     target_compile_definitions(sqlite3 PUBLIC -DSQLITE_OS_UNIX=1)
-endif()
 
-if(NOT WIN32)
     find_package(Threads REQUIRED)
-    target_link_libraries(sqlite3 PUBLIC Threads::Threads ${CMAKE_DL_LIBS})
-endif()
+    target_link_libraries(sqlite3 PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+    string(APPEND PKGCONFIG_LIBS_PRIVATE " -pthread -ldl")
 
-if (WITH_ZLIB)
-    find_package(ZLIB REQUIRED)
-    target_link_libraries(sqlite3 PUBLIC ZLIB::ZLIB)
+    if(ENABLE_FTS5 OR ENABLE_MATH_FUNCTION)
+        find_library(HAVE_LIBM m)
+        if(HAVE_LIBM)
+            target_link_libraries(sqlite3 PRIVATE m)
+            string(APPEND PKGCONFIG_LIBS_PRIVATE " -lm")
+        endif()
+    endif()
 endif()
 
 if(NOT SQLITE3_SKIP_TOOLS)
@@ -162,15 +162,6 @@ install(
 
 install(FILES sqlite3.h sqlite3ext.h DESTINATION include CONFIGURATIONS Release)
 install(EXPORT unofficial-sqlite3-targets NAMESPACE unofficial::sqlite3:: FILE unofficial-sqlite3-targets.cmake DESTINATION share/unofficial-sqlite3)
-
-if(UNIX)
-    set(PKGCONFIG_LIBS_PRIVATE "-lm -ldl")
-    if(NOT ANDROID)
-        string(APPEND PKGCONFIG_LIBS_PRIVATE " -lpthread")
-    endif()
-else()
-    set(PKGCONFIG_LIBS_PRIVATE "")
-endif()
 
 configure_file(sqlite3.pc.in sqlite3.pc @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sqlite3.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -1,4 +1,3 @@
-# Be sure to update both of these versions together.
 string(REGEX REPLACE "^([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]([0-9]+)" "\\1,0\\2,0\\3,0\\4," SQLITE_VERSION "${VERSION}.0")
 string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "\\1\\2\\3\\4" SQLITE_VERSION "${SQLITE_VERSION}")
 

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -1,12 +1,11 @@
 # Be sure to update both of these versions together.
-set(SQLITE_VERSION 3400000)
-set(PKGCONFIG_VERSION 3.40.0)
-set(SQLITE_HASH db099793e05ac0f37355c9bd41173fb63cfe20fe4eea49de227d06f6d22064ded38bb8369c495ce06a1ef1e687d41169d93d74359367333622c6893720f3c1f0)
+string(REGEX REPLACE "^([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]([0-9]+)" "\\1,0\\2,0\\3,0\\4," SQLITE_VERSION "${VERSION}.0")
+string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "\\1\\2\\3\\4" SQLITE_VERSION "${SQLITE_VERSION}")
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2022/sqlite-amalgamation-${SQLITE_VERSION}.zip"
     FILENAME "sqlite-amalgamation-${SQLITE_VERSION}.zip"
-    SHA512 ${SQLITE_HASH}
+    SHA512 863afdabbdbe27baaccc13477e08437ce3b4d7e6f0c51a294d1d71252476af474b6c275729ebe1bc801f004da7ca6775591a30fed1930c3a1920d8118864f1d2
 )
 
 vcpkg_extract_source_archive(
@@ -41,7 +40,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DPKGCONFIG_VERSION=${PKGCONFIG_VERSION}
+        -DPKGCONFIG_VERSION=${VERSION}
     OPTIONS_DEBUG
         -DSQLITE3_SKIP_TOOLS=ON
 )

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.40.0",
-  "port-version": 2,
+  "version": "3.40.1",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://github.com/sqlite/sqlite",
   "license": "blessing",

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "sqlite3",
   "version": "3.40.1",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
-  "homepage": "https://github.com/sqlite/sqlite",
+  "homepage": "https://sqlite.org/",
   "license": "blessing",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7321,8 +7321,8 @@
       "port-version": 0
     },
     "sqlite3": {
-      "baseline": "3.40.0",
-      "port-version": 2
+      "baseline": "3.40.1",
+      "port-version": 0
     },
     "sqlitecpp": {
       "baseline": "3.2.0",

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b7d491c94a15b1d2073dfbb636f712fb5798c1ad",
+      "git-tree": "e906c625a802b4fb35a8ad2ff23016f76a92e7e3",
       "version": "3.40.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b7d491c94a15b1d2073dfbb636f712fb5798c1ad",
+      "version": "3.40.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c8847911865e9de25af862637764ce514feaf36",
       "version": "3.40.0",
       "port-version": 2


### PR DESCRIPTION
Fixes [CVE-2022-46908](https://nvd.nist.gov/vuln/detail/CVE-2022-46908).
Fixes non-windows build errors for features fts5 and math due to missing libm.
Cleanup of configuration inconsistencies in CMakeLists.txt.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
