### PR TITLE
[nanobench] Revert to library version instead of header-only

### DIFF
--- a/ports/nanobench/CMakeLists.txt
+++ b/ports/nanobench/CMakeLists.txt
@@ -4,8 +4,12 @@ project(nanobench LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
-add_library(nanobench INTERFACE)
-target_include_directories(nanobench INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+add_library(nanobench STATIC "${CMAKE_SOURCE_DIR}/src/test/app/nanobench.cpp")
+add_library(nanobench::nanobench ALIAS nanobench)
+set_property(TARGET nanobench PROPERTY CXX_STANDARD 17)
+target_include_directories(nanobench PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 install(TARGETS nanobench EXPORT nanobench)
 

--- a/ports/nanobench/portfile.cmake
+++ b/ports/nanobench/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinus/nanobench
@@ -5,8 +7,6 @@ vcpkg_from_github(
     SHA512 aa00dfc585445fda63b3ba1a802da259993b6b99d0bc2c9bb5f8a9dac64d25e9a61f072846d8f70ee2fea58482431749189179520ba7f6e075dbb223574a3a4d
     HEAD_REF master
 )
-
-set(VCPKG_BUILD_TYPE release) # header-only port
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
@@ -17,7 +17,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/nanobench/vcpkg.json
+++ b/ports/nanobench/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nanobench",
   "version": "4.3.10",
+  "port-version": 1,
   "description": "Simple, fast, accurate single-header microbenchmarking functionality for C++11/14/17/20",
   "homepage": "https://nanobench.ankerl.com",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5266,7 +5266,7 @@
     },
     "nanobench": {
       "baseline": "4.3.10",
-      "port-version": 0
+      "port-version": 1
     },
     "nanodbc": {
       "baseline": "2.13.0",

--- a/versions/n-/nanobench.json
+++ b/versions/n-/nanobench.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "90dbaf4276576bc0ae73f4af33109639f01d698a",
+      "version": "4.3.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "36edb6691f30882941ba28ae9fce39e251398466",
       "version": "4.3.10",
       "port-version": 0


### PR DESCRIPTION
See also https://github.com/microsoft/vcpkg/pull/29468#issuecomment-1424312508
