### PR TITLE
vcpkg - fix spirv-tools static

### DIFF
--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -80,9 +80,5 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    # lesspipe.sh is the only file there
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/spirv-tools/vcpkg.json
+++ b/ports/spirv-tools/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "spirv-tools",
   "version": "2022.4",
+  "port-version": 1,
   "description": "API and commands for processing SPIR-V modules",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Tools",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7426,7 +7426,7 @@
     },
     "spirv-tools": {
       "baseline": "2022.4",
-      "port-version": 0
+      "port-version": 1
     },
     "spix": {
       "baseline": "0.4",

--- a/versions/s-/spirv-tools.json
+++ b/versions/s-/spirv-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d6fbbcc3ba255898f1cf805e2087fd8561e4741",
+      "version": "2022.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "38e7ee249f19adf3574548ce895be13919960fdf",
       "version": "2022.4",
       "port-version": 0


### PR DESCRIPTION
spriv-tools build shared and static no matter what linkage is selected and the find script will complain that the dll is not there when building on static