### PR TITLE
[apr] Update to 1.7.2

### DIFF
--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -72,14 +72,14 @@ else()
     )
     vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES pthread rt dl uuid crypt)
 
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/apr-1-config" "\"${CURRENT_INSTALLED_DIR}\"" "`dirname $0`/../../..")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/apr-1-config" "\"${CURRENT_INSTALLED_DIR}\"" "$(realpath \"`dirname $0`/../../..\")")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/apr-1-config" "APR_SOURCE_DIR=\"${SOURCE_PATH}\"" "")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/apr-1-config" "APR_BUILD_DIR=\"${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel\"" "")
     
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/build-1/libtool" "${CURRENT_INSTALLED_DIR}/lib" "")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/build-1/libtool" "${CURRENT_INSTALLED_DIR}/debug/lib" "")
     if(NOT VCPKG_BUILD_TYPE)
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/apr-1-config" "\"${CURRENT_INSTALLED_DIR}/debug\"" "`dirname $0`/../../../..")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/apr-1-config" "\"${CURRENT_INSTALLED_DIR}/debug\"" "$(realpath \"`dirname $0`/../../../..\")")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/apr-1-config" "APR_SOURCE_DIR=\"${SOURCE_PATH}\"" "")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/apr-1-config" "APR_BUILD_DIR=\"${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg\"" "")
 

--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -7,8 +7,7 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 0a3a27ccc97bbe4865c1bc0b803012e3da6d5b1f17d4fb0da6f5f58eec01f6d2ae1f25e52896ea5f9c5ac04c5fddcfd1ac606b301c322cf40d5c4d4ce0a1b76e
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
+vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         fix-configcmake.patch

--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -1,10 +1,10 @@
 
-set(VERSION 1.7.0)
+set(VERSION 1.7.2)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/apr/apr-${VERSION}.tar.bz2"
     FILENAME "apr-${VERSION}.tar.bz2"
-    SHA512 3dc42d5caf17aab16f5c154080f020d5aed761e22db4c5f6506917f6bfd2bf8becfb40af919042bd4ce1077d5de74aa666f5edfba7f275efba78e8893c115148
+    SHA512 0a3a27ccc97bbe4865c1bc0b803012e3da6d5b1f17d4fb0da6f5f58eec01f6d2ae1f25e52896ea5f9c5ac04c5fddcfd1ac606b301c322cf40d5c4d4ce0a1b76e
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -78,6 +78,8 @@ else()
     
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/build-1/libtool" "${CURRENT_INSTALLED_DIR}/lib" "")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/build-1/libtool" "${CURRENT_INSTALLED_DIR}/debug/lib" "")
+
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/build-1/apr_rules.mk" "${CURRENT_INSTALLED_DIR}" "$(LIBPATH)/..")
     if(NOT VCPKG_BUILD_TYPE)
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/apr-1-config" "\"${CURRENT_INSTALLED_DIR}/debug\"" "$(realpath \"`dirname $0`/../../../..\")")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/apr-1-config" "APR_SOURCE_DIR=\"${SOURCE_PATH}\"" "")
@@ -85,6 +87,8 @@ else()
 
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/build-1/libtool" "${CURRENT_INSTALLED_DIR}/lib" "")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/build-1/libtool" "${CURRENT_INSTALLED_DIR}/debug/lib" "")
+
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/build-1/apr_rules.mk" "${CURRENT_INSTALLED_DIR}/debug" "$(LIBPATH)/..")
     endif()
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 endif()

--- a/ports/apr/vcpkg.json
+++ b/ports/apr/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "apr",
   "version": "1.7.2",
-  "port-version": 0,
   "description": "The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.",
   "homepage": "https://apr.apache.org/",
   "license": "Apache-2.0",

--- a/ports/apr/vcpkg.json
+++ b/ports/apr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "apr",
-  "version": "1.7.0",
-  "port-version": 12,
+  "version": "1.7.2",
+  "port-version": 0,
   "description": "The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.",
   "homepage": "https://apr.apache.org/",
   "license": "Apache-2.0",

--- a/versions/a-/apr.json
+++ b/versions/a-/apr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8d84bc714a5a69676124ccd6a3f6e667aa1f6a35",
+      "git-tree": "0be170a432c4b601d04bf5576b9d7a6e2e3f2da8",
       "version": "1.7.2",
       "port-version": 0
     },

--- a/versions/a-/apr.json
+++ b/versions/a-/apr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ecac0bbe63953e01aed54e7862865733ed946c23",
+      "git-tree": "a68bb37ae242709eb2fab09e1326168d28ab1a56",
       "version": "1.7.2",
       "port-version": 0
     },

--- a/versions/a-/apr.json
+++ b/versions/a-/apr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e96ee826ab1f174fc87690d5563baca38f84a525",
+      "version": "1.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "beb9b88a2d3bcc63f32177c58622d7ad4b6717cf",
       "version": "1.7.0",
       "port-version": 12

--- a/versions/a-/apr.json
+++ b/versions/a-/apr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e96ee826ab1f174fc87690d5563baca38f84a525",
+      "git-tree": "8d84bc714a5a69676124ccd6a3f6e667aa1f6a35",
       "version": "1.7.2",
       "port-version": 0
     },

--- a/versions/a-/apr.json
+++ b/versions/a-/apr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0be170a432c4b601d04bf5576b9d7a6e2e3f2da8",
+      "git-tree": "ecac0bbe63953e01aed54e7862865733ed946c23",
       "version": "1.7.2",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -145,8 +145,8 @@
       "port-version": 0
     },
     "apr": {
-      "baseline": "1.7.0",
-      "port-version": 12
+      "baseline": "1.7.2",
+      "port-version": 0
     },
     "apr-util": {
       "baseline": "1.6.1",


### PR DESCRIPTION
Fixes #30216 (hence, fixes [CVE-2021-35940](https://www.cve.org/CVERecord?id=CVE-2021-35940))

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
