### PR TITLE
[quazip] update and build against Qt6

### DIFF
--- a/ports/quazip/portfile.cmake
+++ b/ports/quazip/portfile.cmake
@@ -1,22 +1,29 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stachenov/quazip
-    REF v1.3
-    SHA512 3861a9084059576ff2690e8b911394b0286a60542ab021a4cc588537a60ea3a186ed7903c76544698001fa383dfd0de96bdfed433abaefc44158d3b30ab16fe2
+    REF v1.4
+    SHA512 38ce3aa77df1fd92229454e56b7290c066d1e319afa36a9f8ec8477004ae94df682e8f454f13cdaf586a1d0b0e033fe698081033a19536ecd53dd1e4b0204af9
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        bzip2 QUAZIP_BZIP2
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DQUAZIP_QT_MAJOR_VERSION=6
+        -DQUAZIP_FETCH_LIBS=OFF
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/QuaZip-Qt5-1.3 PACKAGE_NAME quazip-qt5)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/QuaZip-Qt6-1.4 PACKAGE_NAME quazip-qt6)
 vcpkg_copy_pdbs()
-if(VCPKG_TARGET_IS_WINDOWS)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
-else()
-    vcpkg_fixup_pkgconfig()
-endif()
+# Qt6 pkg-config files not installed https://github.com/microsoft/vcpkg/issues/25988
+# vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/" RENAME copyright)

--- a/ports/quazip/vcpkg.json
+++ b/ports/quazip/vcpkg.json
@@ -1,12 +1,18 @@
 {
   "name": "quazip",
-  "version": "1.3",
-  "port-version": 2,
+  "version": "1.4",
   "description": "Qt/C++ wrapper over minizip",
   "homepage": "https://stachenov.github.io/quazip/",
   "license": "LGPL-2.1-or-later",
   "dependencies": [
-    "qt5-base",
+    {
+      "name": "qt5compat",
+      "default-features": false
+    },
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -16,5 +22,13 @@
       "host": true
     },
     "zlib"
-  ]
+  ],
+  "features": {
+    "bzip2": {
+      "description": "BZIP2 compression",
+      "dependencies": [
+        "bzip2"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6717,8 +6717,8 @@
       "port-version": 1
     },
     "quazip": {
-      "baseline": "1.3",
-      "port-version": 2
+      "baseline": "1.4",
+      "port-version": 0
     },
     "quickfast": {
       "baseline": "1.5",

--- a/versions/q-/quazip.json
+++ b/versions/q-/quazip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20b5c279bf0a7075a9d6cddb9c1de0e4e4adc0ec",
+      "version": "1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "54222787c577b97f8051aa2e69fa89956be6e4b6",
       "version": "1.3",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.