### PR TITLE
[xaudio2redist] port updated to 1.2.11

### DIFF
--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -4,7 +4,7 @@ set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.XAudio2.Redist/${VERSION}"
     FILENAME "xaudio2redist.${VERSION}.zip"
-    SHA512 03aab03f793648a0b1467916a05b22891c32ce44166f85a184746a949338cdeff7104479b88920570e6beeb04395e03669a3ee569c3f2523f3dbc01a368e86b7
+    SHA512 5eae9c94710ba6e51045e6f9dbe381bdfe76184a4272f561976582e8f585ef8343df9f6eaa2d391bfda06796000bc13ccb0f5bf112d7f2c7865f75ab0e89ab56
 )
 
 vcpkg_extract_source_archive(

--- a/ports/xaudio2redist/vcpkg.json
+++ b/ports/xaudio2redist/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xaudio2redist",
-  "version": "1.2.10",
-  "port-version": 1,
+  "version": "1.2.11",
   "description": "Redistributable version of XAudio 2.9 for Windows 7 SP1 or later",
   "homepage": "https://aka.ms/XAudio2Redist",
   "documentation": "https://aka.ms/XAudio2Redist",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8249,8 +8249,8 @@
       "port-version": 1
     },
     "xaudio2redist": {
-      "baseline": "1.2.10",
-      "port-version": 1
+      "baseline": "1.2.11",
+      "port-version": 0
     },
     "xbitmaps": {
       "baseline": "1.1.2",

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9fe9f57e0b392108fb66f0ee68186bdb819dedbf",
+      "version": "1.2.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "bbabce07404d10a9eec61bc9ed7115683be8a0b0",
       "version": "1.2.10",
       "port-version": 1


### PR DESCRIPTION
Updates port for latest NuGet XAudio2Redist release 1.2.11. This release includes fixes to the headers to resolve link-time problems with ``__uuidof`` operations for MinGW toolset builds.

