### PR TITLE
[xpack] Add new port

### DIFF
--- a/ports/xpack/portfile.cmake
+++ b/ports/xpack/portfile.cmake
@@ -8,10 +8,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
-
-# Copy the single reusable library header
-# file(COPY "${SOURCE_PATH}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 file(GLOB header_files 
     "${SOURCE_PATH}/*.h"
     "${SOURCE_PATH}/*.hpp") 

--- a/ports/xpack/portfile.cmake
+++ b/ports/xpack/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xyz347/xpack
-    REF fc9b7808b1f0de81d8c1fa307a04ebe122b30650
-    SHA512 d989da44e5e2f8e32202e5f5d6f5292f88b386cb6cf9d898e74267977f1254d08672773a62378c2cf4c2d72c724ad1e87d019a170d14acbd675c0ca1edbe5e77
+    REF 137467c05badd88b8569d161f27afb498ea4ff9a
+    SHA512 349ff9fb9ca74bd1401d8f0f121b263e40c021fde57a500d31eb14eeba8f3d3e8d7f6f629fc696d3052095d311700aa42b7b3a0a19c61787246e6680ea27928e
     HEAD_REF master
 )
 
@@ -12,9 +12,8 @@ file(GLOB header_files
     "${SOURCE_PATH}/*.h"
     "${SOURCE_PATH}/*.hpp") 
 file(COPY ${header_files}
-    "${SOURCE_PATH}/thirdparty"
 	"${SOURCE_PATH}/xpack.pri"
     DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xpack/portfile.cmake
+++ b/ports/xpack/portfile.cmake
@@ -1,0 +1,24 @@
+# xpack - Header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO xyz347/xpack
+    REF fc9b7808b1f0de81d8c1fa307a04ebe122b30650
+    SHA512 d989da44e5e2f8e32202e5f5d6f5292f88b386cb6cf9d898e74267977f1254d08672773a62378c2cf4c2d72c724ad1e87d019a170d14acbd675c0ca1edbe5e77
+    HEAD_REF master
+)
+
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+# Copy the single reusable library header
+# file(COPY "${SOURCE_PATH}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+file(GLOB header_files 
+    "${SOURCE_PATH}/*.h"
+    "${SOURCE_PATH}/*.hpp") 
+file(COPY ${header_files}
+    "${SOURCE_PATH}/thirdparty"
+	"${SOURCE_PATH}/xpack.pri"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/xpack/vcpkg.json
+++ b/ports/xpack/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "xpack",
+  "version": "1.0.4",
+  "description": "Convert C++ struct from/to json/xml",
+  "homepage": "https://github.com/xyz347/xpack",
+  "license": "Apache-2.0"
+}

--- a/ports/xpack/vcpkg.json
+++ b/ports/xpack/vcpkg.json
@@ -1,7 +1,11 @@
 {
   "name": "xpack",
-  "version": "1.0.4",
+  "version-date": "2023-02-06",
   "description": "Convert C++ struct from/to json/xml",
   "homepage": "https://github.com/xyz347/xpack",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": [
+    "rapidjson",
+    "rapidxml"
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8381,7 +8381,7 @@
       "port-version": 0
     },
     "xpack": {
-      "baseline": "1.0.4",
+      "baseline": "2023-02-06",
       "port-version": 0
     },
     "xproperty": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8380,6 +8380,10 @@
       "baseline": "2021-11-20",
       "port-version": 0
     },
+    "xpack": {
+      "baseline": "1.0.4",
+      "port-version": 0
+    },
     "xproperty": {
       "baseline": "0.8.1",
       "port-version": 1

--- a/versions/x-/xpack.json
+++ b/versions/x-/xpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f88f1fac7f243a7abc00e6499dcf6f6f0b9120d5",
+      "git-tree": "2b6b0c20aaf6c358d24c3d4bdc1ad59da4712909",
       "version": "1.0.4",
       "port-version": 0
     }

--- a/versions/x-/xpack.json
+++ b/versions/x-/xpack.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "2b6b0c20aaf6c358d24c3d4bdc1ad59da4712909",
-      "version": "1.0.4",
+      "git-tree": "5123943d7e13cfac8d5a58f7fe3cf027275e5bee",
+      "version-date": "2023-02-06",
       "port-version": 0
     }
   ]

--- a/versions/x-/xpack.json
+++ b/versions/x-/xpack.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f88f1fac7f243a7abc00e6499dcf6f6f0b9120d5",
+      "version": "1.0.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This is a header-only library for converting between c++ structures and json/xml
- [x] Changes comply with the [maintainer guide]
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.