### PR TITLE
[freeimage] Updated port to prepare for libraw version 0.21

### DIFF
--- a/ports/freeimage/portfile.cmake
+++ b/ports/freeimage/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_from_sourceforge(
         use-typedef-as-already-declared.patch
         use-functions-to-override-libtiff-warning-error-handlers.patch
         remove_auto_ptr.patch
+        rawlib-build-fix.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/freeimage/portfile.cmake
+++ b/ports/freeimage/portfile.cmake
@@ -38,9 +38,8 @@ file(REMOVE_RECURSE ${SOURCE_PATH}/Source/LibWebP)
 file(REMOVE_RECURSE ${SOURCE_PATH}/Source/LibRawLite)
 file(REMOVE_RECURSE ${SOURCE_PATH}/Source/OpenEXR)
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS_DEBUG
       -DINSTALL_HEADERS=OFF
 )

--- a/ports/freeimage/rawlib-build-fix.patch
+++ b/ports/freeimage/rawlib-build-fix.patch
@@ -11,7 +11,7 @@ index c7f8758a..a57fd5f1 100644
 +	// Once the port of FreeImage has been updated to a version greater
 +	// than 3.18.0, this patch should be removed as it will not be needed.
 +#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 20)
-+	LibRaw_abstract_datastream const *substream = nullptr;
++	LibRaw_abstract_datastream *substream = nullptr;
 +#endif
 +
  public:

