### PR TITLE
[libqcow] Update to 20221124

### DIFF
--- a/ports/libqcow/portfile.cmake
+++ b/ports/libqcow/portfile.cmake
@@ -1,36 +1,35 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
-set(LIB_VERSION 20210419)
+set(LIB_VERSION 20221124)
 set(LIB_FILENAME libqcow-alpha-${LIB_VERSION}.tar.gz)
 
 # Release distribution file contains configured sources, while the source code in the repository does not.
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/libyal/libqcow/releases/download/${LIB_VERSION}/${LIB_FILENAME}"
     FILENAME "${LIB_FILENAME}"
-    SHA512 911d29bd880df95288e552356d128d18c924fcd0d61d166fbeaf09936f11bf27b984d8ffd4cdc4bc285e7df295a1fe64ff595b0dfdd10b6fcfbdc6586d6bd3b0
+    SHA512 5e48491ec8951473b8791fd6058d35b2d3c00b0206d4ca4fc69b6d42c26ba0a775efe41974989a3965a6a17f4361dd01f874aadef08fe5d80be75d9e6aea6450
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
+vcpkg_extract_source_archive(
+    SOURCE_PATH
     ARCHIVE ${ARCHIVE}
-    REF ${LIB_VERSION}
+    SOURCE_BASE ${LIB_VERSION}
     PATCHES macos_fixes.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
 )
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/libqcow")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libqcow")
 
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # License and man
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libqcow/vcpkg.json
+++ b/ports/libqcow/vcpkg.json
@@ -1,13 +1,21 @@
 {
   "name": "libqcow",
-  "version-string": "20210419",
-  "port-version": 2,
+  "version": "20221124",
   "description": "Library and tools to access the QEMU Copy-On-Write (QCOW) image format.",
   "homepage": "https://github.com/libyal/libqcow",
+  "license": "LGPL-3.0-or-later",
   "supports": "!uwp",
   "dependencies": [
     "gettext",
     "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4189,8 +4189,8 @@
       "port-version": 1
     },
     "libqcow": {
-      "baseline": "20210419",
-      "port-version": 2
+      "baseline": "20221124",
+      "port-version": 0
     },
     "libqglviewer": {
       "baseline": "2.7.2",

--- a/versions/l-/libqcow.json
+++ b/versions/l-/libqcow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70abb044b3b25aff006a6858812325ad2a923e7f",
+      "version": "20221124",
+      "port-version": 0
+    },
+    {
       "git-tree": "03d185bd85372ecd790739994ef2eb487a9595bc",
       "version-string": "20210419",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
