### PR TITLE
[portmidi] Fix dependency searching

### DIFF
--- a/ports/portmidi/portfile.cmake
+++ b/ports/portmidi/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PortMidi/portmidi
-    REF v2.0.4
+    REF "v${VERSION}"
     SHA512 d9f22d161e1dd9a4bde1971bb2b6e5352da51545f4fe5ecad11c55e7a535f0d88efce18d1c8fd91e93b70a7926150f86a0f53972ad92370e86556a8dd72dc194
     HEAD_REF master
     PATCHES
@@ -9,20 +9,22 @@ vcpkg_from_github(
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL static)
-    SET(PM_USE_STATIC_RUNTIME ON)
+    set(PM_USE_STATIC_RUNTIME ON)
 else()
-    SET(PM_USE_STATIC_RUNTIME OFF)
+    set(PM_USE_STATIC_RUNTIME OFF)
 endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-    -DPM_USE_STATIC_RUNTIME="${PM_USE_STATIC_RUNTIME}"
+        -DPM_USE_STATIC_RUNTIME="${PM_USE_STATIC_RUNTIME}"
 )
-vcpkg_cmake_install()
 
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/PortMidi)
 
-file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license.txt")

--- a/ports/portmidi/portfile.cmake
+++ b/ports/portmidi/portfile.cmake
@@ -27,4 +27,5 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/PortMidi)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license.txt")

--- a/ports/portmidi/portfile.cmake
+++ b/ports/portmidi/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v2.0.4
     SHA512 d9f22d161e1dd9a4bde1971bb2b6e5352da51545f4fe5ecad11c55e7a535f0d88efce18d1c8fd91e93b70a7926150f86a0f53972ad92370e86556a8dd72dc194
     HEAD_REF master
+    PATCHES
+        "search-for-threads-in-config.patch"
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL static)

--- a/ports/portmidi/search-for-threads-in-config.patch
+++ b/ports/portmidi/search-for-threads-in-config.patch
@@ -1,0 +1,12 @@
+diff --git a/packaging/PortMidiConfig.cmake.in b/packaging/PortMidiConfig.cmake.in
+index a04928a..203ba30 100644
+--- a/packaging/PortMidiConfig.cmake.in
++++ b/packaging/PortMidiConfig.cmake.in
+@@ -4,6 +4,7 @@ include(CMakeFindDependencyMacro)
+ if(UNIX AND NOT APPLE AND NOT HAIKU AND (@LINUX_DEFINES@ MATCHES ".*PMALSA.*"))
+   find_dependency(ALSA)
+ endif()
++find_dependency(Threads)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/PortMidiTargets.cmake")
+

--- a/ports/portmidi/usage
+++ b/ports/portmidi/usage
@@ -1,0 +1,4 @@
+portmidi provides CMake targets:
+
+    find_package(PortMidi CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE PortMidi::portmidi)

--- a/ports/portmidi/vcpkg.json
+++ b/ports/portmidi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "portmidi",
   "version": "2.0.4",
+  "port-version": 1,
   "description": "PortMidi is a cross platform (Windows, macOS, Linux, and BSDs which support alsalib) library for interfacing with operating systems' MIDI I/O APIs.",
   "homepage": "https://github.com/PortMidi/portmidi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6186,7 +6186,7 @@
     },
     "portmidi": {
       "baseline": "2.0.4",
-      "port-version": 0
+      "port-version": 1
     },
     "portsmf": {
       "baseline": "0.238",

--- a/versions/p-/portmidi.json
+++ b/versions/p-/portmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8607f833773d8d45e83a3390c2096d28226c1d2",
+      "version": "2.0.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "80e9d16ce38c591b483a1d5b84eeb96a00a4d4ff",
       "version": "2.0.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

When calling `find_package(PortMidi CONFIG REQUIRED)` the call would fail with the following error message:

```
The link interface of target "PortMidi::portmidi" contains:

  Threads::Threads

but the target was not found.
```

This is due to the absence of a call to `find_dependency(Threads)` in the exported CMake config.

In addition to this patch, minor updates were made to the portfile, most notably:
- using `${VERSION}`
- copying pdbs
- installing a usage file
- using `vcpkg_install_copyright` to handle the license file