### PR TITLE
[libsonic] Add new port

### DIFF
--- a/ports/libsonic/CMakeLists.txt
+++ b/ports/libsonic/CMakeLists.txt
@@ -4,6 +4,8 @@ project(sonic
     LANGUAGES C
 )
 
+option(BUILD_TOOL "Build sonic tool" ON)
+
 add_library(libsonic sonic.c)
 set_target_properties(libsonic
     PROPERTIES
@@ -13,15 +15,20 @@ set_target_properties(libsonic
         OUTPUT_NAME sonic
 )
 
-add_executable(sonic wave.c main.c)
-target_link_libraries(sonic
-    PRIVATE
-        libsonic
-)
-
-install(TARGETS libsonic sonic
+install(TARGETS libsonic
     ARCHIVE         DESTINATION lib
     LIBRARY         DESTINATION lib
     PUBLIC_HEADER   DESTINATION include
-    RUNTIME         DESTINATION bin
 )
+
+if (BUILD_TOOL)
+    add_executable(sonic wave.c main.c)
+    target_link_libraries(sonic
+        PRIVATE
+            libsonic
+    )
+
+    install(TARGETS sonic
+        RUNTIME         DESTINATION bin
+    )
+endif()

--- a/ports/libsonic/CMakeLists.txt
+++ b/ports/libsonic/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.8)
+project(sonic
+    VERSION 0.2.0
+    LANGUAGES C
+)
+
+add_library(libsonic sonic.c)
+set_target_properties(libsonic
+    PROPERTIES
+        PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/sonic.h"
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+        VERSION ${CMAKE_PROJECT_VERSION}
+)
+
+add_executable(sonic wave.c main.c)
+target_link_libraries(sonic
+    PRIVATE
+        libsonic
+)
+
+install(TARGETS libsonic sonic
+    ARCHIVE         DESTINATION lib
+    LIBRARY         DESTINATION lib
+    PUBLIC_HEADER   DESTINATION include
+    RUNTIME         DESTINATION bin
+)

--- a/ports/libsonic/CMakeLists.txt
+++ b/ports/libsonic/CMakeLists.txt
@@ -10,6 +10,7 @@ set_target_properties(libsonic
         PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/sonic.h"
         SOVERSION ${PROJECT_VERSION_MAJOR}
         VERSION ${CMAKE_PROJECT_VERSION}
+        OUTPUT_NAME sonic
 )
 
 add_executable(sonic wave.c main.c)

--- a/ports/libsonic/portfile.cmake
+++ b/ports/libsonic/portfile.cmake
@@ -6,15 +6,25 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tool BUILD_TOOL
+)
 
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TOOL=${BUILD_TOOL}
 )
 
 vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_copy_tools(TOOL_NAMES sonic AUTO_CLEAN)
+if(BUILD_TOOL)
+    vcpkg_copy_tools(TOOL_NAMES sonic AUTO_CLEAN)
+endif()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libsonic/portfile.cmake
+++ b/ports/libsonic/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libsonic/portfile.cmake
+++ b/ports/libsonic/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO waywardgeek/sonic
+    REF "release-${VERSION}"
+    SHA512 e70510c89c4f29c30f2a3443a1c4fc1aab2c99147e2ebd1dea3cbb2b89b8bdcee14dc504600ac1f04e82d32c19f17b06fbb417311853beb764c24d15687a126f
+    HEAD_REF master
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_copy_tools(TOOL_NAMES sonic AUTO_CLEAN)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libsonic/vcpkg.json
+++ b/ports/libsonic/vcpkg.json
@@ -9,10 +9,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/libsonic/vcpkg.json
+++ b/ports/libsonic/vcpkg.json
@@ -10,5 +10,10 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tool": {
+      "description": "Build tool"
+    }
+  }
 }

--- a/ports/libsonic/vcpkg.json
+++ b/ports/libsonic/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libsonic",
+  "version": "0.2.0",
+  "description": "Simple library to speed up or slow down speech",
+  "homepage": "https://github.com/waywardgeek/sonic",
+  "license": "Apache-2.0",
+  "supports": "linux | osx",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4320,6 +4320,10 @@
       "baseline": "1.0.18",
       "port-version": 8
     },
+    "libsonic": {
+      "baseline": "0.2.0",
+      "port-version": 0
+    },
     "libsoundio": {
       "baseline": "2.0.0",
       "port-version": 6

--- a/versions/l-/libsonic.json
+++ b/versions/l-/libsonic.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "518310ff33956be3982aabc7a21d727c7e1138c5",
+      "version": "0.2.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libsonic.json
+++ b/versions/l-/libsonic.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4af4a2fcb38a392c3ec0c5063b0c1ef0f93e602e",
+      "git-tree": "b81fb841c7bcf7ce50cedfbdec8ff83b627a2d7a",
       "version": "0.2.0",
       "port-version": 0
     }

--- a/versions/l-/libsonic.json
+++ b/versions/l-/libsonic.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "518310ff33956be3982aabc7a21d727c7e1138c5",
+      "git-tree": "4af4a2fcb38a392c3ec0c5063b0c1ef0f93e602e",
       "version": "0.2.0",
       "port-version": 0
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/26423

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.