### PR TITLE
[libcaer,dv-processing] Port fixes, cleanup

### DIFF
--- a/ports/dv-processing/cmake-project-include.cmake
+++ b/ports/dv-processing/cmake-project-include.cmake
@@ -1,0 +1,5 @@
+if(MSVC)
+    # This port's tools use C++20, but Qt6 (via OpenCV4) uses C++17.
+    # Assuming that no coroutines are passed between the two.
+    add_definitions(-D_ALLOW_COROUTINE_ABI_MISMATCH)
+endif()

--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -15,27 +15,25 @@ vcpkg_from_gitlab(
     SHA512 e7907b1be9d85b02e1a1703cf001765119a7d07b1873148a0fbfe6945c519d85b1f9bc66b24f90d88759c2b32965304e1639f2ff136448be64fc88f81a0d4c2d
     HEAD_REF ec53dae89f6b037e9e640af5340d7bf67d84d278
 )
-
 file(GLOB CMAKEMOD_FILES "${CMAKEMOD_SOURCE_PATH}/*")
 file(COPY ${CMAKEMOD_FILES} DESTINATION "${SOURCE_PATH}/cmake/modules")
 
+set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE # writes to include/cmake/version.hpp
     OPTIONS
+        -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
+        -DCMAKE_REQUIRE_FIND_PACKAGE_lz4=ON
+        -DCMAKE_REQUIRE_FIND_PACKAGE_zstd=ON
         -DENABLE_TESTS=OFF
         -DENABLE_SAMPLES=OFF
         -DENABLE_PYTHON=OFF
         -DENABLE_UTILITIES=OFF
         -DBUILD_CONFIG_VCPKG=ON
 )
