### PR TITLE
[cminpack] Fix exported config, add usage

### DIFF
--- a/ports/cminpack/portfile.cmake
+++ b/ports/cminpack/portfile.cmake
@@ -18,4 +18,5 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/CopyrightMINPACK.txt")

--- a/ports/cminpack/portfile.cmake
+++ b/ports/cminpack/portfile.cmake
@@ -13,9 +13,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
 vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# # Handle copyright
-file(INSTALL "${SOURCE_PATH}/CopyrightMINPACK.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/CopyrightMINPACK.txt")

--- a/ports/cminpack/usage
+++ b/ports/cminpack/usage
@@ -1,0 +1,9 @@
+cminpack provides CMake targets:
+
+    find_package(CMinpack CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE cminpack::cminpack)
+
+    # alternative for single precision
+    target_link_libraries(main PRIVATE cminpack::cminpacks)
+    # alternative for long double precision
+    target_link_libraries(main PRIVATE cminpack::cminpackld)

--- a/ports/cminpack/vcpkg.json
+++ b/ports/cminpack/vcpkg.json
@@ -1,12 +1,17 @@
 {
   "name": "cminpack",
   "version": "1.3.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A C/C++ rewrite of the MINPACK software (originally in FORTRAN) for solving nonlinear equations and nonlinear least squares problems",
   "homepage": "http://devernay.free.fr/hacks/cminpack/",
+  "license": null,
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1574,7 +1574,7 @@
     },
     "cminpack": {
       "baseline": "1.3.8",
-      "port-version": 1
+      "port-version": 2
     },
     "cmocka": {
       "baseline": "2020-08-01",

--- a/versions/c-/cminpack.json
+++ b/versions/c-/cminpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "141d26f7fd5eb7d8bebdabbbb05d4ca23fd8fbbf",
+      "version": "1.3.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "6e903be11f8d868d5fb74f597bc0d2890854eb95",
       "version": "1.3.8",
       "port-version": 1


### PR DESCRIPTION
Fixes #30139.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
