### PR TITLE
[matio] fix inter feature dependencies

### DIFF
--- a/ports/matio/vcpkg.json
+++ b/ports/matio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "matio",
   "version": "1.5.23",
-  "port-version": 1,
+  "port-version": 2,
   "description": "MATLAB MAT File I/O Library",
   "homepage": "https://github.com/tbeu/matio",
   "license": "BSD-2-Clause",
@@ -25,11 +25,27 @@
         {
           "name": "hdf5",
           "default-features": false
+        },
+        {
+          "name": "matio",
+          "default-features": false,
+          "features": [
+            "zlib"
+          ]
         }
       ]
     },
     "mat73": {
-      "description": "Enable support for version 7.3 MAT files"
+      "description": "Enable support for version 7.3 MAT files",
+      "dependencies": [
+        {
+          "name": "matio",
+          "default-features": false,
+          "features": [
+            "hdf5"
+          ]
+        }
+      ]
     },
     "pic": {
       "description": "Enable position-independent code (PIC), i.e., compilation with the -fPIC flag"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4862,7 +4862,7 @@
     },
     "matio": {
       "baseline": "1.5.23",
-      "port-version": 1
+      "port-version": 2
     },
     "matplotlib-cpp": {
       "baseline": "2020-08-27",

--- a/versions/m-/matio.json
+++ b/versions/m-/matio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28df0a44f618c5fd412fafda91507f3bad6ac4b1",
+      "version": "1.5.23",
+      "port-version": 2
+    },
+    {
       "git-tree": "ee4fd8ab9268b332bd49e3b506033487a39afe26",
       "version": "1.5.23",
       "port-version": 1


### PR DESCRIPTION
Fixes matio[core,hdf5]:
```
CMake Error at cmake/src.cmake:80 (target_link_libraries):
  Target "matio" links to:

    MATIO::ZLIB

  but the target was not found.
```
and  
Fixes matio[core,mat73]:
```
CMake Error at cmake/thirdParties.cmake:68 (message):
  MAT73 requires HDF5
Call Stack (most recent call first):
  CMakeLists.txt:29 (include)
```
