### PR TITLE
[libadlmidi] add new port

### DIFF
--- a/ports/libadlmidi/cmake-build-shared-libs-support.patch
+++ b/ports/libadlmidi/cmake-build-shared-libs-support.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 271bb9b..37340f9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -147,8 +147,18 @@ if(NOT EMSCRIPTEN
+    AND NOT NINTENDO_WII
+    AND NOT NINTENDO_WIIU
+    AND NOT ADLMIDI_DOS)
+-    option(libADLMIDI_STATIC   "Build static library of libADLMIDI" ON)
+-    option(libADLMIDI_SHARED   "Build shared library of libADLMIDI" OFF)
++
++    set(libADLMIDI_STATIC_ENABLED_BY_DEFAULT ON)
++    set(libADLMIDI_SHARED_ENABLED_BY_DEFAULT OFF)
++
++    # When defined, respect CMake's BUILD_SHARED_LIBS setting
++    if (BUILD_SHARED_LIBS)
++        set(libADLMIDI_SHARED_ENABLED_BY_DEFAULT ON)
++        set(libADLMIDI_STATIC_ENABLED_BY_DEFAULT OFF)
++    endif()
++
++    option(libADLMIDI_STATIC   "Build static library of libADLMIDI" ${libADLMIDI_STATIC_ENABLED_BY_DEFAULT})
++    option(libADLMIDI_SHARED   "Build shared library of libADLMIDI" ${libADLMIDI_SHARED_ENABLED_BY_DEFAULT})
+ else()
+     set(libADLMIDI_STATIC ON)
+     set(libADLMIDI_SHARED OFF)

