### PR TITLE
[monkeys-audio] Add header file and remove the backup URL

### DIFF
--- a/ports/monkeys-audio/portfile.cmake
+++ b/ports/monkeys-audio/portfile.cmake
@@ -4,7 +4,6 @@ set(MA_VERSION 904)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://monkeysaudio.com/files/MAC_${MA_VERSION}_SDK.zip"
-         "https://web.archive.org/web/20210129190227if_/https://monkeysaudio.com/files/MAC_SDK_607.zip"
     FILENAME "MAC_${MA_VERSION}_SDK.zip"
     SHA512 c42c9bae6690a28a69137445c84d53ad7acbd242c2cfe20f329fda46b56812c60de68874301d99cf72ade3bced90fc5aaedacb6fdbca241d4bf4806f6e238219
 )
@@ -65,6 +64,5 @@ file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include")
 file(COPY           "${SOURCE_PATH}/Shared/"
      DESTINATION    "${CURRENT_PACKAGES_DIR}/include/monkeys-audio"
      FILES_MATCHING PATTERN "*.h")
-file(REMOVE         "${CURRENT_PACKAGES_DIR}/include/monkeys-audio/MACDll.h")
 
 vcpkg_install_copyright(FILE_LIST "${CMAKE_CURRENT_LIST_DIR}/license")

--- a/ports/monkeys-audio/vcpkg.json
+++ b/ports/monkeys-audio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "monkeys-audio",
   "version-string": "9.04",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Monkey's Audio is an excellent audio compression tool which has multiple advantages over traditional methods.",
     "Audio files compressed with it end with .ape extension."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5122,7 +5122,7 @@
     },
     "monkeys-audio": {
       "baseline": "9.04",
-      "port-version": 1
+      "port-version": 2
     },
     "moos-core": {
       "baseline": "10.4.0",

--- a/versions/m-/monkeys-audio.json
+++ b/versions/m-/monkeys-audio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fdafc906d1ff5d300e27dc2e60e807fc7fca0d39",
+      "version-string": "9.04",
+      "port-version": 2
+    },
+    {
       "git-tree": "65d1eadb4f2e5961fec2975b2450513b6c7b6d6a",
       "version-string": "9.04",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/29592
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: Based on the update frequency of the upstream and all URL in the `vcpkg_download_distfile` must be valid, the role of backup cannot be realized.
<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
