### PR TITLE
[qtbase] ios support

### DIFF
--- a/ports/qtbase/fix_glminmax_ios.patch
+++ b/ports/qtbase/fix_glminmax_ios.patch
@@ -1,0 +1,22 @@
+diff --git a/src/gui/rhi/qrhigles2.cpp b/src/gui/rhi/qrhigles2.cpp
+index 89c5d75f..41e3783e 100644
+--- a/src/gui/rhi/qrhigles2.cpp
++++ b/src/gui/rhi/qrhigles2.cpp
+@@ -2446,10 +2446,17 @@ static inline GLenum toGlBlendOp(QRhiGraphicsPipeline::BlendOp op)
+         return GL_FUNC_SUBTRACT;
+     case QRhiGraphicsPipeline::ReverseSubtract:
+         return GL_FUNC_REVERSE_SUBTRACT;
++#if defined(Q_OS_IOS)
++    case QRhiGraphicsPipeline::Min:
++        return GL_MIN_EXT;
++    case QRhiGraphicsPipeline::Max:
++        return GL_MAX_EXT;
++#else
+     case QRhiGraphicsPipeline::Min:
+         return GL_MIN;
+     case QRhiGraphicsPipeline::Max:
+         return GL_MAX;
++#endif
+     default:
+         Q_UNREACHABLE();
+         return GL_FUNC_ADD;

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -19,6 +19,7 @@ set(${PORT}_PATCHES
         clang-cl_QGADGET_fix.diff # Upstream is still figuring out if this is a compiler bug or not.
         installed_dir.patch
         GLIB2-static.patch # alternative is to force pkg-config
+        fix_glminmax_ios.patch
         )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.4.2",
+  "port-version": 1,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -8,7 +9,7 @@
   "dependencies": [
     {
       "name": "libb2",
-      "platform": "!windows"
+      "platform": "!windows & !ios"
     },
     "pcre2",
     {
@@ -108,6 +109,14 @@
     "default-features": {
       "description": "Platform-dependent default features",
       "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "gles2"
+          ],
+          "platform": "ios"
+        },
         {
           "name": "qtbase",
           "default-features": false,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6378,7 +6378,7 @@
     },
     "qtbase": {
       "baseline": "6.4.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtcharts": {
       "baseline": "6.4.2",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55cc489b4d31baaeb3a3e6740d9275dc73904a96",
+      "version": "6.4.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "a4c5fd7ea860b1c35266670b5efe76b65d5ba8f6",
       "version": "6.4.2",
       "port-version": 0


### PR DESCRIPTION
Adds ios support for qtbase

I am only halfway convinced by this, as upstream seems to be able to produce binaries without the patch. But the "controlled" platform headers (`OpenGLES.framework/Headers/ES2/glext.h`) only contains `GL_MIN_EXT` and no `GL_MIN`.
I wonder if upstream builds without `gles2` (which is [deprecated for ios](https://forum.qt.io/topic/101591/qt-and-metal)) or if it's something else.
But since this builds for me, I'll put it up for discussion here anyway.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
