### PR TITLE
[libe57format] Update to 3.0.0

### DIFF
--- a/ports/libe57format/portfile.cmake
+++ b/ports/libe57format/portfile.cmake
@@ -1,13 +1,17 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO asmaloney/libE57Format
-    REF v2.3.0
-    SHA512 44feaf71d09d6765b322e2055efea09d2a99e706aa00dc4fd9281074fc05d06cce932400f5f4b91b20ed1cc070f117b7d39b95c54d33b31bc1e93532d698c175
+    REF "v${VERSION}"
+    SHA512 5458e35b319f41290594daefe5de18476ff1c4ed94712d881ed907b72a9c7a470e4d091d68cc1d6115838843e682ed158fc8c7a9fa68eef6c2cf421cda361f7e
     HEAD_REF master
+    PATCHES
+        prevent_warning_as_errors.diff # see https://github.com/asmaloney/libE57Format/issues/232
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DE57_BUILD_TEST=OFF
 )
 vcpkg_cmake_install()
 

--- a/ports/libe57format/prevent_warning_as_errors.diff
+++ b/ports/libe57format/prevent_warning_as_errors.diff
@@ -1,0 +1,13 @@
+diff --git a/cmake/CompilerWarnings.cmake b/cmake/CompilerWarnings.cmake
+index 9a9e507..eb1a1c5 100644
+--- a/cmake/CompilerWarnings.cmake
++++ b/cmake/CompilerWarnings.cmake
+@@ -86,6 +86,8 @@ endif()
+ 
+ # Treat warnings as errors
+ function( set_warning_as_error )
++    return()
++
+     message( STATUS "[${PROJECT_NAME}] Treating warnings as errors")
+ 
+     if ( CMAKE_VERSION VERSION_GREATER_EQUAL "3.24" )

--- a/ports/libe57format/vcpkg.json
+++ b/ports/libe57format/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libe57format",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "A library to provide read & write support for the E57 file format.",
   "homepage": "https://github.com/asmaloney/libE57Format",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3845,7 +3845,7 @@
       "port-version": 3
     },
     "libe57format": {
-      "baseline": "2.3.0",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "libebur128": {

--- a/versions/l-/libe57format.json
+++ b/versions/l-/libe57format.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc02f3676ee791122d4afca45f363564a293da8a",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f1c43acaa644678ab0a7023a4657235dd73b7860",
       "version": "2.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.