### PR TITLE
[libjxl] remove baseline skip for arm-uwp

### DIFF
--- a/ports/libjxl/vcpkg.json
+++ b/ports/libjxl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libjxl",
   "version-semver": "0.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "JPEG XL image format reference implementation",
   "homepage": "https://github.com/libjxl/libjxl",
   "license": "BSD-3-Clause",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -410,8 +410,6 @@ libigl:arm64-windows=fail
 libigl:arm-uwp=fail
 libigl:x64-uwp=fail
 libirecovery:x64-windows-static-md=fail
-# 120 min build time for libjxl arm-uwp-rel, reason unknown
-libjxl:arm-uwp=skip
 liblemon:arm-uwp=fail
 liblemon:x64-uwp=fail
 liblo:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3970,7 +3970,7 @@
     },
     "libjxl": {
       "baseline": "0.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libkeyfinder": {
       "baseline": "2.2.6",

--- a/versions/l-/libjxl.json
+++ b/versions/l-/libjxl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e7d48f207139ca15a016e84be78b5343bf25fc4",
+      "version-semver": "0.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "e2a279f3663c22d8d36ff1960729f8000535b063",
       "version-semver": "0.8.0",
       "port-version": 1


### PR DESCRIPTION
Thanks to @dg0yt the baseline problem with [libjxl] has been fixed. 