### PR TITLE
[ncurses] Fix "lib model" control.

### DIFF
--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -17,9 +17,9 @@ vcpkg_list(SET OPTIONS)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     list(APPEND OPTIONS
-        --with-shared
         --with-cxx-shared
-        --without-normal
+        --with-shared    # "lib model"
+        --without-normal # "lib model"
     )
 endif()
 
@@ -46,17 +46,12 @@ vcpkg_configure_make(
         --disable-db-install
         --enable-pc-files
         --without-ada
+        --without-debug # "lib model"
         --without-manpages
         --without-progs
         --without-tack
         --without-tests
         --with-pkg-config-libdir=libdir
-    OPTIONS_DEBUG
-        --with-debug
-        --without-normal
-    OPTIONS_RELEASE
-        --without-debug
-        --with-normal
 )
 vcpkg_install_make()
 

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ncurses",
   "version": "6.4",
+  "port-version": 1,
   "description": "Free software emulation of curses in System V Release 4.0, and more",
   "homepage": "https://invisible-island.net/ncurses/announce.html",
   "license": "MIT",

--- a/scripts/test_ports/cmake-user/vcpkg.json
+++ b/scripts/test_ports/cmake-user/vcpkg.json
@@ -134,6 +134,11 @@
           "platform": "!uwp & !mingw"
         },
         {
+          "$package": "Curses",
+          "name": "ncurses",
+          "platform": "!windows | mingw"
+        },
+        {
           "$package": "PhysFS",
           "name": "physfs"
         },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5350,7 +5350,7 @@
     },
     "ncurses": {
       "baseline": "6.4",
-      "port-version": 0
+      "port-version": 1
     },
     "neargye-semver": {
       "baseline": "0.3.0",

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "faaf5fff20ee04db0b33a595cd37f41b89c840d6",
+      "version": "6.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "c557b7daa2f3a87a54e037e7b984ad8a661c5903",
       "version": "6.4",
       "port-version": 0


### PR DESCRIPTION
Fixes #29872.
Add ncurses to cmake-user test port. (Doesn't cover pc files, but detects the absence of the expected debug lib name.)

ncurses has a specifc notion of "lib models" such as normal, shared, debug, profile, ...
vcpkg only needs to choose between two models: normal (i.e. static) or shared.
The debug model is not needed to build the vcpkg debug config type. But it added a `_g`suffix to libs and pc files which break uniform downstream usage with `pkg-config` and `FindCurses.cmake`.

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
