### PR TITLE
[vcpkg baseline][vowpal-wabbit] Fixing conflict with string-view-lite

### DIFF
--- a/ports/vowpal-wabbit/portfile.cmake
+++ b/ports/vowpal-wabbit/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO VowpalWabbit/vowpal_wabbit
-    REF 258731cd116be6fa42d6ff6d2e59d06b9b790dc0
-    SHA512 b8a370c5c20e74ce7ccdb19ea3aa9c6d5287c9cc82d0b613804ab8b6c1d7770aafd15ad900d4933b636662435026c36f6a4b6ec0c66d597bdb52b20a4c0b6c25
+    REF "${VERSION}"
+    SHA512 37c4401e5304c20a7a4c2ffa6102bfa82085c4bbc787c796da295e789996f09472ac4b3e732b0a44016eab6579c2648085b1e67b1df2658257d52f7e46a1b683
     HEAD_REF master
     PATCHES cmake_remove_bin_targets.patch
 )
@@ -21,12 +21,13 @@ vcpkg_cmake_configure(
         -DVW_EIGEN_SYS_DEP=ON
         -DVW_BUILD_VW_C_WRAPPER=OFF
         -DBUILD_TESTING=OFF
+        -DVW_STRING_VIEW_LITE_SYS_DEP=ON
 )
 vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/VowpalWabbit)
 vcpkg_fixup_pkgconfig()

--- a/ports/vowpal-wabbit/vcpkg.json
+++ b/ports/vowpal-wabbit/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vowpal-wabbit",
   "version": "9.8.0",
+  "port-version": 1,
   "description": "Reduction based online learning framework with a focus on contextual bandits and reinforcement learning.",
   "homepage": "https://github.com/vowpalwabbit/vowpal_wabbit",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8246,7 +8246,7 @@
     },
     "vowpal-wabbit": {
       "baseline": "9.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vs-yasm": {
       "baseline": "0.5.0",

--- a/versions/v-/vowpal-wabbit.json
+++ b/versions/v-/vowpal-wabbit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26041121b5911f0f6fb2e755b74747ce3dd2a371",
+      "version": "9.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ed8289aedc37dbd955273a2f211451a44e54d702",
       "version": "9.8.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes vcpkg pipeline issue `vowpal-wabbit` conflict with `string-view-lite`:
```
error: The following files are already installed in /mnt/vcpkg-ci/installed/x64-linux and are in conflict with vowpal-wabbit:x64-linux
Installed by string-view-lite:x64-linux    
include/nonstd/string_view.hpp
```
Adding `-DVW_STRING_VIEW_LITE_SYS_DEP=ON` to override using the submodule for string-view-lite dependency.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
