### PR TITLE
[onnxruntime-gpu] update version to 1.14.1

### DIFF
--- a/ports/onnxruntime-gpu/portfile.cmake
+++ b/ports/onnxruntime-gpu/portfile.cmake
@@ -85,4 +85,4 @@ file(COPY ${SOURCE_PATH}/onnxruntime-win-x64-gpu-${VERSION}/lib/onnxruntime_prov
 file(COPY ${SOURCE_PATH}/onnxruntime-win-x64-gpu-${VERSION}/lib/onnxruntime_providers_cuda.dll
     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
 # # Handle copyright
-file(INSTALL ${SOURCE_PATH}/onnxruntime-win-x64-gpu-${VERSION}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/onnxruntime-win-x64-gpu-${VERSION}/LICENSE")

--- a/ports/onnxruntime-gpu/portfile.cmake
+++ b/ports/onnxruntime-gpu/portfile.cmake
@@ -1,18 +1,15 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-win-x64-gpu-${VERSION}.zip"
     FILENAME "onnxruntime-win-x64-gpu-${VERSION}.zip"
-    SHA512 eea4d95189da1dc0358673d09d66b6c2880cb66333d76d6c6d54cacc87ac04a7a52f4aa911da02c40bc86718e584d130e492d7a0499ed0daa323194c05d41960
+    SHA512 f927302daa7b778eaf15693e446303060c0a38dfd18b8026c28ac65f545dd463ee7cd3f0aa6bfe59301c5c85ccf4512584ed968ac42ce8d78c12a79d8af2de1e
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     NO_REMOVE_ONE_LEVEL
-    REF ${VERSION}
 )
 
 file(MAKE_DIRECTORY

--- a/ports/onnxruntime-gpu/vcpkg.json
+++ b/ports/onnxruntime-gpu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "onnxruntime-gpu",
-  "version": "1.12.1",
+  "version": "1.14.1",
   "description": "onnxruntime (GPU)",
   "homepage": "https://github.com/microsoft/onnxruntime",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5657,7 +5657,7 @@
       "port-version": 0
     },
     "onnxruntime-gpu": {
-      "baseline": "1.12.1",
+      "baseline": "1.14.1",
       "port-version": 0
     },
     "oof": {

--- a/versions/o-/onnxruntime-gpu.json
+++ b/versions/o-/onnxruntime-gpu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "356f4526f3fbe8ac5b1870202a897fd40b596208",
+      "version": "1.14.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c5e4f24f9b3441c5860d6c891e95251ba69193d1",
       "version": "1.12.1",
       "port-version": 0

--- a/versions/o-/onnxruntime-gpu.json
+++ b/versions/o-/onnxruntime-gpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "356f4526f3fbe8ac5b1870202a897fd40b596208",
+      "git-tree": "74bcaaeb54e99b6aee5e6c7560e6fa9935bcbf28",
       "version": "1.14.1",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/30208
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: Update `onnxruntime-gpu` version to 1.14.1
No feature need to test.
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
