### PR TITLE
[libcopp] update to 2.1.2

### DIFF
--- a/ports/libcopp/fix-x86-windows.patch
+++ b/ports/libcopp/fix-x86-windows.patch
@@ -1,9 +1,8 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 95ebe36..658c5e1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -11,12 +11,17 @@
-   libcopp
-   VERSION "1.4.1"
-   DESCRIPTION "Cross-platform coroutine library in C++ ."
+@@ -25,6 +25,11 @@ project(
    HOMEPAGE_URL "https://libcopp.atframe.work"
    LANGUAGES C CXX ASM)
  
@@ -14,7 +13,4 @@
 +
  # ######################################################################################################################
  include("${PROJECT_SOURCE_DIR}/project/cmake/ProjectBuildOption.cmake")
- 
- # # #############################################################################
- echowithcolor(COLOR GREEN "-- Build Type: ${CMAKE_BUILD_TYPE}")
  

--- a/ports/libcopp/portfile.cmake
+++ b/ports/libcopp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO owent/libcopp
-    REF 1.4.1
-    SHA512 eba06bd2de7c9ee557cdd0bf79e0c53e37722b671347436322c14c99e94d955477bfc0980a4f59a5c31051e108f952ec96791024c45fa8eeaa5f7a49099dd8ae
+    REF "v${VERSION}"
+    SHA512 0e18641a8d94527417b9c85b3e2ddd60c6c3dc10a9ccf75186cec4344239114245c50ac154a411f3e42a1f9e021a9bcf3c6b71b0cd2f9be82a76b0cd10791589
     HEAD_REF v2
     PATCHES fix-x86-windows.patch
 )
@@ -24,9 +24,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/BOOST_LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/BOOST_LICENSE_1_0.txt" "${SOURCE_PATH}/LICENSE")
 
 vcpkg_copy_pdbs()
 

--- a/ports/libcopp/vcpkg.json
+++ b/ports/libcopp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libcopp",
-  "version-semver": "1.4.1",
-  "port-version": 3,
+  "version": "2.1.2",
   "maintainers": "owent <admin@owent.net>",
   "description": "A cross-platfrom coroutine library for C++",
   "homepage": "https://github.com/owent/libcopp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3765,8 +3765,8 @@
       "port-version": 2
     },
     "libcopp": {
-      "baseline": "1.4.1",
-      "port-version": 3
+      "baseline": "2.1.2",
+      "port-version": 0
     },
     "libcorrect": {
       "baseline": "2018-10-11",

--- a/versions/l-/libcopp.json
+++ b/versions/l-/libcopp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c8f92b9a9feb08ffcb8212368c74a56efe6c1c8",
+      "version": "2.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "51ec2fdf59199a7fb42a553aa5368175a58128c6",
       "version-semver": "1.4.1",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/29242

Change the `version-semver` to `version` because this port does not follow the semantic versioning conventions.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
