### PR TITLE
[qscintilla] build against Qt6

### DIFF
--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -17,21 +17,24 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_PATH ${PYTHON3} DIRECTORY)
 vcpkg_add_to_path(${PYTHON3_PATH})
 
-vcpkg_configure_qmake(
-    SOURCE_PATH ${SOURCE_PATH}/src
-    OPTIONS
-        CONFIG+=build_all
-        CONFIG-=hide_symbols
-        DEFINES+=SCI_NAMESPACE
+vcpkg_qmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/src"
+    QMAKE_OPTIONS
+        "CONFIG-=hide_symbols"
+        "DEFINES+=SCI_NAMESPACE"
 )
+vcpkg_qmake_install()
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_install_qmake(
-        RELEASE_TARGETS release
-        DEBUG_TARGETS debug
-    )
-else()
-    vcpkg_install_qmake()
+file(GLOB DLLS "${CURRENT_PACKAGES_DIR}/lib/*.dll")
+if(DLLS)
+    file(COPY ${DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE ${DLLS})
+endif()
+
+file(GLOB DEBUG_DLLS "${CURRENT_PACKAGES_DIR}/debug/lib/*.dll")
+if(DEBUG_DLLS)
+    file(COPY ${DEBUG_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(REMOVE ${DEBUG_DLLS})
 endif()
 
 file(GLOB HEADER_FILES ${SOURCE_PATH}/src/Qsci/*)

--- a/ports/qscintilla/vcpkg.json
+++ b/ports/qscintilla/vcpkg.json
@@ -1,21 +1,19 @@
 {
   "name": "qscintilla",
   "version": "2.13.4",
+  "port-version": 1,
   "description": "QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)",
   "homepage": "https://www.riverbankcomputing.com/software/qscintilla",
   "license": "GPL-3.0-or-later",
   "dependencies": [
     {
-      "name": "qt5-base",
+      "name": "qtbase",
       "default-features": false
     },
     {
-      "name": "qt5-macextras",
-      "platform": "osx"
-    },
-    {
-      "name": "qt5-winextras",
-      "platform": "windows"
+      "name": "vcpkg-qmake",
+      "host": true,
+      "default-features": false
     }
   ]
 }

--- a/ports/vcpkg-qmake/vcpkg.json
+++ b/ports/vcpkg-qmake/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-qmake",
-  "version-date": "2022-11-16",
+  "version-date": "2023-03-22",
   "documentation": "https://vcpkg.io/en/docs/README.html",
   "license": "MIT",
   "supports": "native",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8165,7 +8165,7 @@
       "port-version": 1
     },
     "vcpkg-qmake": {
-      "baseline": "2022-11-16",
+      "baseline": "2023-03-22",
       "port-version": 0
     },
     "vcpkg-tool-bazel": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6338,7 +6338,7 @@
     },
     "qscintilla": {
       "baseline": "2.13.4",
-      "port-version": 0
+      "port-version": 1
     },
     "qt": {
       "baseline": "6.4.3",

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "7698a4b73e3ed54fd0cf66cf9e754317763750cb",
+      "git-tree": "4920a3d743be78d0d5be05132786873977677665",
+      "version": "2.13.4",
+      "port-version": 1
+    },
+    {
+      "git-tree": "b5942c0b0a6d9131bc4ad9a1dde662f809a6d965",
       "version": "2.13.4",
       "port-version": 0
     },

--- a/versions/v-/vcpkg-qmake.json
+++ b/versions/v-/vcpkg-qmake.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82e22019ae07b7150c3fb2a8672d4192eed2782c",
+      "version-date": "2023-03-22",
+      "port-version": 0
+    },
+    {
       "git-tree": "993a25e3e7a43175fb3d7d4981bc3e0de1f65c32",
       "version-date": "2022-11-16",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.