### PR TITLE
[faiss] Update to v1.7.3

### DIFF
--- a/ports/faiss/portfile.cmake
+++ b/ports/faiss/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookresearch/faiss
-    REF v1.7.2
-    SHA512 dddf55af3cc73a15fbbd104ab75942194a4d5d088611bd98b11e459e034ba5df1d9247eb8c8b9f4631cc64c6ed284b2cf407041be7b6095f9395f9ac29d78df4
+    REF v1.7.3
+    SHA512 97649772049365363329a70d3baee1b1bd9787ad6b8cbc6ae33108cb7a470a3a0115cdfd2642acd6540808aa1c34a1e8f1216e882a4c1fd67a6d1bc38d4b6a5c
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/faiss/vcpkg.json
+++ b/ports/faiss/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "faiss",
-  "version-semver": "1.7.2",
+  "version-semver": "1.7.3",
   "description": "Faiss is a library for efficient similarity search and clustering of dense vectors.",
   "homepage": "https://github.com/facebookresearch/faiss",
   "license": "MIT",

--- a/ports/faiss/vcpkg.json
+++ b/ports/faiss/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "faiss",
-  "version-semver": "1.7.3",
+  "version": "1.7.3",
   "description": "Faiss is a library for efficient similarity search and clustering of dense vectors.",
   "homepage": "https://github.com/facebookresearch/faiss",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2345,7 +2345,7 @@
       "port-version": 1
     },
     "faiss": {
-      "baseline": "1.7.2",
+      "baseline": "1.7.3",
       "port-version": 0
     },
     "fakeit": {

--- a/versions/f-/faiss.json
+++ b/versions/f-/faiss.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "57fef087dee3ac99e1c198efce982209f1346213",
-      "version-semver": "1.7.3",
+      "git-tree": "f346ac31428205c546269f8107390836185f0d72",
+      "version": "1.7.3",
       "port-version": 0
     },
     {

--- a/versions/f-/faiss.json
+++ b/versions/f-/faiss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "57fef087dee3ac99e1c198efce982209f1346213",
+      "version-semver": "1.7.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f9afe2148c0cfa76354882e136af60bab695061",
       "version-semver": "1.7.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.