### PR TITLE
[libsigcpp]fix libsigcpp include path

### DIFF
--- a/ports/libsigcpp/fix_include_path.patch
+++ b/ports/libsigcpp/fix_include_path.patch
@@ -20,6 +20,16 @@ index 73990c4..38424a2 100644
  set (PROJECT_CONFIG     	"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_CMAKE_NAME}Config.cmake")
  set (CONFIG_INSTALL_DIR 	"lib/cmake/${PROJECT_CMAKE_NAME}")
  set (TARGETS_EXPORT_NAME    "${PROJECT_CMAKE_NAME}Targets")
+diff --git a/sigc++.pc.in b/sigc++.pc.in
+index 05de315..171b38d 100644
+--- a/sigc++.pc.in
++++ b/sigc++.pc.in
+@@ -15,4 +15,4 @@ Description: Typesafe signal and callback system for C++
+ Version: @PACKAGE_VERSION@
+ URL: https://libsigcplusplus.github.io/libsigcplusplus/
+ Libs: -L${libdir} -lsigc-@SIGCXX_API_VERSION@
+-Cflags: -I${includedir}/sigc++-@SIGCXX_API_VERSION@ -I${libdir}/sigc++-@SIGCXX_API_VERSION@/include
++Cflags: -I${includedir}
 diff --git a/sigc++/CMakeLists.txt b/sigc++/CMakeLists.txt
 index 86f1be7..076959b 100644
 --- a/sigc++/CMakeLists.txt

