### PR TITLE
[miniply] add new port

### DIFF
--- a/ports/miniply/fix-cmake.patch
+++ b/ports/miniply/fix-cmake.patch
@@ -1,0 +1,45 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bde25da..e1129db 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,19 +2,29 @@ cmake_minimum_required(VERSION 3.5)
+ 
+ project(miniply LANGUAGES CXX)
+ 
++include(GNUInstallDirs)
++
+ set(CMAKE_CXX_STANDARD 11)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
+-include_directories(.)
++add_library(miniply miniply.cpp)
++
++target_include_directories(miniply
++        PUBLIC
++        $<INSTALL_INTERFACE:include>
++        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
++
++install(FILES ${CMAKE_SOURCE_DIR}/miniply.h
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++
++install(TARGETS miniply EXPORT miniply-config
++        RUNTIME DESTINATION bin
++        ARCHIVE DESTINATION lib
++        LIBRARY DESTINATION lib
++        INCLUDES DESTINATION include)
+ 
+-add_executable(miniply-perf
+-  miniply.cpp
+-  miniply.h
+-  extra/miniply-perf.cpp
+-)
++install(EXPORT miniply-config
++	FILE unofficial-miniply-config.cmake
++	NAMESPACE unofficial::miniply::
++	DESTINATION share/unofficial-miniply)
+ 
+-add_executable(miniply-info
+-  miniply.cpp
+-  miniply.h
+-  extra/miniply-info.cpp
+-)

--- a/ports/miniply/portfile.cmake
+++ b/ports/miniply/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO vilya/miniply
+    REF 1a235c70390fadf789695c9ccbf285ae712416b3
+    SHA512 856bb39bd36dab588026b9ee886a996bd697df5c1a24de2abff822e037a0fb7af0be19dca5e2f6ccc524453b0b9ee6e225510565ca78f6b965dd7406ba67dac1
+    HEAD_REF master
+    PATCHES
+        fix-cmake.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/unofficial-miniply)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/miniply/vcpkg.json
+++ b/ports/miniply/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "miniply",
+  "version-date": "2022-09-15",
+  "description": "A fast and easy-to-use PLY parsing library in a single c++11 header and cpp file",
+  "homepage": "https://github.com/vilya/miniply",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5092,6 +5092,10 @@
       "baseline": "0.1.1",
       "port-version": 1
     },
+    "miniply": {
+      "baseline": "2022-09-15",
+      "port-version": 0
+    },
     "minisat-master-keying": {
       "baseline": "2.3.6",
       "port-version": 0

--- a/versions/m-/miniply.json
+++ b/versions/m-/miniply.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "648516b62e07a6e5c6387f110f9f4bce0d6c67e9",
+      "version-date": "2022-09-15",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.