### PR TITLE
[bxzstr] Added port for bxzstr

### DIFF
--- a/ports/bxzstr/portfile.cmake
+++ b/ports/bxzstr/portfile.cmake
@@ -18,6 +18,4 @@ file(INSTALL
      "${SOURCE_PATH}/include/zstd_stream_wrapper.hpp"
      DESTINATION "${CURRENT_PACKAGES_DIR}/include/bxzstr")
 
-vcpkg_add_to_path("${CURRENT_PACKAGES_DIR}/include/bxzstr")
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bxzstr/portfile.cmake
+++ b/ports/bxzstr/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tmaklin/bxzstr
+  REF "v${VERSION}"
+  SHA512 e357eb99b007031a1b15b20077883ebb20b294fda97d4aa354ded04c8d0b398fdeae9e1e97747caf55699a8feadf8c10eb807a9c6a66837a0816002df34fb7a1
+  HEAD_REF master
+)
+
+file(INSTALL
+     "${SOURCE_PATH}/include/bxzstr.hpp"
+     "${SOURCE_PATH}/include/bz_stream_wrapper.hpp"
+     "${SOURCE_PATH}/include/compression_types.hpp"
+     "${SOURCE_PATH}/include/config.hpp"
+     "${SOURCE_PATH}/include/lzma_stream_wrapper.hpp"
+     "${SOURCE_PATH}/include/stream_wrapper.hpp"
+     "${SOURCE_PATH}/include/strict_fstream.hpp"
+     "${SOURCE_PATH}/include/z_stream_wrapper.hpp"
+     "${SOURCE_PATH}/include/zstd_stream_wrapper.hpp"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/include/bxzstr/")
+
+vcpkg_add_to_path("${CURRENT_PACKAGES_DIR}/include/bxzstr/")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bxzstr/portfile.cmake
+++ b/ports/bxzstr/portfile.cmake
@@ -16,8 +16,8 @@ file(INSTALL
      "${SOURCE_PATH}/include/strict_fstream.hpp"
      "${SOURCE_PATH}/include/z_stream_wrapper.hpp"
      "${SOURCE_PATH}/include/zstd_stream_wrapper.hpp"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/include/bxzstr/")
+     DESTINATION "${CURRENT_PACKAGES_DIR}/include/bxzstr")
 
-vcpkg_add_to_path("${CURRENT_PACKAGES_DIR}/include/bxzstr/")
+vcpkg_add_to_path("${CURRENT_PACKAGES_DIR}/include/bxzstr")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bxzstr/portfile.cmake
+++ b/ports/bxzstr/portfile.cmake
@@ -19,3 +19,5 @@ file(INSTALL
      DESTINATION "${CURRENT_PACKAGES_DIR}/include/bxzstr")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/bxzstr/usage
+++ b/ports/bxzstr/usage
@@ -1,4 +1,4 @@
 The package bxzstr is header only and can be used from CMake via:
 
-    find_path(BXZSTR_INCLUDE_DIRS "bxzstr.hpp")
+    find_path(BXZSTR_INCLUDE_DIRS "bxzstr.hpp" PATH_SUFFIXES "include/bxzstr")
     target_include_directories(main PRIVATE ${BXZSTR_INCLUDE_DIRS})

--- a/ports/bxzstr/usage
+++ b/ports/bxzstr/usage
@@ -1,0 +1,4 @@
+The package bxzstr is header only and can be used from CMake via:
+
+    find_path(BXZSTR_INCLUDE_DIRS "bxzstr.hpp")
+    target_include_directories(main PRIVATE ${BXZSTR_INCLUDE_DIRS})

--- a/ports/bxzstr/vcpkg.json
+++ b/ports/bxzstr/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "bxzstr",
   "version": "1.2.0",
-  "homepage": "https://github.com/tmaklin/bxzstr/",
   "description": "A C++ header-only ZLib/libBZ2/libLZMA/Zstandard wrapper.",
+  "homepage": "https://github.com/tmaklin/bxzstr",
+  "license": "MPL-2.0",
   "dependencies": [
     "bzip2",
     "liblzma",
-    "zstr",
+    "zlib",
     "zstd"
   ]
 }

--- a/ports/bxzstr/vcpkg.json
+++ b/ports/bxzstr/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "bxzstr",
+  "version": "1.2.0",
+  "homepage": "https://github.com/tmaklin/bxzstr/",
+  "description": "A C++ header-only ZLib/libBZ2/libLZMA/Zstandard wrapper.",
+  "dependencies": [
+    "bzip2",
+    "liblzma",
+    "zstr",
+    "zstd"
+  ]
+}

--- a/versions/b-/bxzstr.json
+++ b/versions/b-/bxzstr.json
@@ -1,0 +1,13 @@
+{
+  "name": "bxzstr",
+  "version": "1.2.0",
+  "description": "A C++ header-only ZLib/libBZ2/libLZMA/Zstandard wrapper.",
+  "homepage": "https://github.com/tmaklin/bxzstr",
+  "license": "MPL-2.0",
+  "dependencies": [
+    "bzip2",
+    "liblzma",
+    "zlib",
+    "zstd"
+  ]
+}

--- a/versions/b-/bxzstr.json
+++ b/versions/b-/bxzstr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8663080835df45242f1780a96c8f511f9e65f08a",
+      "git-tree": "ad9511ac67f069a83b89c91a8fb0c995a6aca196",
       "version": "1.2.0",
       "port-version": 0
     }

--- a/versions/b-/bxzstr.json
+++ b/versions/b-/bxzstr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a5903e15f5263e20cc33bfbd5685d8d9e7ba9094",
+      "git-tree": "80f6ef7cc2968621cc533e3c4104b18e52162595",
       "version": "1.2.0",
       "port-version": 0
     }

--- a/versions/b-/bxzstr.json
+++ b/versions/b-/bxzstr.json
@@ -1,13 +1,9 @@
 {
-  "name": "bxzstr",
-  "version": "1.2.0",
-  "description": "A C++ header-only ZLib/libBZ2/libLZMA/Zstandard wrapper.",
-  "homepage": "https://github.com/tmaklin/bxzstr",
-  "license": "MPL-2.0",
-  "dependencies": [
-    "bzip2",
-    "liblzma",
-    "zlib",
-    "zstd"
+  "versions": [
+    {
+      "git-tree": "a5903e15f5263e20cc33bfbd5685d8d9e7ba9094",
+      "version": "1.2.0",
+      "port-version": 0
+    }
   ]
 }

--- a/versions/b-/bxzstr.json
+++ b/versions/b-/bxzstr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "80f6ef7cc2968621cc533e3c4104b18e52162595",
+      "git-tree": "8663080835df45242f1780a96c8f511f9e65f08a",
       "version": "1.2.0",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1288,6 +1288,10 @@
       "baseline": "2019-05-08",
       "port-version": 3
     },
+    "bxzstr": {
+      "baseline": "1.2.0",
+      "port-version": 0
+    },
     "byte-lite": {
       "baseline": "0.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

The library `zstr` has fallen out of development. This patch adds a port for a maintained fork of it.