### PR TITLE
[concurrencpp] Update to 0.1.6

### DIFF
--- a/ports/concurrencpp/fix-include-path.patch
+++ b/ports/concurrencpp/fix-include-path.patch
@@ -1,13 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 351aa65..ab06584 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -94,7 +94,7 @@ include(CMakePackageConfigHelpers)
+@@ -117,7 +117,7 @@ include(CMakePackageConfigHelpers)
  include(GNUInstallDirs)
  
  set(concurrencpp_directory "concurrencpp-${PROJECT_VERSION}")
 -set(concurrencpp_include_directory "${CMAKE_INSTALL_INCLUDEDIR}/${concurrencpp_directory}")
 +set(concurrencpp_include_directory "${CMAKE_INSTALL_INCLUDEDIR}")
  
- install(TARGETS concurrencpp
-         EXPORT concurrencppTargets
+ install(
+   TARGETS concurrencpp

--- a/ports/concurrencpp/portfile.cmake
+++ b/ports/concurrencpp/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO David-Haim/concurrencpp

--- a/ports/concurrencpp/portfile.cmake
+++ b/ports/concurrencpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO David-Haim/concurrencpp
-  REF v.0.1.5
-  SHA512 94f2c4896e3455284874ea1dc7b4a836a5dd634b15b8582e90eaa7b4200e992f7744f025fac2cdb15471da104b40da97072b05bbe6eebecd0146622b747120ca
+  REF v.${VERSION}
+  SHA512 51e8ba898256165ef5173a098e804121ae0d1212b5d83e6356a34c72dc3d66849f7382e1f35f5ec34718425563faf1795675c6eeb5374dd660a65800e8318a1f
   HEAD_REF master
   PATCHES
     fix-include-path.patch
@@ -18,6 +18,6 @@ vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/concurrencpp-0.1.5)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/concurrencpp-${VERSION}")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/concurrencpp/vcpkg.json
+++ b/ports/concurrencpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "concurrencpp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "concurrencpp is a tasking library for C++ allowing developers to write highly concurrent applications easily and safely by using tasks, executors and coroutines.",
   "homepage": "https://github.com/David-Haim/concurrencpp/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1657,7 +1657,7 @@
       "port-version": 0
     },
     "concurrencpp": {
-      "baseline": "0.1.5",
+      "baseline": "0.1.6",
       "port-version": 0
     },
     "concurrentqueue": {

--- a/versions/c-/concurrencpp.json
+++ b/versions/c-/concurrencpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "187669a78bf9f0e304ea85e1cbc745a64f9426dc",
+      "git-tree": "d4d183249579167e00a7717a088721716d66635b",
       "version": "0.1.6",
       "port-version": 0
     },

--- a/versions/c-/concurrencpp.json
+++ b/versions/c-/concurrencpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "187669a78bf9f0e304ea85e1cbc745a64f9426dc",
+      "version": "0.1.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "b83d01e0edaa7fa36ca4e67542201b5fc7354b58",
       "version": "0.1.5",
       "port-version": 0


### PR DESCRIPTION
Updates concurrencpp to 0.1.6

* [x]  Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
* [x]  SHA512s are updated for each updated download
* [x]  The "supports" clause reflects platforms that may be fixed by this new version
* [x]  Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
* [x]  Any patches that are no longer applied are deleted from the port's directory.
* [x]  The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
* [x]  Only one version is added to each modified port's versions file.