### PR TITLE
[wolfssl] fix sha512

### DIFF
--- a/ports/wolfssl/portfile.cmake
+++ b/ports/wolfssl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfssl/wolfssl
     REF v5.5.0-stable
-    SHA512 1f9ffd8e83b26f97c3685315790f3f2b451a23e9dad9e2f09142a3e1e136012293ca2d04f46c267f8275ac9e60894c46c7875353765df6d4fdd93ba666228459
+    SHA512 5d5c42d748725b361fef5f4f73bea3373dcc6bf06534a87bff37d3a43a34fe5ba1f022f51bb53ee23a4d0b3c3eae47472f74ff17324eb3461cbe74b10af6ec33
     HEAD_REF master
     PATCHES
       wolfssl_pr5529.diff

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+        "git-tree": "f75d99e108de349e3753d2259529a73251bd3e6b",
+        "version": "5.5.0",
+        "port-version": 0
+    },
+    {
       "git-tree": "051a3dc2339554716a11e8e90e9ecea1c366ad31",
       "version": "5.5.0",
       "port-version": 0

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-        "git-tree": "f75d99e108de349e3753d2259529a73251bd3e6b",
-        "version": "5.5.0",
-        "port-version": 0
+      "git-tree": "f75d99e108de349e3753d2259529a73251bd3e6b",
+      "version": "5.5.0",
+      "port-version": 0
     },
     {
       "git-tree": "051a3dc2339554716a11e8e90e9ecea1c366ad31",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

