### PR TITLE
[physx] Fix x86 Linux build errors

### DIFF
--- a/ports/physx/fix-compiler-flag.patch
+++ b/ports/physx/fix-compiler-flag.patch
@@ -56,3 +56,20 @@ index a1ab3596..dbd20fb0 100644
  
  # cache lib type defs
  IF(PX_GENERATE_STATIC_LIBRARIES)	
+diff --git a/physx/source/compiler/cmake/linux/CMakeLists.txt b/physx/source/compiler/cmake/linux/CMakeLists.txt
+index 6246e488..7bf0cc30 100644
+--- a/physx/source/compiler/cmake/linux/CMakeLists.txt
++++ b/physx/source/compiler/cmake/linux/CMakeLists.txt
+@@ -36,6 +36,11 @@ IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        SET(PHYSX_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -fno-exceptions -ffunction-sections -fdata-sections -fstrict-aliasing ${CLANG_WARNINGS}" CACHE INTERNAL "PhysX CXX")
+ ELSEIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        SET(PHYSX_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -fno-exceptions -ffunction-sections -fdata-sections -fno-strict-aliasing ${GCC_WARNINGS}" CACHE INTERNAL "PhysX CXX")
++
++       # Enable SSE2 and fix double alignment for 32-bit x86 builds
++       IF (CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*")
++               STRING(APPEND PHYSX_CXX_FLAGS " -malign-double -msse2")
++       ENDIF()
+ ENDIF()
+ 
+ # Build debug info for all configurations
+

--- a/ports/physx/vcpkg.json
+++ b/ports/physx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "physx",
   "version": "4.1.2",
-  "port-version": 5,
+  "port-version": 6,
   "description": "The NVIDIA PhysX SDK is a scalable multi-platform physics solution supporting a wide range of devices, from smartphones to high-end multicore CPUs and GPUs",
   "homepage": "https://github.com/NVIDIAGameWorks/PhysX",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6017,7 +6017,7 @@
     },
     "physx": {
       "baseline": "4.1.2",
-      "port-version": 5
+      "port-version": 6
     },
     "picojson": {
       "baseline": "1.3.0",

--- a/versions/p-/physx.json
+++ b/versions/p-/physx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "038801f9419a356c7082b1501620bdef60da6d66",
+      "version": "4.1.2",
+      "port-version": 6
+    },
+    {
       "git-tree": "b081926dc46f3fadf1696719e4b708f4cd136f25",
       "version": "4.1.2",
       "port-version": 5


### PR DESCRIPTION
As per comments in the source, "some GCC compilers need the compiler flag -malign-double to be set."
https://github.com/NVIDIAGameWorks/PhysX/blob/a2c0428acab643e60618c681b501e86f7fd558cc/pxshared/include/foundation/PxPreprocessor.h#L473

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
