### PR TITLE
[flatbuffers] Update to 23.1.21.

### DIFF
--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/flatbuffers
-    REF af9ceabeef1a10c1004e2741f8c0c090ca59e5af #v23.1.4
-    SHA512 63220e37743b868b4c7c7894a8f64cbb80545feda5d7afb1223d316d9aa6c0c25670563a988971e853db68d98efb692c7d8dd402df7bff7d95db844baba57820
+    REF "v${VERSION}"
+    SHA512 fa62188f773ad044644a58caf1e25bef417dfdea47c9da8a2ea7f997154b4f3976019e32e73cc533696a3d4e45ec4a8402b6df140878dfa2ff078740d61b4b0f
     HEAD_REF master
     PATCHES
         fix-uwp-build.patch
@@ -44,4 +44,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbuffers",
-  "version": "23.1.4",
+  "version": "23.1.21",
   "description": [
     "Memory Efficient Serialization Library",
     "FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2389,7 +2389,7 @@
       "port-version": 0
     },
     "flatbuffers": {
-      "baseline": "23.1.4",
+      "baseline": "23.1.21",
       "port-version": 0
     },
     "flecs": {

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a982b9c31851fcc6ac96cfc1a05fc44144ef1512",
+      "version": "23.1.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "ea66df31df93dca4ac16469f5655ac91cdd8e024",
       "version": "23.1.4",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/29200.
Update flatbuffers to 23.1.21, no feature needs to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.