### PR TITLE
[flecs] Update to 3.1.4.

### DIFF
--- a/ports/flecs/portfile.cmake
+++ b/ports/flecs/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SanderMertens/flecs
-    REF v3.1.0
-    SHA512 422458818e4696359a2e0a3cf52b6d47b4fcfe792b483903cba9d0aad2beee574d1040b0d6286e158145226c8bb9ad897dd74cb87c9e3def0d89cb33e218b20d
+    REF "v${VERSION}"
+    SHA512 06901a137ee4b6b1f6463ca6c35ec7271d21e138be08d3af8fbbf17d6e254242fadcc0e0d944de8ce1c89a6a2babe4e611142f227ef758c6e6b1f48db16740d8
     HEAD_REF master
 )
 
@@ -34,4 +34,4 @@ file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/flecs/vcpkg.json
+++ b/ports/flecs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flecs",
-  "version": "3.1.0",
+  "version": "3.1.4",
   "description": "A fast entity component system (ECS) for C & C++",
   "homepage": "https://github.com/SanderMertens/flecs",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2393,7 +2393,7 @@
       "port-version": 0
     },
     "flecs": {
-      "baseline": "3.1.0",
+      "baseline": "3.1.4",
       "port-version": 0
     },
     "flint": {

--- a/versions/f-/flecs.json
+++ b/versions/f-/flecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b6de4331741a269d57d3844a78ed832d3c6fac07",
+      "version": "3.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b287c3496003f022bc0c1c2d55a775ac591d6e8",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/29227.
Update flecs to 3.1.4. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.