### PR TITLE
[directxtex] update port to add dx11 default feature

### DIFF
--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF ${DIRECTXTEX_TAG}
-    SHA512 5bc6ee9aeff314ef700a2e0b4b87807121eba6298de9c83af9eb9a3ce1956396570d10888b05e0c42eda800c3183023eb9e0e4b5464989a141e30c0097ecd8fc
+    REF jan2023b
+    SHA512 5e107b1bbf2af8c9989e7760f9f8454b1fc956fb948003f92a7cec2954917cecb7d0fb5d076c3f920c57af7c45ca1b7b440acf1cbfd6de8bb57e8d50118df4de
     HEAD_REF main
     )
 

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -2,10 +2,6 @@ set(DIRECTXTEX_TAG jan2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-if(VCPKG_TARGET_IS_MINGW)
-    message(NOTICE "Building ${PORT} for MinGW requires the HLSL Compiler fxc.exe also be in the PATH. See https://aka.ms/windowssdk.")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
@@ -17,16 +13,21 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        dx11 BUILD_DX11
         dx12 BUILD_DX12
         openexr ENABLE_OPENEXR_SUPPORT
         spectre ENABLE_SPECTRE_MITIGATION
 )
 
+if(VCPKG_TARGET_IS_MINGW AND ("dx11" IN_LIST FEATURES))
+    message(NOTICE "Building ${PORT} for MinGW requires the HLSL Compiler fxc.exe also be in the PATH. See https://aka.ms/windowssdk.")
+endif()
+
 if (VCPKG_HOST_IS_LINUX)
     message(WARNING "Build ${PORT} requires GCC version 9 or later")
 endif()
 
-set(EXTRA_OPTIONS -DBUILD_SAMPLE=OFF -DBUILD_TESTING=OFF -DBC_USE_OPENMP=ON -DBUILD_DX11=ON)
+set(EXTRA_OPTIONS -DBUILD_SAMPLE=OFF -DBUILD_TESTING=OFF -DBC_USE_OPENMP=ON)
 
 if(VCPKG_TARGET_IS_UWP)
   list(APPEND EXTRA_OPTIONS -DBUILD_TOOLS=OFF)
@@ -76,7 +77,7 @@ if(VCPKG_HOST_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("
   file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-${DIRECTXTEX_TAG}.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
   file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-${DIRECTXTEX_TAG}.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
 
-elseif(VCPKG_TARGET_IS_WINDOWS AND (NOT VCPKG_TARGET_IS_UWP))
+elseif(VCPKG_TARGET_IS_WINDOWS AND (NOT VCPKG_TARGET_IS_UWP) AND ("dx11" IN_LIST FEATURES))
 
   vcpkg_copy_tools(
         TOOL_NAMES texassemble texconv texdiag

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directxtex",
   "version-date": "2023-01-31",
+  "port-version": 1,
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",
@@ -18,7 +19,13 @@
       "host": true
     }
   ],
+  "default-features": [
+    "dx11"
+  ],
   "features": {
+    "dx11": {
+      "description": "Build with DirectX11 support"
+    },
     "dx12": {
       "description": "Build with DirectX12 support for Windows 10/Windows 11"
     },

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "uvatlas",
   "version-date": "2023-02-06",
+  "port-version": 1,
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",
@@ -15,6 +16,7 @@
     },
     {
       "name": "directxtex",
+      "default-features": false,
       "platform": "!(uwp | linux)"
     },
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7998,7 +7998,7 @@
     },
     "uvatlas": {
       "baseline": "2023-02-06",
-      "port-version": 0
+      "port-version": 1
     },
     "uvw": {
       "baseline": "2.12.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2026,7 +2026,7 @@
     },
     "directxtex": {
       "baseline": "2023-01-31",
-      "port-version": 0
+      "port-version": 1
     },
     "directxtk": {
       "baseline": "2023-02-06",

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b2a18dead4ee1fa01ceb63667d93bd1080822fb2",
+      "version-date": "2023-01-31",
+      "port-version": 1
+    },
+    {
       "git-tree": "a9d1163d38bfe182db6e9011b0b52e682ae02501",
       "version-date": "2023-01-31",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "529a01d54dab048985a62e6f517e8fa007c48238",
+      "version-date": "2023-02-06",
+      "port-version": 1
+    },
+    {
       "git-tree": "e88464e234478d298d2dea4a591ba05082af7f9b",
       "version-date": "2023-02-06",
       "port-version": 0


### PR DESCRIPTION
For some scenarios, I need to be able to skip building the D3D11 functionality which needs FXC.EXE to build the shaders.

This port update adds a **dx11** feature which is default, so it doesn't change any existing scenario for ``[openexr]`` or ``[dx12``]. It's only the ``[core]`` scenario that loses the ``BUILD_DX11=ON`` option.

> Minor upstream fix for when ``BUILD_DX11=OFF`` and ``BUILD_TOOLS=ON``.