### PR TITLE
[collada-dom] drop unused dependency

### DIFF
--- a/ports/collada-dom/vcpkg.json
+++ b/ports/collada-dom/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "collada-dom",
   "version": "2.5.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "The COLLADA Document Object Model (DOM) is an application programming interface (API) that provides a C++ object representation of a COLLADA XML instance document.",
   "homepage": "https://github.com/rdiankov/collada-dom",
   "license": null,
@@ -10,7 +10,6 @@
     "boost-system",
     "libxml2",
     "minizip",
-    "pcre",
     "uriparser",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1610,7 +1610,7 @@
     },
     "collada-dom": {
       "baseline": "2.5.0",
-      "port-version": 7
+      "port-version": 8
     },
     "colmap": {
       "baseline": "2022-03-14",

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52229b10acbed6e24eefd37ef20b30e24c6c7e71",
+      "version": "2.5.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "1e2fef9034d7819a290b57709aa115628cede76a",
       "version": "2.5.0",
       "port-version": 7


### PR DESCRIPTION
this change is important. I forgot to include it in #29562

this dependency is never used but prevents building at least for wasm32-emscripten triplet (I believe for many cross-compiling use cases too)