### PR TITLE
[flatbuffers] Fix config filename when crosscompiling

### DIFF
--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -35,7 +35,7 @@ file(GLOB flatc_path ${CURRENT_PACKAGES_DIR}/bin/flatc*)
 if(flatc_path)
     vcpkg_copy_tools(TOOL_NAMES flatc AUTO_CLEAN)
 else()
-    file(APPEND "${CURRENT_PACKAGES_DIR}/share/flatbuffers/Flatbuffers-config.cmake"
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/flatbuffers/flatbuffers-config.cmake"
 "include(\"\${CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/share/flatbuffers/FlatcTargets.cmake\")\n")
 endif()
 

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "flatbuffers",
   "version": "23.1.21",
+  "port-version": 1,
   "description": [
     "Memory Efficient Serialization Library",
     "FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2454,7 +2454,7 @@
     },
     "flatbuffers": {
       "baseline": "23.1.21",
-      "port-version": 0
+      "port-version": 1
     },
     "flecs": {
       "baseline": "3.1.4",

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8dd8a45a079d9ec27da5352d1d61eb24ff94f5d",
+      "version": "23.1.21",
+      "port-version": 1
+    },
+    {
       "git-tree": "a982b9c31851fcc6ac96cfc1a05fc44144ef1512",
       "version": "23.1.21",
       "port-version": 0


### PR DESCRIPTION
The CMake config file has been renamed from `Flatbuffers-config.cmake` to `flatbuffers-config.cmake` since https://github.com/google/flatbuffers/pull/7502. When cross-compiling the flatc target include is appended to the old file, which leads to errors when CMake is trying to find the `flatbuffers::flatc` target. This PR fixes the config filename.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.