### PR TITLE
[coost] new port

### DIFF
--- a/ports/coost/portfile.cmake
+++ b/ports/coost/portfile.cmake
@@ -1,0 +1,36 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO idealvin/coost
+    REF "v${VERSION}"
+    SHA512 73720a430cb0f5480fcbb5e92d536f07e3a60fa30ca2d60be5ba11f1d5b2bee35da320f8200c18000ff0b1de50e18be0850fab945b48525319bcd198b388fcf6
+    HEAD_REF master
+)
+
+if(VCPKG_CRT_LINKAGE STREQUAL static)
+    set(STATIC_VS_CRT ON)
+else()
+    set(STATIC_VS_CRT OFF)
+endif()
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_ALL=OFF
+)
+vcpkg_cmake_install()
+
+file(INSTALL ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/ DESTINATION ${CURRENT_PACKAGES_DIR}/debug/share)
+file(INSTALL ${CURRENT_PACKAGES_DIR}/lib/cmake/ DESTINATION ${CURRENT_PACKAGES_DIR}/share)
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake")

--- a/ports/coost/vcpkg.json
+++ b/ports/coost/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "coost",
+  "version": "3.0.0",
+  "description": "A tiny boost library in C++11.",
+  "homepage": "https://github.com/idealvin/coost",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1688,6 +1688,10 @@
       "baseline": "6.4.1",
       "port-version": 2
     },
+    "coost": {
+      "baseline": "3.0.0",
+      "port-version": 0
+    },
     "coroutine": {
       "baseline": "1.5.0",
       "port-version": 5

--- a/versions/c-/coost.json
+++ b/versions/c-/coost.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "846212a4d882aeb9593bbc76785858e0988278f3",
+      "version": "3.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.