### PR TITLE
[libtar] new port

### DIFF
--- a/ports/libtar/portfile.cmake
+++ b/ports/libtar/portfile.cmake
@@ -1,8 +1,7 @@
-set(VCPKG_USE_HEAD_VERSION ON)
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://repo.or.cz/libtar.git
-    HEAD_REF v1.2.20
+    REF 6d0ab4c78e7a8305c36a0c3d63fd25cd1493de65 # latest on master
 )
 
 vcpkg_configure_make(
@@ -13,4 +12,4 @@ vcpkg_install_make()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"  "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/ports/libtar/portfile.cmake
+++ b/ports/libtar/portfile.cmake
@@ -1,0 +1,16 @@
+set(VCPKG_USE_HEAD_VERSION ON)
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL https://repo.or.cz/libtar.git
+    HEAD_REF v1.2.20
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_install_make()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"  "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libtar/vcpkg.json
+++ b/ports/libtar/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "libtar",
+  "version": "1.2.20",
+  "description": "libtar - C library for manipulating tar files",
+  "homepage": "https://repo.or.cz/libtar.git",
+  "supports": "!windows"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4480,6 +4480,10 @@
       "baseline": "3.25",
       "port-version": 0
     },
+    "libtar": {
+      "baseline": "1.2.20",
+      "port-version": 0
+    },
     "libtasn1": {
       "baseline": "4.19.0",
       "port-version": 1

--- a/versions/l-/libtar.json
+++ b/versions/l-/libtar.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c981b35ed9259a0f23aefe903584e5adfecc2f08",
+      "version": "1.2.20",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libtar.json
+++ b/versions/l-/libtar.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c981b35ed9259a0f23aefe903584e5adfecc2f08",
+      "git-tree": "88cec24f0726abad060a2741dcd064b2698a886a",
       "version": "1.2.20",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
