### PR TITLE
[msgpack] update version to 6.0.0 and switch to the C++ branch

### DIFF
--- a/ports/coolprop/fix-dependency.patch
+++ b/ports/coolprop/fix-dependency.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 414f380..619dfeb 100644
+index 7bbf8d6..617ac93 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -247,13 +247,10 @@ list(REMOVE_ITEM APP_SOURCES
+@@ -247,13 +247,11 @@ list(REMOVE_ITEM APP_SOURCES
  list(REMOVE_ITEM APP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/CoolPropLib.cpp")
  
  set(APP_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -14,9 +14,10 @@ index 414f380..619dfeb 100644
 -list(APPEND APP_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/externals/fmtlib"
 -)# should be deprecated
 +find_package(Eigen3 CONFIG REQUIRED)
-+find_package(msgpack CONFIG REQUIRED)
++find_package(msgpack-cxx CONFIG REQUIRED)
 +find_package(fmt CONFIG REQUIRED)
-+link_libraries(Eigen3::Eigen fmt::fmt msgpackc-cxx)
++link_libraries(Eigen3::Eigen fmt::fmt)
++include_directories(msgpackc-cxx)
  list(APPEND APP_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include")
  list(APPEND APP_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/src")
  

--- a/ports/coolprop/vcpkg.json
+++ b/ports/coolprop/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "coolprop",
   "version-semver": "6.4.3",
+  "port-version": 1,
   "description": "Thermophysical properties for the masses",
   "homepage": "https://github.com/CoolProp/CoolProp",
   "license": "MIT",

--- a/ports/msgpack/portfile.cmake
+++ b/ports/msgpack/portfile.cmake
@@ -20,7 +20,6 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(PACKAGE_NAME msgpackc-cxx CONFIG_PATH lib/cmake/msgpackc-cxx)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/msgpack/portfile.cmake
+++ b/ports/msgpack/portfile.cmake
@@ -5,9 +5,9 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO msgpack/msgpack-c
-    REF cpp-4.1.3
-    SHA512 1252a2d61b119e9a8db6cc3667d2ae3234784d6607e2d08b836ab2f561455aa8c14ac134de0e8bb47f85a9fa86a9b325babd0a5a437daa0f270143d07738adcf
-    HEAD_REF master
+    REF cpp-6.0.0
+    SHA512 6f2ec74562f30d12ba81659737c412317848eb27fbc607a2f4f8da4b75534fbfba7d280a5af6fdae3581a6a2582e6cf06d7fbfacc3bdee1174456817dd9f7e30
+    HEAD_REF cpp_master
 )
 
 vcpkg_cmake_configure(

--- a/ports/msgpack/portfile.cmake
+++ b/ports/msgpack/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME msgpack-cxx CONFIG_PATH lib/cmake/msgpack-cxx)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/msgpack/vcpkg.json
+++ b/ports/msgpack/vcpkg.json
@@ -5,7 +5,10 @@
   "homepage": "https://github.com/msgpack/msgpack-c",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost",
+    "boost-numeric-conversion",
+    "boost-fusion",
+    "boost-optional",
+    "boost-variant",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/msgpack/vcpkg.json
+++ b/ports/msgpack/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "msgpack",
-  "version": "4.1.3",
+  "version": "6.0.0",
   "description": "MessagePack is an efficient binary serialization format, which lets you exchange data among multiple languages like JSON, except that it's faster and smaller.",
   "homepage": "https://github.com/msgpack/msgpack-c",
   "license": "BSL-1.0",

--- a/ports/msgpack/vcpkg.json
+++ b/ports/msgpack/vcpkg.json
@@ -5,8 +5,8 @@
   "homepage": "https://github.com/msgpack/msgpack-c",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-numeric-conversion",
     "boost-fusion",
+    "boost-numeric-conversion",
     "boost-optional",
     "boost-variant",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5281,7 +5281,7 @@
       "port-version": 0
     },
     "msgpack": {
-      "baseline": "4.1.3",
+      "baseline": "6.0.0",
       "port-version": 0
     },
     "msgpack11": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1690,7 +1690,7 @@
     },
     "coolprop": {
       "baseline": "6.4.3",
-      "port-version": 0
+      "port-version": 1
     },
     "coroutine": {
       "baseline": "1.5.0",

--- a/versions/c-/coolprop.json
+++ b/versions/c-/coolprop.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0bdc5514d6d96d6767c50a09840b164fbf86d93",
+      "version-semver": "6.4.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "ecf4aa81e29286ea194307b2379ef1fd0e3e311f",
       "version-semver": "6.4.3",
       "port-version": 0

--- a/versions/m-/msgpack.json
+++ b/versions/m-/msgpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fe609f1343d62c20d5ec2f4b96c40ebf679a611",
+      "version": "6.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "006d17cf08d5bb92fdb2f4bf33ba97d18cbcc090",
       "version": "4.1.3",
       "port-version": 0

--- a/versions/m-/msgpack.json
+++ b/versions/m-/msgpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a2185e4f5f753a89a5e6536f9629312d49d853c8",
+      "git-tree": "01d97eb7d56dfa3c3e61f1f9981e950828269b79",
       "version": "6.0.0",
       "port-version": 0
     },

--- a/versions/m-/msgpack.json
+++ b/versions/m-/msgpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "01d97eb7d56dfa3c3e61f1f9981e950828269b79",
+      "git-tree": "fc124bda56c5eca176379c3e17f9c2f2d63bbdd9",
       "version": "6.0.0",
       "port-version": 0
     },

--- a/versions/m-/msgpack.json
+++ b/versions/m-/msgpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3fe609f1343d62c20d5ec2f4b96c40ebf679a611",
+      "git-tree": "a2185e4f5f753a89a5e6536f9629312d49d853c8",
       "version": "6.0.0",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/pull/30389 https://github.com/microsoft/vcpkg/pull/28117 https://github.com/microsoft/vcpkg/issues/30615
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: In the latest version, `msgpack` divides the `C` and `C++` libraries into different branches.
The current port `msgpack` is supported as a C++library.
 
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
