### PR TITLE
[liburing] Update to 2.3, fix installation of shared libraries

### DIFF
--- a/ports/liburing/fix-configure.patch
+++ b/ports/liburing/fix-configure.patch
@@ -2,15 +2,15 @@ diff --git a/configure b/configure
 index 2c2441b..620c443 100644
 --- a/configure
 +++ b/configure
-@@ -14,7 +14,7 @@ for opt do
-   ;;
-   --includedir=*) includedir="$optarg"
-   ;;
--  --libdir=*) libdir="$optarg"
-+  --datarootdir=*) libdir="$optarg"
-   ;;
-   --libdevdir=*) libdevdir="$optarg"
-   ;;
+@@ -20,7 +20,7 @@ for opt do
+  ;;
+  --mandir=*) mandir="$optarg"
+  ;;
+-  --datadir=*) datadir="$optarg"
++  --datarootdir=*) datadir="$optarg"
+  ;;
+  --cc=*) cc="$optarg"
+  ;;
 @@ -28,10 +28,12 @@ for opt do
    ;;
    --nolibc) liburing_nolibc="yes"

--- a/ports/liburing/portfile.cmake
+++ b/ports/liburing/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO axboe/liburing
-    REF dda4848a9911120a903bef6284fb88286f4464c9 #liburing-2.2
-    SHA512 c2e4969ffb895996bf7465ce86143d4d3401a052624ec19580d34e8adbb2b57801e03541493f61e19a3137984714db645b135b1bc3b41987bccfd926bb486c09 
+    REF liburing-2.3
+    SHA512 0eda230e527e696189aa04c63f8c444bbfc2e5d2f6b1f2ac9454accdd0aa435979017b803d869c25c29a8575237bec25a8414940a09b6e1e971d84f7e8797506 
     HEAD_REF master
     PATCHES
         fix-configure.patch     # ignore unsupported options, handle ENABLE_SHARED

--- a/ports/liburing/vcpkg.json
+++ b/ports/liburing/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "liburing",
-  "version": "2.2",
-  "port-version": 1,
+  "version": "2.3",
   "description": "Linux-native io_uring I/O access library",
   "homepage": "https://github.com/axboe/liburing",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4557,8 +4557,8 @@
       "port-version": 2
     },
     "liburing": {
-      "baseline": "2.2",
-      "port-version": 1
+      "baseline": "2.3",
+      "port-version": 0
     },
     "libusb": {
       "baseline": "1.0.26",

--- a/versions/l-/liburing.json
+++ b/versions/l-/liburing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2efefeb9eb51d09168ae89524d9860aa4bd0643",
+      "version": "2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "e41ee56c7ceb8925a59b8d427a63990f581c0328",
       "version": "2.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.