### PR TITLE
[zstr] Update to 1.0.7

### DIFF
--- a/ports/zstr/portfile.cmake
+++ b/ports/zstr/portfile.cmake
@@ -1,19 +1,18 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO mateidavid/zstr
-  REF v1.0.4
-  SHA512 148dd7741747917d826f0caf291730e14317c700961bec6ae360c1f6a3988d5db555c36428c9641fba3cd76a63b5880dce6b2af47a4388c5451bddce45c39944
+  REF v1.0.7
+  SHA512 3017da244810a45f7111f76f8d0dd988e162f08eab28b7465cad4549d84200fc834975275daf9588d35c6125e6f167c1e2dd5ec18022dac1eceabdc24d24cffe
   HEAD_REF master
 )
 
 # Install source files
-file(INSTALL ${SOURCE_PATH}/src/strict_fstream.hpp
-     ${SOURCE_PATH}/src/zstr.hpp
-     ${SOURCE_PATH}/src/zstr_make_unique_polyfill.h
-     DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL "${SOURCE_PATH}/src/strict_fstream.hpp"
+     "${SOURCE_PATH}/src/zstr.hpp"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 # Install license
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 # Install usage
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/zstr/portfile.cmake
+++ b/ports/zstr/portfile.cmake
@@ -1,7 +1,8 @@
+# header-only library
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO mateidavid/zstr
-  REF v1.0.7
+  REF "v${VERSION}"
   SHA512 3017da244810a45f7111f76f8d0dd988e162f08eab28b7465cad4549d84200fc834975275daf9588d35c6125e6f167c1e2dd5ec18022dac1eceabdc24d24cffe
   HEAD_REF master
 )
@@ -12,7 +13,7 @@ file(INSTALL "${SOURCE_PATH}/src/strict_fstream.hpp"
      DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 # Install license
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 # Install usage
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/zstr/usage
+++ b/ports/zstr/usage
@@ -1,4 +1,7 @@
 The package zstr is header only and can be used from CMake via:
 
+    find_package(ZLIB REQUIRED)
+    target_link_libraries(main PRIVATE ZLIB::ZLIB)
+
     find_path(ZSTR_INCLUDE_DIRS "zstr.hpp")
     target_include_directories(main PRIVATE ${ZSTR_INCLUDE_DIRS})

--- a/ports/zstr/vcpkg.json
+++ b/ports/zstr/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "zstr",
-  "version-string": "1.0.4",
-  "port-version": 2,
+  "version": "1.0.7",
   "description": "This C++ header-only library enables the use of C++ standard iostreams to access ZLib-compressed streams.",
   "homepage": "https://github.com/mateidavid/zstr",
+  "license": "MIT",
   "dependencies": [
     "zlib"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8481,8 +8481,8 @@
       "port-version": 3
     },
     "zstr": {
-      "baseline": "1.0.4",
-      "port-version": 2
+      "baseline": "1.0.7",
+      "port-version": 0
     },
     "ztd-text": {
       "baseline": "2022-03-21",

--- a/versions/z-/zstr.json
+++ b/versions/z-/zstr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4221f2833dd43fde522109dfa75535a3b427857c",
+      "version": "1.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "7a13e5cb665ce878aa5b6c9723a0e375e1be5c15",
       "version-string": "1.0.4",
       "port-version": 2

--- a/versions/z-/zstr.json
+++ b/versions/z-/zstr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4221f2833dd43fde522109dfa75535a3b427857c",
+      "git-tree": "a70b29925004cfcfd4db7a33cf42c18bc5ad1f76",
       "version": "1.0.7",
       "port-version": 0
     },


### PR DESCRIPTION
Updates zstr to 1.0.7

* [x]  Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
* [x]  SHA512s are updated for each updated download
* [x]  The "supports" clause reflects platforms that may be fixed by this new version
* [x]  Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
* [x]  Any patches that are no longer applied are deleted from the port's directory.
* [x]  The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
* [x]  Only one version is added to each modified port's versions file.