### PR TITLE
[Libmupdf] port upgrade

### DIFF
--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-project(libmupdf VERSION 1.19.0 LANGUAGES C) #1.19.0-rc2#1
+project(libmupdf VERSION 1.21.1 LANGUAGES C) #1.21.1
 
 set(CMAKE_DEBUG_POSTFIX d)
 
@@ -25,11 +25,12 @@ find_package(OpenJPEG CONFIG REQUIRED)
 find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
 
 file(GLOB_RECURSE SOURCES "source/*.c" "generated/*.c")
+file(GLOB_RECURSE HEADER "source/*.h" "include/*.h")
 list(FILTER SOURCES EXCLUDE REGEX "source/tools/[a-z]*\\.c$")
 list(FILTER SOURCES EXCLUDE REGEX "source/tests/.*.c$")
 list(FILTER SOURCES EXCLUDE REGEX "source/fitz/output-docx.c")
 
-add_library(libmupdf ${SOURCES})
+add_library(libmupdf ${SOURCES} ${HEADER})
 
 if(WIN32)
   target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0 -DMEMENTO_MUPDF_HACKS -DFZ_ENABLE_DOCX_OUTPUT=0 -DFZ_ENABLE_ODT_OUTPUT=0)

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -59,9 +59,9 @@ target_link_libraries(libmupdf PRIVATE
 set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
 set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(NAMESPACE "libmupdf::")
+set(NAMESPACE "unofficial::libmupdf::")
 
-export(TARGETS libmupdf NAMESPACE libmupdf:: FILE libmupdfTargets.cmake)
+export(TARGETS libmupdf NAMESPACE ${NAMESPACE} FILE libmupdfTargets.cmake)
 
 install(TARGETS libmupdf
   EXPORT ${TARGETS_EXPORT_NAME}

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-project(libmupdf VERSION 1.21.1 LANGUAGES C) #1.21.1
+project(libmupdf LANGUAGES C) #1.21.1
 
 set(CMAKE_DEBUG_POSTFIX d)
 

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -18,11 +18,9 @@ endif()
 
 find_package(freetype NO_MODULE REQUIRED)
 find_package(JPEG REQUIRED)
-find_path(HARFBUZZ_INCLUDE hb.h PATH_SUFFIXES harfbuzz)
-find_library(HARFBUZZ_LIBRARIES harfbuzz)
+find_package(harfbuzz CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(OpenJPEG CONFIG REQUIRED)
-find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
 
 file(GLOB_RECURSE SOURCES "source/*.c")
 file(GLOB_RECURSE HEADER "source/*.h" "include/*.h")
@@ -37,10 +35,11 @@ if(WIN32)
 else()
   target_compile_definitions(libmupdf PRIVATE -DHAVE_PTHREAD=1 -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0 -DMEMENTO_MUPDF_HACKS -DFZ_ENABLE_DOCX_OUTPUT=0 -DFZ_ENABLE_ODT_OUTPUT=0)
 endif()
-include_directories(include)
+#include_directories(include)
 target_include_directories(libmupdf
-  #PUBLIC
-  #  include
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
   PRIVATE
     generated
     ${JPEG_INCLUDE_DIR}
@@ -50,21 +49,20 @@ target_link_libraries(libmupdf PRIVATE
   openjp2
   freetype
   ${JPEG_LIBRARIES}
-  ${HARFBUZZ_LIBRARIES}
-  ${JBIG2DEC_LIB}
+  harfbuzz::harfbuzz
   ZLIB::ZLIB
-  
 )
 
 # Add CMake find_package() integration
 set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
+set(UNOFFICIAL_PROJECT_NAME "unofficial-${PROJECT_NAME}")
+set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/${UNOFFICIAL_PROJECT_NAME}Config.cmake")
 set(TARGETS_EXPORT_NAME "unofficial-${PROJECT_NAME}Targets")
 set(NAMESPACE "unofficial::libmupdf::")
 
-export(TARGETS libmupdf NAMESPACE ${NAMESPACE} FILE libmupdfTargets.cmake)
+export(TARGETS ${PROJECT_NAME} NAMESPACE ${NAMESPACE} FILE ${TARGETS_EXPORT_NAME}.cmake)
 
-install(TARGETS libmupdf
+install(TARGETS ${PROJECT_NAME}
   EXPORT ${TARGETS_EXPORT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
@@ -74,7 +72,7 @@ install(TARGETS libmupdf
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    libmupdfConfigVersion.cmake
+    ${UNOFFICIAL_PROJECT_NAME}ConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
     COMPATIBILITY AnyNewerVersion
 )

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-project(libmupdf C)
+project(libmupdf C VERSION 1.19.0) #1.19.0-rc2#1
 
 set(CMAKE_DEBUG_POSTFIX d)
 
@@ -15,15 +15,6 @@ else()
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
 endif() 
-
-
-find_package(freetype NO_MODULE REQUIRED)
-find_package(JPEG REQUIRED)
-find_path(HARFBUZZ_INCLUDE hb.h PATH_SUFFIXES harfbuzz)
-find_library(HARFBUZZ_LIBRARIES harfbuzz)
-find_package(ZLIB REQUIRED)
-find_package(OpenJPEG CONFIG REQUIRED)
-find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
 
 file(GLOB_RECURSE SOURCES "source/*.c" "generated/*.c")
 list(FILTER SOURCES EXCLUDE REGEX "source/tools/[a-z]*\\.c$")
@@ -54,13 +45,32 @@ target_link_libraries(libmupdf PRIVATE
   ZLIB::ZLIB
 )
 
+export(TARGETS libmupdf NAMESPACE libmupdf:: FILE libmupdfTargets.cmake)
+
 install(TARGETS libmupdf
+  EXPORT libmupdfTargets
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    libmupdfConfigVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(EXPORT libmupdfTargets
+        FILE libmupdfTargets.cmake
+        NAMESPACE libmupdf::
+        DESTINATION lib/cmake/libmupdf
+)
+
+configure_file(libmupdfConfig.cmake.in libmupdfConfig.cmake @ONLY)
+
 if(BUILD_EXAMPLES)
   add_executable(mu-office-test source/tests/mu-office-test.c)
   target_link_libraries(mu-office-test PRIVATE libmupdf)
 endif()
+        

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-project(libmupdf C VERSION 1.19.0) #1.19.0-rc2#1
+project(libmupdf VERSION 1.19.0 LANGUAGES C) #1.19.0-rc2#1
 
 set(CMAKE_DEBUG_POSTFIX d)
 
@@ -16,6 +16,14 @@ else()
   )
 endif() 
 
+find_package(freetype NO_MODULE REQUIRED)
+find_package(JPEG REQUIRED)
+find_path(HARFBUZZ_INCLUDE hb.h PATH_SUFFIXES harfbuzz)
+find_library(HARFBUZZ_LIBRARIES harfbuzz)
+find_package(ZLIB REQUIRED)
+find_package(OpenJPEG CONFIG REQUIRED)
+find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
+
 file(GLOB_RECURSE SOURCES "source/*.c" "generated/*.c")
 list(FILTER SOURCES EXCLUDE REGEX "source/tools/[a-z]*\\.c$")
 list(FILTER SOURCES EXCLUDE REGEX "source/tests/.*.c$")
@@ -28,9 +36,10 @@ if(WIN32)
 else()
   target_compile_definitions(libmupdf PRIVATE -DHAVE_PTHREAD=1 -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0 -DMEMENTO_MUPDF_HACKS -DFZ_ENABLE_DOCX_OUTPUT=0 -DFZ_ENABLE_ODT_OUTPUT=0)
 endif()
+include_directories(include)
 target_include_directories(libmupdf
-  PUBLIC
-    include
+  #PUBLIC
+  #  include
   PRIVATE
     generated
     ${JPEG_INCLUDE_DIR}
@@ -45,13 +54,20 @@ target_link_libraries(libmupdf PRIVATE
   ZLIB::ZLIB
 )
 
+# Add CMake find_package() integration
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(NAMESPACE "libmupdf::")
+
 export(TARGETS libmupdf NAMESPACE libmupdf:: FILE libmupdfTargets.cmake)
 
 install(TARGETS libmupdf
-  EXPORT libmupdfTargets
+  EXPORT ${TARGETS_EXPORT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
+  INCLUDES include
 )
 
 include(CMakePackageConfigHelpers)
@@ -61,13 +77,12 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion
 )
 
-install(EXPORT libmupdfTargets
-        FILE libmupdfTargets.cmake
-        NAMESPACE libmupdf::
-        DESTINATION lib/cmake/libmupdf
-)
+configure_package_config_file("libmupdfConfig.cmake.in" "${PROJECT_CONFIG}" INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}")
+install(FILES "${PROJECT_CONFIG}" DESTINATION "${CONFIG_INSTALL_DIR}")
 
-configure_file(libmupdfConfig.cmake.in libmupdfConfig.cmake @ONLY)
+install(EXPORT ${TARGETS_EXPORT_NAME}
+        NAMESPACE ${NAMESPACE}
+        DESTINATION "${CONFIG_INSTALL_DIR}")
 
 if(BUILD_EXAMPLES)
   add_executable(mu-office-test source/tests/mu-office-test.c)

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(ZLIB REQUIRED)
 find_package(OpenJPEG CONFIG REQUIRED)
 find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
 
-file(GLOB_RECURSE SOURCES "source/*.c" "generated/*.c")
+file(GLOB_RECURSE SOURCES "source/*.c")
 file(GLOB_RECURSE HEADER "source/*.h" "include/*.h")
 list(FILTER SOURCES EXCLUDE REGEX "source/tools/[a-z]*\\.c$")
 list(FILTER SOURCES EXCLUDE REGEX "source/tests/.*.c$")
@@ -53,6 +53,7 @@ target_link_libraries(libmupdf PRIVATE
   ${HARFBUZZ_LIBRARIES}
   ${JBIG2DEC_LIB}
   ZLIB::ZLIB
+  
 )
 
 # Add CMake find_package() integration

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(libmupdf PRIVATE
 # Add CMake find_package() integration
 set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
-set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(TARGETS_EXPORT_NAME "unofficial-${PROJECT_NAME}Targets")
 set(NAMESPACE "unofficial::libmupdf::")
 
 export(TARGETS libmupdf NAMESPACE ${NAMESPACE} FILE libmupdfTargets.cmake)

--- a/ports/libmupdf/libmupdfConfig.cmake.in
+++ b/ports/libmupdf/libmupdfConfig.cmake.in
@@ -3,13 +3,12 @@
 include(CMakeFindDependencyMacro)
 
 # Same syntax as find_package
-find_package(freetype NO_MODULE REQUIRED)
-find_package(JPEG REQUIRED)
-find_path(HARFBUZZ_INCLUDE hb.h PATH_SUFFIXES harfbuzz)
-find_library(HARFBUZZ_LIBRARIES harfbuzz)
-find_package(ZLIB REQUIRED)
-find_package(OpenJPEG CONFIG REQUIRED)
-find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
+find_dependency(freetype)
+find_dependency(JPEG)
+find_dependency(harfbuzz)
+find_dependency(ZLIB)
+find_dependency(OpenJPEG)
+find_dependency(jbig2decd jbig2dec)
 
 # Any extra setup
 

--- a/ports/libmupdf/libmupdfConfig.cmake.in
+++ b/ports/libmupdf/libmupdfConfig.cmake.in
@@ -3,12 +3,11 @@
 include(CMakeFindDependencyMacro)
 
 # Same syntax as find_package
-find_dependency(freetype)
+find_dependency(freetype NO_MODULE)
 find_dependency(JPEG)
 find_dependency(harfbuzz)
 find_dependency(ZLIB)
 find_dependency(OpenJPEG)
-find_dependency(jbig2decd jbig2dec)
 
 # Any extra setup
 

--- a/ports/libmupdf/libmupdfConfig.cmake.in
+++ b/ports/libmupdf/libmupdfConfig.cmake.in
@@ -1,0 +1,15 @@
+include(CMakeFindDependencyMacro)
+
+# Same syntax as find_package
+find_package(freetype NO_MODULE REQUIRED)
+find_package(JPEG REQUIRED)
+find_path(HARFBUZZ_INCLUDE hb.h PATH_SUFFIXES harfbuzz)
+find_library(HARFBUZZ_LIBRARIES harfbuzz)
+find_package(ZLIB REQUIRED)
+find_package(OpenJPEG CONFIG REQUIRED)
+find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
+
+# Any extra setup
+
+# Add the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/libmupdfTargets.cmake")

--- a/ports/libmupdf/libmupdfConfig.cmake.in
+++ b/ports/libmupdf/libmupdfConfig.cmake.in
@@ -1,3 +1,5 @@
+@PACKAGE_INIT@
+
 include(CMakeFindDependencyMacro)
 
 # Same syntax as find_package
@@ -12,4 +14,4 @@ find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
 # Any extra setup
 
 # Add the targets file
-include("${CMAKE_CURRENT_LIST_DIR}/libmupdfTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -20,7 +20,7 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_EXAMPLES=OFF
-        -DPACKAGE_VERSION=${PACKAGE_VERSION}
+        -DPACKAGE_VERSION=${VERSION}
 )
 
 vcpkg_cmake_install()

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_EXAMPLES=OFF
-        -DPACKAGE_VERSION=
+        -DPACKAGE_VERSION=${PACKAGE_VERSION}
 )
 
 vcpkg_cmake_install()

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF f39eee48564274635e231e2ab652221cce2ec1bd # 1.21.1
     SHA512 aa16d0939739f96c66ee802032c321adcebc86c9fa5bfe7ec64f20614377a4f61c358270216b57a1e4b1929337c4cc856d9ec4666ed8f0edaeaa7f2336a84ac3
     HEAD_REF master
+    PATCHES
+        dont-generate-extract-3rd-party-things.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -10,7 +10,6 @@ vcpkg_from_github(
         dont-generate-extract-3rd-party-things.patch
 )
 
-set(PACKAGE_VERSION "1.21.1")
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/libmupdfConfig.cmake.in" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -21,9 +22,14 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(PACKAGE_NAME libmupdf CONFIG_PATH lib/cmake/libmupdf)
 
 file(COPY "${SOURCE_PATH}/include/mupdf" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+
+

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -1,16 +1,16 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+set(VERSION "1.21.1")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ArtifexSoftware/mupdf
-    REF f39eee48564274635e231e2ab652221cce2ec1bd # 1.21.1
+    REF ${VERSION}
     SHA512 aa16d0939739f96c66ee802032c321adcebc86c9fa5bfe7ec64f20614377a4f61c358270216b57a1e4b1929337c4cc856d9ec4666ed8f0edaeaa7f2336a84ac3
     HEAD_REF master
     PATCHES
         dont-generate-extract-3rd-party-things.patch
 )
-
-set(PACKAGE_VERSION "1.21.1")
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
@@ -21,7 +21,7 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_EXAMPLES=OFF
-        -DPACKAGE_VERSION=${PACKAGE_VERSION}
+        -DPACKAGE_VERSION=${VERSION}
 )
 
 vcpkg_cmake_install()

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_from_github(
         dont-generate-extract-3rd-party-things.patch
 )
 
+set(PACKAGE_VERSION "1.21.1")
+
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/libmupdfConfig.cmake.in" DESTINATION "${SOURCE_PATH}")
@@ -19,6 +21,7 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_EXAMPLES=OFF
+        -DPACKAGE_VERSION=
 )
 
 vcpkg_cmake_install()

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -28,6 +28,3 @@ file(COPY "${SOURCE_PATH}/include/mupdf" DESTINATION "${CURRENT_PACKAGES_DIR}/in
 vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-
-

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -6,12 +6,10 @@ vcpkg_from_github(
     REF f39eee48564274635e231e2ab652221cce2ec1bd # 1.21.1
     SHA512 aa16d0939739f96c66ee802032c321adcebc86c9fa5bfe7ec64f20614377a4f61c358270216b57a1e4b1929337c4cc856d9ec4666ed8f0edaeaa7f2336a84ac3
     HEAD_REF master
-    #PATCHES
-    #    dont-generate-extract-3rd-party-things.patch
-    #    use-if-instead-of-ifdef-in-writer.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/libmupdfConfig.cmake.in" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -3,12 +3,12 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ArtifexSoftware/mupdf
-    REF 61b63d734a7b9df618f6b45dda2466aed442f7f0 # 1.19.0-rc2
-    SHA512 16661c012e18ac72b24c46caf5c02515c29a05e0a8dcf95076eff3a1f2e87c225245037480ed37068858fe6e04ff4a404f69877599b208ab9265d054ec117820
+    REF f39eee48564274635e231e2ab652221cce2ec1bd # 1.21.1
+    SHA512 aa16d0939739f96c66ee802032c321adcebc86c9fa5bfe7ec64f20614377a4f61c358270216b57a1e4b1929337c4cc856d9ec4666ed8f0edaeaa7f2336a84ac3
     HEAD_REF master
-    PATCHES
-        dont-generate-extract-3rd-party-things.patch
-        use-if-instead-of-ifdef-in-writer.patch
+    #PATCHES
+    #    dont-generate-extract-3rd-party-things.patch
+    #    use-if-instead-of-ifdef-in-writer.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 1,
   "description": "a lightweight PDF, XPS, and E-book library",
   "homepage": "https://github.com/ArtifexSoftware/mupdf",
+  "license": "AGPL-3.0",
   "supports": "!osx",
   "dependencies": [
     "curl",

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmupdf",
   "version": "1.21.1",
-  "port-version": 1,
   "description": "a lightweight PDF, XPS, and E-book library",
   "homepage": "https://github.com/ArtifexSoftware/mupdf",
   "license": "AGPL-3.0",

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -18,6 +18,10 @@
       "name": "vcpkg-cmake",
       "host": true
     },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ]
 }

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmupdf",
-  "version": "1.19.0-rc2",
+  "version": "1.21.1",
   "port-version": 1,
   "description": "a lightweight PDF, XPS, and E-book library",
   "homepage": "https://github.com/ArtifexSoftware/mupdf",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4130,7 +4130,7 @@
     },
     "libmupdf": {
       "baseline": "1.21.1",
-      "port-version": 1
+      "port-version": 0
     },
     "libmysql": {
       "baseline": "8.0.20",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4129,7 +4129,7 @@
       "port-version": 0
     },
     "libmupdf": {
-      "baseline": "1.19.0-rc2",
+      "baseline": "1.21.1",
       "port-version": 1
     },
     "libmysql": {

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e8ef969054ee24ec2f386757977977c4c1ab2323",
+      "git-tree": "97380ff295bf78f895419b3ca4a57e0e67322b30",
       "version": "1.21.1",
       "port-version": 0
     },

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,16 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "75099b6a787bdc5ac39b09c5d793938800a69ab9",
-      "version": "1.21.1",
-      "port-version": 0
-    },
-    {
-      "git-tree": "20f05547dbf914d77c450ce8a85a0d1f478d1618",
-      "version": "1.21.1",
-      "port-version": 1
-    },
-    {
       "git-tree": "9ca3ac09949f15d339ff747bb36f8593ff087959",
       "version": "1.19.0-rc2",
       "port-version": 1

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "374459f58f7704aacb54690b1811af64a88abbf7",
+      "git-tree": "20f05547dbf914d77c450ce8a85a0d1f478d1618",
       "version": "1.21.1",
       "port-version": 1
     },

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "97380ff295bf78f895419b3ca4a57e0e67322b30",
+      "git-tree": "b733b38d7c509f86a94088b05fe38f47eea35edd",
       "version": "1.21.1",
       "port-version": 0
     },

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e4f5c8ad423ab2df105529bd44eb7178d1f88361",
+      "git-tree": "27993fc6b1507c8ae233571c1bc28ceea704d1c6",
       "version": "1.21.1",
       "port-version": 0
     },

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "27993fc6b1507c8ae233571c1bc28ceea704d1c6",
+      "git-tree": "e8ef969054ee24ec2f386757977977c4c1ab2323",
       "version": "1.21.1",
       "port-version": 0
     },

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,12 +1,16 @@
 {
   "versions": [
     {
+      "git-tree": "e4f5c8ad423ab2df105529bd44eb7178d1f88361",
+      "version": "1.21.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "20f05547dbf914d77c450ce8a85a0d1f478d1618",
       "version": "1.21.1",
       "port-version": 1
     },
     {
-
       "git-tree": "9ca3ac09949f15d339ff747bb36f8593ff087959",
       "version": "1.19.0-rc2",
       "port-version": 1

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "11ceb21791e73cc730cc6d88fd3203a420341392",
+      "git-tree": "374459f58f7704aacb54690b1811af64a88abbf7",
       "version": "1.21.1",
       "port-version": 1
     },

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11ceb21791e73cc730cc6d88fd3203a420341392",
+      "version": "1.21.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "9ca3ac09949f15d339ff747bb36f8593ff087959",
       "version": "1.19.0-rc2",
       "port-version": 1

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b733b38d7c509f86a94088b05fe38f47eea35edd",
+      "git-tree": "174afefbe80de60456ce43639c1205681228361f",
       "version": "1.21.1",
       "port-version": 0
     },

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "75099b6a787bdc5ac39b09c5d793938800a69ab9",
+      "git-tree": "e4f5c8ad423ab2df105529bd44eb7178d1f88361",
       "version": "1.21.1",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "20f05547dbf914d77c450ce8a85a0d1f478d1618",

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75099b6a787bdc5ac39b09c5d793938800a69ab9",
+      "version": "1.21.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "20f05547dbf914d77c450ce8a85a0d1f478d1618",
       "version": "1.21.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

Tested and working on Windows 11