### PR TITLE
[libidn2] Fix linking static libidn2 into shared library

### DIFF
--- a/ports/libidn2/fix-static-into-shared-linking.patch
+++ b/ports/libidn2/fix-static-into-shared-linking.patch
@@ -1,0 +1,30 @@
+--- a/lib/puny_decode.c
++++ b/lib/puny_decode.c
+@@ -242,12 +242,3 @@
+   /* cannot overflow because out <= old value of *output_length */
+   return punycode_success;
+ }
+-
+-/* Create a compatibility symbol if supported.  Hidden references make
+-   the target symbol hidden, hence the alias.  */
+-#ifdef HAVE_SYMVER_ALIAS_SUPPORT
+-__typeof__ (_idn2_punycode_decode_internal) _idn2_punycode_decode
+-  __attribute__((visibility ("default"),
+-		 alias ("_idn2_punycode_decode_internal")));
+-__asm__ (".symver _idn2_punycode_decode, _idn2_punycode_decode@IDN2_0.0.0");
+-#endif
+--- a/lib/puny_encode.c
++++ b/lib/puny_encode.c
+@@ -243,12 +243,3 @@
+   *output_length = out;
+   return punycode_success;
+ }
+-
+-/* Create a compatibility symbol if supported.  Hidden references make
+-   the target symbol hidden, hence the alias.  */
+-#ifdef HAVE_SYMVER_ALIAS_SUPPORT
+-__typeof__ (_idn2_punycode_encode_internal) _idn2_punycode_encode
+-  __attribute__((visibility ("default"),
+-		 alias ("_idn2_punycode_encode_internal")));
+-__asm__ (".symver _idn2_punycode_encode, _idn2_punycode_encode@IDN2_0.0.0");
+-#endif

--- a/ports/libidn2/portfile.cmake
+++ b/ports/libidn2/portfile.cmake
@@ -8,10 +8,18 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 a6e90ccef56cfd0b37e3333ab3594bb3cec7ca42a138ca8c4f4ce142da208fa792f6c78ca00c01001c2bc02831abcbaf1cf9bcc346a5290fd7b30708f5a462f3
 )
 
+vcpkg_list(SET patches)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    # Fix linking static libidn2 into shared library
+    # https://gitlab.com/libidn/libidn2/-/issues/80
+    vcpkg_list(APPEND patches "fix-static-into-shared-linking.patch")
+endif()
+
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     SOURCE_BASE "v${VERSION}"
     PATCHES
+        ${patches}
         disable-subdirs.patch
         fix-msvc.patch
         fix-uwp.patch

--- a/ports/libidn2/vcpkg.json
+++ b/ports/libidn2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libidn2",
   "version": "2.3.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.",
   "homepage": "https://www.gnu.org/software/libidn/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4010,7 +4010,7 @@
     },
     "libidn2": {
       "baseline": "2.3.4",
-      "port-version": 1
+      "port-version": 2
     },
     "libigl": {
       "baseline": "2.3.0",

--- a/versions/l-/libidn2.json
+++ b/versions/l-/libidn2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4784d5f7f99d7ea1ebe6f1ef01943e402e7bfddf",
+      "version": "2.3.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "111b9ff4af9664333f73344385dfbbfa40d9bc20",
       "version": "2.3.4",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This removes libidn2's workaround for adding back exported symbols that were previously hidden due to being undocumented. The reason is that this workaround causes link errors when libidn2 is built as a static library and linked into shared library (https://gitlab.com/libidn/libidn2/-/issues/80). This breaks ABI but I'm not sure if we care since it's for static build only and we build from source anyway.