### PR TITLE
[unrar] Fix library linkage

### DIFF
--- a/ports/unrar/Config.cmake.in
+++ b/ports/unrar/Config.cmake.in
@@ -3,13 +3,17 @@ get_filename_component(_unrar_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component(_unrar_root "${_unrar_root}" PATH)
 get_filename_component(_unrar_root "${_unrar_root}" PATH)
 
-set(_unrar_lib "${_unrar_root}/lib/unrar.lib")
-if (EXISTS "${_unrar_lib}")
+if (EXISTS "${_unrar_root}/bin/unrar.dll")
 
-    add_library(unofficial::unrar::unrar INTERFACE IMPORTED)
-    set_target_properties(unofficial::unrar::unrar PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_unrar_root}/include")
-    set_target_properties(unofficial::unrar::unrar PROPERTIES IMPORTED_LOCATION "${_unrar_lib}")
-    set_property(TARGET unofficial::unrar::unrar APPEND PROPERTY IMPORTED_CONFIGURATIONS)
+    add_library(unofficial::unrar::unrar SHARED IMPORTED)
+    set_target_properties(unofficial::unrar::unrar PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES   "${_unrar_root}/include"    
+        IMPORTED_LOCATION_DEBUG         "${_unrar_root}/debug/bin/unrar.dll"
+        IMPORTED_IMPLIB_DEBUG           "${_unrar_root}/debug/lib/unrar.lib"
+        IMPORTED_LOCATION_RELEASE       "${_unrar_root}/bin/unrar.dll"
+        IMPORTED_IMPLIB_RELEASE         "${_unrar_root}/lib/unrar.lib"
+        IMPORTED_CONFIGURATIONS         "Debug;Release")
+
     set(unrar_FOUND TRUE)
 
 else()
@@ -17,6 +21,5 @@ else()
     set(unrar_FOUND FALSE)
 
 endif()
-unset(_unrar_lib)
 
 unset(_unrar_root)

--- a/ports/unrar/vcpkg.json
+++ b/ports/unrar/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "unrar",
   "version": "6.1.7",
+  "port-version": 1,
   "description": "rarlab's unrar library",
   "homepage": "https://www.rarlab.com",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8022,7 +8022,7 @@
     },
     "unrar": {
       "baseline": "6.1.7",
-      "port-version": 0
+      "port-version": 1
     },
     "upb": {
       "baseline": "2022-06-21",

--- a/versions/u-/unrar.json
+++ b/versions/u-/unrar.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "282699df90f6c302560fa8fdb097e386ae9de7db",
+      "version": "6.1.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "0181c013ed7f278c6e62725516dbb65b103fa7d7",
       "version": "6.1.7",
       "port-version": 0


### PR DESCRIPTION
Currently, linking library doesn't add unrar.lib to the target, so you get unresolved externals.
This patch fixes the problem.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
