### PR TITLE
[iceoryx] Fix acl dependency

### DIFF
--- a/ports/iceoryx/acl.patch
+++ b/ports/iceoryx/acl.patch
@@ -1,24 +1,30 @@
-diff --git a/iceoryx_hoofs/platform/CMakeLists.txt b/iceoryx_hoofs/platform/CMakeLists.txt
-index 78bad09f8..293784c06 100644
---- a/iceoryx_hoofs/platform/CMakeLists.txt
-+++ b/iceoryx_hoofs/platform/CMakeLists.txt
-@@ -55,6 +55,19 @@ target_link_libraries(iceoryx_platform PRIVATE ${ICEORYX_SANITIZER_FLAGS})
- target_compile_options(iceoryx_platform PRIVATE ${ICEORYX_WARNINGS} ${ICEORYX_SANITIZER_FLAGS})
+diff --git a/iceoryx_hoofs/CMakeLists.txt b/iceoryx_hoofs/CMakeLists.txt
+index a8238ff..9741fd3 100644
+--- a/iceoryx_hoofs/CMakeLists.txt
++++ b/iceoryx_hoofs/CMakeLists.txt
+@@ -217,7 +217,9 @@ target_link_libraries(iceoryx_hoofs
+ )
  
  if(LINUX)
+-    target_link_libraries(iceoryx_hoofs PRIVATE acl atomic ${CODE_COVERAGE_LIBS})
 +    find_package(PkgConfig REQUIRED)
-+    pkg_check_modules(ACL REQUIRED libacl)
-+
-+    target_include_directories(iceoryx_platform
-+        PUBLIC
-+        ${ACL_INCLUDE_DIRS}
-+    )
-+
-+    target_link_directories(iceoryx_platform
-+        PUBLIC
-+        ${ACL_LIBRARY_DIRS}
-+    )
-+
-     target_link_libraries(iceoryx_platform
-         PUBLIC
-         rt
++    pkg_check_modules(ACL REQUIRED IMPORTED_TARGET libacl)
++    target_link_libraries(iceoryx_hoofs PUBLIC PkgConfig::ACL PRIVATE atomic ${CODE_COVERAGE_LIBS})
+ endif()
+ 
+ target_compile_options(iceoryx_hoofs PRIVATE ${ICEORYX_WARNINGS} ${ICEORYX_SANITIZER_FLAGS})
+diff --git a/iceoryx_hoofs/cmake/Config.cmake.in b/iceoryx_hoofs/cmake/Config.cmake.in
+index c03b3b5..731c636 100644
+--- a/iceoryx_hoofs/cmake/Config.cmake.in
++++ b/iceoryx_hoofs/cmake/Config.cmake.in
+@@ -17,6 +17,10 @@
+ @PACKAGE_INIT@
+ 
+ include(CMakeFindDependencyMacro)
++if(LINUX)
++    find_dependency(PkgConfig)
++    pkg_check_modules(ACL REQUIRED libacl IMPORTED_TARGET)
++endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+ list(APPEND CMAKE_MODULE_PATH "@CMAKE_INSTALL_PREFIX@/@DESTINATION_CONFIGDIR@")

--- a/ports/iceoryx/portfile.cmake
+++ b/ports/iceoryx/portfile.cmake
@@ -30,8 +30,11 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME iceoryx_binding_c CONFIG_PATH lib/cmake/ic
 vcpkg_cmake_config_fixup(PACKAGE_NAME iceoryx_hoofs CONFIG_PATH lib/cmake/iceoryx_hoofs DO_NOT_DELETE_PARENT_CONFIG_PATH)
 vcpkg_cmake_config_fixup(PACKAGE_NAME iceoryx_posh CONFIG_PATH lib/cmake/iceoryx_posh)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+)
 
 if(TOML_CONFIG)
     vcpkg_copy_tools(TOOL_NAMES iox-roudi AUTO_CLEAN)

--- a/ports/iceoryx/vcpkg.json
+++ b/ports/iceoryx/vcpkg.json
@@ -26,7 +26,7 @@
   ],
   "features": {
     "many-to-many": {
-      "description": "Using the n:n pattern for communication"
+      "description": "Using the m:n pattern for communication"
     },
     "toml-config": {
       "description": "TOML support for RouDi with dynamic configuration",

--- a/ports/iceoryx/vcpkg.json
+++ b/ports/iceoryx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "iceoryx",
   "version": "2.0.2",
+  "port-version": 1,
   "description": "True zero-copy inter-process-communication",
   "homepage": "https://iceoryx.io",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3026,7 +3026,7 @@
     },
     "iceoryx": {
       "baseline": "2.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "icu": {
       "baseline": "72.1",

--- a/versions/i-/iceoryx.json
+++ b/versions/i-/iceoryx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "01c97cf0c2e2ba63c406b8b0d2b51443dec98ee2",
+      "version": "2.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "77c813fcc56fee86559404c7c22c2396509cff1a",
       "version": "2.0.2",
       "port-version": 0


### PR DESCRIPTION
Alternative to #29257

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
