### PR TITLE
[platform-folders] update version to 4.2.0

### DIFF
--- a/ports/platform-folders/portfile.cmake
+++ b/ports/platform-folders/portfile.cmake
@@ -26,7 +26,7 @@ endif()
 if (VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP OR VCPKG_TARGET_IS_MinGW)
     vcpkg_cmake_config_fixup(PACKAGE_NAME platform_folders CONFIG_PATH cmake)
 else()
-    vcpkg_cmake_config_fixup(PACKAGE_NAME platform_folders CONFIG_PATH cmake)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME platform_folders CONFIG_PATH lib/cmake)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/platform-folders/portfile.cmake
+++ b/ports/platform-folders/portfile.cmake
@@ -4,19 +4,18 @@ set(TARGET_BUILD_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sago007/PlatformFolders
-    REF 4.1.0
-    SHA512 B2C7983399D9EAA8EF95F45E51B7B70626466FC14A0E53C8B497E683D63E40683CC995C75FC9529C7E969BB802CF9C92051B663901326985722AEBF7618C48EB
+    REF 4.2.0
+    SHA512 50a9acd37b8b491e8938190b3b7ed1af2d3cc70bb6e59708dc1928269d5e4b8d52ec02f9330f3d9439099029ac61d193dadbca198e1d561432e02e488e103f7c
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
     OPTIONS
-        -DBUILD_TESTING=OFF
+        -DPLATFORMFOLDERS_BUILD_TESTING=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
     file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
@@ -25,12 +24,12 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
 endif()
 
 if (VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP OR VCPKG_TARGET_IS_MinGW)
-	vcpkg_fixup_cmake_targets(CONFIG_PATH cmake/ TARGET_PATH /share/platform_folders)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME platform_folders CONFIG_PATH cmake)
 else()
-	vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/ TARGET_PATH /share/)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME platform_folders CONFIG_PATH cmake)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_copy_pdbs()

--- a/ports/platform-folders/vcpkg.json
+++ b/ports/platform-folders/vcpkg.json
@@ -1,6 +1,17 @@
 {
   "name": "platform-folders",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "A C++ library to look for special directories like \"My Documents\" and \"%APPDATA%\"",
-  "homepage": "https://github.com/sago007/PlatformFolders"
+  "homepage": "https://github.com/sago007/PlatformFolders",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5929,7 +5929,7 @@
       "port-version": 0
     },
     "platform-folders": {
-      "baseline": "4.1.0",
+      "baseline": "4.2.0",
       "port-version": 0
     },
     "plf-colony": {

--- a/versions/p-/platform-folders.json
+++ b/versions/p-/platform-folders.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5eaf236478aed86d3f66356114f6413026fc8b15",
+      "version": "4.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8bb2bb2c54727cd2fa9b97a09313b1589e8f4e03",
       "version": "4.1.0",
       "port-version": 0

--- a/versions/p-/platform-folders.json
+++ b/versions/p-/platform-folders.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5eaf236478aed86d3f66356114f6413026fc8b15",
+      "git-tree": "8448d41ddd7f2f2302c9a6a80dde44bb8494b096",
       "version": "4.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/29126
No feature needs to test.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
