### PR TITLE
[cyclonedds] Fix idl generation for the linux

### DIFF
--- a/ports/cyclonedds/idlc-generate.patch
+++ b/ports/cyclonedds/idlc-generate.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/Modules/Generate.cmake b/cmake/Modules/Generate.cmake
-index 0ed67d63..c22d9146 100644
+index 0ed67d63..9037fe05 100644
 --- a/cmake/Modules/Generate.cmake
 +++ b/cmake/Modules/Generate.cmake
-@@ -157,11 +157,19 @@ function(IDLC_GENERATE_GENERIC)
+@@ -157,11 +157,25 @@ function(IDLC_GENERATE_GENERIC)
      endforeach()
  
      list(APPEND _outputs ${_file_outputs})
@@ -11,17 +11,23 @@ index 0ed67d63..c22d9146 100644
 -      COMMAND  ${_idlc_executable}
 -      ARGS     ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
 -      DEPENDS  ${_files} ${_depends})
-+    if(NOT APPLE)
-+      add_custom_command(
-+        OUTPUT   ${_file_outputs}
-+        COMMAND  ${_idlc_executable}
-+        ARGS     ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
-+        DEPENDS  ${_files} ${_depends})
-+    else()
++    if(APPLE)
 +      add_custom_command(
 +        OUTPUT   ${_file_outputs}
 +        COMMAND  ${CMAKE_COMMAND}
 +        ARGS     -E env "DYLD_LIBRARY_PATH=$<TARGET_FILE_DIR:${_idlc_executable}>/../../lib" $<TARGET_FILE:${_idlc_executable}> ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
++        DEPENDS  ${_files} ${_depends})
++    elseif(UNIX)
++      add_custom_command(
++        OUTPUT   ${_file_outputs}
++        COMMAND  ${CMAKE_COMMAND}
++        ARGS     -E env "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:${_idlc_executable}>/../../lib" $<TARGET_FILE:${_idlc_executable}> ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
++        DEPENDS  ${_files} ${_depends})
++    else()
++      add_custom_command(
++        OUTPUT   ${_file_outputs}
++        COMMAND  ${_idlc_executable}
++        ARGS     ${_language} ${IDLC_ARGS} ${IDLC_INCLUDE_DIRS} ${_file}
 +        DEPENDS  ${_files} ${_depends})
 +    endif()
    endforeach()

--- a/ports/cyclonedds/vcpkg.json
+++ b/ports/cyclonedds/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cyclonedds",
   "version-semver": "0.10.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Eclipse Cyclone DDS is a very performant and robust open-source implementation of the OMG DDS specification",
   "homepage": "https://cyclonedds.io",
   "license": "EPL-2.0 OR BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1922,7 +1922,7 @@
     },
     "cyclonedds": {
       "baseline": "0.10.2",
-      "port-version": 1
+      "port-version": 2
     },
     "cyclonedds-cxx": {
       "baseline": "0.10.2",

--- a/versions/c-/cyclonedds.json
+++ b/versions/c-/cyclonedds.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88e7a85946eae33b8e9d686107d7e303afa2a59e",
+      "version-semver": "0.10.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "7be6ebe8452bb763bf4dd1374e981ff455b54aaa",
       "version-semver": "0.10.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.