### PR TITLE
[harfbuzz] update to 7.0.0

### DIFF
--- a/ports/harfbuzz/fix-linux-error.patch
+++ b/ports/harfbuzz/fix-linux-error.patch
@@ -1,0 +1,12 @@
+diff --git a/util/hb-info.cc b/util/hb-info.cc
+index b3a8b35..e386124 100644
+--- a/util/hb-info.cc
++++ b/util/hb-info.cc
+@@ -847,6 +847,7 @@ struct info_t :
+       {
+ 	hb_codepoint_t gid = 0;
+ 	bool b = hb_font_get_variation_glyph (font, u, vs, &gid);
++	(void)b;
+ 	assert (b);
+ 
+ 	char glyphname[64];

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -1,10 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
-    REF "${VERSION}"
-    SHA512 7a96b5ffc1c15c919275dad9456575fe12dfa54883fecad5fd42c0e3c64360178425f70d2fbe3c44f39a61361320b4a6ec8af7c4f8378ad788d460a609f3e224
+    REF ${VERSION}
+    SHA512 d7382cda95ac215fafe52d6fc0361affe3d9569a0faa178a553547a5baa168a42550a5918a0bbe30630559200c155839078ae26e7fca8bf32fa45c90ed79248f
     HEAD_REF master
     PATCHES
+        fix-linux-error.patch
 )
 
 if("icu" IN_LIST FEATURES)
@@ -97,7 +98,7 @@ configure_file("${CMAKE_CURRENT_LIST_DIR}/harfbuzzConfig.cmake.in"
 
 vcpkg_list(SET TOOL_NAMES)
 if("glib" IN_LIST FEATURES)
-    vcpkg_list(APPEND TOOL_NAMES hb-subset hb-shape hb-ot-shape-closure)
+    vcpkg_list(APPEND TOOL_NAMES hb-subset hb-shape hb-ot-shape-closure hb-info)
 endif()
 if(TOOL_NAMES)
     vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)
@@ -107,4 +108,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "6.0.0",
-  "port-version": 1,
+  "version": "7.0.0",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2993,8 +2993,8 @@
       "port-version": 0
     },
     "harfbuzz": {
-      "baseline": "6.0.0",
-      "port-version": 1
+      "baseline": "7.0.0",
+      "port-version": 0
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74d44792360393e3c1fee924def05c9d21a5fe3d",
+      "version": "7.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4ffde6e2f07e83bb2aff1abf962b8b21dffbdf83",
       "version": "6.0.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
