### PR TITLE
[rocksdb] update to 7.10.2

### DIFF
--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb
-  REF 444b3f4845dd01b0d127c4b420fdd3b50ad56682 # v7.9.2
-  SHA512 a987abbedcc74d0633977ef3953c50824e1f1afdb2deb52db078a63ce9f0c39d5980fbc5127bbd9d7b6aebdc5268ab0f52b5b476d6cff47fb469a8c567ae70a1
+  REF "v${VERSION}"
+  SHA512 8a64adce7cbb35449fb7f55dc92d1f902f317d9173f7afb02e6f047e42cc648f9f553364fbae14b14ed2fa3f125d32f49cccfb0c49f82f392508575396552c6e
   HEAD_REF main
   PATCHES
     0002-only-build-one-flavor.patch

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rocksdb",
-  "version": "7.9.2",
+  "version": "7.10.2",
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6941,7 +6941,7 @@
       "port-version": 0
     },
     "rocksdb": {
-      "baseline": "7.9.2",
+      "baseline": "7.10.2",
       "port-version": 0
     },
     "rpclib": {

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b09fc2a59392bb41e23e2eb0120eac2a77faca97",
+      "version": "7.10.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ab4b0ca16f88be2bcddaab354944e2650a33b77",
       "version": "7.9.2",
       "port-version": 0


### PR DESCRIPTION
Update the rocksdb port to the new upstream release, 7.10.2.
