### PR TITLE
[imgui] update to 1.89.4

### DIFF
--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -1,12 +1,11 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-vcpkg_minimum_required(VERSION 2022-11-10)
 
 if ("docking-experimental" IN_LIST FEATURES)
     vcpkg_from_github(
        OUT_SOURCE_PATH SOURCE_PATH
        REPO ocornut/imgui
-       REF 192196711a7d0d7c2d60454d42654cf090498a74
-       SHA512 66d8c299773347e69273f21ec5b0b038551ed9e3c88398568549c406e53624c7f87dffc2fb724f4b57bd4f6a9225f0dcdec6518cdbd7bae894ab128cf80cd138
+       REF 9e30fb0ec1b44dc1b041db6bdd53b130b2a18509
+       SHA512 f863bc1cb7482695061bf7012ae71ede87a74d08f7f3abc6360775ed70f14506142c5c751ae398086dcb3d3005a456af9b0267c62953a041502017468151ec35
        HEAD_REF docking
        )
 else()
@@ -14,7 +13,7 @@ else()
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
     REF v${VERSION}
-    SHA512 04b262921ff8987eb174f3326e6ce2b5e2cbdb89606d3d654cb9d0fa899a086ae354c0c9c4c0a65884bf4fcdfff5716cef5cb2815a5df3f6f855dc38e428eb02
+    SHA512 2284baf8628924b8c71f4d6beb78144ec919fd037bf37740244e417804858282d80be0acdc3e3c6273c9a5c1825f3754e2bedc208ff4ef486daf5f326fe3498e
     HEAD_REF master
     )
 endif()

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.89.3",
+  "version": "1.89.4",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/ports/imguizmo/fix-build.patch
+++ b/ports/imguizmo/fix-build.patch
@@ -1,0 +1,41 @@
+diff --git a/GraphEditor.cpp b/GraphEditor.cpp
+index 0f45a40..3a09390 100644
+--- a/GraphEditor.cpp
++++ b/GraphEditor.cpp
+@@ -24,8 +24,8 @@
+ // SOFTWARE.
+ //
+ 
+-#include "imgui.h"
+ #define IMGUI_DEFINE_MATH_OPERATORS
++#include "imgui.h"
+ #include "imgui_internal.h"
+ #include <math.h>
+ #include <vector>
+@@ -186,8 +186,8 @@ static void DisplayLinks(Delegate& delegate,
+         if (options.mDisplayLinksAsCurves)
+         {
+             // curves
+-             drawList->AddBezierCurve(p1, p1 + ImVec2(50, 0) * factor, p2 + ImVec2(-50, 0) * factor, p2, 0xFF000000, options.mLineThickness * 1.5f * factor);
+-             drawList->AddBezierCurve(p1, p1 + ImVec2(50, 0) * factor, p2 + ImVec2(-50, 0) * factor, p2, col, options.mLineThickness * 1.5f * factor);
++             drawList->AddBezierCubic(p1, p1 + ImVec2(50, 0) * factor, p2 + ImVec2(-50, 0) * factor, p2, 0xFF000000, options.mLineThickness * 1.5f * factor);
++             drawList->AddBezierCubic(p1, p1 + ImVec2(50, 0) * factor, p2 + ImVec2(-50, 0) * factor, p2, col, options.mLineThickness * 1.5f * factor);
+              /*
+             ImVec2 p10 = p1 + ImVec2(20.f * factor, 0.f);
+             ImVec2 p20 = p2 - ImVec2(20.f * factor, 0.f);
+diff --git a/ImGuizmo.cpp b/ImGuizmo.cpp
+index ed05fd8..74f0a0b 100644
+--- a/ImGuizmo.cpp
++++ b/ImGuizmo.cpp
+@@ -24,10 +24,10 @@
+ // SOFTWARE.
+ //
+ 
+-#include "imgui.h"
+ #ifndef IMGUI_DEFINE_MATH_OPERATORS
+ #define IMGUI_DEFINE_MATH_OPERATORS
+ #endif
++#include "imgui.h"
+ #include "imgui_internal.h"
+ #include "ImGuizmo.h"
+ 

--- a/ports/imguizmo/portfile.cmake
+++ b/ports/imguizmo/portfile.cmake
@@ -3,9 +3,11 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CedricGuillemet/ImGuizmo
-    REF 1.83
+    REF ${VERSION}
     SHA512 23285398688b4cdf3128ecb918b70c9a52f06c8e911da57430442b838cecf653e233d8cdfefc6acd3e4da381869ffc6fb74bcaaafc8e33657d6060a645517363
     HEAD_REF master
+    PATCHES
+        fix-build.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -21,4 +23,4 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/imguizmo/vcpkg.json
+++ b/ports/imguizmo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imguizmo",
   "version": "1.83",
+  "port-version": 1,
   "description": "Immediate mode 3D gizmo for scene editing and other controls based on Dear ImGui",
   "homepage": "https://github.com/CedricGuillemet/ImGuizmo",
   "dependencies": [

--- a/ports/implot/fix-build.patch
+++ b/ports/implot/fix-build.patch
@@ -1,0 +1,14 @@
+diff --git a/implot.h b/implot.h
+index 997d96f..fb1ff02 100644
+--- a/implot.h
++++ b/implot.h
+@@ -45,6 +45,9 @@
+ // [SECTION] Obsolete API
+ 
+ #pragma once
++#ifndef IMGUI_DEFINE_MATH_OPERATORS
++#define IMGUI_DEFINE_MATH_OPERATORS
++#endif
+ #include "imgui.h"
+ 
+ //-----------------------------------------------------------------------------

--- a/ports/implot/portfile.cmake
+++ b/ports/implot/portfile.cmake
@@ -3,9 +3,11 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO epezent/implot
-    REF v0.14
+    REF v${VERSION}
     SHA512 d33c83762ada55d4e188e975faf0c12d42cb3eb6b63904e6bce5b18d4184a2cdfc14e0b92286717ab86a1361dad7161e24402724f4eda2c0bce5658787d2dbe3
     HEAD_REF master
+    PATCHES
+        fix-build.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -21,4 +23,4 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/implot/vcpkg.json
+++ b/ports/implot/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "implot",
   "version": "0.14",
+  "port-version": 1,
   "description": "Advanced 2D Plotting for Dear ImGui",
   "homepage": "https://github.com/epezent/implot",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3234,7 +3234,7 @@
     },
     "imguizmo": {
       "baseline": "1.83",
-      "port-version": 0
+      "port-version": 1
     },
     "immer": {
       "baseline": "0.8.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3225,7 +3225,7 @@
       "port-version": 0
     },
     "imgui": {
-      "baseline": "1.89.3",
+      "baseline": "1.89.4",
       "port-version": 0
     },
     "imgui-sfml": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3242,7 +3242,7 @@
     },
     "implot": {
       "baseline": "0.14",
-      "port-version": 0
+      "port-version": 1
     },
     "indicators": {
       "baseline": "2.2",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "337ea84e098e85d4706ecdd807fe292933d9e6f8",
+      "version": "1.89.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "11f0d03a214f0dd91b63492cf1a4e5359671d2fb",
       "version": "1.89.3",
       "port-version": 0

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "65d6fab1371929e15b7198e139462218eb179abf",
+      "version": "1.83",
+      "port-version": 1
+    },
+    {
       "git-tree": "9611b5ef89fd20182ee8d6c84c505e986f3ea880",
       "version": "1.83",
       "port-version": 0

--- a/versions/i-/implot.json
+++ b/versions/i-/implot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d43f2b42e6c869ff277987364c11f7c1e6e01938",
+      "version": "0.14",
+      "port-version": 1
+    },
+    {
       "git-tree": "ba255028c68d4a1e37f4dc1a360b892f067f9c45",
       "version": "0.14",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

fixes #30260