### PR TITLE
[fluidsynth] Update patch and portfile

### DIFF
--- a/ports/fluidsynth/add-usage-requirements.patch
+++ b/ports/fluidsynth/add-usage-requirements.patch
@@ -1,17 +1,22 @@
 diff --git a/FluidSynthConfig.cmake.in b/FluidSynthConfig.cmake.in
-index 1ffdf598..44b1768e 100644
+index 1ffdf598..0be65e0e 100644
 --- a/FluidSynthConfig.cmake.in
 +++ b/FluidSynthConfig.cmake.in
-@@ -7,4 +7,12 @@
+@@ -6,5 +6,17 @@
+ # define variables for configuration options:
  # set(network-enabled @enable-network@)
  
- # finally, include the targets file
 +include(CMakeFindDependencyMacro)
-+find_dependency(OpenMP COMPONENTS C REQUIRED)
-+find_dependency(PkgConfig REQUIRED)
-+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0 gthread-2.0)
-+set(enable-libsndfile @enable-libsndfile@)
-+if(enable-libsndfile)
-+  pkg_check_modules(LIBSNDFILE REQUIRED IMPORTED_TARGET sndfile)
++find_dependency(OpenMP COMPONENTS C)
++find_dependency(PkgConfig)
++pkg_check_modules(GLIB IMPORTED_TARGET glib-2.0>=2.6.5 gthread-2.0>=2.6.5)
++set(ALSA_SUPPORT @ALSA_SUPPORT@)
++if(ALSA_SUPPORT)
++  pkg_check_modules(ALSA IMPORTED_TARGET alsa>=0.9.1)
 +endif()
++set(LIBSNDFILE_SUPPORT @LIBSNDFILE_SUPPORT@)
++if(LIBSNDFILE_SUPPORT)
++  pkg_check_modules(LIBSNDFILE IMPORTED_TARGET sndfile>=1.0.0)
++endif()
+ # finally, include the targets file
  include("${CMAKE_CURRENT_LIST_DIR}/FluidSynthTargets.cmake")

--- a/ports/fluidsynth/add-usage-requirements.patch
+++ b/ports/fluidsynth/add-usage-requirements.patch
@@ -1,0 +1,17 @@
+diff --git a/FluidSynthConfig.cmake.in b/FluidSynthConfig.cmake.in
+index 1ffdf598..44b1768e 100644
+--- a/FluidSynthConfig.cmake.in
++++ b/FluidSynthConfig.cmake.in
+@@ -7,4 +7,12 @@
+ # set(network-enabled @enable-network@)
+ 
+ # finally, include the targets file
++include(CMakeFindDependencyMacro)
++find_dependency(OpenMP COMPONENTS C REQUIRED)
++find_dependency(PkgConfig REQUIRED)
++pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0 gthread-2.0)
++set(enable-libsndfile @enable-libsndfile@)
++if(enable-libsndfile)
++  pkg_check_modules(LIBSNDFILE REQUIRED IMPORTED_TARGET sndfile)
++endif()
+ include("${CMAKE_CURRENT_LIST_DIR}/FluidSynthTargets.cmake")

