### PR TITLE
[opencc] update to 1.1.6

### DIFF
--- a/ports/opencc/fix-dependencies.patch
+++ b/ports/opencc/fix-dependencies.patch
@@ -1,14 +1,14 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 11d14e4..0fa3e1e 100644
+index c0a0b10..19f7cbb 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -137,6 +137,21 @@ set_target_properties(
-       1.1
+       ${OPENCC_VERSION_MAJOR}.${OPENCC_VERSION_MINOR}
  )
  
 +if(USE_SYSTEM_RAPIDJSON)
 +  find_package(RapidJSON CONFIG REQUIRED)
-+  target_link_libraries(libopencc PRIVATE rapidjson)
++  target_link_libraries(libopencc rapidjson)
 +endif()
 +
 +if(USE_SYSTEM_TCLAP)

--- a/ports/opencc/portfile.cmake
+++ b/ports/opencc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BYVoid/OpenCC
-    REF ver.1.1.4
-    SHA512 ab8e7e6a0cc71106cf09eb32899fa8620b946a406f042d75a2444096e0b383cb1993d6c2d12cd7862e71854da4cd5893442bce51df84c32ed09fdfb4a2846f46
+    REF "ver.${VERSION}"
+    SHA512 bfc40bdf1348e6a265b3304ab1e8acee2f4b6ac9c377ff3d8c996435a92dee98c3758503186b4fd424653faf44db339f8a90300e3290c59942ccf04b1bbb2a30
     HEAD_REF master
     PATCHES 
         fix-dependencies.patch

--- a/ports/opencc/vcpkg.json
+++ b/ports/opencc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "opencc",
-  "version": "1.1.4",
-  "port-version": 3,
+  "version": "1.1.6",
   "description": "A project for conversions between Traditional Chinese, Simplified Chinese and Japanese Kanji (Shinjitai)",
   "homepage": "https://github.com/BYVoid/OpenCC",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5637,8 +5637,8 @@
       "port-version": 1
     },
     "opencc": {
-      "baseline": "1.1.4",
-      "port-version": 3
+      "baseline": "1.1.6",
+      "port-version": 0
     },
     "opencensus-cpp": {
       "baseline": "2021-08-26",

--- a/versions/o-/opencc.json
+++ b/versions/o-/opencc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "246c0e831df06a5235e750d5af71b7cd9b2cc904",
+      "version": "1.1.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "463a25b4f9bfe6a259042a54cdd813ae7f96f4c9",
       "version": "1.1.4",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/29793
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
