### PR TITLE
[opentelemetry-cpp] Update to v1.8.2

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -5,7 +5,7 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-telemetry/opentelemetry-cpp
-    REF v1.8.2
+    REF "v${VERSION}"
     SHA512 5d3efb7c31626acd9655b795da497ef3829a88f1e33532f26d011fda01ec41e08e88539900151224f5c19161d9bc1f76e502f14a358c4e01440d832432cd0c0b
     HEAD_REF main
     PATCHES

--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-telemetry/opentelemetry-cpp
-    REF v1.8.1
-    SHA512 4ad89ef5e154674c591d7ab49d262f23093db8b4d7cf1c69a844e24adab96cff523de0769e5dfe7b2721f5a5e18790b11020021380f587775dd660b09e65a44a
+    REF v1.8.2
+    SHA512 5d3efb7c31626acd9655b795da497ef3829a88f1e33532f26d011fda01ec41e08e88539900151224f5c19161d9bc1f76e502f14a358c4e01440d832432cd0c0b
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch
@@ -20,6 +20,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         elasticsearch WITH_ELASTICSEARCH
         jaeger WITH_JAEGER
         otlp WITH_OTLP
+        otlp-http WITH_OTLP_HTTP
         zpages WITH_ZPAGES
 )
 

--- a/ports/opentelemetry-cpp/support_absl_cxx17.patch
+++ b/ports/opentelemetry-cpp/support_absl_cxx17.patch
@@ -1,12 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a1b69340..193c9e39 100644
+index 9df8f5ca..f68830cc 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -305,7 +305,11 @@ if(WITH_OTLP)
-                                                        CACHE{WITH_OTLP_HTTP}))
-     find_package(CURL)
+@@ -344,6 +344,11 @@ if(WITH_OTLP)
    endif()
--
+   include(CMakeDependentOption)
+ 
 +  if (ABSL_USE_CXX17)
 +    message(STATUS "Found absl uses CXX17, enable CXX17 feature.")
 +    set(CMAKE_CXX_STANDARD 17)

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
-  "version-semver": "1.8.1",
-  "port-version": 1,
+  "version-semver": "1.8.2",
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -41,6 +41,13 @@
         "protobuf"
       ]
     },
+    "otlp-http": {
+      "description": "Whether to include the OpenTelemetry Protocol over HTTP in the SDK",
+      "dependencies": [
+        "curl",
+        "protobuf"
+      ]
+    },
     "prometheus": {
       "description": "Whether to include the Prometheus Client in the SDK",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5713,8 +5713,8 @@
       "port-version": 0
     },
     "opentelemetry-cpp": {
-      "baseline": "1.8.1",
-      "port-version": 1
+      "baseline": "1.8.2",
+      "port-version": 0
     },
     "opentracing": {
       "baseline": "1.6.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8fed71b4da32ef7b6083e3a4e15b83f52e8fe7ea",
+      "git-tree": "1cdefe92ad0e026532cbbe3cd878d461a76615ee",
       "version-semver": "1.8.2",
       "port-version": 0
     },

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1cdefe92ad0e026532cbbe3cd878d461a76615ee",
+      "git-tree": "b95448067d27169b9b65ed0a60e1caf832fd7e4b",
       "version-semver": "1.8.2",
       "port-version": 0
     },

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fed71b4da32ef7b6083e3a4e15b83f52e8fe7ea",
+      "version-semver": "1.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a2a7c47fdf502e1345d3ba742ded612ba0506764",
       "version-semver": "1.8.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
