### PR TITLE
[simage] use support expression

### DIFF
--- a/ports/simage/portfile.cmake
+++ b/ports/simage/portfile.cmake
@@ -1,4 +1,3 @@
-set(SIMAGE_VERSION 1.8.2)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -30,13 +29,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 # Depends on the platform
 if(VCPKG_TARGET_IS_WINDOWS AND "gdiplus" IN_LIST FEATURES)
     message(WARNING "Feature 'gdiplus' will disable feature 'zlib', 'giflib', 'jpeg', 'png' and 'tiff' automaticly.")
-elseif ((VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
-         AND ("gdiplus" IN_LIST FEATURES OR "avienc" IN_LIST FEATURES))
-    message(FATAL_ERROR "Feature 'avienc' and 'gdiplus' only support Windows.")
 endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}
         -DSIMAGE_BUILD_SHARED_LIBS:BOOL=${SIMAGE_BUILD_SHARED_LIBS}
         -DSIMAGE_USE_STATIC_LIBS:BOOL=${SIMAGE_USE_STATIC_LIBS}
@@ -61,7 +57,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/simage-${SIMAGE_VERSION})
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/simage-${VERSION})
 
 if (NOT VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)
     vcpkg_copy_tools(TOOL_NAMES simage-config AUTO_CLEAN)

--- a/ports/simage/vcpkg.json
+++ b/ports/simage/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "simage",
   "version-semver": "1.8.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Image file format library abstraction layer",
   "homepage": "https://github.com/coin3d/simage",
   "license": "ISC",
@@ -96,10 +96,12 @@
       ]
     },
     "avienc": {
-      "description": "Use Video for Windows for AVI encoding"
+      "description": "Use Video for Windows for AVI encoding",
+      "supports": "windows"
     },
     "gdiplus": {
-      "description": "Use GDI+ on Windows to load/save images"
+      "description": "Use GDI+ on Windows to load/save images",
+      "supports": "windows"
     },
     "giflib": {
       "description": "Enable support for GIF images",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7082,7 +7082,7 @@
     },
     "simage": {
       "baseline": "1.8.2",
-      "port-version": 1
+      "port-version": 2
     },
     "simbody": {
       "baseline": "2023-01-10",

--- a/versions/s-/simage.json
+++ b/versions/s-/simage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e3fa3cf60c5fa543b313ed36d80a09d7a9ec8cd",
+      "version-semver": "1.8.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "d877e927cdad3e67542b5c66c26bdc0bda9f5ade",
       "version-semver": "1.8.2",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
