### PR TITLE
[libtasn1] Fix android clang

### DIFF
--- a/ports/libtasn1/clang-fortify.patch
+++ b/ports/libtasn1/clang-fortify.patch
@@ -1,0 +1,64 @@
+diff --git a/lib/gl/cdefs.h b/lib/gl/cdefs.h
+index 7b8ed5b..63574f9 100644
+--- a/lib/gl/cdefs.h
++++ b/lib/gl/cdefs.h
+@@ -140,6 +140,7 @@
+ #endif
+ 
+ 
++#ifndef __GNULIB_CDEFS
+ /* Fortify support.  */
+ #define __bos(ptr) __builtin_object_size (ptr, __USE_FORTIFY_LEVEL > 1)
+ #define __bos0(ptr) __builtin_object_size (ptr, 0)
+@@ -201,6 +202,8 @@
+       ? __ ## f ## _chk_warn (__VA_ARGS__, (__osz) / (__s))		      \
+       : __ ## f ## _chk (__VA_ARGS__, (__osz) / (__s))))		      \
+ 
++#endif
++
+ #if __GNUC_PREREQ (4,3)
+ # define __warnattr(msg) __attribute__((__warning__ (msg)))
+ # define __errordecl(name, msg) \
+diff --git a/lib/gl/libc-config.h b/lib/gl/libc-config.h
+index a56665b..876e1a1 100644
+--- a/lib/gl/libc-config.h
++++ b/lib/gl/libc-config.h
+@@ -137,8 +137,10 @@
+ # undef __attribute_returns_twice__
+ # undef __attribute_used__
+ # undef __attribute_warn_unused_result__
++# ifndef __GNULIB_CDEFS
+ # undef __bos
+ # undef __bos0
++# endif
+ # undef __errordecl
+ # undef __extension__
+ # undef __extern_always_inline
+@@ -147,21 +149,27 @@
+ # undef __fortified_attr_access
+ # undef __fortify_function
+ # undef __glibc_c99_flexarr_available
++# ifndef __GNULIB_CDEFS
+ # undef __glibc_fortify
+ # undef __glibc_fortify_n
++# endif
+ # undef __glibc_has_attribute
+ # undef __glibc_has_builtin
+ # undef __glibc_has_extension
+ # undef __glibc_likely
+ # undef __glibc_macro_warning
+ # undef __glibc_macro_warning1
++# ifndef __GNULIB_CDEFS
+ # undef __glibc_objsize
+ # undef __glibc_objsize0
+ # undef __glibc_safe_len_cond
+ # undef __glibc_safe_or_unknown_len
++# endif
+ # undef __glibc_unlikely
++# ifndef __GNULIB_CDEFS
+ # undef __glibc_unsafe_len
+ # undef __glibc_unsigned_or_positive
++# endif
+ # undef __inline
+ # undef __ptr_t
+ # undef __restrict

--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -1,7 +1,6 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/gnu/libtasn1/libtasn1-${VERSION}.tar.gz"
+         "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libtasn1/libtasn1-${VERSION}.tar.gz"
     FILENAME "libtasn1-${VERSION}.tar.gz"
     SHA512 287f5eddfb5e21762d9f14d11997e56b953b980b2b03a97ed4cd6d37909bda1ed7d2cdff9da5d270a21d863ab7e54be6b85c05f1075ac5d8f0198997cf335ef4
 )
@@ -11,6 +10,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     SOURCE_BASE "v${VERSION}"
     PATCHES
         msvc_fixes.patch
+        clang-fortify.patch # ported from https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=522aea1093a598246346b3e1c426505c344fe19a
 )
 
 vcpkg_find_acquire_program(BISON)
@@ -31,7 +31,7 @@ if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     list(APPEND EXTRA_OPTS "CFLAGS=\$CFLAGS -DASN1_STATIC")
 endif()
 
-set(ENV{GTKDOCIZE} true)
+set(ENV{GTKDOCIZE} true) # true, the program
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG

--- a/ports/libtasn1/vcpkg.json
+++ b/ports/libtasn1/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libtasn1",
   "version": "4.19.0",
+  "port-version": 1,
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols",
   "homepage": "https://www.gnutls.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4462,7 +4462,7 @@
     },
     "libtasn1": {
       "baseline": "4.19.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libtcod": {
       "baseline": "1.23.1",

--- a/versions/l-/libtasn1.json
+++ b/versions/l-/libtasn1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8d108b8c34710e58f52569772f13a406893c6ee",
+      "version": "4.19.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a1922bb6cb0484a7aff7e4907285fc7f6d98fe4e",
       "version": "4.19.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/29765.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
