### PR TITLE
[iceoryx] Fix acl dependency linking. Fix feature description

### DIFF
--- a/ports/iceoryx/acl.patch
+++ b/ports/iceoryx/acl.patch
@@ -1,24 +1,36 @@
+diff --git a/iceoryx_hoofs/CMakeLists.txt b/iceoryx_hoofs/CMakeLists.txt
+index a8238ffef..8807ff025 100644
+--- a/iceoryx_hoofs/CMakeLists.txt
++++ b/iceoryx_hoofs/CMakeLists.txt
+@@ -217,7 +217,12 @@ target_link_libraries(iceoryx_hoofs
+ )
+
+ if(LINUX)
+-    target_link_libraries(iceoryx_hoofs PRIVATE acl atomic ${CODE_COVERAGE_LIBS})
++    target_link_directories(iceoryx_hoofs PUBLIC $<BUILD_INTERFACE:${ACL_LIBRARY_DIRS}>)
++    target_link_libraries(iceoryx_hoofs
++    PRIVATE
++    $<BUILD_INTERFACE:${ACL_LIBRARIES}>
++    atomic
++    ${CODE_COVERAGE_LIBS})
+ endif()
+
+ target_compile_options(iceoryx_hoofs PRIVATE ${ICEORYX_WARNINGS} ${ICEORYX_SANITIZER_FLAGS})
 diff --git a/iceoryx_hoofs/platform/CMakeLists.txt b/iceoryx_hoofs/platform/CMakeLists.txt
-index 78bad09f8..293784c06 100644
+index 78bad09f8..ff6889bf3 100644
 --- a/iceoryx_hoofs/platform/CMakeLists.txt
 +++ b/iceoryx_hoofs/platform/CMakeLists.txt
-@@ -55,6 +55,19 @@ target_link_libraries(iceoryx_platform PRIVATE ${ICEORYX_SANITIZER_FLAGS})
+@@ -55,6 +55,13 @@ target_link_libraries(iceoryx_platform PRIVATE ${ICEORYX_SANITIZER_FLAGS})
  target_compile_options(iceoryx_platform PRIVATE ${ICEORYX_WARNINGS} ${ICEORYX_SANITIZER_FLAGS})
- 
+
  if(LINUX)
 +    find_package(PkgConfig REQUIRED)
 +    pkg_check_modules(ACL REQUIRED libacl)
 +
 +    target_include_directories(iceoryx_platform
 +        PUBLIC
-+        ${ACL_INCLUDE_DIRS}
++        $<BUILD_INTERFACE:${ACL_INCLUDE_DIRS}>
 +    )
-+
-+    target_link_directories(iceoryx_platform
-+        PUBLIC
-+        ${ACL_LIBRARY_DIRS}
-+    )
-+
      target_link_libraries(iceoryx_platform
          PUBLIC
          rt

--- a/ports/iceoryx/vcpkg.json
+++ b/ports/iceoryx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "iceoryx",
   "version": "2.0.2",
+  "port-version": 1,
   "description": "True zero-copy inter-process-communication",
   "homepage": "https://iceoryx.io",
   "license": "Apache-2.0",
@@ -25,7 +26,7 @@
   ],
   "features": {
     "many-to-many": {
-      "description": "Using the n:n pattern for communication"
+      "description": "Using the m:n pattern for communication"
     },
     "toml-config": {
       "description": "TOML support for RouDi with dynamic configuration",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3018,7 +3018,7 @@
     },
     "iceoryx": {
       "baseline": "2.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "icu": {
       "baseline": "72.1",

--- a/versions/i-/iceoryx.json
+++ b/versions/i-/iceoryx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51fc6e931c8749fabf435313ca17732eac1fa715",
+      "version": "2.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "77c813fcc56fee86559404c7c22c2396509cff1a",
       "version": "2.0.2",
       "port-version": 0


### PR DESCRIPTION
1. fix wrong acl linking (see problem in  https://github.com/microsoft/vcpkg/pull/29150)
2. fix wrong description for the "many-to-many" feature

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.