### PR TITLE
[libmysql] add missing find_dependency

### DIFF
--- a/ports/libmysql/export-cmake-targets.patch
+++ b/ports/libmysql/export-cmake-targets.patch
@@ -11,7 +11,7 @@ index c3a05ec..0d44ef2 100644
    ""
    ${ARGN}
    )
-@@ -115,7 +115,20 @@ FUNCTION(MYSQL_INSTALL_TARGETS)
+@@ -115,7 +115,21 @@ FUNCTION(MYSQL_INSTALL_TARGETS)
    IF(ARG_COMPONENT)
      SET(COMP COMPONENT ${ARG_COMPONENT})
    ENDIF()
@@ -21,6 +21,7 @@ index c3a05ec..0d44ef2 100644
 +"include(CMakeFindDependencyMacro)
 +find_dependency(ZLIB)
 +find_dependency(OpenSSL)
++find_dependency(Threads)
 +include(\"\${CMAKE_CURRENT_LIST_DIR}/${ARG_EXPORT}-targets.cmake\")
 +")
 +    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${ARG_EXPORT}-config.cmake DESTINATION share/${ARG_EXPORT})

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -2,6 +2,10 @@ if (EXISTS "${CURRENT_INSTALLED_DIR}/include/mysql/mysql.h")
     message(FATAL_ERROR "FATAL ERROR: ${PORT} and libmariadb are incompatible.")
 endif()
 
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    message(WARNING "'autoconf-archive' must be installed via your system package manager (brew, apt, etc.).")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mysql/mysql-server
@@ -62,6 +66,10 @@ vcpkg_cmake_configure(
         -DFORCE_UNSUPPORTED_COMPILER=${FORCE_UNSUPPORTED_COMPILER}
         -DINSTALL_STATIC_LIBRARIES=${BUILD_STATIC_LIBS}
         -DLINK_STATIC_RUNTIME_LIBRARIES=${STATIC_CRT_LINKAGE}
+    MAYBE_UNUSED_VARIABLES
+        BUNDLE_RUNTIME_LIBRARIES # only on windows
+        LINK_STATIC_RUNTIME_LIBRARIES # only on windows
+        WIX_DIR # only on windows
 )
 
 vcpkg_cmake_install(ADD_BIN_TO_PATH)

--- a/ports/libmysql/vcpkg.json
+++ b/ports/libmysql/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmysql",
   "version": "8.0.20",
-  "port-version": 9,
+  "port-version": 10,
   "description": "A MySQL client library for C development",
   "homepage": "https://github.com/mysql/mysql-server",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4194,7 +4194,7 @@
     },
     "libmysql": {
       "baseline": "8.0.20",
-      "port-version": 9
+      "port-version": 10
     },
     "libnice": {
       "baseline": "0.1.18",

--- a/versions/l-/libmysql.json
+++ b/versions/l-/libmysql.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "099f0d084c8fdad082e86d8291fb2de18f9e73d4",
+      "version": "8.0.20",
+      "port-version": 10
+    },
+    {
       "git-tree": "3ee63ba895261bab75a62db6f77937f6a3381c43",
       "version": "8.0.20",
       "port-version": 9


### PR DESCRIPTION
The targets `INTERFACE_LINK_LIBRARIES` contains `\$<LINK_ONLY:Threads::Threads>`, but there was not `find_dependency` for this target. 

This fixes the build of `poco[mysql]`