### PR TITLE
[ceres] Fix missing iOS deployment target

### DIFF
--- a/ports/ceres/portfile.cmake
+++ b/ports/ceres/portfile.cmake
@@ -43,10 +43,17 @@ foreach (FEATURE ${FEATURE_OPTIONS})
     message(STATUS "${FEATURE}")
 endforeach()
 
+set(TARGET_OPTIONS )
+if(VCPKG_TARGET_IS_IOS)
+    # Note: CMake uses "OSX" not just for macOS, but also iOS, watchOS and tvOS.
+    list(APPEND TARGET_OPTIONS "-DIOS_DEPLOYMENT_TARGET=${VCPKG_OSX_DEPLOYMENT_TARGET}")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        ${TARGET_OPTIONS}
         -DEXPORT_BUILD_DIR=ON
         -DBUILD_BENCHMARKS=OFF
         -DBUILD_EXAMPLES=OFF

--- a/ports/ceres/vcpkg.json
+++ b/ports/ceres/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ceres",
   "version": "2.1.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "non-linear optimization package",
   "homepage": "https://github.com/ceres-solver/ceres-solver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1378,7 +1378,7 @@
     },
     "ceres": {
       "baseline": "2.1.0",
-      "port-version": 2
+      "port-version": 3
     },
     "cfitsio": {
       "baseline": "3.49",

--- a/versions/c-/ceres.json
+++ b/versions/c-/ceres.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41580e5d78c0894588ee748ef09366ff9309aa0c",
+      "version": "2.1.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "4baf16216d2d50574964ba5795a501bb89193042",
       "version": "2.1.0",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Ceres expects the iOS target version to passed in `IOS_DEPLOYMENT_TARGET`, and even[ forcibly unsets `CMAKE_OSX_DEPLOYMENT_TARGET`](https://github.com/ceres-solver/ceres-solver/blob/f1414cb5bd3fafb54cc4f5bc2d4d4df5f4149ccc/cmake/iOS.cmake#L220-L223).

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
