### PR TITLE
[arg-router] Update to v1.2.2

### DIFF
--- a/ports/arg-router/portfile.cmake
+++ b/ports/arg-router/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO cmannett85/arg_router
     REF v${VERSION}
     HEAD_REF main
-    SHA512 69448b9343247679a7f288c4b69819df68ba8893d3537b2bdfedf77e2c4f8d39696c68f7716eda108810a7b951f2fec57d329d4113623edf2d28c55e3e68329f
+    SHA512 7f19f9b4df8c2b8968cfc05a92eb3dab44fdc261835a75ccf6e0ec64c68059f05fd7125466e81fa8b04638ab79792b2151216214bb121c06c77c4441a6917315
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port
@@ -21,21 +21,9 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
 
-set(CMAKE_FILE_DIR "lib/cmake/arg_router")
-if (WIN32)
-    set(CMAKE_FILE_DIR "cmake")
-elseif (APPLE)
-    set(CMAKE_FILE_DIR "arg_router.framework/Resources/CMake")
-endif()
-
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME arg_router
-    CONFIG_PATH "${CMAKE_FILE_DIR}"
 )
-
-string(FIND "${CMAKE_FILE_DIR}" "/" CMAKE_FILE_DIR_SLASH_IDX)
-string(SUBSTRING "${CMAKE_FILE_DIR}" 0 ${CMAKE_FILE_DIR_SLASH_IDX} CMAKE_FILE_DIR_ROOT)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/${CMAKE_FILE_DIR_ROOT}")
 
 file(REMOVE "${CURRENT_PACKAGES_DIR}/include/arg_router/LICENSE"
             "${CURRENT_PACKAGES_DIR}/include/arg_router/README.md"

--- a/ports/arg-router/usage
+++ b/ports/arg-router/usage
@@ -1,7 +1,7 @@
 The package arg-router is a header-only library and so is typically used like this:
 
     find_package(arg_router REQUIRED)
-    target_link_libraries(my_exe PUBLIC arg_router)
+    target_link_libraries(my_exe PUBLIC arg_router::arg_router)
     
 For more information, see the docs here:
 

--- a/ports/arg-router/vcpkg.json
+++ b/ports/arg-router/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arg-router",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "C++ command line argument parsing and routing.",
   "homepage": "https://github.com/cmannett85/arg_router",
   "documentation": "https://cmannett85.github.io/arg_router/",

--- a/versions/a-/arg-router.json
+++ b/versions/a-/arg-router.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e1db4d06fe1aa7b5f0677d4e843331e7c7b2bca",
+      "version": "1.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2ad077ad64e854b417c0c85f5900528795bc2028",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -165,7 +165,7 @@
       "port-version": 2
     },
     "arg-router": {
-      "baseline": "1.2.0",
+      "baseline": "1.2.2",
       "port-version": 0
     },
     "argagg": {
@@ -3841,7 +3841,8 @@
       "port-version": 6
     },
     "libdeflate": {
-      "baseline": "1.17"
+      "baseline": "1.17",
+      "port-version": 0
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3841,8 +3841,7 @@
       "port-version": 6
     },
     "libdeflate": {
-      "baseline": "1.17",
-      "port-version": 0
+      "baseline": "1.17"
     },
     "libdisasm": {
       "baseline": "0.23",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
