### PR TITLE
[openal-soft] Uses LGPL-2.0-or-later instead of GPL-2.0-or-later

### DIFF
--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "openal-soft",
   "version-semver": "1.22.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
   "homepage": "https://github.com/kcat/openal-soft",
-  "license": "GPL-2.0-or-later",
+  "license": "LGPL-2.0-or-later",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5550,7 +5550,7 @@
     },
     "openal-soft": {
       "baseline": "1.22.2",
-      "port-version": 4
+      "port-version": 5
     },
     "openblas": {
       "baseline": "0.3.21",

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "971382f7c68a055694a35b455deab6384e8cfb25",
+      "version-semver": "1.22.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "8f028dc8de3d983f0844c0b586c1b6ddfad5d899",
       "version-semver": "1.22.2",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
