### PR TITLE
[qca] update to 2.3.5 and build against Qt6

### DIFF
--- a/ports/qca/0002-fix-build-error.patch
+++ b/ports/qca/0002-fix-build-error.patch
@@ -12,18 +12,13 @@ diff --git a/cmake/modules/QcaMacro.cmake b/cmake/modules/QcaMacro.cmake
 index 80af6e84..ba86310d 100644
 --- a/cmake/modules/QcaMacro.cmake
 +++ b/cmake/modules/QcaMacro.cmake
-@@ -69,15 +69,6 @@ macro(add_qca_test TARGET DESCRIPTION)
+@@ -65,10 +65,6 @@ macro(add_qca_test TARGET DESCRIPTION)
  endmacro(add_qca_test)
  
  macro(install_pdb TARGET INSTALL_PATH)
 -  if(MSVC)
--    get_target_property(LOCATION ${TARGET} LOCATION_DEBUG)
--    string(REGEX REPLACE "\\.[^.]*$" ".pdb" LOCATION "${LOCATION}")
--    install(FILES ${LOCATION} DESTINATION ${INSTALL_PATH} CONFIGURATIONS Debug)
--
--    get_target_property(LOCATION ${TARGET} LOCATION_RELWITHDEBINFO)
--    string(REGEX REPLACE "\\.[^.]*$" ".pdb" LOCATION "${LOCATION}")
--    install(FILES ${LOCATION} DESTINATION ${INSTALL_PATH} CONFIGURATIONS RelWithDebInfo)
+-    install(FILES $<TARGET_PDB_FILE:${TARGET}> DESTINATION ${INSTALL_PATH} CONFIGURATIONS Debug)
+-    install(FILES $<TARGET_PDB_FILE:${TARGET}> DESTINATION ${INSTALL_PATH} CONFIGURATIONS RelWithDebInfo)
 -  endif()
  endmacro(install_pdb)
  
@@ -49,23 +44,14 @@ index b2c5d3d3..4250ec26 100644
          else if (type == QLatin1String("tripledes-ecb"))
              return new opensslCipherContext(EVP_des_ede3(), 0, this, type);
          else if (type == QLatin1String("tripledes-cbc"))
-@@ -6872,6 +6875,8 @@ public:
+@@ -6872,6 +6875,7 @@ public:
              return new opensslCipherContext(EVP_des_cfb(), 0, this, type);
          else if (type == QLatin1String("des-ofb"))
              return new opensslCipherContext(EVP_des_ofb(), 0, this, type);
 +#endif
-+#ifndef OPENSSL_NO_CAST
+ #ifndef OPENSSL_NO_CAST
          else if (type == QLatin1String("cast5-ecb"))
              return new opensslCipherContext(EVP_cast5_ecb(), 0, this, type);
-         else if (type == QLatin1String("cast5-cbc"))
-@@ -6882,6 +6887,7 @@ public:
-             return new opensslCipherContext(EVP_cast5_cfb(), 0, this, type);
-         else if (type == QLatin1String("cast5-ofb"))
-             return new opensslCipherContext(EVP_cast5_ofb(), 0, this, type);
-+#endif
-         else if (type == QLatin1String("pkey"))
-             return new MyPKeyContext(this);
-         else if (type == QLatin1String("dlgroup"))
 -- 
 2.31.1
 

--- a/ports/qca/0003-Define-NOMINMAX-for-botan-plugin-with-MSVC.patch
+++ b/ports/qca/0003-Define-NOMINMAX-for-botan-plugin-with-MSVC.patch
@@ -1,0 +1,28 @@
+From f32f5ae8b8b49653bfff87f2f882862bcaa8c3f1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D9=85=D9=87=D8=AF=D9=8A=20=D8=B4=D9=8A=D9=86=D9=88=D9=86?=
+ =?UTF-8?q?=20=28Mehdi=20Chinoune=29?= <mehdi.chinoune@hotmail.com>
+Date: Mon, 20 Mar 2023 16:21:18 +0100
+Subject: [PATCH] Define NOMINMAX to fix building qca-botan plugin with MSVC
+
+---
+ plugins/qca-botan/CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/plugins/qca-botan/CMakeLists.txt b/plugins/qca-botan/CMakeLists.txt
+index 11c0d20..9b8b978 100644
+--- a/plugins/qca-botan/CMakeLists.txt
++++ b/plugins/qca-botan/CMakeLists.txt
+@@ -11,6 +11,10 @@ if(BOTAN_FOUND)
+   set(QCA_BOTAN_SOURCES qca-botan.cpp)
+   add_library(qca-botan ${PLUGIN_TYPE} ${QCA_BOTAN_SOURCES})
+ 
++  if(MSVC)
++    target_compile_definitions(qca-botan PRIVATE NOMINMAX)
++  endif()
++
+   if(APPLE AND ${PLUGIN_TYPE} STREQUAL "MODULE")
+     set_property(TARGET qca-botan  PROPERTY SUFFIX ".dylib")
+   endif()
+-- 
+2.40.0.windows.1
+

--- a/ports/qca/portfile.cmake
+++ b/ports/qca/portfile.cmake
@@ -11,11 +11,12 @@ vcpkg_add_to_path("${PERL_EXE_PATH}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/qca
-    REF v2.3.4
-    SHA512 04583da17531538fc2a7ae18a1a4f89f1e8d303e2bb390520a8f55a20bab17f8407ab07aefef2a75587e2a0521f41b37a9fdd8430ec483daf5d02c05556b8ddb
+    REF v2.3.5
+    SHA512 c83ac69597f22d915479fd4fd1557b89c56ba384321c324f93cf2f1bd32a819cb6d7b008c44e7606fa39c8184043d97c36ee1210d23a6e8ce24c41c8a83e4fb9
     PATCHES
         0001-fix-path-for-vcpkg.patch
         0002-fix-build-error.patch
+        0003-Define-NOMINMAX-for-botan-plugin-with-MSVC.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -57,6 +58,7 @@ vcpkg_cmake_configure(
         -DUSE_RELATIVE_PATHS=ON
         -DBUILD_TESTS=OFF
         -DBUILD_TOOLS=OFF
+        -DBUILD_WITH_QT6=ON
         -DQCA_SUFFIX=OFF
         -DQCA_FEATURE_INSTALL_DIR=share/qca/mkspecs/features
         -DOSX_FRAMEWORK=OFF

--- a/ports/qca/vcpkg.json
+++ b/ports/qca/vcpkg.json
@@ -1,12 +1,15 @@
 {
   "name": "qca",
-  "version": "2.3.4",
-  "port-version": 3,
+  "version": "2.3.5",
   "description": "Qt Cryptographic Architecture (QCA).",
-  "homepage": "https://cgit.kde.org/qca.git/",
+  "homepage": "https://userbase.kde.org/QCA",
   "dependencies": [
     {
-      "name": "qt5-base",
+      "name": "qt5compat",
+      "default-features": false
+    },
+    {
+      "name": "qtbase",
       "default-features": false
     },
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6313,8 +6313,8 @@
       "port-version": 5
     },
     "qca": {
-      "baseline": "2.3.4",
-      "port-version": 3
+      "baseline": "2.3.5",
+      "port-version": 0
     },
     "qcustomplot": {
       "baseline": "2.0.1",

--- a/versions/q-/qca.json
+++ b/versions/q-/qca.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d7c38d61627baf7ae04a7f069fad8f506e5f82d",
+      "version": "2.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "f719790dc5863b3724d0fed5a7179cb1ca41c871",
       "version": "2.3.4",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
