### PR TITLE
[lessmsi] Remove tool from installed tree

### DIFF
--- a/ports/kinectsdk1/portfile.cmake
+++ b/ports/kinectsdk1/portfile.cmake
@@ -28,7 +28,7 @@ file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/src/KinectSDK-${KINECTSDK10_VERSI
 set(KINECTSDK10_MSI_INSTALLER "installer\\wix\\AttachedContainer\\KinectSDK-${KINECTSDK10_VERSION}-${VCPKG_TARGET_ARCHITECTURE}.msi")
 vcpkg_execute_required_process(
     COMMAND
-        "${CURRENT_HOST_INSTALLED_DIR}/tools/vcpkg-tool-lessmsi/lessmsi.exe"
+        "${LESSMSI}"
         x
         "${KINECTSDK10_MSI_INSTALLER}"
     WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src"

--- a/ports/kinectsdk1/vcpkg.json
+++ b/ports/kinectsdk1/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kinectsdk1",
   "version": "1.8",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Kinect for Windows SDK for Kinect v1 sensor.",
   "license": null,
   "supports": "!arm & windows",

--- a/ports/kinectsdk1/vcpkg.json
+++ b/ports/kinectsdk1/vcpkg.json
@@ -8,7 +8,8 @@
   "dependencies": [
     {
       "name": "vcpkg-tool-lessmsi",
-      "host": true
+      "host": true,
+      "version>=": "1.10#1"
     }
   ]
 }

--- a/ports/kinectsdk2/portfile.cmake
+++ b/ports/kinectsdk2/portfile.cmake
@@ -21,7 +21,7 @@ file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/src/KinectSDK-${KINECTSDK20_VERSI
 set(KINECTSDK20_MSI_INSTALLER "installer\\wix\\AttachedContainer\\KinectSDK-${KINECTSDK20_VERSION}-x64.msi")
 vcpkg_execute_required_process(
     COMMAND
-        "${CURRENT_HOST_INSTALLED_DIR}/tools/vcpkg-tool-lessmsi/lessmsi.exe"
+        "${LESSMSI}"
         x
         "${KINECTSDK20_MSI_INSTALLER}"
     WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src"

--- a/ports/kinectsdk2/vcpkg.json
+++ b/ports/kinectsdk2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kinectsdk2",
   "version": "2.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Kinect for Windows SDK for Kinect v2 sensor.",
   "license": null,
   "supports": "!arm & windows",

--- a/ports/kinectsdk2/vcpkg.json
+++ b/ports/kinectsdk2/vcpkg.json
@@ -8,7 +8,8 @@
   "dependencies": [
     {
       "name": "vcpkg-tool-lessmsi",
-      "host": true
+      "host": true,
+      "version>=": "1.10#1"
     }
   ]
 }

--- a/ports/vcpkg-tool-lessmsi/portfile.cmake
+++ b/ports/vcpkg-tool-lessmsi/portfile.cmake
@@ -1,17 +1,4 @@
-set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
 
-set(version v1.10.0)
-
-vcpkg_download_distfile(archive_path
-    URLS "https://github.com/activescott/lessmsi/releases/download/${version}/lessmsi-${version}.zip"
-    FILENAME "lessmsi-${version}.zip"
-    SHA512 91be9363d75e8ca0129304008ddc26fe575cc4fd76d7f43ef0a6ff414855dc1c6e412f4e694b2950026e02cc3d31b18bd8c2e4c03e1ddce01477f3f2d2197479
-)
-
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-
-file(ARCHIVE_EXTRACT
-    INPUT "${archive_path}"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}"
-)
-
+configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-port-config.cmake" @ONLY)
+file(INSTALL "${VCPKG_ROOT_DIR}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/vcpkg-tool-lessmsi/vcpkg-port-config.cmake
+++ b/ports/vcpkg-tool-lessmsi/vcpkg-port-config.cmake
@@ -1,0 +1,16 @@
+include_guard(GLOBAL)
+set(version v1.10.0)
+find_program(LESSMSI PATHS "${DOWNLOADS}/lessmsi-${version}")
+if(NOT LESSMSI)
+    vcpkg_download_distfile(archive_path
+        URLS "https://github.com/activescott/lessmsi/releases/download/${version}/lessmsi-${version}.zip"
+        FILENAME "lessmsi-${version}.zip"
+        SHA512 91be9363d75e8ca0129304008ddc26fe575cc4fd76d7f43ef0a6ff414855dc1c6e412f4e694b2950026e02cc3d31b18bd8c2e4c03e1ddce01477f3f2d2197479
+    )
+    file(MAKE_DIRECTORY "${DOWNLOADS}/lessmsi-${version}")
+    file(ARCHIVE_EXTRACT
+        INPUT "${archive_path}"
+        DESTINATION "${DOWNLOADS}/lessmsi-${version}"
+    )
+    set(LESSMSI "${DOWNLOADS}/lessmsi-${version}/lessmsi@VCPKG_TARGET_EXECUTABLE_SUFFIX@")
+endif()

--- a/ports/vcpkg-tool-lessmsi/vcpkg.json
+++ b/ports/vcpkg-tool-lessmsi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vcpkg-tool-lessmsi",
   "version": "1.10.0",
+  "port-version": 1,
   "description": "This is a utility with a graphical user interface and a command line interface that can be used to view and extract the contents of an MSI file.",
   "homepage": "https://github.com/activescott/lessmsi",
   "license": "MIT",

--- a/ports/vcpkg-tool-python2/portfile.cmake
+++ b/ports/vcpkg-tool-python2/portfile.cmake
@@ -28,7 +28,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     cmake_path(NATIVE_PATH archive_path archive_path_native) # lessmsi is a bit picky about path formats.
     message(STATUS "Extracting Python2 ...")
     vcpkg_execute_in_download_mode(
-                    COMMAND "${CURRENT_HOST_INSTALLED_DIR}/tools/vcpkg-tool-lessmsi/lessmsi.exe" x "${archive_path_native}" # Using output_path here does not work in bash
+                    COMMAND "${LESSMSI}" x "${archive_path_native}" # Using output_path here does not work in bash
                     WORKING_DIRECTORY "${output_path}" 
                     OUTPUT_FILE "${CURRENT_BUILDTREES_DIR}/lessmsi-${TARGET_TRIPLET}-out.log"
                     ERROR_FILE "${CURRENT_BUILDTREES_DIR}/lessmsi-${TARGET_TRIPLET}-err.log"

--- a/ports/vcpkg-tool-python2/vcpkg.json
+++ b/ports/vcpkg-tool-python2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vcpkg-tool-python2",
   "version": "2.7.18",
+  "port-version": 1,
   "description": "Python 2",
   "homepage": "https://www.python.org/download/releases/2.0/",
   "license": "PSF-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3570,11 +3570,11 @@
     },
     "kinectsdk1": {
       "baseline": "1.8",
-      "port-version": 5
+      "port-version": 6
     },
     "kinectsdk2": {
       "baseline": "2.0",
-      "port-version": 4
+      "port-version": 5
     },
     "kissfft": {
       "baseline": "2021-11-14",
@@ -8094,7 +8094,7 @@
     },
     "vcpkg-tool-lessmsi": {
       "baseline": "1.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vcpkg-tool-meson": {
       "baseline": "0.63",
@@ -8114,7 +8114,7 @@
     },
     "vcpkg-tool-python2": {
       "baseline": "2.7.18",
-      "port-version": 0
+      "port-version": 1
     },
     "vectorclass": {
       "baseline": "2.02.00",

--- a/versions/k-/kinectsdk1.json
+++ b/versions/k-/kinectsdk1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc44fc3968647d5e6a43066a8d2b0cf6be3f4405",
+      "version": "1.8",
+      "port-version": 6
+    },
+    {
       "git-tree": "688e49039e9c86fcb57c431b527a7f125a996857",
       "version": "1.8",
       "port-version": 5

--- a/versions/k-/kinectsdk2.json
+++ b/versions/k-/kinectsdk2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0de915e33cfe92b9972e0227eae6be31b6846fc5",
+      "version": "2.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "2fc9568898ab7f14edea8ffb65da87161c9c0b6c",
       "version": "2.0",
       "port-version": 4

--- a/versions/v-/vcpkg-tool-lessmsi.json
+++ b/versions/v-/vcpkg-tool-lessmsi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1025fd8509756f76c07068d4088fbe23d67078d8",
+      "version": "1.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "82ed573f8102d4ac7c15f40c64bba00968085d51",
       "version": "1.10.0",
       "port-version": 0

--- a/versions/v-/vcpkg-tool-python2.json
+++ b/versions/v-/vcpkg-tool-python2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d383d58a63e70ee364c0ec624f493e7097a4b9b",
+      "version": "2.7.18",
+      "port-version": 1
+    },
+    {
       "git-tree": "207c41205cd98688dda41cee13ecec02aae1f5fd",
       "version": "2.7.18",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] ~~SHA512s are updated for each updated download~~
- [x] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [x] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

