### PR TITLE
[armadillo] Update to 12.0.1

### DIFF
--- a/ports/armadillo/dependencies.patch
+++ b/ports/armadillo/dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index da1ff3a..5a7ede9 100644
+index 5b27e3c..78d3952 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -265,7 +265,6 @@ message(STATUS "*** Looking for external libraries")
+@@ -260,7 +260,6 @@ message(STATUS "*** Looking for external libraries")
  ## Find LAPACK and BLAS libraries, or their optimised versions
  ##
  
@@ -10,7 +10,7 @@ index da1ff3a..5a7ede9 100644
  
  if(APPLE)
    message(STATUS "Detected macOS")
-@@ -336,11 +335,16 @@ else()
+@@ -331,11 +330,16 @@ else()
      set(FlexiBLAS_FOUND false)
    endif()
    
@@ -27,15 +27,15 @@ index da1ff3a..5a7ede9 100644
    
    message(STATUS "FlexiBLAS_FOUND = ${FlexiBLAS_FOUND}" )
    message(STATUS "      MKL_FOUND = ${MKL_FOUND}"       )
-@@ -503,7 +507,6 @@ if(DETECT_HDF5)
-   endif()
+@@ -449,7 +453,6 @@ else()
  endif()
+ 
  
 -include(ARMA_FindARPACK)
  message(STATUS "ARPACK_FOUND = ${ARPACK_FOUND}")
  
  if(ARPACK_FOUND)
-@@ -511,7 +514,6 @@ if(ARPACK_FOUND)
+@@ -457,7 +460,6 @@ if(ARPACK_FOUND)
    set(ARMA_LIBS ${ARMA_LIBS} ${ARPACK_LIBRARY})
  endif()
  

--- a/ports/armadillo/portfile.cmake
+++ b/ports/armadillo/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO arma
     FILENAME "armadillo-${VERSION}.tar.xz"
-    SHA512 fa344a0f1dc8270d8aa01c35a00e9dd4182031ab3a0e1ecf8b748151eccdb5445807eb880b454ccba5250749ee02845adb1669732de89a4939e3368d36471015
+    SHA512 b1b9fbce6bdacc3340ab190605aba77e821629e0a51e0c6277840eaf803d037a778b9243c02c5b55d67976c203808a5fc34894f3928b707685f6d8695ef0bc0d
     PATCHES
         cmake-config.patch
         dependencies.patch
@@ -48,4 +48,4 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/armadillo_bits/config.hpp"
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt"  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/armadillo/vcpkg.json
+++ b/ports/armadillo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "armadillo",
-  "version": "11.4.4",
+  "version": "12.0.1",
   "description": "Armadillo is a high quality linear algebra library (matrix maths) for the C++ language, aiming towards a good balance between speed and ease of use",
   "homepage": "https://arma.sourceforge.net/",
   "license": "Apache-2.0",

--- a/versions/a-/armadillo.json
+++ b/versions/a-/armadillo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e222a2972a96da2fbb07a76585574e9512b107f",
+      "version": "12.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f149e3877dead7fd5e1783feb83a64a794eddcba",
       "version": "11.4.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -205,7 +205,7 @@
       "port-version": 0
     },
     "armadillo": {
-      "baseline": "11.4.4",
+      "baseline": "12.0.1",
       "port-version": 0
     },
     "arpack-ng": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/30259
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
