### PR TITLE
[folly] Add feature liburing

### DIFF
--- a/ports/folly/fix-deps.patch
+++ b/ports/folly/fix-deps.patch
@@ -1,8 +1,8 @@
 diff --git a/CMake/folly-config.cmake.in b/CMake/folly-config.cmake.in
-index 1689f9a..801d562 100644
+index 1689f9a..e5d3e22 100644
 --- a/CMake/folly-config.cmake.in
 +++ b/CMake/folly-config.cmake.in
-@@ -28,10 +28,30 @@ endif()
+@@ -28,10 +28,35 @@ endif()
  set(FOLLY_LIBRARIES Folly::folly)
  
  # Find folly's dependencies
@@ -27,6 +27,11 @@ index 1689f9a..801d562 100644
 +if (NOT @CMAKE_DISABLE_FIND_PACKAGE_LZ4@)
 +    find_dependency(lz4 CONFIG)
 +endif()
++
++if (@WITH_liburing@)
++    find_dependency(LibUring)
++endif()
++
 +find_dependency(fmt CONFIG)
  
  set(Boost_USE_STATIC_LIBS "@FOLLY_BOOST_LINK_STATIC@")
@@ -36,7 +41,7 @@ index 1689f9a..801d562 100644
      context
      filesystem
 diff --git a/CMake/folly-deps.cmake b/CMake/folly-deps.cmake
-index 4b78e9f..d4c224e 100644
+index 4b78e9f..ac83c99 100644
 --- a/CMake/folly-deps.cmake
 +++ b/CMake/folly-deps.cmake
 @@ -35,7 +35,7 @@ else()
@@ -156,9 +161,15 @@ index 4b78e9f..d4c224e 100644
  endif()
  
  find_package(LibDwarf)
-@@ -141,9 +146,12 @@ find_package(LibUring)
+@@ -137,13 +142,18 @@ find_package(LibAIO)
+ list(APPEND FOLLY_LINK_LIBRARIES ${LIBAIO_LIBRARIES})
+ list(APPEND FOLLY_INCLUDE_DIRECTORIES ${LIBAIO_INCLUDE_DIRS})
+ 
++if(WITH_liburing)
+ find_package(LibUring)
  list(APPEND FOLLY_LINK_LIBRARIES ${LIBURING_LIBRARIES})
  list(APPEND FOLLY_INCLUDE_DIRECTORIES ${LIBURING_INCLUDE_DIRS})
++endif()
  
 -find_package(Libsodium)
 -list(APPEND FOLLY_LINK_LIBRARIES ${LIBSODIUM_LIBRARIES})
@@ -172,7 +183,7 @@ index 4b78e9f..d4c224e 100644
  
  list(APPEND FOLLY_LINK_LIBRARIES ${CMAKE_DL_LIBS})
  list(APPEND CMAKE_REQUIRED_LIBRARIES ${CMAKE_DL_LIBS})
-@@ -154,9 +162,9 @@ if (PYTHON_EXTENSIONS)
+@@ -154,9 +164,9 @@ if (PYTHON_EXTENSIONS)
  endif ()
  
  find_package(LibUnwind)
@@ -184,7 +195,7 @@ index 4b78e9f..d4c224e 100644
    set(FOLLY_HAVE_LIBUNWIND ON)
  endif()
  if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-@@ -299,11 +307,7 @@ endif()
+@@ -299,11 +309,7 @@ endif()
  
  add_library(folly_deps INTERFACE)
  

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -41,6 +41,7 @@ endif()
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         "zlib"       CMAKE_REQUIRE_FIND_PACKAGE_ZLIB
+        "liburing"   WITH_liburing
     INVERTED_FEATURES
         "bzip2"      CMAKE_DISABLE_FIND_PACKAGE_BZip2
         "lzma"       CMAKE_DISABLE_FIND_PACKAGE_LibLZMA
@@ -51,7 +52,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DMSVC_USE_STATIC_RUNTIME=${MSVC_USE_STATIC_RUNTIME}
         -DCMAKE_DISABLE_FIND_PACKAGE_LibDwarf=ON
@@ -62,6 +63,7 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
     MAYBE_UNUSED_VARIABLES
         LIBAIO_FOUND
+        MSVC_USE_STATIC_RUNTIME
 )
 
 vcpkg_cmake_install(ADD_BIN_TO_PATH)
@@ -85,6 +87,6 @@ FILE(WRITE ${FOLLY_TARGETS_CMAKE} "${_contents}")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "folly",
   "version-string": "2022.10.31.00",
-  "port-version": 3,
+  "port-version": 4,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -51,7 +51,7 @@
       ]
     },
     "liburing": {
-      "description": "Support liburing for compression",
+      "description": "Support compile with liburing",
       "dependencies": [
         "liburing"
       ]

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -50,6 +50,12 @@
         "libsodium"
       ]
     },
+    "liburing": {
+      "description": "Support liburing for compression",
+      "dependencies": [
+        "liburing"
+      ]
+    },
     "lz4": {
       "description": "Support lz4 for compression",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2486,7 +2486,7 @@
     },
     "folly": {
       "baseline": "2022.10.31.00",
-      "port-version": 3
+      "port-version": 4
     },
     "font-chef": {
       "baseline": "1.1.0",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9c34e53bf193893333116c71ff3e2e0f4d24654",
+      "version-string": "2022.10.31.00",
+      "port-version": 4
+    },
+    {
       "git-tree": "134e8cf60a376c02580a13800bf83d345bf082f9",
       "version-string": "2022.10.31.00",
       "port-version": 3

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9c34e53bf193893333116c71ff3e2e0f4d24654",
+      "git-tree": "9f031566a728d2a7adf76c1026324cfc993b02a6",
       "version-string": "2022.10.31.00",
       "port-version": 4
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #29523, feature `folly[liburing]` test pass on Linux.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
