### PR TITLE
[arg-router] Bump to 1.1.1

### DIFF
--- a/ports/arg-router/portfile.cmake
+++ b/ports/arg-router/portfile.cmake
@@ -1,31 +1,29 @@
-set(ARCHIVE_NAME "arg_router-${VERSION}.zip")
-
-vcpkg_download_distfile(
-    ARCHIVE
-    URLS "https://github.com/cmannett85/arg_router/releases/download/v${VERSION}/${ARCHIVE_NAME}"
-    FILENAME "${ARCHIVE_NAME}"
-    SHA512 9cb75dafbdcbc02c774d5dcf17af126b7b1fc032b10cc0a2b5075897fbb80cdb0b84b631d265295210c3a7bdae682065f417d8ca70937118de97f14ed46bd31b
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cmannett85/arg_router
+    REF v1.1.1
+    HEAD_REF main
+    SHA512 2951a54b4fb13abd10d4de3711d4d92f180e582c21e9a0d3599cb327e799727e826ea87aecd0fd7a6203585eac5a934afe25f98488ef6b36c12be97450ab8020
 )
 
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DINSTALLATION_ONLY=ON
 )
 
+vcpkg_cmake_install()
+vcpkg_install_copyright(
+    FILE_LIST "${SOURCE_PATH}/LICENSE"
+)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(
-    COPY "${SOURCE_PATH}/include/arg_router/arg_router-config.cmake"
-         "${SOURCE_PATH}/include/arg_router/arg_router-config-version.cmake"
+    COPY "${CURRENT_PACKAGES_DIR}/include/arg_router/arg_router-config.cmake"
+         "${CURRENT_PACKAGES_DIR}/include/arg_router/arg_router-config-version.cmake"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/arg_router"
-)
-file(
-    COPY "${SOURCE_PATH}/include"
-    DESTINATION "${CURRENT_PACKAGES_DIR}"
 )
 file(
     COPY "${CMAKE_CURRENT_LIST_DIR}/usage"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
 
-vcpkg_install_copyright(
-    FILE_LIST "${SOURCE_PATH}/include/arg_router/LICENSE"
-)

--- a/ports/arg-router/portfile.cmake
+++ b/ports/arg-router/portfile.cmake
@@ -1,13 +1,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cmannett85/arg_router
-    REF v1.1.1
+    REF v${VERSION}
     HEAD_REF main
     SHA512 2951a54b4fb13abd10d4de3711d4d92f180e582c21e9a0d3599cb327e799727e826ea87aecd0fd7a6203585eac5a934afe25f98488ef6b36c12be97450ab8020
 )
 
+set(VCPKG_BUILD_TYPE release) # header-only port
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DINSTALLATION_ONLY=ON
 )
@@ -16,14 +17,21 @@ vcpkg_cmake_install()
 vcpkg_install_copyright(
     FILE_LIST "${SOURCE_PATH}/LICENSE"
 )
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-file(
-    COPY "${CURRENT_PACKAGES_DIR}/include/arg_router/arg_router-config.cmake"
-         "${CURRENT_PACKAGES_DIR}/include/arg_router/arg_router-config-version.cmake"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/arg_router"
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
-file(
-    COPY "${CMAKE_CURRENT_LIST_DIR}/usage"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+
+file(COPY "${CURRENT_PACKAGES_DIR}/include/arg_router/arg_router-config.cmake"
+          "${CURRENT_PACKAGES_DIR}/include/arg_router/arg_router-config-version.cmake"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/arg_router"
+)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME arg_router
+)
+
+file(REMOVE "${CURRENT_PACKAGES_DIR}/include/arg_router/arg_router-config.cmake"
+            "${CURRENT_PACKAGES_DIR}/include/arg_router/arg_router-config-version.cmake"
+            "${CURRENT_PACKAGES_DIR}/include/arg_router/LICENSE"
+            "${CURRENT_PACKAGES_DIR}/include/arg_router/README.md"
 )
 

--- a/ports/arg-router/vcpkg.json
+++ b/ports/arg-router/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arg-router",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "C++ command line argument parsing and routing.",
   "homepage": "https://github.com/cmannett85/arg_router",
   "documentation": "https://cmannett85.github.io/arg_router/",
@@ -9,6 +9,10 @@
     "boost-lexical-cast",
     "boost-mp11",
     "boost-preprocessor",
-    "span-lite"
+    "span-lite",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
   ]
 }

--- a/ports/arg-router/vcpkg.json
+++ b/ports/arg-router/vcpkg.json
@@ -13,6 +13,10 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/versions/a-/arg-router.json
+++ b/versions/a-/arg-router.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "78698722846dfac3d599e8e4fd44d7f134d6790b",
+      "git-tree": "3a12ba85bd70de2d9fdd55ecff2ee394d0ed1b79",
       "version": "1.1.1",
       "port-version": 0
     },

--- a/versions/a-/arg-router.json
+++ b/versions/a-/arg-router.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78698722846dfac3d599e8e4fd44d7f134d6790b",
+      "version": "1.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d6f21738ed53af9693376f8e659485875117f8f5",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -161,7 +161,7 @@
       "port-version": 2
     },
     "arg-router": {
-      "baseline": "1.1.0",
+      "baseline": "1.1.1",
       "port-version": 0
     },
     "argagg": {


### PR DESCRIPTION
Bug fixes:
* Critical issue that prevents non-CMake builds from being built

Improvements:
* Removed the git patch version segment and therefore the requirement on git to build. This allows for building from source without a working copy

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.