### PR TITLE
[directxtk, directxtk12, uvatlas] updates for February 2023 release

### DIFF
--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTK_TAG dec2022)
+set(DIRECTXTK_TAG feb2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
     REF ${DIRECTXTK_TAG}
-    SHA512 4830becb1100566a1f0d176c1eb08f94ce3f36600b7a8e0c55b423e0f9d40bafb5018914be4903b9a21682f04a92571019e2d6c4549a145f0b3f0198c50c639a
+    SHA512 229f51e60937aacf0826d02e4c0869f2801e897efbacd9a2cab6f816c1218903d7dae654ab1ab42678bb2adf98b98d303886f3d51f6642d81b7350297e81068d
     HEAD_REF main
 )
 
@@ -39,19 +39,19 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk)
 
-if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
+if(VCPKG_HOST_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
     URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/MakeSpriteFont.exe"
     FILENAME "makespritefont-${DIRECTXTK_TAG}.exe"
-    SHA512 6cb4351206707308382f2fe152c10dd2c99f300d960e6feac09f63e64c38225381d95f77ec557ec3dc60031227b4b878cfb18059c1bc2122e87cda1f1d25d7e2
+    SHA512 2cf274cd1c9a4692b84bd3ac9c3266eb3a20b1598b29f8f77893cb5911c3e70c4b0151df54a3fdef93215db22c76854a61b6d3688ac9cd1875611fe34d196da3
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
     URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/XWBTool.exe"
     FILENAME "xwbtool-${DIRECTXTK_TAG}.exe"
-    SHA512 901b326b8c86a94c5867e26ca35fa355cadcb283bb81c1fd630385a2ed68ffb43b00ed702953781db660d184ef221184bac0cc905e8502e4d484b01c5b3ff124
+    SHA512 ab328e336228ec5e1abe0aa44707203325d743432728a1d8d01990529350fe6dc0f1bc5d58ce961456f6273922169abc1a4a9ca3804dd7f40198a182462c332d
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk",
-  "version-date": "2022-12-15",
+  "version-date": "2023-02-06",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTK_TAG dec2022)
+set(DIRECTXTK_TAG feb2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
     REF ${DIRECTXTK_TAG}
-    SHA512 2ebff3d18c7d96e402ff3cb8d69f2e650030628375725785b767c9e5784e7933d1bf6264a92ef326f054b5a73c2195f49020bf9773ffd013dc32f4396bd415b6
+    SHA512 e536e5c258266e46b31a5c7af46a70cc8428e71dc495015527a710ccbfc87fc349caeb7ffcf8cfc1ec2a3311eac55ad30ab906cc4abeacb55b63427e2d514e83
     HEAD_REF main
 )
 
@@ -27,19 +27,19 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk12)
 
-if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
+if(VCPKG_HOST_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
     URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/MakeSpriteFont.exe"
     FILENAME "makespritefont-${DIRECTXTK_TAG}.exe"
-    SHA512 6cb4351206707308382f2fe152c10dd2c99f300d960e6feac09f63e64c38225381d95f77ec557ec3dc60031227b4b878cfb18059c1bc2122e87cda1f1d25d7e2
+    SHA512 2cf274cd1c9a4692b84bd3ac9c3266eb3a20b1598b29f8f77893cb5911c3e70c4b0151df54a3fdef93215db22c76854a61b6d3688ac9cd1875611fe34d196da3
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
     URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/XWBTool.exe"
     FILENAME "xwbtool-${DIRECTXTK_TAG}.exe"
-    SHA512 901b326b8c86a94c5867e26ca35fa355cadcb283bb81c1fd630385a2ed68ffb43b00ed702953781db660d184ef221184bac0cc905e8502e4d484b01c5b3ff124
+    SHA512 ab328e336228ec5e1abe0aa44707203325d743432728a1d8d01990529350fe6dc0f1bc5d58ce961456f6273922169abc1a4a9ca3804dd7f40198a182462c332d
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-date": "2022-12-15",
+  "version-date": "2023-02-06",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -1,12 +1,12 @@
-set(UVATLAS_TAG dec2022)
+set(UVATLAS_TAG feb2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
-    REF dec2022b
-    SHA512 305985bee492a5fec85dd46e6e59200f88c963bc4e5e4f9f8319dd3a16f677de9d802db0407b85703e3e5274570bb41ac418c639a595640f6049fad595ba8046
+    REF ${UVATLAS_TAG}
+    SHA512 cc44334fe2a372afd8bfa9c508fe59e6b68a3513ab92c0e3fe5657b539641faaa50625a3aafd65d3cb2023a167bfb7158f6b9ac7262d120fe97d48eb3a3742f5
     HEAD_REF main
     PATCHES openexr.patch
 )
@@ -38,12 +38,12 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/uvatlas)
 
-if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
+if(VCPKG_HOST_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     UVATLASTOOL_EXE
     URLS "https://github.com/Microsoft/UVAtlas/releases/download/${UVATLAS_TAG}/uvatlastool.exe"
     FILENAME "uvatlastool-${UVATLAS_TAG}.exe"
-    SHA512 55c8458964ab7682718decf51e69ab3e2d2e3d56744af3dd4fc678acabbdc90ed663075e5d17e74af1f6a58bf439d314720b7ec1242d85d0e7991237d19265e1
+    SHA512 f34aa4ec7e10bbe24eefe31ddb98841fa097385921d8c3d813e30836749c4b9f4b6e792c371f59c55e446e91845dbd9d333332f6c06cd8cd966cd2bfee89e29e
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/uvatlas/")
@@ -54,7 +54,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
 
   file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-${UVATLAS_TAG}.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
 
-elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
+elseif(VCPKG_TARGET_IS_WINDOWS AND (NOT VCPKG_TARGET_IS_UWP))
 
   vcpkg_copy_tools(
         TOOL_NAMES uvatlastool

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uvatlas",
-  "version-date": "2022-12-15",
+  "version-date": "2023-02-06",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2001,11 +2001,11 @@
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "2022-12-15",
+      "baseline": "2023-02-06",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2022-12-15",
+      "baseline": "2023-02-06",
       "port-version": 0
     },
     "dirent": {
@@ -7949,7 +7949,7 @@
       "port-version": 2
     },
     "uvatlas": {
-      "baseline": "2022-12-15",
+      "baseline": "2023-02-06",
       "port-version": 0
     },
     "uvw": {

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "537a0f7f223101fa1be1efae3571d3ac23bc43c6",
+      "version-date": "2023-02-06",
+      "port-version": 0
+    },
+    {
       "git-tree": "c562456d423e0821f50b8ad2ea94b1ecd7c52b8d",
       "version-date": "2022-12-15",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e0967bd8b20e3ea4986bf4005fca2004eda4db1",
+      "version-date": "2023-02-06",
+      "port-version": 0
+    },
+    {
       "git-tree": "7a61cc956783e1bf296de6516a6fc15e939ad657",
       "version-date": "2022-12-15",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e88464e234478d298d2dea4a591ba05082af7f9b",
+      "version-date": "2023-02-06",
+      "port-version": 0
+    },
+    {
       "git-tree": "9335adc59658d7c81ea85d849249b1bdd4047ef5",
       "version-date": "2022-12-15",
       "port-version": 0


### PR DESCRIPTION
Updates these three ports for the latest February 2023 releases.

* directxtk, directxtk12 includes hardening for a DDS reader issue
* directxtk, directxtk12 includes a fix for an out-of-bounds read error in the audio components
* uvatlas is updated to use January 2023 DirectXTex release
