### PR TITLE
[ismrmrd] Update to version 1.13.2

### DIFF
--- a/ports/ismrmrd/portfile.cmake
+++ b/ports/ismrmrd/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ismrmrd/ismrmrd
-    REF v1.13.0
-    SHA512 4654c416f7acc4e2da2616216706ff3dc98a9b8afbdf38c990a792ad681ce0e95eab8e3b382ad266d67f7b808fb86cc32f2f7b3d950e10e1a1473de38acb8104
+    REF v1.13.2
+    SHA512 8bfdceedefa7dae6cc047e9498f30d3e763f5ab8aa3726f0dc0b2ac086c00a0fddee9c6feadcf4b41c55c692230e8db596cdfc8d79af29c704b79bbad270187b
     HEAD_REF master
     PATCHES
         ${WIN32_INCLUDE_STDDEF_PATCH}
@@ -16,7 +16,6 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DUSE_SYSTEM_PUGIXML=ON
         -DUSE_HDF5_DATASET_SUPPORT=ON
         -DVCPKG_TARGET_TRIPLET=ON
         -DBUILD_TESTS=OFF

--- a/ports/ismrmrd/vcpkg.json
+++ b/ports/ismrmrd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ismrmrd",
-  "version": "1.13.0",
+  "version": "1.13.2",
   "description": "ISMRM Raw Data Format",
   "homepage": "https://github.com/ismrmrd/ismrmrd",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3213,7 +3213,7 @@
       "port-version": 0
     },
     "ismrmrd": {
-      "baseline": "1.13.0",
+      "baseline": "1.13.2",
       "port-version": 0
     },
     "itk": {

--- a/versions/i-/ismrmrd.json
+++ b/versions/i-/ismrmrd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f8f4bb483f585631015c8991706874b535628dec",
+      "version": "1.13.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c19bcebf0417091d459a15d14506b10905e5db8c",
       "version": "1.13.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

