### PR TITLE
[efsw] Update to 1.3.1.

### DIFF
--- a/ports/efsw/portfile.cmake
+++ b/ports/efsw/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SpartanJ/efsw
-    REF 6b51944994b5c77dbd7edce66846e378a3bf4d8e
-    SHA512 f49a8e5f4ec2d05c3d7bcdbfc6b39a9f1bb9667881cb52c065d038b558af0bfe19079bc9937398fc15faab680c1b2a685d00321143a5c324c8a31137549a7d0f
+    REF "${VERSION}"
+    SHA512 f9503a17ff5b6bdb4770b24c69f8015689ee3bc589428696437d887510e0ab38fddd85cc8e75b6f256d2a6362911ded1cb6a37ab33bd38de51bd779dbdbc8321
     HEAD_REF master
 )
 
@@ -17,7 +17,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/efsw)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_copy_pdbs()
 

--- a/ports/efsw/vcpkg.json
+++ b/ports/efsw/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "efsw",
-  "version-date": "2023-01-06",
+  "version": "1.3.1",
   "description": "efsw is a C++ cross-platform file system watcher and notifier.",
   "homepage": "https://github.com/SpartanJ/efsw",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2157,7 +2157,7 @@
       "port-version": 0
     },
     "efsw": {
-      "baseline": "2023-01-06",
+      "baseline": "1.3.1",
       "port-version": 0
     },
     "egl": {

--- a/versions/e-/efsw.json
+++ b/versions/e-/efsw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cdbd9de7e4e09eca9f0937c5b90ca540a66f6409",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "818d58dbad7e02e1fa150ef43c178fc47dd0efac",
       "version-date": "2023-01-06",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/29188. 
Update efsw to `1.3.1`, no feature needs to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.