### PR TITLE
[baseline][flatbuffers] backport fixes for Abseil and C++11

### DIFF
--- a/ports/flatbuffers/fix-abseil-cxx14.patch
+++ b/ports/flatbuffers/fix-abseil-cxx14.patch
@@ -1,16 +1,3 @@
-From a56f9ec50e908362e20254fcef28e62a2f148d91 Mon Sep 17 00:00:00 2001
-From: Even Rouault <even.rouault@spatialys.com>
-Date: Wed, 15 Feb 2023 19:56:16 +0100
-Subject: [PATCH] Only use absl headers if C++14 is available. (#7824)
-
-If flatbuffers is built in C++11 mode, but there is a recent version of
-absl which requires C++14, the build will fail.
-Cf https://github.com/MapServer/MapServer/issues/6822 for the use case
-that triggered this.
----
- include/flatbuffers/base.h | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/include/flatbuffers/base.h b/include/flatbuffers/base.h
 index 86688cc6e40..219b6d308ac 100644
 --- a/include/flatbuffers/base.h

--- a/ports/flatbuffers/fix-abseil-cxx14.patch
+++ b/ports/flatbuffers/fix-abseil-cxx14.patch
@@ -1,0 +1,26 @@
+From a56f9ec50e908362e20254fcef28e62a2f148d91 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Wed, 15 Feb 2023 19:56:16 +0100
+Subject: [PATCH] Only use absl headers if C++14 is available. (#7824)
+
+If flatbuffers is built in C++11 mode, but there is a recent version of
+absl which requires C++14, the build will fail.
+Cf https://github.com/MapServer/MapServer/issues/6822 for the use case
+that triggered this.
+---
+ include/flatbuffers/base.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/flatbuffers/base.h b/include/flatbuffers/base.h
+index 86688cc6e40..219b6d308ac 100644
+--- a/include/flatbuffers/base.h
++++ b/include/flatbuffers/base.h
+@@ -233,7 +233,7 @@ namespace flatbuffers {
+       }
+       #define FLATBUFFERS_HAS_STRING_VIEW 1
+     // Check for absl::string_view
+-    #elif __has_include("absl/strings/string_view.h")
++    #elif __has_include("absl/strings/string_view.h") && (__cplusplus >= 201411)
+       #include "absl/strings/string_view.h"
+       namespace flatbuffers {
+         typedef absl::string_view string_view;

--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-uwp-build.patch
+        fix-abseil-cxx14.patch
 )
 
 set(options "")

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "flatbuffers",
   "version": "23.1.21",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Memory Efficient Serialization Library",
     "FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2454,7 +2454,7 @@
     },
     "flatbuffers": {
       "baseline": "23.1.21",
-      "port-version": 1
+      "port-version": 2
     },
     "flecs": {
       "baseline": "3.1.4",

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb8cde16588624e98a6f402cecbe3f178df74d3e",
+      "version": "23.1.21",
+      "port-version": 2
+    },
+    {
       "git-tree": "c8dd8a45a079d9ec27da5352d1d61eb24ff94f5d",
       "version": "23.1.21",
       "port-version": 1

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fb8cde16588624e98a6f402cecbe3f178df74d3e",
+      "git-tree": "8079babd92cd3c1a80b224beb8f034b1a912a8b6",
       "version": "23.1.21",
       "port-version": 2
     },


### PR DESCRIPTION
Pulls google/flatbuffers#7824 from upstream.  As discussed in #29792.  Fixes #30004 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
