### PR TITLE
[libpcap] Fix incorrect library name in libpcap.pc of static build

### DIFF
--- a/ports/libpcap/install-pc-on-msvc.patch
+++ b/ports/libpcap/install-pc-on-msvc.patch
@@ -13,7 +13,7 @@ index b83fbbd..2f675d1 100644
 +if(BUILD_SHARED_LIBS)
 +    set(PACKAGE_NAME ${LIBRARY_NAME})
 +else()
-+    set(PACKAGE_NAME pcap)
++    set(PACKAGE_NAME ${LIBRARY_NAME}_static)
 +endif()
      set(prefix ${CMAKE_INSTALL_PREFIX})
      set(exec_prefix "\${prefix}")

--- a/ports/libpcap/vcpkg.json
+++ b/ports/libpcap/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpcap",
   "version-semver": "1.10.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A portable C/C++ library for network traffic capture",
   "homepage": "https://www.tcpdump.org/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4278,7 +4278,7 @@
     },
     "libpcap": {
       "baseline": "1.10.1",
-      "port-version": 1
+      "port-version": 2
     },
     "libpff": {
       "baseline": "2021-11-14",

--- a/versions/l-/libpcap.json
+++ b/versions/l-/libpcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b21dafcbcbd4a428b3800a6a686a473db8625ca6",
+      "version-semver": "1.10.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "4a0a395c4b517e9a54e1b96327b1ac90e317c225",
       "version-semver": "1.10.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #28208, fix incorrect library name in libpcap.pc of static build, the link library name should be same with library name.

The incorrect link library name is `pcap` in `libpcap.pc`:
```
Libs: -L"${libdir}" -lpcap -lws2_32 ...
```

`add_library` codes of static build, its library name is `${LIBRARY_NAME}_static`:
```
add_library(${LIBRARY_NAME}_static STATIC
    ${PROJECT_SOURCE_LIST_C}
    ${CMAKE_CURRENT_BINARY_DIR}/grammar.c
    ${CMAKE_CURRENT_BINARY_DIR}/scanner.c
    ${PROJECT_EXTERNAL_OBJECT_LIST}
)
```
Generate `libpcap.pc` should be:
```
if(BUILD_SHARED_LIBS)
    set(PACKAGE_NAME ${LIBRARY_NAME})
else()
    set(PACKAGE_NAME ${LIBRARY_NAME}_static)
endif()
```

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
