### PR TITLE
[docs] Add stub pages for broken links in old vcpkg executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,4 +334,4 @@ You can opt-out of telemetry by
 - passing --disable-metrics to vcpkg on the command line
 - setting the VCPKG_DISABLE_METRICS environment variable
 
-[Read more about vcpkg telemetry](https://learn.microsoft.com/vcpkg/about/privacy.html)
+[Read more about vcpkg telemetry](https://learn.microsoft.com/vcpkg/about/privacy)

--- a/docs/about/privacy.md
+++ b/docs/about/privacy.md
@@ -1,0 +1,5 @@
+# Privacy
+
+The documentation for this topic has been moved to the following articles in [Microsoft Learn](https://learn.microsoft.com/vcpkg):
+
+* [Privacy](https://learn.microsoft.com/vcpkg/about/privacy)

--- a/docs/users/assetcaching.md
+++ b/docs/users/assetcaching.md
@@ -1,0 +1,5 @@
+# Asset Caching
+
+The documentation for this topic has been moved to the following articles in [Microsoft Learn](https://learn.microsoft.com/vcpkg):
+
+* [Asset caching](https://learn.microsoft.com/vcpkg/users/assetcaching)

--- a/docs/users/binarycaching.md
+++ b/docs/users/binarycaching.md
@@ -1,0 +1,5 @@
+# Binary Caching
+
+The documentation for this topic has been moved to the following articles in [Microsoft Learn](https://learn.microsoft.com/vcpkg):
+
+* [Binary caching](https://learn.microsoft.com/vcpkg/users/binarycaching)

--- a/docs/users/manifests.md
+++ b/docs/users/manifests.md
@@ -1,0 +1,6 @@
+# Manifests
+
+The documentation for this topic has been moved to the following articles in [Microsoft Learn](https://learn.microsoft.com/vcpkg):
+
+* [Manifest mode](https://learn.microsoft.com/vcpkg/users/manifests)
+* [vcpkg.json syntax](https://learn.microsoft.com/vcpkg/reference/vcpkg-json)

--- a/docs/users/registries.md
+++ b/docs/users/registries.md
@@ -1,0 +1,6 @@
+# Registries
+
+The documentation for this topic has been moved to the following articles in [Microsoft Learn](https://learn.microsoft.com/vcpkg):
+
+* [Using registries](https://learn.microsoft.com/vcpkg/users/registries)
+* [Creating registries](https://learn.microsoft.com/vcpkg/maintainers/registries)

--- a/docs/users/triplets.md
+++ b/docs/users/triplets.md
@@ -1,0 +1,6 @@
+# Triplets
+
+The documentation for this topic has been moved to the following articles in [Microsoft Learn](https://learn.microsoft.com/vcpkg):
+
+* [Triplet files](https://learn.microsoft.com/vcpkg/users/triplets)
+* [Custom triplets](https://learn.microsoft.com/en-us/vcpkg/users/examples/overlay-triplets-linux-dynamic)

--- a/docs/users/versioning.md
+++ b/docs/users/versioning.md
@@ -1,0 +1,7 @@
+# Versioning
+
+The documentation for this topic has been moved to the following articles in [Microsoft Learn](https://learn.microsoft.com/vcpkg):
+
+* [vcpkg.json version fields](https://learn.microsoft.com/vcpkg/reference/vcpkg-json#version)
+* [Versioning reference](https://learn.microsoft.com/vcpkg/users/versioning)
+* [Versioning resolution algorithm](https://learn.microsoft.com/vcpkg/users/versioning.concepts)


### PR DESCRIPTION
Create stub pages for links provided by old versions of the vcpkg executable.
These stub pages direct users to the appropriate articles in our new docs website.

Related to: https://github.com/microsoft/vcpkg-tool/pull/926

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
