### PR TITLE
[hunspell] fix features tools on x64-osx

### DIFF
--- a/ports/hunspell/0001_fix_unistd.patch
+++ b/ports/hunspell/0001_fix_unistd.patch
@@ -1,17 +1,12 @@
-From 9f33c841afe51be517eaea318d46985c596c94ff Mon Sep 17 00:00:00 2001
-From: Mikhail Paulyshka <me@mixaill.tk>
-Date: Tue, 25 Jul 2017 01:58:39 +0300
-Subject: [PATCH] tools/hzip: fix build with MSVC
-
----
- src/tools/hzip.cxx | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/src/tools/hzip.cxx b/src/tools/hzip.cxx
-index ef1864f..d284c64 100644
+index d7d2d2464..30bb5a32c 100644
 --- a/src/tools/hzip.cxx
 +++ b/src/tools/hzip.cxx
-@@ -41,7 +41,9 @@
+@@ -38,10 +38,13 @@
+ /* hzip: file compression for sorted dictionaries with optional encryption,
+  * algorithm: prefix-suffix encoding and 16-bit Huffman encoding */
+ 
++#include <config.h>
  #include <stdio.h>
  #include <stdlib.h>
  #include <string.h>
@@ -21,58 +16,27 @@ index ef1864f..d284c64 100644
  #include <string>
  #include <sys/stat.h>
  
--- 
-2.12.2.windows.2
-
-From 840f920bcd370668b9e788b3c8272eca1f20ce3a Mon Sep 17 00:00:00 2001
-From: Mikhail Paulyshka <me@mixaill.tk>
-Date: Tue, 25 Jul 2017 01:55:13 +0300
-Subject: [PATCH]  tools/unmunch: fix build with MSVC
-
----
- src/tools/unmunch.cxx | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git a/src/tools/unmunch.cxx b/src/tools/unmunch.cxx
-index 44b4cb1..2144370 100644
---- a/src/tools/unmunch.cxx
-+++ b/src/tools/unmunch.cxx
-@@ -42,7 +42,9 @@
- #include <ctype.h>
- #include <string.h>
- #include <string>
-+#ifdef HAVE_UNISTD_H
- #include <unistd.h>
-+#endif /* HAVE_UNISTD_H */
- #include <stdlib.h>
- #include <stdint.h>
- #include <stdio.h>
--- 
-2.12.2.windows.2
-
-From 1c231aa84624082a0fa52d59be8c449bfe1fadd1 Mon Sep 17 00:00:00 2001
-From: Mikhail Paulyshka <me@mixaill.tk>
-Date: Tue, 25 Jul 2017 01:50:21 +0300
-Subject: [PATCH] tools/munch: fix build with MSVC
-
-Include <unistd.h> only if exists
----
- src/tools/munch.cxx | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/src/tools/munch.cxx b/src/tools/munch.cxx
-index 17fc6fd..8503abe 100644
+index e33ac71e3..1e8342ff5 100644
 --- a/src/tools/munch.cxx
 +++ b/src/tools/munch.cxx
-@@ -40,7 +40,9 @@
+@@ -40,7 +40,6 @@
  #include <ctype.h>
  #include <string.h>
  #include <string>
-+#ifdef HAVE_UNISTD_H
- #include <unistd.h>
-+#endif /* HAVE_UNISTD_H */
+-#include <unistd.h>
  #include <stdlib.h>
  #include <stdint.h>
  #include <stdio.h>
--- 
-2.12.2.windows.2
+diff --git a/src/tools/unmunch.cxx b/src/tools/unmunch.cxx
+index 5a73e6fe9..3d9e31832 100644
+--- a/src/tools/unmunch.cxx
++++ b/src/tools/unmunch.cxx
+@@ -42,7 +42,6 @@
+ #include <ctype.h>
+ #include <string.h>
+ #include <string>
+-#include <unistd.h>
+ #include <stdlib.h>
+ #include <stdint.h>
+ #include <stdio.h>

--- a/ports/hunspell/portfile.cmake
+++ b/ports/hunspell/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 472249309aecbbc58a025445781268867173e0651a6147f29644975ad65af043a1e2fbe91f2094934526889c7f9944739dc0a5f0d25328a77d22db1fd8f055ec
     HEAD_REF master
     PATCHES
-        0001_fix_unistd.patch
+        0001_fix_unistd.patch # from https://github.com/hunspell/hunspell/commit/60980f2bfe6678cca98bea2bf37f0b11bb34f4c5
         0005-autotools-subdirs.patch
 )
 

--- a/ports/hunspell/vcpkg.json
+++ b/ports/hunspell/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hunspell",
   "version": "1.7.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The most popular spellchecking library.",
   "homepage": "https://github.com/hunspell/hunspell",
   "license": "MPL-1.1 OR LGPL-2.1-or-later OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3086,7 +3086,7 @@
     },
     "hunspell": {
       "baseline": "1.7.1",
-      "port-version": 2
+      "port-version": 3
     },
     "hwloc": {
       "baseline": "2.9.0",

--- a/versions/h-/hunspell.json
+++ b/versions/h-/hunspell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "798ac2e490d16afc2713b95740101c03fa555f84",
+      "version": "1.7.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "eb238e0094c8177b2b9ddfe8146c5e516ccbb7dc",
       "version": "1.7.1",
       "port-version": 2


### PR DESCRIPTION
Fixes the build of the feature `tools`. Previously failed with 
```
../.././../src/v1.7.1-cbd2511858.clean/src/tools/hzip.cxx:360:5: error: use of undeclared identifier 'unlink'
    unlink(tmpfiletemplate);
    ^
```