### PR TITLE
[mujs] Missing fixes

### DIFF
--- a/ports/mujs/CMakeLists.txt
+++ b/ports/mujs/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.9)
-project(mujs VERSION 1.3.2)
+cmake_minimum_required(VERSION 3.25)
+project(mujs C)
 
 if(MSVC)
   add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
@@ -7,42 +7,38 @@ endif()
 
 file(GLOB mujs_sources js*.c utf*.c regexp.c)
 
-include_directories(.)
-
 add_library(mujs ${mujs_sources})
 
-target_include_directories(mujs PUBLIC "$<INSTALL_INTERFACE:include>")
-
-# Add CMake find_package() integration
-set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
-set(TARGETS_EXPORT_NAME "unofficial-${PROJECT_NAME}Targets")
-set(NAMESPACE "unofficial::mujs::")
+target_include_directories(mujs
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+    "$<INSTALL_INTERFACE:include>"
+)
 
 install(
   TARGETS mujs
-  EXPORT ${TARGETS_EXPORT_NAME}
+  EXPORT unofficial-mujs-targets
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
-
-export(TARGETS mujs NAMESPACE ${NAMESPACE} FILE mujsTargets.cmake)
+install(
+  EXPORT unofficial-mujs-targets
+  FILE unofficial-mujs-config.cmake
+  NAMESPACE unofficial::mujs::
+  DESTINATION "share/unofficial-mujs"
+)
 
 include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    mujsConfigVersion.cmake
+write_basic_package_version_file(unofficial-mujs-config-version.cmake
     VERSION ${PACKAGE_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/unofficial-mujs-config-version.cmake"
+  DESTINATION "share/unofficial-mujs"
+)
 
-configure_package_config_file("mujsConfig.cmake.in" "${PROJECT_CONFIG}" INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}")
-install(FILES "${PROJECT_CONFIG}" DESTINATION "${CONFIG_INSTALL_DIR}")
-
-install(EXPORT ${TARGETS_EXPORT_NAME}
-        NAMESPACE ${NAMESPACE}
-        DESTINATION "${CONFIG_INSTALL_DIR}")
-        
 if(NOT DISABLE_INSTALL_HEADERS)
   install(FILES mujs.h DESTINATION include)
 endif()

--- a/ports/mujs/CMakeLists.txt
+++ b/ports/mujs/CMakeLists.txt
@@ -1,8 +1,17 @@
 cmake_minimum_required(VERSION 3.25)
 project(mujs C)
 
+set(LINK_LIBRARIES "")
+set(PC_LIBS_PRIVATE "")
+
 if(MSVC)
   add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
+else()
+  find_library(HAVE_LIBM NAMES m)
+  if(HAVE_LIBM)
+    list(APPEND LINK_LIBRARIES m)
+    string(APPEND PC_LIBS_PRIVATE " -lm")
+  endif()
 endif()
 
 file(GLOB mujs_sources js*.c utf*.c regexp.c)
@@ -14,6 +23,8 @@ target_include_directories(mujs
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
     "$<INSTALL_INTERFACE:include>"
 )
+
+target_link_libraries(mujs PRIVATE ${LINK_LIBRARIES})
 
 install(
   TARGETS mujs

--- a/ports/mujs/CMakeLists.txt
+++ b/ports/mujs/CMakeLists.txt
@@ -39,6 +39,12 @@ install(
   DESTINATION "share/unofficial-mujs"
 )
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mujs.pc" "${CMAKE_CURRENT_BINARY_DIR}/mujs.pc" @ONLY)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/mujs.pc"
+  DESTINATION "lib/pkgconfig"
+)
+
 if(NOT DISABLE_INSTALL_HEADERS)
   install(FILES mujs.h DESTINATION include)
 endif()

--- a/ports/mujs/mujs.pc
+++ b/ports/mujs/mujs.pc
@@ -1,0 +1,11 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: mujs
+Description: MuJS embeddable Javascript interpreter
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmujs
+Libs.private: -lm

--- a/ports/mujs/mujs.pc
+++ b/ports/mujs/mujs.pc
@@ -8,4 +8,4 @@ Description: MuJS embeddable Javascript interpreter
 Version: @PACKAGE_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lmujs
-Libs.private: -lm
+Libs.private: @PC_LIBS_PRIVATE@

--- a/ports/mujs/mujsConfig.cmake.in
+++ b/ports/mujs/mujsConfig.cmake.in
@@ -1,8 +1,0 @@
-@PACKAGE_INIT@
-
-include(CMakeFindDependencyMacro)
-
-# Any extra setup
-
-# Add the targets file
-include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")

--- a/ports/mujs/portfile.cmake
+++ b/ports/mujs/portfile.cmake
@@ -1,4 +1,6 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if(VCPKG_TARGET_IS_WINDOWS)
+  vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/mujs/portfile.cmake
+++ b/ports/mujs/portfile.cmake
@@ -26,4 +26,5 @@ vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-mujs)
 vcpkg_copy_pdbs()
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/mujs/portfile.cmake
+++ b/ports/mujs/portfile.cmake
@@ -9,18 +9,18 @@ vcpkg_from_github(
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/mujsConfig.cmake.in" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    "-DPACKAGE_VERSION=${VERSION}"
   OPTIONS_DEBUG
     -DDISABLE_INSTALL_HEADERS=ON
-    -DDISABLE_INSTALL_TOOLS=ON
 )
 
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(PACKAGE_NAME mujs CONFIG_PATH lib/cmake/mujs)
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-mujs)
 vcpkg_copy_pdbs()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/mujs/portfile.cmake
+++ b/ports/mujs/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/mujs.pc" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/mujs/usage
+++ b/ports/mujs/usage
@@ -1,0 +1,6 @@
+mujs can be imported via CMake FindPkgConfig module:
+
+    find_package(PkgConfig)
+    pkg_check_modules(MUJS REQUIRED IMPORTED_TARGET mujs)
+
+    target_link_libraries(main PRIVATE PkgConfig::MUJS)

--- a/ports/mujs/vcpkg.json
+++ b/ports/mujs/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mujs",
   "version": "1.3.2",
+  "port-version": 1,
   "description": "An embeddable Javascript interpreter in C",
   "homepage": "https://github.com/ccxvii/mujs",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5230,7 +5230,7 @@
     },
     "mujs": {
       "baseline": "1.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "munit": {
       "baseline": "2019-04-06",

--- a/versions/m-/mujs.json
+++ b/versions/m-/mujs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3a32c06c1b96616c36a255e3a0883b406281be3a",
+      "version": "1.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "9c67a4a21c48b6ad43918a526e539cf90d822e1a",
       "version": "1.3.2",
       "port-version": 0


### PR DESCRIPTION
Follow-up from #29543:

- Fix name of unofficial cmake config.
- Fix version information of cmake config.
- Add and document official usage: `mujs.pc` (as in upstream makefile)
- Link libm when available  (as in upstream makefile)
- Enable shared linkage for non-windows  (as in upstream makefile)
- Cleanup

Extras remarks (not adressed):
- The unofficial cmake config is fairly obsolete with the official pc file.
- The official downloads are at https://mujs.com/downloads/ 
  There is also a GH organization matching the company's name, but it seems less popular:
  https://github.com/ArtifexSoftware/mujs
- The licensing might be more complex:
  https://tracker.debian.org/media/packages/m/mujs/copyright-1.3.2-1

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.