### PR TITLE
[libe57format] Update to 2.3.0

### DIFF
--- a/ports/libe57format/portfile.cmake
+++ b/ports/libe57format/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO asmaloney/libE57Format
-    REF v2.2.0
-    SHA512 7b788efce2efdbfba83d4e3ab5c4884b3d85b5e44c510954f9200db26fb97c92f4e33d04209c0647fc39c3af081fc09d1ee6a79857b1980a0e1e43586f78bd0c
+    REF v2.3.0
+    SHA512 44feaf71d09d6765b322e2055efea09d2a99e706aa00dc4fd9281074fc05d06cce932400f5f4b91b20ed1cc070f117b7d39b95c54d33b31bc1e93532d698c175
     HEAD_REF master
 )
 
@@ -11,7 +11,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/E57Format")
+vcpkg_cmake_config_fixup(PACKAGE_NAME E57Format CONFIG_PATH "lib/cmake/E57Format")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/libe57format RENAME copyright)

--- a/ports/libe57format/vcpkg.json
+++ b/ports/libe57format/vcpkg.json
@@ -1,7 +1,9 @@
 {
   "name": "libe57format",
-  "version-string": "2.2.0",
+  "version": "2.3.0",
   "description": "A library to provide read & write support for the E57 file format.",
+  "homepage": "https://github.com/asmaloney/libE57Format",
+  "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3777,7 +3777,7 @@
       "port-version": 3
     },
     "libe57format": {
-      "baseline": "2.2.0",
+      "baseline": "2.3.0",
       "port-version": 0
     },
     "libebur128": {

--- a/versions/l-/libe57format.json
+++ b/versions/l-/libe57format.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1c43acaa644678ab0a7023a4657235dd73b7860",
+      "version": "2.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "49edc5b7628b3ce80320347ed3284237b50ac162",
       "version-string": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
