### PR TITLE
[mchehab-zbar] Fix build without nls

### DIFF
--- a/ports/mchehab-zbar/portfile.cmake
+++ b/ports/mchehab-zbar/portfile.cmake
@@ -17,8 +17,20 @@ if("nls" IN_LIST FEATURES)
 else()
     set(ENV{AUTOPOINT} true) # true, the program
     file(TOUCH "${SOURCE_PATH}/po/Makefile.in.in")
-    file(WRITE "${SOURCE_PATH}/config/iconv.m4" "AC_DEFUN([AM_ICONV],[])\n")
-    file(WRITE "${SOURCE_PATH}/config/gettext.m4" "AC_DEFUN([AM_GNU_GETTEXT],[])\nAC_DEFUN([AM_GNU_GETTEXT_VERSION],[])\nAC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION],[])\n")
+    # Get build-time m4 files from gettext
+    set(gettext_version 0.21.1)
+    vcpkg_download_distfile(gettext_archive
+        URLS "https://ftp.gnu.org/pub/gnu/gettext/gettext-${gettext_version}.tar.gz"
+             "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gettext/gettext-${gettext_version}.tar.gz"
+        FILENAME "gettext-${gettext_version}.tar.gz"
+        SHA512 ccd43a43fab3c90ed99b3e27628c9aeb7186398153b137a4997f8c7ddfd9729b0ba9d15348567e5206af50ac027673d2b8a3415bb3fc65f87ad778f85dc03a05
+    )
+    file(ARCHIVE_EXTRACT INPUT "${gettext_archive}"
+        DESTINATION "${SOURCE_PATH}/gettext-for-m4"
+        PATTERNS "*/gettext-runtime/m4/gettext.m4" "*/gettext-runtime/m4/iconv.m4"
+    )
+    file(GLOB_RECURSE m4_files "${SOURCE_PATH}/gettext-for-m4/*/*.m4")
+    file(INSTALL ${m4_files} DESTINATION "${SOURCE_PATH}/config")
     vcpkg_list(APPEND options "--disable-nls")
 endif()
 

--- a/ports/mchehab-zbar/portfile.cmake
+++ b/ports/mchehab-zbar/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_list(SET options)
 if("nls" IN_LIST FEATURES)
     vcpkg_list(APPEND options "--enable-nls")
 else()
+    set(ENV{AUTOPOINT} true) # true, the program
+    file(TOUCH "${SOURCE_PATH}/po/Makefile.in.in")
     vcpkg_list(APPEND options "--disable-nls")
 endif()
 

--- a/ports/mchehab-zbar/portfile.cmake
+++ b/ports/mchehab-zbar/portfile.cmake
@@ -17,6 +17,8 @@ if("nls" IN_LIST FEATURES)
 else()
     set(ENV{AUTOPOINT} true) # true, the program
     file(TOUCH "${SOURCE_PATH}/po/Makefile.in.in")
+    file(WRITE "${SOURCE_PATH}/config/iconv.m4" "AC_DEFUN([AM_ICONV],[])\n")
+    file(WRITE "${SOURCE_PATH}/config/gettext.m4" "AC_DEFUN([AM_GNU_GETTEXT],[])\nAC_DEFUN([AM_GNU_GETTEXT_VERSION],[])\nAC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION],[])\n")
     vcpkg_list(APPEND options "--disable-nls")
 endif()
 

--- a/ports/mchehab-zbar/portfile.cmake
+++ b/ports/mchehab-zbar/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_list(SET options)
 if("nls" IN_LIST FEATURES)
     vcpkg_list(APPEND options "--enable-nls")
 else()
+    vcpkg_list(APPEND options "--disable-nls")
     set(ENV{AUTOPOINT} true) # true, the program
     file(TOUCH "${SOURCE_PATH}/po/Makefile.in.in")
     # Get missing build-time m4 files from gettext source
@@ -29,6 +30,9 @@ else()
         DESTINATION "${SOURCE_PATH}/gettext-autoconf"
         PATTERNS "*/gettext-runtime/m4/gettext.m4"
                  "*/gettext-runtime/m4/iconv.m4"
+                 "*/gettext-runtime/m4/nls.m4"
+                 "*/gettext-runtime/m4/po.m4"
+                 "*/gettext-runtime/gnulib-m4/lib-link.m4"
                  "*/gettext-runtime/gnulib-m4/lib-prefix.m4"
     )
     file(GLOB_RECURSE m4_files "${SOURCE_PATH}/gettext-autoconf/*/*.m4")

--- a/ports/mchehab-zbar/portfile.cmake
+++ b/ports/mchehab-zbar/portfile.cmake
@@ -30,8 +30,12 @@ else()
         DESTINATION "${SOURCE_PATH}/gettext-autoconf"
         PATTERNS "*/gettext-runtime/m4/gettext.m4"
                  "*/gettext-runtime/m4/iconv.m4"
+                 "*/gettext-runtime/m4/intlmacosx.m4"
                  "*/gettext-runtime/m4/nls.m4"
                  "*/gettext-runtime/m4/po.m4"
+                 "*/gettext-runtime/m4/progtest.m4"
+                 "*/gettext-runtime/gnulib-m4/host-cpu-c-abi.m4"
+                 "*/gettext-runtime/gnulib-m4/lib-ld.m4"
                  "*/gettext-runtime/gnulib-m4/lib-link.m4"
                  "*/gettext-runtime/gnulib-m4/lib-prefix.m4"
     )

