### PR TITLE
Add parameter to limit CI to selected triplets

### DIFF
--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -150,3 +150,4 @@ if("tools" IN_LIST FEATURES AND NOT VCPKG_CROSSCOMPILING)
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/gettext-runtime/COPYING" "${SOURCE_PATH}/COPYING")
+message(FATAL_ERROR STOP)

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -150,4 +150,3 @@ if("tools" IN_LIST FEATURES AND NOT VCPKG_CROSSCOMPILING)
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/gettext-runtime/COPYING" "${SOURCE_PATH}/COPYING")
-message(FATAL_ERROR STOP)

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -11,6 +11,10 @@ parameters:
     displayName: 'Custom SHA of vcpkg-tool to use rather than bootstrap'
     type: string
     default: 'use default'
+  - name: tripletPattern
+    displayName: 'Enable triplets which contain this substring'
+    type: string
+    default: ''
 
 jobs:
 - template: windows/azure-pipelines.yml
@@ -19,6 +23,7 @@ jobs:
     jobName: x86_windows
     poolName: $(windows-pool)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
+    tripletPattern: ${{ parameters.tripletPattern }}
 
 - template: windows/azure-pipelines.yml
   parameters:
@@ -26,6 +31,7 @@ jobs:
     jobName: x64_windows
     poolName: $(windows-pool)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
+    tripletPattern: ${{ parameters.tripletPattern }}
 
 - template: windows/azure-pipelines.yml
   parameters:
@@ -33,6 +39,7 @@ jobs:
     jobName: x64_windows_static
     poolName: $(windows-pool)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
+    tripletPattern: ${{ parameters.tripletPattern }}
 
 - template: windows/azure-pipelines.yml
   parameters:
@@ -40,6 +47,7 @@ jobs:
     jobName: x64_windows_static_md
     poolName: $(windows-pool)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
+    tripletPattern: ${{ parameters.tripletPattern }}
 
 - template: windows/azure-pipelines.yml
   parameters:
@@ -47,6 +55,7 @@ jobs:
     jobName: x64_uwp
     poolName: $(windows-pool)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
+    tripletPattern: ${{ parameters.tripletPattern }}
 
 - template: windows/azure-pipelines.yml
   parameters:
@@ -54,6 +63,7 @@ jobs:
     jobName: arm64_windows
     poolName: $(windows-pool)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
+    tripletPattern: ${{ parameters.tripletPattern }}
 
 - template: windows/azure-pipelines.yml
   parameters:
@@ -61,13 +71,16 @@ jobs:
     jobName: arm_uwp
     poolName: $(windows-pool)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
+    tripletPattern: ${{ parameters.tripletPattern }}
 
 - template: osx/azure-pipelines.yml
   parameters:
     poolName: $(osx-pool)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
+    tripletPattern: ${{ parameters.tripletPattern }}
 
 - template: linux/azure-pipelines.yml
   parameters:
     poolName: $(linux-pool)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
+    tripletPattern: ${{ parameters.tripletPattern }}

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -14,7 +14,7 @@ parameters:
   - name: tripletPattern
     displayName: 'Enable triplets which contain this substring'
     type: string
-    default: 'x64-windows$'
+    default: ''
 
 jobs:
 - template: windows/azure-pipelines.yml

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -14,7 +14,7 @@ parameters:
   - name: tripletPattern
     displayName: 'Enable triplets which contain this substring'
     type: string
-    default: ''
+    default: 'x64-windows$'
 
 jobs:
 - template: windows/azure-pipelines.yml

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -16,7 +16,7 @@ parameters:
 
 jobs:
 - job: x64_linux
-  condition: contains('x64-linux', '${{ parameters.tripletPattern }}')
+  condition: contains('^x64-linux$', '${{ parameters.tripletPattern }}')
   pool:
     name: ${{ parameters.poolName }}
   workspace:

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -9,9 +9,14 @@ parameters:
     default: 'use default'
   - name: poolName
     type: string
+  - name: tripletPattern
+    displayName: 'Enable the triplets which contain this substring'
+    type: string
+    default: ''
 
 jobs:
 - job: x64_linux
+  condition: contains('x64-linux', '${{ parameters.tripletPattern }}')
   pool:
     name: ${{ parameters.poolName }}
   workspace:

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -16,7 +16,7 @@ parameters:
 
 jobs:
 - job: x64_osx
-  condition: contains('x64-osx', '${{ parameters.tripletPattern }}')
+  condition: contains('^x64-osx$', '${{ parameters.tripletPattern }}')
   pool:
     name: ${{ parameters.poolName }}
   workspace:

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -9,9 +9,14 @@ parameters:
     default: 'use default'
   - name: poolName
     type: string
+  - name: tripletPattern
+    displayName: 'Enable the triplets which contain this substring'
+    type: string
+    default: ''
 
 jobs:
 - job: x64_osx
+  condition: contains('x64-osx', '${{ parameters.tripletPattern }}')
   pool:
     name: ${{ parameters.poolName }}
   workspace:

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -15,9 +15,14 @@ parameters:
     default: 'x86_windows'
   - name: poolName
     type: string
+  - name: tripletPattern
+    displayName: 'Enable the triplets which contain this substring'
+    type: string
+    default: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
+  condition: contains('${{ parameters.triplet }}', '${{ parameters.tripletPattern }}')
   pool:
     name: ${{ parameters.poolName }}
   workspace:

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -22,7 +22,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.jobName }}
-  condition: contains('${{ parameters.triplet }}', '${{ parameters.tripletPattern }}')
+  condition: contains('^${{ parameters.triplet }}$', '${{ parameters.tripletPattern }}')
   pool:
     name: ${{ parameters.poolName }}
   workspace:


### PR DESCRIPTION
Pull requests which analyze the situation in a particular triplet, arch or platform may temporarily limit the triplets run in CI by overriding the default value of CI parameter 'tripletPattern'.

The special characters `^` and `$` can be used to match at the begin and the end of the triplet (similar to regular expressions): Pattern `x64-windows` matches multiple triplets, but pattern `x64-windows$` needs an exact match at the end.