### PR TITLE
[theia] Fix cmake include

### DIFF
--- a/ports/theia/266.diff
+++ b/ports/theia/266.diff
@@ -1,0 +1,12 @@
+diff --git a/libraries/vlfeat/CMakeLists.txt b/libraries/vlfeat/CMakeLists.txt
+index 7f4ffc796..9535d0c22 100644
+--- a/libraries/vlfeat/CMakeLists.txt
++++ b/libraries/vlfeat/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project(vlfeat)
+ 
+-include("${CMAKE_MODULE_PATH}/OptimizeTheiaCompilerFlags.cmake")
++include(OptimizeTheiaCompilerFlags)
+ optimizetheiacompilerflags()
+ 
+ include_directories(./vl)

--- a/ports/theia/portfile.cmake
+++ b/ports/theia/portfile.cmake
@@ -10,16 +10,17 @@ vcpkg_from_github(
         fix-external-dependencies.patch
         fix-external-dependencies2.patch
         eigen-3.4.patch
+        266.diff
 )
 
-file(REMOVE ${SOURCE_PATH}/cmake/FindSuiteSparse.cmake)
-file(REMOVE ${SOURCE_PATH}/cmake/FindOpenImageIO.cmake)
-file(REMOVE ${SOURCE_PATH}/cmake/FindGflags.cmake)
-file(REMOVE ${SOURCE_PATH}/cmake/FindGlog.cmake)
-file(REMOVE ${SOURCE_PATH}/cmake/FindEigen.cmake)
+file(REMOVE "${SOURCE_PATH}/cmake/FindSuiteSparse.cmake")
+file(REMOVE "${SOURCE_PATH}/cmake/FindOpenImageIO.cmake")
+file(REMOVE "${SOURCE_PATH}/cmake/FindGflags.cmake")
+file(REMOVE "${SOURCE_PATH}/cmake/FindGlog.cmake")
+file(REMOVE "${SOURCE_PATH}/cmake/FindEigen.cmake")
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCMAKE_CXX_STANDARD=14
         -DCMAKE_CXX_EXTENSIONS=OFF
@@ -34,15 +35,15 @@ vcpkg_cmake_config_fixup()
 vcpkg_copy_pdbs()
 
 # Clean
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/optimo)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/optimo)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/theia/libraries/akaze/cimg/cmake-modules)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/theia/libraries/akaze/cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/theia/libraries/akaze/datasets)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/theia/libraries/spectra/doxygen)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/optimo")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/optimo")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/theia/libraries/akaze/cimg/cmake-modules")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/theia/libraries/akaze/cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/theia/libraries/akaze/datasets")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/theia/libraries/spectra/doxygen")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(COPY ${SOURCE_PATH}/data/camera_sensor_database_license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(COPY "${SOURCE_PATH}/data/camera_sensor_database_license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/theia/vcpkg.json
+++ b/ports/theia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "theia",
   "version": "0.8",
-  "port-version": 7,
+  "port-version": 8,
   "description": "An open source library for multiview geometry and structure from motion",
   "homepage": "https://github.com/sweeneychris/TheiaSfM",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7554,7 +7554,7 @@
     },
     "theia": {
       "baseline": "0.8",
-      "port-version": 7
+      "port-version": 8
     },
     "think-cell-range": {
       "baseline": "498839d",

--- a/versions/t-/theia.json
+++ b/versions/t-/theia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fe4bf7c896536d692bedb215d88cae3297b1ae1b",
+      "version": "0.8",
+      "port-version": 8
+    },
+    {
       "git-tree": "e8a6f763efb9bd7657a6be700493a95ab32d1cb6",
       "version": "0.8",
       "port-version": 7


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

