### PR TITLE
[libcbor] Update to 0.10.2

### DIFF
--- a/ports/libcbor/portfile.cmake
+++ b/ports/libcbor/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PJK/libcbor
-    REF v0.9.0
-    SHA512 710239f69d770212a82e933e59df1aba0fb3ec516ef6666a366f30a950565a52981b0d46ca7e0eea739f5785d79cc21fc19acd857a4a0b135f4f6aa3ef5fd3b0
+    REF "v${VERSION}"
+    SHA512 23c6177443778d4b4833ec7ed0d0e639a0d4863372e3a38d772fdce2673eae6d5cb2a31a2a021d1a699082ea53494977c907fd0e94149b97cb23a4b6d039228a
     HEAD_REF master
 )
 
@@ -27,4 +27,4 @@ vcpkg_fixup_pkgconfig()
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/LibCborConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/libcbor/vcpkg.json
+++ b/ports/libcbor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcbor",
-  "version": "0.9.0",
+  "version": "0.10.2",
   "description": "libcbor is a C library for parsing and generating CBOR, the general-purpose schema-less binary data format",
   "homepage": "https://github.com/PJK/libcbor",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3781,7 +3781,7 @@
       "port-version": 4
     },
     "libcbor": {
-      "baseline": "0.9.0",
+      "baseline": "0.10.2",
       "port-version": 0
     },
     "libcds": {

--- a/versions/l-/libcbor.json
+++ b/versions/l-/libcbor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "434c0fd1a103f04179d26deb7f092a99484c1aa4",
+      "version": "0.10.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "5e881ce93b52a9b16f4c03e4bed79c661def7631",
       "version": "0.9.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #30161, no feature to be teated.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.