### PR TITLE
[amqpcpp] update to 4.3.19

### DIFF
--- a/ports/amqpcpp/portfile.cmake
+++ b/ports/amqpcpp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CopernicaMarketingSoftware/AMQP-CPP
-    REF "v${VERSION}" #v4.3.15
+    REF "v${VERSION}"
     SHA512 6220d6cdd3114cf02f08f1d8599d1f6de94df204384f9da7db1c18f74732a5c23063cd50066b7d32906af0a968d600daf0d59f1649d9674fa67446197c6e4988
     HEAD_REF master
     PATCHES

--- a/ports/amqpcpp/portfile.cmake
+++ b/ports/amqpcpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CopernicaMarketingSoftware/AMQP-CPP
-    REF b891cc37a6ff63fcff59a112de281f5964344c91 #v4.3.15
-    SHA512 5c55285e2445752669bfe51a276c3c9cb294eeae74e05124fa7427737e43419493b8a8e199bedba9ab7fba5822a8da530ca442afdbe45d12c2c0c54f9fd59a0c
+    REF "v${VERSION}" #v4.3.15
+    SHA512 6220d6cdd3114cf02f08f1d8599d1f6de94df204384f9da7db1c18f74732a5c23063cd50066b7d32906af0a968d600daf0d59f1649d9674fa67446197c6e4988
     HEAD_REF master
     PATCHES
         find-openssl.patch
@@ -17,7 +17,7 @@ else()
 endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DAMQP-CPP_BUILD_SHARED=OFF
         -DAMQP-CPP_LINUX_TCP=${LINUX_TCP}
@@ -26,8 +26,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/amqpcpp/vcpkg.json
+++ b/ports/amqpcpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "amqpcpp",
-  "version": "4.3.15",
-  "port-version": 1,
+  "version": "4.3.19",
   "description": "AMQP-CPP is a C++ library for communicating with a RabbitMQ message broker",
   "homepage": "https://github.com/CopernicaMarketingSoftware/AMQP-CPP",
   "supports": "!uwp",

--- a/ports/amqpcpp/vcpkg.json
+++ b/ports/amqpcpp/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "4.3.19",
   "description": "AMQP-CPP is a C++ library for communicating with a RabbitMQ message broker",
   "homepage": "https://github.com/CopernicaMarketingSoftware/AMQP-CPP",
+  "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     "openssl",

--- a/versions/a-/amqpcpp.json
+++ b/versions/a-/amqpcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "92c91ddac79214a7dc2c962675a17651cf8e5671",
+      "git-tree": "8c4c943db69e3a3f21a971db40fd3bf7e77518a1",
       "version": "4.3.19",
       "port-version": 0
     },

--- a/versions/a-/amqpcpp.json
+++ b/versions/a-/amqpcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92c91ddac79214a7dc2c962675a17651cf8e5671",
+      "version": "4.3.19",
+      "port-version": 0
+    },
+    {
       "git-tree": "b071aaf9f29af43e9463bcc9a118f4553351eb16",
       "version": "4.3.15",
       "port-version": 1

--- a/versions/a-/amqpcpp.json
+++ b/versions/a-/amqpcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8c4c943db69e3a3f21a971db40fd3bf7e77518a1",
+      "git-tree": "cdf5751364452365ad13aeecc8a74bc6ab15076a",
       "version": "4.3.19",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -105,8 +105,8 @@
       "port-version": 3
     },
     "amqpcpp": {
-      "baseline": "4.3.15",
-      "port-version": 1
+      "baseline": "4.3.19",
+      "port-version": 0
     },
     "anax": {
       "baseline": "2.1.0",


### PR DESCRIPTION
Fix #29672      

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ]~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ]~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ]~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



Note: no feature need to test.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
