### PR TITLE
[sqlite3] fix pc file consumption

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -35,7 +35,6 @@ target_compile_definitions(
 
 if (BUILD_SHARED_LIBS)
     if (WIN32)
-        string(APPEND PKGCONFIG_DEFINES " -DSQLITE_API=__declspec(dllimport)")
         target_compile_definitions(sqlite3 PRIVATE "SQLITE_API=__declspec(dllexport)")
         target_compile_definitions(sqlite3 INTERFACE "SQLITE_API=__declspec(dllimport)")
     else()

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sqlite3",
   "version": "3.40.1",
+  "port-version": 1,
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7330,7 +7330,7 @@
     },
     "sqlite3": {
       "baseline": "3.40.1",
-      "port-version": 0
+      "port-version": 1
     },
     "sqlitecpp": {
       "baseline": "3.2.0",

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68d56a1d54cd17382a2afcaf4bec08edfdb98505",
+      "version": "3.40.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e906c625a802b4fb35a8ad2ff23016f76a92e7e3",
       "version": "3.40.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note the removed declspec is hardcoded in the main header anyway. 