### PR TITLE
[backward-cpp] new port

### DIFF
--- a/ports/backward-cpp/portfile.cmake
+++ b/ports/backward-cpp/portfile.cmake
@@ -6,13 +6,14 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+set(VCPKG_BUILD_TYPE release) # header-only
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME Backward CONFIG_PATH lib/backward)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/backward-cpp/portfile.cmake
+++ b/ports/backward-cpp/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bombela/backward-cpp
+    REF v1.6
+    SHA512 db0256a54819952ff1d92e05d6ab81fe979d4826ebb6651b6b08c30e7a0091879dfeff33d81f9599462152ce68e61e2c8c42bf039129bc6b28d1e68b1eab039b
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME Backward CONFIG_PATH lib/backward)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/backward-cpp/portfile.cmake
+++ b/ports/backward-cpp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bombela/backward-cpp
-    REF v1.6
+    REF "v${VERSION}"
     SHA512 db0256a54819952ff1d92e05d6ab81fe979d4826ebb6651b6b08c30e7a0091879dfeff33d81f9599462152ce68e61e2c8c42bf039129bc6b28d1e68b1eab039b
     HEAD_REF master
 )

--- a/ports/backward-cpp/vcpkg.json
+++ b/ports/backward-cpp/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "1.6",
   "description": "A beautiful stack trace pretty printer for C++",
   "homepage": "https://github.com/bombela/backward-cpp",
+  "supports": "!uwp & !arm",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/backward-cpp/vcpkg.json
+++ b/ports/backward-cpp/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "backward-cpp",
+  "version": "1.6",
+  "description": "A beautiful stack trace pretty printer for C++",
+  "homepage": "https://github.com/bombela/backward-cpp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/backward-cpp/vcpkg.json
+++ b/ports/backward-cpp/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.6",
   "description": "A beautiful stack trace pretty printer for C++",
   "homepage": "https://github.com/bombela/backward-cpp",
-  "supports": "!uwp & !arm",
+  "supports": "!uwp & !(windows & arm)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/b-/backward-cpp.json
+++ b/versions/b-/backward-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0c673f2e097afa52ac617187f74b9018d4752232",
+      "version": "1.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/b-/backward-cpp.json
+++ b/versions/b-/backward-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b296d15ccf55d0069686188877d2d0e5d2aa479b",
+      "git-tree": "ea0cf57b656a5ee3a6b0c7b6309f250626e17790",
       "version": "1.6",
       "port-version": 0
     }

--- a/versions/b-/backward-cpp.json
+++ b/versions/b-/backward-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ea0cf57b656a5ee3a6b0c7b6309f250626e17790",
+      "git-tree": "9fe9415288ccddfe52b145034d889427c54a1ac7",
       "version": "1.6",
       "port-version": 0
     }

--- a/versions/b-/backward-cpp.json
+++ b/versions/b-/backward-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0c673f2e097afa52ac617187f74b9018d4752232",
+      "git-tree": "b296d15ccf55d0069686188877d2d0e5d2aa479b",
       "version": "1.6",
       "port-version": 0
     }

--- a/versions/b-/backward-cpp.json
+++ b/versions/b-/backward-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9fe9415288ccddfe52b145034d889427c54a1ac7",
+      "git-tree": "9f204819a5063dea81b56369e5ce424219e56ca5",
       "version": "1.6",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -468,6 +468,10 @@
       "baseline": "2.0.0.1",
       "port-version": 2
     },
+    "backward-cpp": {
+      "baseline": "1.6",
+      "port-version": 0
+    },
     "basisu": {
       "baseline": "1.11",
       "port-version": 7


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
