### PR TITLE
[spix] update to 0.5 and build against Qt6

### DIFF
--- a/ports/spix/portfile.cmake
+++ b/ports/spix/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO faaxm/spix
-    REF v0.4
-    SHA512 4686199f851b4f06abf963ea79d3d2094d7bd956f009b3fe244dfbcfa7e0756d9971cb882c9963d479b44194806f3d0eaef68ac90b3468bf4ba9139948a9cd7b
+    REF v0.5
+    SHA512 fdc35ff4920a83d4b2d0abe84eae7c8f46cb259e525d4445b091eb01990bcdeade7e60a00795f4acccc09f0702fa61d17ba6c7b8bbf19ff218e8bd42e1eb7f7c
 
     HEAD_REF master
 )
@@ -12,7 +12,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DSPIX_BUILD_EXAMPLES=OFF
         -DSPIX_BUILD_TESTS=OFF
-        -DSPIX_QT_MAJOR=5
+        -DSPIX_QT_MAJOR=6
 )
 
 vcpkg_cmake_install()

--- a/ports/spix/vcpkg.json
+++ b/ports/spix/vcpkg.json
@@ -1,15 +1,16 @@
 {
   "name": "spix",
-  "version": "0.4",
+  "version": "0.5",
   "description": "A minimally invasive UI testing library that enables your Qt/QML app's UI to be controlled either via c++ code, or through an http RPC interface.",
   "homepage": "https://github.com/faaxm/spix",
+  "license": "MIT",
   "dependencies": [
     "anyrpc",
     {
-      "name": "qt5-base",
+      "name": "qtbase",
       "default-features": false
     },
-    "qt5-declarative",
+    "qtdeclarative",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7485,7 +7485,7 @@
       "port-version": 0
     },
     "spix": {
-      "baseline": "0.4",
+      "baseline": "0.5",
       "port-version": 0
     },
     "spout2": {

--- a/versions/s-/spix.json
+++ b/versions/s-/spix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "242f18b432502d15fba249b9b830ee7a4781599b",
+      "version": "0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d26875159ee21430be1cff1f64ebe8dacdcbf7b",
       "version": "0.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.