### PR TITLE
[sdl2-ttf] Bump to 2.20.2

### DIFF
--- a/ports/sdl2-ttf/fix-pkgconfig.patch
+++ b/ports/sdl2-ttf/fix-pkgconfig.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a097d5c..ca2881f 100644
+index 4ea903d..35be59d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -325,7 +333,7 @@ if(SDL2TTF_INSTALL)
+@@ -325,7 +325,7 @@ if(SDL2TTF_INSTALL)
          COMPONENT devel
      )
  
@@ -11,8 +11,8 @@ index a097d5c..ca2881f 100644
          # Only create a .pc file for a shared SDL2_ttf
          set(prefix "${CMAKE_INSTALL_PREFIX}")
          set(exec_prefix "\${prefix}")
-@@ -352,7 +360,7 @@ if(SDL2TTF_INSTALL)
-             \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_ttf.pc\" ONLY_IF_DIFFERENT)
+@@ -353,7 +353,7 @@ if(SDL2TTF_INSTALL)
+             \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_ttf.pc\")
          file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${PC_DESTDIR}\"
              TYPE FILE
 -            FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_ttf.pc\")" CONFIG Release)

--- a/ports/sdl2-ttf/portfile.cmake
+++ b/ports/sdl2-ttf/portfile.cmake
@@ -1,8 +1,7 @@
-vcpkg_minimum_required(VERSION 2022-10-12)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  libsdl-org/SDL_ttf
-    REF release-${VERSION}
+    REF "release-${VERSION}"
     SHA512 ea059fce879f8ddb3b36f8364d65ef922c389db67383d8a5c42c0ebf8a407d55adce42620b4d04caa0b297847362cc733a9d3d9acb843897a535c875fd0c471f
     HEAD_REF main
     PATCHES

--- a/ports/sdl2-ttf/portfile.cmake
+++ b/ports/sdl2-ttf/portfile.cmake
@@ -1,8 +1,9 @@
+vcpkg_minimum_required(VERSION 2022-10-12)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  libsdl-org/SDL_ttf
-    REF f5e4828ffc9d3a84f00011fede4446aecb4a685f #v2.20.0
-    SHA512 c0d2d6107e5427d9c1353e14cb4b0c3957d28391cfc772f1f972fe3aa8ba9e9dfdfcb64acd317a7836d46b3a50da9597b19a832f0baf5198654acb7b31ab1e6b
+    REF release-${VERSION}
+    SHA512 ea059fce879f8ddb3b36f8364d65ef922c389db67383d8a5c42c0ebf8a407d55adce42620b4d04caa0b297847362cc733a9d3d9acb843897a535c875fd0c471f
     HEAD_REF main
     PATCHES
         fix-pkgconfig.patch

--- a/ports/sdl2-ttf/vcpkg.json
+++ b/ports/sdl2-ttf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl2-ttf",
-  "version": "2.20.0",
+  "version": "2.20.2",
   "description": "A library for rendering TrueType fonts with SDL",
   "homepage": "https://www.libsdl.org/projects/SDL_ttf/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7013,7 +7013,7 @@
       "port-version": 1
     },
     "sdl2-ttf": {
-      "baseline": "2.20.0",
+      "baseline": "2.20.2",
       "port-version": 0
     },
     "sdl2pp": {

--- a/versions/s-/sdl2-ttf.json
+++ b/versions/s-/sdl2-ttf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fe146f94091b05940bb82b3d986c69842ddaf0a1",
+      "git-tree": "8ea231424114356e940ea3ac40fdc7da27ea95ad",
       "version": "2.20.2",
       "port-version": 0
     },

--- a/versions/s-/sdl2-ttf.json
+++ b/versions/s-/sdl2-ttf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fe146f94091b05940bb82b3d986c69842ddaf0a1",
+      "version": "2.20.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "85feef1fd925955c314616f7dbb934a401b4a9d1",
       "version": "2.20.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.