### PR TITLE
[ispc] Add new port. 

### DIFF
--- a/ports/ispc/fix-build.patch
+++ b/ports/ispc/fix-build.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 867b46dca..853159bf0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -313,6 +313,7 @@ if (XE_ENABLED)
+ endif()
+ 
+ get_llvm_libfiles(LLVM_LIBRARY_LIST ${LLVM_COMPONENTS})
++list(TRANSFORM LLVM_LIBRARY_LIST REPLACE "/lib/" "$<$<CONFIG:DEBUG>:/debug/lib/")
+ get_llvm_cppflags(LLVM_CPP_FLAGS)
+ 
+ generate_target_builtins(BUILTIN_FILES ${ISPC_TARGETS})
+@@ -502,14 +503,11 @@ if (NOT WIN32 AND NOT APPLE)
+ endif()
+ 
+ # Link against Clang libraries
+-foreach(clangLib ${CLANG_LIBRARY_LIST})
+-    find_library(${clangLib}Path NAMES ${clangLib} HINTS ${LLVM_LIBRARY_DIRS})
+-    list(APPEND CLANG_LIBRARY_FULL_PATH_LIST ${${clangLib}Path})
+-endforeach()
+-target_link_libraries(${PROJECT_NAME} ${CLANG_LIBRARY_FULL_PATH_LIST})
++find_package(Clang REQUIRED)
++target_link_libraries(${PROJECT_NAME} libclang clangInterpreter clangFrontend)
+ 
+ # Link against LLVM libraries
+-target_link_libraries(${PROJECT_NAME} ${LLVM_LIBRARY_LIST} ${CMAKE_DL_LIBS})
++target_link_libraries(${PROJECT_NAME} ${LLVM_AVAILABLE_LIBS} ${CMAKE_DL_LIBS})
+ 
+ if (XE_ENABLED)
+     # Link against Xe libraries

--- a/ports/ispc/portfile.cmake
+++ b/ports/ispc/portfile.cmake
@@ -1,0 +1,43 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO  ispc/ispc
+    REF 222aa0a8628965f2ce5c53e922a7334be75f8c9b
+    SHA512 63ee00e23187b9fa6dda95a0c3e1e7404564e49ea4915b400baaa204d6f6a4b80af94d486c416651893088ff77201246c45dea3e93e7920d5741b1ee41a7a2d9
+    HEAD_REF master
+    PATCHES fix-build.patch
+)
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
+vcpkg_add_to_path("${PYTHON3_DIR}")
+vcpkg_find_acquire_program(FLEX)
+get_filename_component(FLEX_DIR "${FLEX}" DIRECTORY)
+vcpkg_add_to_path("${FLEX_DIR}")
+vcpkg_find_acquire_program(GIT)
+get_filename_component(GIT_DIR "${GIT}" DIRECTORY)
+vcpkg_add_to_path("${GIT_DIR}")
+vcpkg_find_acquire_program(BISON)
+get_filename_component(BISON_DIR "${BISON}" DIRECTORY)
+vcpkg_add_to_path("${BISON_DIR}")
+vcpkg_acquire_msys(MSYS_ROOT PACKAGES m4)
+vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      -DISPC_INCLUDE_TESTS=OFF
+      -DISPC_INCLUDE_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ispcrt-${VERSION} PACKAGE_NAME ispcrt)
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/ispcrt/ispcrtConfig.cmake" "/../include" "/include")
+
+vcpkg_copy_tools(TOOL_NAMES ispc check_isa AUTO_CLEAN)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/ispc/portfile.cmake
+++ b/ports/ispc/portfile.cmake
@@ -22,12 +22,19 @@ vcpkg_add_to_path("${BISON_DIR}")
 vcpkg_acquire_msys(MSYS_ROOT PACKAGES m4)
 vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
 
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ISPCRT_BUILD_STATIC)
+
+vcpkg_replace_string("${SOURCE_PATH}/ispcrt/CMakeLists.txt" [[build_ispcrt(SHARED ${PROJECT_NAME})]] 
+                                                            [[if(BUILD_SHARED_LIBS)\nbuild_ispcrt(SHARED ${PROJECT_NAME})\nendif()]]
+                    )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
       -DISPC_INCLUDE_TESTS=OFF
       -DISPC_INCLUDE_EXAMPLES=OFF
+      -DISPCRT_BUILD_TASK_MODEL=Threads
+      -DISPCRT_BUILD_STATIC=${ISPCRT_BUILD_STATIC}
 )
 
 vcpkg_cmake_install()