--- a/ports/fluidsynth/gentables.patch
+++ b/ports/fluidsynth/gentables.patch
@@ -1,19 +1,18 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index e86a6429..55e702b3 100644
+index e86a6429..9240e091 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -538,6 +538,10 @@ install(EXPORT FluidSynthTargets
+@@ -538,6 +538,9 @@ install(EXPORT FluidSynthTargets
  
  # ******* Auto Generated Lookup Tables ******
  
-+option(VCPKG_BUILD_MAKE_TABLES "Build `make_tables`" OFF)
 +if(VCPKG_BUILD_MAKE_TABLES)
 +    add_subdirectory(gentables)
 +elseif(0)
  include(ExternalProject)
  
  set (GENTAB_SDIR ${CMAKE_CURRENT_SOURCE_DIR}/gentables)
-@@ -557,4 +561,11 @@ ExternalProject_Add(gentables
+@@ -557,4 +560,11 @@ ExternalProject_Add(gentables
          "${CMAKE_COMMAND}" --build "${GENTAB_BDIR}"
      INSTALL_COMMAND ${GENTAB_BDIR}/make_tables.exe "${FluidSynth_BINARY_DIR}/"
  )

--- a/ports/fluidsynth/gentables.patch
+++ b/ports/fluidsynth/gentables.patch
@@ -1,24 +1,22 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index e86a642..426d9e8 100644
+index e86a6429..55e702b3 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -520,6 +520,11 @@ else ( MACOSX_FRAMEWORK )
-    install ( FILES ${public_main_HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
- endif ( MACOSX_FRAMEWORK )
+@@ -538,6 +538,10 @@ install(EXPORT FluidSynthTargets
+ 
+ # ******* Auto Generated Lookup Tables ******
  
 +option(VCPKG_BUILD_MAKE_TABLES "Build `make_tables`" OFF)
 +if(VCPKG_BUILD_MAKE_TABLES)
 +    add_subdirectory(gentables)
 +elseif(0)
-+
- # Exported targets.
+ include(ExternalProject)
  
- # build_interface: for the libfluidsynth target when imported from the build directory.
-@@ -557,4 +562,13 @@ ExternalProject_Add(gentables
+ set (GENTAB_SDIR ${CMAKE_CURRENT_SOURCE_DIR}/gentables)
+@@ -557,4 +561,11 @@ ExternalProject_Add(gentables
          "${CMAKE_COMMAND}" --build "${GENTAB_BDIR}"
      INSTALL_COMMAND ${GENTAB_BDIR}/make_tables.exe "${FluidSynth_BINARY_DIR}/"
  )
-+
 +endif()
 +if(TARGET make_tables AND NOT CMAKE_CROSSCOMPILING)
 +    set(GENTABLES make_tables)
@@ -26,34 +24,29 @@ index e86a642..426d9e8 100644
 +    find_program(GENTABLES make_tables REQUIRED)
 +endif()
 +add_custom_target(gentables COMMAND "${GENTABLES}" "${CMAKE_BINARY_DIR}/")
-+
  add_dependencies(libfluidsynth-OBJ gentables)
 diff --git a/src/gentables/CMakeLists.txt b/src/gentables/CMakeLists.txt
-index 9cb69f2..b88d1d6 100644
+index 9cb69f2b..c393a670 100644
 --- a/src/gentables/CMakeLists.txt
 +++ b/src/gentables/CMakeLists.txt
-@@ -12,6 +12,8 @@ unset(ENV{LDFLAGS})
+@@ -12,6 +12,7 @@ unset(ENV{LDFLAGS})
  
  project (gentables C)
  
 +if (0)
-+
  set ( CMAKE_BUILD_TYPE Debug )
  
  # hardcode ".exe" as suffix to the binary, else in case of cross-platform cross-compiling the calling cmake will not know the suffix used here and fail to find the binary
-@@ -21,6 +23,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+@@ -20,6 +21,7 @@ set ( CMAKE_EXECUTABLE_SUFFIX ".exe" )
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR})
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
- 
 +endif()
-+
+ 
  # Add the executable that generates the table
  add_executable( make_tables
-                 make_tables.c
-@@ -34,3 +38,5 @@ if ( WIN32 )
+@@ -34,3 +36,4 @@ if ( WIN32 )
  else ( WIN32 )
      target_link_libraries (make_tables "m")
  endif ()
-+
 +install(TARGETS make_tables DESTINATION bin)
-

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -45,8 +45,6 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}
         -Denable-framework=OFF # Needs system permission to install framework
-    OPTIONS_DEBUG
-        -Denable-debug:BOOL=ON
     MAYBE_UNUSED_VARIABLES
         enable-coreaudio
         enable-coremidi
@@ -56,7 +54,6 @@ vcpkg_cmake_configure(
         COREMIDI_FOUND
         VCPKG_BUILD_MAKE_TABLES
         enable-framework
-        enable-debug
 )
 
 vcpkg_cmake_install()
@@ -71,13 +68,11 @@ if("buildtools" IN_LIST FEATURES)
 endif()
 vcpkg_copy_tools(TOOL_NAMES ${tools} AUTO_CLEAN)
 
-# Remove unnecessary files
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_copy_pdbs()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/man")
 
-# Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         gentables.patch
+        add-usage-requirements.patch
 )
 
 vcpkg_check_features(

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -76,3 +76,5 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/man")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/fluidsynth/usage
+++ b/ports/fluidsynth/usage
@@ -1,0 +1,5 @@
+The package fluidsynth provides CMake targets:
+
+    find_package(FluidSynth CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE FluidSynth::libfluidsynth)
+    add_custom_command(OUTPUT result COMMAND FluidSynth::fluidsynth ARGS ...)

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fluidsynth",
   "version": "2.3.1",
+  "port-version": 1,
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2466,7 +2466,7 @@
     },
     "fluidsynth": {
       "baseline": "2.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "fmem": {
       "baseline": "c-libs-2ccee3d2fb",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b4f1be942d49eb01944dbf796c5e716110a5a621",
+      "git-tree": "043d4b08b2074547703811f24acebf4e09689701",
       "version": "2.3.1",
       "port-version": 1
     },

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a29a2b7479a3b62c23a9ca0de3b05ec2b07fb0a2",
+      "git-tree": "d165bef87ad633962767f10a3036a2e69f38b7e3",
       "version": "2.3.1",
       "port-version": 1
     },

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "043d4b08b2074547703811f24acebf4e09689701",
+      "git-tree": "a29a2b7479a3b62c23a9ca0de3b05ec2b07fb0a2",
       "version": "2.3.1",
       "port-version": 1
     },

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4f1be942d49eb01944dbf796c5e716110a5a621",
+      "version": "2.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "bb16308067c170bdc65b1a9e1a0db2fc124f2c6b",
       "version": "2.3.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

The updated `gentables.patch` from #29038 accidentally disables the installation of `FluidSynthTargets.cmake`.

Additionally, this PR cleans up a few things in the portfile:
- Install a usage file
- Remove the manual cleanup of `bin` directories since `vcpkg_copy_tools(AUTO_CLEAN)` already handles it
- Copy pdbs
- Remove the installed manpages
- Remove the `enable-debug` option since it no longer exists upstream

Tested with default features on:
- Windows (x64-windows, x86-windows, x64-windows-static)
- macOS (arm64-osx, arm64-osx-dynamic)
- Linux (x64-linux)

Tested with all features on:
- Windows (x64-windows, x86-windows)
- macOS (arm64-osx)