### PR TITLE
[paraview] add missing dependency

### DIFF
--- a/ports/paraview/vcpkg.json
+++ b/ports/paraview/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "paraview",
   "version": "5.11.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "VTK-based Data Analysis and Visualization Application",
   "homepage": "https://www.paraview.org/",
   "license": "BSD-3-Clause",
@@ -12,6 +12,7 @@
     "cgns",
     "protobuf",
     "qt5compat",
+    "qtsvg",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -83,10 +84,7 @@
       ]
     },
     "tools": {
-      "description": "Build paraview tools",
-      "dependencies": [
-        "qtsvg"
-      ]
+      "description": "Build paraview tools"
     },
     "vtkm": {
       "description": "enables vtkm for the build of paraview",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5950,7 +5950,7 @@
     },
     "paraview": {
       "baseline": "5.11.0",
-      "port-version": 1
+      "port-version": 2
     },
     "parmetis": {
       "baseline": "2022-07-27",

--- a/versions/p-/paraview.json
+++ b/versions/p-/paraview.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b93a58c420dc6478318aba2958a0334a7759b36",
+      "version": "5.11.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "7076e5d1dc86dc41ca0f3ad6567ffbe06b86166c",
       "version": "5.11.0",
       "port-version": 1


### PR DESCRIPTION
paraview depends on `qtsvg`
```
-- Could NOT find Qt6Svg (missing: Qt6Svg_DIR)
CMake Warning at /Users/leanderSchulten/git_projekte/vcpkg/scripts/buildsystems/vcpkg.cmake:852 (_find_package):
  Found package configuration file:

    /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/share/Qt6/Qt6Config.cmake

  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT
  FOUND.  Reason given by package:

  Failed to find required Qt component "Svg".

  Expected Config file at
  "/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/share/Qt6Svg/Qt6SvgConfig.cmake"
  does NOT exist

  

  Configuring with --debug-find-pkg=Qt6Svg might reveal details why the
  package was not found.

  Configuring with -DQT_DEBUG_FIND_PACKAGE=ON will print the values of some
  of the path variables that find_package uses to try and find the package.

Call Stack (most recent call first):
  /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/share/vtk/vtkModule.cmake:4573 (find_package)
  Qt/ApplicationComponents/CMakeLists.txt:322 (vtk_module_find_package)


CMake Error at /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/share/vtk/vtkModule.cmake:4579 (message):
  Could not find the Qt6 external dependency.
Call Stack (most recent call first):
  Qt/ApplicationComponents/CMakeLists.txt:322 (vtk_module_find_package)
```