### PR TITLE
[breakpad] Add ATL dependency

### DIFF
--- a/ports/breakpad/vcpkg.json
+++ b/ports/breakpad/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "breakpad",
   "version-date": "2022-07-12",
-  "port-version": 2,
+  "port-version": 3,
   "description": "a set of client and server components which implement a crash-reporting system.",
   "homepage": "https://github.com/google/breakpad",
   "license": "BSD-3-Clause",
   "supports": "!uwp & (!windows | !arm) & (!windows | !arm64)",
   "dependencies": [
+    {
+      "name": "atlmfc",
+      "platform": "windows"
+    },
     "libdisasm",
     {
       "name": "vcpkg-cmake",

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79b0efa7b720fb255c442834270b24a396f01de5",
+      "version-date": "2022-07-12",
+      "port-version": 3
+    },
+    {
       "git-tree": "268892865b8587f365f04b7f2fe62a2359c405ae",
       "version-date": "2022-07-12",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1222,7 +1222,7 @@
     },
     "breakpad": {
       "baseline": "2022-07-12",
-      "port-version": 2
+      "port-version": 3
     },
     "brigand": {
       "baseline": "1.3.0",


### PR DESCRIPTION
Fixes #29531, Add ATL dependency fix `building breakpad requires ATL` error.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

