### PR TITLE
[restbed] Fix usage

### DIFF
--- a/ports/restbed/fix-cmake.patch
+++ b/ports/restbed/fix-cmake.patch
@@ -54,7 +54,7 @@ index e6095da..6bf8d81 100644
  
  if ( BUILD_TESTS )
      find_package( catch REQUIRED )
-@@ -119,5 +133,21 @@ file( GLOB ARTIFACTS "${SOURCE_DIR}/*.hpp" )
+@@ -119,5 +133,26 @@ file( GLOB ARTIFACTS "${SOURCE_DIR}/*.hpp" )
  
  install( FILES "${INCLUDE_DIR}/${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_PREFIX}/include" )
  install( FILES ${ARTIFACTS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/corvusoft/${PROJECT_NAME}" )
@@ -74,6 +74,11 @@ index e6095da..6bf8d81 100644
 +    find_dependency(OpenSSL)
 +endif()
 +include("${CMAKE_CURRENT_LIST_DIR}/unofficial-restbed-target.cmake")
++if("@BUILD_SHARED_LIBS@")
++    add_library(unofficial::restbed::restbed ALIAS unofficial::restbed::restbed-shared)
++else()
++    add_library(unofficial::restbed::restbed ALIAS unofficial::restbed::restbed-static)
++endif()
 +]])
 +
 +configure_file( "${CMAKE_CURRENT_BINARY_DIR}/unofficial-restbed-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/unofficial-restbed-config.cmake" @ONLY)

--- a/ports/restbed/portfile.cmake
+++ b/ports/restbed/portfile.cmake
@@ -26,9 +26,8 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-restbed)
 
-# Remove include debug files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/restbed/usage
+++ b/ports/restbed/usage
@@ -1,0 +1,4 @@
+restbed provides CMake targets:
+
+    find_package(unofficial-restbed CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::restbed::restbed)

--- a/ports/restbed/vcpkg.json
+++ b/ports/restbed/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "restbed",
   "version": "4.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Corvusoft's Restbed framework brings asynchronous RESTful functionality to C++14 applications.",
   "homepage": "https://github.com/corvusoft/restbed",
   "license": "AGPL-3.0-or-later OR CPL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6857,7 +6857,7 @@
     },
     "restbed": {
       "baseline": "4.8",
-      "port-version": 1
+      "port-version": 2
     },
     "restc-cpp": {
       "baseline": "0.10.0",

--- a/versions/r-/restbed.json
+++ b/versions/r-/restbed.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c41ea5f5396b24a4566efaea78d996fcbc2c4ec2",
+      "version": "4.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "17ada73eb1e860f2e1ac3b1dd9769ba3115dea29",
       "version": "4.8",
       "port-version": 1


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/issues/29940#issuecomment-1454762060.
https://github.com/microsoft/vcpkg/pull/29945 added unofficial config export. However, upstream uses different targets for static vs. shared linkage, the PR didn't add a usage file, and the tool heuristics cannot guess uniform usage. This PR fixes it by adding an explicit usage file and a uniform alias target.
CC @Cheney-W 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
