### PR TITLE
[poppler] Update to 23.01.0

### DIFF
--- a/ports/poppler/export-unofficial-poppler.patch
+++ b/ports/poppler/export-unofficial-poppler.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9a0dcb1..c1f2f02 100644
+index 4768ac8..eda857a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -585,9 +585,16 @@ if(MINGW AND BUILD_SHARED_LIBS)
+@@ -615,9 +615,16 @@ if(MINGW AND BUILD_SHARED_LIBS)
      set_target_properties(poppler PROPERTIES SUFFIX "-${POPPLER_SOVERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}")
  endif()
  target_link_libraries(poppler LINK_PRIVATE ${poppler_LIBS})
@@ -21,13 +21,13 @@ index 9a0dcb1..c1f2f02 100644
      poppler/Annot.h
      poppler/AnnotStampImageHelper.h
 diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
-index c37936b..344933c 100644
+index 4885145..ad936f6 100644
 --- a/cpp/CMakeLists.txt
 +++ b/cpp/CMakeLists.txt
-@@ -32,7 +32,8 @@ if(MINGW AND BUILD_SHARED_LIBS)
+@@ -31,7 +31,8 @@ if(MINGW AND BUILD_SHARED_LIBS)
      set_target_properties(poppler-cpp PROPERTIES SUFFIX "-${POPPLER_CPP_SOVERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}")
  endif()
- target_link_libraries(poppler-cpp poppler ${ICONV_LIBRARIES})
+ target_link_libraries(poppler-cpp poppler Iconv::Iconv)
 -install(TARGETS poppler-cpp RUNTIME DESTINATION bin LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +install(TARGETS poppler-cpp EXPORT unofficial-poppler-cpp-targets RUNTIME DESTINATION bin LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +install(EXPORT unofficial-poppler-cpp-targets NAMESPACE unofficial::poppler:: DESTINATION share/unofficial-poppler)

--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -1,9 +1,10 @@
+string(REGEX REPLACE "^([0-9]+)[.]([0-9][.])" "\\1.0\\2" POPPLER_VERSION "${VERSION}")
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO poppler/poppler
-    REF 12853d22e9d0527c10ada02666aef629db3e5e7c #poppler-22.08.0
-    SHA512 d181bc8a521e216f163096e8baad7e73c898c24b18a5a4ab3b687bff4c29333c8c19961adaef54e684c1bdf26dab90183c3553fadb963b7a664e063bd3abcfcf
+    REF "poppler-${POPPLER_VERSION}"
+    SHA512 18649364dc407080941b7c4010c0f26c1ce825d9ec49ff8e9ef298c62afb8d5bb77cea6a5cd1a74615190f433c265613dba42a6b7fdd80c2b5f00d372a31d21d
     HEAD_REF master
     PATCHES
         export-unofficial-poppler.patch
@@ -68,7 +69,7 @@ configure_file("${CMAKE_CURRENT_LIST_DIR}/unofficial-poppler-config.cmake" "${CU
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-poppler)
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/poppler.pc" "Libs:" "Requires.private: ${POPPLER_PC_REQUIRES}\nLibs:")
-if(NOT DEFINED VCPKG_BUILD_TYPE)
+if(NOT VCPKG_BUILD_TYPE)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/poppler.pc" "Libs:" "Requires.private: ${POPPLER_PC_REQUIRES}\nLibs:")
 endif()
 vcpkg_fixup_pkgconfig()

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "poppler",
-  "version": "22.8.0",
-  "port-version": 1,
+  "version": "23.1.0",
   "description": "A PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6013,8 +6013,8 @@
       "port-version": 4
     },
     "poppler": {
-      "baseline": "22.8.0",
-      "port-version": 1
+      "baseline": "23.1.0",
+      "port-version": 0
     },
     "popsift": {
       "baseline": "0.9",

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a901a18c0bb360c8c8707f157202b00620c126e2",
+      "version": "23.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e271252b274bf5737f4e09fd1cf39c75fbdc798d",
       "version": "22.8.0",
       "port-version": 1


### PR DESCRIPTION
Fixes [CVE-2022-38784](https://nvd.nist.gov/vuln/detail/CVE-2022-38784) et al.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
