### PR TITLE
[Kubernetes] Update to 2023-02-11

### DIFF
--- a/ports/kubernetes/portfile.cmake
+++ b/ports/kubernetes/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kubernetes-client/c
-    REF 39a4dab2504c9c26d3577d11a335027f8d782457
-    SHA512  3bdbf12e26d0808818bcb3c28b398650656cabaf3bb364095b277d07f6e35afc6d3aaea9357e6a888dd92edfc0f88d655b59d186150f5b779e7511a924d713bd
+    REF 488460fe9b75ffa61369d45b039fed085d3c817a
+    SHA512  a70a524a90db4976aae05dfca4f2c6fbb255384b0b6f72a3d38434f0f92fdf73da15857d360ad3fdc0dc37164d667279f8a50cba774f064b0841abd2b33a87ea
     HEAD_REF master
     PATCHES
         001-fix-destination.patch

--- a/ports/kubernetes/vcpkg.json
+++ b/ports/kubernetes/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kubernetes",
-  "version-date": "2022-11-09",
+  "version-date": "2023-02-11",
   "description": "Kubernetes C client",
   "homepage": "https://github.com/kubernetes-client/c/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3601,7 +3601,7 @@
       "port-version": 0
     },
     "kubernetes": {
-      "baseline": "2022-11-09",
+      "baseline": "2023-02-11",
       "port-version": 0
     },
     "kuku": {

--- a/versions/k-/kubernetes.json
+++ b/versions/k-/kubernetes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "62e356e2f24792602992ddc5ab72db8f74edcca0",
+      "version-date": "2023-02-11",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6f9cc3e4fcf2a43e2dc3c41b9aa103b7cc1a54c",
       "version-date": "2022-11-09",
       "port-version": 0


### PR DESCRIPTION
Updates Kubernetes client to the latest commit since it has no version releases. This is mostly to resolve a bug introduced last year related to cross-compilation.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.