### PR TITLE
[catch2] Update to 3.3.1

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
     REF v${VERSION}
-    SHA512 a134a87d948cc5e6741116b24c93030b931e4b02feb7f5645a1e5a1f09cefdf6a1515ebeeea4b771303436b34c61d02afc0ee69bd65fd0af4613b66f17a2f5ce
+    SHA512 93aff3549c3d8454c7deded0e64471f2a8290edfd842c2e0816a353ef9ec2896bee25da6d952cc3bbf022262e22ed2a522485dbfe5d1d492f07eb4c0c2ddb779
     HEAD_REF devel
     PATCHES
         fix-install-path.patch

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version-semver": "3.3.0",
+  "version-semver": "3.3.1",
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1333,7 +1333,7 @@
       "port-version": 1
     },
     "catch2": {
-      "baseline": "3.3.0",
+      "baseline": "3.3.1",
       "port-version": 0
     },
     "cccapstone": {

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d7bef305b7affebc6f3ccacd12874ebd4fbfc50",
+      "version-semver": "3.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "cfb2a80de586b148c9dd6956bf6aca7501d411db",
       "version-semver": "3.3.0",
       "port-version": 0


### PR DESCRIPTION
Update catch2 from 3.3.0 to 3.3.1 : https://github.com/catchorg/Catch2/releases/tag/v3.3.1

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.