### PR TITLE
Update vcpkg-tool to 2023-01-24.

### DIFF
--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -3,6 +3,8 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
     message(WARNING "You will need to install Xorg dependencies to build vtk:\napt-get install libxt-dev\n")
 endif()
 
+set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)
+
 vcpkg_download_distfile(
     STRING_PATCH
     URLS https://gitlab.kitware.com/vtk/vtk/-/commit/bfa3e4c7621ddf5826755536eb07284c86db6474.diff

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.2.0-pv5.11.0",
+  "port-version": 1,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -45,7 +45,7 @@ while (!($vcpkgRootDir -eq "") -and !(Test-Path "$vcpkgRootDir\.vcpkg-root"))
 
 Write-Verbose "Examining $vcpkgRootDir for .vcpkg-root - Found"
 
-$versionDate = '2022-12-14'
+$versionDate = '2023-01-24'
 if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64' -or $env:PROCESSOR_IDENTIFIER -match "ARMv[8,9] \(64-bit\)") {
     & "$scriptsDir/tls12-download-arm64.exe" github.com "/microsoft/vcpkg-tool/releases/download/$versionDate/vcpkg-arm64.exe" "$vcpkgRootDir\vcpkg.exe"
 } else {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -126,23 +126,23 @@ fi
 
 # Choose the vcpkg binary to download
 vcpkgDownloadTool="ON"
-vcpkgToolReleaseTag="2022-12-14"
+vcpkgToolReleaseTag="2023-01-24"
 if [ "$UNAME" = "Darwin" ]; then
     echo "Downloading vcpkg-macos..."
-    vcpkgToolReleaseSha="f50874fd20f46aadc8725139790e80d35189b9f96e0c23d6d94e3afe04fe0e3a32d7a0f9666af6e345a8acf1a69e582e366b651ef8196185cfb2810250f19a86"
+    vcpkgToolReleaseSha="c447465f5d7f467e4b9e9eb7f42fdbd2b8973c87a00da8f00bfd937f1ce351e546c15740476df7608d3f8117c10b0e6f693f03f7db63f7982964297eae95e46e"
     vcpkgToolName="vcpkg-macos"
 elif [ "$vcpkgUseMuslC" = "ON" ]; then
     echo "Downloading vcpkg-muslc..."
-    vcpkgToolReleaseSha="229dd7eb19af4ba4362926da5dae64b09382aff6a59ba0652315ff07ebf2cdfa63c8f4a86b634194e7c1c11452b5a70c6825ede915926d710d1d0f4b0605279a"
+    vcpkgToolReleaseSha="bee46fe90410f510a91f213350ffe3245c79cfe5e741c832b22ba4b68a487be903d3198fc0399c3a124c3d6deff2a4d0689fa171d5a710edc67f88d900782fcf"
     vcpkgToolName="vcpkg-muslc"
 elif [ "$ARCH" = "x86_64" ]; then
     echo "Downloading vcpkg-glibc..."
-    vcpkgToolReleaseSha="f12911e70d643cd547875e951cc7c8c3d9941f072abe512cf96c86a1784ea38a8230c3813ff6e9d4149261dfb2ff953b2a3d8752ca4d6f023b9fd5392adec73e"
+    vcpkgToolReleaseSha="64671187c4db1656a5b8249b6094a176d264d70fb315af408eb76eee40118ff8f40fedbbb55239e68d9cefe8736c510785de78280c1c10def82960d803becf4e"
     vcpkgToolName="vcpkg-glibc"
 else
     echo "Unable to determine a binary release of vcpkg; attempting to build from source."
     vcpkgDownloadTool="OFF"
-    vcpkgToolReleaseSha="63db6e7a2f6ac3924e6da07b278549ca043c29d38524ef7d5804dad0d2d0069f542d48ed31601845ddfcbf87471a90a2b4368f645fd3e43066ce7e72aa40bbf6"
+    vcpkgToolReleaseSha="268592bd75916bd4b19b4bd42535d9886dfd46121b222f991daa32b7bb60c98203b8d944eb711ea61841f9085a3eacb09ca7c9ec8553b9eb82beca06b5631787"
 fi
 
 # Do the download or build.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8058,7 +8058,7 @@
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c7f3430079e884ea0ed88e0696fba5f6a839e5e",
+      "version-semver": "9.2.0-pv5.11.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b5abc532a3af0562e38d66493eb784ee92c44337",
       "version-semver": "9.2.0-pv5.11.0",
       "port-version": 0


### PR DESCRIPTION
https://github.com/microsoft/vcpkg-tool/releases/tag/2023-01-24

Full rebuild: https://dev.azure.com/vcpkg/public/_build/results?buildId=84104

REGRESSION: vtk-m:x64-linux failed with POST_BUILD_CHECKS_FAILED. If expected, add vtk-m:x64-linux=fail to /agent/_work/2/s/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: vcpkg-ci-opencv:x64-linux cascaded, but it is required to pass. (/agent/_work/2/s/scripts/azure-pipelines/../ci.baseline.txt).
REGRESSION: vcpkg-ci-openimageio:x64-linux cascaded, but it is required to pass. (/agent/_work/2/s/scripts/azure-pipelines/../ci.baseline.txt).
REGRESSION: vcpkg-ci-paraview:x64-linux cascaded, but it is required to pass. (/agent/_work/2/s/scripts/azure-pipelines/../ci.baseline.txt).

This was https://github.com/microsoft/vcpkg/pull/29110
