### PR TITLE
[uchardet] update to v0.0.8

### DIFF
--- a/ports/uchardet/fix-config-error.patch
+++ b/ports/uchardet/fix-config-error.patch
@@ -1,0 +1,16 @@
+diff --git a/src/tools/CMakeLists.txt b/src/tools/CMakeLists.txt
+index 7afad1d..c7a3cd8 100644
+--- a/src/tools/CMakeLists.txt
++++ b/src/tools/CMakeLists.txt
+@@ -27,10 +27,7 @@ if (GETOPT_INCLUDE_DIR AND GETOPT_LIBRARY)
+     target_link_libraries(${UCHARDET_BINARY} PRIVATE ${GETOPT_LIBRARY})
+ endif (GETOPT_INCLUDE_DIR AND GETOPT_LIBRARY)
+ 
+-target_link_libraries(
+-	${UCHARDET_BINARY}
+-	${UCHARDET_LIBRARY}
+-)
++target_link_libraries(${UCHARDET_BINARY} PRIVATE ${UCHARDET_LIBRARY})
+ 
+ install(
+ 	TARGETS

--- a/ports/uchardet/portfile.cmake
+++ b/ports/uchardet/portfile.cmake
@@ -2,10 +2,12 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uchardet/uchardet
-    REF 6f38ab95f55afd45ee6ccefcb92d21034b4a2521
-    SHA512 a2e655d6e1eb6934cf93d99d27dfebc382eb01b6e62021f56b3fa71d269a851e7d68fe57536d40470e0329b3aa035467a9cdd9e11698f8ff76f06611ea7a58d1
+    REF "${VERSION}"
+    SHA512 8d7a0abe1fcf7e92f9e264252eefa5810176603e3d3d825a23c3f5d23cd4f7cce9a0a9539e84bd70af5b66688394e48af00a00ce759a5a3d69b650f92351b6f2
     HEAD_REF master
-    PATCHES fix-uwp-build.patch
+    PATCHES
+        fix-uwp-build.patch
+        fix-config-error.patch
 )
 
 
@@ -29,7 +31,11 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/uchardet)
+
 vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
 
 if(tool IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES uchardet AUTO_CLEAN)
@@ -41,6 +47,4 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/man"
 )
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/uchardet/portfile.cmake
+++ b/ports/uchardet/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uchardet/uchardet
-    REF "${VERSION}"
+    REF "v${VERSION}"
     SHA512 8d7a0abe1fcf7e92f9e264252eefa5810176603e3d3d825a23c3f5d23cd4f7cce9a0a9539e84bd70af5b66688394e48af00a00ce759a5a3d69b650f92351b6f2
     HEAD_REF master
     PATCHES

--- a/ports/uchardet/vcpkg.json
+++ b/ports/uchardet/vcpkg.json
@@ -3,6 +3,7 @@
   "version-string": "v0.0.8",
   "description": "An encoding detector library ported from Mozilla.",
   "homepage": "https://cgit.freedesktop.org/uchardet/uchardet/",
+  "license": "GPL-2.0 AND MPL-1.1",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/uchardet/vcpkg.json
+++ b/ports/uchardet/vcpkg.json
@@ -1,12 +1,15 @@
 {
   "name": "uchardet",
-  "version-date": "2021-09-03",
-  "port-version": 2,
+  "version-string": "v0.0.8",
   "description": "An encoding detector library ported from Mozilla.",
   "homepage": "https://cgit.freedesktop.org/uchardet/uchardet/",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ],

--- a/ports/uchardet/vcpkg.json
+++ b/ports/uchardet/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uchardet",
-  "version-string": "v0.0.8",
+  "version": "0.0.8",
   "description": "An encoding detector library ported from Mozilla.",
   "homepage": "https://cgit.freedesktop.org/uchardet/uchardet/",
   "license": "GPL-2.0 AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7909,7 +7909,7 @@
       "port-version": 1
     },
     "uchardet": {
-      "baseline": "v0.0.8",
+      "baseline": "0.0.8",
       "port-version": 0
     },
     "umock-c": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7909,8 +7909,8 @@
       "port-version": 1
     },
     "uchardet": {
-      "baseline": "2021-09-03",
-      "port-version": 2
+      "baseline": "v0.0.8",
+      "port-version": 0
     },
     "umock-c": {
       "baseline": "2022-01-21",

--- a/versions/u-/uchardet.json
+++ b/versions/u-/uchardet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a90ad09f5dfa83fd4ae3c5eac30f9ed0625ff517",
+      "version-string": "v0.0.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "8333800cb0daceea8448ca6d20a91a1944b31559",
       "version-date": "2021-09-03",
       "port-version": 2

--- a/versions/u-/uchardet.json
+++ b/versions/u-/uchardet.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "0908be0bf0958228c974eafda23a5e7ba494e4c4",
-      "version-string": "v0.0.8",
+      "git-tree": "a226a1e7f8682190fbfb778afe3659b55817e219",
+      "version": "0.0.8",
       "port-version": 0
     },
     {

--- a/versions/u-/uchardet.json
+++ b/versions/u-/uchardet.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a90ad09f5dfa83fd4ae3c5eac30f9ed0625ff517",
+      "git-tree": "0908be0bf0958228c974eafda23a5e7ba494e4c4",
       "version-string": "v0.0.8",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #29720

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature `tool` tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static
