### PR TITLE
[highway] Update to 1.0.3, dynamic linkage

### DIFF
--- a/ports/highway/portfile.cmake
+++ b/ports/highway/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/highway
@@ -22,6 +20,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/hwy/highway_export.h" "defined(HWY_SHARED_DEFINE)" "1")
+endif()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/highway/portfile.cmake
+++ b/ports/highway/portfile.cmake
@@ -1,11 +1,10 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/highway
-    REF ${VERSION}
-    SHA512 d4c57b297f073dd83535c60151bbc7e7960262990d89bc78882adeb457ed7cf6d54ec852ecb1847c7760de3992267b66538971d20a2c2935828d95d99ddb3a3f
+    REF "${VERSION}"
+    SHA512 fc419c862e1686b6278081e8e10da41dc2bdfbd386a29b59e21a57375a47d3eeb5c7297e3078c78007b212121d936640b192a26a16c941e73cf599f24e081021
     HEAD_REF master
 )
 
@@ -16,19 +15,20 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS}
+    OPTIONS
+        ${FEATURE_OPTIONS}
         -DHWY_ENABLE_EXAMPLES=OFF
         -DHWY_ENABLE_TESTS=OFF
 )
 
 vcpkg_cmake_install()
 
-# remove test-related pkg-config files that break vcpkg_fixup_pkgconfig
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libhwy-test.pc")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libhwy-test.pc")
-
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    # remove test-related pkg-config files that break vcpkg_fixup_pkgconfig
+    "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libhwy-test.pc"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libhwy-test.pc"
+)
 vcpkg_fixup_pkgconfig()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/highway/vcpkg.json
+++ b/ports/highway/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "highway",
-  "version-semver": "1.0.2",
+  "version-semver": "1.0.3",
   "description": "Performance-portable, length-agnostic SIMD with runtime dispatch",
   "homepage": "https://github.com/google/highway",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2969,7 +2969,7 @@
       "port-version": 0
     },
     "highway": {
-      "baseline": "1.0.2",
+      "baseline": "1.0.3",
       "port-version": 0
     },
     "hikogui": {

--- a/versions/h-/highway.json
+++ b/versions/h-/highway.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a0a097af254dce5588475f4b253253b995628aae",
+      "git-tree": "c5445e6987068f7752475cf5f26c3402d3d8ef82",
       "version-semver": "1.0.3",
       "port-version": 0
     },

--- a/versions/h-/highway.json
+++ b/versions/h-/highway.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0a097af254dce5588475f4b253253b995628aae",
+      "version-semver": "1.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "0062f27986b38db6f1e46e3118bef2cdfdd0450f",
       "version-semver": "1.0.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
