### PR TITLE
[cpr] Update to 1.10.0

### DIFF
--- a/ports/cpr/001-cpr-config.patch
+++ b/ports/cpr/001-cpr-config.patch
@@ -1,10 +1,10 @@
 diff --git a/cpr/CMakeLists.txt b/cpr/CMakeLists.txt
-index 66fc9eb..cc00c72 100644
+index 3a182d4..f0725d5 100644
 --- a/cpr/CMakeLists.txt
 +++ b/cpr/CMakeLists.txt
-@@ -30,6 +30,10 @@ set_target_properties(cpr
-      VERSION ${${PROJECT_NAME}_VERSION}
-      SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
+@@ -46,6 +46,10 @@ set_target_properties(cpr
+         VERSION ${${PROJECT_NAME}_VERSION}
+         SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
  
 +if (NOT DISABLE_INSTALL_HEADERS)
 +    install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../include/cpr DESTINATION include)

--- a/ports/cpr/disable_werror.patch
+++ b/ports/cpr/disable_werror.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d0e8854..4a07218 100644
+index cb7c5f042..a5bc0b942 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -103,7 +103,7 @@ if(CPR_ENABLE_CPPCHECK)
+@@ -71,7 +71,7 @@ if(CPR_ENABLE_CPPCHECK)
      include(cmake/cppcheck.cmake)
  endif()
  

--- a/ports/cpr/disable_werror.patch
+++ b/ports/cpr/disable_werror.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cb7c5f042..a5bc0b942 100644
+index d0e8854..4a07218 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -71,7 +71,7 @@ if(CPR_ENABLE_CPPCHECK)
+@@ -103,7 +103,7 @@ if(CPR_ENABLE_CPPCHECK)
      include(cmake/cppcheck.cmake)
  endif()
  

--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libcpr/cpr
-    REF a2d35a1cb9f3f7e2f1469d6a189751331dc99f96 #v1.9.3
-    SHA512 5df799fa53d51ba020a860ff928123921ed0ba59152de2b7e9d88b54ace820f5881fc72d056fca5679a7710357aa25854fa6dd6f9d230338b5378aebfe2bd957
+    REF "${VERSION}"
+    SHA512 90fa19dbb0a8a53e1b6c92a1c6eec7cb1e41f4b56c2c392e4f71edcc5574a6cd5fd906959c1da39d20cb012ab5d430955814bb88ef7f7a74dac7a1f226abbe85
     HEAD_REF master
     PATCHES
         001-cpr-config.patch
@@ -31,4 +31,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/cpr)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cpr/vcpkg.json
+++ b/ports/cpr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpr",
-  "version-semver": "1.9.3",
+  "version-semver": "1.10.0",
   "description": "C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.",
   "homepage": "https://github.com/libcpr/cpr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1781,7 +1781,7 @@
       "port-version": 0
     },
     "cpr": {
-      "baseline": "1.9.3",
+      "baseline": "1.10.0",
       "port-version": 0
     },
     "cpu-features": {

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28f843d954aa7468b9cdfa6e3d7aa4b4a8625454",
+      "version-semver": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "13181536fae6181da65a2d2522a814fffb61bb83",
       "version-semver": "1.9.3",
       "port-version": 0

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28f843d954aa7468b9cdfa6e3d7aa4b4a8625454",
+      "git-tree": "2d13c6b33e70d984e7d23b646f6e6c659da6097d",
       "version-semver": "1.10.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #29863. 
The usage test passed (header files found). 
All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.