### PR TITLE
[arg-router] Add new port

### DIFF
--- a/ports/arg-router/portfile.cmake
+++ b/ports/arg-router/portfile.cmake
@@ -15,8 +15,6 @@ vcpkg_extract_source_archive(
 file(
     COPY "${SOURCE_PATH}/include/arg_router/arg_router-config.cmake"
          "${SOURCE_PATH}/include/arg_router/arg_router-config-version.cmake"
-         "${SOURCE_PATH}/include/arg_router/README.md"
-         "${SOURCE_PATH}/include/arg_router/LICENSE"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/arg_router"
 )
 file(
@@ -29,6 +27,6 @@ file(
 )
 
 vcpkg_install_copyright(
-    FILE_LIST "${CURRENT_PACKAGES_DIR}/share/arg_router/LICENSE"
+    FILE_LIST "${SOURCE_PATH}/include/arg_router/LICENSE"
 )
 

--- a/ports/arg-router/portfile.cmake
+++ b/ports/arg-router/portfile.cmake
@@ -1,0 +1,35 @@
+set(AR_VERSION 1.1.0)
+set(ARCHIVE_NAME arg_router-${AR_VERSION}.zip)
+
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS https://github.com/cmannett85/arg_router/releases/download/v${AR_VERSION}/${ARCHIVE_NAME}
+    FILENAME ${ARCHIVE_NAME}
+    SHA512 9cb75dafbdcbc02c774d5dcf17af126b7b1fc032b10cc0a2b5075897fbb80cdb0b84b631d265295210c3a7bdae682065f417d8ca70937118de97f14ed46bd31b
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
+
+file(
+    COPY "${SOURCE_PATH}/include/arg_router/arg_router-config.cmake"
+         "${SOURCE_PATH}/include/arg_router/arg_router-config-version.cmake"
+         "${SOURCE_PATH}/include/arg_router/README.md"
+         "${SOURCE_PATH}/include/arg_router/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/arg_router"
+)
+file(
+    COPY "${SOURCE_PATH}/include"
+    DESTINATION "${CURRENT_PACKAGES_DIR}"
+)
+file(
+    COPY "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+vcpkg_install_copyright(
+    FILE_LIST "${CURRENT_PACKAGES_DIR}/share/arg_router/LICENSE"
+)
+

--- a/ports/arg-router/portfile.cmake
+++ b/ports/arg-router/portfile.cmake
@@ -1,9 +1,8 @@
-set(AR_VERSION 1.1.0)
-set(ARCHIVE_NAME arg_router-${AR_VERSION}.zip)
+set(ARCHIVE_NAME arg_router-${VERSION}.zip)
 
 vcpkg_download_distfile(
     ARCHIVE
-    URLS https://github.com/cmannett85/arg_router/releases/download/v${AR_VERSION}/${ARCHIVE_NAME}
+    URLS https://github.com/cmannett85/arg_router/releases/download/v${VERSION}/${ARCHIVE_NAME}
     FILENAME ${ARCHIVE_NAME}
     SHA512 9cb75dafbdcbc02c774d5dcf17af126b7b1fc032b10cc0a2b5075897fbb80cdb0b84b631d265295210c3a7bdae682065f417d8ca70937118de97f14ed46bd31b
 )

--- a/ports/arg-router/portfile.cmake
+++ b/ports/arg-router/portfile.cmake
@@ -1,15 +1,15 @@
-set(ARCHIVE_NAME arg_router-${VERSION}.zip)
+set(ARCHIVE_NAME "arg_router-${VERSION}.zip")
 
 vcpkg_download_distfile(
     ARCHIVE
-    URLS https://github.com/cmannett85/arg_router/releases/download/v${VERSION}/${ARCHIVE_NAME}
-    FILENAME ${ARCHIVE_NAME}
+    URLS "https://github.com/cmannett85/arg_router/releases/download/v${VERSION}/${ARCHIVE_NAME}"
+    FILENAME "${ARCHIVE_NAME}"
     SHA512 9cb75dafbdcbc02c774d5dcf17af126b7b1fc032b10cc0a2b5075897fbb80cdb0b84b631d265295210c3a7bdae682065f417d8ca70937118de97f14ed46bd31b
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
 )
 
 file(
@@ -29,4 +29,3 @@ file(
 vcpkg_install_copyright(
     FILE_LIST "${SOURCE_PATH}/include/arg_router/LICENSE"
 )
-

--- a/ports/arg-router/usage
+++ b/ports/arg-router/usage
@@ -1,0 +1,8 @@
+The package arg-router is a header-only library and so is typically used like this:
+
+    find_package(arg_router REQUIRED)
+    include_directories(SYSTEM "${arg_router_INCLUDE_DIRS}")
+    
+For more information, see the docs here:
+
+    https://github.com/cmannett85/arg_router

--- a/ports/arg-router/vcpkg.json
+++ b/ports/arg-router/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "arg-router",
+  "version": "1.1.0",
+  "description": "C++ command line argument parsing and routing.",
+  "homepage": "https://github.com/cmannett85/arg_router",
+  "documentation": "https://cmannett85.github.io/arg_router/",
+  "license": "BSL-1.0",
+  "dependencies": [
+    "boost-lexical-cast",
+    "boost-mp11",
+    "boost-preprocessor",
+    "span-lite"
+  ]
+}

--- a/versions/a-/arg-router.json
+++ b/versions/a-/arg-router.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c9c57d469a253971409688ead6d0f71b3a9f69b4",
+      "git-tree": "657962d68d7f60db63a5352c89b21a8332aac47b",
       "version": "1.1.0",
       "port-version": 0
     }

--- a/versions/a-/arg-router.json
+++ b/versions/a-/arg-router.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "00699fa5e6826f4ecaea41df58aa441aef28639d",
+      "git-tree": "d6f21738ed53af9693376f8e659485875117f8f5",
       "version": "1.1.0",
       "port-version": 0
     }

--- a/versions/a-/arg-router.json
+++ b/versions/a-/arg-router.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "657962d68d7f60db63a5352c89b21a8332aac47b",
+      "git-tree": "00699fa5e6826f4ecaea41df58aa441aef28639d",
       "version": "1.1.0",
       "port-version": 0
     }

--- a/versions/a-/arg-router.json
+++ b/versions/a-/arg-router.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c9c57d469a253971409688ead6d0f71b3a9f69b4",
+      "version": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -152,6 +152,10 @@
       "baseline": "4.10.0",
       "port-version": 2
     },
+    "arg-router": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "argagg": {
       "baseline": "0.4.6",
       "port-version": 1


### PR DESCRIPTION
Header-only library from https://github.com/cmannett85/arg_router.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.