### PR TITLE
[annoy] new port

### DIFF
--- a/ports/annoy/portfile.cmake
+++ b/ports/annoy/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO spotify/annoy
+    REF 0457742d12cf7a263f7c709ef1d470e5f08f791d # master on 2023-02-25
+    SHA512 df26b18a5a165081a9373076f974ee977b0b4b54e7a58da3723f608e4cc46aab1d0978f2663965c8bbb81d123c8efff1a77040ef2bfdc0287b08214514b40ecc
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE "release") # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/annoy)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/annoy/vcpkg.json
+++ b/ports/annoy/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "annoy",
+  "version-date": "2023-02-25",
+  "description": "Approximate Nearest Neighbors optimized for memory usage and loading/saving to disk",
+  "homepage": "https://github.com/spotify/annoy",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/annoy.json
+++ b/versions/a-/annoy.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fb0fa777748e35b69b4d3206cccc7ba770d12ee4",
+      "version-date": "2023-02-25",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -120,6 +120,10 @@
       "baseline": "chromium_5414",
       "port-version": 0
     },
+    "annoy": {
+      "baseline": "2023-02-25",
+      "port-version": 0
+    },
     "antlr4": {
       "baseline": "4.11.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
  - no, using current master with version-date for lastest upstream CMake patches
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.