### PR TITLE
[cyclonedds-cxx] Add new port

### DIFF
--- a/ports/cyclonedds-cxx/portfile.cmake
+++ b/ports/cyclonedds-cxx/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 7131b0980edf4dbd16ffd29edde24b4f31c8a4813eda7dfe93fe11f9eb102ef682651a037a12bf671b4617a673e35d97106172828328e47de51d0baddae22ab6
     HEAD_REF master
+    PATCHES
+        static-idllib.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/cyclonedds-cxx/portfile.cmake
+++ b/ports/cyclonedds-cxx/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO eclipse-cyclonedds/cyclonedds-cxx
+    REF "${VERSION}"
+    SHA512 7131b0980edf4dbd16ffd29edde24b4f31c8a4813eda7dfe93fe11f9eb102ef682651a037a12bf671b4617a673e35d97106172828328e47de51d0baddae22ab6
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "idllib"                    BUILD_IDLLIB
+        "shm"                       ENABLE_SHM
+        "topic-discovery"           ENABLE_TOPIC_DISCOVERY
+        "type-discovery"            ENABLE_TYPE_DISCOVERY
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/CycloneDDS-CXX")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cyclonedds-cxx/portfile.cmake
+++ b/ports/cyclonedds-cxx/portfile.cmake
@@ -11,9 +11,6 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         "idllib"                    BUILD_IDLLIB
-        "shm"                       ENABLE_SHM
-        "topic-discovery"           ENABLE_TOPIC_DISCOVERY
-        "type-discovery"            ENABLE_TYPE_DISCOVERY
 )
 
 vcpkg_cmake_configure(

--- a/ports/cyclonedds-cxx/static-idllib.patch
+++ b/ports/cyclonedds-cxx/static-idllib.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0b7f8cd..deb2b69 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,6 +13,7 @@ cmake_minimum_required(VERSION 3.16)
+ project(CycloneDDS-CXX VERSION 0.10.2 LANGUAGES C CXX)
+ 
+ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
++find_package(OpenSSL REQUIRED)
+ 
+ # Conan
+ if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake" AND NOT CONAN_DEPENDENCIES)
+diff --git a/src/idlcxx/CMakeLists.txt b/src/idlcxx/CMakeLists.txt
+index 13531be..b706668 100644
+--- a/src/idlcxx/CMakeLists.txt
++++ b/src/idlcxx/CMakeLists.txt
+@@ -12,7 +12,7 @@
+ include(GenerateExportHeader)
+ 
+ add_library(
+-  idlcxx SHARED
++  idlcxx
+     src/types.c
+     src/traits.c
+     src/streamers.c

--- a/ports/cyclonedds-cxx/vcpkg.json
+++ b/ports/cyclonedds-cxx/vcpkg.json
@@ -18,10 +18,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "topic-discovery",
-    "type-discovery"
-  ],
   "features": {
     "idllib": {
       "description": "Build IDL preprocessor lib",
@@ -31,50 +27,6 @@
           "default-features": false,
           "features": [
             "idlc"
-          ]
-        }
-      ]
-    },
-    "shm": {
-      "description": "Enable shared memory support",
-      "supports": "!windows",
-      "dependencies": [
-        {
-          "name": "cyclonedds",
-          "default-features": false,
-          "features": [
-            "shm"
-          ]
-        }
-      ]
-    },
-    "topic-discovery": {
-      "description": "Enable Topic Discovery support",
-      "dependencies": [
-        {
-          "name": "cyclonedds",
-          "default-features": false,
-          "features": [
-            "topic-discovery"
-          ]
-        },
-        {
-          "name": "cyclonedds-cxx",
-          "default-features": false,
-          "features": [
-            "type-discovery"
-          ]
-        }
-      ]
-    },
-    "type-discovery": {
-      "description": "Enable Type Discovery support",
-      "dependencies": [
-        {
-          "name": "cyclonedds",
-          "default-features": false,
-          "features": [
-            "type-discovery"
           ]
         }
       ]

--- a/ports/cyclonedds-cxx/vcpkg.json
+++ b/ports/cyclonedds-cxx/vcpkg.json
@@ -9,6 +9,7 @@
       "name": "cyclonedds",
       "default-features": false
     },
