### PR TITLE
[ocilib] Update to 4.7.5

### DIFF
--- a/ports/ocilib/fix-DisableWC4191.patch
+++ b/ports/ocilib/fix-DisableWC4191.patch
@@ -1,7 +1,7 @@
-diff --git a/proj/dll/ocilib_dll_vs2019.vcxproj b/proj/dll/ocilib_dll_vs2019.vcxproj
-index 2d5b3bf..35e4684 100644
---- a/proj/dll/ocilib_dll_vs2019.vcxproj
-+++ b/proj/dll/ocilib_dll_vs2019.vcxproj
+diff --git a/proj/dll/ocilib_dll.vcxproj b/proj/dll/ocilib_dll.vcxproj
+index 1caf1d3..b7d36ea 100644
+--- a/proj/dll/ocilib_dll.vcxproj
++++ b/proj/dll/ocilib_dll.vcxproj
 @@ -116,7 +116,7 @@
        <PrecompiledHeader>
        </PrecompiledHeader>

--- a/ports/ocilib/portfile.cmake
+++ b/ports/ocilib/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vrogier/ocilib
-    REF v${VERSION}
+    REF "v${VERSION}"
     SHA512 310c25fbe47ab59570103afdc6f4517b979d4077c77665c931592d95e8c706dcf34d5c2f10309a9971534499b2c4367efd05b25cdf8ebd4de15cb2c104059760
     HEAD_REF master
     PATCHES fix-DisableWC4191.patch

--- a/ports/ocilib/portfile.cmake
+++ b/ports/ocilib/portfile.cmake
@@ -1,11 +1,12 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vrogier/ocilib
-    REF v4.7.3
-    SHA512 80cf1f76420b506789b1f7edd9af826801236499dd0757be3438e3cdf286b95ddd7dd35909622b3862244f6b535a8744f0b25989fb3740a4a0fd984410fb420b
+    REF v${VERSION}
+    SHA512 310c25fbe47ab59570103afdc6f4517b979d4077c77665c931592d95e8c706dcf34d5c2f10309a9971534499b2c4367efd05b25cdf8ebd4de15cb2c104059760
     HEAD_REF master
     PATCHES fix-DisableWC4191.patch
 )
+
 
 if(VCPKG_TARGET_IS_WINDOWS)
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
@@ -19,7 +20,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     set(VCPKG_BUILD_TYPE release)
     vcpkg_install_msbuild(
         SOURCE_PATH "${SOURCE_PATH}"
-        PROJECT_SUBPATH proj/dll/ocilib_dll_vs2019.sln
+        PROJECT_SUBPATH proj/dll/ocilib_dll.sln
         INCLUDES_SUBPATH include
         LICENSE_SUBPATH LICENSE
         RELEASE_CONFIGURATION "Release - ANSI"

--- a/ports/ocilib/vcpkg.json
+++ b/ports/ocilib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ocilib",
-  "version": "4.7.3",
-  "port-version": 2,
+  "version": "4.7.5",
+  "port-version": 1,
   "description": "OCILIB is an open source and cross platform Oracle Driver that delivers efficient access to Oracle databases.",
   "homepage": "https://vrogier.github.io/ocilib/",
   "license": "Apache-2.0",

--- a/ports/ocilib/vcpkg.json
+++ b/ports/ocilib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ocilib",
   "version": "4.7.5",
-  "port-version": 1,
   "description": "OCILIB is an open source and cross platform Oracle Driver that delivers efficient access to Oracle databases.",
   "homepage": "https://vrogier.github.io/ocilib/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5513,8 +5513,8 @@
       "port-version": 1
     },
     "ocilib": {
-      "baseline": "4.7.3",
-      "port-version": 2
+      "baseline": "4.7.5",
+      "port-version": 1
     },
     "octomap": {
       "baseline": "1.9.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5514,7 +5514,7 @@
     },
     "ocilib": {
       "baseline": "4.7.5",
-      "port-version": 1
+      "port-version": 0
     },
     "octomap": {
       "baseline": "1.9.6",

--- a/versions/o-/ocilib.json
+++ b/versions/o-/ocilib.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "d6b102441f52ef47f5cf9831af64eb10fea909c2",
+      "git-tree": "7890b70b228f5978d5a0be489344380d34c5635f",
       "version": "4.7.5",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "04a952ec38bbc46e3cfa6d5ee6ced8a5e9989e31",

--- a/versions/o-/ocilib.json
+++ b/versions/o-/ocilib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7890b70b228f5978d5a0be489344380d34c5635f",
+      "git-tree": "e77dfc3008f996ea2defcaf771f46d33d81a4470",
       "version": "4.7.5",
       "port-version": 0
     },

--- a/versions/o-/ocilib.json
+++ b/versions/o-/ocilib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6b102441f52ef47f5cf9831af64eb10fea909c2",
+      "version": "4.7.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "04a952ec38bbc46e3cfa6d5ee6ced8a5e9989e31",
       "version": "4.7.3",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


