### PR TITLE
[libcopp] Mark arm-windows as unsupported.

### DIFF
--- a/ports/libcopp/vcpkg.json
+++ b/ports/libcopp/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "libcopp",
   "version-semver": "1.4.1",
-  "port-version": 2,
+  "port-version": 3,
   "maintainers": "owent <admin@owent.net>",
   "description": "A cross-platfrom coroutine library for C++",
   "homepage": "https://github.com/owent/libcopp",
   "documentation": "https://libcopp.atframe.work/",
   "license": "MIT",
+  "supports": "!(windows & arm)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -374,7 +374,6 @@ leveldb:arm-uwp=fail
 leveldb:x64-uwp=fail
 libaiff:x64-linux=fail
 libarchive:arm-uwp=fail
-libcopp:arm64-windows=fail
 # Missing system libraries on linux to run/prepare autoconf
 libgpod:x64-linux=fail
 libgpod:x64-osx=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3722,7 +3722,7 @@
     },
     "libcopp": {
       "baseline": "1.4.1",
-      "port-version": 2
+      "port-version": 3
     },
     "libcorrect": {
       "baseline": "2018-10-11",

--- a/versions/l-/libcopp.json
+++ b/versions/l-/libcopp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51ec2fdf59199a7fb42a553aa5368175a58128c6",
+      "version-semver": "1.4.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "d2f995866846ccb6dd7ae147312e095c66f912db",
       "version-semver": "1.4.1",
       "port-version": 2


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/29267 we asked the user to remove a ci.baseline.txt entry for libcopp , but this failed in the most recent full build https://dev.azure.com/vcpkg/public/_build/results?buildId=84590 . It looks like the port doesn't have the plumbing to hook up ARM or ARM64 compilers on Windows, so this isn't a machine configuration / ci.baseline.txt issue.

There does appear to be some code in upstream trying to select armasm rather than masm to use the arm assembler but the port doesn't know how to hook that up.
