### PR TITLE
[curl] Fix consuming curl via find_package.

### DIFF
--- a/ports/curl/0023-fix-find-cares.patch
+++ b/ports/curl/0023-fix-find-cares.patch
@@ -1,5 +1,19 @@
+diff --git a/CMake/curl-config.cmake.in b/CMake/curl-config.cmake.in
+index 496a92d0e..564415ef6 100644
+--- a/CMake/curl-config.cmake.in
++++ b/CMake/curl-config.cmake.in
+@@ -30,6 +30,9 @@ endif()
+ if(@USE_ZLIB@)
+   find_dependency(ZLIB @ZLIB_VERSION_MAJOR@)
+ endif()
++if(@USE_ARES@)
++  find_dependency(c-ares)
++endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+ check_required_components("@PROJECT_NAME@")
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f6e1071..62aed82 100644
+index b43520751..dbf62751f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -169,8 +169,8 @@ set(CURL_LIBS "")

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "curl",
   "version": "7.88.1",
+  "port-version": 1,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1882,7 +1882,7 @@
     },
     "curl": {
       "baseline": "7.88.1",
-      "port-version": 0
+      "port-version": 1
     },
     "curlpp": {
       "baseline": "2018-06-15",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9be28a8022b91c14e868d88a74eedc0dd891e966",
+      "version": "7.88.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "2b76f0341314696395cfa982b5199c8336192757",
       "version": "7.88.1",
       "port-version": 0


### PR DESCRIPTION
The commit [1] broke consuming curl for downstream projects:

CMake Error at cmake-build-debug/vcpkg_installed/x64-windows-static/share/curl/CURLTargets.cmake:61 (set_target_properties):
  The link interface of target "CURL::libcurl" contains:

    c-ares::cares

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target. 
    * An ALIAS target is missing.

[1]: https://github.com/microsoft/vcpkg/commit/c9eb3bd14ec7f0a03ffaf2bc3ec50dcb09e8d193

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
