### PR TITLE
[qcustomplot] use qt6 and update

### DIFF
--- a/ports/qcustomplot/fix_qt6_build.patch
+++ b/ports/qcustomplot/fix_qt6_build.patch
@@ -1,0 +1,82 @@
+diff --git a/qcustomplot.h b/qcustomplot.h
+index 8f0f78b..8990c4f 100644
+--- a/qcustomplot.h
++++ b/qcustomplot.h
+@@ -153,29 +153,11 @@ class QCPPolarGraph;
+ /*!
+   The QCP Namespace contains general enums, QFlags and functions used throughout the QCustomPlot
+   library.
+-  
++
+   It provides QMetaObject-based reflection of its enums and flags via \a QCP::staticMetaObject.
+ */
+-#ifndef Q_MOC_RUN
+ namespace QCP {
+-#else
+-class QCP { // when in moc-run, make it look like a class, so we get Q_GADGET, Q_ENUMS/Q_FLAGS features in namespace
+-  Q_GADGET
+-  Q_ENUMS(ExportPen)
+-  Q_ENUMS(ResolutionUnit)
+-  Q_ENUMS(SignDomain)
+-  Q_ENUMS(MarginSide)
+-  Q_FLAGS(MarginSides)
+-  Q_ENUMS(AntialiasedElement)
+-  Q_FLAGS(AntialiasedElements)
+-  Q_ENUMS(PlottingHint)
+-  Q_FLAGS(PlottingHints)
+-  Q_ENUMS(Interaction)
+-  Q_FLAGS(Interactions)
+-  Q_ENUMS(SelectionRectMode)
+-  Q_ENUMS(SelectionType)
+-public:
+-#endif
++  Q_NAMESPACE
+ 
+ /*!
+   Defines the different units in which the image resolution can be specified in the export
+@@ -318,6 +300,20 @@ enum SelectionType { stNone                ///< The plottable is not selectable
+                      ,stMultipleDataRanges ///< Any combination of data points/ranges can be selected
+                     };
+ 
++  Q_ENUM_NS(ExportPen)
++  Q_ENUM_NS(ResolutionUnit)
++  Q_ENUM_NS(SignDomain)
++  Q_ENUM_NS(MarginSide)
++  Q_FLAG_NS(MarginSides)
++  Q_ENUM_NS(AntialiasedElement)
++  Q_FLAG_NS(AntialiasedElements)
++  Q_ENUM_NS(PlottingHint)
++  Q_FLAG_NS(PlottingHints)
++  Q_ENUM_NS(Interaction)
++  Q_FLAG_NS(Interactions)
++  Q_ENUM_NS(SelectionRectMode)
++  Q_ENUM_NS(SelectionType)
++
+ /*! \internal
+   
+   Returns whether the specified \a value is considered an invalid data value for plottables (i.e.
+@@ -378,23 +374,12 @@ inline int getMarginValue(const QMargins &margins, QCP::MarginSide side)
+   return 0;
+ }
+ 
+-
+-extern const QMetaObject staticMetaObject; // in moc-run we create a static meta object for QCP "fake" object. This line is the link to it via QCP::staticMetaObject in normal operation as namespace
+-
+ } // end of namespace QCP
+ Q_DECLARE_OPERATORS_FOR_FLAGS(QCP::AntialiasedElements)
+ Q_DECLARE_OPERATORS_FOR_FLAGS(QCP::PlottingHints)
+ Q_DECLARE_OPERATORS_FOR_FLAGS(QCP::MarginSides)
+ Q_DECLARE_OPERATORS_FOR_FLAGS(QCP::Interactions)
+-Q_DECLARE_METATYPE(QCP::ExportPen)
+-Q_DECLARE_METATYPE(QCP::ResolutionUnit)
+-Q_DECLARE_METATYPE(QCP::SignDomain)
+-Q_DECLARE_METATYPE(QCP::MarginSide)
+-Q_DECLARE_METATYPE(QCP::AntialiasedElement)
+-Q_DECLARE_METATYPE(QCP::PlottingHint)
+-Q_DECLARE_METATYPE(QCP::Interaction)
+-Q_DECLARE_METATYPE(QCP::SelectionRectMode)
+-Q_DECLARE_METATYPE(QCP::SelectionType)
++//no need to use Q_DECLARE_METATYPE on enum since Q_ENUM_NS adds enum as metatype automatically
+ 
+ /* end of 'src/global.h' */
+ 

--- a/ports/qcustomplot/portfile.cmake
+++ b/ports/qcustomplot/portfile.cmake
@@ -1,40 +1,59 @@
-set(QCP_VERSION 2.0.1)
+set(QCP_VERSION 2.1.0)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.qcustomplot.com/release/${QCP_VERSION}/QCustomPlot.tar.gz"
+    URLS "https://www.qcustomplot.com/release/${QCP_VERSION}fixed/QCustomPlot.tar.gz"
     FILENAME "QCustomPlot-${QCP_VERSION}.tar.gz"
-    SHA512 a15598718146ed3c6b5d38530a56661c16269e530fe0dedb71b4cb2722b5733a3b57689d668a75994b79c19c6e61dcc133dbcb9ed77b93a165f4ac826a5685b9
+    SHA512 35ea24529c5a2d984fa6335184a17e90309d8e58d7d75e2a8d0ccb5cb1d7ac7bd16e157d5f625736cfe37f2aa8bf38d698058a8a746781876fa051cea2ffc765
 )
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    REF ${QCP_VERSION}
+    ARCHIVE "${ARCHIVE}"
+    REF "${QCP_VERSION}"
+    PATCHES fix_qt6_build.patch
 )
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.qcustomplot.com/release/${QCP_VERSION}/QCustomPlot-sharedlib.tar.gz"
+    URLS "https://www.qcustomplot.com/release/${QCP_VERSION}fixed/QCustomPlot-sharedlib.tar.gz"
     FILENAME "QCustomPlot-sharedlib-${QCP_VERSION}.tar.gz"
