### PR TITLE
[vcpkg script] Fix fish completions

### DIFF
--- a/scripts/vcpkg_completion.fish
+++ b/scripts/vcpkg_completion.fish
@@ -19,9 +19,7 @@ complete -c vcpkg -f --arguments '(_vcpkg_completions)'
 set vcpkg_commands ($vcpkg_executable autocomplete)
 
 function _set_triplet_arguments
-  set triplets ($vcpkg_executable help triplet)
-  set -e triplets[(contains -i -- "Available architecture triplets" $triplets)]
-  set -e triplets[(contains -i -- "" $triplets)]
+  set triplets ($vcpkg_executable help triplet | grep "^\s" | cut -d' ' -f3)
   set triplet_from ""
   for triplet in $triplets
     echo (test -n "$triplet") >> temp.txt


### PR DESCRIPTION
Currently, the installed fish completions break on any situation with the following error:

```
set: -e: option requires an argument

~/.config/fish/completions/vcpkg.fish (line 24): 
  set -e triplets[(contains -i -- "Available architecture triplets" $triplets)]
  ^
in function '_set_triplet_arguments'
	called on line 37 of file ~/.config/fish/completions/vcpkg.fish
from sourcing file ~/.config/fish/completions/vcpkg.fish

(Type 'help set' for related documentation)
set: -e: option requires an argument

~/.config/fish/completions/vcpkg.fish (line 25): 
  set -e triplets[(contains -i -- "" $triplets)]
  ^
in function '_set_triplet_arguments'
	called on line 37 of file ~/.config/fish/completions/vcpkg.fish
from sourcing file ~/.config/fish/completions/vcpkg.fish

(Type 'help set' for related documentation)
```

This is because these lines try to erase a line that is not there. Instead of removing after assignment, change it so that the incorrect entries are never set to the list and it contains valid entries only.