### PR TITLE
[fluidsynth] Disable implicit OpenMP

### DIFF
--- a/ports/fluidsynth/add-usage-requirements.patch
+++ b/ports/fluidsynth/add-usage-requirements.patch
@@ -2,12 +2,11 @@ diff --git a/FluidSynthConfig.cmake.in b/FluidSynthConfig.cmake.in
 index 1ffdf598..0be65e0e 100644
 --- a/FluidSynthConfig.cmake.in
 +++ b/FluidSynthConfig.cmake.in
-@@ -6,5 +6,17 @@
+@@ -6,5 +6,16 @@
  # define variables for configuration options:
  # set(network-enabled @enable-network@)
  
 +include(CMakeFindDependencyMacro)
-+find_dependency(OpenMP COMPONENTS C)
 +find_dependency(PkgConfig)
 +pkg_check_modules(GLIB IMPORTED_TARGET glib-2.0>=2.6.5 gthread-2.0>=2.6.5)
 +set(ALSA_SUPPORT @ALSA_SUPPORT@)

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_check_features(
         sndfile     enable-libsndfile
 )
 
-set(feature_list dbus jack libinstpatch midishare opensles oboe oss sdl2 pulseaudio readline lash systemd dart)
+set(feature_list dbus jack libinstpatch midishare opensles oboe openmp oss sdl2 pulseaudio readline lash systemd dart)
 foreach(_feature IN LISTS feature_list)
     list(APPEND FEATURE_OPTIONS -Denable-${_feature}:BOOL=OFF)
 endforeach()

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fluidsynth",
   "version": "2.3.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2490,7 +2490,7 @@
     },
     "fluidsynth": {
       "baseline": "2.3.1",
-      "port-version": 1
+      "port-version": 2
     },
     "fmem": {
       "baseline": "c-libs-2ccee3d2fb",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7f1e0961e62f96d41646e7eb07ac177e5b240e2",
+      "version": "2.3.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "d165bef87ad633962767f10a3036a2e69f38b7e3",
       "version": "2.3.1",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

The `enable-openmp` option is turned ON by default, which leads to the following issues:
- Not all platforms have OpenMP, resulting in a failure when consuming FluidSynth in cmake. This is due to the unconditional call to `find_dependency(OpenMP COMPONENTS C)` from the patch added in #29636.
- When OpenMP support is not built into the compiler, CMake may pick up a system library (e.g. LLVM's libomp can be installed separately on Homebrew).
- OpenMP is not included in the generated pkg-config module, meaning linking fluidsynth statically fails with undefined references to OpenMP when it isn't a compiler built-in. An issue about it has already been opened upstream FluidSynth/fluidsynth#1224.

I was thinking about making it a feature that takes a dependency on `llvm[openmp]`, but the latter does not seem to build without the `clang` feature (`The dependency target "clang" of target "check-libomp" does not exist.`), which adds a large dependency for something that is not user-visible. Moreover it does not solve the pkg-config issue.