### PR TITLE
[libkml] Add target include directories

### DIFF
--- a/ports/libkml/add-target-include-directories.patch
+++ b/ports/libkml/add-target-include-directories.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/LibKMLHelper.cmake b/cmake/LibKMLHelper.cmake
+index 5cc166a..3ed3079 100644
+--- a/cmake/LibKMLHelper.cmake
++++ b/cmake/LibKMLHelper.cmake
+@@ -1,6 +1,7 @@
+ macro(build_target)
+   cmake_parse_arguments(LIB  "" "NAME" "SRCS;INCS;LINKS;DEPENDS" ${ARGN} )
+   add_library(${LIB_NAME} ${LIB_SRCS})
++  target_include_directories(${LIB_NAME} INTERFACE $<INSTALL_INTERFACE:include>)
+ 
+   foreach(LIB_DEPEND ${LIB_DEPENDS})
+     add_dependencies(${LIB_NAME} ${LIB_DEPEND})

--- a/ports/libkml/portfile.cmake
+++ b/ports/libkml/portfile.cmake
@@ -5,13 +5,14 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libkml/libkml
-    REF   1.3.0
+    REF  "${VERSION}"
     SHA512 aa48158103d3af764bf98c1fb4cf3e1356b9cc6c8e79d80b96850916f0a8ccb1dac3a46427735dd0bf20647daa047d10e722ac3da2a214d4c1559bf6d5d7c853
     HEAD_REF master
     PATCHES
         patch_empty_literal_on_vc.patch
         fix-mingw.patch
         fix-minizip.patch
+        add-target-include-directories.patch
 )
 
 file(REMOVE
@@ -39,4 +40,4 @@ else()
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libkml/vcpkg.json
+++ b/ports/libkml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libkml",
   "version": "1.3.0",
-  "port-version": 10,
+  "port-version": 11,
   "description": "Reference implementation of OGC KML 2.2",
   "homepage": "https://github.com/libkml/libkml",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4018,7 +4018,7 @@
     },
     "libkml": {
       "baseline": "1.3.0",
-      "port-version": 10
+      "port-version": 11
     },
     "liblas": {
       "baseline": "1.8.1",

--- a/versions/l-/libkml.json
+++ b/versions/l-/libkml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4969a3e81df3ef13b5e3f2f94e652311df8bbafe",
+      "version": "1.3.0",
+      "port-version": 11
+    },
+    {
       "git-tree": "8e1c949e666db286674cb1af98edb4d23d7ec843",
       "version": "1.3.0",
       "port-version": 10


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/29542
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
