### PR TITLE
[libtorch] Fix libtorch build

### DIFF
--- a/ports/libtorch/vcpkg-dependencies.cmake
+++ b/ports/libtorch/vcpkg-dependencies.cmake
@@ -160,7 +160,7 @@ endif()
  
 if(USE_ZSTD)
   find_package(zstd CONFIG REQUIRED) # zstd::libzstd_static
-  list(APPEND Caffe2_DEPENDENCY_LIBS zstd::libzstd_static)
+  list(APPEND Caffe2_DEPENDENCY_LIBS $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
 endif()
 
 if(USE_SYSTEM_ONNX)

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libtorch",
   "version": "1.12.1",
+  "port-version": 1,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4426,7 +4426,7 @@
     },
     "libtorch": {
       "baseline": "1.12.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libtorrent": {
       "baseline": "2.0.8",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99e1c00f462716fc1899f7c0f5773e5dccbe8ee8",
+      "version": "1.12.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c9504da41dc33e2294aeda9e3c215c505f1627d0",
       "version": "1.12.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/29440.
Fix `libtocrch` build failed with the following error.
```
CMake Error at caffe2/CMakeLists.txt:1419 (target_link_libraries):
Target "torch_cpu" links to:

zstd::libzstd_static
but the target was not found. Possible reasons include:

* There is a typo in the target name.
* A find_package call is missing for an IMPORTED target.
* An ALIAS target is missing.
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.