-    SHA512 ce90540fca7226eac37746327e1939a9c7af38fc2595f385ed04d6d1f49560da08fb5fae15d1b9d22b6ba578583f70de8f89ef26796770d41bf599c1b15c535d
+    SHA512 5736bff85eab41d9505489c184f38aa5fd5fab84730349a73122fd6cb4f6c283b16425905522d6b37918d70cb2984636b9f64fc9ecf41aa586fe9f3580671314
 )
 vcpkg_extract_source_archive(SharedLib_SOURCE_PATH ARCHIVE "${ARCHIVE}")
-file(RENAME "${SharedLib_SOURCE_PATH}" "${SOURCE_PATH}/qcustomplot-sharedlib")
+file(RENAME "${SharedLib_SOURCE_PATH}" "${SOURCE_PATH}/qcustomplot-sharedlib/")
+set(pro_file "${SOURCE_PATH}/qcustomplot-sharedlib/sharedlib-compilation/sharedlib-compilation.pro")
+vcpkg_replace_string("${pro_file}" "CONFIG += debug_and_release build_all" "")
 
 
-vcpkg_configure_qmake(SOURCE_PATH
-    ${SOURCE_PATH}/qcustomplot-sharedlib/sharedlib-compilation/sharedlib-compilation.pro
-)
+file(READ "${pro_file}" pro_string)
+string(APPEND pro_string [[
+win32 {
+    dlltarget.path = $$[QT_INSTALL_BINS]
+    INSTALLS += dlltarget
+}
+target.path    = $$[QT_INSTALL_LIBS]
+!static: target.CONFIG = no_dll
+INSTALLS     += target
 
-vcpkg_install_qmake(
-    RELEASE_TARGETS release-all
-    DEBUG_TARGETS debug-all
-)
+headers.files += ../../qcustomplot.h
+headers.path = $$[QT_INSTALL_PREFIX]/include
+INSTALLS     += headers
+]])
+file(WRITE "${pro_file}" "${pro_string}")
 
-# Install header file
-file(INSTALL ${SOURCE_PATH}/qcustomplot.h
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include
-)
+vcpkg_qmake_configure(SOURCE_PATH
+                        "${SOURCE_PATH}/qcustomplot-sharedlib/sharedlib-compilation"
+                      QMAKE_OPTIONS
+                        "QT+=opengl"
+                        "CONFIG+=create_prl"
+                        "DEFINES+=QCUSTOMPLOT_USE_OPENGL"
+                        )
+vcpkg_qmake_install()
 
 vcpkg_copy_pdbs()
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/qcustomplot.h" "#ifdef QCUSTOMPLOT_USE_OPENGL" "#define QCUSTOMPLOT_USE_OPENGL\n#ifdef QCUSTOMPLOT_USE_OPENGL")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/qcustomplot.h" "#if defined(QT_STATIC_BUILD)" "#if 1")
+endif()
+
 # Handle copyright
-configure_file(${SOURCE_PATH}/GPL.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file("${SOURCE_PATH}/GPL.txt" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/qcustomplot/vcpkg.json
+++ b/ports/qcustomplot/vcpkg.json
@@ -1,11 +1,19 @@
 {
   "name": "qcustomplot",
-  "version": "2.0.1",
-  "port-version": 5,
+  "version": "2.1.0",
   "description": "QCustomPlot is a Qt C++ widget for plotting and data visualization.",
   "dependencies": [
     {
-      "name": "qt5-base",
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "gui",
+        "widgets"
+      ]
+    },
+    {
+      "name": "vcpkg-qmake",
+      "host": true,
       "default-features": false
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6205,8 +6205,8 @@
       "port-version": 3
     },
     "qcustomplot": {
-      "baseline": "2.0.1",
-      "port-version": 5
+      "baseline": "2.1.0",
+      "port-version": 0
     },
     "qhttpengine": {
       "baseline": "1.0.2",

--- a/versions/q-/qcustomplot.json
+++ b/versions/q-/qcustomplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4a8397771744a9e9201185a399e3a1f25713d5c",
+      "version": "2.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7fcc18d2987ed5b3af803d5e0ac5c9afd026fc37",
       "version": "2.0.1",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [x] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


