### PR TITLE
[ffmpeg] don't enable asm on android for all archs.

### DIFF
--- a/ports/ffmpeg/build.sh.in
+++ b/ports/ffmpeg/build.sh.in
@@ -92,10 +92,17 @@ OSX_ARCH_COUNT=0@OSX_ARCH_COUNT@
 # arm64 Android build fails with 'relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol ff_cos_32; recompile with -fPIC'
 # x86 Android build fails with 'error: inline assembly requires more registers than available'.
 # x64 Android build fails with 'relocation R_X86_64_PC32 cannot be used against symbol ff_h264_cabac_tables; recompile with -fPIC'
-OPTIONS_arm=" --disable-asm --disable-x86asm"
-OPTIONS_arm64=" --enable-asm --disable-x86asm"
-OPTIONS_x86=" --enable-asm --enable-x86asm"
-OPTIONS_x86_64="${OPTIONS_x86}"
+if [ "@VCPKG_CMAKE_SYSTEM_NAME@" = "Android" ]; then
+    OPTIONS_arm=" --disable-asm --disable-x86asm"
+    OPTIONS_arm64=" --disable-asm --disable-x86asm"
+    OPTIONS_x86=" --disable-asm --disable-x86asm"
+    OPTIONS_x86_64="${OPTIONS_x86}"
+else
+    OPTIONS_arm=" --disable-asm --disable-x86asm"
+    OPTIONS_arm64=" --enable-asm --disable-x86asm"
+    OPTIONS_x86=" --enable-asm --enable-x86asm"
+    OPTIONS_x86_64="${OPTIONS_x86}"
+fi
 
 build_ffmpeg() {
     # extract build architecture

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "5.1.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2418,7 +2418,7 @@
     },
     "ffmpeg": {
       "baseline": "5.1.2",
-      "port-version": 4
+      "port-version": 5
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",
@@ -3841,7 +3841,8 @@
       "port-version": 6
     },
     "libdeflate": {
-      "baseline": "1.17"
+      "baseline": "1.17",
+      "port-version": 0
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14577b12f56accfce4428caf17e4b47542f365ec",
+      "version": "5.1.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "d471234dd831fd9a35453db450572b52291ed6ca",
       "version": "5.1.2",
       "port-version": 4


### PR DESCRIPTION
It doesn't build.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->
