### PR TITLE
[opencv2] Delete feature world

### DIFF
--- a/ports/opencv2/portfile.cmake
+++ b/ports/opencv2/portfile.cmake
@@ -1,10 +1,7 @@
-file(READ "${CMAKE_CURRENT_LIST_DIR}/vcpkg.json" _contents)
-string(JSON OPENCV_VERSION GET "${_contents}" version)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO opencv/opencv
-    REF ${OPENCV_VERSION}
+    REF "${VERSION}"
     SHA512 de7d24ac7ed78ac14673011cbecc477cae688b74222a972e553c95a557b5cb8e5913f97db525421d6a72af30998ca300112fa0b285daed65f65832eb2cf7241a
     HEAD_REF master
     PATCHES
@@ -35,7 +32,6 @@ FEATURES
  "png"      WITH_PNG
  "qt"       WITH_QT
  "tiff"     WITH_TIFF
- "world"    BUILD_opencv_world
  "dc1394"   WITH_1394
 )
 
@@ -101,7 +97,6 @@ vcpkg_cmake_configure(
         ###### customized properties
         ## Options from vcpkg_check_features()
         ${FEATURE_OPTIONS}
-        -DWITH_1394=OFF
         -DWITH_IPP=OFF
         -DWITH_LAPACK=OFF
         -DWITH_MSMF=${WITH_MSMF}
@@ -163,4 +158,4 @@ vcpkg_fixup_pkgconfig()
 
 configure_file("${CURRENT_PORT_DIR}/usage.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/opencv2/vcpkg.json
+++ b/ports/opencv2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv2",
   "version": "2.4.13.7",
-  "port-version": 16,
+  "port-version": 17,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",
@@ -135,9 +135,6 @@
       "dependencies": [
         "tiff"
       ]
-    },
-    "world": {
-      "description": "Compile to a single package support for opencv"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3833,7 +3833,8 @@
       "port-version": 6
     },
     "libdeflate": {
-      "baseline": "1.17"
+      "baseline": "1.17",
+      "port-version": 0
     },
     "libdisasm": {
       "baseline": "0.23",
@@ -5689,7 +5690,7 @@
     },
     "opencv2": {
       "baseline": "2.4.13.7",
-      "port-version": 16
+      "port-version": 17
     },
     "opencv3": {
       "baseline": "3.4.18",

--- a/versions/o-/opencv2.json
+++ b/versions/o-/opencv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ba3e456128324fe7c95a571e92788513143ec99",
+      "version": "2.4.13.7",
+      "port-version": 17
+    },
+    {
       "git-tree": "27ef38b20b5788492a6a27370160f435b7d71502",
       "version": "2.4.13.7",
       "port-version": 16


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #29943
`Opencv2` doesn't have the related codes about `BUILD_opencv_world`, `opencv3` and `opencv4` have associated codes, so delete feature `world` from `opencv2`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
