### PR TITLE
[pcl] Fix PCLConfig.cmake for debug configuration

### DIFF
--- a/ports/pcl/pcl_config.patch
+++ b/ports/pcl/pcl_config.patch
@@ -1,5 +1,5 @@
 diff --git a/PCLConfig.cmake.in b/PCLConfig.cmake.in
-index 1d957ce..31ca9f2 100644
+index 1d957ce..7daebe9 100644
 --- a/PCLConfig.cmake.in
 +++ b/PCLConfig.cmake.in
 @@ -386,6 +386,7 @@ file(TO_CMAKE_PATH "${PCL_DIR}" PCL_DIR)
@@ -10,7 +10,7 @@ index 1d957ce..31ca9f2 100644
    if(EXISTS "${PCL_ROOT}/3rdParty")
      set(PCL_ALL_IN_ONE_INSTALLER ON)
    endif()
-@@ -395,21 +396,14 @@ else()
+@@ -395,21 +396,20 @@ else()
  endif()
  
  # check whether PCLConfig.cmake is found into a PCL installation or in a build tree
@@ -25,13 +25,19 @@ index 1d957ce..31ca9f2 100644
 +if(EXISTS "${PCL_ROOT}/include/pcl/pcl_config.h")
    set(PCL_CONF_INCLUDE_DIR "${PCL_ROOT}/include")
 -  set(PCL_LIBRARY_DIRS "${PCL_ROOT}/lib")
-+  set(PCL_LIBRARY_DIRS "${PCL_ROOT}/@LIB_INSTALL_DIR@" "${PCL_ROOT}/debug/@LIB_INSTALL_DIR@")
++  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
++    set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@" "${PCL_DIR}/debug/@LIB_INSTALL_DIR@")
++  else()
++    set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@")
  elseif(EXISTS "${PCL_DIR}/include/pcl/pcl_config.h")
    # Found PCLConfig.cmake in a build tree of PCL
    # pcl_message("PCL found into a build tree.")
    set(PCL_CONF_INCLUDE_DIR "${PCL_DIR}/include") # for pcl_config.h
 -  set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@")
-+  set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@""${PCL_DIR}/debug/@LIB_INSTALL_DIR@")
++  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
++    set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@" "${PCL_DIR}/debug/@LIB_INSTALL_DIR@")
++  else()
++    set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@")
  else()
    pcl_report_not_found("PCL can not be found on this machine")
  endif()

--- a/ports/pcl/pcl_config.patch
+++ b/ports/pcl/pcl_config.patch
@@ -1,5 +1,5 @@
 diff --git a/PCLConfig.cmake.in b/PCLConfig.cmake.in
-index 1d957ce..7daebe9 100644
+index 1d957ce..a98dcac 100644
 --- a/PCLConfig.cmake.in
 +++ b/PCLConfig.cmake.in
 @@ -386,6 +386,7 @@ file(TO_CMAKE_PATH "${PCL_DIR}" PCL_DIR)
@@ -10,7 +10,7 @@ index 1d957ce..7daebe9 100644
    if(EXISTS "${PCL_ROOT}/3rdParty")
      set(PCL_ALL_IN_ONE_INSTALLER ON)
    endif()
-@@ -395,21 +396,20 @@ else()
+@@ -395,21 +396,22 @@ else()
  endif()
  
  # check whether PCLConfig.cmake is found into a PCL installation or in a build tree
@@ -29,6 +29,7 @@ index 1d957ce..7daebe9 100644
 +    set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@" "${PCL_DIR}/debug/@LIB_INSTALL_DIR@")
 +  else()
 +    set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@")
++  endif()
  elseif(EXISTS "${PCL_DIR}/include/pcl/pcl_config.h")
    # Found PCLConfig.cmake in a build tree of PCL
    # pcl_message("PCL found into a build tree.")
@@ -38,6 +39,7 @@ index 1d957ce..7daebe9 100644
 +    set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@" "${PCL_DIR}/debug/@LIB_INSTALL_DIR@")
 +  else()
 +    set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@")
++  endif()
  else()
    pcl_report_not_found("PCL can not be found on this machine")
  endif()

--- a/ports/pcl/pcl_config.patch
+++ b/ports/pcl/pcl_config.patch
@@ -1,17 +1,8 @@
-From 2f4952e1767ad5b0349a03ee56d676d226102381 Mon Sep 17 00:00:00 2001
-From: raahilsha-z <raahil.sha@zimaging.io>
-Date: Wed, 7 Jul 2021 15:59:12 -0400
-Subject: [PATCH] pcl_config
-
----
- PCLConfig.cmake.in | 12 +++---------
- 1 file changed, 3 insertions(+), 9 deletions(-)
-
 diff --git a/PCLConfig.cmake.in b/PCLConfig.cmake.in
-index a1283a810..4137ed18c 100644
+index 1d957ce..31ca9f2 100644
 --- a/PCLConfig.cmake.in
 +++ b/PCLConfig.cmake.in
-@@ -384,6 +384,7 @@ file(TO_CMAKE_PATH "${PCL_DIR}" PCL_DIR)
+@@ -386,6 +386,7 @@ file(TO_CMAKE_PATH "${PCL_DIR}" PCL_DIR)
  if(WIN32 AND NOT MINGW)
  # PCLConfig.cmake is installed to PCL_ROOT/cmake
    get_filename_component(PCL_ROOT "${PCL_DIR}" PATH)
@@ -19,7 +10,7 @@ index a1283a810..4137ed18c 100644
    if(EXISTS "${PCL_ROOT}/3rdParty")
      set(PCL_ALL_IN_ONE_INSTALLER ON)
    endif()
-@@ -393,16 +394,9 @@ else()
+@@ -395,21 +396,14 @@ else()
  endif()
  
  # check whether PCLConfig.cmake is found into a PCL installation or in a build tree
@@ -38,6 +29,9 @@ index a1283a810..4137ed18c 100644
  elseif(EXISTS "${PCL_DIR}/include/pcl/pcl_config.h")
    # Found PCLConfig.cmake in a build tree of PCL
    # pcl_message("PCL found into a build tree.")
--- 
-2.32.0.windows.1
-
+   set(PCL_CONF_INCLUDE_DIR "${PCL_DIR}/include") # for pcl_config.h
+-  set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@")
++  set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@""${PCL_DIR}/debug/@LIB_INSTALL_DIR@")
+ else()
+   pcl_report_not_found("PCL can not be found on this machine")
+ endif()

--- a/ports/pcl/vcpkg.json
+++ b/ports/pcl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pcl",
   "version": "1.13.0",
+  "port-version": 1,
   "description": "Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.",
   "homepage": "https://github.com/PointCloudLibrary/pcl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5934,7 +5934,7 @@
     },
     "pcl": {
       "baseline": "1.13.0",
-      "port-version": 0
+      "port-version": 1
     },
     "pcre": {
       "baseline": "8.45",

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "64f3f3e9b2dd405eab022cc598e5fdc2dfbf4301",
+      "git-tree": "3a40b107ed0cd74170b7b42a4c0870a08465cd3b",
       "version": "1.13.0",
       "port-version": 1
     },

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3a40b107ed0cd74170b7b42a4c0870a08465cd3b",
+      "git-tree": "8b463c031388db2bf33bdf6568dca9de0d60614b",
       "version": "1.13.0",
       "port-version": 1
     },

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64f3f3e9b2dd405eab022cc598e5fdc2dfbf4301",
+      "version": "1.13.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f295f2d1ea57514c89835cd797fa8cca1d0b5fdf",
       "version": "1.13.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/29913
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Add the missing lib path for debug.
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
