### PR TITLE
[raygui] Add new port

### DIFF
--- a/ports/raygui/portfile.cmake
+++ b/ports/raygui/portfile.cmake
@@ -1,0 +1,14 @@
+#header-only library
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO raysan5/raygui
+    REF "${VERSION}"
+    SHA512 09643f3661879a9130122351d0f9310f1ecde5dd1242d15f7b9c61e80dc9acfc3e6b85682ae7079c8579fd39340da8c5dfdea62aabc6cc72a966dea675ddfd38
+    HEAD_REF master
+)
+
+file(INSTALL ${SOURCE_PATH}/src/raygui.h  DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/raygui/portfile.cmake
+++ b/ports/raygui/portfile.cmake
@@ -9,6 +9,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/src/raygui.h  DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL "${SOURCE_PATH}/src/raygui.h"  DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/raygui/vcpkg.json
+++ b/ports/raygui/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "raygui",
+  "version": "3.2",
+  "description": "A simple and easy-to-use immediate-mode gui library",
+  "homepage": "https://github.com/raysan5/raylib",
+  "license": "Zlib"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6644,6 +6644,10 @@
       "baseline": "1.9",
       "port-version": 2
     },
+    "raygui": {
+      "baseline": "3.2",
+      "port-version": 0
+    },
     "raylib": {
       "baseline": "4.2.0",
       "port-version": 1

--- a/versions/r-/raygui.json
+++ b/versions/r-/raygui.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "042db3576c5d79a6b7c92388ab28d7bcc4bd437d",
+      "version": "3.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/r-/raygui.json
+++ b/versions/r-/raygui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "042db3576c5d79a6b7c92388ab28d7bcc4bd437d",
+      "git-tree": "96eade6012fdd28a62fd21748edfd06d63674317",
       "version": "3.2",
       "port-version": 0
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/22935

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.