### PR TITLE
[kd-soap] update to 2.1.1 and build against Qt6

### DIFF
--- a/ports/kd-soap/Ensure-KDSoapConfig-finds-Qt-first.patch
+++ b/ports/kd-soap/Ensure-KDSoapConfig-finds-Qt-first.patch
@@ -1,0 +1,26 @@
+From cb2df4c372c115df84805043a7785f38eb4eb082 Mon Sep 17 00:00:00 2001
+From: David Faure <david.faure@kdab.com>
+Date: Sun, 26 Mar 2023 17:27:02 +0200
+Subject: [PATCH] Ensure KDSoapConfig.cmake finds Qt first.
+
+Fixes #258
+---
+ KDSoapConfig.cmake.in | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/KDSoapConfig.cmake.in b/KDSoapConfig.cmake.in
+index d20649a4..f7bfa82b 100644
+--- a/KDSoapConfig.cmake.in
++++ b/KDSoapConfig.cmake.in
+@@ -8,6 +8,11 @@
+ 
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++
++find_dependency(Qt@Qt_VERSION_MAJOR@Core @QT_MIN_VERSION@)
++find_dependency(Qt@Qt_VERSION_MAJOR@Network @QT_MIN_VERSION@)
++
+ set_and_check(KDSoap_INCLUDE_DIR "@PACKAGE_INSTALL_INCLUDE_DIR@")
+ 
+ set(KDSoap_INCLUDE_DIRS "${KDSoap_INCLUDE_DIR}")

--- a/ports/kd-soap/portfile.cmake
+++ b/ports/kd-soap/portfile.cmake
@@ -1,30 +1,35 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO KDAB/KDSoap
-    REF fb0e905e242c2044fd25683a406eb6d369db052f # kdsoap-1.9.0
-    SHA512 30f78602702f2bb77f72bf0637b413d70976cf10789b18d1eb9c097f6b3821b86e75d0ae921454b2d39b7d023f479dc089cde1915533a37054f9b26893f611d3
-    HEAD_REF master
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/KDAB/KDSoap/releases/download/kdsoap-${VERSION}/kdsoap-${VERSION}.tar.gz"
+    FILENAME "kdsoap-${VERSION}.tar.gz"
+    SHA512 12224f664dcae7ceb7395a7c3de48a208ae81c10f6fba4d0db233613472c6b9cdbea6375297c27b58fe7338d7db27a4447844f4e8f40a24ec1b4dd3fa38d20bb
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        Ensure-KDSoapConfig-finds-Qt-first.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" KDSoap_STATIC)
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
+        -DKDSoap_QT6=ON
         -DKDSoap_STATIC=${KDSoap_STATIC}
         -DKDSoap_EXAMPLES=OFF
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/KDSoap TARGET_PATH share/KDSoap)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME KDSoap-qt6 CONFIG_PATH lib/cmake/KDSoap-qt6)
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools)
-file(RENAME ${CURRENT_PACKAGES_DIR}/bin/kdwsdl2cpp${VCPKG_TARGET_EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/kdwsdl2cpp${VCPKG_TARGET_EXECUTABLE_SUFFIX})
-file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/kdwsdl2cpp${VCPKG_TARGET_EXECUTABLE_SUFFIX})
+vcpkg_copy_tools(TOOL_NAMES kdwsdl2cpp-qt6 AUTO_CLEAN)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/kd-soap/vcpkg.json
+++ b/ports/kd-soap/vcpkg.json
@@ -1,13 +1,21 @@
 {
   "name": "kd-soap",
-  "version-string": "1.9.0",
-  "port-version": 1,
+  "version": "2.1.1",
   "description": "A Qt-based client-side and server-side SOAP component",
   "homepage": "https://www.kdab.com/products/kd-soap",
+  "license": "MIT",
   "dependencies": [
     {
-      "name": "qt5-base",
+      "name": "qtbase",
       "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3421,8 +3421,8 @@
       "port-version": 0
     },
     "kd-soap": {
-      "baseline": "1.9.0",
-      "port-version": 1
+      "baseline": "2.1.1",
+      "port-version": 0
     },
     "kdalgorithms": {
       "baseline": "2023-02-11",

--- a/versions/k-/kd-soap.json
+++ b/versions/k-/kd-soap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25205691e2c5a4f621d6b4c7fbe78f56324a311f",
+      "version": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "64e16ff8d17d3cadb5a951b5b20e15f99b6d82b1",
       "version-string": "1.9.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.