### PR TITLE
[vowpal-wabbit] Update to 9.8.0

### DIFF
--- a/ports/vowpal-wabbit/cmake_remove_bin_targets.patch
+++ b/ports/vowpal-wabbit/cmake_remove_bin_targets.patch
@@ -1,5 +1,5 @@
 diff --git a/vowpalwabbit/CMakeLists.txt b/vowpalwabbit/CMakeLists.txt
-index 39893dae2..cb247c808 100644
+index 6d41aa4a8..378e5084c 100644
 --- a/vowpalwabbit/CMakeLists.txt
 +++ b/vowpalwabbit/CMakeLists.txt
 @@ -1,9 +1,9 @@
@@ -11,15 +11,15 @@ index 39893dae2..cb247c808 100644
  endif()
 -add_subdirectory(cli)
 +#add_subdirectory(cli)
+ add_subdirectory(cache_parser)
  add_subdirectory(common)
  add_subdirectory(config)
- add_subdirectory(core)
-@@ -14,7 +14,7 @@ add_subdirectory(explore)
- add_subdirectory(io)
+@@ -16,7 +16,7 @@ add_subdirectory(io)
+ add_subdirectory(json_parser)
  add_subdirectory(model_merger)
  add_subdirectory(slim)
 -add_subdirectory(spanning_tree_bin)
 +#add_subdirectory(spanning_tree_bin)
  add_subdirectory(spanning_tree)
+ add_subdirectory(text_parser)
  if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
-   add_subdirectory(test_common)

--- a/ports/vowpal-wabbit/cmake_remove_bin_targets.patch
+++ b/ports/vowpal-wabbit/cmake_remove_bin_targets.patch
@@ -1,8 +1,8 @@
 diff --git a/vowpalwabbit/CMakeLists.txt b/vowpalwabbit/CMakeLists.txt
-index 6d41aa4a8..ae575336c 100644
+index 6d41aa4a8..378e5084c 100644
 --- a/vowpalwabbit/CMakeLists.txt
 +++ b/vowpalwabbit/CMakeLists.txt
-@@ -1,27 +1,27 @@
+@@ -1,9 +1,9 @@
 -add_subdirectory(active_interactor)
 +#add_subdirectory(active_interactor)
  add_subdirectory(allreduce)
@@ -10,34 +10,16 @@ index 6d41aa4a8..ae575336c 100644
    add_subdirectory(c_wrapper)
  endif()
 -add_subdirectory(cli)
--add_subdirectory(cache_parser)
 +#add_subdirectory(cli)
-+#add_subdirectory(cache_parser)
+ add_subdirectory(cache_parser)
  add_subdirectory(common)
  add_subdirectory(config)
- add_subdirectory(core)
--if(VW_BUILD_CSV)
--  add_subdirectory(csv_parser)
--endif()
-+#if(VW_BUILD_CSV)
-+#  add_subdirectory(csv_parser)
-+#endif()
- add_subdirectory(explore)
- add_subdirectory(io)
+@@ -16,7 +16,7 @@ add_subdirectory(io)
  add_subdirectory(json_parser)
  add_subdirectory(model_merger)
  add_subdirectory(slim)
 -add_subdirectory(spanning_tree_bin)
 +#add_subdirectory(spanning_tree_bin)
  add_subdirectory(spanning_tree)
--add_subdirectory(text_parser)
-+#add_subdirectory(text_parser)
+ add_subdirectory(text_parser)
  if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
-   add_subdirectory(test_common)
- endif()
--if(BUILD_FLATBUFFERS)
--  add_subdirectory(fb_parser)
--endif()
-+#if(BUILD_FLATBUFFERS)
-+#  add_subdirectory(fb_parser)
-+#endif()

--- a/ports/vowpal-wabbit/cmake_remove_bin_targets.patch
+++ b/ports/vowpal-wabbit/cmake_remove_bin_targets.patch
@@ -1,8 +1,8 @@
 diff --git a/vowpalwabbit/CMakeLists.txt b/vowpalwabbit/CMakeLists.txt
-index 6d41aa4a8..378e5084c 100644
+index 6d41aa4a8..ae575336c 100644
 --- a/vowpalwabbit/CMakeLists.txt
 +++ b/vowpalwabbit/CMakeLists.txt
