### PR TITLE
[etcd-cpp-apiv3] Add etcd-cpp-apiv3 ports.

### DIFF
--- a/ports/etcd-cpp-apiv3/portfile.cmake
+++ b/ports/etcd-cpp-apiv3/portfile.cmake
@@ -18,13 +18,13 @@ set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/etcd-cpp-api)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_copy_pdbs()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/etcd-cpp-apiv3 RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/etcd-cpp-apiv3" RENAME copyright)
 
 # Adding usage text
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/etcd-cpp-apiv3/portfile.cmake
+++ b/ports/etcd-cpp-apiv3/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO etcd-cpp-apiv3/etcd-cpp-apiv3
+    REF 9e1e60af2ee99eafb4ea9b8d275870776b7d8507
+    SHA512 07e7922c96b0b9cb6502820d9dac96c60390e5d3c4d94e9eed7e847a3d1197e79dbfd4259cd1510ca02d669713a976bb027ba5decc2a44ca8e851109f2ef9c15
+    HEAD_REF v0.2.12
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_ETCD_TESTS=OFF
+)
+set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
+set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/etcd-cpp-api)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+vcpkg_copy_pdbs()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/etcd-cpp-apiv3 RENAME copyright)

--- a/ports/etcd-cpp-apiv3/portfile.cmake
+++ b/ports/etcd-cpp-apiv3/portfile.cmake
@@ -25,3 +25,7 @@ vcpkg_copy_pdbs()
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/etcd-cpp-apiv3 RENAME copyright)
+
+# Adding usage text
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+

--- a/ports/etcd-cpp-apiv3/portfile.cmake
+++ b/ports/etcd-cpp-apiv3/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     HEAD_REF v0.2.12
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
@@ -15,8 +15,8 @@ vcpkg_configure_cmake(
 set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
 set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/etcd-cpp-api)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/etcd-cpp-api)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/etcd-cpp-apiv3/usage
+++ b/ports/etcd-cpp-apiv3/usage
@@ -1,0 +1,11 @@
+The package etcd-cpp-apiv3 is compatible with built-in CMake targets:
+
+    find_package(etcd-cpp-api CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE etcd-cpp-api)
+
+In cases where you only need the synchronous runtime and want to avoid the initialization
+of builtin thread pool, use:
+
+    find_package(etcd-cpp-api CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE etcd-cpp-api-core)
+

--- a/ports/etcd-cpp-apiv3/vcpkg.json
+++ b/ports/etcd-cpp-apiv3/vcpkg.json
@@ -5,14 +5,6 @@
   "homepage": "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3",
   "license": "BSD-3-Clause",
   "dependencies": [
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    },
     "boost-asio",
     "boost-random",
     "boost-system",
@@ -20,6 +12,14 @@
     "cpprestsdk",
     "grpc",
     "openssl",
-    "protobuf"
+    "protobuf",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/etcd-cpp-apiv3/vcpkg.json
+++ b/ports/etcd-cpp-apiv3/vcpkg.json
@@ -3,7 +3,16 @@
   "version": "0.2.12",
   "description": "The etcd-cpp-apiv3 is a C++ API for etcd's v3 client API, i.e., ETCDCTL_API=3.",
   "homepage": "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3",
+  "license": "BSD-3-Clause",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "boost-asio",
     "boost-random",
     "boost-system",

--- a/ports/etcd-cpp-apiv3/vcpkg.json
+++ b/ports/etcd-cpp-apiv3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "etcd-cpp-apiv3",
-  "version-string": "0.2.12",
+  "version": "0.2.12",
   "description": "The etcd-cpp-apiv3 is a C++ API for etcd's v3 client API, i.e., ETCDCTL_API=3.",
   "homepage": "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3",
   "dependencies": [

--- a/ports/etcd-cpp-apiv3/vcpkg.json
+++ b/ports/etcd-cpp-apiv3/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "etcd-cpp-apiv3",
+  "version-string": "0.2.12",
+  "description": "The etcd-cpp-apiv3 is a C++ API for etcd's v3 client API, i.e., ETCDCTL_API=3.",
+  "homepage": "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3",
+  "dependencies": [
+    "boost-asio",
+    "boost-random",
+    "boost-system",
+    "boost-thread",
+    "cpprestsdk",
+    "grpc",
+    "openssl",
+    "protobuf"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2220,6 +2220,10 @@
       "baseline": "ca7cb332011ec37",
       "port-version": 1
     },
+    "etcd-cpp-apiv3": {
+      "baseline": "0.2.12",
+      "port-version": 0
+    },
     "etl": {
       "baseline": "20.35.4",
       "port-version": 0

--- a/versions/e-/etcd-cpp-apiv3.json
+++ b/versions/e-/etcd-cpp-apiv3.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1c700da2d3e7ad82e97bca5ecc5b24129519b18d",
+      "version": "0.2.12",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/e-/etcd-cpp-apiv3.json
+++ b/versions/e-/etcd-cpp-apiv3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8ac6dd66dbc8eb4349b1df236e96898e7de654d7",
+      "git-tree": "d11dfdbdc719392013a05c613a68271b167b7ec2",
       "version": "0.2.12",
       "port-version": 0
     }

--- a/versions/e-/etcd-cpp-apiv3.json
+++ b/versions/e-/etcd-cpp-apiv3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1c700da2d3e7ad82e97bca5ecc5b24129519b18d",
+      "git-tree": "8ac6dd66dbc8eb4349b1df236e96898e7de654d7",
       "version": "0.2.12",
       "port-version": 0
     }

--- a/versions/e-/etcd-cpp-apiv3.json
+++ b/versions/e-/etcd-cpp-apiv3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d11dfdbdc719392013a05c613a68271b167b7ec2",
+      "git-tree": "25e86e3e1fbb2d12eb7d32d25f758a6485164834",
       "version": "0.2.12",
       "port-version": 0
     }

--- a/versions/e-/etcd-cpp-apiv3.json
+++ b/versions/e-/etcd-cpp-apiv3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "25e86e3e1fbb2d12eb7d32d25f758a6485164834",
+      "git-tree": "86cc86be00d148aaf3c011e1c248ea16e7e6d2fc",
       "version": "0.2.12",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
