### PR TITLE
[onnx] update to 1.13.1

### DIFF
--- a/ports/onnx/fix-cmakelists.patch
+++ b/ports/onnx/fix-cmakelists.patch
@@ -1,44 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 628dcaa..300e4ea 100644
+index 4dd56b6..2ff3e29 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -111,8 +111,8 @@ endif()
- # find_package Python has replaced PythonInterp and PythonLibs since cmake 3.12
- # Use the following command in the future; now this is only compatible with the latest pybind11
- # find_package(Python ${PY_VERSION} COMPONENTS Interpreter Development REQUIRED)
--find_package(PythonInterp ${PY_VERSION} REQUIRED)
--find_package(PythonLibs ${PY_VERSION})
-+find_package(Python3 ${PY_VERSION} COMPONENTS Interpreter REQUIRED)
-+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
- 
- if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
-   set(CMAKE_NO_SYSTEM_FROM_IMPORTED 1)
-@@ -422,6 +422,7 @@ target_link_libraries(onnx PUBLIC onnx_proto)
- add_onnx_global_defines(onnx)
- 
- if(BUILD_ONNX_PYTHON)
-+  find_package(Python3 ${PY_VERSION} COMPONENTS Development REQUIRED)
-   if("${PY_EXT_SUFFIX}" STREQUAL "")
-     if(MSVC)
-       set(PY_EXT_SUFFIX ".pyd")
-@@ -441,10 +442,13 @@ if(BUILD_ONNX_PYTHON)
-                              $<BUILD_INTERFACE:${ONNX_ROOT}>
-                              $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                              $<INSTALL_INTERFACE:include>
--                             ${PYTHON_INCLUDE_DIR})
--
-+                             ${Python3_INCLUDE_DIRS})
-+  target_link_directories(onnx_cpp2py_export PRIVATE
-+                          ${Python3_LIBRARY_DIRS})
-+  target_link_libraries(onnx_cpp2py_export PRIVATE
-+                        ${Python3_LIBRARIES})
-   # pybind11 is a header only lib
--  find_package(pybind11 2.2)
-+  find_package(pybind11 2.2 CONFIG REQUIRED)
-   if(pybind11_FOUND)
-     target_include_directories(onnx_cpp2py_export PUBLIC
-       ${pybind11_INCLUDE_DIRS})
-@@ -687,6 +691,27 @@ endif()
+@@ -65,6 +65,27 @@ endif()
  
  include(GNUInstallDirs)
  
@@ -63,24 +27,41 @@ index 628dcaa..300e4ea 100644
 +  )
 +endif()
 +
- install(DIRECTORY ${ONNX_ROOT}/onnx
-         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-         FILES_MATCHING
-@@ -639,7 +639,7 @@ endif()
+ set(ONNX_ROOT ${PROJECT_SOURCE_DIR})
  
- if (NOT ANDROID AND NOT IOS)
-   # ---[ ONNXIFI wrapper
--  add_library(onnxifi_wrapper MODULE onnx/onnxifi_wrapper.c)
-+  add_library(onnxifi_wrapper onnx/onnxifi_wrapper.c)
-   if(MSVC)
-     add_msvc_runtime_flag(onnxifi_wrapper)
-   endif()
-@@ -669,7 +669,7 @@ if (NOT ANDROID AND NOT IOS)
+ # Read ONNX version
+@@ -116,7 +137,8 @@ endif()
+ # find_package Python has replaced PythonInterp and PythonLibs since cmake 3.12
+ # Use the following command in the future; now this is only compatible with the latest pybind11
+ # find_package(Python ${PY_VERSION} COMPONENTS Interpreter Development REQUIRED)
+-find_package(PythonInterp ${PY_VERSION} REQUIRED)
++find_package(Python3 ${PY_VERSION} COMPONENTS Interpreter REQUIRED)
++set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+ if(BUILD_ONNX_PYTHON)
+   find_package(PythonLibs ${PY_VERSION})
  endif()
+@@ -434,6 +456,7 @@ target_link_libraries(onnx PUBLIC onnx_proto)
+ add_onnx_global_defines(onnx)
  
- # ---[ ONNXIFI dummy backend
--add_library(onnxifi_dummy SHARED onnx/onnxifi_dummy.c)
-+add_library(onnxifi_dummy onnx/onnxifi_dummy.c)
+ if(BUILD_ONNX_PYTHON)
++  find_package(Python3 ${PY_VERSION} COMPONENTS Development REQUIRED)
+   if("${PY_EXT_SUFFIX}" STREQUAL "")
+     if(MSVC)
+       set(PY_EXT_SUFFIX ".pyd")
+@@ -452,10 +475,14 @@ if(BUILD_ONNX_PYTHON)
+   target_include_directories(onnx_cpp2py_export PRIVATE
+                              $<BUILD_INTERFACE:${ONNX_ROOT}>
+                              $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+-                             $<INSTALL_INTERFACE:include>)
++                             ${Python3_INCLUDE_DIRS})
++  target_link_directories(onnx_cpp2py_export PRIVATE
++                          ${Python3_LIBRARY_DIRS})
++  target_link_libraries(onnx_cpp2py_export PRIVATE
++                        ${Python3_LIBRARIES})
  
- if(ONNXIFI_ENABLE_EXT)
-   add_definitions(-DONNXIFI_ENABLE_EXT=ON)
+   # pybind11 is a header only lib
+-  find_package(pybind11 2.2 CONFIG)
++  find_package(pybind11 2.2 CONFIG REQUIRED)
+   if(NOT pybind11_FOUND)
+     if(EXISTS "${ONNX_ROOT}/third_party/pybind11/include/pybind11/pybind11.h")
+       add_subdirectory("${ONNX_ROOT}/third_party/pybind11")

--- a/ports/onnx/portfile.cmake
+++ b/ports/onnx/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO onnx/onnx
-    REF v1.10.2
-    SHA512 7519d326cd2b2b13a269ec0d01af07c32115d183dae6e1eaae55f5b23b6c92b2aadbb2b1e555557f4201bbcf921fa563d09d45d7f1d3bd2399c1a94a6ef63303
+    REF "v${VERSION}"
+    SHA512 325859f591dece43a083a0945aefe3427bfdb68a98ef5922343bf7ed959528947e7664d6c8e3e3d35c390d6c20ef22d07c672e5311f80c72c199931be6c256c3
     PATCHES
         fix-cmakelists.patch
         fix-dependency-protobuf.patch
@@ -63,7 +63,7 @@ endif()
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ONNX)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
@@ -92,4 +92,6 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_ml"
     "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_data"
     "${CURRENT_PACKAGES_DIR}/include/onnx/onnx_operators_ml"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/reference/ops"
+    "${CURRENT_PACKAGES_DIR}/include/onnx/reference"
 )

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "onnx",
-  "version-semver": "1.10.2",
-  "port-version": 1,
+  "version-semver": "1.13.1",
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5649,8 +5649,8 @@
       "port-version": 1
     },
     "onnx": {
-      "baseline": "1.10.2",
-      "port-version": 1
+      "baseline": "1.13.1",
+      "port-version": 0
     },
     "onnx-optimizer": {
       "baseline": "0.2.6",

--- a/versions/o-/onnx.json
+++ b/versions/o-/onnx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b31a613878d713e6573b82752f4aa6b78e71820",
+      "version-semver": "1.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "62ee0b78332273115540d669065a467314aace3a",
       "version-semver": "1.10.2",
       "port-version": 1


### PR DESCRIPTION
Fixes #30209

Update onnx to the latest version 1.13.1

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->


Feature `pybind11` tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static