### PR TITLE
Get the Actions bot out of the PR review business.

### DIFF
--- a/.github/workflows/trustedPR.yml
+++ b/.github/workflows/trustedPR.yml
@@ -17,8 +17,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' }}
+      ${{ github.event.workflow_run.event == 'pull_request' }}
 
     steps:
       - name: 'Download artifact'
@@ -51,13 +50,41 @@ jobs:
             const body = (await fs.readFile('body', 'utf8')).trim()
             const issue_number = Number(await fs.readFile('./NR'));
 
-            var req = {
-              owner: context.repo.owner,
-              pull_number: issue_number,
-              repo: context.repo.repo,
-              event: event
-            };
-            if (body !== "") {
-              req.body = body;
+            if (event === "APPROVE") {
+              console.log("Approved, trying to delete all GitHub Actions comments");
+              // delete all comments from GitHub Actions
+              var comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number
+              });
+
+              console.log("Comments listed");
+              for (const comment of comments) {
+                console.log(JSON.stringify(comment));
+                if (comment.user.login == "github-actions") {
+                  await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: comment.id
+                  });
+                }
+              }
+
+              return;
             }
-            await github.rest.pulls.createReview(req);
+
+            if (output === "") {
+              console.log("Failed without a comment; this is a bug in this bot.");
+            } else {
+              console.log("Failed, posting comment");
+              // post the comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                body: output
+              });
+            }
+
+            core.setFailed("There are outstanding PR suggestions, please review the comment for more details.");

--- a/.github/workflows/untrustedPR.yml
+++ b/.github/workflows/untrustedPR.yml
@@ -12,12 +12,13 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           # fetch-depth 50 tries to ensure we capture the whole history of the branch
           fetch-depth: 50
 
-      - name: bootstrap
+      - name: Bootstrap
         run: ./bootstrap-vcpkg.sh
 
       - name: Save PR number
@@ -51,7 +52,8 @@ jobs:
           git diff > .github-pr.x-add-version.diff
           git reset HEAD~ --mixed
 
-      - uses: actions/github-script@v6
+      - name: Generate Reply
+        uses: actions/github-script@v6
         with:
           script: |
             const { promises: fs } = require('fs')
@@ -74,7 +76,7 @@ jobs:
               approve = false;
             }
             if (add_version_out !== "") {
-              output += "<details><summary><b>PRs must add only one version and must not modify any published versions</b></summary>\n\n"
+              output += "<details><summary><b>PRs must add only one version, and must not modify any published versions</b></summary>\n\n"
               output += "When making any changes to a library, the version or port-version in `vcpkg.json` or `CONTROL` must be modified.\n"
               output += "```\n" + add_version_out + "\n```\n</details>\n\n"
               approve = false;
@@ -134,12 +136,13 @@ jobs:
             if (approve) {
               await fs.writeFile("pr/event", "APPROVE")
             } else {
-              output = "_This is a new experimental fast check for PR issues. Please let us know if this bot is helpful!_\n\n" + output
               await fs.writeFile("pr/event", "REQUEST_CHANGES")
             }
-            await fs.writeFile("pr/body", output)
 
+            await fs.writeFile("pr/body", output)
             console.log(output);
+
+            core.setFailed("There are outstanding PR suggestions, please review the comment for more details.");
 
       - uses: actions/upload-artifact@v3
         with:

--- a/ports/pprint/vcpkg.json
+++ b/ports/pprint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pprint",
-  "version-string": "2019-07-19",
+  "version-string": "2019-07-19 INTENTIONALLY DAMAGED",
   "port-version": 1,
   "description": "Pretty Printer for Modern C++",
   "homepage": "https://github.com/p-ranav/pprint"


### PR DESCRIPTION
Recently, we are blocked from approving PRs from GitHub Actions across the entire microsoft/ organization. This change just updates a comment and 'fails' the check rather than trying to create reviews.
