### PR TITLE
[msgpack-c] Added msgpack-c version 6.0.0

### DIFF
--- a/ports/msgpack-c/portfile.cmake
+++ b/ports/msgpack-c/portfile.cmake
@@ -1,0 +1,28 @@
+if (EXISTS ${CURRENT_INSTALLED_DIR}/include/msgpack/pack.h)
+    message(FATAL_ERROR "Cannot install ${PORT} when rest-rpc is already installed, please remove rest-rpc using \"./vcpkg remove rest-rpc:${TARGET_TRIPLET}\"")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO msgpack/msgpack-c
+    REF c-6.0.0
+    SHA512 ba7d1b649dd1318f99d45ba5fd44346e53924ba7a121104a080c3865e8c01db3842efa1dc9e01478b962274675ba4632d9daaeb163821d46531b30d6abcda161
+    HEAD_REF c_master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DMSGPACK_BUILD_EXAMPLES=OFF
+        -DMSGPACK_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME msgpack-c CONFIG_PATH lib/cmake/msgpack-c)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/msgpack-c/vcpkg.json
+++ b/ports/msgpack-c/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "msgpack-c",
+  "version": "6.0.0",
+  "description": "MessagePack is an efficient binary serialization format, which lets you exchange data among multiple languages like JSON, except that it's faster and smaller.",
+  "homepage": "https://github.com/msgpack/msgpack-c",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5280,6 +5280,10 @@
       "baseline": "4.1.3",
       "port-version": 0
     },
+    "msgpack-c": {
+      "baseline": "6.0.0",
+      "port-version": 0
+    },
     "msgpack11": {
       "baseline": "0.0.10",
       "port-version": 4

--- a/versions/m-/msgpack-c.json
+++ b/versions/m-/msgpack-c.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "eb07de381e11c13f6d4aa2e2b151efb2d405b85e",
+      "version": "6.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.