### PR TITLE
[qt5-base] Move 'icu' out of 'core' feature

### DIFF
--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -102,7 +102,6 @@ list(APPEND CORE_OPTIONS
     -system-doubleconversion
     -system-sqlite
     -system-harfbuzz
-    -icu
     -no-angle # Qt does not need to build angle. VCPKG will build angle!
     -no-glib
     -openssl-linked
@@ -207,8 +206,7 @@ set(RELEASE_OPTIONS
             "PCRE2_LIBS=${PCRE2_RELEASE}"
             "FREETYPE_LIBS=${FREETYPE_RELEASE_ALL}"
             "QMAKE_LIBS_PRIVATE+=${BZ2_RELEASE}"
-            "QMAKE_LIBS_PRIVATE+=${LIBPNG_RELEASE}"
-            "QMAKE_LIBS_PRIVATE+=${ICU_RELEASE}"
+            "QMAKE_LIBS_PRIVATE+=${LIBPNG_RELEASE} ${ZLIB_RELEASE}"
             "QMAKE_LIBS_PRIVATE+=${ZSTD_RELEASE}"
             )
 set(DEBUG_OPTIONS
@@ -218,20 +216,28 @@ set(DEBUG_OPTIONS
             "PCRE2_LIBS=${PCRE2_DEBUG}"
             "FREETYPE_LIBS=${FREETYPE_DEBUG_ALL}"
             "QMAKE_LIBS_PRIVATE+=${BZ2_DEBUG}"
-            "QMAKE_LIBS_PRIVATE+=${LIBPNG_DEBUG}"
-            "QMAKE_LIBS_PRIVATE+=${ICU_DEBUG}"
+            "QMAKE_LIBS_PRIVATE+=${LIBPNG_DEBUG} ${ZLIB_DEBUG}"
             "QMAKE_LIBS_PRIVATE+=${ZSTD_DEBUG}"
             )
 
-# This if/else corresponds to icu setup in src/corelib/configure.json.
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    list(APPEND CORE_OPTIONS
-        "ICU_LIBS_RELEASE=${ICU_RELEASE}"
-        "ICU_LIBS_DEBUG=${ICU_DEBUG}"
-    )
+if("icu" IN_LIST FEATURES)
+    list(APPEND CORE_OPTIONS -icu)
+
+    # This if/else corresponds to icu setup in src/corelib/configure.json.
+    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        list(APPEND CORE_OPTIONS
+            "ICU_LIBS_RELEASE=${ICU_RELEASE}"
+            "ICU_LIBS_DEBUG=${ICU_DEBUG}"
+        )
+    else()
+        list(APPEND RELEASE_OPTIONS "ICU_LIBS=${ICU_RELEASE}")
+        list(APPEND DEBUG_OPTIONS "ICU_LIBS=${ICU_DEBUG}")
+    endif()
+
+    list(APPEND RELEASE_OPTIONS "QMAKE_LIBS_PRIVATE+=${ICU_RELEASE}")
+    list(APPEND DEBUG_OPTIONS "QMAKE_LIBS_PRIVATE+=${ICU_DEBUG}")
 else()
-    list(APPEND RELEASE_OPTIONS "ICU_LIBS=${ICU_RELEASE}")
-    list(APPEND DEBUG_OPTIONS "ICU_LIBS=${ICU_DEBUG}")
+    list(APPEND CORE_OPTIONS -no-icu)
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.8",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -14,10 +14,6 @@
     },
     "freetype",
     "harfbuzz",
-    {
-      "name": "icu",
-      "platform": "!uwp"
-    },
     "libjpeg-turbo",
     "libpng",
     {
@@ -44,6 +40,15 @@
     "zstd"
   ],
   "features": {
+    "icu": {
+      "description": "Enable ICU support",
+      "dependencies": [
+        {
+          "name": "icu",
+          "platform": "!uwp"
+        }
+      ]
+    },
     "latest": {
       "description": "(deprecated)"
     },

--- a/ports/qt5/vcpkg.json
+++ b/ports/qt5/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5",
   "version": "5.15.8",
+  "port-version": 1,
   "description": "Qt5 Application Framework",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -91,6 +92,7 @@
           "name": "qt5-base",
           "default-features": false,
           "features": [
+            "icu",
             "mysqlplugin",
             "postgresqlplugin"
           ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6326,7 +6326,7 @@
     },
     "qt5": {
       "baseline": "5.15.8",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-3d": {
       "baseline": "5.15.8",
@@ -6342,7 +6342,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.8",
-      "port-version": 4
+      "port-version": 5
     },
     "qt5-canvas3d": {
       "baseline": "0",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51c0d7f3e15a664dba88e8c9891d4a045661f4ec",
+      "version": "5.15.8",
+      "port-version": 5
+    },
+    {
       "git-tree": "1528baab40fce203129dc361128135b453e1ecb1",
       "version": "5.15.8",
       "port-version": 4

--- a/versions/q-/qt5.json
+++ b/versions/q-/qt5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f770e40ee8bc91d18f208ceee737d2c8abfaf8d0",
+      "version": "5.15.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "88647dde8c3f8eee01f4b02b3f5a211046e5e5bd",
       "version": "5.15.8",
       "port-version": 0


### PR DESCRIPTION
Extracted changes related to `icu` from #23668 cc. @dg0yt 

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.