### PR TITLE
[cyclonedds] Fix idlc generation for osx

### DIFF
--- a/ports/cyclonedds/idlc-generate.patch
+++ b/ports/cyclonedds/idlc-generate.patch
@@ -1,0 +1,29 @@
+diff --git a/cmake/Modules/Generate.cmake b/cmake/Modules/Generate.cmake
+index 0ed67d63..c22d9146 100644
+--- a/cmake/Modules/Generate.cmake
++++ b/cmake/Modules/Generate.cmake
+@@ -157,11 +157,19 @@ function(IDLC_GENERATE_GENERIC)
+     endforeach()
+ 
+     list(APPEND _outputs ${_file_outputs})
+-    add_custom_command(
+-      OUTPUT   ${_file_outputs}
+-      COMMAND  ${_idlc_executable}
+-      ARGS     ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
+-      DEPENDS  ${_files} ${_depends})
++    if(NOT APPLE)
++      add_custom_command(
++        OUTPUT   ${_file_outputs}
++        COMMAND  ${_idlc_executable}
++        ARGS     ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
++        DEPENDS  ${_files} ${_depends})
++    else()
++      add_custom_command(
++        OUTPUT   ${_file_outputs}
++        COMMAND  ${CMAKE_COMMAND}
++        ARGS     -E env "DYLD_LIBRARY_PATH=$<TARGET_FILE_DIR:${_idlc_executable}>/../../lib" $<TARGET_FILE:${_idlc_executable}> ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
++        DEPENDS  ${_files} ${_depends})
++    endif()
+   endforeach()
+ 
+   add_custom_target("${_target}_generate" DEPENDS "${_outputs}")

--- a/ports/cyclonedds/portfile.cmake
+++ b/ports/cyclonedds/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         enable-security.patch
+        idlc-generate.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/cyclonedds/vcpkg.json
+++ b/ports/cyclonedds/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cyclonedds",
   "version-semver": "0.10.2",
+  "port-version": 1,
   "description": "Eclipse Cyclone DDS is a very performant and robust open-source implementation of the OMG DDS specification",
   "homepage": "https://cyclonedds.io",
   "license": "EPL-2.0 OR BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1914,7 +1914,7 @@
     },
     "cyclonedds": {
       "baseline": "0.10.2",
-      "port-version": 0
+      "port-version": 1
     },
     "cyclonedds-cxx": {
       "baseline": "0.10.2",
@@ -3833,7 +3833,8 @@
       "port-version": 6
     },
     "libdeflate": {
-      "baseline": "1.17"
+      "baseline": "1.17",
+      "port-version": 0
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/c-/cyclonedds.json
+++ b/versions/c-/cyclonedds.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7be6ebe8452bb763bf4dd1374e981ff455b54aaa",
+      "version-semver": "0.10.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "8432327df58b39777e3debd3310817ec2752dd87",
       "version-semver": "0.10.2",
       "port-version": 0


### PR DESCRIPTION
Fixes a problem with idlc generation on osx

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.