### PR TITLE
[libproxy] Fix link static libmodman

### DIFF
--- a/ports/libmodman/fix-install-path.patch
+++ b/ports/libmodman/fix-install-path.patch
@@ -1,8 +1,8 @@
 diff --git a/libmodman/CMakeLists.txt b/libmodman/CMakeLists.txt
-index 0aff593..a1bbcd5 100644
+index 0aff593..cabc524 100644
 --- a/libmodman/CMakeLists.txt
 +++ b/libmodman/CMakeLists.txt
-@@ -30,28 +30,40 @@ if(NOT WIN32 AND NOT APPLE)
+@@ -30,19 +30,19 @@ if(NOT WIN32 AND NOT APPLE)
    configure_file(libmodman-2.0.pc.in
                   ${CMAKE_CURRENT_BINARY_DIR}/libmodman-2.0.pc @ONLY)
    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libmodman-2.0.pc
@@ -21,18 +21,12 @@ index 0aff593..a1bbcd5 100644
  endif()
  
  # Define the library itself
-+if(BUILD_SHARED_LIBS)
- add_library(modman SHARED
+-add_library(modman SHARED
++add_library(modman
              module.hpp
              module_manager.hpp
              module_manager.cpp)
-+else()
-+add_library(modman STATIC
-+            module.hpp
-+            module_manager.hpp
-+            module_manager.cpp)
-+endif()
- if(NOT WIN32)
+@@ -50,8 +50,13 @@ if(NOT WIN32)
    target_link_libraries(modman dl)
  endif()
  set_target_properties(modman PROPERTIES PREFIX "lib" VERSION 1.0.0 SOVERSION 1)
@@ -49,7 +43,7 @@ index 0aff593..a1bbcd5 100644
  ### Tests
  add_testdirectory(test)
 diff --git a/libmodman/Findlibmodman.cmake.in b/libmodman/Findlibmodman.cmake.in
-index 8459c7f..e9c97e5 100644
+index 8459c7f..efad9d7 100644
 --- a/libmodman/Findlibmodman.cmake.in
 +++ b/libmodman/Findlibmodman.cmake.in
 @@ -12,7 +12,7 @@
@@ -57,7 +51,7 @@ index 8459c7f..e9c97e5 100644
  # Find module_manager.hpp and the corresponding library (libmodman.so)
  FIND_PATH(LIBMODMAN_INCLUDE_DIR libmodman/module_manager.hpp)
 -FIND_LIBRARY(LIBMODMAN_LIBRARIES NAMES modman)
-+FIND_LIBRARY(LIBMODMAN_LIBRARIES NAMES modman libmodman)
++FIND_LIBRARY(LIBMODMAN_LIBRARIES NAMES modman libmodman NAMES_PER_DIR)
  
  # Set library version
  SET(LIBMODMAN_VERSION @PROJECT_VERSION@)

--- a/ports/libmodman/fix-install-path.patch
+++ b/ports/libmodman/fix-install-path.patch
@@ -1,8 +1,8 @@
 diff --git a/libmodman/CMakeLists.txt b/libmodman/CMakeLists.txt
-index 0aff593..9e419ce 100644
+index 0aff593..a1bbcd5 100644
 --- a/libmodman/CMakeLists.txt
 +++ b/libmodman/CMakeLists.txt
-@@ -30,15 +30,15 @@ if(NOT WIN32 AND NOT APPLE)
+@@ -30,28 +30,40 @@ if(NOT WIN32 AND NOT APPLE)
    configure_file(libmodman-2.0.pc.in
                   ${CMAKE_CURRENT_BINARY_DIR}/libmodman-2.0.pc @ONLY)
    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libmodman-2.0.pc
@@ -21,7 +21,18 @@ index 0aff593..9e419ce 100644
  endif()
  
  # Define the library itself
-@@ -50,8 +50,13 @@ if(NOT WIN32)
++if(BUILD_SHARED_LIBS)
+ add_library(modman SHARED
+             module.hpp
+             module_manager.hpp
+             module_manager.cpp)
++else()
++add_library(modman STATIC
++            module.hpp
++            module_manager.hpp
++            module_manager.cpp)
++endif()
+ if(NOT WIN32)
    target_link_libraries(modman dl)
  endif()
  set_target_properties(modman PROPERTIES PREFIX "lib" VERSION 1.0.0 SOVERSION 1)
@@ -37,3 +48,16 @@ index 0aff593..9e419ce 100644
  
  ### Tests
  add_testdirectory(test)
+diff --git a/libmodman/Findlibmodman.cmake.in b/libmodman/Findlibmodman.cmake.in
+index 8459c7f..e9c97e5 100644
+--- a/libmodman/Findlibmodman.cmake.in
++++ b/libmodman/Findlibmodman.cmake.in
+@@ -12,7 +12,7 @@
+ 
+ # Find module_manager.hpp and the corresponding library (libmodman.so)
+ FIND_PATH(LIBMODMAN_INCLUDE_DIR libmodman/module_manager.hpp)
+-FIND_LIBRARY(LIBMODMAN_LIBRARIES NAMES modman)
++FIND_LIBRARY(LIBMODMAN_LIBRARIES NAMES modman libmodman)
+ 
+ # Set library version
+ SET(LIBMODMAN_VERSION @PROJECT_VERSION@)

--- a/ports/libmodman/portfile.cmake
+++ b/ports/libmodman/portfile.cmake
@@ -1,23 +1,17 @@
-# Enable static build in UNIX
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-endif()
-
-set(LIBMODMAN_VER 2.0.1)
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libmodman/libmodman-${LIBMODMAN_VER}.zip"
-    FILENAME "libmodman-${LIBMODMAN_VER}.zip"
+    URLS "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libmodman/libmodman-${VERSION}.zip"
+    FILENAME "libmodman-${VERSION}.zip"
     SHA512 1fecc0fa3637c4aa86d114f5bc991605172d39183fa0f39d8c7858ef5d0d894152025bd426de4dd017a41372d800bf73f53b2328c57b77352a508e12792729fa
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS 
-    tests BUILD_TESTING
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tests BUILD_TESTING
 )
 
-vcpkg_extract_source_archive_ex(
-    ARCHIVE ${ARCHIVE}
-    OUT_SOURCE_PATH SOURCE_PATH
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         fix-install-path.patch
         fix-undefined-typeid.patch
@@ -25,7 +19,8 @@ vcpkg_extract_source_archive_ex(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS}
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -39,4 +34,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_
 
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libmodman/usage
+++ b/ports/libmodman/usage
@@ -1,4 +1,4 @@
-The package libmodman provides CMake targets:
+libmodman provides CMake variables:
 
     find_package(libmodman REQUIRED)
     target_include_directories(main PRIVATE ${LIBMODMAN_INCLUDE_DIR})

--- a/ports/libmodman/usage
+++ b/ports/libmodman/usage
@@ -1,5 +1,5 @@
 The package libmodman provides CMake targets:
 
-    find_package(libmodman CONFIG REQUIRED)
+    find_package(libmodman REQUIRED)
     target_include_directories(main PRIVATE ${LIBMODMAN_INCLUDE_DIR})
     target_link_libraries(main PRIVATE ${LIBMODMAN_LIBRARIES})

--- a/ports/libmodman/vcpkg.json
+++ b/ports/libmodman/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmodman",
-  "version-string": "2.0.1",
+  "version": "2.0.1",
   "port-version": 5,
   "description": "a simple library for managing modules",
   "homepage": "https://code.google.com/p/libmodman",

--- a/ports/libmodman/vcpkg.json
+++ b/ports/libmodman/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmodman",
   "version-string": "2.0.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "a simple library for managing modules",
   "homepage": "https://code.google.com/p/libmodman",
   "supports": "!uwp",

--- a/ports/libproxy/fix-depend-modman.patch
+++ b/ports/libproxy/fix-depend-modman.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 08f9170..06c22de 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,7 +42,7 @@ endif()
+ 
+ ### Subdirectories
+ 
+-add_subdirectory(libmodman)
++find_package(libmodman REQUIRED)
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+ 
+ # Conditionally build bindings
+diff --git a/libproxy/cmake/libproxy.cmk b/libproxy/cmake/libproxy.cmk
+index 3372865..3c3f2de 100644
+--- a/libproxy/cmake/libproxy.cmk
++++ b/libproxy/cmake/libproxy.cmk
+@@ -7,10 +7,11 @@ else ()
+ endif()
+ 
+ if(WIN32)
+-  target_link_libraries(libproxy modman;ws2_32;${LIBPROXY_LIBRARIES})
++  target_link_libraries(libproxy ${LIBMODMAN_LIBRARIES};ws2_32;${LIBPROXY_LIBRARIES})
+ else()
+-  target_link_libraries(libproxy modman;m;pthread;${CMAKE_DL_LIBS};${LIBPROXY_LIBRARIES})
++  target_link_libraries(libproxy ${LIBMODMAN_LIBRARIES};m;pthread;${CMAKE_DL_LIBS};${LIBPROXY_LIBRARIES})
+ endif()
++target_include_directories(libproxy PRIVATE ${LIBMODMAN_INCLUDE_DIR})
+ file(TO_NATIVE_PATH ${MODULE_INSTALL_DIR} MODULE_INSTALL_DIR)
+ if(WIN32)
+   string(REGEX REPLACE "\\\\" "\\\\\\\\" MODULE_INSTALL_DIR ${MODULE_INSTALL_DIR})

--- a/ports/libproxy/fix-depend-modman.patch
+++ b/ports/libproxy/fix-depend-modman.patch
@@ -25,7 +25,7 @@ index 3372865..3c3f2de 100644
 -  target_link_libraries(libproxy modman;m;pthread;${CMAKE_DL_LIBS};${LIBPROXY_LIBRARIES})
 +  target_link_libraries(libproxy ${LIBMODMAN_LIBRARIES};m;pthread;${CMAKE_DL_LIBS};${LIBPROXY_LIBRARIES})
  endif()
-+target_include_directories(libproxy PRIVATE ${LIBMODMAN_INCLUDE_DIR})
++target_include_directories(libproxy PUBLIC ${LIBMODMAN_INCLUDE_DIR})
  file(TO_NATIVE_PATH ${MODULE_INSTALL_DIR} MODULE_INSTALL_DIR)
  if(WIN32)
    string(REGEX REPLACE "\\\\" "\\\\\\\\" MODULE_INSTALL_DIR ${MODULE_INSTALL_DIR})

--- a/ports/libproxy/fix-module-lib-name.patch
+++ b/ports/libproxy/fix-module-lib-name.patch
@@ -7,7 +7,7 @@ index ef44489..c0bd2ae 100644
  # Find proxy.h and the corresponding library (libproxy.so)
  FIND_PATH(LIBPROXY_INCLUDE_DIR proxy.h )
 -FIND_LIBRARY(LIBPROXY_LIBRARIES NAMES proxy )
-+FIND_LIBRARY(LIBPROXY_LIBRARIES NAMES proxy libproxy)
++FIND_LIBRARY(LIBPROXY_LIBRARIES NAMES proxy libproxy NAMES_PER_DIR)
  
  # Set library version
  SET(LIBPROXY_VERSION @PROJECT_VERSION@)

--- a/ports/libproxy/portfile.cmake
+++ b/ports/libproxy/portfile.cmake
@@ -9,8 +9,10 @@ vcpkg_from_github(
         support-windows.patch
         fix-install-py.patch
         fix-module-lib-name.patch
+        fix-depend-modman.patch
 )
 
+file(REMOVE_RECURSE "${SOURCE_PATH}/libmodman")
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATICCRT)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -26,7 +28,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS}
+    OPTIONS
+        ${FEATURE_OPTIONS}
         -DWITH_WEBKIT3=OFF
         -DWITH_KDE=${VCPKG_TARGET_IS_LINUX}
         -DMSVC_STATIC=${STATICCRT}
