### PR TITLE
[qhull] Fix function export declaration

### DIFF
--- a/ports/qhull/portfile.cmake
+++ b/ports/qhull/portfile.cmake
@@ -60,6 +60,10 @@ if(NOT DEFINED VCPKG_BUILD_TYPE)
 endif()
 vcpkg_fixup_pkgconfig()
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libqhull/libqhull.h" "#elif defined(qh_dllimport)" "#elif 1")
+endif()
+
 if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES
         qconvex

--- a/ports/qhull/vcpkg.json
+++ b/ports/qhull/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qhull",
   "version": "8.0.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": "computes the convex hull, Delaunay triangulation, Voronoi diagram",
   "homepage": "https://github.com/qhull/qhull",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6250,7 +6250,7 @@
     },
     "qhull": {
       "baseline": "8.0.2",
-      "port-version": 4
+      "port-version": 5
     },
     "qnnpack": {
       "baseline": "2021-02-26",

--- a/versions/q-/qhull.json
+++ b/versions/q-/qhull.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "713432f98a53e6867f67c48107e1441d4ea0403d",
+      "version": "8.0.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "1cfdbe28c32936c2ac6c9fb8d269f81c2a96415f",
       "version": "8.0.2",
       "port-version": 4


### PR DESCRIPTION
The functions are exported by `.def` files in qhull but the usage is not fixed when building dynamic on Windows.

Fix #29613.