### PR TITLE
[secas] Improve interaction with hdf5[parallel]

### DIFF
--- a/ports/seacas/portfile.cmake
+++ b/ports/seacas/portfile.cmake
@@ -11,6 +11,14 @@ vcpkg_from_github(
             fix-headers.patch
 )
 
+if(NOT "mpi" IN_LIST FEATURES)
+    file(STRINGS "${CURRENT_INSTALLED_DIR}/share/hdf5/vcpkg_abi_info.txt" hdf5_abi_info REGEX "features")
+    if(hdf5_abi_info MATCHES "( |;)parallel")
+        # Fail early and visibly.
+        message(FATAL_ERROR "Cannot build ${PORT} without feature 'mpi':\nDependency hdf5 is installed with feature 'parallel'.")
+    endif()
+endif()
+
 if(NOT VCPKG_TARGET_IS_OSX)
     set(MPI_FEATURES mpi TPL_ENABLE_ParMETIS)
 endif()

--- a/ports/seacas/vcpkg.json
+++ b/ports/seacas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "seacas",
   "version-date": "2022-11-22",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Sandia Engineering Analysis Code Access System (SEACAS) is a suite of preprocessing, postprocessing, translation, and utility applications supporting finite element analysis software using the Exodus database file format.",
   "homepage": "https://github.com/sandialabs/seacas",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7078,7 +7078,7 @@
     },
     "seacas": {
       "baseline": "2022-11-22",
-      "port-version": 2
+      "port-version": 3
     },
     "seal": {
       "baseline": "4.1.1",

--- a/versions/s-/seacas.json
+++ b/versions/s-/seacas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef404b4f8ef531eef5107e24e6382cb03b411c30",
+      "version-date": "2022-11-22",
+      "port-version": 3
+    },
+    {
       "git-tree": "00566c22630c8b3dff31a47c3be03389e4d33b3d",
       "version-date": "2022-11-22",
       "port-version": 2


### PR DESCRIPTION
`vcpkg install seacas` fails after `vcpkg install hdf5[parallel]`, cf. #29462.
This PR adds an early and clear error message.
Alternative: Set option `-DTPL_ENABLE_MPI:BOOL=ON` regardless of requested seacas features.
Related discussion: #29724

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