-
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "dv-processing" CONFIG_PATH "share/dv-processing")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib") # pkgconfig only, but incomplete
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-
-vcpkg_fixup_pkgconfig(SKIP_CHECK)
-
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_check_features(
 set(VCPKG_BUILD_TYPE release) # no lib binaries
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE # writes to include/cmake/version.hpp
+    DISABLE_PARALLEL_CONFIGURE # writes to include/dv-processing/version.hpp
     OPTIONS
         ${FEATURE_OPTIONS}
         "-DCMAKE_PROJECT_INCLUDE=${CMAKE_CURRENT_LIST_DIR}/cmake-project-include.cmake"

--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -30,6 +30,7 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE # writes to include/cmake/version.hpp
     OPTIONS
         ${FEATURE_OPTIONS}
+        "-DCMAKE_PROJECT_INCLUDE=${CMAKE_CURRENT_LIST_DIR}/cmake-project-include.cmake"
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
         -DCMAKE_REQUIRE_FIND_PACKAGE_lz4=ON
         -DCMAKE_REQUIRE_FIND_PACKAGE_zstd=ON
@@ -46,4 +47,5 @@ vcpkg_copy_tools(TOOL_NAMES dv-filestat dv-imu-bias-estimation dv-list-devices d
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib") # pkgconfig only, but incomplete
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -42,7 +42,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 
-# TODO: vcpkg_copy_tools
+vcpkg_copy_tools(TOOL_NAMES dv-filestat dv-imu-bias-estimation dv-list-devices dv-tcpstat AUTO_CLEAN)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib") # pkgconfig only, but incomplete
 

--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -18,21 +18,31 @@ vcpkg_from_gitlab(
 file(GLOB CMAKEMOD_FILES "${CMAKEMOD_SOURCE_PATH}/*")
 file(COPY ${CMAKEMOD_FILES} DESTINATION "${SOURCE_PATH}/cmake/modules")
 
-set(VCPKG_BUILD_TYPE release) # header-only
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools   ENABLE_UTILITIES
+)
+
+set(VCPKG_BUILD_TYPE release) # no lib binaries
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE # writes to include/cmake/version.hpp
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
         -DCMAKE_REQUIRE_FIND_PACKAGE_lz4=ON
         -DCMAKE_REQUIRE_FIND_PACKAGE_zstd=ON
         -DENABLE_TESTS=OFF
         -DENABLE_SAMPLES=OFF
         -DENABLE_PYTHON=OFF
-        -DENABLE_UTILITIES=OFF
         -DBUILD_CONFIG_VCPKG=ON
+#[[ WIP ]] -DENABLE_UTILITIES=ON
+#[[ WIP ]] -DVCPKG_TRACE_FIND_PACKAGE=ON
 )
 vcpkg_cmake_install()
+
+# TODO: vcpkg_copy_tools
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib") # pkgconfig only, but incomplete
 

--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -38,12 +38,12 @@ vcpkg_cmake_configure(
         -DENABLE_SAMPLES=OFF
         -DENABLE_PYTHON=OFF
         -DBUILD_CONFIG_VCPKG=ON
-#[[ WIP ]] -DENABLE_UTILITIES=ON
-#[[ WIP ]] -DVCPKG_TRACE_FIND_PACKAGE=ON
 )
 vcpkg_cmake_install()
 
-vcpkg_copy_tools(TOOL_NAMES dv-filestat dv-imu-bias-estimation dv-list-devices dv-tcpstat AUTO_CLEAN)
+if(ENABLE_UTILITIES)
+    vcpkg_copy_tools(TOOL_NAMES dv-filestat dv-imu-bias-estimation dv-list-devices dv-tcpstat AUTO_CLEAN)
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib") # pkgconfig only, but incomplete
 

--- a/ports/dv-processing/usage
+++ b/ports/dv-processing/usage
@@ -1,0 +1,6 @@
+dv-processing provides CMake targets:
+
+    find_package(dv-processing CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE dv::processing)
+
+Using dv-processing requires a C++20 compliant compiler.

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -36,10 +36,6 @@
       "name": "vcpkg-cmake",
       "host": true
     },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    },
     "zstd"
   ],
   "features": {

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -32,5 +32,10 @@
       "host": true
     },
     "zstd"
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build utilities"
+    }
+  }
 }

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -6,6 +6,7 @@
   "homepage": "https://gitlab.com/inivation/dv/dv-processing",
   "license": "Apache-2.0",
   "dependencies": [
+    "boost-algorithm",
     {
       "name": "boost-asio",
       "features": [
@@ -14,6 +15,8 @@
     },
     "boost-callable-traits",
     "boost-circular-buffer",
+    "boost-core",
+    "boost-endian",
     "boost-geometry",
     "boost-lockfree",
     "boost-nowide",

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -2,10 +2,16 @@
   "name": "dv-processing",
   "version": "1.7.8",
   "port-version": 1,
-  "description": "Generic algorithms for event cameras.",
+  "description": "Generic algorithms for event cameras. (C++20 required.)",
   "homepage": "https://gitlab.com/inivation/dv/dv-processing",
   "license": "Apache-2.0",
   "dependencies": [
+    {
+      "name": "boost-asio",
+      "features": [
+        "ssl"
+      ]
+    },
     "boost-callable-traits",
     "boost-circular-buffer",
     "boost-geometry",

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dv-processing",
   "version": "1.7.8",
+  "port-version": 1,
   "description": "Generic algorithms for event cameras.",
   "homepage": "https://gitlab.com/inivation/dv/dv-processing",
   "license": "Apache-2.0",
@@ -12,13 +13,15 @@
     "boost-nowide",
     "boost-property-tree",
     "boost-stacktrace",
-    "boost-tti",
     "cli11",
     "eigen3",
     "fmt",
     "libcaer",
     "lz4",
-    "opencv4",
+    {
+      "name": "opencv4",
+      "default-features": false
+    },
     "openssl",
     {
       "name": "vcpkg-cmake",
@@ -28,7 +31,6 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "zlib",
     "zstd"
   ]
 }

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -44,7 +44,7 @@
   ],
   "features": {
     "tools": {
-      "description": "Build utilities"
+      "description": "Build CLI utilities"
     }
   }
 }

--- a/ports/libcaer/fix-libusb.diff
+++ b/ports/libcaer/fix-libusb.diff
@@ -1,0 +1,17 @@
+diff --git a/cmakemod/libcaerConfig.cmake.in b/cmakemod/libcaerConfig.cmake.in
+index cdf9f88..475d543 100644
+--- a/cmakemod/libcaerConfig.cmake.in
++++ b/cmakemod/libcaerConfig.cmake.in
+@@ -21,6 +21,12 @@
+ CMAKE_POLICY(PUSH)
+ CMAKE_POLICY(VERSION 3.10)
+ 
++include(CMakeFindDependencyMacro)
++if(NOT "@CC_MSVC@")
++    find_dependency(PkgConfig)
++    pkg_check_modules(libusb REQUIRED IMPORTED_TARGET libusb-1.0)
++endif()
++
+ INCLUDE(@PACKAGE_export_destination@/libcaer-exports.cmake)
+ SET(libcaer_INCLUDE_DIRS @PACKAGE_include_dirs@)
+ 

