### PR TITLE
[Daxa] new port

### DIFF
--- a/ports/daxa/portfile.cmake
+++ b/ports/daxa/portfile.cmake
@@ -28,7 +28,10 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${DAXA_DEFINES}
+    OPTIONS
+        ${DAXA_DEFINES}
+        -DCMAKE_REQUIRE_FIND_PACKAGE_X11=ON
+        -DCMAKE_REQUIRE_FIND_PACKAGE_WAYLAND=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/daxa/portfile.cmake
+++ b/ports/daxa/portfile.cmake
@@ -26,14 +26,13 @@ if(WITH_UTILS_TASK_LIST)
     list(APPEND DAXA_DEFINES "-DDAXA_ENABLE_UTILS_TASK_LIST=true")
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
     OPTIONS ${DAXA_DEFINES}
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${SOURCE_PATH}/LICENSE"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"

--- a/ports/daxa/portfile.cmake
+++ b/ports/daxa/portfile.cmake
@@ -1,0 +1,41 @@
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL https://github.com/Ipotrick/Daxa
+    REF 14d5378a6157b3530c3ff826182706126be135bd
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    utils-imgui WITH_UTILS_IMGUI
+    utils-mem WITH_UTILS_MEM
+    utils-pipeline-manager-glslang WITH_UTILS_PIPELINE_MANAGER_GLSLANG
+    utils-task-list WITH_UTILS_TASK_LIST
+)
+set(DAXA_DEFINES)
+
+if(WITH_UTILS_IMGUI)
+    list(APPEND DAXA_DEFINES "-DDAXA_ENABLE_UTILS_IMGUI=true")
+endif()
+if(WITH_UTILS_MEM)
+    list(APPEND DAXA_DEFINES "-DDAXA_ENABLE_UTILS_MEM=true")
+endif()
+if(WITH_UTILS_PIPELINE_MANAGER_GLSLANG)
+    list(APPEND DAXA_DEFINES "-DDAXA_ENABLE_UTILS_PIPELINE_MANAGER_GLSLANG=true")
+endif()
+if(WITH_UTILS_TASK_LIST)
+    list(APPEND DAXA_DEFINES "-DDAXA_ENABLE_UTILS_TASK_LIST=true")
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
+    OPTIONS ${DAXA_DEFINES}
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL "${SOURCE_PATH}/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+    RENAME copyright
+)

--- a/ports/daxa/vcpkg.json
+++ b/ports/daxa/vcpkg.json
@@ -1,12 +1,11 @@
 {
   "name": "daxa",
   "version-semver": "1.0.0",
-  "port-version": 0,
   "description": "Daxa C++ Vulkan Abstraction",
   "homepage": "https://github.com/Ipotrick/Daxa",
   "dependencies": [
-    "vulkan-memory-allocator",
-    "vulkan"
+    "vulkan",
+    "vulkan-memory-allocator"
   ],
   "default-features": [
     "utils-imgui",

--- a/ports/daxa/vcpkg.json
+++ b/ports/daxa/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Daxa C++ Vulkan Abstraction",
   "homepage": "https://github.com/Ipotrick/Daxa",
   "license": "MIT",
+  "supports": "(windows | linux) & !x86",
   "dependencies": [
     "vulkan",
     "vulkan-memory-allocator"

--- a/ports/daxa/vcpkg.json
+++ b/ports/daxa/vcpkg.json
@@ -3,6 +3,7 @@
   "version-semver": "1.0.0",
   "description": "Daxa C++ Vulkan Abstraction",
   "homepage": "https://github.com/Ipotrick/Daxa",
+  "license": "MIT",
   "dependencies": [
     "vulkan",
     "vulkan-memory-allocator"

--- a/ports/daxa/vcpkg.json
+++ b/ports/daxa/vcpkg.json
@@ -14,13 +14,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-     {
-    "name": "wayland",
-    "default-features": false,
-    "platform": "linux"
-  }
     "vulkan",
-    "vulkan-memory-allocator"
+    "vulkan-memory-allocator",
+    {
+      "name": "wayland",
+      "default-features": false,
+      "platform": "linux"
+    }
   ],
   "default-features": [
     "utils-imgui",

--- a/ports/daxa/vcpkg.json
+++ b/ports/daxa/vcpkg.json
@@ -14,6 +14,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
+     {
+    "name": "wayland",
+    "default-features": false,
+    "platform": "linux"
+  }
     "vulkan",
     "vulkan-memory-allocator"
   ],

--- a/ports/daxa/vcpkg.json
+++ b/ports/daxa/vcpkg.json
@@ -1,0 +1,37 @@
+{
+  "name": "daxa",
+  "version-semver": "1.0.0",
+  "port-version": 0,
+  "description": "Daxa C++ Vulkan Abstraction",
+  "homepage": "https://github.com/Ipotrick/Daxa",
+  "dependencies": [
+    "vulkan-memory-allocator",
+    "vulkan"
+  ],
+  "default-features": [
+    "utils-imgui",
+    "utils-mem",
+    "utils-pipeline-manager-glslang",
+    "utils-task-list"
+  ],
+  "features": {
+    "utils-imgui": {
+      "description": "The ImGUI Daxa utility",
+      "dependencies": [
+        "imgui"
+      ]
+    },
+    "utils-mem": {
+      "description": "The Mem Daxa utility"
+    },
+    "utils-pipeline-manager-glslang": {
+      "description": "Build with glslang",
+      "dependencies": [
+        "glslang"
+      ]
+    },
+    "utils-task-list": {
+      "description": "The Task-List Daxa utility"
+    }
+  }
+}

--- a/ports/daxa/vcpkg.json
+++ b/ports/daxa/vcpkg.json
@@ -1,11 +1,19 @@
 {
   "name": "daxa",
-  "version-semver": "1.0.0",
+  "version": "1.0.0",
   "description": "Daxa C++ Vulkan Abstraction",
   "homepage": "https://github.com/Ipotrick/Daxa",
   "license": "MIT",
   "supports": "(windows | linux) & !x86",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "vulkan",
     "vulkan-memory-allocator"
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1960,6 +1960,10 @@
       "baseline": "2.2.2",
       "port-version": 0
     },
+    "daxa": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "dbg-macro": {
       "baseline": "2021-11-02",
       "port-version": 0

--- a/versions/d-/daxa.json
+++ b/versions/d-/daxa.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "afd7c0156189f01e6e89ca8975296bbe34ea0546",
+      "git-tree": "25a96e0311836a1151731079225a381779fb3a4b",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/d-/daxa.json
+++ b/versions/d-/daxa.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "34fd4b18be63133018abb1c292b24559b8c47fd4",
+      "git-tree": "74eeef09c9de60dccd6a73b145f953b18c6fa874",
       "version-semver": "1.0.0",
       "port-version": 0
     }

--- a/versions/d-/daxa.json
+++ b/versions/d-/daxa.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "74eeef09c9de60dccd6a73b145f953b18c6fa874",
+      "git-tree": "651347518e696fd5445aa795a00d1155680af1e3",
       "version-semver": "1.0.0",
       "port-version": 0
     }

--- a/versions/d-/daxa.json
+++ b/versions/d-/daxa.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "651347518e696fd5445aa795a00d1155680af1e3",
-      "version-semver": "1.0.0",
+      "git-tree": "afd7c0156189f01e6e89ca8975296bbe34ea0546",
+      "version": "1.0.0",
       "port-version": 0
     }
   ]

--- a/versions/t-/daxa.json
+++ b/versions/t-/daxa.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "34fd4b18be63133018abb1c292b24559b8c47fd4",
+      "version-semver": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
