### PR TITLE
[wxwidgets] Temporary apply patch from upstream to fix wx-config when NanoSVG is used.

### DIFF
--- a/ports/wxwidgets/fix-nanosvg.patch
+++ b/ports/wxwidgets/fix-nanosvg.patch
@@ -1,0 +1,19 @@
+diff --git "a/build/cmake/config.cmake" "b/build/cmake/config.cmake"
+index b68d167dac..5de1fd19ad 100644
+--- "a/build/cmake/config.cmake"
++++ "b/build/cmake/config.cmake"
+@@ -40,6 +40,14 @@ macro(wx_get_dependencies var lib)
+                 else()
+                     get_target_property(dep_name ${dep} OUTPUT_NAME)
+                 endif()
++                if(NOT dep_name)
++                    set(prop_suffix)
++                    if (CMAKE_BUILD_TYPE)
++                      string(TOUPPER "${CMAKE_BUILD_TYPE}" prop_suffix)
++                      set(prop_suffix "_${prop_suffix}")
++                    endif()
++                    get_target_property(dep_name ${dep} LOCATION${prop_suffix})
++                endif()
+             else()
+                 # For the value like $<$<CONFIG:DEBUG>:LIB_PATH>
+                 # Or $<$<NOT:$<CONFIG:DEBUG>>:LIB_PATH>

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
     REF "v${VERSION}"
-    SHA512 8ff645fe7ee97bf6358b3619efd737ef8f9eb0235ca481e921a64d451c45eb9671ee4e2807fea285153bc0bb434266234f6f4ab15f396bb8290f262fa879e9b3 
+    SHA512 8ff645fe7ee97bf6358b3619efd737ef8f9eb0235ca481e921a64d451c45eb9671ee4e2807fea285153bc0bb434266234f6f4ab15f396bb8290f262fa879e9b3
     HEAD_REF master
     PATCHES
         install-layout.patch
@@ -13,6 +13,7 @@ vcpkg_from_github(
         gtk3-link-libraries.patch
         sdl2.patch
         fix_include.patch
+        fix-nanosvg.patch
 )
 
 vcpkg_check_features(

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wxwidgets",
   "version": "3.2.2.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8434,7 +8434,7 @@
     },
     "wxwidgets": {
       "baseline": "3.2.2.1",
-      "port-version": 1
+      "port-version": 2
     },
     "wyhash": {
       "baseline": "2023-01-25",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f6e3030aa5a9fa6b83099a43a0e98c8c06f0f68",
+      "version": "3.2.2.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "73c660df48132ff4b831c5f3445b361476990c70",
       "version": "3.2.2.1",
       "port-version": 1


### PR DESCRIPTION
This fixes #30361
