### PR TITLE
[libtorrent] fix build error on windows arm64 target

### DIFF
--- a/ports/libtorrent/0001-fix-build-error-on-Windows-ARM64-by-add-new-define.patch
+++ b/ports/libtorrent/0001-fix-build-error-on-Windows-ARM64-by-add-new-define.patch
@@ -1,0 +1,45 @@
+From 24b9c178ed316b39236e62dd655c85f3405e147a Mon Sep 17 00:00:00 2001
+From: David Liu <wbsdty331@outlook.com>
+Date: Mon, 13 Feb 2023 18:03:58 +0800
+Subject: [PATCH] fix build error on Windows ARM64 by add new define
+
+fix build error on Windows ARM64 by add new define
+---
+ src/assert.cpp | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/src/assert.cpp b/src/assert.cpp
+index d623605b5..482345451 100644
+--- a/src/assert.cpp
++++ b/src/assert.cpp
+@@ -190,16 +190,21 @@ TORRENT_EXPORT void print_backtrace(char* out, int len, int max_depth
+ 	std::array<void*, 50> stack;
+ 
+ 	STACKFRAME64 stack_frame = {};
+-#if defined(_WIN64)
+-	int const machine_type = IMAGE_FILE_MACHINE_AMD64;
+-	stack_frame.AddrPC.Offset = context_record.Rip;
+-	stack_frame.AddrFrame.Offset = context_record.Rbp;
+-	stack_frame.AddrStack.Offset = context_record.Rsp;
+-#else
++#if defined(_M_IX86)
+ 	int const machine_type = IMAGE_FILE_MACHINE_I386;
+ 	stack_frame.AddrPC.Offset = context_record.Eip;
+ 	stack_frame.AddrFrame.Offset = context_record.Ebp;
+ 	stack_frame.AddrStack.Offset = context_record.Esp;
++#elif defined(_M_X64)
++	int const machine_type = IMAGE_FILE_MACHINE_AMD64;
++	stack_frame.AddrPC.Offset = context_record.Rip;
++	stack_frame.AddrFrame.Offset = context_record.Rbp;
++	stack_frame.AddrStack.Offset = context_record.Rsp;
++#elif defined(_M_ARM64)
++	int const machine_type = IMAGE_FILE_MACHINE_ARM64;
++	stack_frame.AddrPC.Offset = context_record.Pc;
++	stack_frame.AddrFrame.Offset = context_record.Fp;
++	stack_frame.AddrStack.Offset = context_record.Sp;
+ #endif
+ 	stack_frame.AddrPC.Mode = AddrModeFlat;
+ 	stack_frame.AddrFrame.Mode = AddrModeFlat;
+-- 
+2.39.1.windows.1
+

--- a/ports/libtorrent/portfile.cmake
+++ b/ports/libtorrent/portfile.cmake
@@ -33,6 +33,8 @@ vcpkg_from_github(
         REF 64817e0e8793d0875fc10245de52ffb2540a223d # v2.0.8
         SHA512 607172e6a806d78bb34443101bd384ac7a42e0edc3e7c4a2cf5c3ab5f2be64f84557726dce16c2fbaaa2ba254529a8871b3123b0e79fe87cd5bf26021ecb59da
         HEAD_REF RC_2_0
+        PATCHES
+            0001-fix-build-error-on-Windows-ARM64-by-add-new-define.patch
 )
 
 vcpkg_from_github(

--- a/ports/libtorrent/vcpkg.json
+++ b/ports/libtorrent/vcpkg.json
@@ -6,7 +6,7 @@
   "homepage": "https://libtorrent.org",
   "documentation": "https://libtorrent.org/reference.html",
   "license": "BSD-2-Clause",
-  "supports": "!uwp & !(windows & arm)",
+  "supports": "!uwp",
   "dependencies": [
     "boost-asio",
     "boost-chrono",

--- a/versions/l-/libtorrent.json
+++ b/versions/l-/libtorrent.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a46af2f37d80871bd43e4fcaea0b0a8ac72fe369",
+      "git-tree": "884acf58813237198df4d1265661ad93b6b57955",
       "version": "2.0.8",
       "port-version": 0
     },

--- a/versions/l-/libtorrent.json
+++ b/versions/l-/libtorrent.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d333acbdb5428b1468d2a83036b08b72543639be",
+      "git-tree": "a46af2f37d80871bd43e4fcaea0b0a8ac72fe369",
       "version": "2.0.8",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
fixes: #17320 
libtorrent only focus AMD64 and i386 platform, when build for arm64 it will throw error. This pr fix it.

reference:  https://github.com/arvidn/libtorrent/issues/7313

If upstream merge my pr and release new version, I will delete this path from vcpkg repoistry.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

