### PR TITLE
[adios2] Add zfp feature

### DIFF
--- a/ports/adios2/portfile.cmake
+++ b/ports/adios2/portfile.cmake
@@ -1,9 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO ornladios/ADIOS2 
+    REPO ornladios/ADIOS2
     REF 473fe8c7d1a13c0746910361aa45ee1b96f57bfb
     SHA512 ef8af30419cf57183b52ce9cb29613a381b06e16848a6d22d83c751c43b8485e504be90cead1381adcc92bb8d4912611083cd6d0b73d161b33f779231a041e6c
     HEAD_REF master
+    PATCHES
+        zfp-version.patch # Backport zfp 1.0 support to v2.8.3 (https://github.com/ornladios/ADIOS2/pull/3312), included upstream in v2.9.0 when released.
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -11,10 +13,11 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         mpi     ADIOS2_USE_MPI
         cuda    ADIOS2_USE_CUDA
         python  ADIOS2_USE_Python # requires numpy / mpi4py; so not exposed in the manifest yet
+        zfp     ADIOS2_USE_ZFP
 )
 
 set(disabled_options "")
-list(APPEND disabled_options ZFP SZ LIBPRESSIO MGARD DAOS DataMan DataSpaces MHS SST BP5 IME Fortran SysVShMem Profiling)
+list(APPEND disabled_options SZ LIBPRESSIO MGARD DAOS DataMan DataSpaces MHS SST BP5 IME Fortran SysVShMem Profiling)
 list(TRANSFORM disabled_options PREPEND "-DADIOS2_USE_")
 list(TRANSFORM disabled_options APPEND  ":BOOL=OFF")
 set(enabled_options "")

--- a/ports/adios2/vcpkg.json
+++ b/ports/adios2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "adios2",
   "version": "2.8.3",
+  "port-version": 1,
   "description": "Next generation of ADIOS developed in the Exascale Computing Program",
   "homepage": "https://github.com/ornladios/ADIOS2",
   "license": "Apache-2.0",
@@ -53,6 +54,12 @@
           "name": "python3",
           "host": true
         }
+      ]
+    },
+    "zfp": {
+      "description": "Enable zfp support",
+      "dependencies": [
+        "zfp"
       ]
     }
   }

