### PR TITLE
[iceoryx] Update to 2.0.3

### DIFF
--- a/ports/iceoryx/portfile.cmake
+++ b/ports/iceoryx/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eclipse-iceoryx/iceoryx
     REF "v${VERSION}"
-    SHA512 b860452373dc41d6b0dd0042d1fc4c97621f143d20e9354a1572126ab815ee0cec6548ddfab9fa276943ed33d9ffd8810243e67eb5fae1d11f18ef0b2b074650    
+    SHA512 b860452373dc41d6b0dd0042d1fc4c97621f143d20e9354a1572126ab815ee0cec6548ddfab9fa276943ed33d9ffd8810243e67eb5fae1d11f18ef0b2b074650
     HEAD_REF master
     PATCHES
         acl.patch

--- a/ports/iceoryx/portfile.cmake
+++ b/ports/iceoryx/portfile.cmake
@@ -6,7 +6,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eclipse-iceoryx/iceoryx
     REF "v${VERSION}"
-    SHA512 b860452373dc41d6b0dd0042d1fc4c97621f143d20e9354a1572126ab815ee0cec6548ddfab9fa276943ed33d9ffd8810243e67eb5fae1d11f18ef0b2b074650    HEAD_REF master
+    SHA512 b860452373dc41d6b0dd0042d1fc4c97621f143d20e9354a1572126ab815ee0cec6548ddfab9fa276943ed33d9ffd8810243e67eb5fae1d11f18ef0b2b074650    
+    HEAD_REF master
     PATCHES
         acl.patch
 )

--- a/ports/iceoryx/portfile.cmake
+++ b/ports/iceoryx/portfile.cmake
@@ -6,8 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eclipse-iceoryx/iceoryx
     REF "v${VERSION}"
-    SHA512 a354ed59eab8730238c828a6477bc6d9f8a5c27009e72406dd2f081cd1d490888d6c1ef31609b35599d30da6e32c1d9ddfaad2f5f50360dcd95015febba3d1ff
-    HEAD_REF master
+    SHA512 b860452373dc41d6b0dd0042d1fc4c97621f143d20e9354a1572126ab815ee0cec6548ddfab9fa276943ed33d9ffd8810243e67eb5fae1d11f18ef0b2b074650    HEAD_REF master
     PATCHES
         acl.patch
 )

--- a/ports/iceoryx/vcpkg.json
+++ b/ports/iceoryx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "iceoryx",
-  "version": "2.0.2",
-  "port-version": 1,
+  "version": "2.0.3",
   "description": "True zero-copy inter-process-communication",
   "homepage": "https://iceoryx.io",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3041,8 +3041,8 @@
       "port-version": 0
     },
     "iceoryx": {
-      "baseline": "2.0.2",
-      "port-version": 1
+      "baseline": "2.0.3",
+      "port-version": 0
     },
     "icu": {
       "baseline": "72.1",

--- a/versions/i-/iceoryx.json
+++ b/versions/i-/iceoryx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "25162dafd0b3ef400e6e93e5206a17436882b400",
+      "git-tree": "bb960b0f9f6f909467d87fa171e5909c318953dc",
       "version": "2.0.3",
       "port-version": 0
     },

--- a/versions/i-/iceoryx.json
+++ b/versions/i-/iceoryx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25162dafd0b3ef400e6e93e5206a17436882b400",
+      "version": "2.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "01c97cf0c2e2ba63c406b8b0d2b51443dec98ee2",
       "version": "2.0.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.