### PR TITLE
[vcpkg_configure_meson] Update compiler flags parsing

### DIFF
--- a/scripts/cmake/vcpkg_configure_meson.cmake
+++ b/scripts/cmake/vcpkg_configure_meson.cmake
@@ -57,11 +57,9 @@ function(z_vcpkg_meson_set_proglist_variables config_type)
 endfunction()
 
 function(z_vcpkg_meson_convert_compiler_flags_to_list out_var compiler_flags)
-    string(REPLACE ";" [[\;]] tmp_var "${compiler_flags}")
-    string(REGEX REPLACE [=[( +|^)((\"(\\"|[^"])+"|\\"|\\ |[^ ])+)]=] ";\\2" tmp_var "${tmp_var}")
-    vcpkg_list(POP_FRONT tmp_var) # The first element is always empty due to the above replacement
-    list(TRANSFORM tmp_var STRIP) # Strip leading trailing whitespaces from each element in the list.
-    set("${out_var}" "${tmp_var}" PARENT_SCOPE)
+    separate_arguments(cmake_list NATIVE_COMMAND "${compiler_flags}")
+    list(TRANSFORM cmake_list REPLACE ";" [[\\;]])
+    set("${out_var}" "${cmake_list}" PARENT_SCOPE)
 endfunction()
 
 function(z_vcpkg_meson_convert_list_to_python_array out_var)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30270. More generally, fixes parsing of fully quoted elements in flags detected from the cmake toolchain.
The parsing code for flags is now similar to what is in `vcpkg_configure_make`: The input is a single string of options for the native command line, so `separate_arguments` should do the right thing.

Tested with fribidi:arm64-android and NDK 25.

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
