### PR TITLE
[gtest] Update version to 1.13.0

### DIFF
--- a/ports/gtest/001-fix-UWP-death-test.patch
+++ b/ports/gtest/001-fix-UWP-death-test.patch
@@ -1,0 +1,13 @@
+diff --git a/googletest/src/gtest.cc b/googletest/src/gtest.cc
+index a64e887c..45ff24c3 100644
+--- a/googletest/src/gtest.cc
++++ b/googletest/src/gtest.cc
+@@ -5409,7 +5409,7 @@ int UnitTest::Run() {
+   // used for the duration of the program.
+   impl()->set_catch_exceptions(GTEST_FLAG_GET(catch_exceptions));
+ 
+-#if GTEST_OS_WINDOWS
++#if GTEST_OS_WINDOWS && GTEST_HAS_DEATH_TEST
+   // Either the user wants Google Test to catch exceptions thrown by the
+   // tests or this is executing in the context of death test child
+   // process. In either case the user does not want to see pop-up dialogs

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     SHA512 70c0cfb1b4147bdecb467ecb22ae5b5529eec0abc085763213a796b7cdbd81d1761d12b342060539b936fa54f345d33f060601544874d6213fdde79111fa813e
     HEAD_REF main
     PATCHES
+        001-fix-UWP-death-test.patch
         clang-tidy-no-lint.patch
         fix-main-lib-path.patch
 )

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
-    REF release-1.12.1
-    SHA512 a9104dc6c53747e36e7dd7bb93dfce51a558bd31b487a9ef08def095518e1296da140e0db263e0644d9055dbd903c0cb69380cb2322941dbfb04780ef247df9c
+    REF v1.13.0
+    SHA512 70c0cfb1b4147bdecb467ecb22ae5b5529eec0abc085763213a796b7cdbd81d1761d12b342060539b936fa54f345d33f060601544874d6213fdde79111fa813e
     HEAD_REF main
     PATCHES
         clang-tidy-no-lint.patch

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gtest",
-  "version-semver": "1.12.1",
-  "port-version": 1,
+  "version-semver": "1.13.0",
   "description": "GoogleTest and GoogleMock testing frameworks",
   "homepage": "https://github.com/google/googletest",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2909,8 +2909,8 @@
       "port-version": 1
     },
     "gtest": {
-      "baseline": "1.12.1",
-      "port-version": 1
+      "baseline": "1.13.0",
+      "port-version": 0
     },
     "gtk": {
       "baseline": "4.6.8",

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d388d021abdf1562032aed1587f8bc201a480918",
+      "version-semver": "1.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ef23f1c9e2976fec20c4a4512935da901180dc17",
       "version-semver": "1.12.1",
       "port-version": 1

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d388d021abdf1562032aed1587f8bc201a480918",
+      "git-tree": "3f70f42192aacc5f8242c14d959d02a802f7559c",
       "version-semver": "1.13.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [x] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory. -- I actually believe that the clang-tidy patch goes against vcpkg rules about only modifying upstream when necessary for packaging, but upstream has not changed to make it obsolete 🤷 .
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
