### PR TITLE
[cdt] Add new port

### DIFF
--- a/ports/cdt/boost-link.patch
+++ b/ports/cdt/boost-link.patch
@@ -1,0 +1,13 @@
+diff --git a/CDT/CMakeLists.txt b/CDT/CMakeLists.txt
+index 555fb4e..86be850 100644
+--- a/CDT/CMakeLists.txt
++++ b/CDT/CMakeLists.txt
+@@ -155,7 +155,7 @@ target_compile_definitions(
+ )
+ 
+ if(CDT_USE_BOOST)
+-    target_link_libraries(${PROJECT_NAME} INTERFACE Boost::boost)
++    target_link_libraries(${PROJECT_NAME} PUBLIC Boost::boost)
+ endif()
+ 
+ 

--- a/ports/cdt/portfile.cmake
+++ b/ports/cdt/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 811d1fede4960808954bc17f37c8639f52800c98562e9283517c666735ddf3b2f2f8a57992669899be13c40b0fc4439d3cd1a101cb596d2335ef4fc307408c63
     HEAD_REF master
+    PATCHES
+        boost-link.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/cdt/portfile.cmake
+++ b/ports/cdt/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO artem-ogre/CDT
+    REF "${VERSION}"
+    SHA512 811d1fede4960808954bc17f37c8639f52800c98562e9283517c666735ddf3b2f2f8a57992669899be13c40b0fc4439d3cd1a101cb596d2335ef4fc307408c63
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "64-bit-index-type"     CDT_USE_64_BIT_INDEX_TYPE
+        "as-compiled-library"   CDT_USE_AS_COMPILED_LIBRARY
+        "boost"                 CDT_USE_BOOST
+)
+
+if (NOT CDT_USE_AS_COMPILED_LIBRARY)
+    set(VCPKG_BUILD_TYPE "release") # header-only
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/CDT"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+
+if (CDT_USE_AS_COMPILED_LIBRARY)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cdt/portfile.cmake
+++ b/ports/cdt/portfile.cmake
@@ -26,6 +26,15 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
+if(CDT_USE_BOOST)
+    set(CDT_USE_BOOST_STR "#if 1")
+else()
+    set(CDT_USE_BOOST_STR "#if 0")
+endif()
+foreach(FILE CDTUtils.h Triangulation.hpp)
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/${FILE}" "#ifdef CDT_USE_BOOST" "${CDT_USE_BOOST_STR}")
+endforeach()
+
 if (CDT_USE_AS_COMPILED_LIBRARY)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 endif()

--- a/ports/cdt/vcpkg.json
+++ b/ports/cdt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt",
-  "version-semver": "1.2.0",
+  "version": "1.2.0",
   "description": "Constrained Delaunay Triangulation",
   "homepage": "https://github.com/artem-ogre/CDT.git",
   "license": "MPL-2.0",

--- a/ports/cdt/vcpkg.json
+++ b/ports/cdt/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "cdt",
+  "version-semver": "1.2.0",
+  "description": "Constrained Delaunay Triangulation",
+  "homepage": "https://github.com/artem-ogre/CDT.git",
+  "license": "MPL-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "64-bit-index-type": {
+      "description": "64bits are used to store vertex/triangle index types"
+    },
+    "as-compiled-library": {
+      "description": "Templates for float and double will be instantiated and compiled into a library"
+    },
+    "boost": {
+      "description": "Boost is used as a fall-back for features missing in C++98 and performance tweaks"
+    }
+  }
+}

--- a/ports/cdt/vcpkg.json
+++ b/ports/cdt/vcpkg.json
@@ -22,7 +22,10 @@
       "description": "Templates for float and double will be instantiated and compiled into a library"
     },
     "boost": {
-      "description": "Boost is used as a fall-back for features missing in C++98 and performance tweaks"
+      "description": "Boost is used as a fall-back for features missing in C++98 and performance tweaks",
+      "dependencies": [
+        "boost-container"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1356,6 +1356,10 @@
       "baseline": "2.3",
       "port-version": 3
     },
+    "cdt": {
+      "baseline": "1.2.0",
+      "port-version": 0
+    },
     "celero": {
       "baseline": "2.8.5",
       "port-version": 0

--- a/versions/c-/cdt.json
+++ b/versions/c-/cdt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "002b5841cd0600e2104188e9c6d2f27b74caab1a",
+      "git-tree": "d04985a703ae8b9201876879003d44c84f719a3a",
       "version": "1.2.0",
       "port-version": 0
     }

--- a/versions/c-/cdt.json
+++ b/versions/c-/cdt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6c5e64273872865966ab48229f73fe9b69be0dc1",
+      "git-tree": "002b5841cd0600e2104188e9c6d2f27b74caab1a",
       "version": "1.2.0",
       "port-version": 0
     }

--- a/versions/c-/cdt.json
+++ b/versions/c-/cdt.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "217d25a0d73031841511158354a6162f61fb964e",
-      "version-semver": "1.2.0",
+      "git-tree": "6c5e64273872865966ab48229f73fe9b69be0dc1",
+      "version": "1.2.0",
       "port-version": 0
     }
   ]

--- a/versions/c-/cdt.json
+++ b/versions/c-/cdt.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "217d25a0d73031841511158354a6162f61fb964e",
+      "version-semver": "1.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/28238.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
