### PR TITLE
[liblas] fix cmake consumption

### DIFF
--- a/ports/liblas/fix-cmake-config.patch
+++ b/ports/liblas/fix-cmake-config.patch
@@ -8,6 +8,7 @@ index 175e997..8a55804 100644
  
 +include(CMakeFindDependencyMacro)
 +find_dependency(GeoTIFF CONFIG)
- include ("${_DIR}/liblas-depends.cmake")
+-include ("${_DIR}/liblas-depends.cmake")
++include ("${CMAKE_CURRENT_LIST_DIR}/liblas-depends.cmake")
  if(WIN32)
    set (libLAS_LIBRARIES liblas liblas_c)

--- a/ports/liblas/portfile.cmake
+++ b/ports/liblas/portfile.cmake
@@ -43,6 +43,10 @@ else()
     vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/libLAS)
 endif()
 
+vcpkg_replace_string ("${CURRENT_PACKAGES_DIR}/share/liblas/liblas-config.cmake" "_DIR}/.." "_DIR}/../..")
+vcpkg_replace_string ("${CURRENT_PACKAGES_DIR}/share/liblas/liblas-config.cmake" "/lib" "$<$<CONFIG:DEBUG>:/debug>/lib")
+vcpkg_replace_string ("${CURRENT_PACKAGES_DIR}/share/liblas/liblas-config.cmake" "/bin" "/tools/${PORT}")
+
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"

--- a/ports/liblas/vcpkg.json
+++ b/ports/liblas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "liblas",
   "version": "1.8.1",
-  "port-version": 10,
+  "port-version": 11,
   "description": "A C/C++ library for reading and writing the very common LAS LiDAR format.",
   "license": null,
   "supports": "!arm & !staticcrt",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3982,7 +3982,7 @@
     },
     "liblas": {
       "baseline": "1.8.1",
-      "port-version": 10
+      "port-version": 11
     },
     "liblbfgs": {
       "baseline": "1.10",

--- a/versions/l-/liblas.json
+++ b/versions/l-/liblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aff83be201bcfe7db23231cf8ab667541294c4a6",
+      "version": "1.8.1",
+      "port-version": 11
+    },
+    {
       "git-tree": "59d85ba2350ba688af5aad5a538382fd7b2963e3",
       "version": "1.8.1",
       "port-version": 10


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
