### PR TITLE
[google-cloud-cpp] update to latest release (v2.8.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v2.7.0
-    SHA512 d87b79b64dd224088ae9473a828909313f4c7c64abc815ebf9105eca5ff2dee11199f2fecff2862559b16cd96550bc9f7b7a30299aae7a32fbea1fdce101897d
+    REF v2.8.0
+    SHA512 d764793c66e06afc9a91622ec32808088b2a0cfedac7876682caded967a06f9f8b0dbebe9dadd36cf75350027dcd1aeed631072d4b8610f1793caf49c2f50f1c
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/support_absl_cxx17.patch
+++ b/ports/google-cloud-cpp/support_absl_cxx17.patch
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a0d07d1..18320b6 100644
+index 3fb0564..b4a251b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -43,6 +43,14 @@ if (APPLE AND NOT DEFINED CMAKE_CXX_STANDARD)
-     set(CMAKE_CXX_STANDARD 14)
+@@ -29,6 +29,14 @@ if (NOT "${PROJECT_VERSION_PRE_RELEASE}" STREQUAL "")
+     set(PROJECT_VERSION "${PROJECT_VERSION}-${PROJECT_VERSION_PRE_RELEASE}")
  endif ()
  
 +find_package(absl CONFIG REQUIRED)
@@ -17,16 +17,3 @@ index a0d07d1..18320b6 100644
  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
      if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.3)
          message(
-diff --git a/google/cloud/internal/port_platform.h b/google/cloud/internal/port_platform.h
-index b61eb48..327278f 100644
---- a/google/cloud/internal/port_platform.h
-+++ b/google/cloud/internal/port_platform.h
-@@ -49,6 +49,8 @@
- // Abort compilation if the compiler does not support C++14.
- #if GOOGLE_CLOUD_CPP_CPP_VERSION < 201402L
- #  error "C++14 or newer is required"
-+#elif defined(ABSL_USE_CXX17) && GOOGLE_CLOUD_CPP_CPP_VERSION < 201703L
-+#  error "Compiled to use Abseil with C++17 support, but using with C++ < C++17"
- #endif  // GOOGLE_CLOUD_CPP_CPP_VERSION < 201402L
- 
- // Abort the build if the version of the compiler is too old. This simplifies

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -50,6 +50,30 @@
         }
       ]
     },
+    "advisorynotifications": {
+      "description": "Advisory Notifications API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "alloydb": {
+      "description": "Alloy DB API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "apigateway": {
       "description": "API Gateway API C++ Client Library",
       "dependencies": [
@@ -64,6 +88,18 @@
     },
     "apigeeconnect": {
       "description": "Apigee Connect API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "apikeys": {
+      "description": "API Keys API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2821,7 +2821,7 @@
       "port-version": 1
     },
     "google-cloud-cpp": {
-      "baseline": "2.7.0",
+      "baseline": "2.8.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cd39ca22d68218395284a484878ecf7774f1a23c",
+      "version": "2.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9430285a9f961b1defe7394130aac23e6f65b97f",
       "version": "2.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
