### PR TITLE
[soci] Update to 4.0.3

### DIFF
--- a/ports/soci/portfile.cmake
+++ b/ports/soci/portfile.cmake
@@ -29,7 +29,7 @@ foreach(_feature IN LISTS ALL_FEATURES)
     endif()
 
     if(_feature MATCHES "mysql")
-        set(MYSQL_OPT -DMYSQL_INCLUDE_DIR="${CURRENT_INSTALLED_DIR}/include/mysql")
+        set(MYSQL_OPT "-DMYSQL_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include/mysql")
     endif()
 endforeach()
 

--- a/ports/soci/portfile.cmake
+++ b/ports/soci/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SOCI/soci
-    REF 99e2d567161a302de4f99832af76e6d3b75b68e6 #version 4.0.2
-    SHA512 d08d2383808d46d5e9550e9c7d93fb405d9e336eb38d974ba429e5b9446d3af53d4e702b90e80c67e298333da0145457fa1146d9773322676030be69de4ec4f4
+    REF "v${VERSION}"
+    SHA512 d501f55e7e7408e46b4823fd8a97d6ef587f5db0f5b98434be8dfc5693c91b8c3b84a24454279c83142ab1cd1fa139c6e54d6d9a67397b2ead61650fcc88bcdb
     HEAD_REF master
     PATCHES
         fix-dependency-libmysql.patch
@@ -29,7 +29,7 @@ foreach(_feature IN LISTS ALL_FEATURES)
     endif()
 
     if(_feature MATCHES "mysql")
-        set(MYSQL_OPT -DMYSQL_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include/mysql)
+        set(MYSQL_OPT -DMYSQL_INCLUDE_DIR="${CURRENT_INSTALLED_DIR}/include/mysql")
     endif()
 endforeach()
 
@@ -58,4 +58,4 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE_1_0.txt")

--- a/ports/soci/vcpkg.json
+++ b/ports/soci/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "soci",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "SOCI database access library",
   "homepage": "https://github.com/SOCI/soci",
+  "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7269,7 +7269,7 @@
       "port-version": 0
     },
     "soci": {
-      "baseline": "4.0.2",
+      "baseline": "4.0.3",
       "port-version": 0
     },
     "socket-io-client": {

--- a/versions/s-/soci.json
+++ b/versions/s-/soci.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ffc3970b85692097eeddfdb2b5bc58955a447596",
+      "version": "4.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "885023b9eb3db14a25a785e0f67e3a1585f07a02",
       "version": "4.0.2",
       "port-version": 0

--- a/versions/s-/soci.json
+++ b/versions/s-/soci.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ffc3970b85692097eeddfdb2b5bc58955a447596",
+      "git-tree": "11a646f331554958a517bc644c54df99dfbbbd1b",
       "version": "4.0.3",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/29675
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

All features passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static