### PR TITLE
[open-dis-cpp] add new port

### DIFF
--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -9,7 +9,8 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        ${options}
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO wadehunk/open-dis-cpp
+    REPO open-dis/open-dis-cpp
     REF "v${VERSION}"
     SHA512 0
     HEAD_REF master

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -13,6 +13,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 vcpkg_cmake_config_fixup(PACKAGE_NAME OpenDIS CONFIG_PATH lib/cmake/OpenDIS)
 
 # Handle copyright

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-dis/open-dis-cpp
     REF a17466dabb2944ee608330d0c0ea8d69e3defde8
-    SHA512 0
+    SHA512 d0578fed46deb9422a5d4f0c95fc0367e844d4f77911dbb9597ccf1e9550c7a9627e4bf2c7148bafa424c12f8a8be54ee8b0629d734a926443f350a155518080
     HEAD_REF master
 )
 

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
     OPTIONS
         ${options}
 )

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -9,8 +9,6 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_EXAMPLES=OFF
-        -DBUILD_TESTS=OFF
         ${options}
 )
 

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -18,5 +18,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME OpenDIS CONFIG_PATH lib/cmake/OpenDIS)
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO open-dis/open-dis-cpp
+    REF "v${VERSION}"
+    SHA512 fa62188f773ad044644a58caf1e25bef417dfdea47c9da8a2ea7f997154b4f3976019e32e73cc533696a3d4e45ec4a8402b6df140878dfa2ff078740d61b4b0f
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_TESTS=OFF
+        ${options}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME OpenDIS CONFIG_PATH lib/cmake/OpenDIS)
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-dis/open-dis-cpp
     REF "v${VERSION}"
-    SHA512 0
+    SHA512 e6d38f55beabf85d0319be21d9cec07f818b833dfa14dcb649cacbc8ea86779c29ac2717579239378ace1ae62054864851ecb55402e82fe4d083ab483218260e
     HEAD_REF master
 )
 

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wadehunk/open-dis-cpp
-    REF 6145d31a11ad6effc215a517f0aa19ef7128828d
-    SHA512 61676d3dc459afe240ece6a47e848337bc332e945f961a6e64ad69446a9120feccd3ec0ba11ef4368908d72daa6a7f202e604e9314b3c91db28240da2d7eed1e
+    REF "v${VERSION}"
+    SHA512 0
     HEAD_REF master
 )
 

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO open-dis/open-dis-cpp
-    REF a17466dabb2944ee608330d0c0ea8d69e3defde8
-    SHA512 d0578fed46deb9422a5d4f0c95fc0367e844d4f77911dbb9597ccf1e9550c7a9627e4bf2c7148bafa424c12f8a8be54ee8b0629d734a926443f350a155518080
+    REPO wadehunk/open-dis-cpp
+    REF 6145d31a11ad6effc215a517f0aa19ef7128828d
+    SHA512 0
     HEAD_REF master
 )
 

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wadehunk/open-dis-cpp
     REF 6145d31a11ad6effc215a517f0aa19ef7128828d
-    SHA512 0
+    SHA512 61676d3dc459afe240ece6a47e848337bc332e945f961a6e64ad69446a9120feccd3ec0ba11ef4368908d72daa6a7f202e604e9314b3c91db28240da2d7eed1e
     HEAD_REF master
 )
 

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -1,14 +1,13 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-dis/open-dis-cpp
-    REF "master"
-    SHA512 fa62188f773ad044644a58caf1e25bef417dfdea47c9da8a2ea7f997154b4f3976019e32e73cc533696a3d4e45ec4a8402b6df140878dfa2ff078740d61b4b0f
+    REF a17466dabb2944ee608330d0c0ea8d69e3defde8
+    SHA512 0
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
     OPTIONS
         ${options}
 )

--- a/ports/open-dis-cpp/portfile.cmake
+++ b/ports/open-dis-cpp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-dis/open-dis-cpp
-    REF "v${VERSION}"
+    REF "master"
     SHA512 fa62188f773ad044644a58caf1e25bef417dfdea47c9da8a2ea7f997154b4f3976019e32e73cc533696a3d4e45ec4a8402b6df140878dfa2ff078740d61b4b0f
     HEAD_REF master
 )