--- a/ports/libadlmidi/cmake-package-export.patch
+++ b/ports/libadlmidi/cmake-package-export.patch
@@ -1,0 +1,114 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 271bb9b..1b6ba8f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -313,7 +313,7 @@ if(libADLMIDI_STATIC OR WITH_VLC_PLUGIN)
+     else()
+         set_target_properties(ADLMIDI_static PROPERTIES OUTPUT_NAME ADLMIDI)
+     endif()
+-    target_include_directories(ADLMIDI_static PUBLIC ${libADLMIDI_SOURCE_DIR}/include)
++    target_include_directories(ADLMIDI_static PUBLIC $<BUILD_INTERFACE:${libADLMIDI_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+     set_legacy_standard(ADLMIDI_static)
+     set_visibility_hidden(ADLMIDI_static)
+     handle_options(ADLMIDI_static)
+@@ -336,7 +336,7 @@ if(libADLMIDI_SHARED)
+         VERSION ${libADLMIDI_VERSION}
+         SOVERSION ${libADLMIDI_VERSION_MAJOR}
+     )
+-    target_include_directories(ADLMIDI_shared PUBLIC ${libADLMIDI_SOURCE_DIR}/include)
++    target_include_directories(ADLMIDI_shared PUBLIC $<BUILD_INTERFACE:${libADLMIDI_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+     set_legacy_standard(ADLMIDI_shared)
+     set_visibility_hidden(ADLMIDI_shared)
+     handle_options(ADLMIDI_shared)
+@@ -418,22 +418,44 @@ if(WIN32 AND WITH_WINMMDRV)
+     add_subdirectory(utils/winmm_drv)
+ endif()
+ 
+-set(libADLMIDI_INSTALLS )
+-foreach(lib ADLMIDI_static ADLMIDI_shared)
+-    if(TARGET ${lib})
+-        list(APPEND libADLMIDI_INSTALLS ${lib})
+-    endif()
+-endforeach()
++if(libADLMIDI_STATIC)
++    install(TARGETS ADLMIDI_static
++            EXPORT libADLMIDIStaticTargets
++            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
++
++    install(EXPORT libADLMIDIStaticTargets
++            FILE libADLMIDI-static-targets.cmake
++            NAMESPACE libADLMIDI::
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libADLMIDI")
++endif()
++
++if(libADLMIDI_SHARED)
++    install(TARGETS ADLMIDI_shared
++            EXPORT libADLMIDISharedTargets
++            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+ 
+-install(TARGETS ${libADLMIDI_INSTALLS}
+-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++    install(EXPORT libADLMIDISharedTargets
++            FILE libADLMIDI-shared-targets.cmake
++            NAMESPACE libADLMIDI::
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libADLMIDI")
++endif()
+ 
+ install(FILES
+         include/adlmidi.h
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++        
++include(CMakePackageConfigHelpers)
++configure_package_config_file(libADLMIDI-config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/libADLMIDI-config.cmake"
++    PATH_VARS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_FULL_BINDIR CMAKE_INSTALL_FULL_INCLUDEDIR CMAKE_INSTALL_FULL_LIBDIR
++    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libADLMIDI"
++)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libADLMIDI-config.cmake
++    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libADLMIDI"
++)
+ 
+ file(GLOB DOCTXT_FILES
+     "${libADLMIDI_SOURCE_DIR}/LICENSE*.txt"
+diff --git a/libADLMIDI-config.cmake.in b/libADLMIDI-config.cmake.in
+new file mode 100644
+index 0000000..bd875fc
+--- /dev/null
++++ b/libADLMIDI-config.cmake.in
+@@ -0,0 +1,30 @@
++include(FeatureSummary)
++set_package_properties(libADLMIDI PROPERTIES
++  URL "https://github.com/Wohlstand/libADLMIDI"
++  DESCRIPTION "libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation"
++)
++
++@PACKAGE_INIT@
++
++if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/libADLMIDI-shared-targets.cmake")
++    include("${CMAKE_CURRENT_LIST_DIR}/libADLMIDI-shared-targets.cmake")
++endif()
++if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/libADLMIDI-static-targets.cmake")
++    include("${CMAKE_CURRENT_LIST_DIR}/libADLMIDI-static-targets.cmake")
++endif()
++
++if(TARGET libADLMIDI::ADLMIDI_shared)
++    if(CMAKE_VERSION VERSION_LESS "3.18")
++        add_library(libADLMIDI::ADLMIDI INTERFACE IMPORTED)
++        set_target_properties(libADLMIDI::ADLMIDI PROPERTIES INTERFACE_LINK_LIBRARIES "libADLMIDI::ADLMIDI_shared")
++    else()
++        add_library(libADLMIDI::ADLMIDI ALIAS libADLMIDI::ADLMIDI_shared)
++    endif()
++else()
++    if(CMAKE_VERSION VERSION_LESS "3.18")
++        add_library(libADLMIDI::ADLMIDI INTERFACE IMPORTED)
++        set_target_properties(libADLMIDI::ADLMIDI PROPERTIES INTERFACE_LINK_LIBRARIES "libADLMIDI::ADLMIDI_static")
++    else()
++        add_library(libADLMIDI::ADLMIDI ALIAS libADLMIDI::ADLMIDI_static)
++    endif()
++endif()

--- a/ports/libadlmidi/portfile.cmake
+++ b/ports/libadlmidi/portfile.cmake
@@ -1,0 +1,45 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Wohlstand/libADLMIDI
+    REF v${VERSION}
+    SHA512 d827f13c60086b62bb4ffb098faeaa214fd83df52d3d5c19533b970d74b470c677e0aec76e91e05753574cf9bae1ccd02b77bd24d0ec1b2ad80b21cf541c7261
+    PATCHES
+        cmake-package-export.patch
+        cmake-build-shared-libs-support.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        midi-sequencer  WITH_MIDI_SEQUENCER
+        embedded-banks  WITH_EMBEDDED_BANKS
+        mus             WITH_MUS_SUPPORT
+        xmi             WITH_XMI_SUPPORT
+        dosbox-emulator USE_DOSBOX_EMULATOR
+        nuked-emulator  USE_NUKED_EMULATOR
+        opal-emulator   USE_OPAL_EMULATOR
+        java-emulator   USE_JAVA_EMULATOR
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libADLMIDI)
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSE*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/libadlmidi/usage
+++ b/ports/libadlmidi/usage
@@ -1,0 +1,4 @@
+libadlmidi provides CMake targets:
+
+    find_package(libADLMIDI CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE libADLMIDI::ADLMIDI)

--- a/ports/libadlmidi/vcpkg.json
+++ b/ports/libadlmidi/vcpkg.json
@@ -1,0 +1,52 @@
+{
+  "name": "libadlmidi",
+  "version": "1.5.1",
+  "description": "libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation",
+  "homepage": "https://github.com/Wohlstand/libADLMIDI",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "dosbox-emulator",
+    "embedded-banks",
+    "java-emulator",
+    "midi-sequencer",
+    "mus",
+    "nuked-emulator",
+    "opal-emulator",
+    "xmi"
+  ],
+  "features": {
+    "dosbox-emulator": {
+      "description": "Build with DosBox 0.74 OPL3 emulator (well-accurate and fast)"
+    },
+    "embedded-banks": {
+      "description": "Build with embedded banks"
+    },
+    "java-emulator": {
+      "description": "Build with Java OPL3 emulator (semi-accurate)"
+    },
+    "midi-sequencer": {
+      "description": "Build with embedded MIDI sequencer"
+    },
+    "mus": {
+      "description": "Support for DMX MUS files"
+    },
+    "nuked-emulator": {
+      "description": "Build with Nuked OPL3 emulator (very-accurate, needs more CPU power)"
+    },
+    "opal-emulator": {
+      "description": "Build with Opal OPL3 emulator (innacurate)"
+    },
+    "xmi": {
+      "description": "Support for AIL XMI files"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3696,6 +3696,10 @@
       "baseline": "2.36",
       "port-version": 0
     },
+    "libadlmidi": {
+      "baseline": "1.5.1",
+      "port-version": 0
+    },
     "libadwaita": {
       "baseline": "1.2.0",
       "port-version": 0

--- a/versions/l-/libadlmidi.json
+++ b/versions/l-/libadlmidi.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "81e5c1700a6eab87c9d855b0a206ad6dadaf6ff2",
+      "version": "1.5.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Patches are in upstream already, they can be removed when new version is out.
