### PR TITLE
Adapted port with CMake find_package.

### DIFF
--- a/ports/mujs/CMakeLists.txt
+++ b/ports/mujs/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(mujs ${mujs_sources})
 set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
 set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(NAMESPACE "mujs::")
+set(NAMESPACE "unofficial::mujs::")
 
 install(
   TARGETS mujs
@@ -25,7 +25,7 @@ install(
   ARCHIVE DESTINATION lib
 )
 
-export(TARGETS mujs NAMESPACE mujs:: FILE mujsTargets.cmake)
+export(TARGETS mujs NAMESPACE ${NAMESPACE} FILE mujsTargets.cmake)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(

--- a/ports/mujs/CMakeLists.txt
+++ b/ports/mujs/CMakeLists.txt
@@ -1,24 +1,46 @@
 cmake_minimum_required(VERSION 3.9)
-project(mujs)
+project(mujs VERSION 1.3.2)
 
 if(MSVC)
   add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
-file(GLOB libmujs_sources js*.c utf*.c regexp.c)
+file(GLOB mujs_sources js*.c utf*.c regexp.c)
 
 include_directories(.)
 
+add_library(mujs ${mujs_sources})
 
-add_library(libmujs ${libmujs_sources})
+# Add CMake find_package() integration
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(NAMESPACE "mujs::")
 
 install(
-  TARGETS libmujs
+  TARGETS mujs
+  EXPORT ${TARGETS_EXPORT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
+export(TARGETS mujs NAMESPACE mujs:: FILE mujsTargets.cmake)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    mujsConfigVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file("mujsConfig.cmake.in" "${PROJECT_CONFIG}" INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}")
+install(FILES "${PROJECT_CONFIG}" DESTINATION "${CONFIG_INSTALL_DIR}")
+
+install(EXPORT ${TARGETS_EXPORT_NAME}
+        NAMESPACE ${NAMESPACE}
+        DESTINATION "${CONFIG_INSTALL_DIR}")
+        
 if(NOT DISABLE_INSTALL_HEADERS)
   install(FILES mujs.h DESTINATION include)
 endif()

--- a/ports/mujs/mujsConfig.cmake.in
+++ b/ports/mujs/mujsConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Any extra setup
+
+# Add the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")

--- a/ports/mujs/portfile.cmake
+++ b/ports/mujs/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/mujsConfig.cmake.in DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
@@ -17,6 +18,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(PACKAGE_NAME mujs CONFIG_PATH lib/cmake/mujs)
 vcpkg_copy_pdbs()
 
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/mujs RENAME copyright)

--- a/ports/mujs/vcpkg.json
+++ b/ports/mujs/vcpkg.json
@@ -1,7 +1,19 @@
 {
   "name": "mujs",
-  "version-string": "2018-07-30",
+  "version-string": "1.3.2",
   "port-version": 2,
   "description": "An embeddable Javascript interpreter in C",
-  "homepage": "https://github.com/ccxvii/mujs"
+  "homepage": "https://github.com/ccxvii/mujs",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ]
+
 }

--- a/ports/mujs/vcpkg.json
+++ b/ports/mujs/vcpkg.json
@@ -12,8 +12,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    "zlib"
+    }
   ]
-
 }

--- a/ports/mujs/vcpkg.json
+++ b/ports/mujs/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mujs",
   "version": "1.3.2",
-  "port-version": 2,
+  "port-version": 1,
   "description": "An embeddable Javascript interpreter in C",
   "homepage": "https://github.com/ccxvii/mujs",
   "dependencies": [

--- a/ports/mujs/vcpkg.json
+++ b/ports/mujs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mujs",
-  "version-string": "1.3.2",
+  "version": "1.3.2",
   "port-version": 2,
   "description": "An embeddable Javascript interpreter in C",
   "homepage": "https://github.com/ccxvii/mujs",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5201,8 +5201,8 @@
       "port-version": 3
     },
     "mujs": {
-      "baseline": "2018-07-30",
-      "port-version": 2
+      "baseline": "1.3.2",
+      "port-version": 1
     },
     "munit": {
       "baseline": "2019-04-06",

--- a/versions/m-/mujs.json
+++ b/versions/m-/mujs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7323115493d8c380e81567a4d4ad4ecd1633c718",
+      "version": "1.3.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "b08453227e8770baadeb826bb3cd711815e6a865",
       "version-string": "2018-07-30",
       "port-version": 2

--- a/versions/m-/mujs.json
+++ b/versions/m-/mujs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28705877fe60310038183dd8546cbe3d982e3a76",
+      "version": "1.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "7323115493d8c380e81567a4d4ad4ecd1633c718",
       "version": "1.3.2",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
