### PR TITLE
[opencv4] add dnn-cuda feature

### DIFF
--- a/ports/opencv/vcpkg.json
+++ b/ports/opencv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opencv",
   "version": "4.7.0",
+  "port-version": 1,
   "description": "Computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -58,6 +59,18 @@
           "default-features": false,
           "features": [
             "cudnn"
+          ]
+        }
+      ]
+    },
+    "dnn-cuda": {
+      "description": "Build dnn module with CUDA support",
+      "dependencies": [
+        {
+          "name": "opencv4",
+          "default-features": false,
+          "features": [
+            "dnn-cuda"
           ]
         }
       ]

--- a/ports/opencv/vcpkg.json
+++ b/ports/opencv/vcpkg.json
@@ -63,18 +63,6 @@
         }
       ]
     },
-    "dnn-cuda": {
-      "description": "Build dnn module with CUDA support",
-      "dependencies": [
-        {
-          "name": "opencv4",
-          "default-features": false,
-          "features": [
-            "dnn-cuda"
-          ]
-        }
-      ]
-    },
     "dc1394": {
       "description": "Dc1394 support for opencv",
       "dependencies": [
@@ -120,6 +108,18 @@
           "default-features": false,
           "features": [
             "dnn"
+          ]
+        }
+      ]
+    },
+    "dnn-cuda": {
+      "description": "Build dnn module with CUDA support",
+      "dependencies": [
+        {
+          "name": "opencv4",
+          "default-features": false,
+          "features": [
+            "dnn-cuda"
           ]
         }
       ]

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -50,6 +50,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  "cuda"      WITH_CUBLAS
  "cuda"      WITH_CUDA
  "cudnn"     WITH_CUDNN
+ "dnn-cuda"  OPENCV_DNN_CUDA
  "eigen"     WITH_EIGEN
  "ffmpeg"    WITH_FFMPEG
  "freetype"  WITH_FREETYPE

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.7.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -65,6 +65,19 @@
           "default-features": false,
           "features": [
             "cuda"
+          ]
+        }
+      ]
+    },
+    "dnn-cuda": {
+      "description": "Build dnn module with CUDA support",
+      "dependencies": [
+        {
+          "name": "opencv4",
+          "default-features": false,
+          "features": [
+            "cudnn",
+            "dnn"
           ]
         }
       ]

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -69,19 +69,6 @@
         }
       ]
     },
-    "dnn-cuda": {
-      "description": "Build dnn module with CUDA support",
-      "dependencies": [
-        {
-          "name": "opencv4",
-          "default-features": false,
-          "features": [
-            "cudnn",
-            "dnn"
-          ]
-        }
-      ]
-    },
     "dc1394": {
       "description": "Dc1394 support for opencv",
       "dependencies": [
@@ -117,6 +104,19 @@
       "description": "Enable dnn module",
       "dependencies": [
         "protobuf"
+      ]
+    },
+    "dnn-cuda": {
+      "description": "Build dnn module with CUDA support",
+      "dependencies": [
+        {
+          "name": "opencv4",
+          "default-features": false,
+          "features": [
+            "cudnn",
+            "dnn"
+          ]
+        }
       ]
     },
     "eigen": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5666,7 +5666,7 @@
     },
     "opencv": {
       "baseline": "4.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opencv2": {
       "baseline": "2.4.13.7",
@@ -5678,7 +5678,7 @@
     },
     "opencv4": {
       "baseline": "4.7.0",
-      "port-version": 2
+      "port-version": 3
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv.json
+++ b/versions/o-/opencv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c13270745cf85fc4146cd4f21ee4f71eb2ca7e1",
+      "version": "4.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "562bbf3bc1027e73456d71a10020ba984eec0eb1",
       "version": "4.7.0",
       "port-version": 0

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca4b616630bef409960661592549086539a7e28e",
+      "version": "4.7.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "6a62c7557d02936ea929e86836f324d09c787de5",
       "version": "4.7.0",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Before there was no way to enable CUDA support in the DNN module. It's default off (as documented [here](https://docs.opencv.org/4.x/db/d05/tutorial_config_reference.html#tutorial_config_reference_dnn) and confirmed). Depends on CUBLAS (which is enabled with the `cuda` feature) as well as cudnn. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
