### PR TITLE
[libsmacker] add new port

### DIFF
--- a/ports/libsmacker/CMakeLists.txt
+++ b/ports/libsmacker/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.20)
+project(libsmacker C)
+
+option(LIBSMACKER_BUILD_TOOLS "Build smk2avi and driver executables" OFF)
+
+add_library(libsmacker smacker.c)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    target_sources(libsmacker PRIVATE smacker.def)
+endif()
+
+if(MSVC)
+    target_compile_definitions(libsmacker PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+endif()
+
+target_include_directories(libsmacker PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+set_target_properties(libsmacker PROPERTIES PUBLIC_HEADER "smacker.h")
+
+install(TARGETS libsmacker
+    EXPORT libsmackerTargets
+    PUBLIC_HEADER DESTINATION include
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(EXPORT libsmackerTargets
+    FILE unofficial-libsmacker-config.cmake
+    NAMESPACE unofficial::libsmacker::
+    DESTINATION share/unofficial-libsmacker
+)
+
+if(LIBSMACKER_BUILD_TOOLS)
+    add_executable(driver driver.c)
+    target_include_directories(driver PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    target_link_libraries(driver libsmacker)
+    install(TARGETS driver RUNTIME DESTINATION bin)
+
+    add_executable(smk2avi smk2avi.c)
+    target_include_directories(driver PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    target_link_libraries(smk2avi libsmacker)
+    install(TARGETS smk2avi RUNTIME DESTINATION bin)
+endif()

--- a/ports/libsmacker/portfile.cmake
+++ b/ports/libsmacker/portfile.cmake
@@ -1,0 +1,38 @@
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libsmacker
+    REF libsmacker-1.2
+    FILENAME "libsmacker-1.2.0r43.tar.gz"
+    SHA512 1785b000884a6f93b621c1503adef100ac9b8c6e7ed5ef4d85b9ea4819715c40f9af3d930490b33ca079f531103acc69de2a800756ed7678c820ff155f86aaeb
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/smacker.def" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools LIBSMACKER_BUILD_TOOLS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        ${FEATURE_OPTIONS}
+    OPTIONS_DEBUG
+        -DLIBSMACKER_BUILD_TOOLS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-libsmacker)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES driver smk2avi AUTO_CLEAN)
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libsmacker/smacker.def
+++ b/ports/libsmacker/smacker.def
@@ -1,0 +1,19 @@
+LIBRARY libsmacker
+EXPORTS
+    smk_open_file
+    smk_open_filepointer
+    smk_open_memory
+    smk_close
+    smk_info_all
+    smk_info_video
+    smk_info_audio
+    smk_enable_all
+    smk_enable_video
+    smk_enable_audio
+    smk_get_palette
+    smk_get_video
+    smk_get_audio
+    smk_get_audio_size
+    smk_first
+    smk_next
+    smk_seek_keyframe

--- a/ports/libsmacker/vcpkg.json
+++ b/ports/libsmacker/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "libsmacker",
+  "version": "1.2.0",
+  "description": "libsmacker is a cross-platform C library which can be used for decoding Smacker Video files produced by RAD Game Tools",
+  "homepage": "https://libsmacker.sourceforge.net",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tools": {
+      "description": "Build driver (dump tool) and smk2avi"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4332,6 +4332,10 @@
       "baseline": "1.2.3",
       "port-version": 1
     },
+    "libsmacker": {
+      "baseline": "1.2.0",
+      "port-version": 0
+    },
     "libsmb2": {
       "baseline": "2021-04-29",
       "port-version": 1

--- a/versions/l-/libsmacker.json
+++ b/versions/l-/libsmacker.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5f1215439019175174db527493e0372d6f521eb7",
+      "version": "1.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

