### PR TITLE
[ffmpeg] Enable openmpt and update feature platforms.

### DIFF
--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "5.1.2",
+  "port-version": 1,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -33,6 +34,7 @@
           "name": "ffmpeg",
           "default-features": false,
           "features": [
+            "aom",
             "avcodec",
             "avdevice",
             "avfilter",
@@ -43,6 +45,7 @@
             "lzma",
             "mp3lame",
             "openjpeg",
+            "openmpt",
             "opus",
             "snappy",
             "soxr",
@@ -149,17 +152,9 @@
           "name": "ffmpeg",
           "default-features": false,
           "features": [
-            "aom"
+            "amf"
           ],
-          "platform": "!(windows & arm & !uwp)"
-        },
-        {
-          "name": "ffmpeg",
-          "default-features": false,
-          "features": [
-            "dav1d"
-          ],
-          "platform": "!(uwp | arm | x86 | osx)"
+          "platform": "!osx & !uwp"
         },
         {
           "name": "ffmpeg",
@@ -181,17 +176,17 @@
           "name": "ffmpeg",
           "default-features": false,
           "features": [
-            "tesseract"
+            "dav1d"
           ],
-          "platform": "!(windows & arm) & !static & !uwp"
+          "platform": "!(uwp | (windows & x86 & !static))"
         },
         {
           "name": "ffmpeg",
           "default-features": false,
           "features": [
-            "amf"
+            "tesseract"
           ],
-          "platform": "linux | (!osx & !uwp & !(arm & windows))"
+          "platform": "!(windows & arm) & !static & !uwp"
         },
         {
           "name": "ffmpeg",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2346,7 +2346,7 @@
     },
     "ffmpeg": {
       "baseline": "5.1.2",
-      "port-version": 0
+      "port-version": 1
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b241f0d72b16fbf34178d215d17f21e33d356af",
+      "version": "5.1.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "b288cec1b63010d1cb92e18256bc49a48b4bca52",
       "version": "5.1.2",
       "port-version": 0


### PR DESCRIPTION
[ffmpeg] Add openmpt to the 'all' feature so that it is actually tested by CI
[ffmpeg] Update dav1d feature to support additional systems [#28737](https://github.com/microsoft/vcpkg/pull/28737)
[ffmpeg] Update aom feature to support additional systems [#28739](https://github.com/microsoft/vcpkg/pull/28739)
[ffmpeg] Enable amf on more systems.