### PR TITLE
[libpng] Fix arm-neon-android

### DIFF
--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_minimum_required(VERSION 2022-09-15) # for ${VERSION}
-
 # Download the apng patch
 set(LIBPNG_APNG_PATCH_PATH "")
 set(LIBPNG_APNG_OPTION "")
@@ -56,8 +54,14 @@ vcpkg_list(SET LD_VERSION_SCRIPT_OPTION)
 if(VCPKG_TARGET_IS_ANDROID)
     vcpkg_list(APPEND LD_VERSION_SCRIPT_OPTION "-Dld-version-script=OFF")
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
-        # for armeabi-v7a, check whether NEON is available
-        vcpkg_list(APPEND LIBPNG_HARDWARE_OPTIMIZATIONS_OPTION "-DPNG_ARM_NEON=check")
+        vcpkg_cmake_get_vars(cmake_vars_file)
+        include("${cmake_vars_file}")
+        if(VCPKG_DETECTED_CMAKE_ANDROID_ARM_NEON)
+            vcpkg_list(APPEND LIBPNG_HARDWARE_OPTIMIZATIONS_OPTION "-DPNG_ARM_NEON=on")
+        else()
+            # for armeabi-v7a, check whether NEON is available
+            vcpkg_list(APPEND LIBPNG_HARDWARE_OPTIMIZATIONS_OPTION "-DPNG_ARM_NEON=check")
+        endif()
     endif()
 endif()
 

--- a/ports/libpng/vcpkg.json
+++ b/ports/libpng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpng",
   "version": "1.6.39",
+  "port-version": 1,
   "description": "libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files",
   "homepage": "https://github.com/glennrp/libpng",
   "license": "libpng-2.0",
@@ -12,6 +13,11 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true,
+      "platform": "arm & android"
     },
     "zlib"
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4294,7 +4294,7 @@
     },
     "libpng": {
       "baseline": "1.6.39",
-      "port-version": 0
+      "port-version": 1
     },
     "libpopt": {
       "baseline": "1.16",

--- a/versions/l-/libpng.json
+++ b/versions/l-/libpng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af144fe56e6e4c08cd8089d2e1dd46bae60a5062",
+      "version": "1.6.39",
+      "port-version": 1
+    },
+    {
       "git-tree": "5418b205ed842ffdcd4d65c07f43087e0afcf3f3",
       "version": "1.6.39",
       "port-version": 0


### PR DESCRIPTION
Fixes:
~~~
FAILED: CMakeFiles/png_static.dir/arm/arm_init.c.o 
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang --target=armv7-none-linux-androideabi21 --sysroot=/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DPNG_ARM_NEON_CHECK_SUPPORTED -I/home/dg0yt/vcpkg/installed/arm-neon-android/include -I/home/dg0yt/vcpkg/buildtrees/libpng/arm-neon-android-dbg -I/home/dg0yt/vcpkg/buildtrees/libpng/src/v1.6.39-a77eb96d39.clean -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security  -fPIC   -fno-limit-debug-info    -fPIC -MD -MT CMakeFiles/png_static.dir/arm/arm_init.c.o -MF CMakeFiles/png_static.dir/arm/arm_init.c.o.d -o CMakeFiles/png_static.dir/arm/arm_init.c.o -c /home/dg0yt/vcpkg/buildtrees/libpng/src/v1.6.39-a77eb96d39.clean/arm/arm_init.c
/home/dg0yt/vcpkg/buildtrees/libpng/src/v1.6.39-a77eb96d39.clean/arm/arm_init.c:42:6: error: "PNG_ARM_NEON_CHECK_SUPPORTED must not be defined on this CPU arch"
#    error "PNG_ARM_NEON_CHECK_SUPPORTED must not be defined on this CPU arch"
     ^
1 error generated.
~~~

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.