--- a/ports/ispc/portfile.cmake
+++ b/ports/ispc/portfile.cmake
@@ -25,7 +25,7 @@ vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ISPCRT_BUILD_STATIC)
 
 vcpkg_replace_string("${SOURCE_PATH}/ispcrt/CMakeLists.txt" [[build_ispcrt(SHARED ${PROJECT_NAME})]] 
-                                                            [[if(BUILD_SHARED_LIBS)\nbuild_ispcrt(SHARED ${PROJECT_NAME})\nendif()]]
+                                                            "if(BUILD_SHARED_LIBS)\nbuild_ispcrt(SHARED \${PROJECT_NAME})\nendif()"
                     )
 
 vcpkg_cmake_configure(

--- a/ports/ispc/vcpkg.json
+++ b/ports/ispc/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "ispc",
+  "version": "1.18.1",
+  "description": "Intel® Open Volume Kernel Library (Intel® Open VKL) is a collection of high-performance volume computation kernels, developed at Intel.",
+  "homepage": "http://www.openvkl.org",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "llvm",
+      "features": [
+        "enable-assertions",
+        "openmp",
+        "target-aarch64",
+        "target-arm",
+        "target-x86"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/ispc/vcpkg.json
+++ b/ports/ispc/vcpkg.json
@@ -9,7 +9,6 @@
       "name": "llvm",
       "features": [
         "enable-assertions",
-        "openmp",
         "target-aarch64",
         "target-arm",
         "target-x86"

--- a/ports/ispc/vcpkg.json
+++ b/ports/ispc/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "ispc",
   "version": "1.18.1",
-  "description": "Intel® Open Volume Kernel Library (Intel® Open VKL) is a collection of high-performance volume computation kernels, developed at Intel.",
-  "homepage": "http://www.openvkl.org",
+  "description": "ispc is a compiler for a variant of the C programming language, with extensions for single program, multiple data programming. Under the SPMD model, the programmer writes a program that generally appears to be a regular serial program, though the execution model is actually that a number of program instances execute in parallel on the hardware.",
+  "homepage": "https://ispc.github.io/",
   "license": "Apache-2.0",
   "dependencies": [
     {

--- a/ports/ispc/vcpkg.json
+++ b/ports/ispc/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.18.1",
   "description": "ispc is a compiler for a variant of the C programming language, with extensions for single program, multiple data programming. Under the SPMD model, the programmer writes a program that generally appears to be a regular serial program, though the execution model is actually that a number of program instances execute in parallel on the hardware.",
   "homepage": "https://ispc.github.io/",
-  "license": "Apache-2.0",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "llvm",

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -247,6 +247,7 @@ vcpkg_cmake_configure(
         # Limit the maximum number of concurrent link jobs to 1. This should fix low amount of memory issue for link.
         "-DLLVM_PARALLEL_LINK_JOBS=${LLVM_LINK_JOBS}"
         -DLLVM_TOOLS_INSTALL_DIR=tools/llvm
+        -DLLDB_INCLUDE_TESTS=OFF
 )
 
 vcpkg_cmake_install(ADD_BIN_TO_PATH)

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -247,7 +247,8 @@ vcpkg_cmake_configure(
         # Limit the maximum number of concurrent link jobs to 1. This should fix low amount of memory issue for link.
         "-DLLVM_PARALLEL_LINK_JOBS=${LLVM_LINK_JOBS}"
         -DLLVM_TOOLS_INSTALL_DIR=tools/llvm
-        -DLLDB_INCLUDE_TESTS=OFF
+        -DLLDB_INCLUDE_TESTS:BOOL=OFF
+        -DLLVM_INCLUDE_TESTS:BOOL=OFF
 )
 
 vcpkg_cmake_install(ADD_BIN_TO_PATH)

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -238,6 +238,14 @@
           "features": [
             "tools"
           ]
+        },
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "libcxx"
+          ],
+          "platform": "osx"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3216,6 +3216,10 @@
       "baseline": "1.13.2",
       "port-version": 0
     },
+    "ispc": {
+      "baseline": "1.18.1",
+      "port-version": 0
+    },
     "itk": {
       "baseline": "5.2.1",
       "port-version": 4

--- a/versions/i-/ispc.json
+++ b/versions/i-/ispc.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "38a4934c9ea655b084e19f3081674ac6e34eee5e",
+      "version": "1.18.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/i-/ispc.json
+++ b/versions/i-/ispc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "38a4934c9ea655b084e19f3081674ac6e34eee5e",
+      "git-tree": "41564d1866693510de62fc30e03e02174ba9c7e9",
       "version": "1.18.1",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
https://repology.org/project/ispc/versions
- [ ] ~~Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)~~ shouldn't have any
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

this builds the ispc compiler and the corresponding crt library if I see it correctly. I need it for other libs down the path. 