### PR TITLE
[foonathan-memory] Update to 0.7-3

### DIFF
--- a/ports/foonathan-memory/portfile.cmake
+++ b/ports/foonathan-memory/portfile.cmake
@@ -57,20 +57,9 @@ file(COPY
     ${COMP_INCLUDE_FILES}
     DESTINATION ${CURRENT_PACKAGES_DIR}/include/foonathan
 )
-# Commenting below since this file does not seem to exist anymore.
-#file(COPY
-#    ${CURRENT_PACKAGES_DIR}/include/foonathan_memory/config_impl.hpp
-#    DESTINATION ${CURRENT_PACKAGES_DIR}/include/foonathan/memory
-#)
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/include/foonathan_memory
 )
-# Commenting below since this file does not seem to exist anymore.
-#vcpkg_replace_string(
-#    ${CURRENT_PACKAGES_DIR}/share/foonathan_memory/foonathan_memory-config.cmake
-#    "\${_IMPORT_PREFIX}/include/foonathan_memory/comp;\${_IMPORT_PREFIX}/include/foonathan_memory"
-#    "\${_IMPORT_PREFIX}/include"
-#)
 # Place header files into the right folders - Done!
 
 # The Debug version of this lib is built with:

--- a/ports/foonathan-memory/portfile.cmake
+++ b/ports/foonathan-memory/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO foonathan/memory
-    REF 0f0775770fd1c506fa9c5ad566bd6ba59659db66
+    REF v0.7-3
     SHA512 cea17694971de46ae2f680a300fdf1921a6999f7c6c991c0905940880f751ac5ae296fd7b349d0080f31e5eb5b4c3ca0b0616a29525db7b22e4f3b41a47d4796
     HEAD_REF master
 )

--- a/ports/foonathan-memory/portfile.cmake
+++ b/ports/foonathan-memory/portfile.cmake
@@ -57,7 +57,7 @@ file(COPY
     ${COMP_INCLUDE_FILES}
     DESTINATION ${CURRENT_PACKAGES_DIR}/include/foonathan
 )
-# Commenting below since this file does not exist in the new version.
+# Commenting below since this file does not seem to exist anymore.
 #file(COPY
 #    ${CURRENT_PACKAGES_DIR}/include/foonathan_memory/config_impl.hpp
 #    DESTINATION ${CURRENT_PACKAGES_DIR}/include/foonathan/memory
@@ -65,7 +65,7 @@ file(COPY
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/include/foonathan_memory
 )
-# Commenting below since this file does not exist in the new version.
+# Commenting below since this file does not seem to exist anymore.
 #vcpkg_replace_string(
 #    ${CURRENT_PACKAGES_DIR}/share/foonathan_memory/foonathan_memory-config.cmake
 #    "\${_IMPORT_PREFIX}/include/foonathan_memory/comp;\${_IMPORT_PREFIX}/include/foonathan_memory"

--- a/ports/foonathan-memory/portfile.cmake
+++ b/ports/foonathan-memory/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO foonathan/memory
-    REF 885a9d97bebe9a2f131d21d3c0928c42ab377c8b
-    SHA512 7ce78a6e67d590a41b7f8a3d4ae0f6c1fa157c561b718a63973dffc000df74a9f0a0d7955a099e84fbeb3cf4085092eb866a6b8cec8bafd50bdcee94d069f65d
+    REF 0f0775770fd1c506fa9c5ad566bd6ba59659db66
+    SHA512 cea17694971de46ae2f680a300fdf1921a6999f7c6c991c0905940880f751ac5ae296fd7b349d0080f31e5eb5b4c3ca0b0616a29525db7b22e4f3b41a47d4796
     HEAD_REF master
 )
 