--- a/ports/mchehab-zbar/portfile.cmake
+++ b/ports/mchehab-zbar/portfile.cmake
@@ -17,7 +17,7 @@ if("nls" IN_LIST FEATURES)
 else()
     set(ENV{AUTOPOINT} true) # true, the program
     file(TOUCH "${SOURCE_PATH}/po/Makefile.in.in")
-    # Get build-time m4 files from gettext
+    # Get missing build-time m4 files from gettext source
     set(gettext_version 0.21.1)
     vcpkg_download_distfile(gettext_archive
         URLS "https://ftp.gnu.org/pub/gnu/gettext/gettext-${gettext_version}.tar.gz"
@@ -26,12 +26,13 @@ else()
         SHA512 ccd43a43fab3c90ed99b3e27628c9aeb7186398153b137a4997f8c7ddfd9729b0ba9d15348567e5206af50ac027673d2b8a3415bb3fc65f87ad778f85dc03a05
     )
     file(ARCHIVE_EXTRACT INPUT "${gettext_archive}"
-        DESTINATION "${SOURCE_PATH}/gettext-for-m4"
-        PATTERNS "*/gettext-runtime/m4/gettext.m4" "*/gettext-runtime/m4/iconv.m4"
+        DESTINATION "${SOURCE_PATH}/gettext-autoconf"
+        PATTERNS "*/gettext-runtime/m4/gettext.m4"
+                 "*/gettext-runtime/m4/iconv.m4"
+                 "*/gettext-runtime/gnulib-m4/lib-prefix.m4"
     )
-    file(GLOB_RECURSE m4_files "${SOURCE_PATH}/gettext-for-m4/*/*.m4")
+    file(GLOB_RECURSE m4_files "${SOURCE_PATH}/gettext-autoconf/*/*.m4")
     file(INSTALL ${m4_files} DESTINATION "${SOURCE_PATH}/config")
-    vcpkg_list(APPEND options "--disable-nls")
 endif()
 
 vcpkg_configure_make(

--- a/ports/mchehab-zbar/portfile.cmake
+++ b/ports/mchehab-zbar/portfile.cmake
@@ -46,6 +46,7 @@ endif()
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
+    ADD_BIN_TO_PATH # checking for working iconv
     OPTIONS
         ${options}
         --without-dbus

--- a/ports/mchehab-zbar/vcpkg.json
+++ b/ports/mchehab-zbar/vcpkg.json
@@ -1,16 +1,12 @@
 {
   "name": "mchehab-zbar",
   "version": "0.23.90",
-  "port-version": 2,
+  "port-version": 3,
   "description": "ZBar is an open source software suite for reading bar codes from various sources, including webcams. This fork is actively maintained.",
   "homepage": "https://github.com/mchehab/zbar",
   "license": "LGPL-2.1-or-later",
   "supports": "!uwp",
   "dependencies": [
-    {
-      "name": "gettext",
-      "host": true
-    },
     "libiconv"
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4906,7 +4906,7 @@
     },
     "mchehab-zbar": {
       "baseline": "0.23.90",
-      "port-version": 2
+      "port-version": 3
     },
     "mcpp": {
       "baseline": "2.7.2.14",

--- a/versions/m-/mchehab-zbar.json
+++ b/versions/m-/mchehab-zbar.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "78af6695c1ae1889782321149f71f12547f6ea66",
+      "git-tree": "25b923000586733fcae49bf028e7d6be7aea5b1c",
       "version": "0.23.90",
       "port-version": 3
     },

--- a/versions/m-/mchehab-zbar.json
+++ b/versions/m-/mchehab-zbar.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3ed6ffc669564d78e83a01eead9a2c2b8e4c8766",
+      "git-tree": "935ceb14fbc62e378361d15466182ae4b88cf37a",
       "version": "0.23.90",
       "port-version": 3
     },

--- a/versions/m-/mchehab-zbar.json
+++ b/versions/m-/mchehab-zbar.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "692b86ac5546c9b25e2c126653ca1d5f55002d88",
+      "version": "0.23.90",
+      "port-version": 3
+    },
+    {
       "git-tree": "af1f66aef9076cd2e27c941851d1549d1cbffe00",
       "version": "0.23.90",
       "port-version": 2

--- a/versions/m-/mchehab-zbar.json
+++ b/versions/m-/mchehab-zbar.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "692b86ac5546c9b25e2c126653ca1d5f55002d88",
+      "git-tree": "3ed6ffc669564d78e83a01eead9a2c2b8e4c8766",
       "version": "0.23.90",
       "port-version": 3
     },

--- a/versions/m-/mchehab-zbar.json
+++ b/versions/m-/mchehab-zbar.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "935ceb14fbc62e378361d15466182ae4b88cf37a",
+      "git-tree": "78af6695c1ae1889782321149f71f12547f6ea66",
       "version": "0.23.90",
       "port-version": 3
     },

--- a/versions/m-/mchehab-zbar.json
+++ b/versions/m-/mchehab-zbar.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "25b923000586733fcae49bf028e7d6be7aea5b1c",
+      "git-tree": "cbfdaff081849a8db3f594914f32408c9df4aec5",
       "version": "0.23.90",
       "port-version": 3
     },

--- a/versions/m-/mchehab-zbar.json
+++ b/versions/m-/mchehab-zbar.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cbfdaff081849a8db3f594914f32408c9df4aec5",
+      "git-tree": "09371ba90d3c31d038bffd54a90203b5b4f7fdc8",
       "version": "0.23.90",
       "port-version": 3
     },


### PR DESCRIPTION
Fixes #29366.
Unlike other autotools packages, this one neither provides a generated `Configure` nor all m4 macros needed for generation. To avoid the dependency on the gettext[tools] binary artifact (slow build on windows), this PR directly picks the m4 files from gettext sources.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
