### PR TITLE
[qtdeclarative] add long path warning

### DIFF
--- a/ports/qtdeclarative/portfile.cmake
+++ b/ports/qtdeclarative/portfile.cmake
@@ -3,6 +3,7 @@ include("${SCRIPT_PATH}/qt_install_submodule.cmake")
 
 string(LENGTH "${CURRENT_BUILDTREES_DIR}" buildtrees_path_length)
 if(buildtrees_path_length GREATER 44 AND CMAKE_HOST_WIN32)
+    vcpkg_buildpath_length_warning(44)
     message(WARNING "The ${PORT} source was will be extracted to ${CURRENT_BUILDTREES_DIR} , which has more then 44 characters in length.")
     message(FATAL_ERROR "terminating due to ${CURRENT_BUILDTREES_DIR} being too long. Pass --x-buildtrees-root=<shortpath> to vcpkg")
 endif()

--- a/ports/qtdeclarative/portfile.cmake
+++ b/ports/qtdeclarative/portfile.cmake
@@ -1,12 +1,7 @@
 set(SCRIPT_PATH "${CURRENT_INSTALLED_DIR}/share/qtbase")
 include("${SCRIPT_PATH}/qt_install_submodule.cmake")
 
-string(LENGTH "${CURRENT_BUILDTREES_DIR}" buildtrees_path_length)
-if(buildtrees_path_length GREATER 44 AND CMAKE_HOST_WIN32)
-    vcpkg_buildpath_length_warning(44)
-    message(WARNING "The ${PORT} source was will be extracted to ${CURRENT_BUILDTREES_DIR} , which has more then 44 characters in length.")
-    message(FATAL_ERROR "terminating due to ${CURRENT_BUILDTREES_DIR} being too long. Pass --x-buildtrees-root=<shortpath> to vcpkg")
-endif()
+vcpkg_buildpath_length_warning(44)
 
  set(TOOL_NAMES 
         qml

--- a/ports/qtdeclarative/portfile.cmake
+++ b/ports/qtdeclarative/portfile.cmake
@@ -1,6 +1,13 @@
 set(SCRIPT_PATH "${CURRENT_INSTALLED_DIR}/share/qtbase")
 include("${SCRIPT_PATH}/qt_install_submodule.cmake")
 
+string(LENGTH "${CURRENT_BUILDTREES_DIR}" buildtrees_path_length)
+if(buildtrees_path_length GREATER 44 AND CMAKE_HOST_WIN32)
+    vcpkg_buildpath_length_warning(44)
+    message(WARNING "The ${PORT} source was will be extracted to ${CURRENT_BUILDTREES_DIR} , which has more then 44 characters in length.")
+    message(FATAL_ERROR "terminating due to ${CURRENT_BUILDTREES_DIR} being too long.")
+endif()
+
  set(TOOL_NAMES 
         qml
         qmlcachegen

--- a/ports/qtdeclarative/portfile.cmake
+++ b/ports/qtdeclarative/portfile.cmake
@@ -3,9 +3,8 @@ include("${SCRIPT_PATH}/qt_install_submodule.cmake")
 
 string(LENGTH "${CURRENT_BUILDTREES_DIR}" buildtrees_path_length)
 if(buildtrees_path_length GREATER 44 AND CMAKE_HOST_WIN32)
-    vcpkg_buildpath_length_warning(44)
     message(WARNING "The ${PORT} source was will be extracted to ${CURRENT_BUILDTREES_DIR} , which has more then 44 characters in length.")
-    message(FATAL_ERROR "terminating due to ${CURRENT_BUILDTREES_DIR} being too long.")
+    message(FATAL_ERROR "terminating due to ${CURRENT_BUILDTREES_DIR} being too long. Pass --x-buildtrees-root=<shortpath> to vcpkg")
 endif()
 
  set(TOOL_NAMES 

--- a/ports/qtdeclarative/vcpkg.json
+++ b/ports/qtdeclarative/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtdeclarative",
   "version": "6.4.2",
+  "port-version": 1,
   "description": "Qt Declarative (Quick 2)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6418,7 +6418,7 @@
     },
     "qtdeclarative": {
       "baseline": "6.4.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtdeviceutilities": {
       "baseline": "6.4.2",

--- a/versions/q-/qtdeclarative.json
+++ b/versions/q-/qtdeclarative.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9eee650bf7c4489a3ae324dd3a0d6ba85db65057",
+      "git-tree": "3f5d46fcaae15b0c653996603f73f91954e4f0be",
       "version": "6.4.2",
       "port-version": 1
     },

--- a/versions/q-/qtdeclarative.json
+++ b/versions/q-/qtdeclarative.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6c0fa965ab59fbd00e83c2b1f328e9f4ec4abb46",
+      "git-tree": "70badba61897e63a26540f70ff53e0df92ff01bb",
       "version": "6.4.2",
       "port-version": 1
     },

--- a/versions/q-/qtdeclarative.json
+++ b/versions/q-/qtdeclarative.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9eee650bf7c4489a3ae324dd3a0d6ba85db65057",
+      "version": "6.4.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "005e51361039c1a03018a94d3f2da31bea63ab59",
       "version": "6.4.2",
       "port-version": 0

--- a/versions/q-/qtdeclarative.json
+++ b/versions/q-/qtdeclarative.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3f5d46fcaae15b0c653996603f73f91954e4f0be",
+      "git-tree": "6c0fa965ab59fbd00e83c2b1f328e9f4ec4abb46",
       "version": "6.4.2",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Fixes https://github.com/microsoft/vcpkg/issues/29454
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
