### PR TITLE
[daw-utf-range] update to 2.2.3

### DIFF
--- a/ports/daw-utf-range/portfile.cmake
+++ b/ports/daw-utf-range/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/utf_range
-    REF 105862ffe283e96ae514d4a6ec98d6ea16b25827 #v2.2.2
-    SHA512 49772c7450ec432925b44ecddaee594ecec01afa4cc49db88e798347d6e5df51b7acf2bea7e11951b7de42a0a4d5a6c9046d5cb101a65e7da68b7d7242ad5b1c
+    REF "v${VERSION}"
+    SHA512 61da92145417cfa1eb3f7b533e4da5f37618aa9a02d3f0c08af76fca6c8d71e423bf607fc9277f2c354205932ffd911940d3270ce105df41d07d9ab48698b5f9
     HEAD_REF master
 )
 
@@ -19,4 +19,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 # remove empty lib and debug/lib directories (and duplicate files from debug/include)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/daw-utf-range/vcpkg.json
+++ b/ports/daw-utf-range/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daw-utf-range",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Header-only utf8 string range used by daw-json-link. Includes a constexpr/noexcept modified version of utfcpp.",
   "homepage": "https://github.com/beached/header_libraries",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1969,7 +1969,7 @@
       "port-version": 0
     },
     "daw-utf-range": {
-      "baseline": "2.2.2",
+      "baseline": "2.2.3",
       "port-version": 0
     },
     "dbg-macro": {

--- a/versions/d-/daw-utf-range.json
+++ b/versions/d-/daw-utf-range.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07d29cf2ac643cf7895ced80bb77b081cb602501",
+      "version": "2.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "de67e1228f3effe508a68cf6080c6ba6e3343fb0",
       "version": "2.2.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30080
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.