### PR TITLE
[gumbo, litehtml] fix dupplicate gumbo symbols

### DIFF
--- a/ports/gumbo/CMakeLists.txt
+++ b/ports/gumbo/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.8.0)
 
 project(gumbo)
 
+set(gumbo_public_headers
+  src/gumbo.h 
+  src/tag_enum.h
+)
+
 set(gumbo_srcs
   src/attribute.c
   src/char_ref.c
@@ -23,11 +28,22 @@ endif (MSVC)
 
 add_library(gumbo ${gumbo_srcs})
 
+set_target_properties(gumbo PROPERTIES
+    C_STANDARD 99
+    PUBLIC_HEADER "${gumbo_public_headers}"
+)
+
+target_include_directories(gumbo PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/>)
+
 install(
   TARGETS gumbo  EXPORT unofficial-gumbo-config
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
+  PUBLIC_HEADER DESTINATION include
 )
 
 install(EXPORT unofficial-gumbo-config
@@ -37,6 +53,4 @@ install(EXPORT unofficial-gumbo-config
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/gumbo.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/lib/pkgconfig/gumbo.pc" @ONLY)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib/pkgconfig/gumbo.pc" DESTINATION "lib/pkgconfig")
-if(NOT DISABLE_INSTALL_HEADERS)
-  install(FILES  src/gumbo.h src/tag_enum.h DESTINATION include)
-endif()
+

--- a/ports/gumbo/portfile.cmake
+++ b/ports/gumbo/portfile.cmake
@@ -12,8 +12,6 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS_DEBUG 
-       -DDISABLE_INSTALL_HEADERS=ON
 )
 
 vcpkg_cmake_install()
@@ -24,6 +22,7 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-gumbo CONFIG_PATH share/unoffic
 
 vcpkg_fixup_pkgconfig()
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/gumbo" RENAME copyright)

--- a/ports/gumbo/vcpkg.json
+++ b/ports/gumbo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gumbo",
   "version": "0.10.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "An HTML5 parsing library in pure C99",
   "homepage": "https://github.com/google/gumbo-parser",
   "license": "Apache-2.0",

--- a/ports/litehtml/fix-relative-includes.patch
+++ b/ports/litehtml/fix-relative-includes.patch
@@ -1,0 +1,32 @@
+From 42cf79c0292d655eec41c486710bf610063bdfd8 Mon Sep 17 00:00:00 2001
+From: Sean Farrell <sean.farrell@rioki.org>
+Date: Thu, 23 Feb 2023 14:17:52 +0100
+Subject: [PATCH] Fix relative includes.
+
+---
+ include/litehtml.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/include/litehtml.h b/include/litehtml.h
+index 98a24e0..d20addd 100644
+--- a/include/litehtml.h
++++ b/include/litehtml.h
+@@ -1,10 +1,10 @@
+ #ifndef LITEHTML_H
+ #define LITEHTML_H
+ 
+-#include <litehtml/html.h>
+-#include <litehtml/document.h>
+-#include <litehtml/html_tag.h>
+-#include <litehtml/stylesheet.h>
+-#include <litehtml/element.h>
++#include <html.h>
++#include <document.h>
++#include <html_tag.h>
++#include <stylesheet.h>
++#include <element.h>
+ 
+ #endif  // LITEHTML_H
+-- 
+2.33.0.windows.2
+

--- a/ports/litehtml/portfile.cmake
+++ b/ports/litehtml/portfile.cmake
@@ -3,6 +3,7 @@ vcpkg_from_github(
     REPO litehtml/litehtml
     REF v0.6
     SHA512 b774ed96e53780865e789875f571f96ebce1cd2ff0c05a06ae68a67aec44375cc282c07f77fc87131d422aceddba32bbf3e8e498c870883d8e042adb30834c39
+    PATCHES use-vcpkg-gumbo.patch
 )
 
 if (VCPKG_TARGET_IS_WINDOWS)
@@ -17,7 +18,6 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME gumbo CONFIG_PATH lib/cmake/gumbo DO_NOT_DELETE_PARENT_CONFIG_PATH)
 vcpkg_cmake_config_fixup(PACKAGE_NAME litehtml CONFIG_PATH lib/cmake/litehtml)
 
 

--- a/ports/litehtml/portfile.cmake
+++ b/ports/litehtml/portfile.cmake
@@ -3,7 +3,9 @@ vcpkg_from_github(
     REPO litehtml/litehtml
     REF v0.6
     SHA512 b774ed96e53780865e789875f571f96ebce1cd2ff0c05a06ae68a67aec44375cc282c07f77fc87131d422aceddba32bbf3e8e498c870883d8e042adb30834c39
-    PATCHES use-vcpkg-gumbo.patch
+    PATCHES 
+      use-vcpkg-gumbo.patch
+      fix-relative-includes.patch
 )
 
 if (VCPKG_TARGET_IS_WINDOWS)

