### PR TITLE
[recast] fix include paths

### DIFF
--- a/ports/recast/CMakeLists.txt
+++ b/ports/recast/CMakeLists.txt
@@ -41,12 +41,12 @@ target_include_directories(
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DetourCrowd/Include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DetourTileCache/Include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Recast/Include>
-  $<INSTALL_INTERFACE:include>
-  $<INSTALL_INTERFACE:include/Detour/Include>
-  $<INSTALL_INTERFACE:include/DetourCrowd/Include>
-  $<INSTALL_INTERFACE:include/DetourTileCache/Include>
-  $<INSTALL_INTERFACE:include/Recast/Include>
-  $<INSTALL_INTERFACE:include/DebugUtils/Include>
+  $<INSTALL_INTERFACE:include/recast/>
+  $<INSTALL_INTERFACE:include/recast/Detour/Include>
+  $<INSTALL_INTERFACE:include/recast/DetourCrowd/Include>
+  $<INSTALL_INTERFACE:include/recast/DetourTileCache/Include>
+  $<INSTALL_INTERFACE:include/recast/Recast/Include>
+  $<INSTALL_INTERFACE:include/recast/DebugUtils/Include>
 )
 
 install(
@@ -59,9 +59,9 @@ install(
 install(EXPORT unofficial-recast-config DESTINATION share/unofficial-recast)
 
 if(NOT DISABLE_INSTALL_HEADERS)
-  install(DIRECTORY DebugUtils/Include/ DESTINATION include/recast/DebugUtils)
-  install(DIRECTORY Detour/Include/ DESTINATION include/recast/Detour)
-  install(DIRECTORY DetourCrowd/Include/ DESTINATION include/recast/DetourCrowd)
-  install(DIRECTORY DetourTileCache/Include/ DESTINATION include/recast/DetourTileCache)
-  install(DIRECTORY Recast/Include/ DESTINATION include/recast/Recast)
+  install(DIRECTORY DebugUtils/Include/ DESTINATION include/recast/DebugUtils/Include)
+  install(DIRECTORY Detour/Include/ DESTINATION include/recast/Detour/Include)
+  install(DIRECTORY DetourCrowd/Include/ DESTINATION include/recast/DetourCrowd/Include)
+  install(DIRECTORY DetourTileCache/Include/ DESTINATION include/recast/DetourTileCache/Include)
+  install(DIRECTORY Recast/Include/ DESTINATION include/recast/Recast/Include)
 endif()

--- a/ports/recast/vcpkg.json
+++ b/ports/recast/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "recast",
   "version": "1.5.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Navigation-mesh Toolset for Games",
   "homepage": "https://github.com/recastnavigation/recastnavigation",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6798,7 +6798,7 @@
     },
     "recast": {
       "baseline": "1.5.1",
-      "port-version": 5
+      "port-version": 6
     },
     "recycle": {
       "baseline": "6.0.0",

--- a/versions/r-/recast.json
+++ b/versions/r-/recast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f6f99b923ad8fbbee1aafd0deb361f8cf7eb7bd6",
+      "version": "1.5.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "fe2b42ef737e0b51a58bb9f56340e324ab8f82c3",
       "version": "1.5.1",
       "port-version": 5


### PR DESCRIPTION
Fixes #29859 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
