### PR TITLE
[seacas] Fix header file 'cctype' declaration

### DIFF
--- a/ports/seacas/fix-headers.patch
+++ b/ports/seacas/fix-headers.patch
@@ -1,0 +1,13 @@
+diff --git a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshFuncs.h b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshFuncs.h
+index 67512ba..589cac2 100644
+--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshFuncs.h
++++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshFuncs.h
+@@ -6,7 +6,7 @@
+ 
+ // #######################  Start Clang Header Tool Managed Headers ########################
+ // clang-format off
+-#include <ctype.h>                                   // for toupper
++#include <cctype>                                    // for toupper, isspace, isdigit
+ #include <stddef.h>                                  // for size_t
+ #include <algorithm>                                 // for remove, etc
+ #include <iterator>                                  // for insert_iterator

--- a/ports/seacas/portfile.cmake
+++ b/ports/seacas/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
             fix-ioss-includes.patch
             deps-and-shared.patch
             fix-mpi.patch
+            fix-headers.patch
 )
 
 if(NOT VCPKG_TARGET_IS_OSX)
@@ -86,8 +87,6 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/Seacas")
     # Case sensitive filesystems will have two Seacas folders
     vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/Seacas" PACKAGE_NAME cmake/Seacas DO_NOT_DELETE_PARENT_CONFIG_PATH NO_PREFIX_CORRECTION)
 endif()
-
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/Iotm_TextMeshFuncs.h" "#include <ctype.h>" "#include <cctype> // for toupper, isspace, isdigit")
 
 set(tool_names  cgns_decomp cth_pressure_map
                 io_info io_modify io_shell

--- a/ports/seacas/portfile.cmake
+++ b/ports/seacas/portfile.cmake
@@ -87,6 +87,8 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/Seacas")
     vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/Seacas" PACKAGE_NAME cmake/Seacas DO_NOT_DELETE_PARENT_CONFIG_PATH NO_PREFIX_CORRECTION)
 endif()
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/Iotm_TextMeshFuncs.h" "#include <ctype.h>" "#include <cctype> // for toupper, isspace, isdigit")
+
 set(tool_names  cgns_decomp cth_pressure_map
                 io_info io_modify io_shell
                 shell_to_hex skinner sphgen struc_to_unstruc)

--- a/ports/seacas/vcpkg.json
+++ b/ports/seacas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "seacas",
   "version-date": "2022-11-22",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Sandia Engineering Analysis Code Access System (SEACAS) is a suite of preprocessing, postprocessing, translation, and utility applications supporting finite element analysis software using the Exodus database file format.",
   "homepage": "https://github.com/sandialabs/seacas",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7022,7 +7022,7 @@
     },
     "seacas": {
       "baseline": "2022-11-22",
-      "port-version": 1
+      "port-version": 2
     },
     "seal": {
       "baseline": "4.1.1",

--- a/versions/s-/seacas.json
+++ b/versions/s-/seacas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3cc41bb99dee24138a40b08a8ce8793092e2630a",
+      "version-date": "2022-11-22",
+      "port-version": 2
+    },
+    {
       "git-tree": "bafa7bc405fca4be4118663c533a48d7fb2725ec",
       "version-date": "2022-11-22",
       "port-version": 1

--- a/versions/s-/seacas.json
+++ b/versions/s-/seacas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3cc41bb99dee24138a40b08a8ce8793092e2630a",
+      "git-tree": "00566c22630c8b3dff31a47c3be03389e4d33b3d",
       "version-date": "2022-11-22",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes #29456. Use &#60;cctype&#62; instead of &#60;ctype.h&#62; to solve the following error:
```
e:\code\vcpkg\buildtrees\seacas\src\76a825bc51-907a76ce33.clean\packages\seacas\libraries\ioss\src\text_mesh\Iotm_TextMeshFuncs.h(66): error C2039: 'isspace': is not a member of 'std'
D:\Program Files\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\numeric(14): note: see declaration of 'std'
e:\code\vcpkg\buildtrees\seacas\src\76a825bc51-907a76ce33.clean\packages\seacas\libraries\ioss\src\text_mesh\Iotm_TextMeshFuncs.h(68): error C2039: 'isspace': is not a member of 'std'
D:\Program Files\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\numeric(14): note: see declaration of 'std'
e:\code\vcpkg\buildtrees\seacas\src\76a825bc51-907a76ce33.clean\packages\seacas\libraries\ioss\src\text_mesh\Iotm_TextMeshFuncs.h(106): error C2039: 'isdigit': is not a member of 'std'
D:\Program Files\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\numeric(14): note: see declaration of 'std'
```

All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.