### PR TITLE
[openblas] disable build in Visual Studio with feature 'dynamic-arch'

### DIFF
--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -40,12 +40,6 @@ if(VCPKG_TARGET_IS_OSX)
     endif()
 endif()
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    if("dynamic-arch" IN_LIST FEATURES)
-        message(FATAL_ERROR "Openbals can not build with an opeion DYNAMIC_ARCH=ON in a Visual Studio")
-    endif()
-endif()
-
 set(OPENBLAS_EXTRA_OPTIONS)
 # for UWP version, must build non uwp first for helper
 # binaries.

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -40,6 +40,12 @@ if(VCPKG_TARGET_IS_OSX)
     endif()
 endif()
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    if("dynamic-arch" IN_LIST FEATURES)
+        message(FATAL_ERROR "Openbals can not build with an opeion DYNAMIC_ARCH=ON in a Visual Studio")
+    endif()
+endif()
+
 set(OPENBLAS_EXTRA_OPTIONS)
 # for UWP version, must build non uwp first for helper
 # binaries.

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -26,7 +26,8 @@
   ],
   "features": {
     "dynamic-arch": {
-      "description": "Support for multiple targets in a single library"
+      "description": "Support for multiple targets in a single library",
+      "supports": "mingw"
     },
     "simplethread": {
       "description": "Use simple thread",

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openblas",
   "version": "0.3.21",
+  "port-version": 1,
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/xianyi/OpenBLAS",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5678,7 +5678,7 @@
     },
     "openblas": {
       "baseline": "0.3.21",
-      "port-version": 0
+      "port-version": 1
     },
     "opencascade": {
       "baseline": "7.6.2",

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "77c25b7224cecbd3c0f1952fbb3de0f7024a762c",
+      "git-tree": "86949dd1db1c79ae88f2354225c4363e7200ad66",
       "version": "0.3.21",
       "port-version": 1
     },

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77c25b7224cecbd3c0f1952fbb3de0f7024a762c",
+      "version": "0.3.21",
+      "port-version": 1
+    },
+    {
       "git-tree": "17b5c709377ee3e375a3b6b165ac9acb9752c3f6",
       "version": "0.3.21",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/29994
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: According to the upstream description: 
```
 For the same reason it is not possible (and not necessary) to use -DDYNAMIC_ARCH=ON in a Visual Studio build) 
 ```
 So disable option `dynamic-arch` when use build in Visual Studio cmake project.
https://github.com/xianyi/OpenBLAS/wiki/How-to-use-OpenBLAS-in-Microsoft-Visual-Studio#cmake-and-visual-studio:~:text=This%20method%20may,GNU%20(MinGW)%20ABI.
<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
