### PR TITLE
[bullet3] Update to version 3.25.

### DIFF
--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bulletphysics/bullet3
     REF "${VERSION}"
-    SHA512 edacf643ca9621523812effe69a7499716bc65282c58c1f5b4eb4f17b2b1ab55a4f71b06a73483f57e57a5b032c234d09ba5fab9881321f2cbc3c27b43fdc95d
+    SHA512 7086e5fcf69635801bb311261173cb8d173b712ca1bd78be03df48fad884674e85512861190e45a1a62d5627aaad65cde08c175c44a3be9afa410d3dfd5358d4
     HEAD_REF master
     PATCHES
         cmake-fix.patch

--- a/ports/bullet3/vcpkg.json
+++ b/ports/bullet3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "bullet3",
-  "version": "3.22",
-  "port-version": 2,
+  "version": "3.25",
   "description": "Bullet Physics is a professional collision detection, rigid body, and soft body dynamics library",
   "homepage": "https://github.com/bulletphysics/bullet3",
   "license": "Zlib",

--- a/versions/b-/bullet3.json
+++ b/versions/b-/bullet3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ddb8da6a7bd04aff093231935f5ead2a8ee7c79",
+      "version": "3.25",
+      "port-version": 0
+    },
+    {
       "git-tree": "fa19f46a232f321eca98906bc2b25dbf782b924b",
       "version": "3.22",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1273,8 +1273,8 @@
       "port-version": 0
     },
     "bullet3": {
-      "baseline": "3.22",
-      "port-version": 2
+      "baseline": "3.25",
+      "port-version": 0
     },
     "bustache": {
       "baseline": "1.1.0",


### PR DESCRIPTION
[ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
[ ] SHA512s are updated for each updated download
[ ] The "supports" clause reflects platforms that may be fixed by this new version
[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
[ ] Any patches that are no longer applied are deleted from the port's directory.
[ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
[ ] Only one version is added to each modified port's versions file.

