### PR TITLE
[apr] Change resource and update to version 1.7.1

### DIFF
--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -1,15 +1,9 @@
-
-set(VERSION 1.7.0)
-
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.apache.org/dist/apr/apr-${VERSION}.tar.bz2"
-    FILENAME "apr-${VERSION}.tar.bz2"
-    SHA512 3dc42d5caf17aab16f5c154080f020d5aed761e22db4c5f6506917f6bfd2bf8becfb40af919042bd4ce1077d5de74aa666f5edfba7f275efba78e8893c115148
-)
-
-vcpkg_extract_source_archive_ex(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
+    REPO apache/apr
+    REF "${VERSION}"
+    SHA512 d214cf7bdf479b6213e71b09e7bd817720c5f46284b5c1518805890e8755229b4e7259d516926ea7420676d5414c4fab8c349d45e028f25bfea893a13579ea67
+    HEAD_REF trunk
     PATCHES
         fix-configcmake.patch
         unglue.patch
@@ -90,4 +84,4 @@ else()
 endif()
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/apr/vcpkg.json
+++ b/ports/apr/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "apr",
-  "version": "1.7.0",
-  "port-version": 11,
+  "version": "1.7.1",
   "description": "The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.",
-  "homepage": "https://apr.apache.org/",
+  "homepage": "https://github.com/apache/apr",
   "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/a-/apr.json
+++ b/versions/a-/apr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a8ef6ea50d1fa5a1ca0cd6a77931c5b25e05c900",
+      "version": "1.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2f23cf24a3496f9fb519512245a3e0f1a66c8ed9",
       "version": "1.7.0",
       "port-version": 11

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -133,8 +133,8 @@
       "port-version": 0
     },
     "apr": {
-      "baseline": "1.7.0",
-      "port-version": 11
+      "baseline": "1.7.1",
+      "port-version": 0
     },
     "apr-util": {
       "baseline": "1.6.1",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #29344 
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
