### PR TITLE
[qtimgui] Initial port

### DIFF
--- a/ports/qtimgui/0001-cmake-files.patch
+++ b/ports/qtimgui/0001-cmake-files.patch
@@ -72,10 +72,11 @@ index 1f44de1..ac4bea9 100644
 +install(FILES QtImGui.h DESTINATION include)
 diff --git a/unofficial-qtimgui-config.cmake b/unofficial-qtimgui-config.cmake
 new file mode 100644
-index 0000000..a177826
+index 0000000..81ec378
 --- /dev/null
 +++ b/unofficial-qtimgui-config.cmake
-@@ -0,0 +1,3 @@
+@@ -0,0 +1,4 @@
 +include(CMakeFindDependencyMacro)
++find_dependency(Qt5 COMPONENTS Core Gui Widgets)
 +find_dependency(imgui)
 +include("${CMAKE_CURRENT_LIST_DIR}/unofficial-qtimgui-targets.cmake")

--- a/ports/qtimgui/0001-cmake-files.patch
+++ b/ports/qtimgui/0001-cmake-files.patch
@@ -1,0 +1,81 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 481894f..7adbd2b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,11 @@ cmake_minimum_required (VERSION 3.8.1)
+ project(qtimgui_sln)
+ 
+ # goto subs
+-add_subdirectory(examples)
++option(QTIMGUI_BUILD_EXAMPLES "Build examples" ON)
++if(QTIMGUI_BUILD_EXAMPLES)
++    add_subdirectory(examples)
++endif()
+ add_subdirectory(modules)
+ add_subdirectory(src)
++
++install(FILES unofficial-qtimgui-config.cmake DESTINATION share/unofficial-qtimgui)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 1f44de1..ac4bea9 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -4,7 +4,8 @@ project(qtimgui)
+ set(CMAKE_AUTOMOC ON)
+ set(CMAKE_AUTORCC ON)
+ set(CMAKE_AUTOUIC ON)
+-find_package(Qt5 COMPONENTS Core Quick Gui Widgets REQUIRED)
++find_package(Qt5 COMPONENTS Core Gui Widgets REQUIRED)
++find_package(imgui CONFIG REQUIRED)
+ 
+ set(
+     qt_imgui_sources
+@@ -16,11 +17,14 @@ set(
+ 
+ # qt_imgui_quick: library with a qt renderer for Qml / QtQuick applications
+ add_library(qt_imgui_quick STATIC ${qt_imgui_sources})
+-target_include_directories(qt_imgui_quick PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
++target_include_directories(qt_imgui_quick PUBLIC
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++    $<INSTALL_INTERFACE:include>
++)
+ target_link_libraries(
+     qt_imgui_quick
+     PUBLIC
+-    imgui
++    imgui::imgui
+     Qt5::Gui
+     )
+ if (ANDROID)
+@@ -29,14 +33,21 @@ endif()
+ 
+ # qt_imgui_widget: library with a qt renderer for classic Qt Widget applications
+ add_library(qt_imgui_widgets STATIC ${qt_imgui_sources})
+-target_include_directories(qt_imgui_widgets PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
++target_include_directories(qt_imgui_widgets PUBLIC
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++    $<INSTALL_INTERFACE:include>
++)
+ target_link_libraries(
+     qt_imgui_widgets
+     PUBLIC
+-    imgui
++    imgui::imgui
+     Qt5::Widgets
+     )
+ if (ANDROID)
+     target_link_libraries(qt_imgui_widgets PUBLIC log dl GLESv2 z)
+ endif()
+ target_compile_definitions(qt_imgui_widgets PUBLIC QT_WIDGETS_LIB)
++
++install(TARGETS qt_imgui_quick qt_imgui_widgets EXPORT unofficial-qtimgui-targets)
++install(EXPORT unofficial-qtimgui-targets NAMESPACE unofficial::qtimgui:: DESTINATION share/unofficial-qtimgui)
++install(FILES QtImGui.h DESTINATION include)
+diff --git a/unofficial-qtimgui-config.cmake b/unofficial-qtimgui-config.cmake
+new file mode 100644
+index 0000000..a177826
+--- /dev/null
++++ b/unofficial-qtimgui-config.cmake
+@@ -0,0 +1,3 @@
++include(CMakeFindDependencyMacro)
++find_dependency(imgui)
++include("${CMAKE_CURRENT_LIST_DIR}/unofficial-qtimgui-targets.cmake")

--- a/ports/qtimgui/0002-fix-keymap.patch
+++ b/ports/qtimgui/0002-fix-keymap.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ImGuiRenderer.cpp b/src/ImGuiRenderer.cpp
+index 92a4fb3..ad62349 100644
+--- a/src/ImGuiRenderer.cpp
++++ b/src/ImGuiRenderer.cpp
+@@ -45,7 +45,7 @@ const QHash<int, ImGuiKey> keyMap = {
+     { Qt::Key_X, ImGuiKey_X },
+     { Qt::Key_Y, ImGuiKey_Y },
+     { Qt::Key_Z, ImGuiKey_Z },
+-    { Qt::MiddleButton, ImGuiMouseButton_Middle }
++    { Qt::MiddleButton, ImGuiKey_MouseMiddle }
+ };
+ 
+ #ifndef QT_NO_CURSOR

--- a/ports/qtimgui/0002-fix-keymap.patch
+++ b/ports/qtimgui/0002-fix-keymap.patch
@@ -1,13 +1,35 @@
 diff --git a/src/ImGuiRenderer.cpp b/src/ImGuiRenderer.cpp
-index 92a4fb3..ad62349 100644
+index 92a4fb3..7eaf527 100644
 --- a/src/ImGuiRenderer.cpp
 +++ b/src/ImGuiRenderer.cpp
-@@ -45,7 +45,7 @@ const QHash<int, ImGuiKey> keyMap = {
+@@ -45,7 +45,6 @@ const QHash<int, ImGuiKey> keyMap = {
      { Qt::Key_X, ImGuiKey_X },
      { Qt::Key_Y, ImGuiKey_Y },
      { Qt::Key_Z, ImGuiKey_Z },
 -    { Qt::MiddleButton, ImGuiMouseButton_Middle }
-+    { Qt::MiddleButton, ImGuiKey_MouseMiddle }
  };
  
  #ifndef QT_NO_CURSOR
+@@ -81,11 +80,6 @@ void ImGuiRenderer::initialize(WindowWrapper *window) {
+     #endif
+     io.BackendPlatformName = "qtimgui";
+     
+-    // Setup keyboard mapping
+-    for (ImGuiKey key : keyMap.values()) {
+-        io.KeyMap[key] = key;
+-    }
+-    
+     // io.RenderDrawListsFn = [](ImDrawData *drawData) {
+     //    instance()->renderDrawList(drawData);
+     // };
+@@ -432,8 +426,8 @@ void ImGuiRenderer::onKeyPressRelease(QKeyEvent *event)
+     // Translate `Qt::Key` into `ImGuiKey`, and apply 'pressed' state for that key
+     const auto key_it = keyMap.constFind( event->key() );
+     if (key_it != keyMap.constEnd()) { // Qt's key found in keyMap
+-        const int imgui_key = *(key_it);
+-        io.KeysDown[imgui_key] = key_pressed;
++        const auto imgui_key = *(key_it);
++        io.AddKeyEvent(imgui_key, key_pressed);
+     }
+ 
+     if (key_pressed) {

--- a/ports/qtimgui/portfile.cmake
+++ b/ports/qtimgui/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO seanchas116/qtimgui
+    REF 48d64a715b75dee24e398f7e5b0942c2ca329334
+    SHA512 072d730f907c876297611736d76e738ab3d2cef968a6ca59d799a487357a998d9841ce2973ccb0880851740e1149e8c6bdd989527b5b3f505bce1c3330d6b901
+    HEAD_REF master
+    PATCHES
+        0001-cmake-files.patch
+        0002-fix-keymap.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DQTIMGUI_BUILD_IMGUI=OFF
+        -DQTIMGUI_BUILD_IMPLOT=OFF
+        -DQTIMGUI_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-qtimgui)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qtimgui/vcpkg.json
+++ b/ports/qtimgui/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "qtimgui",
+  "version-date": "2022-12-10",
+  "description": "Qt (QOpenGLWidget / QOpenGLWindow) backend for ImGui",
+  "homepage": "https://github.com/seanchas116/qtimgui",
+  "license": "MIT",
+  "dependencies": [
+    "imgui",
+    "qt5-base",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6456,6 +6456,10 @@
       "baseline": "6.4.2",
       "port-version": 0
     },
+    "qtimgui": {
+      "baseline": "2022-12-10",
+      "port-version": 0
+    },
     "qtinterfaceframework": {
       "baseline": "6.4.2",
       "port-version": 0

--- a/versions/q-/qtimgui.json
+++ b/versions/q-/qtimgui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fcc627c5ae1b0fa2161cf1904842939a9df58240",
+      "git-tree": "27bf52305359a8e7fa43d6f54d079d8fff4db87b",
       "version-date": "2022-12-10",
       "port-version": 0
     }

--- a/versions/q-/qtimgui.json
+++ b/versions/q-/qtimgui.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6d2007e5ab4dcc1db76bfea74cb94dfa19aafe14",
+      "version-date": "2022-12-10",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/q-/qtimgui.json
+++ b/versions/q-/qtimgui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d2007e5ab4dcc1db76bfea74cb94dfa19aafe14",
+      "git-tree": "fcc627c5ae1b0fa2161cf1904842939a9df58240",
       "version-date": "2022-12-10",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.