+    "openssl",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/cyclonedds-cxx/vcpkg.json
+++ b/ports/cyclonedds-cxx/vcpkg.json
@@ -19,27 +19,10 @@
     }
   ],
   "default-features": [
-    "deadline-missed",
-    "ipv6",
-    "lifespan",
-    "security",
-    "source-specific-multicast",
     "topic-discovery",
     "type-discovery"
   ],
   "features": {
-    "deadline-missed": {
-      "description": "Enable Deadline Missed QoS suppor",
-      "dependencies": [
-        {
-          "name": "cyclonedds",
-          "default-features": false,
-          "features": [
-            "deadline-missed"
-          ]
-        }
-      ]
-    },
     "idllib": {
       "description": "Build IDL preprocessor lib",
       "dependencies": [
@@ -48,42 +31,6 @@
           "default-features": false,
           "features": [
             "idlc"
-          ]
-        }
-      ]
-    },
-    "ipv6": {
-      "description": "Enable ipv6 support",
-      "dependencies": [
-        {
-          "name": "cyclonedds",
-          "default-features": false,
-          "features": [
-            "ipv6"
-          ]
-        }
-      ]
-    },
-    "lifespan": {
-      "description": "Enable Lifespan QoS support",
-      "dependencies": [
-        {
-          "name": "cyclonedds",
-          "default-features": false,
-          "features": [
-            "lifespan"
-          ]
-        }
-      ]
-    },
-    "security": {
-      "description": "Enable OMG DDS Security support",
-      "dependencies": [
-        {
-          "name": "cyclonedds",
-          "default-features": false,
-          "features": [
-            "security"
           ]
         }
       ]
@@ -97,30 +44,6 @@
           "default-features": false,
           "features": [
             "shm"
-          ]
-        }
-      ]
-    },
-    "source-specific-multicast": {
-      "description": "Enable support for source-specific multicast",
-      "dependencies": [
-        {
-          "name": "cyclonedds",
-          "default-features": false,
-          "features": [
-            "security"
-          ]
-        }
-      ]
-    },
-    "ssl": {
-      "description": "Enable OpenSSL support",
-      "dependencies": [
-        {
-          "name": "cyclonedds",
-          "default-features": false,
-          "features": [
-            "ssl"
           ]
         }
       ]

--- a/ports/cyclonedds-cxx/vcpkg.json
+++ b/ports/cyclonedds-cxx/vcpkg.json
@@ -1,0 +1,160 @@
+{
+  "name": "cyclonedds-cxx",
+  "version": "0.10.2",
+  "description": "C++ binding for Eclipse Cyclone DDS",
+  "homepage": "https://cyclonedds.io",
+  "license": "EPL-2.0",
+  "dependencies": [
+    {
+      "name": "cyclonedds",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "deadline-missed",
+    "ipv6",
+    "lifespan",
+    "security",
+    "source-specific-multicast",
+    "topic-discovery",
+    "type-discovery"
+  ],
+  "features": {
+    "deadline-missed": {
+      "description": "Enable Deadline Missed QoS suppor",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "deadline-missed"
+          ]
+        }
+      ]
+    },
+    "idllib": {
+      "description": "Build IDL preprocessor lib",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "idlc"
+          ]
+        }
+      ]
+    },
+    "ipv6": {
+      "description": "Enable ipv6 support",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "ipv6"
+          ]
+        }
+      ]
+    },
+    "lifespan": {
+      "description": "Enable Lifespan QoS support",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "lifespan"
+          ]
+        }
+      ]
+    },
+    "security": {
+      "description": "Enable OMG DDS Security support",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "security"
+          ]
+        }
+      ]
+    },
+    "shm": {
+      "description": "Enable shared memory support",
+      "supports": "!windows",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "shm"
+          ]
+        }
+      ]
+    },
+    "source-specific-multicast": {
+      "description": "Enable support for source-specific multicast",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "security"
+          ]
+        }
+      ]
+    },
+    "ssl": {
+      "description": "Enable OpenSSL support",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "ssl"
+          ]
+        }
+      ]
+    },
+    "topic-discovery": {
+      "description": "Enable Topic Discovery support",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "topic-discovery"
+          ]
+        },
+        {
+          "name": "cyclonedds-cxx",
+          "default-features": false,
+          "features": [
+            "type-discovery"
+          ]
+        }
+      ]
+    },
+    "type-discovery": {
+      "description": "Enable Type Discovery support",
+      "dependencies": [
+        {
+          "name": "cyclonedds",
+          "default-features": false,
+          "features": [
+            "type-discovery"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1880,6 +1880,10 @@
       "baseline": "0.10.2",
       "port-version": 0
     },
+    "cyclonedds-cxx": {
+      "baseline": "0.10.2",
+      "port-version": 0
+    },
     "czmq": {
       "baseline": "4.2.1",
       "port-version": 1

--- a/versions/c-/cyclonedds-cxx.json
+++ b/versions/c-/cyclonedds-cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d18445756942d6493f1b46593ea0bce4cadd659",
+      "git-tree": "163e5b6e1b6e95281b7888cf31b6407c40981040",
       "version": "0.10.2",
       "port-version": 0
     }

--- a/versions/c-/cyclonedds-cxx.json
+++ b/versions/c-/cyclonedds-cxx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7e547c0704618df24210c3f0f843c05e3718c9e8",
+      "version": "0.10.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/cyclonedds-cxx.json
+++ b/versions/c-/cyclonedds-cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "31021de965a87943ec47328da3c59a17a91e07d3",
+      "git-tree": "e991575e42395208f48ab2505e428390494cae54",
       "version": "0.10.2",
       "port-version": 0
     }

--- a/versions/c-/cyclonedds-cxx.json
+++ b/versions/c-/cyclonedds-cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7e547c0704618df24210c3f0f843c05e3718c9e8",
+      "git-tree": "31021de965a87943ec47328da3c59a17a91e07d3",
       "version": "0.10.2",
       "port-version": 0
     }

--- a/versions/c-/cyclonedds-cxx.json
+++ b/versions/c-/cyclonedds-cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e991575e42395208f48ab2505e428390494cae54",
+      "git-tree": "6d18445756942d6493f1b46593ea0bce4cadd659",
       "version": "0.10.2",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.