### PR TITLE
[openimageio] Fix openEXR targets were not found

### DIFF
--- a/ports/openimageio/fix-openexr-target-missing.patch
+++ b/ports/openimageio/fix-openexr-target-missing.patch
@@ -1,0 +1,13 @@
+diff --git a/src/cmake/Config.cmake.in b/src/cmake/Config.cmake.in
+index 08401a2..4f2694e 100644
+--- a/src/cmake/Config.cmake.in
++++ b/src/cmake/Config.cmake.in
+@@ -24,6 +24,8 @@ if (NOT @OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH@ AND NOT OPENIMAGEIO_CONFIG_DO_NOT
+     if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 3.0)
+         find_dependency(Imath @Imath_VERSION@
+                         HINTS @Imath_DIR@)
++        find_dependency(OpenEXR @OpenEXR_VERSION@
++                        HINTS @OpenEXR_DIR@)
+     elseif (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.4 AND @FOUND_OPENEXR_WITH_CONFIG@)
+         find_dependency(IlmBase @OpenEXR_VERSION@
+                         HINTS @IlmBase_DIR@ @OpenEXR_DIR@)

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -1,9 +1,7 @@
-vcpkg_minimum_required(VERSION 2022-10-12)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenImageIO/oiio
-    REF v${VERSION}
+    REF "v${VERSION}"
     SHA512 c7a4283b78197c262d8da31460ce8b07b44546f822142e32e6c1ea22376e1c4b9cfe9c39cc0994987c6c4f653c1f2764057944da97a3a090bf1bcb74a2a0b2c2
     HEAD_REF master
     PATCHES
@@ -15,6 +13,7 @@ vcpkg_from_github(
         fix-vs2019-encoding-conversion.patch
         qt6.patch
         more_qt6.patch
+        fix-openexr-target-missing.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/ext")
@@ -93,7 +92,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc"
 vcpkg_fixup_pkgconfig()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
 file(READ "${SOURCE_PATH}/THIRD-PARTY.md" third_party)
 string(REGEX REPLACE
     "^.*The remainder of this file"

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openimageio",
   "version": "2.4.5.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5694,7 +5694,7 @@
     },
     "openimageio": {
       "baseline": "2.4.5.0",
-      "port-version": 4
+      "port-version": 5
     },
     "openjpeg": {
       "baseline": "2.5.0",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18125d8c18cd384804b12c5839331a6312c3ba6f",
+      "version": "2.4.5.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "3c8df049a8e7b1c3e48006e78c4f5a9d451860a0",
       "version": "2.4.5.0",
       "port-version": 4


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/29284
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
