### PR TITLE
[nativefiledialog-extended] new port

### DIFF
--- a/ports/nativefiledialog-extended/portfile.cmake
+++ b/ports/nativefiledialog-extended/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO btzy/nativefiledialog-extended
+    REF v${VERSION}
+    SHA512 3992b4e9ea87fd2f0f85c9e5952fb19b7006f2c9709f1b1c4925de329f3dc1065d2c1af851cba4afbbfa95f0ed764ec36a1f55d7a4720e813563e4e6f533024a
+    HEAD_REF master
+)
+
+set(NFDE_SHARED OFF)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(NFDE_SHARED ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=${NFDE_SHARED}
+        -DNFD_PORTAL=${VCPKG_TARGET_IS_LINUX}
+        -DNFD_BUILD_TESTS=OFF
+        -DNFD_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/nativefiledialog-extended/vcpkg.json
+++ b/ports/nativefiledialog-extended/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "nativefiledialog-extended",
+  "version-semver": "1.0.1",
+  "description": "Native file dialog library with C and C++ bindings, based on mlabbe/nativefiledialog.",
+  "homepage": "https://github.com/btzy/nativefiledialog-extended",
+  "license": "Zlib",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "dbus",
+      "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5372,6 +5372,10 @@
       "baseline": "2022-01-20",
       "port-version": 0
     },
+    "nativefiledialog-extended": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "nayuki-qr-code-generator": {
       "baseline": "1.7.0",
       "port-version": 0

--- a/versions/n-/nativefiledialog-extended.json
+++ b/versions/n-/nativefiledialog-extended.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "17f057dc556c581c20bc36d92ee2e9e90b1ac4fb",
+      "version-semver": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.

This port doesn't provide a CMake config, so that's why there is no usage.