### PR TITLE
[quickfast] add missing dependency

### DIFF
--- a/ports/quickfast/vcpkg.json
+++ b/ports/quickfast/vcpkg.json
@@ -1,11 +1,13 @@
 {
   "name": "quickfast",
-  "version-string": "1.5",
-  "port-version": 2,
+  "version": "1.5",
+  "port-version": 3,
   "description": "QuickFAST is an Open Source native C++ implementation of the FAST Protocol [SM].",
   "homepage": "https://github.com/objectcomputing/quickfast",
+  "license": "BSD-3-Clause",
   "dependencies": [
     "boost-asio",
+    "boost-thread",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6714,7 +6714,7 @@
     },
     "quickfast": {
       "baseline": "1.5",
-      "port-version": 2
+      "port-version": 3
     },
     "quickfix": {
       "baseline": "1.15.1",

--- a/versions/q-/quickfast.json
+++ b/versions/q-/quickfast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77f7681738424a915e7c12e3b9ea0576c5549032",
+      "version": "1.5",
+      "port-version": 3
+    },
+    {
       "git-tree": "0fccc4f826e7b7002dca145c70c29dd1c062d6d6",
       "version-string": "1.5",
       "port-version": 2


### PR DESCRIPTION
Adds a missing dependency to `boost-thread`. Before that the build failed with 
```
CMake Error at /Users/leanderSchulten/git_projekte/vcpkg/downloads/tools/cmake-3.25.1-osx/cmake-3.25.1-macos-universal/CMake.app/Contents/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Boost (missing: thread) (found version "1.81.0")
Call Stack (most recent call first):
  /Users/leanderSchulten/git_projekte/vcpkg/downloads/tools/cmake-3.25.1-osx/cmake-3.25.1-macos-universal/CMake.app/Contents/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /Users/leanderSchulten/git_projekte/vcpkg/downloads/tools/cmake-3.25.1-osx/cmake-3.25.1-macos-universal/CMake.app/Contents/share/cmake-3.25/Modules/FindBoost.cmake:2376 (find_package_handle_standard_args)
  /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/share/boost/vcpkg-cmake-wrapper.cmake:11 (_find_package)
  /Users/leanderSchulten/git_projekte/vcpkg/scripts/buildsystems/vcpkg.cmake:806 (include)
  CMakeLists.txt:6 (find_package)
```