### PR TITLE
[libdeflate] New port

### DIFF
--- a/ports/libdeflate/portfile.cmake
+++ b/ports/libdeflate/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ebiggers/libdeflate
+    REF "v${VERSION}"
+    SHA512 4e2c0f78e55befc8cbc390722ee5e9e7662315eaafe1979e300972990acf4afffc32a1220cca7a6e944d551a430dd13d36b40066dfe8141789de1a5418ac620f
+    HEAD_REF master
+    PATCHES
+        remove_wrong_c_flags_modification.diff
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        compression   LIBDEFLATE_COMPRESSION_SUPPORT
+        decompression LIBDEFLATE_DECOMPRESSION_SUPPORT
+        gzip          LIBDEFLATE_ZLIB_SUPPORT
+        zlib          LIBDEFLATE_GZIP_SUPPORT
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LIBDEFLATE_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIBDEFLATE_BUILD_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLIBDEFLATE_BUILD_SHARED_LIB=${LIBDEFLATE_BUILD_SHARED}
+        -DLIBDEFLATE_BUILD_STATIC_LIB=${LIBDEFLATE_BUILD_STATIC}
+        -DLIBDEFLATE_BUILD_GZIP=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libdeflate")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libdeflate/remove_wrong_c_flags_modification.diff
+++ b/ports/libdeflate/remove_wrong_c_flags_modification.diff
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0acd26f..218c48b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -61,7 +61,6 @@ if(NOT LIBDEFLATE_BUILD_STATIC_LIB)
+ endif()
+ 
+ # Set common C compiler flags for all targets (the library and the programs).
+-set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+ set(CMAKE_C_STANDARD 99)
+ if(NOT MSVC)
+     check_c_compiler_flag(-Wdeclaration-after-statement HAVE_WDECLARATION_AFTER_STATEMENT)

--- a/ports/libdeflate/usage
+++ b/ports/libdeflate/usage
@@ -1,0 +1,4 @@
+The package zstd provides CMake targets:
+
+    find_package(libdeflate CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:libdeflate::libdeflate_shared>,libdeflate::libdeflate_shared,libdeflate::libdeflate_static>)

--- a/ports/libdeflate/vcpkg.json
+++ b/ports/libdeflate/vcpkg.json
@@ -1,0 +1,37 @@
+{
+  "name": "libdeflate",
+  "version": "1.17",
+  "description": "libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.",
+  "homepage": "https://github.com/ebiggers/libdeflate",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "compression",
+    "decompression",
+    "gzip",
+    "zlib"
+  ],
+  "features": {
+    "compression": {
+      "description": "Support compression"
+    },
+    "decompression": {
+      "description": "Support decompression"
+    },
+    "gzip": {
+      "description": "Support the gzip format"
+    },
+    "zlib": {
+      "description": "Support the zlib format"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3824,6 +3824,9 @@
       "baseline": "1.0.8",
       "port-version": 6
     },
+    "libdeflate": {
+      "baseline": "1.17"
+    },
     "libdisasm": {
       "baseline": "0.23",
       "port-version": 9

--- a/versions/l-/libdeflate.json
+++ b/versions/l-/libdeflate.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "023c8297e1d45d680194366783974818522294bd",
+      "version": "1.17",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Unfortunately, the library only creates specific targets for each library linkage type:
```
find_package(libdeflate CONFIG REQUIRED)
target_link_libraries(main PRIVATE libdeflate::libdeflate_static)
```

So there is no target `libdeflate::libdeflate`, i.e. you cannot simply switch from the triplet `x64-windows` to `x64-windows-static`. Should I add a patch to add an `ALIAS` target?