### PR TITLE
[nayuki-qr-code-generator] Bump version to v1.8.0

### DIFF
--- a/ports/nayuki-qr-code-generator/portfile.cmake
+++ b/ports/nayuki-qr-code-generator/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nayuki/QR-Code-generator
-    REF v1.7.0
-    SHA512 34efa40c382b6e7d060a764936c4e2faa4fbbecd5ea4730492a2cb1960656ed67242d84e20a42400ffdee063ed6bcf3b860fef309d09ee71303f44abaafe9328
+    REF v1.8.0
+    SHA512 0cdf0873e71aed124fc7357da86fb26f23fd26432f94c9752fa5a044085b26e5aece2115134d0e50213ff24be7c55818e7dec31205a68751065bc82ab0c2c6ac
     HEAD_REF master
 )
 

--- a/ports/nayuki-qr-code-generator/vcpkg.json
+++ b/ports/nayuki-qr-code-generator/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nayuki-qr-code-generator",
-  "version": "1.7.0",
-  "port-version": 1,
+  "version": "1.8.0",
   "description": "High-quality QR Code generator library in C++",
   "homepage": "https://github.com/nayuki/QR-Code-generator",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5385,8 +5385,8 @@
       "port-version": 0
     },
     "nayuki-qr-code-generator": {
-      "baseline": "1.7.0",
-      "port-version": 1
+      "baseline": "1.8.0",
+      "port-version": 0
     },
     "nccl": {
       "baseline": "2.4.6",

--- a/versions/n-/nayuki-qr-code-generator.json
+++ b/versions/n-/nayuki-qr-code-generator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "376b1b6483e138ceda93ab3b1aab6f3e51be74ad",
+      "version": "1.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a53df304990ba731189df6b4391c5eede88bd90c",
       "version": "1.7.0",
       "port-version": 1


### PR DESCRIPTION
Fix incorrect installation path of the config files and bump version to v1.8.0

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