--- a/ports/libsigcpp/fix_include_path.patch
+++ b/ports/libsigcpp/fix_include_path.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 73990c4..38424a2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,7 +84,7 @@ add_custom_target(uninstall
+ install (FILES
+ 			"${CMAKE_CURRENT_BINARY_DIR}/sigc++config.h"
+ 		DESTINATION
+-			"${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}-${SIGCXX_API_VERSION}/include")
++			"${CMAKE_INSTALL_PREFIX}/include")
+ 
+ install (FILES 
+ 			"${CMAKE_CURRENT_BINARY_DIR}/sigc++-${SIGCXX_API_VERSION}.pc"
+@@ -102,7 +102,7 @@ add_subdirectory (sigc++)
+ 
+ set (PROJECT_CMAKE_NAME		"${PROJECT_NAME}-3")
+ set (VERSION_CONFIG     	"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_CMAKE_NAME}ConfigVersion.cmake")
+-set (LIBSIGCXX_INCLUDE_DIR	"${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}-${SIGCXX_API_VERSION}/include")
++set (LIBSIGCXX_INCLUDE_DIR	"${CMAKE_INSTALL_PREFIX}/include")
+ set (PROJECT_CONFIG     	"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_CMAKE_NAME}Config.cmake")
+ set (CONFIG_INSTALL_DIR 	"lib/cmake/${PROJECT_CMAKE_NAME}")
+ set (TARGETS_EXPORT_NAME    "${PROJECT_CMAKE_NAME}Targets")
+diff --git a/sigc++/CMakeLists.txt b/sigc++/CMakeLists.txt
+index 86f1be7..076959b 100644
+--- a/sigc++/CMakeLists.txt
++++ b/sigc++/CMakeLists.txt
+@@ -29,7 +29,7 @@ set_property (TARGET ${SIGCPP_LIB_NAME} PROPERTY VERSION ${PACKAGE_VERSION})
+ set_property(TARGET ${SIGCPP_LIB_NAME}  PROPERTY SOVERSION ${LIBSIGCPP_SOVERSION})
+ target_compile_definitions( ${SIGCPP_LIB_NAME} PRIVATE -DSIGC_BUILD )
+ 
+-set (INCLUDE_INSTALL_DIR "include/${PROJECT_NAME}-${SIGCXX_API_VERSION}")
++set (INCLUDE_INSTALL_DIR "include/")
+ 
+ install (
+ 	DIRECTORY "${PROJECT_SOURCE_DIR}"

--- a/ports/libsigcpp/portfile.cmake
+++ b/ports/libsigcpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsigcplusplus/libsigcplusplus
-    REF 3.2.0
-    SHA512 95ab0acfc2c5a151335e73bdc9b0e058af67d9706d0697bfd938e38c51e853fdb29d7a26484f192abe150640c60d5e30075a23deaa043a8deed70616bc9f508a
+    REF 3.4.0
+    SHA512 8b80f0988daea4eb2c827be57de21167f54a9bf3e9704d64d17d12aef064d8ad87d00f95ce4b5add7666452561c5ca42aa45cf677e54068974a4ea813af3b235
     HEAD_REF master
     PATCHES
         disable_tests_enable_static_build.patch

--- a/ports/libsigcpp/portfile.cmake
+++ b/ports/libsigcpp/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     PATCHES
         disable_tests_enable_static_build.patch
         fix-shared-windows-build.patch
-		fix_include_path.patch
+        fix_include_path.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/libsigcpp/portfile.cmake
+++ b/ports/libsigcpp/portfile.cmake
@@ -4,9 +4,10 @@ vcpkg_from_github(
     REF 3.2.0
     SHA512 95ab0acfc2c5a151335e73bdc9b0e058af67d9706d0697bfd938e38c51e853fdb29d7a26484f192abe150640c60d5e30075a23deaa043a8deed70616bc9f508a
     HEAD_REF master
-    PATCHES 
+    PATCHES
         disable_tests_enable_static_build.patch
         fix-shared-windows-build.patch
+		fix_include_path.patch
 )
 
 vcpkg_cmake_configure(
@@ -18,7 +19,7 @@ vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(PACKAGE_NAME sigc++-3 CONFIG_PATH lib/cmake/sigc++-3)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/sigc++-3.0/include/sigc++config.h" "ifdef BUILD_SHARED" "if 1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/sigc++config.h" "ifdef BUILD_SHARED" "if 1")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libsigcpp/portfile.cmake
+++ b/ports/libsigcpp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsigcplusplus/libsigcplusplus
-    REF 3.4.0
+    REF "${VERSION}"
     SHA512 8b80f0988daea4eb2c827be57de21167f54a9bf3e9704d64d17d12aef064d8ad87d00f95ce4b5add7666452561c5ca42aa45cf677e54068974a4ea813af3b235
     HEAD_REF master
     PATCHES

--- a/ports/libsigcpp/vcpkg.json
+++ b/ports/libsigcpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libsigcpp",
   "version": "3.2.0",
+  "port-version": 1,
   "description": "Typesafe callback framework for C++",
   "homepage": "https://libsigcplusplus.github.io/libsigcplusplus/",
   "license": "LGPL-3.0",

--- a/ports/libsigcpp/vcpkg.json
+++ b/ports/libsigcpp/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "libsigcpp",
-  "version": "3.2.0",
-  "port-version": 1,
+  "version": "3.4.0",
   "description": "Typesafe callback framework for C++",
   "homepage": "https://libsigcplusplus.github.io/libsigcplusplus/",
-  "license": "LGPL-3.0",
+  "license": "LGPL-3.0-or-later",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4317,8 +4317,8 @@
       "port-version": 0
     },
     "libsigcpp": {
-      "baseline": "3.2.0",
-      "port-version": 1
+      "baseline": "3.4.0",
+      "port-version": 0
     },
     "libsigcpp-3": {
       "baseline": "3.0.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4318,7 +4318,7 @@
     },
     "libsigcpp": {
       "baseline": "3.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libsigcpp-3": {
       "baseline": "3.0.3",

--- a/versions/l-/libsigcpp.json
+++ b/versions/l-/libsigcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "615673ef2e248f06af15a811f33734bc058faa3f",
+      "git-tree": "e0d2ecff344939de909128adad035c86c81f1a40",
       "version": "3.2.0",
       "port-version": 1
     },

--- a/versions/l-/libsigcpp.json
+++ b/versions/l-/libsigcpp.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "e0d2ecff344939de909128adad035c86c81f1a40",
-      "version": "3.2.0",
-      "port-version": 1
+      "git-tree": "3cb8e9465eb99786950e54f510e326f07971046b",
+      "version": "3.4.0",
+      "port-version": 0
     },
     {
       "git-tree": "7631555eb4ab142a7f643a266f79a87bc8aeca12",

--- a/versions/l-/libsigcpp.json
+++ b/versions/l-/libsigcpp.json
@@ -8,7 +8,7 @@
     {
       "git-tree": "7631555eb4ab142a7f643a266f79a87bc8aeca12",
       "version": "3.2.0",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "bdb51863c5589b8e47c717b7c96a1ead39d4dd27",

--- a/versions/l-/libsigcpp.json
+++ b/versions/l-/libsigcpp.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "7631555eb4ab142a7f643a266f79a87bc8aeca12",
+      "git-tree": "1adc777baf3e0980d2fa879d14cbe8ef815e412b",
       "version": "3.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "bdb51863c5589b8e47c717b7c96a1ead39d4dd27",

--- a/versions/l-/libsigcpp.json
+++ b/versions/l-/libsigcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3cb8e9465eb99786950e54f510e326f07971046b",
+      "git-tree": "4aba60e7d2936fd4a786b50f14cbdd99dbf21805",
       "version": "3.4.0",
       "port-version": 0
     },

--- a/versions/l-/libsigcpp.json
+++ b/versions/l-/libsigcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "615673ef2e248f06af15a811f33734bc058faa3f",
+      "version": "3.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7631555eb4ab142a7f643a266f79a87bc8aeca12",
       "version": "3.2.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #21496
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
