### PR TITLE
[sdl2] Re-enable ibus in build

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         x11      SDL_X11
         wayland  SDL_WAYLAND
         samplerate SDL_LIBSAMPLERATE
+        ibus     SDL_IBUS
 )
 
 if ("x11" IN_LIST FEATURES)
@@ -26,6 +27,9 @@ if ("x11" IN_LIST FEATURES)
 endif()
 if ("wayland" IN_LIST FEATURES)
     message(WARNING "You will need to install Wayland dependencies to use feature wayland:\nsudo apt install libwayland-dev libxkbcommon-dev libegl1-mesa-dev\n")
+endif()
+if ("ibus" IN_LIST FEATURES)
+    message(WARNING "You will need to install ibus dependencies to use feature ibus:\nsudo apt install libibus-1.0-dev\n")
 endif()
 
 if(VCPKG_TARGET_IS_UWP)
@@ -41,7 +45,6 @@ vcpkg_cmake_configure(
         -DSDL_FORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
         -DSDL_LIBC=ON
         -DSDL_TEST=OFF
-        -DSDL_IBUS=OFF
         -DSDL_INSTALL_CMAKEDIR="cmake"
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
         -DSDL_LIBSAMPLERATE_SHARED=OFF

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.26.3",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",
@@ -25,12 +26,17 @@
           "name": "sdl2",
           "default-features": false,
           "features": [
+            "ibus",
             "wayland",
             "x11"
           ],
           "platform": "linux"
         }
       ]
+    },
+    "ibus": {
+      "description": "Build with ibus IME support",
+      "supports": "linux"
     },
     "samplerate": {
       "description": "Use libsamplerate for audio rate conversion",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7042,7 +7042,7 @@
     },
     "sdl2": {
       "baseline": "2.26.3",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fca6245cea40954b09d7091b4a0ab02b16b3907c",
+      "version": "2.26.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "693dd875c592f310f23cf34ee7fbfb7e1be0dff8",
       "version": "2.26.3",
       "port-version": 0


### PR DESCRIPTION
This was disabled in #14275 because it caused the relevant libraries (ibus, glib, ...) to be depended on transitively.

Nowadays, SDL2 loads these completely at runtime, only needing the headers and such at compile time. It should be safe to re-enable this again.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.