### PR TITLE
[nghttp2-asio] remove feature

### DIFF
--- a/ports/nghttp2-asio/vcpkg.json
+++ b/ports/nghttp2-asio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nghttp2-asio",
   "version-date": "2022-08-11",
+  "port-version": 1,
   "description": "High level abstraction API to build HTTP/2 applications with nghttp2 and boost asio.",
   "homepage": "https://github.com/nghttp2/nghttp2-asio",
   "license": "MIT",
@@ -16,26 +17,10 @@
       "name": "nghttp2",
       "version>=": "1.51.0"
     },
+    "openssl",
     {
       "name": "vcpkg-cmake",
       "host": true
     }
-  ],
-  "default-features": [
-    "tls"
-  ],
-  "features": {
-    "tls": {
-      "description": "Support HTTP/2 over TLS aka h2.",
-      "dependencies": [
-        {
-          "name": "boost-asio",
-          "features": [
-            "ssl"
-          ]
-        },
-        "openssl"
-      ]
-    }
-  }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5450,7 +5450,7 @@
     },
     "nghttp2-asio": {
       "baseline": "2022-08-11",
-      "port-version": 0
+      "port-version": 1
     },
     "nghttp3": {
       "baseline": "0.9.0",

--- a/versions/n-/nghttp2-asio.json
+++ b/versions/n-/nghttp2-asio.json
@@ -1,9 +1,14 @@
 {
   "versions": [
     {
+      "git-tree": "ad42ffe88b18eda0e2807ada97bc51b76239e953",
+      "version-date": "2022-08-11",
+      "port-version": 1
+    },
+    {
       "git-tree": "a2ef24d2428ea9d1a4cb733d3e4ce00e3f6f5c8d",
-      "port-version": 0,
-      "version-date": "2022-08-11"
+      "version-date": "2022-08-11",
+      "port-version": 0
     }
   ]
 }


### PR DESCRIPTION
Remove the `tsl` feature and integrate it into `core` because the feature was enables by default, not used in the portfile and `core` was broken. So this "removes" the broken "core" feature. 