### PR TITLE
[baseline][crashpad] Remove from ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -168,9 +168,7 @@ cppcoro:x64-uwp=fail
 # The x64-linux pipeline uses gcc 9.3.0, which lacks C++20 coroutine support.
 # This is known to work on x64-linux as of gcc 10.3.0.
 cppgraphqlgen:x64-linux=fail
-crashpad:arm64-windows=fail
 crashpad:arm-uwp=fail
-crashpad:x86-windows=fail
 cuda:x64-osx=fail
 # Since pipeline cannot automatically install dbghelp dependency, skip this detection
 dbghelp:arm-uwp=skip


### PR DESCRIPTION
Fixed [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=84296&view=results) issue:
```
PASSING,REMOVE FROM FAIL LIST: crashpad:x86-windows 
PASSING,REMOVE FROM FAIL LIST: crashpad:arm64-windows
```

`crashpad:arm64-windows=fail` and `crashpad:x86-windows=fail` were added into the `ci.baseline.txt` by PR https://github.com/microsoft/vcpkg/pull/10505,
they have been fixed in PR #29058, so remove the records from `ci.baseline.txt`. 
