### PR TITLE
[ktx] Static build fix

### DIFF
--- a/ports/ktx/0001-Use-vcpkg-zstd.patch
+++ b/ports/ktx/0001-Use-vcpkg-zstd.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f1d37cf7..9cf43c75 100644
+index bc679fd1..c726fa71 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -174,7 +174,6 @@ set(KTX_MAIN_SRC
+@@ -185,7 +185,6 @@ set(KTX_MAIN_SRC
      lib/basisu/transcoder/basisu_transcoder.cpp
      lib/basisu/transcoder/basisu_transcoder.h
      lib/basisu/transcoder/basisu.h
@@ -10,7 +10,7 @@ index f1d37cf7..9cf43c75 100644
      lib/checkheader.c
      lib/dfdutils/createdfd.c
      lib/dfdutils/colourspaces.c
-@@ -284,7 +283,6 @@ macro(commom_lib_settings lib write)
+@@ -304,7 +303,6 @@ macro(commom_lib_settings lib write)
          $<INSTALL_INTERFACE:lib/basisu/transcoder>
  
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/basisu/zstd>
@@ -18,7 +18,7 @@ index f1d37cf7..9cf43c75 100644
  
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/other_include>
          $<INSTALL_INTERFACE:other_include>
-@@ -370,6 +368,10 @@ macro(commom_lib_settings lib write)
+@@ -390,6 +388,10 @@ macro(commom_lib_settings lib write)
          target_compile_definitions(${lib} PUBLIC KTX_FEATURE_KTX2)
      endif()
  
@@ -29,8 +29,23 @@ index f1d37cf7..9cf43c75 100644
      if(WIN32)
          # By wrapping in generator expression we force multi configuration
          # generators (like Visual Studio) to take the exact path and not
+diff --git a/cmake/KtxConfig.cmake b/cmake/KtxConfig.cmake
+index 6386ba2f..537bf4f2 100644
+--- a/cmake/KtxConfig.cmake
++++ b/cmake/KtxConfig.cmake
+@@ -1,7 +1,8 @@
+ # Copyright 2015-2020 The Khronos Group Inc.
+ # SPDX-License-Identifier: Apache-2.0
+ 
+-# include(CMakeFindDependencyMacro)
+-# find_dependency()
++include(CMakeFindDependencyMacro)
++find_dependency(Threads)
++find_dependency(zstd CONFIG)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/KtxTargets.cmake")
 diff --git a/lib/basisu/CMakeLists.txt b/lib/basisu/CMakeLists.txt
-index 492233a..8786d16 100644
+index 492233ae..8786d16c 100644
 --- a/lib/basisu/CMakeLists.txt
 +++ b/lib/basisu/CMakeLists.txt
 @@ -146,7 +146,7 @@ set(BASISU_SRC_LIST ${COMMON_SRC_LIST}
@@ -54,7 +69,7 @@ index 492233a..8786d16 100644
  	# For Non-Windows builds, let cmake try and find the system OpenCL headers/libs for us.
  	if (OPENCL_FOUND)
 diff --git a/lib/basisu/webgl/encoder/CMakeLists.txt b/lib/basisu/webgl/encoder/CMakeLists.txt
-index 588d91b..0b38012 100644
+index 588d91b4..0b380129 100644
 --- a/lib/basisu/webgl/encoder/CMakeLists.txt
 +++ b/lib/basisu/webgl/encoder/CMakeLists.txt
 @@ -34,9 +34,7 @@ if (EMSCRIPTEN)
@@ -80,7 +95,7 @@ index 588d91b..0b38012 100644
        OUTPUT_NAME "basis_encoder"
        SUFFIX ".js"
 diff --git a/lib/basisu/webgl/transcoder/CMakeLists.txt b/lib/basisu/webgl/transcoder/CMakeLists.txt
-index 372653d..f75e3a3 100644
+index 372653de..f75e3a35 100644
 --- a/lib/basisu/webgl/transcoder/CMakeLists.txt
 +++ b/lib/basisu/webgl/transcoder/CMakeLists.txt
 @@ -28,9 +28,7 @@ if (EMSCRIPTEN)

--- a/ports/ktx/0003-libtool.patch
+++ b/ports/ktx/0003-libtool.patch
@@ -1,32 +1,22 @@
-From 46ae9af513ad669ca4e075e5d63f6eb77e9ad2b1 Mon Sep 17 00:00:00 2001
-From: 06393993 <33996375+06393993@users.noreply.github.com>
-Date: Mon, 3 Oct 2022 01:41:24 -0700
-Subject: [PATCH] Fix static build on Linux (#635)
-
-On Linux, it is very likely that a GNU libtool is used, and different
-parameters are needed for libtool to combine libraries.
----
- CMakeLists.txt | 8 +++++++-
- 1 file changed, 7 insertions(+), 1 deletion(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d19e7dbc2..2b0e31751 100644
+index bc679fd1..13052501 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -830,9 +830,15 @@ set_property(TARGET ${ASTC_LIB_TARGET} PROPERTY POSITION_INDEPENDENT_CODE ON)
- if(KTX_FEATURE_STATIC_LIBRARY AND NOT WIN32 AND NOT EMSCRIPTEN)
+@@ -826,7 +826,7 @@ set(CLI OFF) # Only build as library not the CLI astcencoder
+ add_subdirectory(lib/astc-encoder)
+ set_property(TARGET ${ASTC_LIB_TARGET} PROPERTY POSITION_INDEPENDENT_CODE ON)
+ 
+-if(KTX_FEATURE_STATIC_LIBRARY AND NOT WIN32 AND NOT EMSCRIPTEN)
++if(KTX_FEATURE_STATIC_LIBRARY AND APPLE)
      # Make a single static library to simplify linking.
      add_dependencies(ktx ${ASTC_LIB_TARGET})
-+    set(LIBTOOL_ARGS)
-+    if(LINUX)
-+        set(LIBTOOL_ARGS ${LIBTOOL_ARGS} --mode=link --tag=CC cc)
-+    endif()
-+    set(LIBTOOL_ARGS ${LIBTOOL_ARGS} -static -o
-+        $<TARGET_FILE:ktx> $<TARGET_FILE:ktx> $<TARGET_FILE:${ASTC_LIB_TARGET}>)
      add_custom_command( TARGET ktx
-         POST_BUILD
--        COMMAND libtool -static -o $<TARGET_FILE:ktx> $<TARGET_FILE:ktx> $<TARGET_FILE:${ASTC_LIB_TARGET}>
-+        COMMAND libtool ${LIBTOOL_ARGS}
-     )
+@@ -856,7 +856,7 @@ if(KTX_FEATURE_DOC)
+ endif()
  
-     # Don't know libtool equivalent on Windows or Emscripten. Applications
+ set(KTX_INSTALL_TARGETS ktx)
+-if(KTX_FEATURE_STATIC_LIBRARY AND (WIN32 OR EMSCRIPTEN))
++if(KTX_FEATURE_STATIC_LIBRARY AND NOT APPLE)
+     list(APPEND KTX_INSTALL_TARGETS ${ASTC_LIB_TARGET})
+ endif()
+ 

--- a/ports/ktx/vcpkg.json
+++ b/ports/ktx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ktx",
   "version-semver": "4.1.0-rc3",
+  "port-version": 1,
   "description": "A small library of functions for writing and reading KTX files, and instantiating OpenGL®, OpenGL ES™️ and Vulkan® textures from them",
   "homepage": "https://github.com/KhronosGroup/KTX-Software",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3598,7 +3598,7 @@
     },
     "ktx": {
       "baseline": "4.1.0-rc3",
-      "port-version": 0
+      "port-version": 1
     },
     "kubazip": {
       "baseline": "0.2.4",

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b347df16db358ecb56e49c982c9a48f732f5da2f",
+      "version-semver": "4.1.0-rc3",
+      "port-version": 1
+    },
+    {
       "git-tree": "832cadbd81cd45323fcfa4b877299fc738e83606",
       "version-semver": "4.1.0-rc3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Currently, [KTX port](https://github.com/microsoft/vcpkg/tree/master/ports/ktx) has 2 issues that prevent static build (in particularly on Linux with default triplet):
1. There is a patch applied for replacing zstd dependency (that is embedded directly into ktx library) on version from vcpkg port,  and for static build configuration fails with:
```
CMake Error at builds/ninja-multiconfiguration-vcpkg/vcpkg_installed/x64-linux/share/ktx/KtxTargets.cmake:60 (set_target_properties):
  The link interface of target "KTX::ktx" contains:

    zstd::libzstd_static

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  builds/ninja-multiconfiguration-vcpkg/vcpkg_installed/x64-linux/share/ktx/KtxConfig.cmake:7 (include)
  vcpkg/scripts/buildsystems/vcpkg.cmake:843 (_find_package)
  CMakeLists.txt:5 (find_package)
```
It looks like there are missing find_dependency() commands in KtxConfig.cmake, after adding them to the `0001-Use-vcpkg-zstd.patch` build completes successfully.

2. The issue with GNU libtool that manifests only in static build with enabled KTX_FEATURE_TOOLS option ('tools' feature in vcpkg port): [details](https://github.com/KhronosGroup/KTX-Software/issues/652#issuecomment-1371077391), [fix in upstream](https://github.com/KhronosGroup/KTX-Software/pull/664). Since `0003-libtool.patch` (that was also cherry-picked from upstream) doesn't fully resolve this problem, it was updated with newer fix.

Testing: checked on Linux machine with GCC 12.1.1 in manifest mode, with all features ('tools' and 'vulkan') enabled, build is completed successfully.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
