### PR TITLE
[OpenSSL] Update to 3.0.8

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -16,10 +16,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
     REF "openssl-${VERSION}"
-    SHA512 27dd3ef0c1827a74ec880d20232acb818c7d05e004ad7389c355e200a01e899f1b1ba5c34dcce44ecf7c8767c5e1bfbb2c795e3fa5461346087e7e3b95c8a51f
+    SHA512 5a821aaaaa89027ce08a347e5fc216757c2971e29f7d24792609378c54f657839b3775bf639e7330b28b4f96ef0d32869f0a96afcb25c8a2e1c2fe51a6eb4aa3
     PATCHES
         windows/install-layout.patch
         windows/install-pdbs.patch
+        windows/umul128-arm64.patch # Fixed upstream in https://github.com/openssl/openssl/pull/20244, but not released as of 3.0.8
 )
 
 vcpkg_find_acquire_program(PERL)

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openssl",
-  "version": "3.0.7",
-  "port-version": 2,
+  "version": "3.0.8",
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/ports/openssl/windows/umul128-arm64.patch
+++ b/ports/openssl/windows/umul128-arm64.patch
@@ -1,0 +1,40 @@
+diff --git a/crypto/bn/rsa_sup_mul.c b/crypto/bn/rsa_sup_mul.c
+index 0e0d02e1946e..3b57161b4589 100644
+--- a/crypto/bn/rsa_sup_mul.c
++++ b/crypto/bn/rsa_sup_mul.c
+@@ -110,12 +110,34 @@ static ossl_inline void _mul_limb(limb_t *hi, limb_t *lo, limb_t a, limb_t b)
+     *lo = (limb_t)t;
+ }
+ #elif (BN_BYTES == 8) && (defined _MSC_VER)
+-/* https://learn.microsoft.com/en-us/cpp/intrinsics/umul128?view=msvc-170 */
++# if defined(_M_X64)
++/*
++ * on x86_64 (x64) we can use the _umul128 intrinsic to get one `mul`
++ * instruction to get both high and low 64 bits of the multiplication.
++ * https://learn.microsoft.com/en-us/cpp/intrinsics/umul128?view=msvc-140
++ */
++#include <intrin.h>
+ #pragma intrinsic(_umul128)
+ static ossl_inline void _mul_limb(limb_t *hi, limb_t *lo, limb_t a, limb_t b)
+ {
+     *lo = _umul128(a, b, hi);
+ }
++# elif defined(_M_ARM64) || defined (_M_IA64)
++/*
++ * We can't use the __umulh() on x86_64 as then msvc generates two `mul`
++ * instructions; so use this more portable intrinsic on platforms that
++ * don't support _umul128 (like aarch64 (ARM64) or ia64)
++ * https://learn.microsoft.com/en-us/cpp/intrinsics/umulh?view=msvc-140
++ */
++#include <intrin.h>
++static ossl_inline void _mul_limb(limb_t *hi, limb_t *lo, limb_t a, limb_t b)
++{
++    *lo = a * b;
++    *hi = __umulh(a, b);
++}
++# else
++# error Only x64, ARM64 and IA64 supported.
++# endif /* defined(_M_X64) */
+ #else
+ /*
+  * if the compiler doesn't have either a 128bit data type nor a "return

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5705,8 +5705,8 @@
       "port-version": 0
     },
     "openssl": {
-      "baseline": "3.0.7",
-      "port-version": 2
+      "baseline": "3.0.8",
+      "port-version": 0
     },
     "openssl-unix": {
       "baseline": "deprecated",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9cd36489fc65db87c4cd94ac606abd05c1db8f2d",
+      "version": "3.0.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "71beae5ba81d9198d1ca12024325630b6ad81446",
       "version": "3.0.7",
       "port-version": 2


### PR DESCRIPTION
Fixes a high severity vulnerability: https://www.openssl.org/news/secadv/20230207.txt.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
