### PR TITLE
[libpcap] Fix incorrect library name in libpcap.pc of non-windows build

### DIFF
--- a/ports/libpcap/install-pc-on-msvc.patch
+++ b/ports/libpcap/install-pc-on-msvc.patch
@@ -10,10 +10,10 @@ index b83fbbd..2f675d1 100644
 -# pcap-config and process man pages and arrange that they be installed.
 -if(NOT MSVC)
 +# Generate libpcap.pc
-+if(BUILD_SHARED_LIBS)
-+    set(PACKAGE_NAME ${LIBRARY_NAME})
-+else()
++if(MSVC AND NOT BUILD_SHARED_LIBS)
 +    set(PACKAGE_NAME ${LIBRARY_NAME}_static)
++else()
++    set(PACKAGE_NAME ${LIBRARY_NAME})
 +endif()
      set(prefix ${CMAKE_INSTALL_PREFIX})
      set(exec_prefix "\${prefix}")

--- a/ports/libpcap/vcpkg.json
+++ b/ports/libpcap/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libpcap",
   "version-semver": "1.10.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A portable C/C++ library for network traffic capture",
   "homepage": "https://www.tcpdump.org/",
+  "license": "BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4286,7 +4286,7 @@
     },
     "libpcap": {
       "baseline": "1.10.1",
-      "port-version": 2
+      "port-version": 3
     },
     "libpff": {
       "baseline": "2021-11-14",

--- a/versions/l-/libpcap.json
+++ b/versions/l-/libpcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6cf3667c0320e2ff5d92d45e91b07fb3bf2fe05e",
+      "version-semver": "1.10.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "b21dafcbcbd4a428b3800a6a686a473db8625ca6",
       "version-semver": "1.10.1",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix incorrect library name in `libpcap.pc` of non-windows build, see https://github.com/microsoft/vcpkg/pull/30326#issuecomment-1480737167
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
