### PR TITLE
[libssh] Fix Android build (again)

### DIFF
--- a/ports/libssh/0004-file-permissions-constants.patch
+++ b/ports/libssh/0004-file-permissions-constants.patch
@@ -1,12 +1,13 @@
 diff --git a/src/misc.c b/src/misc.c
 --- a/src/misc.c	(revision 9941e89f307e73352d887cac14e4e26b481a0a82)
 +++ b/src/misc.c	(date 1675868320486)
-@@ -24,6 +24,10 @@
+@@ -24,6 +24,11 @@
  
  #include "config.h"
  
 +#ifdef __ANDROID__
 +#define _S_IWRITE S_IWUSR
++#define S_IWRITE S_IWUSR
 +#endif
 +
  #ifndef _WIN32

--- a/ports/libssh/vcpkg.json
+++ b/ports/libssh/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libssh",
   "version": "0.10.4+20221123",
-  "port-version": 2,
+  "port-version": 3,
   "description": "libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side",
   "homepage": "https://www.libssh.org/",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4410,7 +4410,7 @@
     },
     "libssh": {
       "baseline": "0.10.4+20221123",
-      "port-version": 2
+      "port-version": 3
     },
     "libssh2": {
       "baseline": "1.10.0",

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28e13fcd9d75f1564e60ddef67f0aac982203740",
+      "git-tree": "e15d10eb435fbd46abba95b50c8d47d2ff166603",
       "version": "0.10.4+20221123",
       "port-version": 3
     },

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28e13fcd9d75f1564e60ddef67f0aac982203740",
+      "version": "0.10.4+20221123",
+      "port-version": 3
+    },
+    {
       "git-tree": "4c7fcb482d4861f5656bfbedcfdab39b67a7813f",
       "version": "0.10.4+20221123",
       "port-version": 2


### PR DESCRIPTION
This update adds a patch to replace S_IWRITE with in order to be able to build against the latest Android NDK and SDK. In the [previous patch](https://github.com/microsoft/vcpkg/pull/29515) I forgot to commit the change in the constant above and only changed _S_IWRITE.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.