@@ -21,7 +21,7 @@ vcpkg_from_github(
 file(COPY ${COMP_SOURCE_PATH}/comp_base.cmake DESTINATION ${SOURCE_PATH}/cmake/comp)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    tool FOONATHAN_MEMORY_BUILD_TOOLS
+    FEATURES tool FOONATHAN_MEMORY_BUILD_TOOLS
 )
 
 vcpkg_configure_cmake(
@@ -57,18 +57,20 @@ file(COPY
     ${COMP_INCLUDE_FILES}
     DESTINATION ${CURRENT_PACKAGES_DIR}/include/foonathan
 )
-file(COPY
-    ${CURRENT_PACKAGES_DIR}/include/foonathan_memory/config_impl.hpp
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include/foonathan/memory
-)
+# Commenting below since this file does not exist in the new version.
+#file(COPY
+#    ${CURRENT_PACKAGES_DIR}/include/foonathan_memory/config_impl.hpp
+#    DESTINATION ${CURRENT_PACKAGES_DIR}/include/foonathan/memory
+#)
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/include/foonathan_memory
 )
-vcpkg_replace_string(
-    ${CURRENT_PACKAGES_DIR}/share/foonathan_memory/foonathan_memory-config.cmake
-    "\${_IMPORT_PREFIX}/include/foonathan_memory/comp;\${_IMPORT_PREFIX}/include/foonathan_memory"
-    "\${_IMPORT_PREFIX}/include"
-)
+# Commenting below since this file does not exist in the new version.
+#vcpkg_replace_string(
+#    ${CURRENT_PACKAGES_DIR}/share/foonathan_memory/foonathan_memory-config.cmake
+#    "\${_IMPORT_PREFIX}/include/foonathan_memory/comp;\${_IMPORT_PREFIX}/include/foonathan_memory"
+#    "\${_IMPORT_PREFIX}/include"
+#)
 # Place header files into the right folders - Done!
 
 # The Debug version of this lib is built with:

--- a/ports/foonathan-memory/vcpkg.json
+++ b/ports/foonathan-memory/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "foonathan-memory",
   "version-string": "0.7-3",
-  "port-version": 2,
   "description": "STL compatible C++ memory allocator library",
   "homepage": "https://foonathan.net/doc/memory/",
   "default-features": [

--- a/ports/foonathan-memory/vcpkg.json
+++ b/ports/foonathan-memory/vcpkg.json
@@ -3,6 +3,7 @@
   "version-string": "0.7-3",
   "description": "STL compatible C++ memory allocator library",
   "homepage": "https://foonathan.net/doc/memory/",
+  "license": "Zlib",
   "default-features": [
     "tool"
   ],

--- a/ports/foonathan-memory/vcpkg.json
+++ b/ports/foonathan-memory/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "foonathan-memory",
-  "version-string": "2019-07-21",
+  "version-string": "0.7-3",
   "port-version": 2,
   "description": "STL compatible C++ memory allocator library",
   "homepage": "https://foonathan.net/doc/memory/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2529,7 +2529,7 @@
       "port-version": 0
     },
     "foonathan-memory": {
-      "baseline": "2019-07-21",
+      "baseline": "0.7-3",
       "port-version": 2
     },
     "forest": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2530,7 +2530,7 @@
     },
     "foonathan-memory": {
       "baseline": "0.7-3",
-      "port-version": 2
+      "port-version": 0
     },
     "forest": {
       "baseline": "12.1.0",

--- a/versions/f-/foonathan-memory.json
+++ b/versions/f-/foonathan-memory.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2c99fd44b39514c81bb8fec5b2a15f6d246f550d",
+      "git-tree": "8301ed62813a040665ecf32feebf5e5aac8506b7",
       "version-string": "0.7-3",
       "port-version": 0
     },

--- a/versions/f-/foonathan-memory.json
+++ b/versions/f-/foonathan-memory.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "952852b634f1bcfb48037d4d67816d8bc93c604b",
+      "version-string": "0.7-3",
+      "port-version": 2
+    },
+    {
       "git-tree": "6e97aca605e065b0df1adaed316adc03d63b6334",
       "version-string": "2019-07-21",
       "port-version": 2

--- a/versions/f-/foonathan-memory.json
+++ b/versions/f-/foonathan-memory.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "952852b634f1bcfb48037d4d67816d8bc93c604b",
+      "git-tree": "2c99fd44b39514c81bb8fec5b2a15f6d246f550d",
       "version-string": "0.7-3",
-      "port-version": 2
+      "port-version": 0
     },
     {
       "git-tree": "6e97aca605e065b0df1adaed316adc03d63b6334",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

