### PR TITLE
[highfive] fix SHA of the downloaded patch

### DIFF
--- a/ports/highfive/portfile.cmake
+++ b/ports/highfive/portfile.cmake
@@ -1,8 +1,8 @@
 # Must be removed on next release
 vcpkg_download_distfile(CATCH2_PATCH
     URLS https://github.com/BlueBrain/HighFive/commit/be9285ee4661ff4154830989899a2a050d6fbc64.patch?full_index=1
-    FILENAME ${PORT}-669-cd784f8d.diff
-    SHA512 cd784f8d4543cf1eaaba027a01d6042fe156e15d2ce59630ddf7dd2709c17d8ac8518954f6262de4d2ebfdf626467cdf6d16d072c17adb98b799d82ccda8792a
+    FILENAME ${PORT}-669-be9285ee.diff
+    SHA512 d4b085557fdcfaed195efaa25e02358714e6ccb00cc532594592183e934d99e3b80883991fcac1d073fbedb5773d76a5e9a58da4328b71215dd30b259df1eba3
 )
 
 vcpkg_from_github(

--- a/ports/highfive/vcpkg.json
+++ b/ports/highfive/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "highfive",
   "version": "2.6.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "HighFive is a modern header-only C++/C++11 friendly interface for libhdf5",
   "homepage": "https://github.com/BlueBrain/HighFive",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3030,7 +3030,7 @@
     },
     "highfive": {
       "baseline": "2.6.2",
-      "port-version": 1
+      "port-version": 2
     },
     "highway": {
       "baseline": "1.0.3",

--- a/versions/h-/highfive.json
+++ b/versions/h-/highfive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6139bdb8e7791f8cc8cf5a355dad303f277e2c6e",
+      "version": "2.6.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "053a5d7a36102b9cc8c57ef4853bd904765dbf33",
       "version": "2.6.2",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
There is still an issue for highfive. 

https://github.com/hpc-maths/samurai/actions/runs/4193861295/jobs/7466677031

I made a mistake in the last PR. I added `?full_index=1`at the end of the url and I tried to install highfive locally. But I already had the patch and then the SHA was not verified.
In this PR, the SHA is the good one. 

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
