### PR TITLE
[dataframe] Update to 1.22.0.

### DIFF
--- a/ports/dataframe/portfile.cmake
+++ b/ports/dataframe/portfile.cmake
@@ -1,25 +1,22 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hosseinmoein/DataFrame
-    REF 1.19.0
-    SHA512 4415644b04d9c3b5ab3487ee896d0f020f0659d71b8bc128a649e14c6edb22c4848d228016a0108a122060d5aa9452260a3936761cf228eb7a7a436a64f031ff
+    REF "${VERSION}"
+    SHA512 e37df83396746620d4d1de3a9ef20cf4beea5c47970da2c9c368aa56a2a783396658a218d922a6e840fd1ad2a0aa54d4ad8dfbfe3b33b555efae6fe2deea00b5
     HEAD_REF master
 )
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DENABLE_TESTING:BOOL=OFF
+        -DHMDF_TESTING:BOOL=OFF
 )
 
 vcpkg_cmake_install()
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
-else()
-    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/DataFrame)
-endif()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/DataFrame)
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/License" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License")

--- a/ports/dataframe/vcpkg.json
+++ b/ports/dataframe/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "dataframe",
-  "version": "1.19.0",
+  "version": "1.22.0",
   "description": "This is a C++ statistical library that provides an interface similar to Pandas package in Python",
   "homepage": "https://github.com/hosseinmoein/DataFrame",
+  "license": "BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1905,7 +1905,7 @@
       "port-version": 1
     },
     "dataframe": {
-      "baseline": "1.19.0",
+      "baseline": "1.22.0",
       "port-version": 0
     },
     "date": {

--- a/versions/d-/dataframe.json
+++ b/versions/d-/dataframe.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1dbcb0119d811c5e0ef7e36d5ee456396ac3c10a",
+      "version": "1.22.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7f3b69090a3dce2e274e137efce5c2fb859d25ef",
       "version": "1.19.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #29443. Update dataframe to 1.22.0, no feature needs to be tested, the usage test passed.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.