### PR TITLE
[vcpkg baseline] [superlu] Use the correct option to avoid lib conflicts.

### DIFF
--- a/ports/superlu/portfile.cmake
+++ b/ports/superlu/portfile.cmake
@@ -17,7 +17,8 @@ vcpkg_cmake_configure(
     OPTIONS
     -DXSDK_ENABLE_Fortran=OFF
     -Denable_tests=OFF
-    -Denable_blaslib=OFF
+    -Denable_internal_blaslib=OFF
+    -Denable_doc=OFF
 )
 
 vcpkg_cmake_install()
@@ -26,4 +27,4 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")

--- a/ports/superlu/portfile.cmake
+++ b/ports/superlu/portfile.cmake
@@ -5,7 +5,7 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiaoyeli/superlu
-    REF v${VERSION}
+    REF "v${VERSION}"
     SHA512 1461b52bc18a8b0345beb70fdd46e07df497a13be840bcc061158ea1d0e61c8745806d1ad21cb2723db80f5ed762c3741f9c0ded2b2013df46da0e8bb6b77b83
     HEAD_REF master
     PATCHES

--- a/ports/superlu/portfile.cmake
+++ b/ports/superlu/portfile.cmake
@@ -9,20 +9,20 @@ vcpkg_from_github(
     SHA512 1461b52bc18a8b0345beb70fdd46e07df497a13be840bcc061158ea1d0e61c8745806d1ad21cb2723db80f5ed762c3741f9c0ded2b2013df46da0e8bb6b77b83
     HEAD_REF master
     PATCHES
-      remove-make.inc.patch
+        remove-make.inc.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-    -DXSDK_ENABLE_Fortran=OFF
-    -Denable_tests=OFF
-    -Denable_internal_blaslib=OFF
-    -Denable_doc=OFF
+        -DXSDK_ENABLE_Fortran=OFF
+        -Denable_tests=OFF
+        -Denable_internal_blaslib=OFF
+        -Denable_doc=OFF
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/superlu/vcpkg.json
+++ b/ports/superlu/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "superlu",
   "version": "5.3.0",
+  "port-version": 1,
   "description": "Supernodal sparse direct solver.",
   "homepage": "https://github.com/xiaoyeli/superlu",
   "license": "BSD-3-Clause-LBNL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7506,7 +7506,7 @@
     },
     "superlu": {
       "baseline": "5.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "symengine": {
       "baseline": "0.9.0",

--- a/versions/s-/superlu.json
+++ b/versions/s-/superlu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "092a6490572b27c4b44fdb42cf3812952bafd23e",
+      "version": "5.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "70b5d8ecd8bdca0344fc176833037b95b116219e",
       "version": "5.3.0",
       "port-version": 0

--- a/versions/s-/superlu.json
+++ b/versions/s-/superlu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8d57e74fb17ae1e0cbabcb81a787486c01058814",
+      "git-tree": "bcc27a8221ab0323b537025944ebc20ae56c36ac",
       "version": "5.3.0",
       "port-version": 1
     },

--- a/versions/s-/superlu.json
+++ b/versions/s-/superlu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "092a6490572b27c4b44fdb42cf3812952bafd23e",
+      "git-tree": "8d57e74fb17ae1e0cbabcb81a787486c01058814",
       "version": "5.3.0",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=84895&view=results).
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
In latest source of `superlu`, option `enable_blaslib` was changed to `enable_internal_blaslib` by upstream. Since the PR https://github.com/microsoft/vcpkg/pull/29452 didn't modify the old option, port `superlu` build conflict with port `lapack-reference`. The error message is as below:
```
error: The following files are already installed in D:/installed/x64-windows-static and are in conflict with superlu:x64-windows-static
Installed by lapack-reference:x64-windows-static    
debug/lib/blas.lib
    lib/blas.lib
 ```
The related upstream codes of `superlu:` https://github.com/xiaoyeli/superlu/blob/e8ed45225963c85a708c129bbcec17ec745d09f5/CMakeLists.txt#L80

Update the correct option to resolve this issue.
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
