### PR TITLE
[qscintilla] update version to 2.13.4

### DIFF
--- a/ports/qscintilla/fix-static.patch
+++ b/ports/qscintilla/fix-static.patch
@@ -16,9 +16,9 @@ index 8d0acd2..2246442 100644
 -!CONFIG(staticlib) {
 +!CONFIG(static) {
      DEFINES += QSCINTILLA_MAKE_DLL
- }
- DEFINES += SCINTILLA_QT SCI_LEXER INCLUDE_DEPRECATED_FEATURES
-@@ -82,7 +82,7 @@ qsci.files = ../qsci
+ 
+     # Comment this in to build a dynamic library supporting multiple
+@@ -86,7 +86,7 @@ qsci.files = ../qsci
  INSTALLS += qsci
  
  features.path = $$[QT_HOST_DATA]/mkspecs/features

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -1,11 +1,11 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz"
-    FILENAME "QScintilla-2.12.0.tar.gz"
-    SHA512 9bdaba5c33c1b11ccad83eb1fda72142758afc50c955a62d5a8ff102b41d4b67d897bf96ce0540e16bc5a7fae2ce1acbf06931d5f0ae6768759c9ff072c03daa
+    URLS "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.13.4/QScintilla_src-2.13.4.tar.gz"
+    FILENAME "QScintilla-2.13.4.tar.gz"
+    SHA512 591379f4d48a6de1bc61db93f6c0d1c48b6830a852679b51e27debb866524c320e2db27d919baf32576c2bf40bba62e38378673a86f22db9839746e26b0f77cd
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
+vcpkg_extract_source_archive(
+    SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     PATCHES
         fix-static.patch

--- a/ports/qscintilla/vcpkg.json
+++ b/ports/qscintilla/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "qscintilla",
-  "version": "2.12.0",
-  "port-version": 1,
+  "version": "2.13.4",
   "description": "QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)",
   "homepage": "https://www.riverbankcomputing.com/software/qscintilla",
-  "supports": "!(windows & (arm | arm64))",
+  "license": "GPL-3.0-or-later",
   "dependencies": [
     {
       "name": "qt5-base",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6329,8 +6329,8 @@
       "port-version": 3
     },
     "qscintilla": {
-      "baseline": "2.12.0",
-      "port-version": 1
+      "baseline": "2.13.4",
+      "port-version": 0
     },
     "qt": {
       "baseline": "6.4.2",

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7698a4b73e3ed54fd0cf66cf9e754317763750cb",
+      "version": "2.13.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "63f2d1f0287a6d61b5c85b428920b0fbe102adec",
       "version": "2.12.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
