### PR TITLE
[cppslippi] Add new port

### DIFF
--- a/ports/cppslippi/portfile.cmake
+++ b/ports/cppslippi/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            cppslippi
+    FILENAME        "CppSlippi-${VERSION}.zip"
+    SHA512          5057758ed7da1f8d3bbdcd0eb783e93aa07d501a5333c48707f588bd3370551fce65a22074da9cbe4aa69fa32fa6c826a2aa039911cff7be5b8548842d135ece
+    NO_REMOVE_ONE_LEVEL
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_TESTING=False
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/CppSlippi)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(COPY "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/cppslippi/usage
+++ b/ports/cppslippi/usage
@@ -1,0 +1,4 @@
+The package cppslippi provides CMake targets:
+
+    find_package(CppSlippi CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CppSlippi::CppSlippi)

--- a/ports/cppslippi/vcpkg.json
+++ b/ports/cppslippi/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "cppslippi",
+  "version": "1.0.3.14",
+  "description": "C++ Slippi replay file parser.",
+  "homepage": "https://sourceforge.net/projects/cppslippi/",
+  "license": "MIT",
+  "dependencies": [
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -165,6 +165,9 @@ cppmicroservices:arm-uwp=fail
 cppmicroservices:x64-uwp=fail
 cpp-netlib:arm-uwp=fail
 cpp-netlib:x64-uwp=fail
+# Requires full C++20 support, currently absent from CI for these triplets.
+cppslippi:x64-linux=fail
+cppslippi:x64-osx=fail
 cppcoro:x64-linux=fail
 cppcoro:arm-uwp=fail
 cppcoro:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1776,6 +1776,10 @@
       "baseline": "2.10.18",
       "port-version": 2
     },
+    "cppslippi": {
+      "baseline": "1.0.3.14",
+      "port-version": 0
+    },
     "cpptoml": {
       "baseline": "v0.1.1",
       "port-version": 2

--- a/versions/c-/cppslippi.json
+++ b/versions/c-/cppslippi.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3cb6381580bcf82551009114b87021b0b1bc9885",
+      "version": "1.0.3.14",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.