### PR TITLE
[abseil] Test

### DIFF
--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -50,4 +50,4 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     )
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "abseil",
   "version": "20230125.0",
-  "port-version": "1",
+  "port-version": 1,
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "abseil",
   "version": "20230125.0",
+  "port-version": "1",
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42416ea7cedce04067522eb6315e02ad3c24a987",
+      "version": "20230125.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "aa4f29f110c771e7096ba356501e4a0d6d3d9baa",
       "version": "20230125.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "abseil": {
       "baseline": "20230125.0",
-      "port-version": 0
+      "port-version": 1
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.