### PR TITLE
[hazelcast-cpp-client] update to v5.2.0

### DIFF
--- a/ports/hazelcast-cpp-client/portfile.cmake
+++ b/ports/hazelcast-cpp-client/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hazelcast/hazelcast-cpp-client
-    REF v5.1.0
-    SHA512 ffb7a00f432098b64e1455074843ca7d592b4ccf169f6c51234840ca13dc9f69ef424b1ace04455a80a6f93d230d44d5323baa4b95017f84c71f1e31ff320088 
+    REF v5.2.0
+    SHA512 1e4203b546f3737e7fd2ea7a7ed04fa5b0663e7c319ed796140407d4e56d70e40eb5a9497d9f9eb7be182b038efe36f6ba1a42f10d24d3732cf54886c40db8eb 
     HEAD_REF master
 )
 

--- a/ports/hazelcast-cpp-client/portfile.cmake
+++ b/ports/hazelcast-cpp-client/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hazelcast/hazelcast-cpp-client
-    REF v5.2.0
+    REF "v${VERSION}"
     SHA512 1e4203b546f3737e7fd2ea7a7ed04fa5b0663e7c319ed796140407d4e56d70e40eb5a9497d9f9eb7be182b038efe36f6ba1a42f10d24d3732cf54886c40db8eb 
     HEAD_REF master
 )

--- a/ports/hazelcast-cpp-client/vcpkg.json
+++ b/ports/hazelcast-cpp-client/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hazelcast-cpp-client",
-  "version-semver": "5.1.0",
+  "version-semver": "5.2.0",
   "description": "C++ client library for Hazelcast in-memory database.",
   "homepage": "https://github.com/hazelcast/hazelcast-cpp-client",
   "documentation": "http://hazelcast.github.io/hazelcast-cpp-client/index.html",

--- a/ports/hazelcast-cpp-client/vcpkg.json
+++ b/ports/hazelcast-cpp-client/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "hazelcast-cpp-client",
-  "version-semver": "5.2.0",
+  "version": "5.2.0",
   "description": "C++ client library for Hazelcast in-memory database.",
   "homepage": "https://github.com/hazelcast/hazelcast-cpp-client",
   "documentation": "http://hazelcast.github.io/hazelcast-cpp-client/index.html",
+  "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     "boost-any",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3013,7 +3013,7 @@
       "port-version": 1
     },
     "hazelcast-cpp-client": {
-      "baseline": "5.1.0",
+      "baseline": "5.2.0",
       "port-version": 0
     },
     "hdf5": {

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80a165c1b6f95c2e1d320249b7bf0b2782d7adee",
+      "version-semver": "5.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "25883c041e091cbbb7501788378bd542f6433be6",
       "version-semver": "5.1.0",
       "port-version": 0

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "80a165c1b6f95c2e1d320249b7bf0b2782d7adee",
-      "version-semver": "5.2.0",
+      "git-tree": "eda58413d2940bc24bef92485ff1fce31e2e583c",
+      "version": "5.2.0",
       "port-version": 0
     },
     {


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


