### PR TITLE
[x86-simd-sort] Add new port

### DIFF
--- a/ports/x86-simd-sort/portfile.cmake
+++ b/ports/x86-simd-sort/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
 )
 
 # Copy headers
-file(COPY ${SOURCE_PATH}/src/ DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY "${SOURCE_PATH}/src/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/x86-simd-sort/portfile.cmake
+++ b/ports/x86-simd-sort/portfile.cmake
@@ -1,0 +1,13 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO intel/x86-simd-sort
+    REF 7d7591cf5927e83e4a1e7c4b6f2c4dc91a97889f
+    SHA512 6b71f25e0ec1adcd81a6ce3ecf60316a841c48d9b438ae2afde9b2a17a90d13047cb1d7bce7dcecf15718f4fb299adad7875b022b57f90965f5e7a25e16e6721
+    HEAD_REF master
+)
+
+# Copy headers
+file(COPY ${SOURCE_PATH}/src/ DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/x86-simd-sort/portfile.cmake
+++ b/ports/x86-simd-sort/portfile.cmake
@@ -6,8 +6,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-# Copy headers
 file(COPY "${SOURCE_PATH}/src/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/x86-simd-sort/vcpkg.json
+++ b/ports/x86-simd-sort/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "x86-simd-sort",
+  "version-date": "2023-03-04",
+  "description": "C++ header file library for high performance SIMD based sorting algorithms for primitive datatypes",
+  "homepage": "https://github.com/intel/x86-simd-sort",
+  "license": "BSD-3-Clause"
+}

--- a/ports/x86-simd-sort/vcpkg.json
+++ b/ports/x86-simd-sort/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x86-simd-sort",
   "version-date": "2023-03-04",
-  "description": "C++ header file library for high performance SIMD based sorting algorithms for primitive datatypes",
+  "description": "C++ header file library for high-performance SIMD-based sorting algorithms for primitive datatypes",
   "homepage": "https://github.com/intel/x86-simd-sort",
   "license": "BSD-3-Clause"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3841,7 +3841,8 @@
       "port-version": 6
     },
     "libdeflate": {
-      "baseline": "1.17"
+      "baseline": "1.17",
+      "port-version": 0
     },
     "libdisasm": {
       "baseline": "0.23",
@@ -8402,6 +8403,10 @@
     "x265": {
       "baseline": "3.4",
       "port-version": 8
+    },
+    "x86-simd-sort": {
+      "baseline": "2023-03-04",
+      "port-version": 0
     },
     "xapian": {
       "baseline": "1.4.21",

--- a/versions/x-/x86-simd-sort.json
+++ b/versions/x-/x86-simd-sort.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8c02923393c7bcafc05c7f25a17ea64c58f51880",
+      "git-tree": "15e4b0be3b09b45594f3341c956bef6bb85253b9",
       "version-date": "2023-03-04",
       "port-version": 0
     }

--- a/versions/x-/x86-simd-sort.json
+++ b/versions/x-/x86-simd-sort.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "15e4b0be3b09b45594f3341c956bef6bb85253b9",
+      "git-tree": "a7b6ead19483862d2070b96b2139729346119e80",
       "version-date": "2023-03-04",
       "port-version": 0
     }

--- a/versions/x-/x86-simd-sort.json
+++ b/versions/x-/x86-simd-sort.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8c02923393c7bcafc05c7f25a17ea64c58f51880",
+      "version-date": "2023-03-04",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/x-/x86-simd-sort.json
+++ b/versions/x-/x86-simd-sort.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7b6ead19483862d2070b96b2139729346119e80",
+      "git-tree": "dbe8f88ac8cc85689eb7666fa8beb6d819c4573a",
       "version-date": "2023-03-04",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
