### PR TITLE
[qcustomplot] update and build against Qt6

### DIFF
--- a/ports/qcustomplot/config.patch
+++ b/ports/qcustomplot/config.patch
@@ -1,0 +1,25 @@
+--- a/sharedlib-compilation/sharedlib-compilation.pro
++++ b/sharedlib-compilation/sharedlib-compilation.pro
+@@ -10,7 +10,6 @@
+ 
+ DEFINES += QCUSTOMPLOT_COMPILE_LIBRARY
+ TEMPLATE = lib
+-CONFIG += debug_and_release build_all
+ static {
+   CONFIG += static
+ } else {
+@@ -33,3 +32,14 @@
+ 
+ SOURCES += ../../qcustomplot.cpp
+ HEADERS += ../../qcustomplot.h
++win32 {
++    dlltarget.path = $$[QT_INSTALL_BINS]
++    INSTALLS += dlltarget
++}
++target.path    = $$[QT_INSTALL_LIBS]
++!static: target.CONFIG = no_dll
++INSTALLS     += target
++
++headers.files += ../../qcustomplot.h
++headers.path = $$[QT_INSTALL_PREFIX]/include
++INSTALLS     += headers

--- a/ports/qcustomplot/portfile.cmake
+++ b/ports/qcustomplot/portfile.cmake
@@ -1,38 +1,32 @@
-set(QCP_VERSION 2.0.1)
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.qcustomplot.com/release/${QCP_VERSION}/QCustomPlot.tar.gz"
-    FILENAME "QCustomPlot-${QCP_VERSION}.tar.gz"
-    SHA512 a15598718146ed3c6b5d38530a56661c16269e530fe0dedb71b4cb2722b5733a3b57689d668a75994b79c19c6e61dcc133dbcb9ed77b93a165f4ac826a5685b9
+    URLS "https://www.qcustomplot.com/release/${VERSION}/QCustomPlot.tar.gz"
+    FILENAME "QCustomPlot-${VERSION}.tar.gz"
+    SHA512 2e49a9b3f7ab03bcd580e5f3c3ae0d5e8c57d3ccce0ceed9862cde7ea23e2f3672a963af988be60e504cb5aa50bc462e4b28acf577eae41cc6fea2802642dc19
 )
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    REF ${QCP_VERSION}
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
 )
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.qcustomplot.com/release/${QCP_VERSION}/QCustomPlot-sharedlib.tar.gz"
-    FILENAME "QCustomPlot-sharedlib-${QCP_VERSION}.tar.gz"
-    SHA512 ce90540fca7226eac37746327e1939a9c7af38fc2595f385ed04d6d1f49560da08fb5fae15d1b9d22b6ba578583f70de8f89ef26796770d41bf599c1b15c535d
+    URLS "https://www.qcustomplot.com/release/${VERSION}/QCustomPlot-sharedlib.tar.gz"
+    FILENAME "QCustomPlot-sharedlib-${VERSION}.tar.gz"
+    SHA512 c661e4a835066fee92b254fbd7b825dbd5c58973189ff2099a01308cb81fe6bf3bac1456f5da91f01c6265f8f548f61b57e237d00a9b5c2c94acf1a024baa18e
 )
-vcpkg_extract_source_archive(SharedLib_SOURCE_PATH ARCHIVE "${ARCHIVE}")
+vcpkg_extract_source_archive(
+    SharedLib_SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        config.patch
+)
 file(RENAME "${SharedLib_SOURCE_PATH}" "${SOURCE_PATH}/qcustomplot-sharedlib")
 
-
-vcpkg_configure_qmake(SOURCE_PATH
-    ${SOURCE_PATH}/qcustomplot-sharedlib/sharedlib-compilation/sharedlib-compilation.pro
+vcpkg_qmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/qcustomplot-sharedlib/sharedlib-compilation/sharedlib-compilation.pro"
+    QMAKE_OPTIONS
+        "${OSX_OPTIONS}"
 )
-
-vcpkg_install_qmake(
-    RELEASE_TARGETS release-all
-    DEBUG_TARGETS debug-all
-)
-
-# Install header file
-file(INSTALL ${SOURCE_PATH}/qcustomplot.h
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include
-)
+vcpkg_qmake_install()
 
 vcpkg_copy_pdbs()
 

--- a/ports/qcustomplot/vcpkg.json
+++ b/ports/qcustomplot/vcpkg.json
@@ -1,11 +1,17 @@
 {
   "name": "qcustomplot",
-  "version": "2.0.1",
-  "port-version": 5,
+  "version": "2.1.1",
   "description": "QCustomPlot is a Qt C++ widget for plotting and data visualization.",
+  "homepage": "https://www.qcustomplot.com/",
+  "license": "GPL-3.0-or-later",
   "dependencies": [
     {
-      "name": "qt5-base",
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-qmake",
+      "host": true,
       "default-features": false
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6341,8 +6341,8 @@
       "port-version": 0
     },
     "qcustomplot": {
-      "baseline": "2.0.1",
-      "port-version": 5
+      "baseline": "2.1.1",
+      "port-version": 0
     },
     "qhttpengine": {
       "baseline": "1.0.2",

--- a/versions/q-/qcustomplot.json
+++ b/versions/q-/qcustomplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fa5ea943fa7d0b35422a11a04d01491745bf990",
+      "version": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7fcc18d2987ed5b3af803d5e0ac5c9afd026fc37",
       "version": "2.0.1",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.