### PR TITLE
[usd] Update to 23.02

### DIFF
--- a/ports/usd/fix_build-location.patch
+++ b/ports/usd/fix_build-location.patch
@@ -10,4 +10,4 @@ index 3825e2a19..0a79b49bd 100644
 +            PXR_BUILD_LOCATION=../lib/usd
              PXR_PLUGIN_BUILD_LOCATION=../plugin/usd
              ${pxrInstallLocation}
-             ${pythonModulesEnabled}
+             ${apiPrivate}

--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -10,11 +10,13 @@ If you must use this port in your project, pin a version of tbb of 2020_U3 or ol
 See https://vcpkg.io/en/docs/examples/versioning.getting-started.html for instructions.
 ]=])
 
+string(REGEX REPLACE "^([0-9]+)[.]([0-9])\$" "\\1.0\\2" USD_VERSION "${VERSION}")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PixarAnimationStudios/USD
-    REF 71b4baace2044ea4400ba802e91667f9ebe342f0 # v20.08
-    SHA512 0f23b84d314d88d3524f22ebc344e2b506cb7e8ac064726df432a968a4bae0fd2249e968bd10845de9067290eaaa3f8c9e2a483551ffc06b826f3eba816061a9
+    REF "v${USD_VERSION}"
+    SHA512 2529aec788cab3ff4c47041f5bc0043fde81dcef8ca313f6390f2e5fb7a10b1b0b1dd47fd6c86e3b4cfc0a1b27bff4d9b94b96bfba6bec3d5ff8f6e2fccb9e11
     HEAD_REF master
     PATCHES
         fix_build-location.patch
@@ -35,7 +37,6 @@ vcpkg_cmake_configure(
         -DPXR_BUILD_ALEMBIC_PLUGIN:BOOL=OFF
         -DPXR_BUILD_EMBREE_PLUGIN:BOOL=OFF
         -DPXR_BUILD_IMAGING:BOOL=OFF
-        -DPXR_BUILD_MAYA_PLUGIN:BOOL=OFF
         -DPXR_BUILD_MONOLITHIC:BOOL=OFF
         -DPXR_BUILD_TESTS:BOOL=OFF
         -DPXR_BUILD_USD_IMAGING:BOOL=OFF
@@ -57,6 +58,7 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake PACKAGE_NAME pxr)
 vcpkg_copy_pdbs()
 
 # Remove duplicates in debug folder
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/pxrConfig.cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright

--- a/ports/usd/vcpkg.json
+++ b/ports/usd/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "usd",
-  "version-string": "20.08",
-  "port-version": 4,
+  "version": "23.2",
   "description": "Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.",
   "homepage": "https://github.com/PixarAnimationStudios/USD",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8045,8 +8045,8 @@
       "port-version": 3
     },
     "usd": {
-      "baseline": "20.08",
-      "port-version": 4
+      "baseline": "23.2",
+      "port-version": 0
     },
     "usockets": {
       "baseline": "0.8.5",

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f52bda67df8cc837cf678d105ecba88358c016c0",
+      "version": "23.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b4c2d8c578eff85a0c1c897c595ddc35240cce98",
       "version-string": "20.08",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
