### PR TITLE
[libadlmidi] Fix CMake config for Linux/MacOS

### DIFF
--- a/ports/libadlmidi/cmake-package-export.patch
+++ b/ports/libadlmidi/cmake-package-export.patch
@@ -66,21 +66,21 @@ index 271bb9b..1b6ba8f 100644
          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 +        
 +include(CMakePackageConfigHelpers)
-+configure_package_config_file(libADLMIDI-config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/libADLMIDI-config.cmake"
++configure_package_config_file(libADLMIDIConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/libADLMIDIConfig.cmake"
 +    PATH_VARS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_FULL_BINDIR CMAKE_INSTALL_FULL_INCLUDEDIR CMAKE_INSTALL_FULL_LIBDIR
 +    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libADLMIDI"
 +)
-+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libADLMIDI-config.cmake
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libADLMIDIConfig.cmake
 +    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libADLMIDI"
 +)
  
  file(GLOB DOCTXT_FILES
      "${libADLMIDI_SOURCE_DIR}/LICENSE*.txt"
-diff --git a/libADLMIDI-config.cmake.in b/libADLMIDI-config.cmake.in
+diff --git a/libADLMIDIConfig.cmake.in b/libADLMIDIConfig.cmake.in
 new file mode 100644
 index 0000000..bd875fc
 --- /dev/null
-+++ b/libADLMIDI-config.cmake.in
++++ b/libADLMIDIConfig.cmake.in
 @@ -0,0 +1,30 @@
 +include(FeatureSummary)
 +set_package_properties(libADLMIDI PROPERTIES

--- a/ports/libadlmidi/portfile.cmake
+++ b/ports/libadlmidi/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v${VERSION}
     SHA512 d827f13c60086b62bb4ffb098faeaa214fd83df52d3d5c19533b970d74b470c677e0aec76e91e05753574cf9bae1ccd02b77bd24d0ec1b2ad80b21cf541c7261
     PATCHES
+        # patches from master, they should be removed when a new version is out
         cmake-package-export.patch
         cmake-build-shared-libs-support.patch
 )

--- a/ports/libadlmidi/vcpkg.json
+++ b/ports/libadlmidi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libadlmidi",
   "version": "1.5.1",
+  "port-version": 1,
   "description": "libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation",
   "homepage": "https://github.com/Wohlstand/libADLMIDI",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3722,7 +3722,7 @@
     },
     "libadlmidi": {
       "baseline": "1.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libadwaita": {
       "baseline": "1.2.0",

--- a/versions/l-/libadlmidi.json
+++ b/versions/l-/libadlmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5cbc0a9338616c735a4cf4d8ccc2b4c81ccc61c5",
+      "version": "1.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "81e5c1700a6eab87c9d855b0a206ad6dadaf6ff2",
       "version": "1.5.1",
       "port-version": 0


### PR DESCRIPTION
This change is coming from upstream: https://github.com/Wohlstand/libADLMIDI/commit/4dcc62645e6d500d5256bdd013cd44786e1775ff
It fixes finding the package on case-sensitive filesystems.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.