### PR TITLE
[wxWidgets] Update to v3.2.2.1

### DIFF
--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
-    REF v3.2.2.1
+    REF "v{VERSION}"
     SHA512 8ff645fe7ee97bf6358b3619efd737ef8f9eb0235ca481e921a64d451c45eb9671ee4e2807fea285153bc0bb434266234f6f4ab15f396bb8290f262fa879e9b3 
     HEAD_REF master
     PATCHES

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
-    REF 97e99707c5d2271a70cb686720b48dbf34ced496 # v3.2.1
-    SHA512 b47d3f4560f0ba24e95ce4fba0a807cc47807df57d54b70e22a34a5a15fc1e35ccedf1938203046c8950db9115ed09cb66fa1ca30b2e5f1b4c0d529a812497c4 
+    REF v3.2.2.1
+    SHA512 8ff645fe7ee97bf6358b3619efd737ef8f9eb0235ca481e921a64d451c45eb9671ee4e2807fea285153bc0bb434266234f6f4ab15f396bb8290f262fa879e9b3 
     HEAD_REF master
     PATCHES
         install-layout.patch

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
-    REF "v{VERSION}"
+    REF "v${VERSION}"
     SHA512 8ff645fe7ee97bf6358b3619efd737ef8f9eb0235ca481e921a64d451c45eb9671ee4e2807fea285153bc0bb434266234f6f4ab15f396bb8290f262fa879e9b3 
     HEAD_REF master
     PATCHES

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wxwidgets",
-  "version": "3.2.1",
-  "port-version": 4,
+  "version": "3.2.2.1",
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8325,8 +8325,8 @@
       "port-version": 0
     },
     "wxwidgets": {
-      "baseline": "3.2.1",
-      "port-version": 4
+      "baseline": "3.2.2.1",
+      "port-version": 0
     },
     "wyhash": {
       "baseline": "2023-01-25",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fdb7ffc63f835bc110c24d18aaf8389d78befcff",
+      "git-tree": "58e5426e4b893d57ccee94cc545893c03c7d21cf",
       "version": "3.2.2.1",
       "port-version": 0
     },

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fdb7ffc63f835bc110c24d18aaf8389d78befcff",
+      "version": "3.2.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "12b6474f28b37b6ebb29b391fb6ebffd7fc70450",
       "version": "3.2.1",
       "port-version": 4

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "58e5426e4b893d57ccee94cc545893c03c7d21cf",
+      "git-tree": "3c0bf69a4eb558abcf43df76b79a84038000190d",
       "version": "3.2.2.1",
       "port-version": 0
     },


### PR DESCRIPTION
Update wxWidgets from v3.2.1 to v3.2.2.1

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.