### PR TITLE
[daw-json-link] Update to 3.15.0

### DIFF
--- a/ports/daw-json-link/portfile.cmake
+++ b/ports/daw-json-link/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/daw_json_link
-    REF 1db43f50928dae135ac9560f01bd62cff122fb74  #v3.10.0
-    SHA512 a3001a36c57bab40eb7dd4d99a34b18fd831e30036b174db58be94ef1273a81136f32b11953601b975b17c016d87c9bedcc9caa37488c326ea8fb39cb82babe0
+    REF "v${VERSION}"  #v3.10.0
+    SHA512 dc412cf07c1ef8cdb2b6267d6b630b6396541a49c44ee2d2b2b21f49c61cde387aff81548635c7c043a88aa90f3632aefe6bf0ec79453c5b58c80669e6a84cd2
     HEAD_REF master
 )
 
@@ -37,4 +37,4 @@ file(APPEND "${SOURCE_PATH}/copyright" [=[
 
 file(READ "${SOURCE_PATH}/LICENSE_Dragonbox" dragonbox_copywrite)
 file(APPEND "${SOURCE_PATH}/copyright" ${dragonbox_copywrite})
-file(INSTALL "${SOURCE_PATH}/copyright" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/copyright")

--- a/ports/daw-json-link/portfile.cmake
+++ b/ports/daw-json-link/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/daw_json_link
-    REF "v${VERSION}"  #v3.10.0
+    REF "v${VERSION}"
     SHA512 dc412cf07c1ef8cdb2b6267d6b630b6396541a49c44ee2d2b2b21f49c61cde387aff81548635c7c043a88aa90f3632aefe6bf0ec79453c5b58c80669e6a84cd2
     HEAD_REF master
 )

--- a/ports/daw-json-link/vcpkg.json
+++ b/ports/daw-json-link/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daw-json-link",
-  "version": "3.10.0",
+  "version": "3.15.0",
   "description": "Perhaps the fastest JSON deserializer/serializer posssible or at least close to it.",
   "homepage": "https://github.com/beached/daw_json_link",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1961,7 +1961,7 @@
       "port-version": 0
     },
     "daw-json-link": {
-      "baseline": "3.10.0",
+      "baseline": "3.15.0",
       "port-version": 0
     },
     "daw-utf-range": {
@@ -3833,7 +3833,8 @@
       "port-version": 6
     },
     "libdeflate": {
-      "baseline": "1.17"
+      "baseline": "1.17",
+      "port-version": 0
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/d-/daw-json-link.json
+++ b/versions/d-/daw-json-link.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "030d61b7e27ad1e8697f5f05813485a92c735674",
+      "git-tree": "2b4fd6d994392648fb87dec71c1f23e0d8fc6d85",
       "version": "3.15.0",
       "port-version": 0
     },

--- a/versions/d-/daw-json-link.json
+++ b/versions/d-/daw-json-link.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "030d61b7e27ad1e8697f5f05813485a92c735674",
+      "version": "3.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "86e36aa9af8fa4ffb8d7a80bbf120a986fe7c796",
       "version": "3.10.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/29912

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Tested usage successfully by the daw-json-link:x86-windows triplet.
