### PR TITLE
[physac] Add new port

### DIFF
--- a/ports/physac/LICENSE
+++ b/ports/physac/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Víctor Fisac
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ports/physac/portfile.cmake
+++ b/ports/physac/portfile.cmake
@@ -1,0 +1,14 @@
+#header-only library
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO victorfisac/Physac
+    REF "${VERSION}"
+    SHA512 c539ee73d6f456e592d4a92cc5707278476632626b0fa0edfe6396cd4460fe0c2669843f4df3a22a132664d1981d261601061cca76ad1e4b63510a901fc3987b
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/src/physac.h"  DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${CMAKE_CURRENT_LIST_DIR}/LICENSE")

--- a/ports/physac/vcpkg.json
+++ b/ports/physac/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "physac",
+  "version": "1.1",
+  "description": "2D physics header-only library for videogames developed in C using raylib library.",
+  "homepage": "https://github.com/victorfisac/Physac",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5888,6 +5888,10 @@
       "baseline": "2020-12-21",
       "port-version": 0
     },
+    "physac": {
+      "baseline": "1.1",
+      "port-version": 0
+    },
     "physfs": {
       "baseline": "3.2.0",
       "port-version": 1

--- a/versions/p-/physac.json
+++ b/versions/p-/physac.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9223c960b5280c6fed8fb4289523a3433b50349e",
+      "version": "1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/22935

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.