### PR TITLE
[vtk] update pegtl to version 3

### DIFF
--- a/ports/vtk/pegtl.patch
+++ b/ports/vtk/pegtl.patch
@@ -1,8 +1,64 @@
+diff --git a/IO/MotionFX/vtkMotionFXCFGGrammar.h b/IO/MotionFX/vtkMotionFXCFGGrammar.h
+index dba137386..4cb03e054 100644
+--- a/IO/MotionFX/vtkMotionFXCFGGrammar.h
++++ b/IO/MotionFX/vtkMotionFXCFGGrammar.h
+@@ -23,7 +23,7 @@
+ 
+ // for debugging
+ // clang-format off
+-#include VTK_PEGTL(pegtl/contrib/tracer.hpp)
++#include VTK_PEGTL(pegtl/contrib/trace.hpp)
+ // clang-format on
+ 
+ namespace MotionFX
+diff --git a/IO/MotionFX/vtkMotionFXCFGReader.cxx b/IO/MotionFX/vtkMotionFXCFGReader.cxx
+index 338aa736e..374e54b94 100644
+--- a/IO/MotionFX/vtkMotionFXCFGReader.cxx
++++ b/IO/MotionFX/vtkMotionFXCFGReader.cxx
+@@ -1213,7 +1213,7 @@ bool PositionFileMotion::read_position_file(const std::string& rootDir) const
+     }
+     return true;
+   }
+-  catch (const tao::pegtl::input_error& e)
++  catch (const tao::pegtl::parse_error& e)
+   {
+     vtkGenericWarningMacro("PositionFileMotion::read_position_file failed: " << e.what());
+   }
+@@ -1232,7 +1232,7 @@ bool UniversalTransformMotion::read_universaltransform_file(const std::string& r
+       in, numbers, this->transforms);
+     return true;
+   }
+-  catch (const tao::pegtl::input_error& e)
++  catch (const tao::pegtl::parse_error&& e)
+   {
+     vtkGenericWarningMacro(
+       "UniversalTransformMotion::read_universaltransform_file failed: " << e.what());
+@@ -1267,7 +1267,7 @@ public:
+       if (getenv("MOTIONFX_DEBUG_GRAMMAR") != nullptr)
+       {
+         tao::pegtl::read_input<> in2(filename);
+-        tao::pegtl::parse<MotionFX::CFG::Grammar, tao::pegtl::nothing, tao::pegtl::tracer>(in2);
++        tao::pegtl::complete_trace<MotionFX::CFG::Grammar>(in2);
+       }
+       return false;
+     }
+diff --git a/ThirdParty/pegtl/CMakeLists.txt b/ThirdParty/pegtl/CMakeLists.txt
+index 9bbd4c828..0cdb1f53d 100644
+--- a/ThirdParty/pegtl/CMakeLists.txt
++++ b/ThirdParty/pegtl/CMakeLists.txt
+@@ -5,7 +5,6 @@ vtk_module_third_party(
+     VERSION       "2.8.3"
+   EXTERNAL
+     PACKAGE PEGTL
+-    VERSION 2.0.0
+     TARGETS PEGTL::PEGTL
+     STANDARD_INCLUDE_DIRS)
+ 
 diff --git a/CMake/FindPEGTL.cmake b/CMake/FindPEGTL.cmake
 index 73eee02f7..22d8bc159 100644
 --- a/CMake/FindPEGTL.cmake	
 +++ b/CMake/FindPEGTL.cmake
-@@ -19,31 +19,42 @@
+@@ -19,31 +19,43 @@
  # Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
  # Redistribution and use is allowed according to the terms of the 2-clause BSD license.
  
@@ -12,12 +68,13 @@ index 73eee02f7..22d8bc159 100644
 -  DOC "Path to PEGTL headers")
 -mark_as_advanced(PEGTL_INCLUDE_DIR)
 +message(STATUS "Searching for PEGTL")
-+find_package(PEGTL CONFIG NAMES PEGTL-2)
++find_package(PEGTL CONFIG REQUIRED)
 +if(TARGET taocpp::pegtl)
 +    message(STATUS "Searching for PEGTL - found target taocpp::pegtl")
 +    set_target_properties(taocpp::pegtl PROPERTIES IMPORTED_GLOBAL TRUE)
 +    if(NOT TARGET PEGTL::PEGTL)
-+    add_library(PEGTL::PEGTL ALIAS taocpp::pegtl)
++       add_library(PEGTL::PEGTL IMPORTED INTERFACE)
++       target_link_libraries(PEGTL::PEGTL INTERFACE taocpp::pegtl)
 +    endif()
 +else()
 +    find_path(PEGTL_INCLUDE_DIR

--- a/ports/vtk/pegtl.patch
+++ b/ports/vtk/pegtl.patch
@@ -29,7 +29,7 @@ index 338aa736e..374e54b94 100644
      return true;
    }
 -  catch (const tao::pegtl::input_error& e)
-+  catch (const tao::pegtl::parse_error&& e)
++  catch (const tao::pegtl::parse_error& e)
    {
      vtkGenericWarningMacro(
        "UniversalTransformMotion::read_universaltransform_file failed: " << e.what());

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.2.0-pv5.11.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",
@@ -30,7 +30,7 @@
     "libxml2",
     "lz4",
     "netcdf-c",
-    "pegtl-2",
+    "pegtl",
     "proj",
     "pugixml",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8162,7 +8162,7 @@
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",
-      "port-version": 2
+      "port-version": 3
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35bdd05c8d99bc4933c899b76357830bfeebe01a",
+      "version-semver": "9.2.0-pv5.11.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "df558a4d65780495ca4ba4710306eb337f23bf93",
       "version-semver": "9.2.0-pv5.11.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] ~~SHA512s are updated for each updated download~~
- [x] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [x] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
