### PR TITLE
[paraview] Fix feature python missing dependency qtsvg

### DIFF
--- a/ports/paraview/portfile.cmake
+++ b/ports/paraview/portfile.cmake
@@ -87,7 +87,8 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-     OPTIONS ${FEATURE_OPTIONS}
+     OPTIONS
+        ${FEATURE_OPTIONS}
         -DPARAVIEW_PLUGIN_DISABLE_XML_DOCUMENTATION:BOOL=ON
         -DPARAVIEW_BUILD_WITH_EXTERNAL:BOOL=ON
         -DPARAVIEW_USE_EXTERNAL_VTK:BOOL=ON
@@ -104,6 +105,8 @@ vcpkg_cmake_configure(
         ${ADDITIONAL_OPTIONS}
 
         #-DPARAVIEW_ENABLE_FFMPEG:BOOL=OFF
+    MAYBE_UNUSED_VARIABLES
+        PARAVIEW_ENABLE_EMBEDDED_DOCUMENTATION
 )
 if(CMAKE_HOST_UNIX)
     # ParaView runs Qt tools so LD_LIBRARY_PATH must be set correctly for them to find *.so files
@@ -166,8 +169,7 @@ endforeach()
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
 
 # # Handle copyright
-file(INSTALL "${SOURCE_PATH}/Copyright.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME Copyright.txt) # Which one is the correct one?
-file(INSTALL "${SOURCE_PATH}/License_v1.2.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License_v1.2.txt")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     macro(move_bin_to_lib name)

--- a/ports/paraview/vcpkg.json
+++ b/ports/paraview/vcpkg.json
@@ -76,14 +76,14 @@
     "python": {
       "description": "enables the build of python wrappers",
       "dependencies": [
+        "qtsvg",
         {
           "name": "vtk",
           "default-features": false,
           "features": [
             "python"
           ]
-        },
-        "qtsvg"
+        }
       ]
     },
     "tools": {

--- a/ports/paraview/vcpkg.json
+++ b/ports/paraview/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "paraview",
   "version": "5.11.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "VTK-based Data Analysis and Visualization Application",
   "homepage": "https://www.paraview.org/",
   "license": "BSD-3-Clause",
@@ -27,6 +27,9 @@
         "paraview"
       ]
     }
+  ],
+  "default-features": [
+    "python"
   ],
   "features": {
     "all-modules": {
@@ -79,7 +82,8 @@
           "features": [
             "python"
           ]
-        }
+        },
+        "qtsvg"
       ]
     },
     "tools": {

--- a/ports/paraview/vcpkg.json
+++ b/ports/paraview/vcpkg.json
@@ -28,9 +28,6 @@
       ]
     }
   ],
-  "default-features": [
-    "python"
-  ],
   "features": {
     "all-modules": {
       "description": "enables the build of all paraview modules",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5906,7 +5906,7 @@
     },
     "paraview": {
       "baseline": "5.11.0",
-      "port-version": 1
+      "port-version": 2
     },
     "parmetis": {
       "baseline": "2022-07-27",

--- a/versions/p-/paraview.json
+++ b/versions/p-/paraview.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fe20ae0cd2501a47ac008e9b54e44c5acbbb7a20",
+      "git-tree": "d8f9030dd50a819356a50ec0844b83a412ae4088",
       "version": "5.11.0",
       "port-version": 2
     },

--- a/versions/p-/paraview.json
+++ b/versions/p-/paraview.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fe20ae0cd2501a47ac008e9b54e44c5acbbb7a20",
+      "version": "5.11.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "7076e5d1dc86dc41ca0f3ad6567ffbe06b86166c",
       "version": "5.11.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #25078
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature `paraview[python]` test pass on the following triplets:
```
x64-windows
x86-windows
x64-linux
```
It build failed on x64-windows-static due to its dependency `vtk` build failed.
<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
