### PR TITLE
[openimageio] add libheif as an optional dependency, remove libsquish as a dependency

### DIFF
--- a/ports/openimageio/fix-dependencies.patch
+++ b/ports/openimageio/fix-dependencies.patch
@@ -2,11 +2,13 @@ diff --git a/src/cmake/Config.cmake.in b/src/cmake/Config.cmake.in
 index 0a6afeb..2a67ee3 100644
 --- a/src/cmake/Config.cmake.in
 +++ b/src/cmake/Config.cmake.in
-@@ -2,6 +2,22 @@
+@@ -2,6 +2,24 @@
  
  include(CMakeFindDependencyMacro)
  
-+find_dependency(libheif CONFIG)
++if (@USE_LIBHEIF@)
++    find_dependency(libheif CONFIG)
++endif()
 +find_dependency(PNG)
 +find_dependency(unofficial-libsquish CONFIG)
 +if(@USE_OPENCV@)

--- a/ports/openimageio/fix-dependencies.patch
+++ b/ports/openimageio/fix-dependencies.patch
@@ -2,7 +2,7 @@ diff --git a/src/cmake/Config.cmake.in b/src/cmake/Config.cmake.in
 index 0a6afeb..2a67ee3 100644
 --- a/src/cmake/Config.cmake.in
 +++ b/src/cmake/Config.cmake.in
-@@ -2,6 +2,24 @@
+@@ -2,6 +2,23 @@
  
  include(CMakeFindDependencyMacro)
  
@@ -10,7 +10,6 @@ index 0a6afeb..2a67ee3 100644
 +    find_dependency(libheif CONFIG)
 +endif()
 +find_dependency(PNG)
-+find_dependency(unofficial-libsquish CONFIG)
 +if(@USE_OPENCV@)
 +    find_dependency(OpenCV CONFIG)
 +endif()

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -69,7 +69,7 @@ vcpkg_cmake_configure(
         -DINSTALL_DOCS=OFF
         -DENABLE_INSTALL_testtex=OFF
         "-DFMT_INCLUDES=${CURRENT_INSTALLED_DIR}/include"
-        "-DREQUIRED_DEPS=fmt;JPEG;Libsquish;PNG;Robinmap"
+        "-DREQUIRED_DEPS=fmt;JPEG;PNG;Robinmap"
     MAYBE_UNUSED_VARIABLES
         ENABLE_INSTALL_testtex
 )

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -41,6 +41,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         opencv      USE_OPENCV
         openjpeg    USE_OPENJPEG
         webp        USE_WEBP
+        libheif     USE_LIBHEIF
         pybind11    USE_PYTHON
         tools       OIIO_BUILD_TOOLS
         tools       USE_OPENGL
@@ -68,7 +69,7 @@ vcpkg_cmake_configure(
         -DINSTALL_DOCS=OFF
         -DENABLE_INSTALL_testtex=OFF
         "-DFMT_INCLUDES=${CURRENT_INSTALLED_DIR}/include"
-        "-DREQUIRED_DEPS=fmt;JPEG;Libheif;Libsquish;PNG;Robinmap"
+        "-DREQUIRED_DEPS=fmt;JPEG;Libsquish;PNG;Robinmap"
     MAYBE_UNUSED_VARIABLES
         ENABLE_INSTALL_testtex
 )

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -37,12 +37,6 @@
     "zlib"
   ],
   "features": {
-    "libheif": {
-      "description": "Enable heif support for openimageio",
-      "dependencies": [
-        "libheif"
-      ]
-    },
     "ffmpeg": {
       "description": "Enable ffmpeg support for openimageio",
       "dependencies": [
@@ -65,6 +59,12 @@
       "description": "Enable giflib support for openimageio",
       "dependencies": [
         "giflib"
+      ]
+    },
+    "libheif": {
+      "description": "Enable heif support for openimageio",
+      "dependencies": [
+        "libheif"
       ]
     },
     "libraw": {

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -22,7 +22,6 @@
     "fmt",
     "libjpeg-turbo",
     "libpng",
-    "libsquish",
     "openexr",
     "robin-map",
     "tiff",

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openimageio",
   "version": "2.4.5.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",
@@ -20,7 +20,6 @@
     "boost-thread",
     "boost-type-traits",
     "fmt",
-    "libheif",
     "libjpeg-turbo",
     "libpng",
     "libsquish",
@@ -38,6 +37,12 @@
     "zlib"
   ],
   "features": {
+    "libheif": {
+      "description": "Enable heif support for openimageio",
+      "dependencies": [
+        "libheif"
+      ]
+    },
     "ffmpeg": {
       "description": "Enable ffmpeg support for openimageio",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5618,7 +5618,7 @@
     },
     "openimageio": {
       "baseline": "2.4.5.0",
-      "port-version": 3
+      "port-version": 4
     },
     "openjpeg": {
       "baseline": "2.5.0",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "95bf3bbb0b939b6d495fe8933b7ebbc83cd54540",
+      "git-tree": "3c8df049a8e7b1c3e48006e78c4f5a9d451860a0",
       "version": "2.4.5.0",
       "port-version": 4
     },

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "13afc5b97d4af52174e30adf32b821b5f19404c5",
+      "git-tree": "95bf3bbb0b939b6d495fe8933b7ebbc83cd54540",
       "version": "2.4.5.0",
       "port-version": 4
     },

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13afc5b97d4af52174e30adf32b821b5f19404c5",
+      "version": "2.4.5.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "d89c769d1b813eadd08173e4e9d18049ac8c1d23",
       "version": "2.4.5.0",
       "port-version": 3


### PR DESCRIPTION
Workaound for #29156, but also is a good feature. Additionally, libsquish is not a dependency as of https://github.com/OpenImageIO/oiio/commit/5e67c09ecede66cc26c05d7134934c1b92385e9a#diff-0d57038c2e7b5bf8660e3859a78c7e96fbdb6b77604d4510e137de90b9e8f9e7

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
