### PR TITLE
[nifticlib] fix feature tools

### DIFF
--- a/ports/nifticlib/portfile.cmake
+++ b/ports/nifticlib/portfile.cmake
@@ -11,7 +11,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS FEATURES
     "cifti"         USE_CIFTI_CODE
     "fsl"           USE_FSL_CODE
     "nifti2"        USE_NIFTI2_CODE
@@ -21,22 +21,27 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 set(TOOL_NAMES)
 if("tools" IN_LIST FEATURES)
-    list(APPEND TOOL_NAMES nifti_stats nifti_tool nifti1_tool)
-endif()
-if("tests" IN_LIST FEATURES)
-    list(APPEND TOOL_NAMES nifit_test) 
+    list(APPEND TOOL_NAMES nifti1_tool) 
+    if("nifti2" IN_LIST FEATURES)
+        list(APPEND TOOL_NAMES nifti_tool) 
+    endif()
+    if("nifticdf" IN_LIST FEATURES)
+        list(APPEND TOOL_NAMES nifti_stats) 
+    endif()
+    if("cifti" IN_LIST FEATURES AND "nifti2" IN_LIST FEATURES)
+        list(APPEND TOOL_NAMES cifti_tool afni_xml_tool) 
+    endif()
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake TARGET_PATH share)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake)
 
 if(TOOL_NAMES)
     vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)
@@ -45,4 +50,4 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nifticlib/vcpkg.json
+++ b/ports/nifticlib/vcpkg.json
@@ -1,12 +1,20 @@
 {
   "name": "nifticlib",
   "version-date": "2020-04-30",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Nifticlib is a C I/O library for reading and writing files in the nifti-1 data format.",
   "homepage": "https://github.com/NIFTI-Imaging/nifti_clib",
   "license": null,
   "supports": "!uwp",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ],
   "default-features": [
@@ -15,22 +23,19 @@
   ],
   "features": {
     "cifti": {
-      "description": "Build cifti libraries and tools"
+      "description": "Build cifti libraries"
     },
     "fsl": {
-      "description": "Build fsl libraries and tools"
+      "description": "Build fsl libraries"
     },
     "nifti2": {
-      "description": "Build nifti2 libraries and tools"
+      "description": "Build nifti2 libraries"
     },
     "nifticdf": {
-      "description": "Build nifticdf libraries and tools"
-    },
-    "tests": {
-      "description": "Build tests"
+      "description": "Build nifticdf libraries"
     },
     "tools": {
-      "description": "Build tools"
+      "description": "Builds the core tool and the tools for 'nifti2' and 'nifticdf' if selected"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5322,7 +5322,7 @@
     },
     "nifticlib": {
       "baseline": "2020-04-30",
-      "port-version": 2
+      "port-version": 3
     },
     "nlohmann-fifo-map": {
       "baseline": "2018.05.07",

--- a/versions/n-/nifticlib.json
+++ b/versions/n-/nifticlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c571b3db6efc2e8065ba99424995e6d720a444f",
+      "version-date": "2020-04-30",
+      "port-version": 3
+    },
+    {
       "git-tree": "bee84e9bdd74b5b80c68eb3c8933a86a51b37915",
       "version-date": "2020-04-30",
       "port-version": 2


### PR DESCRIPTION
Otherwise you get a lot of failures like
```
CMake Error at scripts/cmake/vcpkg_copy_tools.cmake:32 (message):
  Couldn't find tool "nifit_test":

      neither "/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/packages/nifticlib_arm64-osx/bin/nifit_test" nor "/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/packages/nifticlib_arm64-osx/bin/nifit_test.app" exists
Call Stack (most recent call first):
  ports/nifticlib/portfile.cmake:42 (vcpkg_copy_tools)
  scripts/ports.cmake:147 (include)
```