### PR TITLE
[abseil] Test

### DIFF
--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -50,4 +50,4 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     )
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "abseil",
   "version": "20230125.0",
+  "port-version": 1,
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42416ea7cedce04067522eb6315e02ad3c24a987",
+      "version": "20230125.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "aa4f29f110c771e7096ba356501e4a0d6d3d9baa",
       "version": "20230125.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "abseil": {
       "baseline": "20230125.0",
-      "port-version": 0
+      "port-version": 1
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
Since the [mnn:x64-linux CI error](https://dev.azure.com/vcpkg/public/_build/results?buildId=85785&view=logs&j=f79cfdd7-47a8-597f-8f57-dc3e21a8f2ad&t=da63cf11-1f12-503b-6d64-3b2fb713c172) caused by `abseil` cannot be reproduced locally, this PR is used to reproduce it. In fact, this PR does not change anything.

```
/mnt/vcpkg-ci/installed/x64-linux/include/absl/base/policy_checks.h:79:2: error: #error "C++ versions less than C++14 are not supported."
   79 | #error "C++ versions less than C++14 are not supported."
      |  ^~~~~
```