### PR TITLE
[grantlee] build against Qt6

### DIFF
--- a/ports/grantlee/portfile.cmake
+++ b/ports/grantlee/portfile.cmake
@@ -10,7 +10,9 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure (
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS -DBUILD_TESTS=off
+    OPTIONS
+        -DGRANTLEE_BUILD_WITH_QT6=ON
+        -DBUILD_TESTS=OFF
 )
 
 vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" [[set( PLUGIN_INSTALL_DIR ${LIB_INSTALL_DIR}/grantlee/${Grantlee5_MAJOR_MINOR_VERSION_STRING} )]] [[set( PLUGIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/bin)]])

--- a/ports/grantlee/vcpkg.json
+++ b/ports/grantlee/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "grantlee",
   "version": "5.3.1",
+  "port-version": 1,
   "description": "Libraries for text templating with Qt",
   "homepage": "https://github.com/steveire/grantlee",
   "license": "LGPL-2.1-or-later",
   "supports": "!staticcrt",
   "dependencies": [
-    "qt5-declarative",
+    "qtdeclarative",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2878,7 +2878,7 @@
     },
     "grantlee": {
       "baseline": "5.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "graphene": {
       "baseline": "1.10.8",

--- a/versions/g-/grantlee.json
+++ b/versions/g-/grantlee.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5828abf42559b6f3db682f7827f502cf75c7ec32",
+      "version": "5.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "36162cae49c2b9664a73f0e2a1f74544e4447a7b",
       "version": "5.3.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.