### PR TITLE
[zxing-cpp] Enable stack guard on Windows

### DIFF
--- a/ports/nu-book-zxing-cpp/0001-Change-CXX-compile-options.patch
+++ b/ports/nu-book-zxing-cpp/0001-Change-CXX-compile-options.patch
@@ -1,0 +1,25 @@
+From 3b8b151d4a432e6e5f61a0540150b3c5b98b27db Mon Sep 17 00:00:00 2001
+From: Qingnan Duan <duanqn_own_1@yeah.net>
+Date: Tue, 31 Jan 2023 14:09:04 +0800
+Subject: [PATCH] Change CXX compile options
+
+---
+ CMakeLists.txt | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ab3dcafc..988f80ec 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,8 +21,6 @@ if (MSVC)
+ 
+     add_definitions (-DUNICODE -D_UNICODE -D_CRT_SECURE_NO_WARNINGS)
+     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+-    set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Oi /GS-")
+-    set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oi /GS-")
+     if (LINK_CPP_STATICALLY)
+         set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+         set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+-- 
+2.37.0.windows.1
+

--- a/ports/nu-book-zxing-cpp/portfile.cmake
+++ b/ports/nu-book-zxing-cpp/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v2.0.0
     SHA512 fa22164f834a42194eafd0d3e9c09d953233c69843ac6e79c8d6513314be28d8082382b436c379368e687e0eed05cb5e566d2893ec6eb29233a36643904ae083
     HEAD_REF master
+    PATCHES
+        0001-Change-CXX-compile-options.patch
 )
 
 if (VCPKG_TARGET_IS_UWP)

--- a/ports/nu-book-zxing-cpp/vcpkg.json
+++ b/ports/nu-book-zxing-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nu-book-zxing-cpp",
   "version": "2.0.0",
+  "port-version": 1,
   "description": "Barcode detection and decoding library.",
   "homepage": "https://github.com/zxing-cpp/zxing-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5386,7 +5386,7 @@
     },
     "nu-book-zxing-cpp": {
       "baseline": "2.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nuklear": {
       "baseline": "2022-05-12",

--- a/versions/n-/nu-book-zxing-cpp.json
+++ b/versions/n-/nu-book-zxing-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2350a4990de85702a957883b749cd12f35a5cf5",
+      "version": "2.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "78c8636186395a676c941dc214b01d4576d643b6",
       "version": "2.0.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #29310 
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
