### PR TITLE
[cppwinrt] Update version to 2.0.230207.1

### DIFF
--- a/ports/cppwinrt/portfile.cmake
+++ b/ports/cppwinrt/portfile.cmake
@@ -1,9 +1,8 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Windows.CppWinRT/${VERSION}"
     FILENAME "cppwinrt.${VERSION}.zip"
-    SHA512 0a5a46bf2508ee396861b810a2196e694f351385700c267cb6637dcbb966a4017703020378289aebb50c508cf082c9be9b7f4c756fd757d177ebd74480b7d13e
+    SHA512 6ce0764c3558d94b0ec72daa6d6d139df3942d33f51d1f3a670b888fbba2b556e35df831fa9eea42d4fc9a0a1f0ca94abef1c4013dcc9b51053bffe2af4dfd85
 )
 
 vcpkg_extract_source_archive(

--- a/ports/cppwinrt/vcpkg.json
+++ b/ports/cppwinrt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppwinrt",
-  "version": "2.0.221121.5",
+  "version": "2.0.230207.1",
   "description": "C++/WinRT is a standard C++ language projection for the Windows Runtime.",
   "homepage": "https://github.com/microsoft/cppwinrt",
   "documentation": "https://docs.microsoft.com/windows/uwp/cpp-and-winrt-apis/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1745,7 +1745,7 @@
       "port-version": 3
     },
     "cppwinrt": {
-      "baseline": "2.0.221121.5",
+      "baseline": "2.0.230207.1",
       "port-version": 0
     },
     "cppxaml": {

--- a/versions/c-/cppwinrt.json
+++ b/versions/c-/cppwinrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3c57356ebb8b59a5f12468f180728751d16581b",
+      "version": "2.0.230207.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1d3deb9b47938422fb8f885f19a677ff51a4b6bc",
       "version": "2.0.221121.5",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/pull/28635#issuecomment-1421442615
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- ~~[ ] The "supports" clause reflects platforms that may be fixed by this new version~~
- ~~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- ~~[ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
