### PR TITLE
[status-code] Disable find boost

### DIFF
--- a/ports/status-code/portfile.cmake
+++ b/ports/status-code/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DPROJECT_IS_DEPENDENCY=On
+        -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/status-code/vcpkg.json
+++ b/ports/status-code/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "status-code",
   "version-date": "2023-01-27",
+  "port-version": 1,
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7390,7 +7390,7 @@
     },
     "status-code": {
       "baseline": "2023-01-27",
-      "port-version": 0
+      "port-version": 1
     },
     "status-value-lite": {
       "baseline": "1.1.0",

--- a/versions/s-/status-code.json
+++ b/versions/s-/status-code.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e920c8de8cd88a6a9f9a4d1c378c21a36759123b",
+      "version-date": "2023-01-27",
+      "port-version": 1
+    },
+    {
       "git-tree": "0242a08fe7d2d12bcfcbdefe919bc9afabfdc5fd",
       "version-date": "2023-01-27",
       "port-version": 0


### PR DESCRIPTION
Unbeknownst to me, the libraries test suite optionally tests compatibility against boost types which is completely unnecessary in our case and violates the maintainer guidelines. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
