### PR TITLE
[pcl] fix example feature

### DIFF
--- a/ports/pcl/vcpkg.json
+++ b/ports/pcl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pcl",
   "version": "1.13.0",
+  "port-version": 1,
   "description": "Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.",
   "homepage": "https://github.com/PointCloudLibrary/pcl",
   "license": "BSD-3-Clause",
@@ -61,7 +62,12 @@
     "examples": {
       "description": "Build PCL examples",
       "dependencies": [
-        "vtk"
+        {
+          "name": "pcl",
+          "features": [
+            "visualization"
+          ]
+        }
       ]
     },
     "libusb": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5974,7 +5974,7 @@
     },
     "pcl": {
       "baseline": "1.13.0",
-      "port-version": 0
+      "port-version": 1
     },
     "pcre": {
       "baseline": "8.45",

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b992407a0319c7dc434236acb567e629367d8eff",
+      "version": "1.13.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f295f2d1ea57514c89835cd797fa8cca1d0b5fdf",
       "version": "1.13.0",
       "port-version": 0


### PR DESCRIPTION
Currently no example was build because the [`examples` "subsystem" depends](https://github.com/PointCloudLibrary/pcl/blob/master/examples/CMakeLists.txt#L3) on [`outofcore` which depends on](https://github.com/PointCloudLibrary/pcl/blob/master/outofcore/CMakeLists.txt#L3) `visualization`