### PR TITLE
[plplot] fix example x11

### DIFF
--- a/ports/plplot/vcpkg.json
+++ b/ports/plplot/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "plplot",
   "version-semver": "5.15.0",
+  "port-version": 1,
   "description": "PLplot is a cross-platform software package for creating scientific plots whose (UTF-8) plot symbols and text are limited in practice only by what Unicode-aware system fonts are installed on a user's computer.",
   "homepage": "http://plplot.org/",
   "license": null,
@@ -32,6 +33,12 @@
     "x11": {
       "description": "Enable X11 support",
       "dependencies": [
+        {
+          "name": "cairo",
+          "features": [
+            "x11"
+          ]
+        },
         "libx11"
       ]
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6114,7 +6114,7 @@
     },
     "plplot": {
       "baseline": "5.15.0",
-      "port-version": 0
+      "port-version": 1
     },
     "plustache": {
       "baseline": "0.4.0",

--- a/versions/p-/plplot.json
+++ b/versions/p-/plplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fb1fa2f2f5f9c3ea3543f5ba3074138be2d2320",
+      "version-semver": "5.15.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "64ccc268bbc73be54e54d41880327163e2c96d54",
       "version-semver": "5.15.0",
       "port-version": 0


### PR DESCRIPTION
It currently failed with
```
FAILED: src/CMakeFiles/plplot.dir/__/drivers/cairo.c.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DPLPLOT_HAVE_CONFIG_H -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/plplot/src/5453324556-b51b1f0191.clean/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/plplot/src/5453324556-b51b1f0191.clean/lib/qsastime -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/plplot/arm64-osx-dbg -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/plplot/arm64-osx-dbg/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/plplot/arm64-osx-dbg/lib/qsastime -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/plplot/arm64-osx-dbg/lib/csa -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk -fPIC -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include/pango-1.0 -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include/glib-2.0 -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../lib/glib-2.0/include -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include/fribidi -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include/harfbuzz -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include/cairo -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include/libpng16 -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../../include/pixman-1 -I/opt/X11/include -I/opt/homebrew/include -MD -MT src/CMakeFiles/plplot.dir/__/drivers/cairo.c.o -MF src/CMakeFiles/plplot.dir/__/drivers/cairo.c.o.d -o src/CMakeFiles/plplot.dir/__/drivers/cairo.c.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/plplot/src/5453324556-b51b1f0191.clean/drivers/cairo.c
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/plplot/src/5453324556-b51b1f0191.clean/drivers/cairo.c:49:10: fatal error: 'cairo-xlib.h' file not found
#include <cairo-xlib.h>
         ^~~~~~~~~~~~~~
1 error generated.
```