### PR TITLE
[opusfile] Fix CMake config on case-sensitive filesystem

### DIFF
--- a/ports/opusfile/portfile.cmake
+++ b/ports/opusfile/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
 
 file(WRITE "${SOURCE_PATH}/package_version" "PACKAGE_VERSION=${VERSION}")
 
+vcpkg_replace_string("${SOURCE_PATH}/cmake/OpusFileConfig.cmake.in" "opusfileTargets.cmake" "OpusFileTargets.cmake")
+
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     INVERTED_FEATURES

--- a/ports/opusfile/vcpkg.json
+++ b/ports/opusfile/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opusfile",
   "version": "0.12+20221121",
+  "port-version": 1,
   "description": "Stand-alone decoder library for .opus streams",
   "homepage": "https://github.com/xiph/opusfile",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5802,7 +5802,7 @@
     },
     "opusfile": {
       "baseline": "0.12+20221121",
-      "port-version": 0
+      "port-version": 1
     },
     "orc": {
       "baseline": "1.7.6",

--- a/versions/o-/opusfile.json
+++ b/versions/o-/opusfile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b39a2d4ff309c4e2bedf74adeb1cd18f7ab16c9",
+      "version": "0.12+20221121",
+      "port-version": 1
+    },
+    {
       "git-tree": "7694ad3ef2bc0532b9c18a69dc120f2382cf06b2",
       "version": "0.12+20221121",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

On case-sensitive filesystems, OpusFileConfig.cmake fails to include the exported targets due to mismatched capitalisation (`OpusFileTargets.cmake` exported in the CMakeLists, `opusfileTargets.cmake` in the OpusFileConfig).
