### PR TITLE
Add a new port h265nal to vcpkg

### DIFF
--- a/ports/h265nal/portfile.cmake
+++ b/ports/h265nal/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO chemag/h265nal
+    REF v0.38
+    SHA512 690f7596c12f3f71e6ef2d37c2f2c5bd4714530d0467a8a946230d728f0b224164a966334d0e7c744c5d4cd7888e8e3ff5cde196ab73c7476ae688ce2ba6f268
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+
+vcpkg_cmake_install()
+
+file(
+    INSTALL "${SOURCE_PATH}/LICENSE" 
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" 
+    RENAME copyright
+    )

--- a/ports/h265nal/vcpkg.json
+++ b/ports/h265nal/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "h265nal",
+  "version-string": "0.38",
+  "description": ["H265 NAL unit parser, that accepts a file in h265 Annex B format (.265) and dumps the contents of the parsed NALs."],
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    { 
+     "name": "vcpkg-cmake-config", 
+     "host": true 
+    },
+    {
+      "name": "gtest"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
