### PR TITLE
[mchehab-zbar] Fix dependencies

### DIFF
--- a/ports/mchehab-zbar/portfile.cmake
+++ b/ports/mchehab-zbar/portfile.cmake
@@ -1,11 +1,7 @@
-if(EXISTS ${CURRENT_INSTALLED_DIR}/share/zbar/copyright)
-    message(FATAL_ERROR "${PORT} conflicts with zbar. Please remove zbar before installing ${PORT}.")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mchehab/zbar
-    REF 0.23.90
+    REF "${VERSION}"
     SHA512 d73d71873bec68ee021997512a9edbd223f5f5fe43c66c4dd3502224ba6009be2e5e1714766cb8e1056244673e87e0939ed0319116f61d7371b5ab79fb5e04eb
     HEAD_REF master
     PATCHES
@@ -15,35 +11,40 @@ vcpkg_from_github(
         x64.patch
 )
 
+vcpkg_list(SET options)
+if("nls" IN_LIST FEATURES)
+    vcpkg_list(APPEND options "--enable-nls")
+else()
+    vcpkg_list(APPEND options "--disable-nls")
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
-    NO_ADDITIONAL_PATHS
-    ADD_BIN_TO_PATH
-    ADDITIONAL_MSYS_PACKAGES findutils gettext gettext-devel liblzma tar xz
+    AUTOCONFIG
     OPTIONS
-        --disable-video
+        ${options}
+        --without-dbus
         --without-gtk
         --without-imagemagick
         --without-java
+        --without-jpeg
         --without-python
         --without-qt
+        --disable-video
         --without-xv
+    OPTIONS_RELEASE
+        --disable-assert
 )
 
 vcpkg_install_make()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE
-        "${CURRENT_PACKAGES_DIR}/bin"
-        "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
-
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
-    "${CURRENT_PACKAGES_DIR}/share/doc")
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+    "${CURRENT_PACKAGES_DIR}/tools"
+)
 
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/zbar" "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-configure_file("${SOURCE_PATH}/COPYING" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/mchehab-zbar/vcpkg.json
+++ b/ports/mchehab-zbar/vcpkg.json
@@ -1,12 +1,31 @@
 {
   "name": "mchehab-zbar",
   "version": "0.23.90",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ZBar is an open source software suite for reading bar codes from various sources, including webcams. This fork is actively maintained.",
   "homepage": "https://github.com/mchehab/zbar",
   "license": "LGPL-2.1-or-later",
-  "supports": "windows & !uwp",
+  "supports": "!uwp",
   "dependencies": [
+    {
+      "name": "gettext",
+      "host": true
+    },
     "libiconv"
-  ]
+  ],
+  "features": {
+    "nls": {
+      "description": "Native Language Support",
+      "dependencies": [
+        "gettext",
+        {
+          "name": "gettext",
+          "host": true,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/ports/mchehab-zbar/windows.patch
+++ b/ports/mchehab-zbar/windows.patch
@@ -11,19 +11,6 @@ index c8fea14..eb0a097 100644
  AM_CXXFLAGS="$AM_CFLAGS"
  AC_SUBST([AM_CPPFLAGS])
  AC_SUBST([AM_CFLAGS])
-diff --git a/zbar/Makefile.am b/zbar/Makefile.am
-index ca54d01..6c0cd83 100644
---- a/zbar/Makefile.am
-+++ b/zbar/Makefile.am
-@@ -68,7 +68,7 @@ if WIN32
- 
- libzbar_la_SOURCES += processor/win.c libzbar.rc
- libzbar_la_CPPFLAGS += -mthreads
--libzbar_la_LDFLAGS += -mthreads
-+libzbar_la_LDFLAGS += -mthreads -Xcompiler -Wl,-DEBUG
- # FIXME broken
- libzbar_la_LIBADD += libzbar-rc.lo
- else
 diff --git a/zbar/libzbar.rc b/zbar/libzbar.rc
 index 413635b..c241f82 100644
 --- a/zbar/libzbar.rc

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4882,7 +4882,7 @@
     },
     "mchehab-zbar": {
       "baseline": "0.23.90",
-      "port-version": 1
+      "port-version": 2
     },
     "mcpp": {
       "baseline": "2.7.2.14",

--- a/versions/m-/mchehab-zbar.json
+++ b/versions/m-/mchehab-zbar.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af1f66aef9076cd2e27c941851d1549d1cbffe00",
+      "version": "0.23.90",
+      "port-version": 2
+    },
+    {
       "git-tree": "545ecda77fa95f46216d944ca8ab1f7e12378930",
       "version": "0.23.90",
       "port-version": 1


### PR DESCRIPTION
msys2 dev lib dependency found while working at https://github.com/microsoft/vcpkg/pull/29067.
Build locally tested on x64-linux host with mingw and linux triplets.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
