### PR TITLE
[libjxl] update to 0.8.0

### DIFF
--- a/ports/libjxl/fix-dependencies.patch
+++ b/ports/libjxl/fix-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/jxl.cmake b/lib/jxl.cmake
-index 72c07f4..5675d1e 100644
+index a8a96e1..98d69d6 100644
 --- a/lib/jxl.cmake
 +++ b/lib/jxl.cmake
 @@ -3,6 +3,15 @@
@@ -19,10 +19,10 @@ index 72c07f4..5675d1e 100644
  # by the encoder: the encoder uses both dec and enc ourse files, while the
  # decoder uses only dec source files.
 diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
-index 50cc72c..fed027e 100644
+index 8ee9864..57993ea 100644
 --- a/third_party/CMakeLists.txt
 +++ b/third_party/CMakeLists.txt
-@@ -45,36 +45,7 @@ else()
+@@ -45,59 +45,7 @@ else()
  endif()
  
  # brotli
@@ -55,12 +55,35 @@ index 50cc72c..fed027e 100644
 -      add_library(${brlib} ALIAS ${brlib}-static)
 -    endforeach()
 -  endif()  # BROTLI_EMSCRIPTEN
+-  if(APPLE)
+-    if(NOT DEFINED CMAKE_MACOSX_RPATH)
+-      # Use @rpath in install_name when CMAKE_MACOSX_RPATH is not set.
+-      set_property(TARGET brotlienc PROPERTY MACOSX_RPATH TRUE)
+-      set_property(TARGET brotlidec PROPERTY MACOSX_RPATH TRUE)
+-      set_property(TARGET brotlicommon PROPERTY MACOSX_RPATH TRUE)
+-    endif()
+-    if((NOT DEFINED CMAKE_MACOSX_RPATH) OR CMAKE_MACOSX_RPATH)
+-      # Set library search path when @rpath is used.
+-      if(NOT DEFINED CMAKE_INSTALL_RPATH)
+-        set_property(TARGET brotlienc PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+-        set_property(TARGET brotlidec PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+-        set_property(TARGET brotlicommon PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+-      endif()
+-    else()
+-      # Set conventional install_name when @rpath is not used.
+-      if(NOT DEFINED CMAKE_INSTALL_NAME_DIR)
+-        set_property(TARGET brotlienc PROPERTY INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+-        set_property(TARGET brotlidec PROPERTY INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+-        set_property(TARGET brotlicommon PROPERTY INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+-      endif()
+-    endif()
+-  endif()  # APPLE
 -endif()
 +find_package(unofficial-brotli CONFIG REQUIRED)
  
  # *cms
  if (JPEGXL_ENABLE_SKCMS OR JPEGXL_ENABLE_PLUGINS)
-@@ -86,18 +57,7 @@ if (JPEGXL_ENABLE_SKCMS OR JPEGXL_ENABLE_PLUGINS)
+@@ -109,18 +57,7 @@ if (JPEGXL_ENABLE_SKCMS OR JPEGXL_ENABLE_PLUGINS)
    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/skcms/LICENSE"
                   ${PROJECT_BINARY_DIR}/LICENSE.skcms COPYONLY)
  endif ()
@@ -79,4 +102,4 @@ index 50cc72c..fed027e 100644
 +find_package(lcms2 CONFIG REQUIRED)
  
  # libpng
- if (JPEGXL_EMSCRIPTEN)
+ if (JPEGXL_BUNDLE_LIBPNG AND JPEGXL_EMSCRIPTEN)

--- a/ports/libjxl/portfile.cmake
+++ b/ports/libjxl/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libjxl/libjxl
     REF "v${VERSION}"
-    SHA512 c73039606acf7b2cbc331c6787af5167d711fd1af22bc616e1f478c531b087da82c98f2cb7e88c4d1f8bcfdc4e053ae0dc99cc9a811545b7f9658041489ed04b
+    SHA512 ef472ddc5e277f3d41491c2acc03ed0152ec3ea87efb9e3320cfd830ceb383728658318444b06a3e9f8662bc11c0014675966572ce33f49c8e5cb13c5ed48de1
     HEAD_REF main
     PATCHES
         fix-dependencies.patch
@@ -92,4 +90,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
 endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libjxl/vcpkg.json
+++ b/ports/libjxl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libjxl",
-  "version-semver": "0.7.0",
+  "version-semver": "0.8.0",
   "description": "JPEG XL image format reference implementation",
   "homepage": "https://github.com/libjxl/libjxl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3969,7 +3969,7 @@
       "port-version": 0
     },
     "libjxl": {
-      "baseline": "0.7.0",
+      "baseline": "0.8.0",
       "port-version": 0
     },
     "libkeyfinder": {

--- a/versions/l-/libjxl.json
+++ b/versions/l-/libjxl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef11c9864441ebeee257d1baedf1d29d208087f5",
+      "version-semver": "0.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1012fef90a25836b40b40275eb7e4ccde46d0521",
       "version-semver": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
