### PR TITLE
[qtdeclarative] Add qmlls tool

### DIFF
--- a/ports/qtdeclarative/portfile.cmake
+++ b/ports/qtdeclarative/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_buildpath_length_warning(44)
         qmltyperegistrar
         qmldom
         qmltc
+        qmlls
     )
 
 qt_install_submodule(PATCHES    ${${PORT}_PATCHES}

--- a/ports/qtdeclarative/vcpkg.json
+++ b/ports/qtdeclarative/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtdeclarative",
   "version": "6.4.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Declarative (Quick 2)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6554,7 +6554,7 @@
     },
     "qtdeclarative": {
       "baseline": "6.4.2",
-      "port-version": 1
+      "port-version": 2
     },
     "qtdeviceutilities": {
       "baseline": "6.4.2",

--- a/versions/q-/qtdeclarative.json
+++ b/versions/q-/qtdeclarative.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c82d03c38977a78521811ef6f91197b7f75f03e",
+      "version": "6.4.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "70badba61897e63a26540f70ff53e0df92ff01bb",
       "version": "6.4.2",
       "port-version": 1


### PR DESCRIPTION
Fixes #30152

Add miss tool qmlls to qtdeclarative
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

