### PR TITLE
[saucer] build against Qt6

### DIFF
--- a/ports/saucer/portfile.cmake
+++ b/ports/saucer/portfile.cmake
@@ -11,9 +11,18 @@ vcpkg_from_github(
         fix-source-generation.patch
 )
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(BACKEND_OPTION "-Dsaucer_backend=WebView2")
+else()
+    set(BACKEND_OPTION "-Dsaucer_backend=Qt6")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH} 
-    OPTIONS -Dsaucer_prefer_remote=OFF -Dsaucer_remote_webview2=OFF
+    OPTIONS
+        ${BACKEND_OPTION}
+        -Dsaucer_prefer_remote=OFF
+        -Dsaucer_remote_webview2=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/saucer/vcpkg.json
+++ b/ports/saucer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "saucer",
   "version": "1.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Next-gen desktop apps with web-frontend in C++",
   "homepage": "https://saucer.github.io/",
   "license": "MIT",
@@ -12,11 +12,11 @@
     "lockpp",
     "nlohmann-json",
     {
-      "name": "qt5-webchannel",
+      "name": "qtwebchannel",
       "platform": "!windows"
     },
     {
-      "name": "qt5-webengine",
+      "name": "qtwebengine",
       "platform": "!windows"
     },
     "tl-expected",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7062,7 +7062,7 @@
     },
     "saucer": {
       "baseline": "1.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "sbp": {
       "baseline": "3.4.10",

--- a/versions/s-/saucer.json
+++ b/versions/s-/saucer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15c87104efda5c84346ed7a7302713283e82eaaa",
+      "version": "1.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "ce7e88eac61c5e370dbf6d5dc7ad56dbdded879d",
       "version": "1.0.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.