@@ -38,6 +41,7 @@ vcpkg_cmake_configure(
         WITH_PYTHON3
         WITH_VALA
         MSVC_STATIC
+        WITH_GNOME3
 )
 
 vcpkg_cmake_install()
@@ -50,4 +54,4 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
           DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libproxy/usage
+++ b/ports/libproxy/usage
@@ -1,5 +1,5 @@
 The package libproxy provides CMake targets:
 
-    find_package(libproxy CONFIG REQUIRED)
+    find_package(libproxy REQUIRED)
     target_include_directories(main PRIVATE ${LIBPROXY_INCLUDE_DIR})
     target_link_libraries(main PRIVATE ${LIBPROXY_LIBRARIES})

--- a/ports/libproxy/usage
+++ b/ports/libproxy/usage
@@ -1,4 +1,4 @@
-The package libproxy provides CMake targets:
+libproxy provides CMake variables:
 
     find_package(libproxy REQUIRED)
     target_include_directories(main PRIVATE ${LIBPROXY_INCLUDE_DIR})

--- a/ports/libproxy/vcpkg.json
+++ b/ports/libproxy/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "libproxy",
   "version": "0.4.18",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libproxy is a library that provides automatic proxy configuration management.",
   "homepage": "https://github.com/libproxy/libproxy",
   "license": "LGPL-2.1-only",
   "supports": "!uwp",
   "dependencies": [
+    "libmodman",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -432,7 +432,6 @@ libmesh:x64-linux=skip
 # Build fails since PIC is not enabled and some configuration tests do not work properly on UWP
 libmicrodns:arm-uwp=fail
 libmicrodns:x64-uwp=fail
-libmodman:x64-windows-static=fail
 libmodplug:arm-uwp=fail
 libmodplug:x64-uwp=fail
 libmpeg2:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4154,7 +4154,7 @@
     },
     "libmodman": {
       "baseline": "2.0.1",
-      "port-version": 4
+      "port-version": 5
     },
     "libmodplug": {
       "baseline": "0.8.9.0",
@@ -4302,7 +4302,7 @@
     },
     "libproxy": {
       "baseline": "0.4.18",
-      "port-version": 1
+      "port-version": 2
     },
     "libqcow": {
       "baseline": "20221124",

--- a/versions/l-/libmodman.json
+++ b/versions/l-/libmodman.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "55fa7a202e49c36dcf1485c660a4669a20b68080",
+      "git-tree": "f059fcd6b2a104662205e25354360b57f7ba0d57",
       "version": "2.0.1",
       "port-version": 5
     },

