### PR TITLE
[catch2] Update to 3.3.2

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
     REF v${VERSION}
-    SHA512 93aff3549c3d8454c7deded0e64471f2a8290edfd842c2e0816a353ef9ec2896bee25da6d952cc3bbf022262e22ed2a522485dbfe5d1d492f07eb4c0c2ddb779
+    SHA512 3d0c5666509a19be54ea0c48a3c8e1c4a951a2d991a7c9f7fe6d326661464538f1ab9dc573b1b2647f49fb6bef45bbd866142a4ce0fba38545ad182b8d55f61f
     HEAD_REF devel
     PATCHES
         fix-install-path.patch

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version-semver": "3.3.1",
+  "version-semver": "3.3.2",
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version": "3.3.2",
+  "version-semver": "3.3.2",
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version-semver": "3.3.2",
+  "version": "3.3.2",
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1365,7 +1365,7 @@
       "port-version": 1
     },
     "catch2": {
-      "baseline": "3.3.1",
+      "baseline": "3.3.2",
       "port-version": 0
     },
     "cccapstone": {

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e776d4cb313c846f6de82c05fa2ab9b7748edb6b",
+      "version-semver": "3.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "7d7bef305b7affebc6f3ccacd12874ebd4fbfc50",
       "version-semver": "3.3.1",
       "port-version": 0

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "15602055f827885ae439449b001ed3323c9e769c",
-      "version": "3.3.2",
+      "git-tree": "e776d4cb313c846f6de82c05fa2ab9b7748edb6b",
+      "version-semver": "3.3.2",
       "port-version": 0
     },
     {

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "e776d4cb313c846f6de82c05fa2ab9b7748edb6b",
-      "version-semver": "3.3.2",
+      "git-tree": "15602055f827885ae439449b001ed3323c9e769c",
+      "version": "3.3.2",
       "port-version": 0
     },
     {


### PR DESCRIPTION
Update catch2 from 3.3.1 to 3.3.2 : https://github.com/catchorg/Catch2/releases/tag/v3.3.2

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.