### PR TITLE
[qtkeychain] add missing dependency

### DIFF
--- a/ports/qtkeychain/vcpkg.json
+++ b/ports/qtkeychain/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtkeychain",
   "version": "0.13.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "(Unaffiliated with Qt) Platform-independent Qt5 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",
@@ -10,6 +10,7 @@
       "name": "libsecret",
       "platform": "!(windows | uwp | osx)"
     },
+    "qt5-base",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6598,7 +6598,7 @@
     },
     "qtkeychain": {
       "baseline": "0.13.2",
-      "port-version": 3
+      "port-version": 4
     },
     "qtkeychain-qt6": {
       "baseline": "0.13.2",

--- a/versions/q-/qtkeychain.json
+++ b/versions/q-/qtkeychain.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "516e24d31a7d28d7b5df372f99cf2780a3a7edbc",
+      "version": "0.13.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "eda48d2b83676b8209a40d68b286c570aeed785e",
       "version": "0.13.2",
       "port-version": 3


### PR DESCRIPTION
The qtkeychain[core] package currently does not has a dependency to qt5-base, but depends on it. 