-@@ -1,9 +1,9 @@
+@@ -1,27 +1,27 @@
 -add_subdirectory(active_interactor)
 +#add_subdirectory(active_interactor)
  add_subdirectory(allreduce)
@@ -10,16 +10,34 @@ index 6d41aa4a8..378e5084c 100644
    add_subdirectory(c_wrapper)
  endif()
 -add_subdirectory(cli)
+-add_subdirectory(cache_parser)
 +#add_subdirectory(cli)
- add_subdirectory(cache_parser)
++#add_subdirectory(cache_parser)
  add_subdirectory(common)
  add_subdirectory(config)
-@@ -16,7 +16,7 @@ add_subdirectory(io)
+ add_subdirectory(core)
+-if(VW_BUILD_CSV)
+-  add_subdirectory(csv_parser)
+-endif()
++#if(VW_BUILD_CSV)
++#  add_subdirectory(csv_parser)
++#endif()
+ add_subdirectory(explore)
+ add_subdirectory(io)
  add_subdirectory(json_parser)
  add_subdirectory(model_merger)
  add_subdirectory(slim)
 -add_subdirectory(spanning_tree_bin)
 +#add_subdirectory(spanning_tree_bin)
  add_subdirectory(spanning_tree)
- add_subdirectory(text_parser)
+-add_subdirectory(text_parser)
++#add_subdirectory(text_parser)
  if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+   add_subdirectory(test_common)
+ endif()
+-if(BUILD_FLATBUFFERS)
+-  add_subdirectory(fb_parser)
+-endif()
++#if(BUILD_FLATBUFFERS)
++#  add_subdirectory(fb_parser)
++#endif()

--- a/ports/vowpal-wabbit/portfile.cmake
+++ b/ports/vowpal-wabbit/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO VowpalWabbit/vowpal_wabbit
-    REF 16e9114f41343eed0a5f3f9881b171ce4ea6774a
-    SHA512 a9244c9791d672f57e06cafc0de753c307976f35f975b6f17ac0e5f8f773f4236674232afada015cd47c4ee2e4d0f550680251772693d4abf2b525dd9b3617f5
+    REF 258731cd116be6fa42d6ff6d2e59d06b9b790dc0
+    SHA512 b8a370c5c20e74ce7ccdb19ea3aa9c6d5287c9cc82d0b613804ab8b6c1d7770aafd15ad900d4933b636662435026c36f6a4b6ec0c66d597bdb52b20a4c0b6c25
     HEAD_REF master
     PATCHES cmake_remove_bin_targets.patch
 )

--- a/ports/vowpal-wabbit/vcpkg.json
+++ b/ports/vowpal-wabbit/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vowpal-wabbit",
-  "version": "9.6.0",
+  "version": "9.8.0",
   "description": "Reduction based online learning framework with a focus on contextual bandits and reinforcement learning.",
   "homepage": "https://github.com/vowpalwabbit/vowpal_wabbit",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8233,7 +8233,7 @@
       "port-version": 1
     },
     "vowpal-wabbit": {
-      "baseline": "9.6.0",
+      "baseline": "9.8.0",
       "port-version": 0
     },
     "vs-yasm": {

--- a/versions/v-/vowpal-wabbit.json
+++ b/versions/v-/vowpal-wabbit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "83403f8f1d2ccd46d4edfb16cd2f71ce829a4bc5",
+      "version": "9.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "93cd564360ea4185d144f884ffa817fd97f19458",
       "version": "9.6.0",
       "port-version": 0

--- a/versions/v-/vowpal-wabbit.json
+++ b/versions/v-/vowpal-wabbit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "17afa44e7ffde0de1fe31435a1cd161a94c0e5d7",
+      "git-tree": "ed8289aedc37dbd955273a2f211451a44e54d702",
       "version": "9.8.0",
       "port-version": 0
     },

--- a/versions/v-/vowpal-wabbit.json
+++ b/versions/v-/vowpal-wabbit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "83403f8f1d2ccd46d4edfb16cd2f71ce829a4bc5",
+      "git-tree": "17afa44e7ffde0de1fe31435a1cd161a94c0e5d7",
       "version": "9.8.0",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
