### PR TITLE
[stdexec] new port

### DIFF
--- a/ports/stdexec/fix-include-location.patch
+++ b/ports/stdexec/fix-include-location.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d59e51d5..166bab1a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -115,6 +115,7 @@ set_target_properties(stdexec PROPERTIES
+                       SOVERSION "${STDEXEC_VERSION_MAJOR}")
+ 
+ # Declare the public include directories
++include(GNUInstallDirs)
+ target_include_directories(stdexec INTERFACE
+                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+@@ -276,7 +277,6 @@ endif()
+ # Install targets ------------------------------------------------------------
+ 
+ include(CPack)
+-include(GNUInstallDirs)
+ 
+ install(TARGETS stdexec
+         DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ports/stdexec/portfile.cmake
+++ b/ports/stdexec/portfile.cmake
@@ -1,0 +1,50 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/stdexec
+    REF 6247237ca9e061401f90a8d320bfe33a61d69a31
+    SHA512 485a8c5a5cd7de9a8875aff769d2c07fb0c7d01d552a0d53c215115384baa23b50524fdb093e5b9c7b8652f463e591df31c7cc45594f7e287664fe1106f1cd3c
+    HEAD_REF main
+    PATCHES
+        fix-include-location.patch # From https://github.com/NVIDIA/stdexec/pull/803
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH_RAPIDS
+    REPO rapidsai/rapids-cmake
+    REF c7a28304639a2ed460181b4753f3280c7833c718
+    SHA512 9a87fdef490199337778b8c9b4df31ca37d65df23803d058f13b406dcfda4d96d992b2780b0b878b61b027c0dc848351496a0f32e779f95298f259bab040b49b
+    HEAD_REF main
+)
+
+vcpkg_download_distfile(RAPIDS_cmake
+    URLS "https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.02/RAPIDS.cmake"
+    FILENAME "RAPIDS.cmake"
+    SHA512 e7830364222a9ea46fe7756859dc8d36e401c720f6a49880a2945a9ebc5bd9aa7e40a8bd382e1cae3af4235d5c9a7998f38331e23b676af7c5c72e7f00e61f0c
+)
+file(COPY "${RAPIDS_cmake}" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
+
+vcpkg_download_distfile(execution_bs
+    URLS "https://raw.githubusercontent.com/brycelelbach/wg21_p2300_execution/main/execution.bs"
+    FILENAME "execution.bs"
+    SHA512 8b976ab932019794d356cf36744af09e027a78488b44d70772675e2c23de0a6fac4e5aaa2ed339d2975b04c75ad27c06c4c3ed95bc2bd9d13370682a019656f2
+)
+file(COPY "${execution_bs}" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
+
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSTDEXEC_BUILD_TESTS=OFF
+        -DSTDEXEC_BUILD_EXAMPLES=OFF
+        -DFETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE="${SOURCE_PATH_RAPIDS}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/stdexec)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/stdexec/vcpkg.json
+++ b/ports/stdexec/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "stdexec",
+  "version-date": "2023-03-05",
+  "description": "stdexec is an experimental reference implementation of the Senders model of asynchronous programming proposed by P2300 - std::execution for adoption into the C++ Standard.",
+  "homepage": "https://github.com/NVIDIA/stdexec",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3841,7 +3841,8 @@
       "port-version": 6
     },
     "libdeflate": {
-      "baseline": "1.17"
+      "baseline": "1.17",
+      "port-version": 0
     },
     "libdisasm": {
       "baseline": "0.23",
@@ -7533,6 +7534,10 @@
     },
     "stb": {
       "baseline": "2022-09-09",
+      "port-version": 0
+    },
+    "stdexec": {
+      "baseline": "2023-03-05",
       "port-version": 0
     },
     "stduuid": {

--- a/versions/s-/stdexec.json
+++ b/versions/s-/stdexec.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f0dea0ac2888c1fe01a7521f5cddabfc86d6fd8d",
+      "version-date": "2023-03-05",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #29184
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


