### PR TITLE
[applocal.ps1] Fix -targetBinary without drive letter (#29890)

### DIFF
--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -94,7 +94,7 @@ function resolve([string]$targetBinary) {
     $targetBinaryDir = Split-Path $targetBinaryPath -parent
 
     if (Get-Command "dumpbin" -ErrorAction SilentlyContinue) {
-        $a = $(dumpbin /DEPENDENTS $targetBinary | ? { $_ -match "^    [^ ].*\.dll" } | % { $_ -replace "^    ","" })
+        $a = $(dumpbin /DEPENDENTS $targetBinaryPath| ? { $_ -match "^    [^ ].*\.dll" } | % { $_ -replace "^    ","" })
     } elseif (Get-Command "llvm-objdump" -ErrorAction SilentlyContinue) {
         $a = $(llvm-objdump -p $targetBinary| ? { $_ -match "^ {4}DLL Name: .*\.dll" } | % { $_ -replace "^ {4}DLL Name: ","" })
     } elseif (Get-Command "objdump" -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
On Windows, running applocal.ps1 with "-targetBinary /foo/bar.exe" (without drive letter) did not install dependencies. The dumpbin executable was called with /foo/bar.exe, and dumpbin interpreted this as unknown command line argument. No dependencies were resolved.

We're already resolving the full path of the target binary some lines above the dumpbin call. The $targetBinaryPath variable contains the target binary's path including the drive letter, and dumpbin successfully reports the executable's dependencies.

Fixes #29890