### PR TITLE
[libde265] enable on arm linux + ios

### DIFF
--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "libde265",
   "version": "1.0.8",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",
   "license": "LGPL-3.0-only",
-  "supports": "!(arm | uwp)",
+  "supports": "!uwp & !(arm & windows)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3750,7 +3750,7 @@
     },
     "libde265": {
       "baseline": "1.0.8",
-      "port-version": 5
+      "port-version": 6
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f781eec5a444ba998fc1e8e3dd31172806005d3",
+      "version": "1.0.8",
+      "port-version": 6
+    },
+    {
       "git-tree": "404108a20a6a0699d08f867b7da085ef3d91360b",
       "version": "1.0.8",
       "port-version": 5


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
