### PR TITLE
[libopnmidi] Fix CMake config for Linux/MacOS

### DIFF
--- a/ports/libopnmidi/cmake-package-export.patch
+++ b/ports/libopnmidi/cmake-package-export.patch
@@ -76,21 +76,21 @@ index 66d4848..4276e23 100644
          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
  
 +include(CMakePackageConfigHelpers)
-+configure_package_config_file(libOPNMIDI-config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/libOPNMIDI-config.cmake"
++configure_package_config_file(libOPNMIDIConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/libOPNMIDIConfig.cmake"
 +    PATH_VARS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_FULL_BINDIR CMAKE_INSTALL_FULL_INCLUDEDIR CMAKE_INSTALL_FULL_LIBDIR
 +    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libOPNMIDI"
 +)
-+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libOPNMIDI-config.cmake
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libOPNMIDIConfig.cmake
 +        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libOPNMIDI")
 +
  if(WITH_EXTRA_BANKS AND NOT APPLE)
      file(GLOB WOPN_FILES ${libOPNMIDI_SOURCE_DIR}/fm_banks/*.wopn)
      install(FILES ${WOPN_FILES}
-diff --git a/libOPNMIDI-config.cmake.in b/libOPNMIDI-config.cmake.in
+diff --git a/libOPNMIDIConfig.cmake.in b/libOPNMIDIConfig.cmake.in
 new file mode 100644
 index 0000000..f292e48
 --- /dev/null
-+++ b/libOPNMIDI-config.cmake.in
++++ b/libOPNMIDIConfig.cmake.in
 @@ -0,0 +1,33 @@
 +include(FeatureSummary)
 +set_package_properties(libOPNMIDI PROPERTIES

--- a/ports/libopnmidi/vcpkg.json
+++ b/ports/libopnmidi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libopnmidi",
   "version": "1.5.1",
+  "port-version": 1,
   "description": "libOPNMIDI is a free Software MIDI synthesizer library with OPN2 (YM2612) and OPNA (YM2608) emulation",
   "homepage": "https://github.com/Wohlstand/libOPNMIDI",
   "license": "LGPL-2.1-or-later OR GPL-2.0-or-later OR GPL-3.0-or-later OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4250,7 +4250,7 @@
     },
     "libopnmidi": {
       "baseline": "1.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libopusenc": {
       "baseline": "0.2.1",

--- a/versions/l-/libopnmidi.json
+++ b/versions/l-/libopnmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2451642c9d81eff6810839a5174ca60053330780",
+      "version": "1.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "552bea42a6f0f15bb5564602b51d9cda0a09dfd7",
       "version": "1.5.1",
       "port-version": 0


### PR DESCRIPTION
This change is coming from upstream: https://github.com/Wohlstand/libOPNMIDI/commit/b4fe23ce96581739da6d2dddb9c470f427adbced
It fixes finding the package on case-sensitive filesystems.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
