### PR TITLE
[breakpad] Fix library exports main function

### DIFF
--- a/ports/breakpad/CMakeLists.txt
+++ b/ports/breakpad/CMakeLists.txt
@@ -24,13 +24,13 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Android)
     file(GLOB_RECURSE LIBBREAKPAD_SOURCES src/processor/*.cc)
     if(WIN32)
         list(FILTER LIBBREAKPAD_SOURCES EXCLUDE REGEX
-            "_unittest|synth_minidump|/tests|/testdata|/linux|/mac|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
+            "_unittest|_selftest|synth_minidump|/tests|/testdata|/linux|/mac|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
     elseif(APPLE)
         list(FILTER LIBBREAKPAD_SOURCES EXCLUDE REGEX
-            "_unittest|synth_minidump|/tests|/testdata|/linux|/windows|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
+            "_unittest|_selftest|synth_minidump|/tests|/testdata|/linux|/windows|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
     else()
         list(FILTER LIBBREAKPAD_SOURCES EXCLUDE REGEX
-            "_unittest|synth_minidump|/tests|/testdata|/mac|/windows|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
+            "_unittest|_selftest|synth_minidump|/tests|/testdata|/mac|/windows|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
     endif()
 
     find_library(LIBDISASM_LIB NAMES libdisasmd libdisasm)

--- a/ports/breakpad/portfile.cmake
+++ b/ports/breakpad/portfile.cmake
@@ -42,8 +42,8 @@ if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES microdump_stackwalk minidump_dump minidump_stackwalk core2md pid2md dump_syms minidump-2-core minidump_upload sym_upload core_handler AUTO_CLEAN)
 endif()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-breakpad CONFIG_PATH share/unofficial-breakpad)
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-breakpad)
 
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/breakpad/vcpkg.json
+++ b/ports/breakpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "breakpad",
   "version-date": "2022-07-12",
-  "port-version": 3,
+  "port-version": 4,
   "description": "a set of client and server components which implement a crash-reporting system.",
   "homepage": "https://github.com/google/breakpad",
   "license": "BSD-3-Clause",

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26e6e78bdd989c749aa0f61ad6357374480bc184",
+      "version-date": "2022-07-12",
+      "port-version": 4
+    },
+    {
       "git-tree": "79b0efa7b720fb255c442834270b24a396f01de5",
       "version-date": "2022-07-12",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1234,7 +1234,7 @@
     },
     "breakpad": {
       "baseline": "2022-07-12",
-      "port-version": 3
+      "port-version": 4
     },
     "brigand": {
       "baseline": "1.3.0",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/28517

`src/processor/stackwalker_selftest.cc` file was compiled, resulting in the main function being exported.
For fixing this issue, removed `src/processor/stackwalker_selftest.cc` from the list of source files to be compiled.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
