### PR TITLE
[icu] Add tools, fix building for ios

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -37,6 +37,11 @@ list(APPEND CONFIGURE_OPTIONS_DEBUG  --enable-debug --disable-release)
 set(RELEASE_TRIPLET ${TARGET_TRIPLET}-rel)
 set(DEBUG_TRIPLET ${TARGET_TRIPLET}-dbg)
 
+if("tools" IN_LIST FEATURES)
+  list(APPEND CONFIGURE_OPTIONS --enable-tools)
+else()
+  list(APPEND CONFIGURE_OPTIONS --disable-tools)
+endif()
 if(CMAKE_HOST_WIN32 AND VCPKG_TARGET_IS_MINGW AND NOT HOST_TRIPLET MATCHES "mingw")
     # Assuming no cross compiling because the host (windows) pkgdata tool doesn't
     # use the '/' path separator when creating compiler commands for mingw bash.

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "icu",
   "version": "72.1",
+  "port-version": 1,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",
@@ -8,7 +9,15 @@
   "dependencies": [
     {
       "name": "icu",
-      "host": true
+      "host": true,
+      "features": [
+        "tools"
+      ]
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build tools"
+    }
+  }
 }

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.8",
+  "port-version": 1,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -15,6 +16,9 @@
     "harfbuzz",
     {
       "name": "icu",
+      "features": [
+        "tools"
+      ],
       "platform": "!uwp"
     },
     "libjpeg-turbo",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6206,7 +6206,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.8",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-canvas3d": {
       "baseline": "0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3022,7 +3022,7 @@
     },
     "icu": {
       "baseline": "72.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ideviceinstaller": {
       "baseline": "1.1.2.23",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a4109603660116f3cb7477c234d3f0275124738",
+      "version": "72.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "ca8792e25fbaf4f4d507eef05e2235b0449ed155",
       "version": "72.1",
       "port-version": 0

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ca5efe99e5f582864670520199ec5da387ceb80",
+      "version": "5.15.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "9bc09074d246485cea02dc5ba92ffcbae8f28cad",
       "version": "5.15.8",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/26727

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
