### PR TITLE
[icu] Fix x86 MinGW build

### DIFF
--- a/ports/icu/mingw-dll-install.patch
+++ b/ports/icu/mingw-dll-install.patch
@@ -1,5 +1,18 @@
+diff --git a/source/config/mh-mingw b/source/config/mh-mingw
+index 30f6e5be81..b6364551ea 100644
+--- a/source/config/mh-mingw
++++ b/source/config/mh-mingw
+@@ -13,7 +13,7 @@
+ # On Windows we generally have the DLLs in the bin directory rather than the lib directory.
+ # This setting moves the ICU DLLs into the bin folder for MinGW/MSYS2 when "make install" is run.
+ # If you prefer to have the DLLs in the lib folder, then set this to NO instead.
+-MINGW_MOVEDLLSTOBINDIR = YES
++MINGW_MOVEDLLSTOBINDIR = NO
+ 
+ # We install sbin tools into the same bin directory because
+ # pkgdata needs some of the tools in sbin, and we can't always depend on
 diff --git a/source/config/mh-mingw64 b/source/config/mh-mingw64
-index fb64c56..a43cc4d 100644
+index fb64c56260..a43cc4dd71 100644
 --- a/source/config/mh-mingw64
 +++ b/source/config/mh-mingw64
 @@ -10,7 +10,7 @@

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "72.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3054,7 +3054,7 @@
     },
     "icu": {
       "baseline": "72.1",
-      "port-version": 2
+      "port-version": 3
     },
     "ideviceinstaller": {
       "baseline": "1.1.2.23",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "36a3246630c4794b3781e881e5a57db36092deea",
+      "version": "72.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "c06697d7c811e568d2e520db13e41fe656bb5468",
       "version": "72.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.