### PR TITLE
[libgme] add new port

### DIFF
--- a/ports/libgme/disable-player-and-demo.patch
+++ b/ports/libgme/disable-player-and-demo.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6b352102db48f265448a35b731cb712b8e112d39..62349bd48ddd3d6c44e6ee68243605781814de2f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -102,5 +102,3 @@ endif ()
+ add_subdirectory(gme)
+ 
+ # EXCLUDE_FROM_ALL adds build rules but keeps it out of default build
+-add_subdirectory(player EXCLUDE_FROM_ALL)
+-add_subdirectory(demo EXCLUDE_FROM_ALL)

--- a/ports/libgme/disable-static-zlib-hack.patch
+++ b/ports/libgme/disable-static-zlib-hack.patch
@@ -1,0 +1,13 @@
+diff --git a/gme/CMakeLists.txt b/gme/CMakeLists.txt
+index b1b2bf0aee0d79dbeb76fd46756ad9709af57ae3..aacb5a8067f77cfeac560d65cc1538dd75008c9b 100644
+--- a/gme/CMakeLists.txt
++++ b/gme/CMakeLists.txt
+@@ -17,7 +17,7 @@ set(libgme_SRCS Blip_Buffer.cpp
+ # static builds need to find static zlib (and static forms of other needed
+ # libraries.  Ensure CMake looks only for static libs if we're doing a static
+ # build.  See https://stackoverflow.com/a/44738756
+-if(NOT BUILD_SHARED_LIBS)
++if(0)
+     set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+ endif()
+ 

--- a/ports/libgme/portfile.cmake
+++ b/ports/libgme/portfile.cmake
@@ -1,0 +1,66 @@
+vcpkg_from_bitbucket(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mpyne/game-music-emu
+    REF "${VERSION}"
+    SHA512 3d5e0dafb7ba239fb1c4cebf47c7e195a350bfe7a43606deff1ecff1ab21a0aac47343205004c0aba06ae249a0e186122c1b7dec06fc52272d4baaea9a480796
+    PATCHES
+        disable-player-and-demo.patch
+        disable-static-zlib-hack.patch
+)
+
+# This file is generated during the CMake build
+file(REMOVE "${SOURCE_PATH}/gme/gme_types.h")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        ay      USE_GME_AY
+        gbs     USE_GME_GBS
+        gym     USE_GME_GYM
+        hes     USE_GME_HES
+        kss     USE_GME_KSS
+        nsf     USE_GME_NSF
+        nsfe    USE_GME_NSFE
+        sap     USE_GME_SAP
+        spc     USE_GME_SPC
+        vgm     USE_GME_VGM
+        spc-isolated-echo-buffer    GME_SPC_ISOLATED_ECHO_BUFFER
+)
+
+set(CMAKE_DISABLE_FIND_PACKAGE_ZLIB ON)
+set(CMAKE_REQUIRE_FIND_PACKAGE_ZLIB OFF)
+if("vgm" IN_LIST FEATURES)
+    set(CMAKE_DISABLE_FIND_PACKAGE_ZLIB OFF)
+    set(CMAKE_REQUIRE_FIND_PACKAGE_ZLIB ON)
+endif()
+
+if("vgm" IN_LIST FEATURES OR "gym" IN_LIST FEATURES)
+    set(GME_YM2612_EMU Nuked)
+    message(STATUS "This version of libgme uses the Nuked YM2612 emulator. To use the MAME or GENS instead, create an overlay port of this with GME_YM2612_EMU set to \"MAME\" or \"GENS\" accordingly.")
+    message(STATUS "This recipe is at ${CMAKE_CURRENT_LIST_DIR}")
+    message(STATUS "See the overlay ports documentation at https://github.com/microsoft/vcpkg/blob/master/docs/specifications/ports-overlay.md")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DGME_YM2612_EMU=${GME_YM2612_EMU}
+        -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB=${CMAKE_DISABLE_FIND_PACKAGE_ZLIB}
+        -DCMAKE_REQUIRE_FIND_PACKAGE_ZLIB=${CMAKE_REQUIRE_FIND_PACKAGE_ZLIB}
+        -DENABLE_UBSAN=OFF
+    MAYBE_UNUSED_VARIABLES
+        GME_YM2612_EMU
+        GME_SPC_ISOLATED_ECHO_BUFFER
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/license*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/libgme/vcpkg.json
+++ b/ports/libgme/vcpkg.json
@@ -1,0 +1,63 @@
+{
+  "name": "libgme",
+  "version": "0.6.3",
+  "description": "Video game music file emulation/playback library",
+  "homepage": "https://bitbucket.org/mpyne/game-music-emu/wiki/Home",
+  "license": "LGPL-2.1-or-later OR GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "ay",
+    "gbs",
+    "gym",
+    "hes",
+    "kss",
+    "nsf",
+    "nsfe",
+    "sap",
+    "spc",
+    "vgm"
+  ],
+  "features": {
+    "ay": {
+      "description": "Enable Spectrum ZX music emulation"
+    },
+    "gbs": {
+      "description": "Enable Game Boy music emulation"
+    },
+    "gym": {
+      "description": "Enable Sega MegaDrive/Genesis music emulation"
+    },
+    "hes": {
+      "description": "Enable PC Engine/TurboGrafx-16 music emulation"
+    },
+    "kss": {
+      "description": "Enable MSX or other Z80 systems music emulation"
+    },
+    "nsf": {
+      "description": "Enable NES NSF music emulation"
+    },
+    "nsfe": {
+      "description": "Enable NES NSFE and NSF music emulation"
+    },
+    "sap": {
+      "description": "Enable Atari SAP music emulation"
+    },
+    "spc": {
+      "description": "Enable SNES SPC music emulation"
+    },
+    "spc-isolated-echo-buffer": {
+      "description": "Enable isolated echo buffer on SPC emulator to allow correct playing of \"dodgy\" SPC files made for various ROM hacks ran on ZSNES"
+    },
+    "vgm": {
+      "description": "Enable Sega VGM/VGZ music emulation",
+      "dependencies": [
+        "zlib"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3960,6 +3960,10 @@
       "baseline": "1.4.2",
       "port-version": 0
     },
+    "libgme": {
+      "baseline": "0.6.3",
+      "port-version": 0
+    },
     "libgnutls": {
       "baseline": "3.7.8",
       "port-version": 0

--- a/versions/l-/libgme.json
+++ b/versions/l-/libgme.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2472a6f203e9ed53baddf37ab2c075a57254d68a",
+      "version": "0.6.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
