### PR TITLE
[directx-dxc] Fix version year for port

### DIFF
--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx-dxc",
-  "version-date": "2022-03-01",
+  "version-date": "2023-03-01",
   "description": "DirectX Shader Compiler (LLVM/Clang)",
   "homepage": "https://github.com/microsoft/DirectXShaderCompiler",
   "documentation": "https://github.com/microsoft/DirectXShaderCompiler/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2021,7 +2021,7 @@
       "port-version": 0
     },
     "directx-dxc": {
-      "baseline": "2022-03-01",
+      "baseline": "2023-03-01",
       "port-version": 0
     },
     "directx-headers": {

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77fecec712c29a857b7036d0ccc817488df868ea",
+      "version-date": "2023-03-01",
+      "port-version": 0
+    },
+    {
       "git-tree": "20d76f8fd2bb7b07fa76370b7198e0ce8f7b316b",
       "version-date": "2022-03-01",
       "port-version": 0


### PR DESCRIPTION
The [PR](https://github.com/microsoft/vcpkg/pull/29987) used the wrong year in a classic 'checking writing new year' style bug.

This fixes the version.