### PR TITLE
[libopnmidi] add new port

### DIFF
--- a/ports/libopnmidi/cmake-build-shared-libs-support.patch
+++ b/ports/libopnmidi/cmake-build-shared-libs-support.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4276e23..1d6ac82 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -120,8 +120,17 @@ if(NOT EMSCRIPTEN
+    AND NOT NINTENDO_WIIU
+    AND NOT NINTENDO_SWITCH
+    AND NOT MSDOS)
+-    option(libOPNMIDI_STATIC   "Build static library of libOPNMIDI" ON)
+-    option(libOPNMIDI_SHARED   "Build shared library of libOPNMIDI" OFF)
++    set(libOPNMIDI_STATIC_ENABLED_BY_DEFAULT ON)
++    set(libOPNMIDI_SHARED_ENABLED_BY_DEFAULT OFF)
++
++    # When defined, respect CMake's BUILD_SHARED_LIBS setting
++    if (BUILD_SHARED_LIBS)
++        set(libOPNMIDI_SHARED_ENABLED_BY_DEFAULT ON)
++        set(libOPNMIDI_STATIC_ENABLED_BY_DEFAULT OFF)
++    endif()
++
++    option(libOPNMIDI_STATIC   "Build static library of libOPNMIDI" ${libOPNMIDI_STATIC_ENABLED_BY_DEFAULT})
++    option(libOPNMIDI_SHARED   "Build shared library of libOPNMIDI" ${libOPNMIDI_SHARED_ENABLED_BY_DEFAULT})
+ else()
+     set(libOPNMIDI_STATIC ON)
+     set(libOPNMIDI_SHARED OFF)

