### PR TITLE
[vcpkg baseline][monkeys-audio] Fixing error C2471 and error C1090

### DIFF
--- a/ports/monkeys-audio/fix-C2471.patch
+++ b/ports/monkeys-audio/fix-C2471.patch
@@ -1,0 +1,13 @@
+diff --git a/Source/Projects/VS2019/MACDll/MACDll.vcxproj b/Source/Projects/VS2019/MACDll/MACDll.vcxproj
+index 0fcfc94..c0caf12 100644
+--- a/Source/Projects/VS2019/MACDll/MACDll.vcxproj
++++ b/Source/Projects/VS2019/MACDll/MACDll.vcxproj
+@@ -108,7 +108,7 @@
+       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
+       <PrecompiledHeader>Use</PrecompiledHeader>
+       <WarningLevel>Level3</WarningLevel>
+-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
++      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+     </ClCompile>
+     <ResourceCompile>
+       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/ports/monkeys-audio/portfile.cmake
+++ b/ports/monkeys-audio/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_extract_source_archive(
     PATCHES
         fix-project-config.patch
         remove-certificate-step.patch
+        fix-C2471.patch
 )
 
 file(REMOVE_RECURSE

--- a/ports/monkeys-audio/vcpkg.json
+++ b/ports/monkeys-audio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "monkeys-audio",
   "version-string": "9.04",
-  "Port-version": 1,
+  "port-version": 1,
   "description": [
     "Monkey's Audio is an excellent audio compression tool which has multiple advantages over traditional methods.",
     "Audio files compressed with it end with .ape extension."

--- a/ports/monkeys-audio/vcpkg.json
+++ b/ports/monkeys-audio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "monkeys-audio",
   "version-string": "9.04",
+  "Port-version": 1,
   "description": [
     "Monkey's Audio is an excellent audio compression tool which has multiple advantages over traditional methods.",
     "Audio files compressed with it end with .ape extension."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5118,7 +5118,7 @@
     },
     "monkeys-audio": {
       "baseline": "9.04",
-      "port-version": 0
+      "port-version": 1
     },
     "moos-core": {
       "baseline": "10.4.0",

--- a/versions/m-/monkeys-audio.json
+++ b/versions/m-/monkeys-audio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "65d1eadb4f2e5961fec2975b2450513b6c7b6d6a",
+      "version-string": "9.04",
+      "port-version": 1
+    },
+    {
       "git-tree": "ae5b8fee2db96b691e609427278a6974180e68d4",
       "version-string": "9.04",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
`monkeys-audio:x86-windows` install failed with following errors in CI:
```
14.34.31933\atlmfc\include\afx.inl : error C2471: cannot update program database 
Windows Kits\10\Include\10.0.22000.0\um\shellapi.h : error C2471: cannot update program database
Source\Shared\WAVInfoDialog.cpp(158,1): error C2471: cannot update program database '???'
Windows Kits\10\Include\10.0.22000.0\um\propsys.h(803,1): fatal  error C1090: PDB API call failed, error code '23': (0x00000006)
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
