### PR TITLE
[baseline][cppkafka] Add DISABLE_PARALLEL_CONFIGURE

### DIFF
--- a/ports/cppkafka/portfile.cmake
+++ b/ports/cppkafka/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mfontanini/cppkafka
-    REF v0.3.1
+    REF "v${VERSION}"
     SHA512 60d01ce1dd9bd9119676be939ed5ab03539abb1f945c1b31e432edfe0f06542778f7fef37696f5ff19c53024f44d5cbd8aeddbbb231c38b098e05285d3ff0cab
     HEAD_REF master
     PATCHES fix-dynamic.patch
@@ -15,6 +15,7 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
        -DCPPKAFKA_BUILD_SHARED=${CPPKAFKA_BUILD_SHARED}
        -DCPPKAFKA_DISABLE_TESTS=ON
@@ -28,4 +29,4 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cppkafka/vcpkg.json
+++ b/ports/cppkafka/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppkafka",
-  "version-string": "0.3.1",
+  "version": "0.3.1",
   "port-version": 5,
   "description": "cppkafka allows C++ applications to consume and produce messages using the Apache Kafka protocol. The library is built on top of librdkafka, and provides a high level API that uses modern C++ features to make it easier to write code while keeping the wrapper's performance overhead to a minimum.",
   "homepage": "https://github.com/mfontanini/cppkafka",

--- a/ports/cppkafka/vcpkg.json
+++ b/ports/cppkafka/vcpkg.json
@@ -1,18 +1,15 @@
 {
   "name": "cppkafka",
   "version-string": "0.3.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "cppkafka allows C++ applications to consume and produce messages using the Apache Kafka protocol. The library is built on top of librdkafka, and provides a high level API that uses modern C++ features to make it easier to write code while keeping the wrapper's performance overhead to a minimum.",
   "homepage": "https://github.com/mfontanini/cppkafka",
+  "license": "BSD-2-Clause",
   "dependencies": [
     "boost-program-options",
     "librdkafka",
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1762,7 +1762,7 @@
     },
     "cppkafka": {
       "baseline": "0.3.1",
-      "port-version": 4
+      "port-version": 5
     },
     "cppmicroservices": {
       "baseline": "3.6.0",

--- a/versions/c-/cppkafka.json
+++ b/versions/c-/cppkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a33f71df221cb16bb2f7b1ce5d9cd0043a525e00",
+      "version": "0.3.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "c06b1731643d212f178623c88e8319c4c40104dc",
       "version-string": "0.3.1",
       "port-version": 4


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes `cppkafka:x64-osx` failed to install in [CI baseline](https://dev.azure.com/vcpkg/public/_build/results?buildId=86378&view=results) with below error:
```
CMake Error at include/cppkafka/CMakeLists.txt:13 (configure_file):
  No such file or directory
```
This error is because the CMakeLists.txt of cppkafka has the following contents:
```
#create file from template
configure_file(${PROJECT_SOURCE_DIR}/cppkafka.h.in ${CPPKAFKA_HEADER})
```
Adding `DISABLE_PARALLEL_CONFIGURE` option into the `vcpkg_cmake_configure()` to fix this issue.
Modernize `portfile.cmake` and remove unused dependence.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