--- a/ports/libopnmidi/cmake-package-export.patch
+++ b/ports/libopnmidi/cmake-package-export.patch
@@ -1,0 +1,127 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 66d4848..4276e23 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -155,8 +155,6 @@ if(WIN32)
+     option(WITH_WINMMDRV    "Build a WinMM MIDI driver" OFF)
+ endif()
+ 
+-set(libOPNMIDI_INSTALLS)
+-
+ include_directories(${libOPNMIDI_SOURCE_DIR}/include)
+ include_directories(${libOPNMIDI_SOURCE_DIR}/src/)
+ link_directories(${libOPNMIDI_BINARY_DIR}/)
+@@ -317,10 +315,9 @@ if(libOPNMIDI_STATIC OR WITH_VLC_PLUGIN)
+     else()
+         set_target_properties(OPNMIDI_static PROPERTIES OUTPUT_NAME OPNMIDI)
+     endif()
+-    target_include_directories(OPNMIDI_static PUBLIC ${libOPNMIDI_SOURCE_DIR}/include)
++    target_include_directories(OPNMIDI_static PUBLIC $<BUILD_INTERFACE:${libOPNMIDI_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+     set_legacy_standard(OPNMIDI_static)
+     set_visibility_hidden(OPNMIDI_static)
+-    list(APPEND libOPNMIDI_INSTALLS OPNMIDI_static)
+ 
+     # -fPIC thing
+     if(ENABLE_FPIC)
+@@ -340,10 +337,9 @@ if(libOPNMIDI_SHARED)
+         VERSION ${libOPNMIDI_VERSION}
+         SOVERSION ${libOPNMIDI_VERSION_MAJOR}
+     )
+-    target_include_directories(OPNMIDI_shared PUBLIC ${libOPNMIDI_SOURCE_DIR}/include)
++    target_include_directories(OPNMIDI_shared PUBLIC $<BUILD_INTERFACE:${libOPNMIDI_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+     set_legacy_standard(OPNMIDI_shared)
+     set_visibility_hidden(OPNMIDI_shared)
+-    list(APPEND libOPNMIDI_INSTALLS OPNMIDI_shared)
+ 
+     if(WIN32)
+         target_compile_definitions(OPNMIDI_shared PRIVATE "-DOPNMIDI_BUILD_DLL")
+@@ -416,17 +412,45 @@ if(WITH_HQ_RESAMPLER)
+     endif()
+ endif()
+ 
+-install(TARGETS ${libOPNMIDI_INSTALLS}
+-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++if(libOPNMIDI_STATIC)
++    install(TARGETS OPNMIDI_static
++            EXPORT libOPNMIDIStaticTargets
++            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
++
++    install(EXPORT libOPNMIDIStaticTargets
++            FILE libOPNMIDI-static-targets.cmake
++            NAMESPACE libOPNMIDI::
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libOPNMIDI")
++endif()
++
++if(libOPNMIDI_SHARED)
++    install(TARGETS OPNMIDI_shared
++            EXPORT libOPNMIDISharedTargets
++            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
++
++    install(EXPORT libOPNMIDISharedTargets
++            FILE libOPNMIDI-shared-targets.cmake
++            NAMESPACE libOPNMIDI::
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libOPNMIDI")
++endif()
+ 
+ install(FILES
+         include/opnmidi.h
+         #include/opnmidi.hpp # WIP
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+ 
++include(CMakePackageConfigHelpers)
++configure_package_config_file(libOPNMIDI-config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/libOPNMIDI-config.cmake"
++    PATH_VARS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_FULL_BINDIR CMAKE_INSTALL_FULL_INCLUDEDIR CMAKE_INSTALL_FULL_LIBDIR
++    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libOPNMIDI"
++)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libOPNMIDI-config.cmake
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libOPNMIDI")
++
+ if(WITH_EXTRA_BANKS AND NOT APPLE)
+     file(GLOB WOPN_FILES ${libOPNMIDI_SOURCE_DIR}/fm_banks/*.wopn)
+     install(FILES ${WOPN_FILES}
+diff --git a/libOPNMIDI-config.cmake.in b/libOPNMIDI-config.cmake.in
+new file mode 100644
+index 0000000..f292e48
+--- /dev/null
++++ b/libOPNMIDI-config.cmake.in
+@@ -0,0 +1,33 @@
++include(FeatureSummary)
++set_package_properties(libOPNMIDI PROPERTIES
++    URL "https://github.com/Wohlstand/libOPNMIDI"
++    DESCRIPTION "libOPNMIDI is a free Software MIDI synthesizer library with OPN2 (YM2612) and OPNA (YM2608) emulation"
++)
++
++@PACKAGE_INIT@
++
++if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/libOPNMIDI-shared-targets.cmake")
++    include("${CMAKE_CURRENT_LIST_DIR}/libOPNMIDI-shared-targets.cmake")
++endif()
++if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/libOPNMIDI-static-targets.cmake")
++    include("${CMAKE_CURRENT_LIST_DIR}/libOPNMIDI-static-targets.cmake")
++endif()
++
++if(TARGET libOPNMIDI::OPNMIDI_shared)
++    if(CMAKE_VERSION VERSION_LESS "3.18")
++        add_library(libOPNMIDI::OPNMIDI_IF INTERFACE IMPORTED)
++        set_target_properties(libOPNMIDI::OPNMIDI_IF PROPERTIES INTERFACE_LINK_LIBRARIES "libOPNMIDI::OPNMIDI_shared")
++    else()
++        add_library(libOPNMIDI::OPNMIDI_IF ALIAS libOPNMIDI::OPNMIDI_shared)
++    endif()
++else()
++    if(CMAKE_VERSION VERSION_LESS "3.18")
++        add_library(libOPNMIDI::OPNMIDI_IF INTERFACE IMPORTED)
++        set_target_properties(libOPNMIDI::OPNMIDI_IF PROPERTIES INTERFACE_LINK_LIBRARIES "libOPNMIDI::OPNMIDI_static")
++        add_library(libOPNMIDI::OPNMIDI_IF_STATIC INTERFACE IMPORTED)
++        set_target_properties(libOPNMIDI::OPNMIDI_IF_STATIC PROPERTIES INTERFACE_LINK_LIBRARIES "libOPNMIDI::OPNMIDI_static")
++    else()
++        add_library(libOPNMIDI::OPNMIDI_IF ALIAS libOPNMIDI::OPNMIDI_static)
++        add_library(libOPNMIDI::OPNMIDI_IF_STATIC ALIAS libOPNMIDI::OPNMIDI_static)
++    endif()
++endif()

--- a/ports/libopnmidi/disable-wopn2hpp.patch
+++ b/ports/libopnmidi/disable-wopn2hpp.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ee71863..66d4848 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -144,6 +144,7 @@ option(USE_VGM_FILE_DUMPER  "Use VGM File Dumper (required to build the MIDI2VGM
+ 
+ option(WITH_MIDIPLAY        "Build also demo MIDI player" OFF)
+ option(WITH_MIDI2VGM        "Build also MIDI to VGM converter tool" OFF)
++option(WITH_WOPN2HPP        "Build also the WOPN to C++ header source converter tool" OFF)
+ option(WITH_VLC_PLUGIN      "Build also a plugin for VLC Media Player" OFF)
+ option(VLC_PLUGIN_NOINSTALL "Don't install VLC plugin into VLC directory" OFF)
+ option(WITH_DAC_UTIL        "Build also OPN2 DAC testing utility" OFF)
+@@ -388,13 +389,7 @@ if(WITH_MIDI2VGM)
+     add_subdirectory(utils/midi2vgm)
+ endif()
+ 
+-if(NOT ANDROID
+-   AND NOT EMSCRIPTEN
+-   AND NOT VITA
+-   AND NOT NINTENDO_3DS
+-   AND NOT NINTENDO_WII
+-   AND NOT NINTENDO_WIIU
+-   AND NOT NINTENDO_SWITCH)
++if(WITH_WOPN2HPP)
+     add_subdirectory(utils/wopn2hpp)
+ endif()
+ 
+@@ -493,6 +488,7 @@ message("USE_VGM_FILE_DUMPER      = ${USE_VGM_FILE_DUMPER}")
+ 
+ message("===== Utils and extras =====")
+ message("WITH_MIDIPLAY            = ${WITH_MIDIPLAY}")
++message("WITH_WOPN2HPP            = ${WITH_WOPN2HPP}")
+ message("WITH_VLC_PLUGIN          = ${WITH_VLC_PLUGIN}")
+ message("WITH_DAC_UTIL            = ${WITH_DAC_UTIL}")
+ if(WIN32)

--- a/ports/libopnmidi/fix-build-without-sequencer.patch
+++ b/ports/libopnmidi/fix-build-without-sequencer.patch
@@ -1,0 +1,49 @@
+diff --git a/src/opnmidi.cpp b/src/opnmidi.cpp
+index c70197f..98226dc 100644
+--- a/src/opnmidi.cpp
++++ b/src/opnmidi.cpp
+@@ -433,7 +433,7 @@ OPNMIDI_EXPORT void opn2_setLoopCount(OPN2_MIDIPlayer *device, int loopCount)
+ 
+ OPNMIDI_EXPORT void opn2_setLoopHooksOnly(OPN2_MIDIPlayer *device, int loopHooksOnly)
+ {
+-#ifndef ADLMIDI_DISABLE_MIDI_SEQUENCER
++#ifndef OPNMIDI_DISABLE_MIDI_SEQUENCER
+     if(!device)
+         return;
+     MidiPlayer *play = GET_MIDI_PLAYER(device);
+@@ -576,7 +576,7 @@ OPNMIDI_EXPORT int opn2_openData(OPN2_MIDIPlayer *device, const void *mem, unsig
+ 
+ OPNMIDI_EXPORT void opn2_selectSongNum(struct OPN2_MIDIPlayer *device, int songNumber)
+ {
+-#ifndef ADLMIDI_DISABLE_MIDI_SEQUENCER
++#ifndef OPNMIDI_DISABLE_MIDI_SEQUENCER
+     if(!device)
+         return;
+ 
+@@ -591,7 +591,7 @@ OPNMIDI_EXPORT void opn2_selectSongNum(struct OPN2_MIDIPlayer *device, int songN
+ 
+ OPNMIDI_EXPORT int opn2_getSongsCount(struct OPN2_MIDIPlayer *device)
+ {
+-#ifndef ADLMIDI_DISABLE_MIDI_SEQUENCER
++#ifndef OPNMIDI_DISABLE_MIDI_SEQUENCER
+     if(!device)
+         return 0;
+ 
+@@ -986,7 +986,7 @@ OPNMIDI_EXPORT void opn2_setLoopStartHook(struct OPN2_MIDIPlayer *device, OPN2_L
+     assert(play);
+     play->hooks.onLoopStart = loopStartHook;
+     play->hooks.onLoopStart_userData = userData;
+-#ifndef ADLMIDI_DISABLE_MIDI_SEQUENCER
++#ifndef OPNMIDI_DISABLE_MIDI_SEQUENCER
+     play->m_sequencerInterface->onloopStart = loopStartHook;
+     play->m_sequencerInterface->onloopStart_userData = userData;
+ #endif
+@@ -1001,7 +1001,7 @@ OPNMIDI_EXPORT void opn2_setLoopEndHook(struct OPN2_MIDIPlayer *device, OPN2_Loo
+     assert(play);
+     play->hooks.onLoopEnd = loopEndHook;
+     play->hooks.onLoopEnd_userData = userData;
+-#ifndef ADLMIDI_DISABLE_MIDI_SEQUENCER
++#ifndef OPNMIDI_DISABLE_MIDI_SEQUENCER
+     play->m_sequencerInterface->onloopEnd = loopEndHook;
+     play->m_sequencerInterface->onloopEnd_userData = userData;
+ #endif

--- a/ports/libopnmidi/fix-pmdwin-emulator-include.patch
+++ b/ports/libopnmidi/fix-pmdwin-emulator-include.patch
@@ -1,0 +1,29 @@
+diff --git a/src/chips/pmdwin/opna.c b/src/chips/pmdwin/opna.c
+index 3dbf164..78b88a5 100644
+--- a/src/chips/pmdwin/opna.c
++++ b/src/chips/pmdwin/opna.c
+@@ -27,7 +27,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ #include <stdint.h>
+ #include <stdarg.h>
+ #include <math.h>
+-#include <unistd.h>
+ #include <assert.h>
+ #include "op.h"
+ #include "psg.h"
+diff --git a/src/chips/pmdwin/psg.c b/src/chips/pmdwin/psg.c
+index 44a7cf0..a1b1c43 100644
+--- a/src/chips/pmdwin/psg.c
++++ b/src/chips/pmdwin/psg.c
+@@ -39,7 +39,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ #include <stdlib.h>
+ #include <string.h>
+ #include <math.h>
+-#include <unistd.h>
+ #include "op.h"
+ #include "psg.h"
+ 
+@@ -340,4 +339,3 @@ void PSGMix(PSG *psg, int32_t *dest, uint32_t nsamples)
+         }
+     }
+ }
+-

--- a/ports/libopnmidi/portfile.cmake
+++ b/ports/libopnmidi/portfile.cmake
@@ -1,0 +1,53 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Wohlstand/libOPNMIDI
+    REF "v${VERSION}"
+    SHA512 735af8c65c54e1e57e9d3e8582465636c0efeb7a03c7b0f5e2ef16f5cfd14fb34e99f738bb5a5cb43fe44fc584c3241eee6ae21a0f604702f101442f42601bcd
+    PATCHES 
+        # patches from master, they should be removed when a new version is out
+        cmake-package-export.patch
+        cmake-build-shared-libs-support.patch
+        disable-wopn2hpp.patch
+        fix-build-without-sequencer.patch
+        fix-pmdwin-emulator-include.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        midi-sequencer          WITH_MIDI_SEQUENCER
+        mame-ym2612-emulator    USE_MAME_EMULATOR
+        mame-ym2608-emulator    USE_MAME_2608_EMULATOR  
+        nuked-emulator          USE_NUKED_EMULATOR
+        gens-emulator           USE_GENS_EMULATOR
+        gx-emulator             USE_GX_EMULATOR
+        np2-emulator            USE_NP2_EMULATOR
+        pmdwin-emulator         USE_PMDWIN_EMULATOR
+        mus                     WITH_MUS_SUPPORT
+        xmi                     WITH_XMI_SUPPORT
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        ${FEATURE_OPTIONS}
+        -DUSE_VGM_FILE_DUMPER=OFF
+        -DWITH_WOPN2HPP=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libOPNMIDI)
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSE*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/libopnmidi/usage
+++ b/ports/libopnmidi/usage
@@ -1,0 +1,4 @@
+libopnmidi provides CMake targets:
+
+    find_package(libOPNMIDI CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE libOPNMIDI::OPNMIDI_IF)

--- a/ports/libopnmidi/vcpkg.json
+++ b/ports/libopnmidi/vcpkg.json
@@ -1,0 +1,59 @@
+{
+  "name": "libopnmidi",
+  "version": "1.5.1",
+  "description": "libOPNMIDI is a free Software MIDI synthesizer library with OPN2 (YM2612) and OPNA (YM2608) emulation",
+  "homepage": "https://github.com/Wohlstand/libOPNMIDI",
+  "license": "LGPL-2.1-or-later OR GPL-2.0-or-later OR GPL-3.0-or-later OR MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "gens-emulator",
+    "mame-ym2608-emulator",
+    "mame-ym2612-emulator",
+    "midi-sequencer",
+    "mus",
+    "np2-emulator",
+    "nuked-emulator",
+    "xmi"
+  ],
+  "features": {
+    "gens-emulator": {
+      "description": "Build with GENS 2.10 emulator (innacurate, fastest)"
+    },
+    "gx-emulator": {
+      "description": "Build with Genesis Plus GX emulator (experimental)"
+    },
+    "mame-ym2608-emulator": {
+      "description": "Build with MAME YM2608 emulator (well-accurate and fast)"
+    },
+    "mame-ym2612-emulator": {
+      "description": "Build with MAME YM2612 emulator (well-accurate and fast)"
+    },
+    "midi-sequencer": {
+      "description": "Build with embedded MIDI sequencer"
+    },
+    "mus": {
+      "description": "Support for DMX MUS files"
+    },
+    "np2-emulator": {
+      "description": "Build with Neko Project 2 YM2608 emulator (semi-accurate and fast)"
+    },
+    "nuked-emulator": {
+      "description": "Build with Nuked OPN2 emulator (very accurate, needs more CPU power)"
+    },
+    "pmdwin-emulator": {
+      "description": "Build with PMDWin emulator (experimental)"
+    },
+    "xmi": {
+      "description": "Support for AIL XMI files"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4216,6 +4216,10 @@
       "baseline": "1.5.2",
       "port-version": 1
     },
+    "libopnmidi": {
+      "baseline": "1.5.1",
+      "port-version": 0
+    },
     "libopusenc": {
       "baseline": "0.2.1",
       "port-version": 1

--- a/versions/l-/libopnmidi.json
+++ b/versions/l-/libopnmidi.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "552bea42a6f0f15bb5564602b51d9cda0a09dfd7",
+      "version": "1.5.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
All provided patches are in upstream:
cmake-build-shared-libs-support.patch - https://github.com/Wohlstand/libOPNMIDI/commit/76e461033e83f9b2a77285146d249bd682bf5bb4
cmake-package-export.patch -https://github.com/Wohlstand/libOPNMIDI/commit/a48f3f7d702faab815d43a29959ecd1f959a6e07
disable-wopn2hpp.patch - https://github.com/Wohlstand/libOPNMIDI/commit/0a91e141218dd5c330bd6ccb1910bad25dba56f9
fix-build-without-sequencer.patch -https://github.com/Wohlstand/libOPNMIDI/commit/2c348b348fadce0a84d743c1c09b2f1e16eb0436
fix-pmdwin-emulator-include.patch - https://github.com/Wohlstand/libOPNMIDI/commit/81178c3ff0f7f1073f0758e074ea4ab992ab510d

All features are additive.
**There are two experimental emulators (pmdwin-emulator and gx-emulator), should they be included in default features? What's the best practice here?**

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

