### PR TITLE
[ryu] Fix VS2022 build

### DIFF
--- a/ports/ryu/usage
+++ b/ports/ryu/usage
@@ -1,0 +1,4 @@
+The package ryu provides CMake targets:
+
+    find_package(ryu CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE RYU::ryu)

--- a/ports/ryu/vcpkg.json
+++ b/ports/ryu/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "ryu",
   "version": "2.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Ryu generates the shortest decimal representation of a floating point number that maintains round-trip safety.",
   "homepage": "https://github.com/ulfjack/ryu",
-  "supports": "!(uwp | arm | x86)"
+  "supports": "!(uwp | arm | x86)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-bazel",
+      "host": true
+    }
+  ]
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -857,11 +857,6 @@ rtlsdr:arm-uwp=fail
 rtlsdr:x64-linux=fail
 rtlsdr:x64-osx=fail
 
-# ryu does not support VS2022 yet
-ryu:x64-windows=fail
-ryu:x64-windows-static=fail
-ryu:x64-windows-static-md=fail
-
 sciter:arm64-windows=skip
 sciter:arm-uwp=skip
 sciter:x64-linux=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7070,7 +7070,7 @@
     },
     "ryu": {
       "baseline": "2.0",
-      "port-version": 6
+      "port-version": 7
     },
     "s2geometry": {
       "baseline": "0.10.0",

--- a/versions/r-/ryu.json
+++ b/versions/r-/ryu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9eef3ab0a0bafea6db1a02920f60b756c3eeabfc",
+      "version": "2.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "b500b4b86daab326db966564fcd439215eae86ee",
       "version": "2.0",
       "port-version": 6


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.