--- a/ports/libcaer/portfile.cmake
+++ b/ports/libcaer/portfile.cmake
@@ -5,11 +5,13 @@ vcpkg_from_gitlab(
     REF 933dfa60a138091afb03014f8c24183bab7bba4e
     SHA512 f3ac74bb4cfc4077e5a226307f66a9b8b263201d2342d9e61ee98a23f95e7897895da9f148b4e910535779f779a26f5c192925386a99a70e9d22540a5421d646
     HEAD_REF master
+    PATCHES
+        fix-libusb.diff
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
+    DISABLE_PARALLEL_CONFIGURE # writes to include/libcaer/libcaer.h
     OPTIONS
         -DENABLE_OPENCV=ON
         -DEXAMPLES_INSTALL=OFF
@@ -18,8 +20,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "libcaer" CONFIG_PATH "share/libcaer")
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libcaer/vcpkg.json
+++ b/ports/libcaer/vcpkg.json
@@ -1,13 +1,16 @@
 {
   "name": "libcaer",
   "version-date": "2022-07-25",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Minimal C library to access, configure and get data from neuromorphic sensors and processors.",
   "homepage": "https://gitlab.com/inivation/dv/libcaer",
   "license": "BSD-2-Clause",
   "dependencies": [
     "libusb",
-    "opencv4",
+    {
+      "name": "opencv4",
+      "default-features": false
+    },
     "pkgconf",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3766,7 +3766,7 @@
     },
     "libcaer": {
       "baseline": "2022-07-25",
-      "port-version": 2
+      "port-version": 3
     },
     "libcanberra": {
       "baseline": "0.30",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2146,7 +2146,7 @@
     },
     "dv-processing": {
       "baseline": "1.7.8",
-      "port-version": 0
+      "port-version": 1
     },
     "dx": {
       "baseline": "1.0.1",

--- a/versions/d-/dv-processing.json
+++ b/versions/d-/dv-processing.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eb0a76029b92d2df35bb050c66c6adf43ab6df54",
+      "git-tree": "d501b6b860a75321634d378924af617142341fce",
       "version": "1.7.8",
       "port-version": 1
     },

--- a/versions/d-/dv-processing.json
+++ b/versions/d-/dv-processing.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d870e09729d36b26a63bd4cc38b0a04f5b6c1486",
+      "git-tree": "eb0a76029b92d2df35bb050c66c6adf43ab6df54",
       "version": "1.7.8",
       "port-version": 1
     },

--- a/versions/d-/dv-processing.json
+++ b/versions/d-/dv-processing.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d501b6b860a75321634d378924af617142341fce",
+      "git-tree": "8b60bb354ea9ab03a96d4ab7c0c51bca9580cf72",
       "version": "1.7.8",
       "port-version": 1
     },

--- a/versions/d-/dv-processing.json
+++ b/versions/d-/dv-processing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d870e09729d36b26a63bd4cc38b0a04f5b6c1486",
+      "version": "1.7.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "0ea0c583d83278f6190e7d0734425c65347555d8",
       "version": "1.7.8",
       "port-version": 0

--- a/versions/l-/libcaer.json
+++ b/versions/l-/libcaer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "131181ae3b3608e511cf7db3c3091612b8af0e03",
+      "version-date": "2022-07-25",
+      "port-version": 3
+    },
+    {
       "git-tree": "ccbe6ec937f8f140cd99fb3a88b7afcb65ad3389",
       "version-date": "2022-07-25",
       "port-version": 2


### PR DESCRIPTION
[libcaer] Fix export of libusb dependency.
[dv-processing] Fixes configuration race. (https://github.com/microsoft/vcpkg/pull/29843#issuecomment-1458339685)

`dv-processing[tools]` is known to build on Windows (MSVC, tested in vcpkg CI) and on macOS (more recent toolchain than in vcpkg CI, tested locally).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
