### PR TITLE
[litehtml] Fix litehtml.h under Visual Studio

### DIFF
--- a/ports/litehtml/fix-relative-includes.patch
+++ b/ports/litehtml/fix-relative-includes.patch
@@ -20,11 +20,11 @@ index 98a24e0..d20addd 100644
 -#include <litehtml/html_tag.h>
 -#include <litehtml/stylesheet.h>
 -#include <litehtml/element.h>
-+#include <html.h>
-+#include <document.h>
-+#include <html_tag.h>
-+#include <stylesheet.h>
-+#include <element.h>
++#include "html.h"
++#include "document.h"
++#include "html_tag.h"
++#include "stylesheet.h"
++#include "element.h"
  
  #endif  // LITEHTML_H
 -- 

--- a/ports/litehtml/vcpkg.json
+++ b/ports/litehtml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "litehtml",
   "version": "0.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "litehtml is the lightweight HTML rendering engine with CSS2/CSS3 support.",
   "homepage": "https://github.com/litehtml/litehtml",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4734,7 +4734,7 @@
     },
     "litehtml": {
       "baseline": "0.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "live555": {
       "baseline": "2023-01-19",

--- a/versions/l-/litehtml.json
+++ b/versions/l-/litehtml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbbd4d593d570ec75f5a02fea10a236aecc810d4",
+      "version": "0.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "2f2981f2edef7c5f69ba42716c007822f74e99ae",
       "version": "0.6.0",
       "port-version": 1


### PR DESCRIPTION
Fixes litehtml.h header under Visual Studio.

Visual Studio (msc) looks for angle includes in the search path but not relative to the file. The patch fix-relative-includes.patch fixes clang and the vcpkg CI builds but breaks VS builds using litehtml directly. This change fixes both.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.