### PR TITLE
[blend2d|osgearth] Allow blend2d and osgearth[blend2d] on ARM

### DIFF
--- a/ports/blend2d/vcpkg.json
+++ b/ports/blend2d/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "blend2d",
   "version-date": "2022-12-31",
+  "port-version": 1,
   "description": "Beta 2D Vector Graphics Powered by a JIT Compiler",
   "homepage": "https://github.com/blend2d/blend2d",
   "documentation": "https://blend2d.com/doc/index.html",
   "license": "Zlib",
-  "supports": "!arm & !uwp & !wasm32",
+  "supports": "!(arm & windows) & !uwp & !wasm32",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osgearth",
   "version": "3.3",
-  "port-version": 4,
+  "port-version": 5,
   "description": "osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2021 Pelican Mapping.",
   "homepage": "https://github.com/gwaldron/osgearth",
   "license": "LGPL-3.0-or-later",
@@ -54,7 +54,7 @@
           "features": [
             "blend2d"
           ],
-          "platform": "!arm & !uwp & !wasm32"
+          "platform": "!(arm & windows) & !uwp & !wasm32"
         }
       ]
     },

--- a/versions/b-/blend2d.json
+++ b/versions/b-/blend2d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc33e610ee62c7cc13415a1e18e682ccbb56a68d",
+      "version-date": "2022-12-31",
+      "port-version": 1
+    },
+    {
       "git-tree": "838a7227b29f1b1beb7daf181cfc97e5674e0270",
       "version-date": "2022-12-31",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5738,7 +5738,7 @@
     },
     "osgearth": {
       "baseline": "3.3",
-      "port-version": 4
+      "port-version": 5
     },
     "osi": {
       "baseline": "0.108.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -550,7 +550,7 @@
     },
     "blend2d": {
       "baseline": "2022-12-31",
-      "port-version": 0
+      "port-version": 1
     },
     "blitz": {
       "baseline": "2020-03-25",

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "606bbaf1456dc9d5a6f5ef879a54b894c4ace5b3",
+      "version": "3.3",
+      "port-version": 5
+    },
+    {
       "git-tree": "208b0c23a8e79910067bb0b8a6dc589da7307de5",
       "version": "3.3",
       "port-version": 4


### PR DESCRIPTION
Fixes #28909 

This change allows blend2d on ARM platforms. As mentioned in the issue above, the blend2d project now supports this architecture, and I have confirmed that both blend2d and osgearth can be compiled on Ubuntu 20.04 with an `arm64-linux-dynamic` triplet.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
