### PR TITLE
[joltphysics] Disable treats all compiler warnings as errors

### DIFF
--- a/ports/joltphysics/disable-warningC5266.patch
+++ b/ports/joltphysics/disable-warningC5266.patch
@@ -7,7 +7,7 @@ index 27c4c64..78f3947 100644
  
  	# Set general compiler flags
 -	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /Zc:__cplusplus /Gm- /Wall /WX /MP /nologo /diagnostics:classic /FC /fp:except- /Zc:inline /Zi")
-+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /Zc:__cplusplus /Gm- /Wall /WX /MP /nologo /diagnostics:classic /FC /fp:except- /Zc:inline /Zi /wd5266")
++	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /Zc:__cplusplus /Gm- /Wall /WX- /MP /nologo /diagnostics:classic /FC /fp:except- /Zc:inline /Zi")
  
  	# Remove any existing compiler flag that enables RTTI
  	string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})

--- a/ports/joltphysics/disable-warningC5266.patch
+++ b/ports/joltphysics/disable-warningC5266.patch
@@ -1,0 +1,13 @@
+diff --git a/Build/CMakeLists.txt b/Build/CMakeLists.txt
+index 27c4c64..78f3947 100644
+--- a/Build/CMakeLists.txt
++++ b/Build/CMakeLists.txt
+@@ -53,7 +53,7 @@ if (("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUA
+ 	endif()
+ 
+ 	# Set general compiler flags
+-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /Zc:__cplusplus /Gm- /Wall /WX /MP /nologo /diagnostics:classic /FC /fp:except- /Zc:inline /Zi")
++	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /Zc:__cplusplus /Gm- /Wall /WX /MP /nologo /diagnostics:classic /FC /fp:except- /Zc:inline /Zi /wd5266")
+ 
+ 	# Remove any existing compiler flag that enables RTTI
+ 	string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})

--- a/ports/joltphysics/portfile.cmake
+++ b/ports/joltphysics/portfile.cmake
@@ -3,9 +3,11 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jrouwe/JoltPhysics
-    REF v2.0.1
+    REF "v${VERSION}"
     SHA512 c5848fe7a28de1b34259d3d21e4cd35bec4002eee926445e05d902934c43ab4cafcfa24ceb037c59cc66c3dcea5f3a737546f88c20be594dafe6ce6d1f637abb
     HEAD_REF master
+    PATCHES
+        disable-warningC5266.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" USE_STATIC_CRT)
@@ -43,4 +45,4 @@ else()
 endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/joltphysics/vcpkg.json
+++ b/ports/joltphysics/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "joltphysics",
   "version": "2.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A multi core friendly rigid body physics and collision detection library suitable for games and VR applications",
   "homepage": "https://github.com/jrouwe/JoltPhysics",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3262,7 +3262,7 @@
     },
     "joltphysics": {
       "baseline": "2.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "josuttis-jthread": {
       "baseline": "2020-07-21",

--- a/versions/j-/joltphysics.json
+++ b/versions/j-/joltphysics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d54b2c66a959b479009101b71e0655022cd53f9",
+      "version": "2.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "5e739c5e65a72603e92f5ca31b07a8a78a918166",
       "version": "2.0.1",
       "port-version": 1

--- a/versions/j-/joltphysics.json
+++ b/versions/j-/joltphysics.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0d54b2c66a959b479009101b71e0655022cd53f9",
+      "git-tree": "845755ddfb9fa5d6f88c836cffdb1f497e69ad46",
       "version": "2.0.1",
       "port-version": 2
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
In an internal version of MSVC compiler, `joltphysics` install failed with following error:
```
D:\buildtrees\joltphysics\src\v2.0.1-76420d93c1.clean\Jolt\Core\Reference.h(115): error C2220: the following warning is treated as an error
D:\buildtrees\joltphysics\src\v2.0.1-76420d93c1.clean\Jolt\Core\Result.h(161): note: see reference to class template instantiation 'JPH::Ref<JPH::Shape>' being compiled
D:\buildtrees\joltphysics\src\v2.0.1-76420d93c1.clean\Jolt\Physics\Collision\Shape\Shape.h(137): note: see reference to class template instantiation 'JPH::Result<JPH::Ref<JPH::Shape>>' being compiled
D:\buildtrees\joltphysics\src\v2.0.1-76420d93c1.clean\Jolt\Core\Reference.h(115): warning C5266: 'const' qualifier on return type has no effect
D:\buildtrees\joltphysics\src\v2.0.1-76420d93c1.clean\Jolt\Core\Reference.h(115): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
```
I have confirmed with developer, this change is by design and we need to disable this warning.
