### PR TITLE
[maddy] New port

### DIFF
--- a/ports/maddy/CMakeLists.txt
+++ b/ports/maddy/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+project(maddy LANGUAGES CXX)
+
+include(GNUInstallDirs)
+
+add_library(maddy INTERFACE)
+target_include_directories(maddy INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+install(TARGETS maddy EXPORT unofficial-maddy)
+
+install(
+    EXPORT unofficial-maddy
+    FILE unofficial-maddy-config.cmake
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/unofficial-maddy"
+    NAMESPACE unofficial::maddy::
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/maddy"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)

--- a/ports/maddy/portfile.cmake
+++ b/ports/maddy/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO progsource/maddy
+    REF f3d934d6ec70bd4c077acfb810026d5f15e11001 #1.1.2+20210419
+    SHA512 7ac4c7e1077f2315c19945d994fa8c13538908f8b477d71c38c245826bff70987eb169eabdd756bfdd240be0f985f047298e0cd0706aaf5bc892bc9b0e804776
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/maddy/usage
+++ b/ports/maddy/usage
@@ -1,0 +1,4 @@
+maddy provides CMake targets:
+
+    find_package(unofficial-maddy CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::maddy::maddy)

--- a/ports/maddy/vcpkg.json
+++ b/ports/maddy/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "maddy",
+  "version": "1.1.2+20210419",
+  "homepage": "https://github.com/progsource/maddy",
+  "description": "C++ Markdown to HTML header-only parser library",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/maddy/vcpkg.json
+++ b/ports/maddy/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "maddy",
   "version": "1.1.2+20210419",
-  "homepage": "https://github.com/progsource/maddy",
   "description": "C++ Markdown to HTML header-only parser library",
+  "homepage": "https://github.com/progsource/maddy",
   "license": "MIT",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4912,6 +4912,10 @@
       "baseline": "2020-07-30",
       "port-version": 1
     },
+    "maddy": {
+      "baseline": "1.1.2+20210419",
+      "port-version": 0
+    },
     "magic-enum": {
       "baseline": "0.8.2",
       "port-version": 0

--- a/versions/m-/maddy.json
+++ b/versions/m-/maddy.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "469c585ac08f057d3716d962b9d048fe0b851e83",
+      "version": "1.1.2+20210419",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Close #30250