### PR TITLE
[mfl] fix clang build

### DIFF
--- a/ports/mfl/fix-clang-detection.patch
+++ b/ports/mfl/fix-clang-detection.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/CompilerWarnings.cmake b/cmake/CompilerWarnings.cmake
+index 34f1cc8..bda884d 100644
+--- a/cmake/CompilerWarnings.cmake
++++ b/cmake/CompilerWarnings.cmake
+@@ -79,7 +79,7 @@ function(set_project_warnings project_name)
+ 
+     if(MSVC)
+         set(PROJECT_WARNINGS ${MSVC_WARNINGS})
+-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
++    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+         set(PROJECT_WARNINGS ${CLANG_WARNINGS})
+     else()
+         set(PROJECT_WARNINGS ${GCC_WARNINGS})

--- a/ports/mfl/portfile.cmake
+++ b/ports/mfl/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         disable-tests.patch
+        fix-clang-detection.patch
 )
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")

--- a/ports/mfl/vcpkg.json
+++ b/ports/mfl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mfl",
   "version": "0.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Computes the layout information for mathematical formulas provided in TeX-like syntax.",
   "homepage": "https://github.com/cpp-niel/mfl",
   "license": "MIT",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -547,9 +547,7 @@ mecab:x86-windows        = skip
 # Missing dependent libraries.
 mesa:x64-linux=fail
 mesa:x64-osx=fail
-mfl:x64-linux=skip
-mfl:x64-osx=skip
-mfl:arm64-osx=skip
+mfl:x64-linux=fail # requires a c++20 compiler
 milerius-sfml-imgui:x64-windows-static=fail
 miniupnpc:arm-uwp=fail
 miniupnpc:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5038,7 +5038,7 @@
     },
     "mfl": {
       "baseline": "0.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "mfx-dispatch": {
       "baseline": "1.35.1",

--- a/versions/m-/mfl.json
+++ b/versions/m-/mfl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a987e0da7b7b8bee335c9764cf2b8abcc6b68d2a",
+      "version": "0.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "5ad7af919e311136c6d46434a2a71b5e064a2d67",
       "version": "0.0.1",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
