### PR TITLE
[mapnik] build against Qt6

### DIFF
--- a/ports/mapnik/vcpkg.json
+++ b/ports/mapnik/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mapnik",
   "version-date": "2023-01-17",
+  "port-version": 1,
   "description": "Mapnik is an open source toolkit for developing mapping applications.",
   "homepage": "https://github.com/mapnik/mapnik",
   "license": "LGPL-2.1-only",
@@ -210,7 +211,7 @@
     "viewer": {
       "description": "Make demo viewer application",
       "dependencies": [
-        "qt5-base"
+        "qtbase"
       ]
     },
     "webp": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4954,7 +4954,7 @@
     },
     "mapnik": {
       "baseline": "2023-01-17",
-      "port-version": 0
+      "port-version": 1
     },
     "marble": {
       "baseline": "22.04.0",

--- a/versions/m-/mapnik.json
+++ b/versions/m-/mapnik.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d63cf0864443e19122d1901bc944a89274aba0c",
+      "version-date": "2023-01-17",
+      "port-version": 1
+    },
+    {
       "git-tree": "6fc189206b9c2055b544278ede1ce5be2e0f48ff",
       "version-date": "2023-01-17",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.