### PR TITLE
[antlr4] fix MSVC linker errors

### DIFF
--- a/ports/antlr4/portfile.cmake
+++ b/ports/antlr4/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     SHA512 a52356410c95ec6d7128b856dcf4c20a17cdd041270d2c4d700ef02ea715c87a00a87c2ad560277424b300435c6e9b196c8bc9c9f50ae5b6804d8214b4d397d0
     PATCHES
         fix_build_4.11.1.patch
-		set-export-macro-define-as-private.patch
+        set-export-macro-define-as-private.patch
 )
 
 set(RUNTIME_PATH "${SOURCE_PATH}/runtime/Cpp")

--- a/ports/antlr4/portfile.cmake
+++ b/ports/antlr4/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     SHA512 a52356410c95ec6d7128b856dcf4c20a17cdd041270d2c4d700ef02ea715c87a00a87c2ad560277424b300435c6e9b196c8bc9c9f50ae5b6804d8214b4d397d0
     PATCHES
         fix_build_4.11.1.patch
+		set-export-macro-define-as-private.patch
 )
 
 set(RUNTIME_PATH "${SOURCE_PATH}/runtime/Cpp")

--- a/ports/antlr4/set-export-macro-define-as-private.patch
+++ b/ports/antlr4/set-export-macro-define-as-private.patch
@@ -1,0 +1,13 @@
+diff --git a/runtime/Cpp/runtime/CMakeLists.txt b/runtime/Cpp/runtime/CMakeLists.txt
+index 19cc21c..2a33fe9 100644
+--- a/runtime/Cpp/runtime/CMakeLists.txt
++++ b/runtime/Cpp/runtime/CMakeLists.txt
+@@ -103,7 +103,7 @@ set(static_lib_suffix "")
+ if (WIN32)
+   set(static_lib_suffix "-static")
+   if(BUILD_SHARED_LIBS)
+-  target_compile_definitions(antlr4_shared PUBLIC ANTLR4CPP_EXPORTS)
++  target_compile_definitions(antlr4_shared PRIVATE ANTLR4CPP_EXPORTS)
+   else()
+   target_compile_definitions(antlr4_static PUBLIC ANTLR4CPP_STATIC)
+   endif()

--- a/ports/antlr4/vcpkg.json
+++ b/ports/antlr4/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "antlr4",
   "version": "4.11.1",
+  "port-version": 1, 
   "description": "ANother Tool for Language Recognition",
   "homepage": "https://www.antlr.org",
   "license": "BSD-3-Clause",

--- a/ports/antlr4/vcpkg.json
+++ b/ports/antlr4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "antlr4",
   "version": "4.11.1",
-  "port-version": 1, 
+  "port-version": 1,
   "description": "ANother Tool for Language Recognition",
   "homepage": "https://www.antlr.org",
   "license": "BSD-3-Clause",

--- a/versions/a-/antlr4.json
+++ b/versions/a-/antlr4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "162afe92eab004d57c6b0c972ea5e9b371ccb23a",
+      "version": "4.11.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "adff4448fb67cdc7d7a478d5f5f3e973ad65a386",
       "version": "4.11.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -114,7 +114,7 @@
     },
     "antlr4": {
       "baseline": "4.11.1",
-      "port-version": 0
+      "port-version": 1
     },
     "any-lite": {
       "baseline": "0.4.0",


### PR DESCRIPTION
Fixes #29326

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
