### PR TITLE
[kdalgorithms] Add new port

### DIFF
--- a/ports/kdalgorithms/portfile.cmake
+++ b/ports/kdalgorithms/portfile.cmake
@@ -1,0 +1,18 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDAB/KDAlgorithms
+    REF 45501fa595dfda00d6af44bfadbf4520cc4e07c1
+    SHA512 69cdc6644b16fff0eb494e9b21082ae32e0b437e225a161ecf644ad83b74d2957ed97e8b6b5674778b4d2c68b2be02ae4e90c1a30b8c8d1eed79e758d4d4b10e
+    HEAD_REF master
+)
+
+file(INSTALL ${SOURCE_PATH}/src/kdalgorithms.h ${SOURCE_PATH}/src/bits
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+    RENAME copyright)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/kdalgorithms/portfile.cmake
+++ b/ports/kdalgorithms/portfile.cmake
@@ -10,9 +10,7 @@ vcpkg_from_github(
 file(INSTALL "${SOURCE_PATH}/src/kdalgorithms.h" "${SOURCE_PATH}/src/bits"
     DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
-    RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/kdalgorithms/portfile.cmake
+++ b/ports/kdalgorithms/portfile.cmake
@@ -1,4 +1,4 @@
-
+# header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDAB/KDAlgorithms

--- a/ports/kdalgorithms/portfile.cmake
+++ b/ports/kdalgorithms/portfile.cmake
@@ -7,8 +7,8 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/src/kdalgorithms.h ${SOURCE_PATH}/src/bits
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+file(INSTALL "${SOURCE_PATH}/src/kdalgorithms.h" "${SOURCE_PATH}/src/bits"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt
     DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}

--- a/ports/kdalgorithms/usage
+++ b/ports/kdalgorithms/usage
@@ -1,0 +1,4 @@
+kdalgorithms is header-only and can be used from CMake via:
+
+    find_path(KDALGORITHMS_INCLUDE_DIRS "kdalgorithms/kdalgorithms.h")
+    target_include_directories(main PRIVATE ${KDALGORITHMS_INCLUDE_DIRS}/kdalgorithms)

--- a/ports/kdalgorithms/usage
+++ b/ports/kdalgorithms/usage
@@ -1,4 +1,4 @@
 kdalgorithms is header-only and can be used from CMake via:
 
-    find_path(KDALGORITHMS_INCLUDE_DIRS "kdalgorithms/kdalgorithms.h")
-    target_include_directories(main PRIVATE ${KDALGORITHMS_INCLUDE_DIRS}/kdalgorithms)
+    find_path(KDALGORITHMS_INCLUDE_DIRS "kdalgorithms.h" PATH_SUFFIXES kdalgorithms)
+    target_include_directories(main PRIVATE ${KDALGORITHMS_INCLUDE_DIRS})

--- a/ports/kdalgorithms/vcpkg.json
+++ b/ports/kdalgorithms/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "kdalgorithms",
+  "version-date": "2023-01-31",
+  "description": "KDAB's algorithm helpers for C++14 and up",
+  "homepage": "https://github.com/KDAB/KDAlgorithms",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3336,6 +3336,10 @@
       "baseline": "1.9.0",
       "port-version": 1
     },
+    "kdalgorithms": {
+      "baseline": "2023-01-31",
+      "port-version": 0
+    },
     "kdbindings": {
       "baseline": "1.0.0",
       "port-version": 0

--- a/versions/k-/kdalgorithms.json
+++ b/versions/k-/kdalgorithms.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f12630b2806a82732ae91e9550b23b8980f4bdb5",
+      "git-tree": "b8b744bbe193f6bbfbe4b02cd8215dc1d8e560a2",
       "version-date": "2023-01-31",
       "port-version": 0
     }

--- a/versions/k-/kdalgorithms.json
+++ b/versions/k-/kdalgorithms.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7648cb03e208b5e45f0fc77629c514eb9308e0a5",
+      "version-date": "2023-01-31",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/k-/kdalgorithms.json
+++ b/versions/k-/kdalgorithms.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7648cb03e208b5e45f0fc77629c514eb9308e0a5",
+      "git-tree": "f12630b2806a82732ae91e9550b23b8980f4bdb5",
       "version-date": "2023-01-31",
       "port-version": 0
     }


### PR DESCRIPTION
This is a header-only library with some stl algorithm wrappers.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.