### PR TITLE
[abseil] Fix activation of `cxx17` feature

### DIFF
--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -12,11 +12,16 @@ vcpkg_from_github(
         fix-dll-support.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cxx17 ABSL_USE_CXX17
+)
+
 # With ABSL_PROPAGATE_CXX_STD=ON abseil automatically detect if it is being
 # compiled with C++14 or C++17, and modifies the installed `absl/base/options.h`
 # header accordingly. This works even if CMAKE_CXX_STANDARD is not set. Abseil
 # uses the compiler default behavior to update `absl/base/options.h` as needed.
-if (ABSL_USE_CXX17 IN_LIST FEATURES)
+if (ABSL_USE_CXX17)
     set(ABSL_USE_CXX17_OPTION "-DCMAKE_CXX_STANDARD=17")
 endif ()
 

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "abseil",
   "version": "20230125.0",
+  "port-version": 1,
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a88e9003e0d38c2cfbcc676931a0204d749e6629",
+      "version": "20230125.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "aa4f29f110c771e7096ba356501e4a0d6d3d9baa",
       "version": "20230125.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "abseil": {
       "baseline": "20230125.0",
-      "port-version": 0
+      "port-version": 1
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
Previously nothing would happen when specifying the `cxx17` feature, because the detection in the portfile is wrong.