### PR TITLE
[fmilib] Change to the github and update to fix bug of libexpat

### DIFF
--- a/ports/fmilib/portfile.cmake
+++ b/ports/fmilib/portfile.cmake
@@ -1,16 +1,11 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://jmodelica.org/fmil/FMILibrary-${VERSION}-src.zip"
-    FILENAME "FMILibrary-${VERSION}-src.zip"
-    SHA512 86e4b5019d8f2a76b01141411845d977fb3949617604de0b34351f23647e3e8b378477de184e1c4f2f59297bc4c7de3155e0edba9099b8924594a36b37b04cc8
-)
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO modelon-community/fmi-library
+    REF "${VERSION}"
+    SHA512 65c2dc11116737e4e2ee91a4ec58d2cf24003774fd6d9b8b1d6521f046be9e8f8a963ebedb50a161ad264927062f41ce757c84563cfe628d47614910e8730349
+    HEAD_REF master
     PATCHES
         0001-remove-install-prefix.patch
         0002-include-sys-stat.h-for-mkdir.patch

--- a/ports/fmilib/vcpkg.json
+++ b/ports/fmilib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fmilib",
-  "version": "2.0.3",
-  "port-version": 5,
+  "version": "2.4.1",
   "description": "FMI library is intended as a foundation for applications interfacing FMUs (Functional Mockup Units) that follow FMI Standard. This version of the library supports FMI 1.0 and FMI2.0.",
   "homepage": "https://www.fmi-standard.org/",
   "license": null,

--- a/ports/fmilib/vcpkg.json
+++ b/ports/fmilib/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "2.4.1",
   "description": "FMI library is intended as a foundation for applications interfacing FMUs (Functional Mockup Units) that follow FMI Standard. This version of the library supports FMI 1.0 and FMI2.0.",
   "homepage": "https://www.fmi-standard.org/",
-  "license": null,
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2481,8 +2481,8 @@
       "port-version": 0
     },
     "fmilib": {
-      "baseline": "2.0.3",
-      "port-version": 5
+      "baseline": "2.4.1",
+      "port-version": 0
     },
     "fmt": {
       "baseline": "9.1.0",

--- a/versions/f-/fmilib.json
+++ b/versions/f-/fmilib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1d4a17469c9429b6e4ab4005e2cffa5a91667498",
+      "git-tree": "34b7f7cc468b8eecb267b5fd750cb1e602d36248",
       "version": "2.4.1",
       "port-version": 0
     },

--- a/versions/f-/fmilib.json
+++ b/versions/f-/fmilib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d4a17469c9429b6e4ab4005e2cffa5a91667498",
+      "version": "2.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c30d1f2f0827e03141bda90fe3ae2b462f93c116",
       "version": "2.0.3",
       "port-version": 5


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/27890
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note:   The official statement has been transferred to github,  https://jmodelica.org/ so it has been changed to `github` download. And the problem about `libexpat` has been solved in the latest version `2.4.1` https://github.com/modelon-community/fmi-library/issues/18#issuecomment-1247834281
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
