### PR TITLE
[sdl2] Bump to 2.26.4

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -1,9 +1,8 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL
-    REF release-${VERSION}
-    SHA512 af50ae4dd86ee5827b27e4789c3bb071ea8e3e31e5e8d6cf7d66eef5ae9f3b9683f4adc92b5a30e15513ff6e2773f5978cdbd6484e1e259b1153303ae123539f
+    REF "release-${VERSION}"
+    SHA512 b795810fdf18affd3a03f79354e8ac5525f1023b27cdf7858d463781c5977eea8b34e39c089f71c3ca2d23722af55a3910af79f70c021f40c6281ab1476e1818
     HEAD_REF main
     PATCHES
         deps.patch

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdl2",
-  "version": "2.26.3",
-  "port-version": 1,
+  "version": "2.26.4",
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7097,8 +7097,8 @@
       "port-version": 5
     },
     "sdl2": {
-      "baseline": "2.26.3",
-      "port-version": 1
+      "baseline": "2.26.4",
+      "port-version": 0
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b63b10452df400319db87cadc9a3e1d9d1b752a5",
+      "version": "2.26.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "fca6245cea40954b09d7091b4a0ab02b16b3907c",
       "version": "2.26.3",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