--- a/ports/adios2/zfp-version.patch
+++ b/ports/adios2/zfp-version.patch
@@ -1,0 +1,65 @@
+diff --git a/cmake/DetectOptions.cmake b/cmake/DetectOptions.cmake
+index d4e2e5dbf..c96536c57 100644
+--- a/cmake/DetectOptions.cmake
++++ b/cmake/DetectOptions.cmake
+@@ -89,9 +89,9 @@ endif()
+ 
+ # ZFP
+ if(ADIOS2_USE_ZFP STREQUAL AUTO)
+-  find_package(ZFP 0.5.1 CONFIG)
++  find_package(ZFP 1.0.0 CONFIG)
+ elseif(ADIOS2_USE_ZFP)
+-  find_package(ZFP 0.5.1 REQUIRED CONFIG)
++  find_package(ZFP 1.0.0 REQUIRED CONFIG)
+ endif()
+ if(ZFP_FOUND)
+   set(ADIOS2_HAVE_ZFP TRUE)
+diff --git a/source/adios2/operator/compress/CompressZFP.cpp b/source/adios2/operator/compress/CompressZFP.cpp
+index 77aaa6f08..e8162f97a 100644
+--- a/source/adios2/operator/compress/CompressZFP.cpp
++++ b/source/adios2/operator/compress/CompressZFP.cpp
+@@ -13,7 +13,7 @@
+ #include <zfp.h>
+ 
+ /* CMake will make sure zfp >= 5.0.1 */
+-#if ZFP_VERSION_RELEASE > 1 && !defined(ZFP_DEFAULT_EXECUTION_POLICY)
++//#if ZFP_VERSION_RELEASE > 1 && !defined(ZFP_DEFAULT_EXECUTION_POLICY)
+ 
+ /* ZFP will default to SERIAL if CUDA is not available */
+ #ifdef ADIOS2_HAVE_ZFP_CUDA
+@@ -22,7 +22,7 @@
+ #define ZFP_DEFAULT_EXECUTION_POLICY zfp_exec_serial
+ #endif
+ 
+-#endif
++//#endif
+ 
+ namespace adios2
+ {
+@@ -80,7 +80,7 @@ size_t CompressZFP::Operate(const char *dataIn, const Dims &blockStart,
+     PutParameter(bufferOut, bufferOutOffset,
+                  static_cast<uint8_t>(ZFP_VERSION_MINOR));
+     PutParameter(bufferOut, bufferOutOffset,
+-                 static_cast<uint8_t>(ZFP_VERSION_RELEASE));
++                 static_cast<uint8_t>(ZFP_VERSION_PATCH));
+     PutParameters(bufferOut, bufferOutOffset, m_Parameters);
+     // zfp V1 metadata end
+ 
+@@ -302,7 +302,7 @@ zfp_stream *GetZFPStream(const Dims &dimensions, DataType type,
+     auto itPrecision = parameters.find("precision");
+     const bool hasPrecision = itPrecision != parameters.end();
+ 
+-#if ZFP_VERSION_RELEASE > 1
++//#if ZFP_VERSION_RELEASE > 1
+     auto itBackend = parameters.find("backend");
+     const bool hasBackend = itBackend != parameters.end();
+ 
+@@ -332,7 +332,7 @@ zfp_stream *GetZFPStream(const Dims &dimensions, DataType type,
+ 
+         zfp_stream_set_execution(stream, policy);
+     }
+-#endif
++//#endif
+ 
+     if ((hasAccuracy && hasPrecision) || (hasAccuracy && hasRate) ||
+         (hasPrecision && hasRate) ||

--- a/ports/adios2/zfp-version.patch
+++ b/ports/adios2/zfp-version.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/DetectOptions.cmake b/cmake/DetectOptions.cmake
-index d4e2e5dbf..c96536c57 100644
+index d4e2e5dbf..80f231c16 100644
 --- a/cmake/DetectOptions.cmake
 +++ b/cmake/DetectOptions.cmake
 @@ -89,9 +89,9 @@ endif()
@@ -7,10 +7,10 @@ index d4e2e5dbf..c96536c57 100644
  # ZFP
  if(ADIOS2_USE_ZFP STREQUAL AUTO)
 -  find_package(ZFP 0.5.1 CONFIG)
-+  find_package(ZFP 1.0.0 CONFIG)
++  find_package(ZFP CONFIG)
  elseif(ADIOS2_USE_ZFP)
 -  find_package(ZFP 0.5.1 REQUIRED CONFIG)
-+  find_package(ZFP 1.0.0 REQUIRED CONFIG)
++  find_package(ZFP REQUIRED CONFIG)
  endif()
  if(ZFP_FOUND)
    set(ADIOS2_HAVE_ZFP TRUE)

--- a/versions/a-/adios2.json
+++ b/versions/a-/adios2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eaff12231ad89050448a4257970ab6290afa9ced",
+      "git-tree": "fac4ec886b3d46f0a48ee44988fc8224bce59ad7",
       "version": "2.8.3",
       "port-version": 1
     },

--- a/versions/a-/adios2.json
+++ b/versions/a-/adios2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eaff12231ad89050448a4257970ab6290afa9ced",
+      "version": "2.8.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "1a832feea61b7166bf688a246cda2f7c038aeeac",
       "version": "2.8.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -42,7 +42,7 @@
     },
     "adios2": {
       "baseline": "2.8.3",
-      "port-version": 0
+      "port-version": 1
     },
     "advobfuscator": {
       "baseline": "2020-06-26",


### PR DESCRIPTION
Add zfp feature to the adios2 port.
The latest adios2 (stable) release wants zfp 0.5.1, but the vcpkg zfp port is already at 1.0, therefore, backport zfp 1.0 support as patch (see https://github.com/ornladios/ADIOS2/pull/3312 and https://github.com/ornladios/ADIOS2/issues/3303#issuecomment-1207253418).
There is a release candidate available for the next adios2 version supporting zfp 1.0 directly. But the next adios2 version also uses Blosc2 instead of Blosc, and the current Blosc port is still at 1.x (I don't know how big this update will be, but there are a few other ports requiring it). And I'm unsure if you generally want release candidates in ports in vcpkg.
Therefore, I think patching zfp 1.0 support seems to be the simplest option for now.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
