### PR TITLE
[daw-header-libraries] update to 2.88.0

### DIFF
--- a/ports/daw-header-libraries/portfile.cmake
+++ b/ports/daw-header-libraries/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/header_libraries
-    REF a744feca74db57fa59f1b1dd09ad8e7cd03118f7 #v2.76.2
-    SHA512 9b8769a656047b880d1e56493fa501407c259069681c8bdd3f55fd6c7088de7be825db5450de26caf3cdd781948a8865501d35175977355df117320312b1f77d
+    REF "v${VERSION}"
+    SHA512 caa975cbaa48367148b1f0f13fc12896ff5dd921a7a851853e9e4f4110004fe913f5f18fad6636a281c5c177da77c04877a92c82e40dfa47cc71434087e7fb45
     HEAD_REF master
 )
 
@@ -15,4 +15,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 # remove empty lib and debug/lib directories (and duplicate files from debug/include)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/daw-header-libraries/vcpkg.json
+++ b/ports/daw-header-libraries/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daw-header-libraries",
-  "version": "2.76.2",
+  "version": "2.88.0",
   "description": "Set of header-only algorithms used in daw-utf8-range and daw-json-link.",
   "homepage": "https://github.com/beached/header_libraries",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1961,7 +1961,7 @@
       "port-version": 1
     },
     "daw-header-libraries": {
-      "baseline": "2.76.2",
+      "baseline": "2.88.0",
       "port-version": 0
     },
     "daw-json-link": {

--- a/versions/d-/daw-header-libraries.json
+++ b/versions/d-/daw-header-libraries.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d509d523fd58793c43034e371dd65d499cec986",
+      "version": "2.88.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "604923901ffc292d9455d073d42e66bd5624690c",
       "version": "2.76.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30081

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.