### PR TITLE
[fltk] fix narrowing error in clang-cl

### DIFF
--- a/ports/fltk/fix-narrow.patch
+++ b/ports/fltk/fix-narrow.patch
@@ -1,0 +1,13 @@
+diff --git a/fluid/ExternalCodeEditor_WIN32.cxx b/fluid/ExternalCodeEditor_WIN32.cxx
+index 4646fe5..3b7f693 100644
+--- a/fluid/ExternalCodeEditor_WIN32.cxx
++++ b/fluid/ExternalCodeEditor_WIN32.cxx
+@@ -474,7 +474,7 @@ void ExternalCodeEditor::reap_cleanup() {
+ int ExternalCodeEditor::reap_editor(DWORD *pid_reaped) {
+   if ( pid_reaped ) *pid_reaped = 0;
+   if ( !is_editing() ) return -2;
+-  int err;
++  DWORD err;
+   DWORD msecs_wait = 50;   // .05 sec
+   switch ( err = WaitForSingleObject(pinfo_.hProcess, msecs_wait) ) {
+     case WAIT_TIMEOUT: {   // process didn't reap, still running

--- a/ports/fltk/portfile.cmake
+++ b/ports/fltk/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         include.patch
         fix-system-link.patch
         math-h-polyfill.patch
+        fix-narrow.patch
 )
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/jpeg"

--- a/ports/fltk/vcpkg.json
+++ b/ports/fltk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fltk",
   "version": "1.3.8",
-  "port-version": 4,
+  "port-version": 5,
   "description": "FLTK (pronounced fulltick) is a cross-platform C++ GUI toolkit for UNIX/Linux (X11), Microsoft Windows, and MacOS X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL and its built-in GLUT emulation.",
   "homepage": "https://www.fltk.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2470,7 +2470,7 @@
     },
     "fltk": {
       "baseline": "1.3.8",
-      "port-version": 4
+      "port-version": 5
     },
     "fluidlite": {
       "baseline": "2020-08-27",

--- a/versions/f-/fltk.json
+++ b/versions/f-/fltk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb00fc235046a91ebcdb47e9bcb4474b82cb81d8",
+      "version": "1.3.8",
+      "port-version": 5
+    },
+    {
       "git-tree": "20def1217e8d9ac6306e900f9bdc5662bf593d82",
       "version": "1.3.8",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] ~~SHA512s are updated for each updated download~~
- [x] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [x] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
