### PR TITLE
[zstd] Fix emscripten

### DIFF
--- a/ports/zstd/emscripten.patch
+++ b/ports/zstd/emscripten.patch
@@ -1,0 +1,14 @@
+diff --git a/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake b/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
+index 0265349..1807d6e 100644
+--- a/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
++++ b/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
+@@ -54,7 +54,9 @@ macro(ADD_ZSTD_COMPILATION_FLAGS)
+         endif ()
+         # Add noexecstack flags
+         # LDFLAGS
++        if(NOT EMSCRIPTEN)
+         EnableCompilerFlag("-z noexecstack" false false true)
++        endif()
+         # CFLAGS & CXXFLAGS
+         EnableCompilerFlag("-Qunused-arguments" true true false)
+         EnableCompilerFlag("-Wa,--noexecstack" true true false)

--- a/ports/zstd/portfile.cmake
+++ b/ports/zstd/portfile.cmake
@@ -1,4 +1,3 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/zstd
@@ -7,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF dev
     PATCHES
         no-static-suffix.patch
+        emscripten.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ZSTD_BUILD_STATIC)

--- a/ports/zstd/vcpkg.json
+++ b/ports/zstd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zstd",
   "version": "1.5.4",
+  "port-version": 1,
   "description": "Zstandard - Fast real-time compression algorithm",
   "homepage": "https://facebook.github.io/zstd/",
   "license": "BSD-3-Clause OR GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8674,7 +8674,7 @@
     },
     "zstd": {
       "baseline": "1.5.4",
-      "port-version": 0
+      "port-version": 1
     },
     "zstr": {
       "baseline": "1.0.7",

--- a/versions/z-/zstd.json
+++ b/versions/z-/zstd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b61cbe1e314aa678d7cbf37a24b59e37694f4a6",
+      "version": "1.5.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "16ff2b227a85c9f483480a6bb6d5eb0103ceee44",
       "version": "1.5.4",
       "port-version": 0


### PR DESCRIPTION
Fixes #30146. Fixes #29718.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
