### PR TITLE
[libressl] Update to 3.6.2

### DIFF
--- a/ports/libressl/0001-enable-ocspcheck-on-msvc.patch
+++ b/ports/libressl/0001-enable-ocspcheck-on-msvc.patch
@@ -1,5 +1,5 @@
 diff --git a/apps/ocspcheck/CMakeLists.txt b/apps/ocspcheck/CMakeLists.txt
-index 3c80458..e8d3bf5 100644
+index 2dddb6e..fd35685 100644
 --- a/apps/ocspcheck/CMakeLists.txt
 +++ b/apps/ocspcheck/CMakeLists.txt
 @@ -1,5 +1,3 @@
@@ -9,7 +9,7 @@ index 3c80458..e8d3bf5 100644
  	OCSPCHECK_SRC
  	http.c
 @@ -13,13 +11,27 @@ else()
-         set(OCSPCHECK_SRC ${OCSPCHECK_SRC} compat/strtonum.c)
+         set(OCSPCHECK_SRC ${OCSPCHECK_SRC} compat/memmem.c)
  endif()
  
 +check_function_exists(getopt HAVE_GETOPT)
@@ -34,10 +34,10 @@ index 3c80458..e8d3bf5 100644
  
 -add_executable(ocspcheck ${OCSPCHECK_SRC})
 +add_executable(ocspcheck ${OCSPCHECK_SRC} ${GETOPT_SRC} ${FTRUNCATE_SRC})
+ target_include_directories(ocspcheck PUBLIC ../../include)
  target_include_directories(ocspcheck PRIVATE . ./compat ../../include/compat)
  target_link_libraries(ocspcheck tls ${OPENSSL_LIBS})
- 
-@@ -28,5 +40,3 @@ if(ENABLE_LIBRESSL_INSTALL)
+@@ -29,5 +41,3 @@ if(ENABLE_LIBRESSL_INSTALL)
  	install(FILES ocspcheck.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)
  
  endif(ENABLE_LIBRESSL_INSTALL)

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -8,7 +8,8 @@ set(LIBRESSL_HASH 8fc81e05d1c9f9259d06508ca97d5a1ba5d46b857088c273c20e6b242921f7
 
 vcpkg_download_distfile(
     LIBRESSL_SOURCE_ARCHIVE
-    URLS "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${PORT}-${VERSION}.tar.gz" "https://ftp.fau.de/openbsd/LibreSSL/${PORT}-${VERSION}.tar.gz"
+    URLS "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${PORT}-${VERSION}.tar.gz"
+         "https://ftp.fau.de/openbsd/LibreSSL/${PORT}-${VERSION}.tar.gz"
     FILENAME "${PORT}-${VERSION}.tar.gz"
     SHA512 "${LIBRESSL_HASH}"
 )

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -4,14 +4,12 @@ if(EXISTS "${CURRENT_INSTALLED_DIR}/include/openssl/ssl.h")
   return()
 endif()
 
-set(LIBRESSL_HASH 8fc81e05d1c9f9259d06508ca97d5a1ba5d46b857088c273c20e6b242921f7eac58a1136564ad9831c923758ee63f7b0897c8c6c7b1e53ab8132a995cc559aeb)
-
 vcpkg_download_distfile(
     LIBRESSL_SOURCE_ARCHIVE
     URLS "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${PORT}-${VERSION}.tar.gz"
          "https://ftp.fau.de/openbsd/LibreSSL/${PORT}-${VERSION}.tar.gz"
     FILENAME "${PORT}-${VERSION}.tar.gz"
-    SHA512 "${LIBRESSL_HASH}"
+    SHA512 8fc81e05d1c9f9259d06508ca97d5a1ba5d46b857088c273c20e6b242921f7eac58a1136564ad9831c923758ee63f7b0897c8c6c7b1e53ab8132a995cc559aeb
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -4,20 +4,18 @@ if(EXISTS "${CURRENT_INSTALLED_DIR}/include/openssl/ssl.h")
   return()
 endif()
 
-set(LIBRESSL_VERSION 3.4.2)
-set(LIBRESSL_HASH ae91a840b29330681dc2a4f55a9bd760e6fe1bdfb3399017aae3a16bd21b413e97cbb8ba504400f0a1f42757f6128b3fa763d06bae4fc9f2b9dbeea867a57ad2)
+set(LIBRESSL_HASH 8fc81e05d1c9f9259d06508ca97d5a1ba5d46b857088c273c20e6b242921f7eac58a1136564ad9831c923758ee63f7b0897c8c6c7b1e53ab8132a995cc559aeb)
 
 vcpkg_download_distfile(
     LIBRESSL_SOURCE_ARCHIVE
-    URLS "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${PORT}-${LIBRESSL_VERSION}.tar.gz" "https://ftp.fau.de/openbsd/LibreSSL/${PORT}-${LIBRESSL_VERSION}.tar.gz"
-    FILENAME "${PORT}-${LIBRESSL_VERSION}.tar.gz"
+    URLS "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${PORT}-${VERSION}.tar.gz" "https://ftp.fau.de/openbsd/LibreSSL/${PORT}-${VERSION}.tar.gz"
+    FILENAME "${PORT}-${VERSION}.tar.gz"
     SHA512 "${LIBRESSL_HASH}"
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
+vcpkg_extract_source_archive(
+    SOURCE_PATH
     ARCHIVE "${LIBRESSL_SOURCE_ARCHIVE}"
-    REF "${LIBRESSL_VERSION}"
     PATCHES
         0001-enable-ocspcheck-on-msvc.patch
         0002-suppress-msvc-warnings.patch
@@ -59,7 +57,7 @@ file(REMOVE_RECURSE
 
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
     file(GLOB_RECURSE LIBS "${CURRENT_PACKAGES_DIR}/*.lib")

--- a/ports/libressl/vcpkg.json
+++ b/ports/libressl/vcpkg.json
@@ -1,15 +1,12 @@
 {
   "name": "libressl",
-  "version": "3.4.2",
+  "version": "3.6.2",
   "description": "LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014, with goals of modernizing the codebase, improving security, and applying best practice development processes.",
+  "license": "ISC",
   "supports": "!(uwp | arm)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4345,7 +4345,7 @@
       "port-version": 0
     },
     "libressl": {
-      "baseline": "3.4.2",
+      "baseline": "3.6.2",
       "port-version": 0
     },
     "librsvg": {

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "01a94864a4e5f2f4cb2c4c0d10813313d0b46c3f",
+      "git-tree": "dbc5385ec4d693da812158dc9e2c1eaaaf9c6908",
       "version": "3.6.2",
       "port-version": 0
     },

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5541398ed0000178fd272257cdf333a222877c76",
+      "git-tree": "01a94864a4e5f2f4cb2c4c0d10813313d0b46c3f",
       "version": "3.6.2",
       "port-version": 0
     },

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5541398ed0000178fd272257cdf333a222877c76",
+      "version": "3.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "09613175bb9f051a273b68c0520ad4017d8fabd9",
       "version": "3.4.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/30159

Feature passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static 
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
