### PR TITLE
[libspatialite] Fix android

### DIFF
--- a/ports/libspatialite/fix-linux-configure.patch
+++ b/ports/libspatialite/fix-linux-configure.patch
@@ -10,19 +10,15 @@ index ead87caff..47abb90f0 100644
    AC_ARG_WITH([geosconfig],
          [AS_HELP_STRING([--with-geosconfig=FILE], [specify an alternative geos-config file])],
  	[GEOSCONFIG="$withval"], [GEOSCONFIG=""])
-@@ -327,6 +328,7 @@ if test x"$enable_geos" != "xno"; then
-   # Extract the linker and include flags
-   GEOS_LDFLAGS=`$GEOSCONFIG --ldflags`
-   GEOS_CFLAGS=-I`$GEOSCONFIG --includes`
-+ fi
-   AC_SUBST([GEOS_LDFLAGS])
-   AC_SUBST([GEOS_CFLAGS])	
+@@ -327,14 +328,17 @@ if test x"$enable_geos" != "xno"; then
    # Ensure that we can parse geos_c.h
-@@ -335,11 +337,13 @@ if test x"$enable_geos" != "xno"; then
+   CPPFLAGS_SAVE="$CPPFLAGS"
+   CPPFLAGS="$GEOS_CFLAGS"
++ fi
    AC_CHECK_HEADERS([geos_c.h],, [AC_MSG_ERROR([could not find geos_c.h - you may need to specify the directory of a geos-config file using --with-geosconfig])])
++ if 0; then
    CPPFLAGS="$CPPFLAGS_SAVE"	
    # Ensure we can link against libgeos_c
-+ if 0; then
    LIBS_SAVE="$LIBS"
    LIBS="$GEOS_LDFLAGS"
    AC_SEARCH_LIBS(GEOSCoveredBy,geos_c,,AC_MSG_ERROR([could not find libgeos_c (or obsolete 'libgeos_c' < v.3.3.0 found) - you may need to specify the directory of a geos-config file using --with-geosconfig]))

--- a/ports/libspatialite/vcpkg.json
+++ b/ports/libspatialite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libspatialite",
   "version": "5.0.1",
-  "port-version": 9,
+  "port-version": 10,
   "description": "SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.",
   "homepage": "https://www.gaia-gis.it/gaia-sins/libspatialite-sources",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4434,7 +4434,7 @@
     },
     "libspatialite": {
       "baseline": "5.0.1",
-      "port-version": 9
+      "port-version": 10
     },
     "libspnav": {
       "baseline": "0.2.3",

--- a/versions/l-/libspatialite.json
+++ b/versions/l-/libspatialite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da8932bd2fee04aa815f758bb119f072d39051d6",
+      "version": "5.0.1",
+      "port-version": 10
+    },
+    {
       "git-tree": "b68031f4e06a096cf94f5b1c685f97b642667818",
       "version": "5.0.1",
       "port-version": 9


### PR DESCRIPTION
Modification of the current patch: Really don't allow any flag modifications before testing for the geos header. The external flags are needed and, in vcpkg, sufficient.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
