### PR TITLE
[cxxopts] Update to 3.1.1

### DIFF
--- a/ports/cxxopts/portfile.cmake
+++ b/ports/cxxopts/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jarro2783/cxxopts
-    REF v3.1.0
-    SHA512 bfb593f6393160ae3eeff1fe7bc77394606c3af6ae3b785f9740d178514a8fd286556440aa8a2932633f65b6336695fa286d503f3ac544d0f73affd49051e85d
+    REF "v${VERSION}"
+    SHA512 248e54e23564660467c7ecf50676b86d3cd10ade89e0ac1d23deb71334cb89cc5eb50f624b385d5119a43ca68ff8b1c74af82dc699b5ccfae54d6dcad4fd9447
     HEAD_REF master
 )
 
@@ -22,4 +22,4 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/cxxopts" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cxxopts/vcpkg.json
+++ b/ports/cxxopts/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cxxopts",
-  "version-semver": "3.1.0",
+  "version-semver": "3.1.1",
   "description": "This is a lightweight C++ option parser library, supporting the standard GNU style syntax for options",
   "homepage": "https://github.com/jarro2783/cxxopts",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1913,7 +1913,7 @@
       "port-version": 0
     },
     "cxxopts": {
-      "baseline": "3.1.0",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "cyclonedds": {

--- a/versions/c-/cxxopts.json
+++ b/versions/c-/cxxopts.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ba8ad462aef9c5cc6e4539c3c600bccfd110c6c",
+      "version-semver": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "eb6aeb15747814f3c2b84f15582889d9052e0ae1",
       "version-semver": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30055

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
