### PR TITLE
[lz4] Add "tools" feature

### DIFF
--- a/ports/lz4/CMakeLists.txt
+++ b/ports/lz4/CMakeLists.txt
@@ -12,15 +12,33 @@ set(INSTALL_LIB_DIR      "lib"                       CACHE PATH "Path where lib 
 set(INSTALL_INCLUDE_DIR  "include"                   CACHE PATH "Path where headers will be installed")
 set(INSTALL_CMAKE_DIR    "share/lz4"                 CACHE PATH "Path where cmake configs will be installed")
 
+option(LZ4_BUILD_TOOLS "Build tools" OFF)
+
 file(GLOB LZ4_HEADERS lib/*.h)
 list(REMOVE_ITEM LZ4_HEADERS "${CMAKE_CURRENT_LIST_DIR}/lib/xxhash.h")
 
-add_library(lz4
-    ${LZ4_HEADERS}
+set(LZ4_SOURCES
     lib/lz4.c
     lib/lz4frame.c
     lib/lz4hc.c
     lib/xxhash.c
+)
+
+set(LZ4CLI_SOURCES
+    programs/bench.c
+    programs/lz4cli.c
+    programs/lz4io.c
+    programs/datagen.c
+)
+
+# lz4cli uses internal APIs, not exposed in shared lib
+if(NOT BUILD_STATIC_LIBS)
+    list(APPEND LZ4CLI_SOURCES ${LZ4_SOURCES})
+endif()
+
+add_library(lz4
+    ${LZ4_HEADERS}
+    ${LZ4_SOURCES}
 )
 
 target_include_directories(lz4 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/lib> $<INSTALL_INTERFACE:include>)
@@ -45,6 +63,24 @@ install(EXPORT lz4Config
   NAMESPACE lz4::
   DESTINATION "${INSTALL_CMAKE_DIR}"
 )
+
+if (LZ4_BUILD_TOOLS)
+    add_executable(lz4cli
+        ${LZ4_HEADERS}
+        ${LZ4_SOURCES}
+        ${LZ4CLI_SOURCES}
+    )
+    set_target_properties(lz4cli PROPERTIES OUTPUT_NAME lz4)
+    target_include_directories(lz4cli PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/lib> $<INSTALL_INTERFACE:include>)
+    if(BUILD_STATIC_LIBS)
+        target_link_libraries(lz4cli lz4)
+    endif()
+
+    install(TARGETS lz4cli
+        RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+        COMPONENT runtime
+    )
+endif()
 
 # Export the package for use from the build-tree (this registers the build-tree with a global CMake-registry)
 export(PACKAGE lz4)

--- a/ports/lz4/portfile.cmake
+++ b/ports/lz4/portfile.cmake
@@ -8,8 +8,15 @@ vcpkg_from_github(
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "tools" LZ4_BUILD_TOOLS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLZ4_BUILD_TOOLS=${LZ4_BUILD_TOOLS}
     OPTIONS_DEBUG
         -DCMAKE_DEBUG_POSTFIX=d
 )
@@ -33,6 +40,10 @@ vcpkg_cmake_config_fixup()
 vcpkg_fixup_pkgconfig()
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/liblz4.pc" " -llz4" " -llz4d")
+endif()
+
+if (${LZ4_BUILD_TOOLS})
+   vcpkg_copy_tools(TOOL_NAMES lz4 AUTO_CLEAN)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/lz4/vcpkg.json
+++ b/ports/lz4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lz4",
   "version": "1.9.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Lossless compression algorithm, providing compression speed at 400 MB/s per core.",
   "homepage": "https://github.com/lz4/lz4",
   "license": "BSD-2-Clause AND GPL-2.0-only",
@@ -14,5 +14,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build lz4 binary",
+      "supports": "!uwp"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4878,7 +4878,7 @@
     },
     "lz4": {
       "baseline": "1.9.4",
-      "port-version": 1
+      "port-version": 2
     },
     "lzfse": {
       "baseline": "1.0",

--- a/versions/l-/lz4.json
+++ b/versions/l-/lz4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53abe2add60d895fda74dc81c67a36ece0c21af6",
+      "version": "1.9.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "d7704e3869f579ffdf927b5419579473e9d702d4",
       "version": "1.9.4",
       "port-version": 1


### PR DESCRIPTION
I would like to use the lz4 binary in tests when building with lz4 support. Unfortunately the vcpkg port of lz4 does not build the lz4 binary. This PR adds a feature, defaulting to off, to enable tools to be built.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
