### PR TITLE
[liblsl] Update to 1.16.1

### DIFF
--- a/ports/liblsl/portfile.cmake
+++ b/ports/liblsl/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sccn/liblsl
-    REF v1.16.0 # NOTE: when updating version, also change it in the parameter to vcpkg_cmake_configure
-    SHA512 bfd54c6cca944ed33622da74dc1417ab75b542002c02c83bb86c917fd5968936c4b56ec734bd6d757e9fa67364f9dc85fd15ed28697ed410305df4928cf6790b
+    REF v${VERSION}
+    SHA512 d3af9be687c11272f0122585c8ba48c5d7482af6e6f0cecf640e674682da319246b490b536a890407c7511fcc07a59749ed43134bf7683d30304ac4e3989a73c
     HEAD_REF master
     PATCHES
         use-find-package-asio.patch
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
         -DLSL_BUILD_STATIC=${LSL_BUILD_STATIC}
         -DLSL_BUNDLED_BOOST=OFF # we use the boost vcpkg packages instead
         -DLSL_BUNDLED_PUGIXML=OFF # we use the pugixml vcpkg package instead
-        -Dlslgitrevision=v1.16.0
+        -Dlslgitrevision=v${VERSION}
         -Dlslgitbranch=master
 )
 

--- a/ports/liblsl/vcpkg.json
+++ b/ports/liblsl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblsl",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "C++ lsl library for multi-modal time-synched data transmission over the local network",
   "homepage": "https://github.com/sccn/liblsl",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4073,7 +4073,7 @@
       "port-version": 0
     },
     "liblsl": {
-      "baseline": "1.16.0",
+      "baseline": "1.16.1",
       "port-version": 0
     },
     "liblsquic": {

--- a/versions/l-/liblsl.json
+++ b/versions/l-/liblsl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0992324287a25dd60723ae90e8ff2e53d357cb6",
+      "version": "1.16.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "282fee909d2df5c818b0577a4c063c146376cef5",
       "version": "1.16.0",
       "port-version": 0


### PR DESCRIPTION
Updates liblsl to 1.16.1

* [x]  Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
* [x]  SHA512s are updated for each updated download
* [x]  The "supports" clause reflects platforms that may be fixed by this new version
* [x]  Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
* [x]  Any patches that are no longer applied are deleted from the port's directory.
* [x]  The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
* [x]  Only one version is added to each modified port's versions file.