### PR TITLE
[sail] Remove feature svg

### DIFF
--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
 # Enable selected codecs
 set(ONLY_CODECS "")
 
-foreach(CODEC avif bmp gif ico jpeg jpeg2000 pcx png psd qoi svg tga tiff wal webp xbm)
+foreach(CODEC avif bmp gif ico jpeg jpeg2000 pcx png psd qoi tga tiff wal webp xbm)
     if (${CODEC} IN_LIST FEATURES)
         list(APPEND ONLY_CODECS ${CODEC})
     endif()
@@ -19,7 +19,6 @@ list(JOIN ONLY_CODECS "\;" ONLY_CODECS_ESCAPED)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-
     OPTIONS
         -DSAIL_COMBINE_CODECS=ON
         -DSAIL_ONLY_CODECS=${ONLY_CODECS_ESCAPED}
@@ -57,4 +56,4 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/sail/sail-common/config.h"
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sail",
   "version-semver": "0.9.0-rc3",
+  "port-version": 1,
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -133,9 +133,6 @@
     "qoi": {
       "description": "Enable QOI codec"
     },
-    "svg": {
-      "description": "Enable SVG codec"
-    },
     "tga": {
       "description": "Enable TGA codec"
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7038,7 +7038,7 @@
     },
     "sail": {
       "baseline": "0.9.0-rc3",
-      "port-version": 0
+      "port-version": 1
     },
     "sais": {
       "baseline": "2.4.1",

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66576c788934d4684f862ba663b49f1bb80c4d4d",
+      "version-semver": "0.9.0-rc3",
+      "port-version": 1
+    },
+    {
       "git-tree": "3ead16b38ab4954a49a3c353b5f7b6fdaf5b7b42",
       "version-semver": "0.9.0-rc3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #29195, remove feature `svg`, because it need add new port `resvg`.
New port [`resvg`](https://github.com/RazrFalcon/resvg) need use tool `cargo` to install, but vcpkg doesn't support it now, the related issue: https://github.com/microsoft/vcpkg/issues/20619.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
