### PR TITLE
[gmp] Feature fat couldn't build on Windows

### DIFF
--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gmp",
   "version": "6.2.1",
-  "port-version": 16,
+  "port-version": 17,
   "description": "The GNU Multiple Precision Arithmetic Library",
   "homepage": "https://gmplib.org",
   "license": "LGPL-3.0-only OR GPL-2.0-only",
@@ -18,7 +18,7 @@
   "features": {
     "fat": {
       "description": "Enable runtime selection of optimized low level routines",
-      "supports": "(x86 | x64) & !(mingw & !static)"
+      "supports": "!windows, mingw"
     }
   }
 }

--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -18,7 +18,7 @@
   "features": {
     "fat": {
       "description": "Enable runtime selection of optimized low level routines",
-      "supports": "!windows | mingw | (arm64 & windows)"
+      "supports": "!windows | mingw"
     }
   }
 }

--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -18,7 +18,7 @@
   "features": {
     "fat": {
       "description": "Enable runtime selection of optimized low level routines",
-      "supports": "!windows, mingw"
+      "supports": "!windows | mingw | (arm64 & windows)"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2826,7 +2826,7 @@
     },
     "gmp": {
       "baseline": "6.2.1",
-      "port-version": 16
+      "port-version": 17
     },
     "gmsh": {
       "baseline": "4.9.0",

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3b7dcc69d8c0afcfd5987a5f9dc597c983f4074",
+      "version": "6.2.1",
+      "port-version": 17
+    },
+    {
       "git-tree": "dfe62625c288d20cd69758931e19feda98c7e3e8",
       "version": "6.2.1",
       "port-version": 16

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3b7dcc69d8c0afcfd5987a5f9dc597c983f4074",
+      "git-tree": "fe5b1bdf0f80a7d3bf3727a0b024d44475f3ff1a",
       "version": "6.2.1",
       "port-version": 17
     },

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fe5b1bdf0f80a7d3bf3727a0b024d44475f3ff1a",
+      "git-tree": "82d0d40ea6ffa93a17c696a2c2fac9a436d67958",
       "version": "6.2.1",
       "port-version": 17
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #27957, `gmp[fat]` can't build on windows because the following error, so change it `supports` to disable windows build temporarily.

Thanks fkonvick's investigation and dg0yt's help ♥.
```
C:\BUILD\vcpkg\buildtrees\gmp\src\v6.2.1-0c723d4b6f.clean\gmp-impl.h(4686): error C2071: 'preinv_mod_1': illegal storage classlibtool: compile:  .././../src/v6.2.1-0c723d4b6f.clean/mpn/m4-ccas --m4=m4 clang.exe -DHAVE_CONFIG_H -I. -I.././../src/v6.2.1-0c723d4b6f.clean/mpn -I.. -D__GMP_WITHIN_GMP -I.././../src/v6.2.1-0c723d4b6f.clean -DOPERATION_x86_64_mod_34lsub1 -DWIN32 -D_WINDOWS -D_DEBUG -c --target=x86_64-pc-windows-msvc x86_64_mod_34lsub1.asm  -DDLL_EXPORT -DPIC -o .libs/x86_64_mod_34lsub1.obj

C:\BUILD\vcpkg\buildtrees\gmp\src\v6.2.1-0c723d4b6f.clean\gmp-impl.h(4687): error C2071: 'redc_1': illegal storage class
C:\BUILD\vcpkg\buildtrees\gmp\src\v6.2.1-0c723d4b6f.clean\gmp-impl.h(4688): error C2071: 'redc_2': illegal storage class
C:\BUILD\vcpkg\buildtrees\gmp\src\v6.2.1-0c723d4b6f.clean\gmp-impl.h(4689): error C2071: 'rshift': illegal storage class
C:\BUILD\vcpkg\buildtrees\gmp\src\v6.2.1-0c723d4b6f.clean\gmp-impl.h(4690): error C2071: 'sqr_basecase': illegal storage class
C:\BUILD\vcpkg\buildtrees\gmp\src\v6.2.1-0c723d4b6f.clean\gmp-impl.h(4691): error C2071: 'sub_n': illegal storage class
C:\BUILD\vcpkg\buildtrees\gmp\src\v6.2.1-0c723d4b6f.clean\gmp-impl.h(4692): error C2071: 'sublsh1_n': illegal storage class
C:\BUILD\vcpkg\buildtrees\gmp\src\v6.2.1-0c723d4b6f.clean\gmp-impl.h(4693): error C2071: 'submul_1': illegal storage class
``` 
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
