### PR TITLE
Only use prebuilt musl libc binary with x86_64 arch

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -93,9 +93,11 @@ vcpkgCheckRepoTool tar
 UNAME="$(uname)"
 ARCH="$(uname -m)"
 
-if [ -e /etc/alpine-release -a "$ARCH" = "x86_64" ]; then
+if [ -e /etc/alpine-release ]; then
     vcpkgUseSystem="ON"
-    vcpkgUseMuslC="ON"
+    if [ "$ARCH" = "x86_64" ]; then
+        vcpkgUseMuslC="ON"
+    fi
 fi
 
 if [ "$UNAME" = "OpenBSD" ]; then

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -93,7 +93,7 @@ vcpkgCheckRepoTool tar
 UNAME="$(uname)"
 ARCH="$(uname -m)"
 
-if [ -e /etc/alpine-release ]; then
+if [ -e /etc/alpine-release -a "$ARCH" = "x86_64" ]; then
     vcpkgUseSystem="ON"
     vcpkgUseMuslC="ON"
 fi


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #30170
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

As described in https://github.com/microsoft/vcpkg/issues/30170, `bootstrap-vcpkg.sh` currently incorrectly downloads x86_64 binaries for arm hosts, if the host is running alpine linux, regardless of the host architecture.  
This PR fixes this issue, by checking the platform architecture along `/etc/alpine-release`. If the architecture is not x86_64, it will default to compiling the source, as it already happens on other distributions, e.g. ubuntu.
