### PR TITLE
[szip] Allow cross compiling for arm64-osx

### DIFF
--- a/ports/szip/portfile.cmake
+++ b/ports/szip/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_extract_source_archive_ex(
         mingw-lib-names.patch
 )
 
-if (VCPKG_TARGET_IS_IOS)
+if (VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_OSX)
     # when cross-compiling, try_run will not work.
     # LFS "large file support" is keyed on 
     # 1) 64-bit off_t (https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/transition/transition.html table 2-1)

--- a/ports/szip/vcpkg.json
+++ b/ports/szip/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "szip",
   "version": "2.1.1",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Szip compression software, providing lossless compression of scientific data",
   "homepage": "https://support.hdfgroup.org/ftp/lib-external/szip",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7630,7 +7630,7 @@
     },
     "szip": {
       "baseline": "2.1.1",
-      "port-version": 9
+      "port-version": 10
     },
     "tabulate": {
       "baseline": "1.4",

--- a/versions/s-/szip.json
+++ b/versions/s-/szip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d56cd5d38926df8d26c6ed3a829a392726ee27a",
+      "version": "2.1.1",
+      "port-version": 10
+    },
+    {
       "git-tree": "f07c4350652c50e80bc78edb3db20a1c748d99ec",
       "version": "2.1.1",
       "port-version": 9


### PR DESCRIPTION
I was thinking about adding a check for "HOST_ARCH != TARGET_ARCH", so whenever we are _not_ cross compiling the check would still be run. But if we trust that the check can be avoided we don't even need to run it when not cross compiling.