### PR TITLE
Use msys2 bash regardless of target and of Windows Apps

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -201,7 +201,52 @@ function(vcpkg_configure_make)
 
     set(configure_env "V=1")
 
-    # macOS - cross-compiling support
+    # Establish a bash environment as expected by autotools.
+    if(CMAKE_HOST_WIN32)
+        list(APPEND msys_require_packages binutils libtool autoconf automake-wrapper automake1.16 m4 which)
+        vcpkg_acquire_msys(MSYS_ROOT PACKAGES ${msys_require_packages} ${arg_ADDITIONAL_MSYS_PACKAGES})
+        set(base_cmd "${MSYS_ROOT}/usr/bin/bash.exe" --noprofile --norc --debug)
+        vcpkg_list(SET add_to_env)
+        if(arg_USE_WRAPPERS AND VCPKG_TARGET_IS_WINDOWS)
+            vcpkg_list(APPEND add_to_env "${SCRIPTS}/buildsystems/make_wrapper") # Other required wrappers are also located there
+            vcpkg_list(APPEND add_to_env "${MSYS_ROOT}/usr/share/automake-1.16")
+        endif()
+        cmake_path(CONVERT "$ENV{PATH}" TO_CMAKE_PATH_LIST path_list NORMALIZE)
+        cmake_path(CONVERT "$ENV{SystemRoot}" TO_CMAKE_PATH_LIST system_root NORMALIZE)
+        file(REAL_PATH "${system_root}" system_root)
+
+        message(DEBUG "path_list:${path_list}") # Just to have --trace-expand output
+
+        set(find_system_dirs 
+                "${system_root}/system32"
+                "${system_root}/System32"
+                "${system_root}/system32/"
+                "${system_root}/System32/")
+
+        string(TOUPPER "${find_system_dirs}" find_system_dirs_upper)
+
+        set(index "-1")
+        foreach(system_dir IN LISTS find_system_dirs find_system_dirs_upper)
+            list(FIND path_list "${system_dir}" index)
+            if(NOT index EQUAL "-1")
+                break()
+            endif()
+        endforeach()
+
+        if(index GREATER_EQUAL "0")
+            vcpkg_list(INSERT path_list "${index}" ${add_to_env} "${MSYS_ROOT}/usr/bin")
+        else()
+            message(WARNING "Unable to find system32 dir in the PATH variable! Appending required msys paths!")
+            vcpkg_list(APPEND path_list ${add_to_env} "${MSYS_ROOT}/usr/bin")
+        endif()
+
+        cmake_path(CONVERT "${path_list}" TO_NATIVE_PATH_LIST native_path_list)
+        set(ENV{PATH} "${native_path_list}")
+    else()
+        find_program(base_cmd bash REQUIRED)
+    endif()
+
+   # macOS - cross-compiling support
     if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
         if (requires_autoconfig AND NOT arg_BUILD_TRIPLET OR arg_DETERMINE_BUILD_TRIPLET)
             z_vcpkg_determine_autotools_host_arch_mac(BUILD_ARCH) # machine you are building on => --build=
@@ -232,13 +277,9 @@ function(vcpkg_configure_make)
             debug_message("Using make triplet: ${arg_BUILD_TRIPLET}")
         endif()
     endif()
-    
+
     # Pre-processing windows configure requirements
     if (VCPKG_TARGET_IS_WINDOWS)
-        if(CMAKE_HOST_WIN32)
-            list(APPEND msys_require_packages binutils libtool autoconf automake-wrapper automake1.16 m4 which)
-            vcpkg_acquire_msys(MSYS_ROOT PACKAGES ${msys_require_packages} ${arg_ADDITIONAL_MSYS_PACKAGES})
-        endif()
         if (arg_DETERMINE_BUILD_TRIPLET OR NOT arg_BUILD_TRIPLET)
             z_vcpkg_determine_autotools_host_cpu(BUILD_ARCH) # VCPKG_HOST => machine you are building on => --build=
             z_vcpkg_determine_autotools_target_cpu(TARGET_ARCH)
