### PR TITLE
[libffi] add risc-v support

### DIFF
--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 # config variables for ffi.h.in
 set(VERSION 3.4.4)
 
-set(KNOWN_PROCESSORS x86 x86_64 amd64 arm arm64 i386 i686 armv7l armv7-a aarch64 mips64el)
+set(KNOWN_PROCESSORS x86 x86_64 amd64 arm arm64 i386 i686 armv7l armv7-a aarch64 mips64el riscv32 riscv64)
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" lower_system_processor)
 
@@ -33,6 +33,8 @@ elseif(lower_system_processor MATCHES "mips64")
     set(TARGET MIPS64)
 elseif(lower_system_processor MATCHES "arm")
     set(TARGET ARM)
+elseif(lower_system_processor MATCHES "riscv")
+    set(TARGET RISCV)
 elseif(CMAKE_SYSTEM_NAME MATCHES "BSD" AND CMAKE_SIZEOF_VOID_P EQUAL 4)
     set(TARGET X86_FREEBSD)
 elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin"  AND CMAKE_SIZEOF_VOID_P EQUAL 4)
@@ -62,6 +64,8 @@ elseif ("${TARGET}" STREQUAL "ARM_WIN32" OR "${TARGET}" STREQUAL "ARM")
     file(COPY src/arm/ffitarget.h DESTINATION ${CMAKE_BINARY_DIR}/include)
 elseif ("${TARGET}" MATCHES "MIPS")
     file(COPY src/mips/ffitarget.h DESTINATION ${CMAKE_BINARY_DIR}/include)
+elseif ("${TARGET}" STREQUAL "RISCV")
+    file(COPY src/riscv/ffitarget.h DESTINATION ${CMAKE_BINARY_DIR}/include)
 else()
     file(COPY src/x86/ffitarget.h DESTINATION ${CMAKE_BINARY_DIR}/include)
 endif()
@@ -93,6 +97,10 @@ elseif("${TARGET}" MATCHES "MIPS")
     set(FFI_SOURCES
         ${FFI_SOURCES}
         src/mips/ffi.c)
+elseif("${TARGET}" STREQUAL "RISCV")
+   set(FFI_SOURCES
+	${FFI_SOURCES}
+	src/riscv/ffi.c)
 else()
     set(FFI_SOURCES
         ${FFI_SOURCES}
@@ -199,6 +207,8 @@ elseif("${TARGET}" STREQUAL "ARM64")
     add_assembly(src/aarch64/sysv.S)
 elseif("${TARGET}" MATCHES "MIPS")
     add_assembly(src/mips/n32.S)
+elseif("${TARGET}" MATCHES "RISCV")
+    add_assembly(src/riscv/sysv.S)
 else()
     message(FATAL_ERROR "Target not implemented")
 endif()

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libffi",
   "version": "3.4.4",
+  "port-version": 1,
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3878,7 +3878,7 @@
     },
     "libffi": {
       "baseline": "3.4.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libfido2": {
       "baseline": "1.10.0",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2422375e9ac93e01de0b511e1181000c340da613",
+      "version": "3.4.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "6552925531e923480b50d806c7d4538c1ff15481",
       "version": "3.4.4",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Add risc-v support for libffi. Tested with Ubuntu 22.04.1 LTS (GNU/Linux 5.19.0-1012-generic riscv64).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

