### PR TITLE
[mpg123] Bump to 1.31.3

### DIFF
--- a/ports/mpg123/portfile.cmake
+++ b/ports/mpg123/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_sourceforge(
     REPO mpg123/mpg123
     REF "${VERSION}"
     FILENAME "mpg123-${VERSION}.tar.bz2"
-    SHA512 eca285382ee3e780353834addf1336c4a2f8f11256af22f95e11efa243de669761c083c86ddfc6ac8c02a920a3c4ab4ad767efa2739fb052e9719f35ef407bc3
+    SHA512 5dd550e06f5d0d432cac1b7e546215e56378b44588c1a98031498473211e08bc4228de45be41f7ba764f7f6c0eb752a6501235bcc3712c9a8d8852ae3c607d98
     PATCHES
         fix-modulejack.patch
         fix-m1-build.patch

--- a/ports/mpg123/portfile.cmake
+++ b/ports/mpg123/portfile.cmake
@@ -23,15 +23,11 @@ vcpkg_cmake_configure(
         BUILD_PROGRAMS
 )
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-if(VCPKG_TARGET_IS_OSX)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/mpg123/vcpkg.json
+++ b/ports/mpg123/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mpg123",
-  "version": "1.31.2",
+  "version": "1.31.3",
   "description": "mpg123 is a real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3 (MPEG 1.0 layer 3 also known as MP3).",
   "homepage": "https://sourceforge.net/projects/mpg123/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5225,7 +5225,7 @@
       "port-version": 0
     },
     "mpg123": {
-      "baseline": "1.31.2",
+      "baseline": "1.31.3",
       "port-version": 0
     },
     "mpi": {

--- a/versions/m-/mpg123.json
+++ b/versions/m-/mpg123.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a328d4e2a48af20df2ff33217be9c27343a56d4b",
+      "version": "1.31.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "635b5b51532f7cec33d16ada405e517be936c014",
       "version": "1.31.2",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

In addition to the version bump, the portfile was updated:
- Copy pdbs.
- Remove the cleanup of `bin` directories on macOS. 
Testing on all four macOS triplets (`x64-osx`, `x64-osx-dynamic`, `arm64-osx`, and `arm64-osx-dynamic`), no `bin` or `debug/bin` directories were created during the install using this version.