### PR TITLE
[cairo] update to 1.17.8

### DIFF
--- a/ports/cairo/cairo_static_fix.patch
+++ b/ports/cairo/cairo_static_fix.patch
@@ -1,8 +1,9 @@
 --- meson.build.orig	2022-03-19 03:40:07.000000000 +0900
 +++ meson.build	2022-03-29 21:32:41.000000000 +0900
-@@ -100,6 +100,13 @@
- # Autotools compatibility
- add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
+@@ -96,6 +96,13 @@
+ endif
+
+ add_project_arguments('-D_GNU_SOURCE', language: 'c')
  
 +if host_machine.system() == 'windows'
 +  lib_default = get_option('default_library')

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -4,12 +4,11 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 endif()
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://gitlab.freedesktop.org
     REPO cairo/cairo
-    REF b43e7c6f3cf7855e16170a06d3a9c7234c60ca94 #v1.17.6
-    SHA512 2d8f0cbb11638610eda104a370bb8450e28d835852b0f861928738a60949e0aaba7a554a9f9efabbefda10a37616d4cd0d3021b3fbb4ced1d52db1edb49bc358
-    HEAD_REF master
+    REF ${VERSION}
+    SHA512 e12f4b05326c1ac7d930e18d95398dc9c65f3af9745d7fd301ef1663dd378feeb43acc47de17fd082d0acf96e9fc60310557c24e3fe8af06d17931590c7759c6
     PATCHES
         cairo_static_fix.patch
         disable-atomic-ops-check.patch # See https://gitlab.freedesktop.org/cairo/cairo/-/issues/554

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cairo",
-  "version": "1.17.6",
-  "port-version": 5,
+  "version": "1.17.8",
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1309,8 +1309,8 @@
       "port-version": 8
     },
     "cairo": {
-      "baseline": "1.17.6",
-      "port-version": 5
+      "baseline": "1.17.8",
+      "port-version": 0
     },
     "cairomm": {
       "baseline": "1.16.2",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "062c7e11a8b910e76a2f16e57e3ffe0d59bd905e",
+      "version": "1.17.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "d4e8c89704a7354fbae6bd789d5744d37021aacc",
       "version": "1.17.6",
       "port-version": 5


### PR DESCRIPTION
update cairo to 1.17.8
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
