### PR TITLE
[qt5-webengine] Fix x64-linux-dynamic build error

### DIFF
--- a/ports/qt5-webengine/build_3.patch
+++ b/ports/qt5-webengine/build_3.patch
@@ -1,0 +1,14 @@
+diff --git a/src/3rdparty/chromium/third_party/libxml/src/encoding.c b/src/3rdparty/chromium/third_party/libxml/src/encoding.c
+index c34aca44663..707aea5bc1a 100644
+--- a/src/3rdparty/chromium/third_party/libxml/src/encoding.c
++++ b/src/3rdparty/chromium/third_party/libxml/src/encoding.c
+@@ -2004,7 +2004,7 @@ xmlEncOutputChunk(xmlCharEncodingHandler *handler, unsigned char *out,
+ #ifdef LIBXML_ICU_ENABLED
+     else if (handler->uconv_out != NULL) {
+         ret = xmlUconvWrapper(handler->uconv_out, 0, out, outlen, in, inlen,
+-                              TRUE);
++                              true);
+     }
+ #endif /* LIBXML_ICU_ENABLED */
+     else {
+

--- a/ports/qt5-webengine/portfile.cmake
+++ b/ports/qt5-webengine/portfile.cmake
@@ -49,6 +49,7 @@ set(PATCHES common.pri.patch
             gl.patch
             build_1.patch
             build_2.patch
+            build_3.patch
             workaround-msvc2022-ice.patch)
 
 set(OPTIONS)
@@ -56,7 +57,11 @@ if("proprietary-codecs" IN_LIST FEATURES)
     list(APPEND OPTIONS "-webengine-proprietary-codecs")
 endif()
 if(NOT VCPKG_TARGET_IS_WINDOWS)
-    list(APPEND OPTIONS "-webengine-system-libwebp" "-webengine-system-ffmpeg" "-webengine-system-icu")
+    list(APPEND OPTIONS "-system-webengine-webp" "-system-webengine-icu")
+    vcpkg_host_path_list(PREPEND ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}/lib/pkgconfig")
+    vcpkg_host_path_list(PREPEND ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include")
+    vcpkg_host_path_list(PREPEND ENV{C_INCLUDE_PATH} "${CURRENT_INSTALLED_DIR}/include")
+    vcpkg_host_path_list(PREPEND ENV{CPLUS_INCLUDE_PATH} "${CURRENT_INSTALLED_DIR}/include")
 endif()
 
 qt_submodule_installation(PATCHES ${PATCHES} BUILD_OPTIONS ${OPTIONS})

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6510,7 +6510,7 @@
     },
     "qt5-webengine": {
       "baseline": "5.15.8",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-webglplugin": {
       "baseline": "5.15.8",

--- a/versions/q-/qt5-webengine.json
+++ b/versions/q-/qt5-webengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26346c15b6590806424177c8e9a17ca30c7bb600",
+      "version": "5.15.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "4cb036e21b5fa8db1033739c264a6bf2936960db",
       "version": "5.15.8",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.