### PR TITLE
[armadillo] Update to 11.4.4

### DIFF
--- a/ports/armadillo/portfile.cmake
+++ b/ports/armadillo/portfile.cmake
@@ -1,11 +1,10 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO arma
     FILENAME "armadillo-${VERSION}.tar.xz"
-    SHA512 3ca620e686487dd3392b30c184be6f7f89eb13a63668f54b3d39cd6d29c7e024423819e948aea01247935ca3bf7b0b0d5f0004dc60395195beb7d14feef484b1
+    SHA512 fa344a0f1dc8270d8aa01c35a00e9dd4182031ab3a0e1ecf8b748151eccdb5445807eb880b454ccba5250749ee02845adb1669732de89a4939e3368d36471015
     PATCHES
         cmake-config.patch
         dependencies.patch

--- a/ports/armadillo/usage
+++ b/ports/armadillo/usage
@@ -3,7 +3,7 @@ armadillo provides CMake targets:
     find_package(Armadillo CONFIG REQUIRED)
     target_link_libraries(main PRIVATE armadillo)
 
-armadillo is compatible with built-in CMake targets:
+armadillo is compatible with built-in CMake variables:
 
     find_package(Armadillo REQUIRED)
     target_include_directories(main PRIVATE ${ARMADILLO_INCLUDE_DIRS})

--- a/ports/armadillo/vcpkg.json
+++ b/ports/armadillo/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "armadillo",
-  "version": "11.4.3",
+  "version": "11.4.4",
   "description": "Armadillo is a high quality linear algebra library (matrix maths) for the C++ language, aiming towards a good balance between speed and ease of use",
-  "homepage": "http://arma.sourceforge.net",
+  "homepage": "https://arma.sourceforge.net/",
   "license": "Apache-2.0",
   "dependencies": [
     "blas",

--- a/versions/a-/armadillo.json
+++ b/versions/a-/armadillo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f149e3877dead7fd5e1783feb83a64a794eddcba",
+      "version": "11.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "325a64512ffbc2d8bfb94ff44c5a86c55252dc58",
       "version": "11.4.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -201,7 +201,7 @@
       "port-version": 0
     },
     "armadillo": {
-      "baseline": "11.4.3",
+      "baseline": "11.4.4",
       "port-version": 0
     },
     "arrayfire": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
