### PR TITLE
[nghttp2-asio] Add nghttp2-asio port

### DIFF
--- a/ports/nghttp2-asio/0001-Fix-exception-in-server.patch
+++ b/ports/nghttp2-asio/0001-Fix-exception-in-server.patch
@@ -1,0 +1,45 @@
+From b4745aa3d87916c7d3da33c00da400b22a0539b5 Mon Sep 17 00:00:00 2001
+From: m8mble <m8mble@vivaldi.net>
+Date: Fri, 20 Jan 2023 16:36:30 +0100
+Subject: [PATCH 1/1] Fix exception in server
+
+It can happen that a connection handler calls writefun when the
+connection is already destroyed. This causes bad_weak_ptr exceptions
+thrown from the server.
+
+Fix this issue by skipping the respective do_write invocations.
+
+Signed-off-by: m8mble <m8mble@vivaldi.net>
+---
+ lib/asio_server_connection.h | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/lib/asio_server_connection.h b/lib/asio_server_connection.h
+index a948965..94ed59f 100644
+--- a/lib/asio_server_connection.h
++++ b/lib/asio_server_connection.h
+@@ -88,9 +88,20 @@ public:
+   void start() {
+     boost::system::error_code ec;
+ 
++    auto make_writefun = [original_self = this->shared_from_this()] {
++        return [weak = std::weak_ptr<connection>{original_self}]() {
++            auto self = weak.lock();
++            // If connection already got destroyed, the socket is already closed in particular.
++            // Therefore we can simply ignore further calls to write.
++            if (self) {
++                self->do_write();
++            }
++        };
++    };
++
+     handler_ = std::make_shared<http2_handler>(
+         GET_IO_SERVICE(socket_), socket_.lowest_layer().remote_endpoint(ec),
+-        [this]() { do_write(); }, mux_);
++        make_writefun(), mux_);
+     if (handler_->start() != 0) {
+       stop();
+       return;
+-- 
+2.39.1
+

--- a/ports/nghttp2-asio/0002-Honor-BUILD_SHARED_LIBS.patch
+++ b/ports/nghttp2-asio/0002-Honor-BUILD_SHARED_LIBS.patch
@@ -1,0 +1,26 @@
+From c68e0a22f8a96ceb5011aa09c4ad93d26c31dc0c Mon Sep 17 00:00:00 2001
+From: m8mble <m8mble@vivaldi.net>
+Date: Fri, 24 Feb 2023 11:36:19 +0100
+Subject: [PATCH 1/1] Honor BUILD_SHARED_LIBS
+
+Signed-off-by: m8mble <m8mble@vivaldi.net>
+---
+ lib/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index ee8f87d..0a67c14 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -36,7 +36,7 @@ set(NGHTTP2_ASIO_SOURCES
+   asio_client_tls_context.cc
+ )
+ 
+-add_library(nghttp2_asio SHARED
++add_library(nghttp2_asio
+   ${NGHTTP2_ASIO_SOURCES}
+   $<TARGET_OBJECTS:url-parser>
+ )
+-- 
+2.39.1
+

--- a/ports/nghttp2-asio/portfile.cmake
+++ b/ports/nghttp2-asio/portfile.cmake
@@ -1,0 +1,40 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nghttp2/nghttp2-asio
+    REF e877868abe06a83ed0a6ac6e245c07f6f20866b5
+    SHA512 ed9112d8062dc624cb954c6b4366f79e1e4a8c814a12c9f428a3da882127895b6ea0ff82a3660469c2bef29e3dea906ad9127faa46df773e00ed93b8c7c31d9c
+    PATCHES
+        0001-Fix-exception-in-server.patch
+        0002-Honor-BUILD_SHARED_LIBS.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" ENABLE_STATIC_CRT)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC_LIB)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED_LIB)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DENABLE_STATIC_CRT=${ENABLE_STATIC_CRT}"
+        "-DENABLE_STATIC_LIB=${ENABLE_STATIC_LIB}"
+        "-DENABLE_SHARED_LIB=${ENABLE_SHARED_LIB}"
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/man"
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/nghttp2-asio/vcpkg.json
+++ b/ports/nghttp2-asio/vcpkg.json
@@ -1,0 +1,41 @@
+{
+  "name": "nghttp2-asio",
+  "version-date": "2022-08-11",
+  "description": "High level abstraction API to build HTTP/2 applications with nghttp2 and boost asio.",
+  "homepage": "https://github.com/nghttp2/nghttp2-asio",
+  "license": "MIT",
+  "supports": "!windows",
+  "dependencies": [
+    {
+      "name": "boost-asio",
+      "version>=": "1.81.0"
+    },
+    "boost-system",
+    "boost-thread",
+    {
+      "name": "nghttp2",
+      "version>=": "1.51.0"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "tls"
+  ],
+  "features": {
+    "tls": {
+      "description": "Support HTTP/2 over TLS aka h2.",
+      "dependencies": [
+        {
+          "name": "boost-asio",
+          "features": [
+            "ssl"
+          ]
+        },
+        "openssl"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5376,6 +5376,10 @@
       "baseline": "1.51.0",
       "port-version": 0
     },
+    "nghttp2-asio": {
+      "baseline": "2022-08-11",
+      "port-version": 0
+    },
     "nghttp3": {
       "baseline": "0.8.0",
       "port-version": 0

--- a/versions/n-/nghttp2-asio.json
+++ b/versions/n-/nghttp2-asio.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a2ef24d2428ea9d1a4cb733d3e4ce00e3f6f5c8d",
+      "port-version": 0,
+      "version-date": "2022-08-11"
+    }
+  ]
+}


### PR DESCRIPTION
The nghttp2_asio library was formerly part of nghttp2 but by now is distributed as [separate library](https://github.com/nghttp2/nghttp2-asio). Add a port for this library.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. (*Note*: It doesn't exist, but it's accurate.)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
