### PR TITLE
[xmlsec] Update to 1.2.37

### DIFF
--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lsh123/xmlsec
     REF "${release_tag}"
-    SHA512 c74c0854f0afdf97651cb8ae26430a43ebb7d849b7715fdec3abcd96e61f67f0d2bac82b68b10c97dc90ee52b14ba426bbf9413f71caa7de5fa6ecb945cba0d1
+    SHA512 4e4a9d6be76582e207c6c678feeaf1d572e2eac04fb032fa742e059e45f1eeebf664535d723e27cefb7026604cb445faecec0a801dcf65c95ae6d5cf046a0d1f
     HEAD_REF master
     PATCHES 
         pkgconfig_fixes.patch

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xmlsec",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8521,7 +8521,7 @@
       "port-version": 1
     },
     "xmlsec": {
-      "baseline": "1.2.36",
+      "baseline": "1.2.37",
       "port-version": 0
     },
     "xnnpack": {

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "90c79a327b276a7cb1f9eb3e76020cd7483e4899",
+      "version": "1.2.37",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b3111c9880e6e3737f334dc37432a121a3220ef",
       "version": "1.2.36",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.