### PR TITLE
[opencascade] Update to 7.6.3

### DIFF
--- a/ports/opencascade/portfile.cmake
+++ b/ports/opencascade/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Open-Cascade-SAS/OCCT
-    REF bb368e271e24f63078129283148ce83db6b9670a #V7.6.2
-    SHA512 500c7ff804eb6b202bef48e1be904fe43a3c0137e9a402affe128b3b75a1adbb20bfe383cee82503b13efc083a95eb97425f1afb1f66bae38543d29f871a91f9
+    REF b079fb9877ef64d4a8158a60fa157f59b096debb #V7.6.3
+    SHA512 f4c067936d41088f14394a873858b1e90e2868c28e2a6266e40e38d8b19784d5885c775cfe72cd56ec7d84f93fd1b9155ac8b0d7ea717f5a1efc893d95003f75
     HEAD_REF master
     PATCHES
         fix-pdb-find.patch
@@ -46,6 +46,15 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/opencascade)
+
+# OCCT Config will reference transitive dependencies in the form of target interface link libraries
+# Fix up the config by finding ensuring we find the dependencies 
+file(READ "${CURRENT_PACKAGES_DIR}/share/opencascade/OpenCASCADEConfig.cmake" CONFIG_CONTENTS)
+string(APPEND CONFIG_CONTENTS "\nif(OpenCASCADE_WITH_FREETYPE)\nfind_dependency(freetype CONFIG)\nendif()\n")
+string(APPEND CONFIG_CONTENTS "\nif(OpenCASCADE_WITH_TBB)\nfind_dependency(tbb CONFIG)\nendif()\n")
+string(APPEND CONFIG_CONTENTS "\nif(OpenCASCADE_WITH_FREEIMAGE)\nfind_dependency(freeimage CONFIG)\nendif()\n")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/opencascade/OpenCASCADEConfig.cmake" "${CONFIG_CONTENTS}")
+
 
 #make occt includes relative to source_file
 list(APPEND ADDITIONAL_HEADERS 

--- a/ports/opencascade/vcpkg.json
+++ b/ports/opencascade/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "opencascade",
-  "version": "7.6.2",
-  "port-version": 1,
+  "version": "7.6.3",
   "description": "Open CASCADE Technology (OCCT) is an open-source software development platform for 3D CAD, CAM, CAE.",
   "homepage": "https://github.com/Open-Cascade-SAS/OCCT",
   "license": "LGPL-2.1",
-  "supports": "!(uwp | osx | arm)",
+  "supports": "!(uwp | osx)",
   "dependencies": [
     "fontconfig",
     "freetype",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5641,8 +5641,8 @@
       "port-version": 0
     },
     "opencascade": {
-      "baseline": "7.6.2",
-      "port-version": 1
+      "baseline": "7.6.3",
+      "port-version": 0
     },
     "opencc": {
       "baseline": "1.1.6",

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89f1302efd0251b7384ea216e594bc986980eea0",
+      "version": "7.6.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "137097588b2328c3d7f66c4f0e46e6e4fe1559cf",
       "version": "7.6.2",
       "port-version": 1


### PR DESCRIPTION
Updates to 7.6.3 that was released some time ago

Enables arm builds as they compile successfully.


<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->