--- a/ports/freeimage/rawlib-build-fix.patch
+++ b/ports/freeimage/rawlib-build-fix.patch
@@ -1,0 +1,66 @@
+diff --git a/Source/FreeImage/PluginRAW.cpp b/Source/FreeImage/PluginRAW.cpp
+index c7f8758a..a57fd5f1 100644
+--- a/Source/FreeImage/PluginRAW.cpp
++++ b/Source/FreeImage/PluginRAW.cpp
+@@ -63,17 +63,14 @@ public:
+ 	}
+ 
+     int read(void *buffer, size_t size, size_t count) { 
+-		if(substream) return substream->read(buffer, size, count);
+ 		return _io->read_proc(buffer, (unsigned)size, (unsigned)count, _handle);
+ 	}
+ 
+     int seek(INT64 offset, int origin) { 
+-        if(substream) return substream->seek(offset, origin);
+ 		return _io->seek_proc(_handle, (long)offset, origin);
+ 	}
+ 
+     INT64 tell() { 
+-		if(substream) return substream->tell();
+         return _io->tell_proc(_handle);
+     }
+ 	
+@@ -83,13 +80,11 @@ public:
+ 
+     int get_char() { 
+ 		int c = 0;
+-		if(substream) return substream->get_char();
+ 		if(!_io->read_proc(&c, 1, 1, _handle)) return -1;
+ 		return c;
+    }
+ 	
+ 	char* gets(char *buffer, int length) { 
+-		if (substream) return substream->gets(buffer, length);
+ 		memset(buffer, 0, length);
+ 		for(int i = 0; i < length; i++) {
+ 			if(!_io->read_proc(&buffer[i], 1, 1, _handle))
+@@ -103,8 +98,7 @@ public:
+ 	int scanf_one(const char *fmt, void* val) {
+ 		std::string buffer;
+ 		char element = 0;
+-		bool bDone = false;
+-		if(substream) return substream->scanf_one(fmt,val);				
++		bool bDone = false;			
+ 		do {
+ 			if(_io->read_proc(&element, 1, 1, _handle) == 1) {
+ 				switch(element) {
+@@ -127,7 +121,6 @@ public:
+ 	}
+ 
+ 	int eof() { 
+-		if(substream) return substream->eof();
+         return (_io->tell_proc(_handle) >= _eof);
+     }
+ 
+@@ -694,7 +687,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
+ 		// --------------------------------------------
+ 
+ 		// (-s [0..N-1]) Select one raw image from input file
++#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
++		RawProcessor->imgdata.rawparams.shot_select = 0;
++#else
+ 		RawProcessor->imgdata.params.shot_select = 0;
++#endif
+ 		// (-w) Use camera white balance, if possible (otherwise, fallback to auto_wb)
+ 		RawProcessor->imgdata.params.use_camera_wb = 1;
+ 		// (-M) Use any color matrix from the camera metadata. This option only affects Olympus, Leaf, and Phase One cameras.

--- a/ports/freeimage/rawlib-build-fix.patch
+++ b/ports/freeimage/rawlib-build-fix.patch
@@ -2,57 +2,18 @@ diff --git a/Source/FreeImage/PluginRAW.cpp b/Source/FreeImage/PluginRAW.cpp
 index c7f8758a..a57fd5f1 100644
 --- a/Source/FreeImage/PluginRAW.cpp
 +++ b/Source/FreeImage/PluginRAW.cpp
-@@ -63,17 +63,14 @@ public:
- 	}
+@@ -46,6 +46,10 @@ private:
+ 	long _eof;
+ 	INT64 _fsize;
  
-     int read(void *buffer, size_t size, size_t count) { 
--		if(substream) return substream->read(buffer, size, count);
- 		return _io->read_proc(buffer, (unsigned)size, (unsigned)count, _handle);
- 	}
- 
-     int seek(INT64 offset, int origin) { 
--        if(substream) return substream->seek(offset, origin);
- 		return _io->seek_proc(_handle, (long)offset, origin);
- 	}
- 
-     INT64 tell() { 
--		if(substream) return substream->tell();
-         return _io->tell_proc(_handle);
-     }
- 	
-@@ -83,13 +80,11 @@ public:
- 
-     int get_char() { 
- 		int c = 0;
--		if(substream) return substream->get_char();
- 		if(!_io->read_proc(&c, 1, 1, _handle)) return -1;
- 		return c;
-    }
- 	
- 	char* gets(char *buffer, int length) { 
--		if (substream) return substream->gets(buffer, length);
- 		memset(buffer, 0, length);
- 		for(int i = 0; i < length; i++) {
- 			if(!_io->read_proc(&buffer[i], 1, 1, _handle))
-@@ -103,8 +98,7 @@ public:
- 	int scanf_one(const char *fmt, void* val) {
- 		std::string buffer;
- 		char element = 0;
--		bool bDone = false;
--		if(substream) return substream->scanf_one(fmt,val);				
-+		bool bDone = false;			
- 		do {
- 			if(_io->read_proc(&element, 1, 1, _handle) == 1) {
- 				switch(element) {
-@@ -127,7 +121,6 @@ public:
- 	}
- 
- 	int eof() { 
--		if(substream) return substream->eof();
-         return (_io->tell_proc(_handle) >= _eof);
-     }
- 
-@@ -694,7 +687,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
++#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
++	LibRaw_abstract_datastream *substream = nullptr; // polyfill
++#endif
++
+ public:
+ 	LibRaw_freeimage_datastream(FreeImageIO *io, fi_handle handle) : _io(io), _handle(handle) {
+ 		long start_pos = io->tell_proc(handle);
+@@ -694,7 +698,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
  		// --------------------------------------------
  
  		// (-s [0..N-1]) Select one raw image from input file

--- a/ports/freeimage/rawlib-build-fix.patch
+++ b/ports/freeimage/rawlib-build-fix.patch
@@ -2,18 +2,30 @@ diff --git a/Source/FreeImage/PluginRAW.cpp b/Source/FreeImage/PluginRAW.cpp
 index c7f8758a..a57fd5f1 100644
 --- a/Source/FreeImage/PluginRAW.cpp
 +++ b/Source/FreeImage/PluginRAW.cpp
-@@ -46,6 +46,10 @@ private:
+@@ -46,6 +46,11 @@ private:
  	long _eof;
  	INT64 _fsize;
  
 +#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
++protected:
 +	LibRaw_abstract_datastream *substream = nullptr; // polyfill
 +#endif
 +
  public:
  	LibRaw_freeimage_datastream(FreeImageIO *io, fi_handle handle) : _io(io), _handle(handle) {
  		long start_pos = io->tell_proc(handle);
-@@ -694,7 +698,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
+@@ -56,6 +61,10 @@ public:
+ 	}
+ 
+ 	~LibRaw_freeimage_datastream() {
++#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
++		if (substream)
++			delete substream;
++#endif
+ 	}
+ 
+     int valid() { 
+@@ -694,7 +703,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
  		// --------------------------------------------
  
  		// (-s [0..N-1]) Select one raw image from input file

--- a/ports/freeimage/rawlib-build-fix.patch
+++ b/ports/freeimage/rawlib-build-fix.patch
@@ -2,34 +2,26 @@ diff --git a/Source/FreeImage/PluginRAW.cpp b/Source/FreeImage/PluginRAW.cpp
 index c7f8758a..a57fd5f1 100644
 --- a/Source/FreeImage/PluginRAW.cpp
 +++ b/Source/FreeImage/PluginRAW.cpp
-@@ -46,6 +46,11 @@ private:
+@@ -46,6 +46,14 @@ private:
  	long _eof;
  	INT64 _fsize;
  
-+#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
-+protected:
-+	LibRaw_abstract_datastream *substream = nullptr; // polyfill
++	// Minimal change to make version 3.18.0 of FreeImage compile with
++	// LibRaw 0.20 and later versions.
++	// Once the port of FreeImage has been updated to a version greater
++	// than 3.18.0, this patch should be removed as it will not be needed.
++#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 20)
++	LibRaw_abstract_datastream const *substream = nullptr;
 +#endif
 +
  public:
  	LibRaw_freeimage_datastream(FreeImageIO *io, fi_handle handle) : _io(io), _handle(handle) {
  		long start_pos = io->tell_proc(handle);
-@@ -56,6 +61,10 @@ public:
- 	}
- 
- 	~LibRaw_freeimage_datastream() {
-+#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
-+		if (substream)
-+			delete substream;
-+#endif
- 	}
- 
-     int valid() { 
-@@ -694,7 +703,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
+@@ -694,7 +702,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
  		// --------------------------------------------
  
  		// (-s [0..N-1]) Select one raw image from input file
-+#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
++#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 20)
 +		RawProcessor->imgdata.rawparams.shot_select = 0;
 +#else
  		RawProcessor->imgdata.params.shot_select = 0;

--- a/ports/freeimage/vcpkg.json
+++ b/ports/freeimage/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "freeimage",
   "version": "3.18.0",
-  "port-version": 24,
+  "port-version": 25,
   "description": "Support library for graphics image formats",
   "homepage": "https://sourceforge.net/projects/freeimage/",
   "license": "GPL-2.0-only OR GPL-3.0-only OR FreeImage",

--- a/ports/freeimage/vcpkg.json
+++ b/ports/freeimage/vcpkg.json
@@ -18,6 +18,10 @@
     "openexr",
     "openjpeg",
     "tiff",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
     "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2538,7 +2538,7 @@
     },
     "freeimage": {
       "baseline": "3.18.0",
-      "port-version": 24
+      "port-version": 25
     },
     "freeopcua": {
       "baseline": "20190125",

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "11a3fd352601befcb802ead59b120d0e00ac4ea1",
+      "git-tree": "8caa81875fa3bc889a4ab3d15d8ce6ca4e384d22",
       "version": "3.18.0",
       "port-version": 25
     },

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "be93b16bc021f1ea376ee6844fe95f09567ccae1",
+      "git-tree": "11a3fd352601befcb802ead59b120d0e00ac4ea1",
       "version": "3.18.0",
       "port-version": 25
     },

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cb6f9cfb5aa22c56a2e0cc45dc4f21d33e6f165d",
+      "git-tree": "cc93034ad63e18d6571baee948e3bf58fe822510",
       "version": "3.18.0",
       "port-version": 25
     },

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e396e22aa14864a00bf2684cc98503c5c245584a",
+      "version": "3.18.0",
+      "port-version": 25
+    },
+    {
       "git-tree": "b72eaa94f12facf42b2180bf49ff9121d9477eaa",
       "version": "3.18.0",
       "port-version": 24

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e396e22aa14864a00bf2684cc98503c5c245584a",
+      "git-tree": "be93b16bc021f1ea376ee6844fe95f09567ccae1",
       "version": "3.18.0",
       "port-version": 25
     },

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8caa81875fa3bc889a4ab3d15d8ce6ca4e384d22",
+      "git-tree": "cb6f9cfb5aa22c56a2e0cc45dc4f21d33e6f165d",
       "version": "3.18.0",
       "port-version": 25
     },


### PR DESCRIPTION
Updated the freeimage port to prepare it for libraw version 0.21 (which will be added in a separate PR,)

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
