### PR TITLE
[hdf5] fix config patch

### DIFF
--- a/ports/hdf5/hdf5_config.patch
+++ b/ports/hdf5/hdf5_config.patch
@@ -1,8 +1,8 @@
 diff --git a/config/cmake/hdf5-config.cmake.in b/config/cmake/hdf5-config.cmake.in
-index 4d02c9c..8c10d2d 100644
+index 1a3fb7bbf2..79081ce040 100644
 --- a/config/cmake/hdf5-config.cmake.in
 +++ b/config/cmake/hdf5-config.cmake.in
-@@ -55,7 +55,10 @@ set (${HDF5_PACKAGE_NAME}_PARALLEL_FILTERED_WRITES "@PARALLEL_FILTERED_WRITES@")
+@@ -56,7 +56,10 @@ set (${HDF5_PACKAGE_NAME}_PARALLEL_FILTERED_WRITES "@PARALLEL_FILTERED_WRITES@")
  #-----------------------------------------------------------------------------
  # Dependencies
  #-----------------------------------------------------------------------------
@@ -13,10 +13,10 @@ index 4d02c9c..8c10d2d 100644
    set (${HDF5_PACKAGE_NAME}_MPI_C_INCLUDE_PATH "@MPI_C_INCLUDE_DIRS@")
    set (${HDF5_PACKAGE_NAME}_MPI_C_LIBRARIES    "@MPI_C_LIBRARIES@")
    if (${HDF5_PACKAGE_NAME}_BUILD_FORTRAN)
-@@ -111,11 +114,9 @@ set (${HDF5_PACKAGE_NAME}_VERSION_MINOR  @HDF5_VERSION_MINOR@)
+@@ -114,11 +117,11 @@ set (${HDF5_PACKAGE_NAME}_VERSION_MINOR  @HDF5_VERSION_MINOR@)
  # project which has already built hdf5 as a subproject
  #-----------------------------------------------------------------------------
--if (NOT TARGET "@HDF5_PACKAGE@")
+ if (NOT TARGET "@HDF5_PACKAGE@")
 -  if (${HDF5_PACKAGE_NAME}_ENABLE_Z_LIB_SUPPORT AND ${HDF5_PACKAGE_NAME}_PACKAGE_EXTLIBS)
 -    include (@PACKAGE_SHARE_INSTALL_DIR@/@ZLIB_PACKAGE_NAME@@HDF_PACKAGE_EXT@-targets.cmake)
 +  if (${HDF5_PACKAGE_NAME}_ENABLE_Z_LIB_SUPPORT)
@@ -26,6 +26,6 @@ index 4d02c9c..8c10d2d 100644
 -    include (@PACKAGE_SHARE_INSTALL_DIR@/@SZIP_PACKAGE_NAME@@HDF_PACKAGE_EXT@-targets.cmake)
 +  if (${HDF5_PACKAGE_NAME}_ENABLE_SZIP_SUPPORT)
 +    find_dependency(szip)
--  endif ()
+   endif ()
    include (@PACKAGE_SHARE_INSTALL_DIR@/@HDF5_PACKAGE@@HDF_PACKAGE_EXT@-targets.cmake)
  endif ()

--- a/ports/hdf5/vcpkg.json
+++ b/ports/hdf5/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hdf5",
   "version": "1.12.2",
-  "port-version": 5,
+  "port-version": 6,
   "description": "HDF5 is a data model, library, and file format for storing and managing data",
   "homepage": "https://www.hdfgroup.org/downloads/hdf5/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2946,7 +2946,7 @@
     },
     "hdf5": {
       "baseline": "1.12.2",
-      "port-version": 5
+      "port-version": 6
     },
     "healpix": {
       "baseline": "1.12.10",

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85fe6e7c6caeadc116edbb67dcee675f36801d7d",
+      "version": "1.12.2",
+      "port-version": 6
+    },
+    {
       "git-tree": "71726aefa4830ee87043862a8541853861cd8333",
       "version": "1.12.2",
       "port-version": 5


### PR DESCRIPTION
Fixes #29389

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
