### PR TITLE
add unofficial facebook cachelib port

### DIFF
--- a/ports/cachelib/fix-build.patch
+++ b/ports/cachelib/fix-build.patch
@@ -1,0 +1,97 @@
+ diff --git a/cachelib/CMakeLists.txt b/cachelib/CMakeLists.txt
+index 36df0dc1..64d67701 100644
+--- a/cachelib/CMakeLists.txt
++++ b/cachelib/CMakeLists.txt
+@@ -333,6 +333,7 @@ configure_package_config_file(
+ install(
+   FILES ${CMAKE_CURRENT_BINARY_DIR}/cachelib-config.cmake
+   DESTINATION ${CMAKE_INSTALL_DIR}
++  RENAME unofficial-cachelib-config.cmake
+ )
+ 
+ install(
+@@ -361,8 +362,8 @@ install(TARGETS
+   )
+ 
+ install(EXPORT cachelib-exports
+-        FILE cachelib-targets.cmake
+-        #NAMESPACE cachelib::
++        FILE unofficial-cachelib-targets.cmake
++        NAMESPACE unofficial::cachelib::
+         DESTINATION ${CMAKE_INSTALL_DIR})
+ 
+ if (BUILD_SHARED_LIBS)
+diff --git a/cachelib/cachebench/util/JSONConfig.h b/cachelib/cachebench/util/JSONConfig.h
+index 7da93fc4..81820c76 100644
+--- a/cachelib/cachebench/util/JSONConfig.h
++++ b/cachelib/cachebench/util/JSONConfig.h
+@@ -146,10 +146,10 @@ struct Options {};
+ 
+ template <typename Type, size_t size>
+ constexpr void checkCorrectSize() {
+-#ifndef SKIP_OPTION_SIZE_VERIFY
+-  Options<sizeof(Type)> var = Options<size>{};
+-  (void)var;
+-#endif
++  // #ifndef SKIP_OPTION_SIZE_VERIFY
++  //   Options<sizeof(Type)> var = Options<size>{};
++  //   (void)var;
++  // #endif
+ }
+ } // namespace cachebench
+ } // namespace cachelib
+diff --git a/cachelib/cmake/cachelib-config.cmake.in b/cachelib/cmake/cachelib-config.cmake.in
+index 6e850f55..15b12790 100644
+--- a/cachelib/cmake/cachelib-config.cmake.in
++++ b/cachelib/cmake/cachelib-config.cmake.in
+@@ -36,7 +36,7 @@ find_dependency(wangle)
+ find_dependency(FBThrift)
+ 
+ if (NOT TARGET cachelib)
+-	include("${CACHELIB_CMAKE_DIR}/cachelib-targets.cmake")
++	include("${CACHELIB_CMAKE_DIR}/unofficial-cachelib-targets.cmake")
+ endif()
+ 
+ set(CACHELIB_LIBRARIES cachelib)
+diff --git a/cachelib/common/CMakeLists.txt b/cachelib/common/CMakeLists.txt
+index 1e6d1a88..fad14a18 100644
+--- a/cachelib/common/CMakeLists.txt
++++ b/cachelib/common/CMakeLists.txt
+@@ -36,9 +36,6 @@ target_link_libraries(cachelib_common PUBLIC
+   FBThrift::thriftprotocol
+   Folly::folly
+   Folly::follybenchmark
+-  Folly::folly_exception_tracer
+-  Folly::folly_exception_tracer_base
+-  Folly::folly_exception_counter
+ )
+ 
+ install(TARGETS cachelib_common
+diff --git a/cachelib/common/Utils.cpp b/cachelib/common/Utils.cpp
+index 3e149469..f5bcab8d 100644
+--- a/cachelib/common/Utils.cpp
++++ b/cachelib/common/Utils.cpp
+@@ -15,7 +15,6 @@
+  */
+ 
+ #include <dirent.h>
+-#include <folly/experimental/exception_tracer/ExceptionTracer.h>
+ #include <sys/mman.h>
+ #include <sys/resource.h>
+ #include <sys/shm.h>
+@@ -420,10 +419,10 @@ size_t getMemAvailable() {
+ }
+ 
+ void printExceptionStackTraces() {
+-  auto exceptions = folly::exception_tracer::getCurrentExceptions();
+-  for (auto& exc : exceptions) {
+-    std::cerr << exc << std::endl;
+-  }
++  // auto exceptions = folly::exception_tracer::getCurrentExceptions();
++  // for (auto& exc : exceptions) {
++  //   std::cerr << exc << std::endl;
++  // }
+ }
+ 
+ } // namespace util
+

--- a/ports/cachelib/portfile.cmake
+++ b/ports/cachelib/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO facebook/CacheLib
+    REF dd0af61a5fcb621ac253f67715b5fad8994627c7 # v2023.02.27.00
+    SHA512 24b40f16c281df2784fea260b66040a716a80603d61fe5cb666fca72c305a3568f63353a18bf4913a379e7e0b78eb35d5b22889315ec48d400de8f1f6a2fc018
+    HEAD_REF master
+    PATCHES
+        fix-build.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/cachelib"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+        -DCMAKE_INSTALL_DIR=share/unofficial-cachelib
+)
+
+vcpkg_cmake_install()
+# vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/unofficial-cachelib PACKAGE_NAME unofficial-cachelib)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+vcpkg_fixup_pkgconfig()
+

--- a/ports/cachelib/vcpkg.json
+++ b/ports/cachelib/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "cachelib",
+  "version-date": "2023-02-27",
+  "description": "unofficial facebook cachelib",
+  "homepage": "https://github.com/facebook/CacheLib",
+  "license": "Apache-2.0",
+  "supports": "!windows & !arm",
+  "dependencies": [
+    "gflags",
+    "glog",
+    "gtest",
+    "wangle",
+    "fbthrift",
+    "tsl-sparse-map",
+    "fmt",
+    "fizz",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