--- a/versions/l-/libmodman.json
+++ b/versions/l-/libmodman.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d290bf1e0b06196686644194c93d984290a212dd",
+      "version": "2.0.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "64d71ad6052dd0027325c7e9390ad4264dbef108",
       "version-string": "2.0.1",
       "port-version": 4

--- a/versions/l-/libmodman.json
+++ b/versions/l-/libmodman.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d290bf1e0b06196686644194c93d984290a212dd",
+      "git-tree": "55fa7a202e49c36dcf1485c660a4669a20b68080",
       "version": "2.0.1",
       "port-version": 5
     },

--- a/versions/l-/libproxy.json
+++ b/versions/l-/libproxy.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b0c1ed7b3b3de44b4ee3c93ab36cd22715c25623",
+      "git-tree": "457a7faab115443587822fecbe61656784e1beed",
       "version": "0.4.18",
       "port-version": 2
     },

--- a/versions/l-/libproxy.json
+++ b/versions/l-/libproxy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "065b4b6896683066be348ccf33d29036f8cdcda1",
+      "version": "0.4.18",
+      "port-version": 2
+    },
+    {
       "git-tree": "74ecff4623774abaa9333489e644bdbc881e268f",
       "version": "0.4.18",
       "port-version": 1

--- a/versions/l-/libproxy.json
+++ b/versions/l-/libproxy.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "065b4b6896683066be348ccf33d29036f8cdcda1",
+      "git-tree": "b0c1ed7b3b3de44b4ee3c93ab36cd22715c25623",
       "version": "0.4.18",
       "port-version": 2
     },

--- a/versions/l-/libproxy.json
+++ b/versions/l-/libproxy.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "457a7faab115443587822fecbe61656784e1beed",
+      "git-tree": "d53cdbb2a889ae6bb61b81d63a9837169fb14a1c",
       "version": "0.4.18",
       "port-version": 2
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #28417
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix `libmodman` static build, let `libproxy` link `libmodman` installed by vcpkg.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
