### PR TITLE
[dav1d] Update to 1.1.0

### DIFF
--- a/ports/dav1d/portfile.cmake
+++ b/ports/dav1d/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_gitlab(
     GITLAB_URL https://code.videolan.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO videolan/dav1d
-    REF 1.1.0
+    REF "${VERSION}"
     SHA512 53b3fc0363504d4b9dd29bc88d3c8510ae65ac69b04e97d650e78c9fb5e2b95816d5c29dbc454aa5c2e539401c4be88ae88d7a7a8224007a05183fd249677f31
 )
 

--- a/ports/dav1d/portfile.cmake
+++ b/ports/dav1d/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://code.videolan.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO videolan/dav1d
-    REF 99172b11470776177939c3d2bc366fe8d904eab7  #v1.0.0
-    SHA512 8ab32d7f1e7ec0fb2aae9ae19e199f7a6b17f88af2287c13a9ca577f80f02351e601fb6c6f03c9505d6cecd047b823007ffef83a5ca3703e4d2a4dd5ff6d5d3b
+    REF 1.1.0
+    SHA512 53b3fc0363504d4b9dd29bc88d3c8510ae65ac69b04e97d650e78c9fb5e2b95816d5c29dbc454aa5c2e539401c4be88ae88d7a7a8224007a05183fd249677f31
 )
 
 vcpkg_find_acquire_program(NASM)

--- a/ports/dav1d/vcpkg.json
+++ b/ports/dav1d/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dav1d",
-  "version": "1.0.0",
-  "port-version": 1,
+  "version": "1.1.0",
   "description": "dav1d is a new open-source AV1 decoder developed by the VideoLAN and FFmpeg communities and sponsored by the Alliance for Open Media.",
   "homepage": "https://code.videolan.org/videolan/dav1d",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1945,8 +1945,8 @@
       "port-version": 2
     },
     "dav1d": {
-      "baseline": "1.0.0",
-      "port-version": 1
+      "baseline": "1.1.0",
+      "port-version": 0
     },
     "daw-header-libraries": {
       "baseline": "2.76.2",

--- a/versions/d-/dav1d.json
+++ b/versions/d-/dav1d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0e367d019339989398f929d319b7e3bef7edc7fa",
+      "git-tree": "2533f95516074908ec446a13ea70f8f8346494e3",
       "version": "1.1.0",
       "port-version": 0
     },

--- a/versions/d-/dav1d.json
+++ b/versions/d-/dav1d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e367d019339989398f929d319b7e3bef7edc7fa",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d5a7b193225074fb9ffe0f4ec2acec1086e13a9",
       "version": "1.0.0",
       "port-version": 1


### PR DESCRIPTION
Release on Feb 14: https://code.videolan.org/videolan/dav1d/-/tags/1.1.0

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
