### PR TITLE
[ftxui] Backport clang ICE workaround

### DIFF
--- a/ports/ftxui/fix_clang_crash-094d8d9d.patch
+++ b/ports/ftxui/fix_clang_crash-094d8d9d.patch
@@ -1,0 +1,41 @@
+From 094d8d9d0a3cd19a7258a13d21ccb6acca60b858 Mon Sep 17 00:00:00 2001
+From: AMS21 <AMS21.github@gmail.com>
+Date: Tue, 14 Jun 2022 21:03:03 +0200
+Subject: [PATCH] Fix border charset array being to large (#421)
+
+This for some reason caused the clang compiler to crash, while also
+being incorrect as the tables are actually only 5x6.
+
+See the LLVM issue here:
+https://github.com/llvm/llvm-project/issues/56016
+---
+ src/ftxui/dom/border.cpp | 2 +-
+ src/ftxui/dom/table.cpp  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/ftxui/dom/border.cpp b/src/ftxui/dom/border.cpp
+index 0466dd9e..f39eb523 100644
+--- a/src/ftxui/dom/border.cpp
++++ b/src/ftxui/dom/border.cpp
+@@ -14,7 +14,7 @@
+ namespace ftxui {
+ 
+ using Charset = std::array<std::string, 6>;  // NOLINT
+-using Charsets = std::array<Charset, 6>;     // NOLINT
++using Charsets = std::array<Charset, 5>;     // NOLINT
+ // NOLINTNEXTLINE
+ static Charsets simple_border_charset = {
+     Charset{"┌", "┐", "└", "┘", "─", "│"},
+diff --git a/src/ftxui/dom/table.cpp b/src/ftxui/dom/table.cpp
+index 50da0918..081011f9 100644
+--- a/src/ftxui/dom/table.cpp
++++ b/src/ftxui/dom/table.cpp
+@@ -14,7 +14,7 @@ bool IsCell(int x, int y) {
+ }
+ 
+ // NOLINTNEXTLINE
+-static std::string charset[6][6] = {
++static std::string charset[5][6] = {
+     {"┌", "┐", "└", "┘", "─", "│"},  //
+     {"┏", "┓", "┗", "┛", "━", "┃"},  //
+     {"╔", "╗", "╚", "╝", "═", "║"},  //

--- a/ports/ftxui/portfile.cmake
+++ b/ports/ftxui/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF c033ca61ae8fb264542d0326d1309e0a3bde945a # 3.0.0
     SHA512 ca1468f30f90c3a886fbb6dea113699623d601da10b39a6a33d89780cd825bec8deb431872a2515fce05c7a5d581d4b56860b19654df8cf90e389dfa964f013c
     HEAD_REF master
+    PATCHES
+        fix_clang_crash-094d8d9d.patch # Included in next release. Upstream PR https://github.com/ArthurSonzogni/FTXUI/pull/421
 )
 
 vcpkg_cmake_configure(
@@ -23,4 +25,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ftxui/vcpkg.json
+++ b/ports/ftxui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ftxui",
   "version-semver": "3.0.0",
+  "port-version": 1,
   "description": "C++ Functional Terminal User Interface",
   "homepage": "https://github.com/ArthurSonzogni/FTXUI",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2562,7 +2562,7 @@
     },
     "ftxui": {
       "baseline": "3.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "function2": {
       "baseline": "4.2.2",

--- a/versions/f-/ftxui.json
+++ b/versions/f-/ftxui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29dcc8c936cb0fb0e7703aef2ebfedadb47a738a",
+      "version-semver": "3.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "42d65bbb4e3ffbb459b80b05de4322fa10593e29",
       "version-semver": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
There hasn't been a release containing the fix for more than half a year. Without the backport this port stays unusable with any clang before version 16 in C++20 (cf. ArthurSonzogni/FTXUI#421).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
