### PR TITLE
[libdivide] no werror et al

### DIFF
--- a/ports/libdivide/no-werror.patch
+++ b/ports/libdivide/no-werror.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7800a13..f01a139 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,10 +15,10 @@ include(CMakeSanitize)
+ 
+ # Maximum warnings level & warnings as error
+ add_compile_options(
+-    "$<$<CXX_COMPILER_ID:MSVC>:/W4;/WX>"
+-    "$<$<CXX_COMPILER_ID:GNU>:-Wall;-Wextra;-pedantic;-Werror>"
+-    "$<$<CXX_COMPILER_ID:Clang>:-Wall;-Wextra;-pedantic;-Werror>"
+-    "$<$<CXX_COMPILER_ID:AppleClang>:-Wall;-Wextra;-pedantic;-Werror>"
++    "$<$<CXX_COMPILER_ID:MSVC>:/W4>"
++    "$<$<CXX_COMPILER_ID:GNU>:-Wall;-Wextra;-pedantic>"
++    "$<$<CXX_COMPILER_ID:Clang>:-Wall;-Wextra;-pedantic>"
++    "$<$<CXX_COMPILER_ID:AppleClang>:-Wall;-Wextra;-pedantic>"
+ )
+ 
+ # Build options ################################################

--- a/ports/libdivide/portfile.cmake
+++ b/ports/libdivide/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 5.0
     SHA512 89581efab63a0668405196d4d8188e03f3b87027e9014ef7238e1d79fe369d8abbca0e44b00cf02b00be29c272feb34c9b9290313596adbef9b46ae0715c29dd
     HEAD_REF master
+    PATCHES
+        no-werror.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libdivide/vcpkg.json
+++ b/ports/libdivide/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdivide",
   "version": "5.0",
+  "port-version": 1,
   "description": "libdivide.h is a header-only C/C++ library for optimizing integer division.",
   "homepage": "https://github.com/ridiculousfish/libdivide",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3854,7 +3854,7 @@
     },
     "libdivide": {
       "baseline": "5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libdjinterop": {
       "baseline": "0.16.0",

--- a/versions/l-/libdivide.json
+++ b/versions/l-/libdivide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c646f5a84a408b48ecdad13220a2186fa4b4e692",
+      "version": "5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b13f3b926e61d104e85e04bf192fabe29cd5f05e",
       "version": "5.0",
       "port-version": 0


### PR DESCRIPTION
Don't use `-Werror` et al. It caused the build to fail on osx for the `test` feature. 