### PR TITLE
[directxtex] port update for January 2023 release

### DIFF
--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTEX_TAG dec2022)
+set(DIRECTXTEX_TAG jan2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -9,8 +9,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF dec2022b
-    SHA512 353ac25b77218e7e7f11495d51bf10552444f71b2dd3a13e64264328fd8814fb3d65704dc7c517ff349a5143e9c454ae6a7782c16dc74f992b0ae9d517daa404
+    REF ${DIRECTXTEX_TAG}
+    SHA512 5bc6ee9aeff314ef700a2e0b4b87807121eba6298de9c83af9eb9a3ce1956396570d10888b05e0c42eda800c3183023eb9e0e4b5464989a141e30c0097ecd8fc
     HEAD_REF main
     )
 
@@ -42,26 +42,26 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtex)
 
-if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
+if(VCPKG_HOST_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     TEXASSEMBLE_EXE
     URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texassemble.exe"
     FILENAME "texassemble-${DIRECTXTEX_TAG}.exe"
-    SHA512 78f556d6fa7808f6c22b6b1fa130c7c0c694ab8011ebb2ed633d3f35b281b39a2aee2c171da665ccbbbc49be1af6e90bdecc7d837a789aac5d9ef54afd2d0951
+    SHA512 a339b725107d8b45e73e2cf24a989844a98a28cda2a01ff760cc46dea49f09b27b5d8d4c1c6940b323b0d0cc83492d21895a958e11ba82a0bbfdd877bfad7ded
   )
 
   vcpkg_download_distfile(
     TEXCONV_EXE
     URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texconv.exe"
     FILENAME "texconv-${DIRECTXTEX_TAG}.exe"
-    SHA512 6bd3f5d9a986887b618d3cb2c765f29c8e632f70df96c60ee3492bed26f1f3407e5293177c479b7f80d8178491dbe22b25737b34e426712e6e1dede7eebb84df
+    SHA512 6dc472cec94c771bb289a927ee0cce0507332394353306806a7d244999591f9f7c46dd86a55cf24c727fb0592f777b2a4df4f4edaecc72c40ee72a00830372f2
   )
 
   vcpkg_download_distfile(
     TEXDIAG_EXE
     URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texdiag.exe"
     FILENAME "texdiag-${DIRECTXTEX_TAG}.exe"
-    SHA512 e443407d69e628341d72b18a6ae2ebddf69d0554c468a7aa77e2dbf87a4498c4cefe59be709d9d786c7a940ac4cc523e95a31a1a8fd056b103045ef0412f3775
+    SHA512 512346a880459179fb585dfb2ca97ef6a668e803be201de180e6ca3e431c61b73204f80cabe9b3aced97a33abdfd831cce56eb9228726db5ae9fe993c59845a6
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
@@ -76,7 +76,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
   file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-${DIRECTXTEX_TAG}.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
   file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-${DIRECTXTEX_TAG}.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
 
-elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
+elseif(VCPKG_TARGET_IS_WINDOWS AND (NOT VCPKG_TARGET_IS_UWP))
 
   vcpkg_copy_tools(
         TOOL_NAMES texassemble texconv texdiag

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtex",
-  "version-date": "2022-12-15",
+  "version-date": "2023-01-31",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",
@@ -20,7 +20,7 @@
   ],
   "features": {
     "dx12": {
-      "description": "Build with DirectX12 support for Windows 10"
+      "description": "Build with DirectX12 support for Windows 10/Windows 11"
     },
     "openexr": {
       "description": "Enable OpenEXR support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1977,7 +1977,7 @@
       "port-version": 5
     },
     "directxtex": {
-      "baseline": "2022-12-15",
+      "baseline": "2023-01-31",
       "port-version": 0
     },
     "directxtk": {

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9d1163d38bfe182db6e9011b0b52e682ae02501",
+      "version-date": "2023-01-31",
+      "port-version": 0
+    },
+    {
       "git-tree": "79c75c423a2d930e31e207bfb8c2d4bfe5ea85d6",
       "version-date": "2022-12-15",
       "port-version": 0


### PR DESCRIPTION
* Fixed memory overwrite bug in **ConvertToSinglePlane** that can lead to a potential security issue for untrusted planar video format DDS files
* Make sure ScratchImage zero-fills image memory
* Fix DirectX12 GPU-validation warnings for texture loaders

> First issue is a fix for a security bug reported by a researcher. See [this notice](https://github.com/microsoft/DirectXTex/security/advisories/GHSA-3w9w-9833-gcpv).