### PR TITLE
[xerces-c] Fix iOS build

### DIFF
--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -20,11 +20,18 @@ vcpkg_check_features(
         icu     CMAKE_DISABLE_FIND_PACKAGE_ICU
 )
 if("icu" IN_LIST FEATURES)
-    vcpkg_list(APPEND options transcoder=icu)
+    vcpkg_list(APPEND options -Dtranscoder=icu)
 elseif(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_list(APPEND options transcoder=windows)
+    vcpkg_list(APPEND options -Dtranscoder=windows)
 elseif(VCPKG_TARGET_IS_OSX)
-    vcpkg_list(APPEND options transcoder=macosunicodeconverter)
+    vcpkg_list(APPEND options -Dtranscoder=macosunicodeconverter)
+elseif(VCPKG_HOST_IS_OSX)
+    # Because of a bug in the transcoder selection script, the option
+    # "macosunicodeconverter" is always selected when building on macOS,
+    # regardless of the target platform. This breaks cross-compiling.
+    # As a workaround we force "iconv", which should at least work for iOS.
+    # Upstream fix: https://github.com/apache/xerces-c/pull/52
+    vcpkg_list(APPEND options -Dtranscoder=iconv)
 else()
     # xercesc chooses gnuiconv or iconv (cmake/XercesTranscoderSelection.cmake)
 endif()

--- a/ports/xerces-c/vcpkg.json
+++ b/ports/xerces-c/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "xerces-c",
   "version": "3.2.4",
+  "port-version": 1,
   "description": "Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.",
   "homepage": "https://github.com/apache/xerces-c",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8314,7 +8314,7 @@
     },
     "xerces-c": {
       "baseline": "3.2.4",
-      "port-version": 0
+      "port-version": 1
     },
     "xeus": {
       "baseline": "0.24.3",

--- a/versions/x-/xerces-c.json
+++ b/versions/x-/xerces-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad60daf68b377020d6ea29ef4a078a43e66fe846",
+      "version": "3.2.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "8b0ef386f33522a64bc06e375ff5e85ce05de31b",
       "version": "3.2.4",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

- The `transcoder` option was not prefixed with `-D` so CMake was ignoring it.
- There is a bug in Xerces' automatic transcoder selection: it checks if the host is macOS, instead of the checking the target. This break cross-compiling on macOS. I also opened an issue upstream to fix this.
- When building for iOS, because of the bug above, `macosunicodeconverter` gets selected by default, but is not actually available. Instead `iconv` should be used. Since the port already explicitly picks the transcoder for various platforms, I added a case for iOS.