@@ -267,46 +308,6 @@ function(vcpkg_configure_make)
                 string(APPEND arg_BUILD_TRIPLET " --host=${TARGET_ARCH}-unknown-mingw32")
             endif()
             debug_message("Using make triplet: ${arg_BUILD_TRIPLET}")
-        endif()
-        if(CMAKE_HOST_WIN32)
-            vcpkg_list(SET add_to_env)
-            if(arg_USE_WRAPPERS)
-                vcpkg_list(APPEND add_to_env "${SCRIPTS}/buildsystems/make_wrapper") # Other required wrappers are also located there
-                vcpkg_list(APPEND add_to_env "${MSYS_ROOT}/usr/share/automake-1.16")
-            endif()
-            cmake_path(CONVERT "$ENV{PATH}" TO_CMAKE_PATH_LIST path_list NORMALIZE)
-            cmake_path(CONVERT "$ENV{SystemRoot}" TO_CMAKE_PATH_LIST system_root NORMALIZE)
-            file(REAL_PATH "${system_root}" system_root)
-
-            message(DEBUG "path_list:${path_list}") # Just to have --trace-expand output
-
-            set(find_system_dirs 
-                    "${system_root}/system32"
-                    "${system_root}/System32"
-                    "${system_root}/system32/"
-                    "${system_root}/System32/")
-
-            string(TOUPPER "${find_system_dirs}" find_system_dirs_upper)
-
-            set(index "-1")
-            foreach(system_dir IN LISTS find_system_dirs find_system_dirs_upper)
-                list(FIND path_list "${system_dir}" index)
-                if(NOT index EQUAL "-1")
-                    break()
-                endif()
-            endforeach()
-
-            if(index GREATER_EQUAL "0")
-                vcpkg_list(INSERT path_list "${index}" ${add_to_env} "${MSYS_ROOT}/usr/bin")
-            else()
-                message(WARNING "Unable to find system32 dir in the PATH variable! Appending required msys paths!")
-                vcpkg_list(APPEND path_list ${add_to_env} "${MSYS_ROOT}/usr/bin")
-            endif()
-
-            cmake_path(CONVERT "${path_list}" TO_NATIVE_PATH_LIST native_path_list)
-            set(ENV{PATH} "${native_path_list}")
-
-            set(bash_executable "${MSYS_ROOT}/usr/bin/bash.exe")
         endif()
 
         # Remove full filepaths due to spaces and prepend filepaths to PATH (cross-compiling tools are unlikely on path by default)
@@ -517,13 +518,6 @@ function(vcpkg_configure_make)
     endif()
 
     file(RELATIVE_PATH relative_build_path "${CURRENT_BUILDTREES_DIR}" "${arg_SOURCE_PATH}/${arg_PROJECT_SUBPATH}")
-
-    set(base_cmd)
-    if(CMAKE_HOST_WIN32)
-        set(base_cmd ${bash_executable} --noprofile --norc --debug)
-    else()
-        find_program(base_cmd bash REQUIRED)
-    endif()
 
     # Used by CL 
     vcpkg_host_path_list(PREPEND ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include")

--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -223,8 +223,8 @@ function(vcpkg_configure_make)
             "${system_root}/System32"
             "${system_root}/system32/"
             "${system_root}/System32/"
-            "${local_app_data}/Windows/Apps"
-            "${local_app_data}/Windows/Apps/"
+            "${local_app_data}/Microsoft/WindowsApps"
+            "${local_app_data}/Microsoft/WindowsApps/"
         )
 
         string(TOUPPER "${find_system_dirs}" find_system_dirs_upper)


### PR DESCRIPTION
Moving Windows msys2 bash setup out of `VCPKG_TARGET_IS_WINDOWS`.
Fixes building for Android on Windows.
Together with #29966, fixes #30065.

Ensures that msys root is inserted into `PATH` before Windows Apps dir.
Fixes #29658, interference between msys and WSL executables. Cf. https://github.com/microsoft/vcpkg/pull/30172#discussion_r1136595012

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.