### PR TITLE
[libde265] use supports expression

### DIFF
--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libde265",
   "version": "1.0.8",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",
   "license": "LGPL-3.0-only",
@@ -18,7 +18,8 @@
   ],
   "features": {
     "sse": {
-      "description": "Enable SSE optimizations"
+      "description": "Enable SSE optimizations",
+      "supports": "x86 | x64"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3842,7 +3842,7 @@
     },
     "libde265": {
       "baseline": "1.0.8",
-      "port-version": 6
+      "port-version": 7
     },
     "libdeflate": {
       "baseline": "1.17",

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bba9b6bf501c046f81f7335d1efff23ed0845ed4",
+      "version": "1.0.8",
+      "port-version": 7
+    },
+    {
       "git-tree": "0f781eec5a444ba998fc1e8e3dd31172806005d3",
       "version": "1.0.8",
       "port-version": 6


### PR DESCRIPTION
SSE is only available on x86/x64 architectures 