--- a/ports/open-dis-cpp/usage
+++ b/ports/open-dis-cpp/usage
@@ -1,0 +1,5 @@
+The package open-dis-cpp provides CMake targets:
+
+    find_package(OpenDIS CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE OpenDIS::OpenDIS6)
+    target_link_libraries(main PRIVATE OpenDIS::OpenDIS7)

--- a/ports/open-dis-cpp/vcpkg.json
+++ b/ports/open-dis-cpp/vcpkg.json
@@ -9,10 +9,6 @@
   "license": "BSD-2-Clause",
   "dependencies": [
     {
-      "name": "open-dis-cpp",
-      "host": true
-    },
-    {
       "name": "vcpkg-cmake",
       "host": true
     },

--- a/ports/open-dis-cpp/vcpkg.json
+++ b/ports/open-dis-cpp/vcpkg.json
@@ -2,9 +2,23 @@
   "name": "open-dis-cpp",
   "version": "1.0.0",
   "description": [
-    "Memory Efficient Serialization Library",
-    "FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility."
+    "DIS v6/v7 Library",
+    "C++ implementation of the IEEE-1278.1 Distributed Interactive Simulation (DIS) application protocol v6 and v7"
   ],
   "homepage": "https://open-dis.org",
-  "license": "BSD-2-Clause"
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "open-dis-cpp",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/open-dis-cpp/vcpkg.json
+++ b/ports/open-dis-cpp/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "open-dis-cpp",
+  "version": "1.0.0",
+  "description": [
+    "Memory Efficient Serialization Library",
+    "FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility."
+  ],
+  "homepage": "https://open-dis.org",
+  "license": "BSD-2-Clause"
+}

--- a/ports/open-dis-cpp/vcpkg.json
+++ b/ports/open-dis-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "open-dis-cpp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": [
     "DIS v6/v7 Library",
     "C++ implementation of the IEEE-1278.1 Distributed Interactive Simulation (DIS) application protocol v6 and v7"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5564,6 +5564,10 @@
       "baseline": "2021-11-23",
       "port-version": 0
     },
+    "open-dis-cpp": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "open62541": {
       "baseline": "1.2.3",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5565,7 +5565,7 @@
       "port-version": 0
     },
     "open-dis-cpp": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "open62541": {

--- a/versions/o-/open-dis-cpp.json
+++ b/versions/o-/open-dis-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f05072352e2ac54f4c0ce00dde679e1331bb823",
+      "git-tree": "044f953e62d00086021c231face998ce58ad2b05",
       "version": "1.0.1",
       "port-version": 0
     }

--- a/versions/o-/open-dis-cpp.json
+++ b/versions/o-/open-dis-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9ee1fc1238643a48076469b3b6c50562124adda6",
+      "git-tree": "58378b3cc3df339c6aa4e364536800cc7e1c04ac",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/o-/open-dis-cpp.json
+++ b/versions/o-/open-dis-cpp.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "3123e1e98d65ee83d8143018f8e1c2c68ee3056d",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "port-version": 0
     }
   ]

--- a/versions/o-/open-dis-cpp.json
+++ b/versions/o-/open-dis-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "58378b3cc3df339c6aa4e364536800cc7e1c04ac",
+      "git-tree": "3123e1e98d65ee83d8143018f8e1c2c68ee3056d",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/o-/open-dis-cpp.json
+++ b/versions/o-/open-dis-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9ee1fc1238643a48076469b3b6c50562124adda6",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/o-/open-dis-cpp.json
+++ b/versions/o-/open-dis-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3123e1e98d65ee83d8143018f8e1c2c68ee3056d",
+      "git-tree": "7f05072352e2ac54f4c0ce00dde679e1331bb823",
       "version": "1.0.1",
       "port-version": 0
     }


### PR DESCRIPTION
Fixes #29471 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

