### PR TITLE
[libopenmpt] fix resulting lib name

### DIFF
--- a/ports/libopenmpt/CMakeLists.txt
+++ b/ports/libopenmpt/CMakeLists.txt
@@ -43,6 +43,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(libopenmpt ${SOURCES})
+set_target_properties(libopenmpt PROPERTIES OUTPUT_NAME openmpt)
 
 target_compile_definitions(libopenmpt PRIVATE
   -DMPT_WITH_MPG123 -DMPT_WITH_OGG

--- a/ports/libopenmpt/vcpkg.json
+++ b/ports/libopenmpt/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "libopenmpt",
   "version": "0.5.12",
+  "port-version": 1,
   "description": "a library to render tracker music",
   "homepage": "https://openmpt.org/",
+  "license": "BSD-3-Clause",
   "dependencies": [
     "libogg",
     "libvorbis",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4130,7 +4130,7 @@
     },
     "libopenmpt": {
       "baseline": "0.5.12",
-      "port-version": 0
+      "port-version": 1
     },
     "libopensp": {
       "baseline": "1.5.2",

--- a/versions/l-/libopenmpt.json
+++ b/versions/l-/libopenmpt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77855e30f0796a3254ce7c87449c8098854f85a5",
+      "version": "0.5.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "8cb8a2342ad5552d311c9f38d399b2ca55726f8a",
       "version": "0.5.12",
       "port-version": 0


### PR DESCRIPTION
Currently the resulting lib name was `liblibopenmpt` what breaks ffmpeg[openmpt] (See https://github.com/microsoft/vcpkg/pull/28955#issuecomment-1383182247). `ffmpeg[openmpt]` now works 