### PR TITLE
[cyclonedds] Update to 0.10.3

### DIFF
--- a/ports/cyclonedds/portfile.cmake
+++ b/ports/cyclonedds/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eclipse-cyclonedds/cyclonedds
     REF "${VERSION}"
-    SHA512 2cc8668a5d42b4391edfee7310c868bc6a5cd0e96f478c270cc19cf9aeb86f057f43753c2c27f79912a5eca478404526bb9c7041e60669f7cf5a7fa931bf1d89
+    SHA512 02cc883a892e07865b7b362919d0a756db8c20f2d4ff7912738ccaaa512a83db4114a4da74f87b5bf743891871402cc4e9d472eaf6718ef409776fa2817ce288
     HEAD_REF master
     PATCHES
         enable-security.patch

--- a/ports/cyclonedds/vcpkg.json
+++ b/ports/cyclonedds/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cyclonedds",
-  "version-semver": "0.10.2",
-  "port-version": 2,
+  "version-semver": "0.10.3",
   "description": "Eclipse Cyclone DDS is a very performant and robust open-source implementation of the OMG DDS specification",
   "homepage": "https://cyclonedds.io",
   "license": "EPL-2.0 OR BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1925,8 +1925,8 @@
       "port-version": 0
     },
     "cyclonedds": {
-      "baseline": "0.10.2",
-      "port-version": 2
+      "baseline": "0.10.3",
+      "port-version": 0
     },
     "cyclonedds-cxx": {
       "baseline": "0.10.2",

--- a/versions/c-/cyclonedds.json
+++ b/versions/c-/cyclonedds.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c255b603065059864d3a144db77cf44b15514222",
+      "version-semver": "0.10.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "88e7a85946eae33b8e9d686107d7e303afa2a59e",
       "version-semver": "0.10.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.