### PR TITLE
[activemq-cpp,apr,arrow] Switch apache urls to pull from "archive" 

### DIFF
--- a/ports/activemq-cpp/portfile.cmake
+++ b/ports/activemq-cpp/portfile.cmake
@@ -11,7 +11,7 @@ if (NOT VCPKG_TARGET_IS_LINUX)
 endif()
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.apache.org/dist/activemq/activemq-cpp/${VERSION}/activemq-cpp-library-${VERSION}-src.tar.bz2"
+    URLS "https://archive.apache.org/dist/activemq/activemq-cpp/${VERSION}/activemq-cpp-library-${VERSION}-src.tar.bz2"
     FILENAME "activemq-cpp-library-${VERSION}-src.tar.bz2"
     SHA512 83692d3dfd5ecf557fc88d204a03bf169ce6180bcff27be41b09409b8f7793368ffbeed42d98ef6374c6b6b477d9beb8a4a9ac584df9e56725ec59ceceaa6ae2
 )

--- a/ports/activemq-cpp/vcpkg.json
+++ b/ports/activemq-cpp/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "activemq-cpp",
   "version-semver": "3.9.5",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Apache ActiveMQ is the most popular and powerful open source messaging and Integration Patterns server.",
+  "license": "Apache-2.0",
   "supports": "!(uwp | osx)",
   "dependencies": [
     "apr",

--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -2,7 +2,7 @@
 set(VERSION 1.7.0)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.apache.org/dist/apr/apr-${VERSION}.tar.bz2"
+    URLS "https://archive.apache.org/dist/apr/apr-${VERSION}.tar.bz2"
     FILENAME "apr-${VERSION}.tar.bz2"
     SHA512 3dc42d5caf17aab16f5c154080f020d5aed761e22db4c5f6506917f6bfd2bf8becfb40af919042bd4ce1077d5de74aa666f5edfba7f275efba78e8893c115148
 )

--- a/ports/apr/vcpkg.json
+++ b/ports/apr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "apr",
   "version": "1.7.0",
-  "port-version": 11,
+  "port-version": 12,
   "description": "The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.",
   "homepage": "https://apr.apache.org/",
   "license": "Apache-2.0",

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_download_distfile(
     ARCHIVE_PATH
-    URLS "https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
+    URLS "https://archive.apache.org/dist/arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
     FILENAME apache-arrow-${VERSION}.tar.gz
     SHA512 c6198e5c9b8fe5ccd89e445c9252da44d8d7c9e0c8eb5a802fa0cabf89482fddf775ed383bac1acc9331bc3195d21df7ea02c4a73aa6ee163c2959f34175d650
 )

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrow",
   "version": "10.0.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/activemq-cpp.json
+++ b/versions/a-/activemq-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2cf2310a238e646e62043be2f553332d8bd4c171",
+      "version-semver": "3.9.5",
+      "port-version": 10
+    },
+    {
       "git-tree": "4f5d3901f612afe54e714fb14e47d343822e398e",
       "version-semver": "3.9.5",
       "port-version": 9

--- a/versions/a-/apr.json
+++ b/versions/a-/apr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "beb9b88a2d3bcc63f32177c58622d7ad4b6717cf",
+      "version": "1.7.0",
+      "port-version": 12
+    },
+    {
       "git-tree": "2f23cf24a3496f9fb519512245a3e0f1a66c8ed9",
       "version": "1.7.0",
       "port-version": 11

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04944a4d39fe590b7fed071475502fa8bcfe5a27",
+      "version": "10.0.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "3829a0697ffe3ba8cb1274e2edd7cfbcbc48482b",
       "version": "10.0.1",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -30,7 +30,7 @@
     },
     "activemq-cpp": {
       "baseline": "3.9.5",
-      "port-version": 9
+      "port-version": 10
     },
     "ade": {
       "baseline": "0.1.1f",
@@ -134,7 +134,7 @@
     },
     "apr": {
       "baseline": "1.7.0",
-      "port-version": 11
+      "port-version": 12
     },
     "apr-util": {
       "baseline": "1.6.1",
@@ -198,7 +198,7 @@
     },
     "arrow": {
       "baseline": "10.0.1",
-      "port-version": 3
+      "port-version": 4
     },
     "ashes": {
       "baseline": "2022-06-08",


### PR DESCRIPTION
Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
