### PR TITLE
[libredwg] Add new port

### DIFF
--- a/ports/libredwg/fix_arm64_build.patch
+++ b/ports/libredwg/fix_arm64_build.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8906fed..e953b76 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,8 +11,11 @@ if(MSVC)
+   set(redwg libredwg)
+   # Disable some overly strict MSVC warnings.
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -wd4244 -wd4800 -wd4805 -wd4101 -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS")
+-else()
++  else()
+   set(redwg redwg)
++  endif()
++if(MSVC AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
++  add_compile_options(/Gy)
+ endif()
+ 
+ if (EXISTS ".version")

--- a/ports/libredwg/fix_dependency.patch
+++ b/ports/libredwg/fix_dependency.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8263f23..8906fed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -201,7 +201,8 @@ target_include_directories(${redwg} PRIVATE
+          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ target_include_directories(${redwg} PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+-
++find_path(JSMN_INCLUDE_DIRS "jsmn.h")
++target_include_directories(${redwg} PRIVATE ${JSMN_INCLUDE_DIRS})
+ link_libraries(${redwg} ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+ 
+ if(NOT LIBREDWG_LIBONLY)
+diff --git a/src/in_json.c b/src/in_json.c
+index d66f1ab..724505b 100644
+--- a/src/in_json.c
++++ b/src/in_json.c
+@@ -51,7 +51,7 @@ static unsigned int loglevel;
+ // In strict mode an object or array can't become a key
+ // In strict mode primitives are: numbers and booleans
+ #undef JSMN_STRICT
+-#include "../jsmn/jsmn.h"
++#include "jsmn.h"
+ 
+ typedef struct jsmntokens
+ {

--- a/ports/libredwg/fix_install.patch
+++ b/ports/libredwg/fix_install.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f0e04be..8263f23 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -196,10 +196,11 @@ if (BUILD_SHARED_LIBS)
+   target_compile_definitions(${redwg} PUBLIC DLL_EXPORT;ENABLE_SHARED)
+ endif()
+ target_include_directories(${redwg} PRIVATE
+-    ${CMAKE_CURRENT_SOURCE_DIR}/src
+-    ${CMAKE_CURRENT_BINARY_DIR}/src)
++  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
++         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
++         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ target_include_directories(${redwg} PUBLIC
+-  ${CMAKE_CURRENT_SOURCE_DIR}/include)
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+ 
+ link_libraries(${redwg} ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+ 
+@@ -309,7 +310,7 @@ add_custom_target(
+   COMMAND etags --language=c++ *.c *.h
+   DEPENDS ${SRCS}
+   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+-
++if(0)
+ if(MSVC)
+   install(TARGETS ${redwg} RUNTIME PUBLIC_HEADER
+           DESTINATION libredwg-${PACKAGE_VERSION})
+@@ -331,7 +332,21 @@ else()
+   endif()
+ endif()
+ install(TARGETS RUNTIME)
+-
++endif()
++include(GNUInstallDirs)
++install(
++    TARGETS ${redwg}
++    EXPORT libredwg-core
++    COMPONENT libredwg
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    PUBLIC_HEADER DESTINATION include/libredwg)
++if(NOT LIBREDWG_LIBONLY)
++  install(TARGETS ${executables_TARGETS}
++          DESTINATION "${CMAKE_INSTALL_BINDIR}")
++endif()
++install(EXPORT libredwg-core FILE unofficial-libredwg-config.cmake NAMESPACE unofficial::libredwg:: DESTINATION share/unofficial-libredwg)
+ if(WIN32)
+   add_custom_target(dist
+     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/README README

--- a/ports/libredwg/portfile.cmake
+++ b/ports/libredwg/portfile.cmake
@@ -1,0 +1,55 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO LibreDWG/libredwg
+  REF ${VERSION}
+  SHA512 8696289ea7ff542bd48d4e1f0e959b95574a7741ba0c80238ad31aff28f1861f0c00dfb1dc78e998b043a4300ff976ba324f5a41195f799f9d31e2b5be288bc7
+  HEAD_REF master
+  PATCHES
+    fix_install.patch
+    fix_dependency.patch
+    fix_arm64_build.patch
+)
+
+# If generate dwg manipulation tools
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        tools LIBREDWG_LIBONLY
+)
+
+# libredwg will read the version
+file(WRITE "${SOURCE_PATH}/.version" ${VERSION})
+
+# Fix https://github.com/LibreDWG/libredwg/issues/652#issuecomment-1454035167
+if(APPLE)
+  vcpkg_replace_string("${SOURCE_PATH}/src/common.h"
+    [[defined(COMMON_TEST_C)]]
+    [[1]]
+  )
+  vcpkg_replace_string("${SOURCE_PATH}/src/common.c"
+    [[defined(COMMON_TEST_C)]]
+    [[1]]
+  )
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    ${FEATURE_OPTIONS}
+    -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-libredwg CONFIG_PATH share/unofficial-libredwg)
+
+if("tools" IN_LIST FEATURES)
+  vcpkg_copy_tools(TOOL_NAMES dwg2dxf dwg2SVG dwgbmp dwggrep dwglayers dwgread dwgrewrite dwgwrite dxf2dwg AUTO_CLEAN)
+  vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/libredwg")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libredwg/usage
+++ b/ports/libredwg/usage
@@ -1,0 +1,4 @@
+libredwg provides CMake targets:
+
+    find_package(unofficial-libredwg CONFIG REQUIRED)
+    target_link_libraries(main unofficial::libredwg::libredwg)

--- a/ports/libredwg/vcpkg.json
+++ b/ports/libredwg/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "libredwg",
+  "version": "0.12.5.5178",
+  "description": "GNU LibreDWG is a free C library to handle DWG files. It aims to be a free replacement for the OpenDWG libraries. DWG is the native file format of AutoCAD.",
+  "homepage": "https://www.gnu.org/software/libredwg/",
+  "license": "GPL-3.0",
+  "dependencies": [
+    "jsmn",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tools": {
+      "description": "Build dwg/dxf manipulation command-line tools"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4323,6 +4323,10 @@
       "baseline": "2.0.2",
       "port-version": 0
     },
+    "libredwg": {
+      "baseline": "0.12.5.5178",
+      "port-version": 0
+    },
     "libressl": {
       "baseline": "3.4.2",
       "port-version": 0

--- a/versions/l-/libredwg.json
+++ b/versions/l-/libredwg.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "aa161067eef7398933b726e81cd4824733a9c9a6",
+      "version": "0.12.5.5178",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:



- [- ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [- ] SHA512s are updated for each updated download
- [- ] The "supports" clause reflects platforms that may be fixed by this new version
- [-] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

Fixes https://github.com/microsoft/vcpkg/issues/29980


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.