--- a/ports/litehtml/use-vcpkg-gumbo.patch
+++ b/ports/litehtml/use-vcpkg-gumbo.patch
@@ -1,0 +1,52 @@
+From 26b1491a8b1ed27d17f3d131342ff4aa9c65af7d Mon Sep 17 00:00:00 2001
+From: Sean Farrell <sean.farrell@rioki.org>
+Date: Thu, 23 Feb 2023 08:15:37 +0100
+Subject: [PATCH] Adapt CMakeLists.txt to vcpkg with gumbo package.
+
+---
+ CMakeLists.txt   | 8 ++------
+ src/document.cpp | 2 +-
+ 2 files changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fe71729..21e77c8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,11 +10,7 @@ enable_testing()
+ set(PROJECT_MAJOR 0)
+ set(PROJECT_MINOR 0)
+ 
+-option(EXTERNAL_GUMBO "Link against external gumbo instead of shipping a bundled copy" OFF)
+-
+-if(NOT EXTERNAL_GUMBO)
+-    add_subdirectory(src/gumbo)
+-endif()
++find_package(unofficial-gumbo CONFIG REQUIRED)
+ 
+ set(SOURCE_LITEHTML
+     src/background.cpp
+@@ -153,7 +149,7 @@ if (LITEHTML_UTF8)
+ endif()
+ 
+ # Gumbo
+-target_link_libraries(${PROJECT_NAME} PUBLIC gumbo)
++target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::gumbo::gumbo)
+ 
+ # install and export
+ install(TARGETS ${PROJECT_NAME}
+diff --git a/src/document.cpp b/src/document.cpp
+index 8bd1ea8..51a9d42 100644
+--- a/src/document.cpp
++++ b/src/document.cpp
+@@ -26,7 +26,7 @@
+ #include <cstdio>
+ #include <algorithm>
+ #include <functional>
+-#include "gumbo.h"
++#include <gumbo.h>
+ #include "utf8_strings.h"
+ 
+ litehtml::document::document(litehtml::document_container* objContainer, litehtml::context* ctx)
+-- 
+2.33.0.windows.2
+

--- a/ports/litehtml/use-vcpkg-gumbo.patch
+++ b/ports/litehtml/use-vcpkg-gumbo.patch
@@ -1,12 +1,13 @@
-From 26b1491a8b1ed27d17f3d131342ff4aa9c65af7d Mon Sep 17 00:00:00 2001
+From 4ca6d9846bfc39c4aa98d6a41f298078b4bebf8d Mon Sep 17 00:00:00 2001
 From: Sean Farrell <sean.farrell@rioki.org>
 Date: Thu, 23 Feb 2023 08:15:37 +0100
-Subject: [PATCH] Adapt CMakeLists.txt to vcpkg with gumbo package.
+Subject: [PATCH] Use vcpkg's gumbo
 
 ---
- CMakeLists.txt   | 8 ++------
- src/document.cpp | 2 +-
- 2 files changed, 3 insertions(+), 7 deletions(-)
+ CMakeLists.txt             | 8 ++------
+ cmake/litehtmlConfig.cmake | 2 +-
+ src/document.cpp           | 2 +-
+ 3 files changed, 4 insertions(+), 8 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index fe71729..21e77c8 100644
@@ -34,6 +35,15 @@ index fe71729..21e77c8 100644
  
  # install and export
  install(TARGETS ${PROJECT_NAME}
+diff --git a/cmake/litehtmlConfig.cmake b/cmake/litehtmlConfig.cmake
+index 5eedcf4..1027913 100644
+--- a/cmake/litehtmlConfig.cmake
++++ b/cmake/litehtmlConfig.cmake
+@@ -1,3 +1,3 @@
+ include(CMakeFindDependencyMacro)
+-find_dependency(gumbo)
++find_dependency(unofficial-gumbo)
+ include(${CMAKE_CURRENT_LIST_DIR}/litehtmlTargets.cmake)
 diff --git a/src/document.cpp b/src/document.cpp
 index 8bd1ea8..51a9d42 100644
 --- a/src/document.cpp

--- a/ports/litehtml/vcpkg.json
+++ b/ports/litehtml/vcpkg.json
@@ -1,10 +1,12 @@
 {
   "name": "litehtml",
   "version": "0.6.0",
-  "description": "litehtml is the lightweight HTML rendering engine with CSS2/CSS3 support. ",
+  "port-version": 1,
+  "description": "litehtml is the lightweight HTML rendering engine with CSS2/CSS3 support.",
   "homepage": "https://github.com/litehtml/litehtml",
   "license": "BSD-3-Clause",
   "dependencies": [
+    "gumbo",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2950,7 +2950,7 @@
     },
     "gumbo": {
       "baseline": "0.10.1",
-      "port-version": 5
+      "port-version": 6
     },
     "gzip-hpp": {
       "baseline": "0.1.0",
@@ -4734,7 +4734,7 @@
     },
     "litehtml": {
       "baseline": "0.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "live555": {
       "baseline": "2023-01-19",

--- a/versions/g-/gumbo.json
+++ b/versions/g-/gumbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0b57c7286bdadcc64d0e4b2f5b5aca951bb1749",
+      "version": "0.10.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "33203d45b5dcbc9d4bb0175691909a4e9c930d81",
       "version": "0.10.1",
       "port-version": 5

--- a/versions/l-/litehtml.json
+++ b/versions/l-/litehtml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d3aa522b91b10b71baf7e79b5677b223b8c08a5",
+      "git-tree": "a40497c2f1f2613da5d4f9564a71f803dbb76f35",
       "version": "0.6.0",
       "port-version": 1
     },

--- a/versions/l-/litehtml.json
+++ b/versions/l-/litehtml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d3aa522b91b10b71baf7e79b5677b223b8c08a5",
+      "version": "0.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "64b99f7658dac91ee9c3ed9749b0fd3718f3a4a9",
       "version": "0.6.0",
       "port-version": 0

--- a/versions/l-/litehtml.json
+++ b/versions/l-/litehtml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a40497c2f1f2613da5d4f9564a71f803dbb76f35",
+      "git-tree": "2f2981f2edef7c5f69ba42716c007822f74e99ae",
       "version": "0.6.0",
       "port-version": 1
     },


### PR DESCRIPTION
1. Fixes duplicate gumbo symbols introduced by PR##29673
2. Fixes gumbo CMake include folder exports

And because I am an external contributor:

- [x] Changes where crosschecked with other gumbo users (libmupdf)
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
