### PR TITLE
[nayuki-qr-code-generator] fix installation path of config files

### DIFF
--- a/ports/nayuki-qr-code-generator/CMakeLists.txt
+++ b/ports/nayuki-qr-code-generator/CMakeLists.txt
@@ -19,6 +19,6 @@ install(TARGETS nayuki-qr-code-generator EXPORT unofficial-nayuki-qr-code-genera
 install(
     EXPORT unofficial-nayuki-qr-code-generator-config
     NAMESPACE unofficial::nayuki-qr-code-generator::
-    DESTINATION share/nayuki-qr-code-generator
+    DESTINATION share/unofficial-nayuki-qr-code-generator
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
 )

--- a/ports/nayuki-qr-code-generator/portfile.cmake
+++ b/ports/nayuki-qr-code-generator/portfile.cmake
@@ -16,8 +16,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup()
-
+vcpkg_cmake_config_fixup(CONFIG_PATH share/unofficial-nayuki-qr-code-generator PACKAGE_NAME unofficial-nayuki-qr-code-generator)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright

--- a/ports/nayuki-qr-code-generator/vcpkg.json
+++ b/ports/nayuki-qr-code-generator/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nayuki-qr-code-generator",
   "version": "1.7.0",
+  "port-version": 1,
   "description": "High-quality QR Code generator library in C++",
   "homepage": "https://github.com/nayuki/QR-Code-generator",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5378,7 +5378,7 @@
     },
     "nayuki-qr-code-generator": {
       "baseline": "1.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nccl": {
       "baseline": "2.4.6",

--- a/versions/n-/nayuki-qr-code-generator.json
+++ b/versions/n-/nayuki-qr-code-generator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a53df304990ba731189df6b4391c5eede88bd90c",
+      "version": "1.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9131848b9c36878cb0944b3e8058fa0d25b0d335",
       "version": "1.7.0",
       "port-version": 0


### PR DESCRIPTION
Fix config installation path, such that it can be found with `find_package`.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
