### PR TITLE
[libiconv] Fix android

### DIFF
--- a/ports/libiconv/clang-fortify.patch
+++ b/ports/libiconv/clang-fortify.patch
@@ -1,0 +1,64 @@
+diff --git a/srclib/cdefs.h b/srclib/cdefs.h
+index 7b8ed5b..63574f9 100644
+--- a/srclib/cdefs.h
++++ b/srclib/cdefs.h
+@@ -140,6 +140,7 @@
+ #endif
+ 
+ 
++#ifndef __GNULIB_CDEFS
+ /* Fortify support.  */
+ #define __bos(ptr) __builtin_object_size (ptr, __USE_FORTIFY_LEVEL > 1)
+ #define __bos0(ptr) __builtin_object_size (ptr, 0)
+@@ -201,6 +202,8 @@
+       ? __ ## f ## _chk_warn (__VA_ARGS__, (__osz) / (__s))		      \
+       : __ ## f ## _chk (__VA_ARGS__, (__osz) / (__s))))		      \
+ 
++#endif
++
+ #if __GNUC_PREREQ (4,3)
+ # define __warnattr(msg) __attribute__((__warning__ (msg)))
+ # define __errordecl(name, msg) \
+diff --git a/srclib/libc-config.h b/srclib/libc-config.h
+index a56665b..876e1a1 100644
+--- a/srclib/libc-config.h
++++ b/srclib/libc-config.h
+@@ -137,8 +137,10 @@
+ # undef __attribute_returns_twice__
+ # undef __attribute_used__
+ # undef __attribute_warn_unused_result__
++# ifndef __GNULIB_CDEFS
+ # undef __bos
+ # undef __bos0
++# endif
+ # undef __errordecl
+ # undef __extension__
+ # undef __extern_always_inline
+@@ -147,21 +149,27 @@
+ # undef __fortified_attr_access
+ # undef __fortify_function
+ # undef __glibc_c99_flexarr_available
++# ifndef __GNULIB_CDEFS
+ # undef __glibc_fortify
+ # undef __glibc_fortify_n
++# endif
+ # undef __glibc_has_attribute
+ # undef __glibc_has_builtin
+ # undef __glibc_has_extension
+ # undef __glibc_likely
+ # undef __glibc_macro_warning
+ # undef __glibc_macro_warning1
++# ifndef __GNULIB_CDEFS
+ # undef __glibc_objsize
+ # undef __glibc_objsize0
+ # undef __glibc_safe_len_cond
+ # undef __glibc_safe_or_unknown_len
++# endif
+ # undef __glibc_unlikely
++# ifndef __GNULIB_CDEFS
+ # undef __glibc_unsafe_len
+ # undef __glibc_unsigned_or_positive
++# endif
+ # undef __inline
+ # undef __ptr_t
+ # undef __restrict

--- a/ports/libiconv/portfile.cmake
+++ b/ports/libiconv/portfile.cmake
@@ -5,17 +5,15 @@ if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_ANDROID)
     return()
 endif()
 
-set(LIBICONV_VERSION 1.17)
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnu.org/gnu/libiconv/libiconv-${LIBICONV_VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libiconv/libiconv-${LIBICONV_VERSION}.tar.gz"
-    FILENAME "libiconv-${LIBICONV_VERSION}.tar.gz"
+    URLS "https://ftp.gnu.org/gnu/libiconv/libiconv-${VERSION}.tar.gz"
+         "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libiconv/libiconv-${VERSION}.tar.gz"
+    FILENAME "libiconv-${VERSION}.tar.gz"
     SHA512 18a09de2d026da4f2d8b858517b0f26d853b21179cf4fa9a41070b2d140030ad9525637dc4f34fc7f27abca8acdc84c6751dfb1d426e78bf92af4040603ced86
 )
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
+vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
-    REF "${LIBICONV_VERSION}"
+    SOURCE_BASE "v${VERSION}"
     PATCHES
         0002-Config-for-MSVC.patch
         0003-Add-export.patch
@@ -23,8 +21,9 @@ vcpkg_extract_source_archive_ex(
         clang-fortify.patch # ported from https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=522aea1093a598246346b3e1c426505c344fe19a
 )
 
+vcpkg_list(SET OPTIONS)
 if (NOT VCPKG_TARGET_IS_ANDROID)
-    list(APPEND OPTIONS --enable-relocatable)
+    vcpkg_list(APPEND OPTIONS --enable-relocatable)
 endif()
 
 vcpkg_configure_make(

--- a/ports/libiconv/portfile.cmake
+++ b/ports/libiconv/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_extract_source_archive_ex(
         0002-Config-for-MSVC.patch
         0003-Add-export.patch
         0004-ModuleFileName.patch
+        clang-fortify.patch # ported from https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=522aea1093a598246346b3e1c426505c344fe19a
 )
 
 if (NOT VCPKG_TARGET_IS_ANDROID)

--- a/ports/libiconv/vcpkg.json
+++ b/ports/libiconv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libiconv",
   "version": "1.17",
+  "port-version": 1,
   "description": "GNU Unicode text conversion",
   "homepage": "https://www.gnu.org/software/libiconv/",
   "license": null

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4022,7 +4022,7 @@
     },
     "libiconv": {
       "baseline": "1.17",
-      "port-version": 0
+      "port-version": 1
     },
     "libics": {
       "baseline": "1.6.5",

--- a/versions/l-/libiconv.json
+++ b/versions/l-/libiconv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff437a7a8b3b89f4b132e633e3eb49a111a8dbac",
+      "version": "1.17",
+      "port-version": 1
+    },
+    {
       "git-tree": "1f92b7d29ce3243d3d51e07686869eca63ece88a",
       "version": "1.17",
       "port-version": 0

--- a/versions/l-/libiconv.json
+++ b/versions/l-/libiconv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff437a7a8b3b89f4b132e633e3eb49a111a8dbac",
+      "git-tree": "4226589d5d658f4d96df83f8539de54dc57a5996",
       "version": "1.17",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #29719. Fixes #27304.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
