### PR TITLE
[libass] update to 0.17.1

### DIFF
--- a/ports/libass/CMakeLists.txt
+++ b/ports/libass/CMakeLists.txt
@@ -1,23 +1,20 @@
 cmake_minimum_required(VERSION 3.9)
-project(libass C CXX)
+project(libass C)
 
-set(LIBASS_VERSION 0.16.0)
-
-configure_file (${CMAKE_CURRENT_SOURCE_DIR}/config.h.in config.h)
+set(LIBASS_VERSION 0.17.1)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-add_compile_definitions(CONFIG_FREETYPE)
-add_compile_definitions(CONFIG_FRIBIDI)
-add_compile_definitions(CONFIG_HARFBUZZ)
+set(CONFIG_FREETYPE 1)
+set(CONFIG_FRIBIDI 1)
+set(CONFIG_HARFBUZZ 1)
 
-file (GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/libass/*.c)
+file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/libass/*.c)
 
-include(CheckCSourceCompiles)
 set(PKG_REQUIRES_LIBASS "harfbuzz >= 1.2.3, fribidi >= 0.19.1, freetype2 >= 9.17.3")
 set(PKG_LIBS_LIBASS)
 if(WIN32)
-  add_compile_definitions(CONFIG_DIRECTWRITE)
+  set(CONFIG_DIRECTWRITE 1)
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_coretext.c$")
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_fontconfig.c$")
 
@@ -25,10 +22,11 @@ if(WIN32)
   set(FONT_LIBRARY gdi32)
   set(PKG_LIBS_LIBASS -lgdi32)
 elseif(APPLE)
-  add_compile_definitions(CONFIG_CORETEXT)
+  set(CONFIG_CORETEXT 1)
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_directwrite.c$")
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_fontconfig.c$")
 
+  include(CheckCSourceCompiles)
   check_c_source_compiles(
     "
     #include <ApplicationServices/ApplicationServices.h>
@@ -39,56 +37,51 @@ elseif(APPLE)
     "
     CHECK_OLD_OSX
   )
-  if (CHECK_OLD_OSX)
+  if(CHECK_OLD_OSX)
     set(FONT_LIBRARY "-framework ApplicationServices -framework CoreFoundation")
     set(PKG_LIBS_LIBASS "-framework ApplicationServices -framework CoreFoundation")
   else()
     set(FONT_LIBRARY "-framework CoreText -framework CoreFoundation")
     set(PKG_LIBS_LIBASS "-framework CoreText -framework CoreFoundation")
   endif()
-else()
-  add_compile_definitions(CONFIG_FONTCONFIG)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(CONFIG_FONTCONFIG 1)
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_coretext.c$")
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_directwrite.c$")
 
   find_package(Fontconfig REQUIRED)
   set(FONT_LIBRARY Fontconfig::Fontconfig)
   set(PKG_REQUIRES_LIBASS "fontconfig >= 2.10.92, ${PKG_REQUIRES_LIBASS}")
+else()
+  list(FILTER SOURCES EXCLUDE REGEX ".*ass_directwrite.c$")
+  list(FILTER SOURCES EXCLUDE REGEX ".*ass_coretext.c$")
+  list(FILTER SOURCES EXCLUDE REGEX ".*ass_fontconfig.c$")
 endif()
 
-if (NOT WIN32)
+if(NOT WIN32)
   set(PKG_LIBS_LIBASS "${PKG_LIBS_LIBASS} -lm")
 endif()
 
 find_package(Freetype REQUIRED)
 
-find_path(FRIBIDI_INCLUDE_DIR
-          NAMES fribidi.h
-          PATH_SUFFIXES fribidi)
-
-find_path(HARFBUZZ_INCLUDE_DIR
-          NAMES hb.h
-          PATH_SUFFIXES harfbuzz)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(FRIBIDI REQUIRED IMPORTED_TARGET fribidi)
+pkg_check_modules(HARFBUZZ REQUIRED IMPORTED_TARGET harfbuzz)
 
 # libass use win32 api to open files on windows since https://github.com/libass/libass/commit/f664ced049394e2a5d4300ba526e206df73ec729
 # so remove dependency dirent.
 
-find_library(FRIBIDI_LIBRARY NAMES libfribidi fribidi)
-find_library(HARFBUZZ_LIBRARY NAMES harfbuzz)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in config.h)
 
 add_library(ass ${SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/libass.def)
 
 target_include_directories(ass PRIVATE
-  ${FRIBIDI_INCLUDE_DIR}
-  ${HARFBUZZ_INCLUDE_DIR})
-if(DIRENT_INCLUDE_DIR)
-    target_include_directories(ass PRIVATE
-      ${DIRENT_INCLUDE_DIR})
-endif()
+  PkgConfig::FRIBIDI
+  PkgConfig::HARFBUZZ)
 target_link_libraries(ass PRIVATE
   Freetype::Freetype
-  ${FRIBIDI_LIBRARY}
-  ${HARFBUZZ_LIBRARY}
+  PkgConfig::FRIBIDI
+  PkgConfig::HARFBUZZ
   ${FONT_LIBRARY})
 
 install(TARGETS ass
@@ -103,11 +96,11 @@ set(libdir ${CMAKE_INSTALL_PREFIX}/lib)
 set(includedir ${CMAKE_INSTALL_PREFIX}/include)
 set(PACKAGE_VERSION ${LIBASS_VERSION})
 if(BUILD_SHARED_LIBS)
-  set(PKG_REQUIRES_PRIVATE ${PKG_REQUIRES_LIBASS})
-  set(PKG_LIBS_PRIVATE ${PKG_LIBS_LIBASS})
-else()
   set(PKG_REQUIRES_PUBLIC ${PKG_REQUIRES_LIBASS})
   set(PKG_LIBS_PUBLIC ${PKG_LIBS_LIBASS})
+else()
+  set(PKG_REQUIRES_PRIVATE ${PKG_REQUIRES_LIBASS})
+  set(PKG_LIBS_PRIVATE ${PKG_LIBS_LIBASS})
 endif()
 configure_file(libass.pc.in libass.pc @ONLY)
 install(FILES

--- a/ports/libass/config.h.in
+++ b/ports/libass/config.h.in
@@ -1,1 +1,14 @@
-#define CONFIG_SOURCEVERSION "tarball: 0.16.0"
+#define CONFIG_SOURCEVERSION "tarball: @LIBASS_VERSION@"
+
+#cmakedefine CONFIG_ICONV
+#cmakedefine CONFIG_FREETYPE
+#cmakedefine CONFIG_FRIBIDI
+#cmakedefine CONFIG_HARFBUZZ
+#cmakedefine CONFIG_LIBPNG
+#cmakedefine CONFIG_UNIBREAK
+#cmakedefine CONFIG_FONTCONFIG
+#cmakedefine CONFIG_CORETEXT
+#cmakedefine CONFIG_DIRECTWRITE
+#cmakedefine01 CONFIG_ASM
+#cmakedefine01 ARCH_X86
+#cmakedefine01 CONFIG_LARGE_TILES

--- a/ports/libass/portfile.cmake
+++ b/ports/libass/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libass/libass
-    REF 0.16.0
-    SHA512 fea93b36d05cd69a5920b603951dd63f46b2434e0dcbb12414bf6e1e584bacc2743fbfc03682d0a672bbfe9bcc057452a942f9967d95a30e535bd3694e40fc7d
+    REF 0.17.1
+    SHA512 8bc83347c87c47577cd52230b3698c34301250e9a23f190a565c913defcd47a05695a4f7d9cd2e9a6ad0cfc6341e8ea2d6d779b1d714b2d6144466d2dea53951
     HEAD_REF master
 )
 
@@ -14,6 +14,10 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/libass.def DESTINATION ${SOURCE_PATH})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 file(COPY ${SOURCE_PATH}/libass/ass.h ${SOURCE_PATH}/libass/ass_types.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/ass)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+get_filename_component(PKGCONFIG_EXE_PATH ${PKGCONFIG} DIRECTORY)
+vcpkg_add_to_path(${PKGCONFIG_EXE_PATH})
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/libass/vcpkg.json
+++ b/ports/libass/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libass",
-  "version": "0.16.0",
+  "version": "0.17.1",
   "description": "libass is a portable subtitle renderer for the ASS/SSA (Advanced Substation Alpha/Substation Alpha) subtitle format",
   "homepage": "https://github.com/libass/libass",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3713,7 +3713,7 @@
       "port-version": 0
     },
     "libass": {
-      "baseline": "0.16.0",
+      "baseline": "0.17.1",
       "port-version": 0
     },
     "libassuan": {

--- a/versions/l-/libass.json
+++ b/versions/l-/libass.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c71ba164ee51e31be931c03973fbeb756de7631e",
+      "version": "0.17.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b5dfc84a884c525317deec9d8e62df51d64a8e3d",
       "version": "0.16.0",
       "port-version": 0


### PR DESCRIPTION
libass used asm optimization to significantly improve the rendering speed. In this pull request, i simulated how the original repository compiles code with autotools using cmake instead.
related issue #29752 
