### PR TITLE
[nifticlib] fix installation of cmake config files

### DIFF
--- a/ports/nifticlib/portfile.cmake
+++ b/ports/nifticlib/portfile.cmake
@@ -41,7 +41,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/NIFTI PACKAGE_NAME nifti)
 
 if(TOOL_NAMES)
     vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)

--- a/ports/nifticlib/vcpkg.json
+++ b/ports/nifticlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nifticlib",
   "version-date": "2020-04-30",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Nifticlib is a C I/O library for reading and writing files in the nifti-1 data format.",
   "homepage": "https://github.com/NIFTI-Imaging/nifti_clib",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5446,7 +5446,7 @@
     },
     "nifticlib": {
       "baseline": "2020-04-30",
-      "port-version": 3
+      "port-version": 4
     },
     "nlohmann-fifo-map": {
       "baseline": "2018.05.07",

--- a/versions/n-/nifticlib.json
+++ b/versions/n-/nifticlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d889870db5d6d2e5afc8e738c6f6451c7d237a4c",
+      "version-date": "2020-04-30",
+      "port-version": 4
+    },
+    {
       "git-tree": "3c571b3db6efc2e8065ba99424995e6d720a444f",
       "version-date": "2020-04-30",
       "port-version": 3


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/pull/29371#discussion_r1126605508.
Now the following is emitted:
```
nifticlib provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(NIFTI CONFIG REQUIRED)
    target_link_libraries(main PRIVATE NIFTI::znz NIFTI::niftiio)
```