### PR TITLE
[miniaudio] Add new port

### DIFF
--- a/ports/miniaudio/portfile.cmake
+++ b/ports/miniaudio/portfile.cmake
@@ -1,0 +1,13 @@
+# Header-only library
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO mackron/miniaudio
+  REF a0dc1037f99a643ff5fad7272cd3d6461f2d63fa
+  SHA512 396608d8326777adfffb50216322198b9f86d73c6a83c5886dc9eaef93b82a4e8f44f446192990b7b9fabac53fad073546214692a000415307e70812a50fb0c2
+  HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/miniaudio.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/miniaudio/portfile.cmake
+++ b/ports/miniaudio/portfile.cmake
@@ -10,4 +10,4 @@ vcpkg_from_github(
 file(INSTALL "${SOURCE_PATH}/miniaudio.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/miniaudio/vcpkg.json
+++ b/ports/miniaudio/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "miniaudio",
+  "version": "0.11.11",
+  "description": "Audio playback and capture library written in C, in a single source file",
+  "homepage": "https://github.com/mackron/miniaudio",
+  "license": "Unlicense OR MIT-0"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5044,6 +5044,10 @@
       "baseline": "1.3.3",
       "port-version": 3
     },
+    "miniaudio": {
+      "baseline": "0.11.11",
+      "port-version": 0
+    },
     "minifb": {
       "baseline": "2023-02-03",
       "port-version": 0

--- a/versions/m-/miniaudio.json
+++ b/versions/m-/miniaudio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0977e55b62f46fe9dba8d74315fe972946679749",
+      "git-tree": "8a7494389f8cefc6d039938d2416fa56d94ee72d",
       "version": "0.11.11",
       "port-version": 0
     }

--- a/versions/m-/miniaudio.json
+++ b/versions/m-/miniaudio.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0977e55b62f46fe9dba8d74315fe972946679749",
+      "version": "0.11.11",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

This PR adds a port for miniaudio (header-only library): https://github.com/mackron/miniaudio

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. (*Usage text was not added explicitly, but it's still accurate*)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Port was tested on Linux machine with GCC 12.1.1 in manifest mode, everything works as expected.