### PR TITLE
[Help needed][gazebo] Fix gazebo dependencies

### DIFF
--- a/ports/gazebo/0001-Fix-deps.patch
+++ b/ports/gazebo/0001-Fix-deps.patch
@@ -1,26 +1,120 @@
-﻿diff --git a/cmake/SearchForStuff.cmake b/cmake/SearchForStuff.cmake
-index 4085b5aaeb..f89ac88333 100644
+diff --git a/cmake/FindFreeimage.cmake b/cmake/FindFreeimage.cmake
+--- a/cmake/FindFreeimage.cmake
++++ b/cmake/FindFreeimage.cmake
+@@ -2,16 +2,19 @@
+ include (${gazebo_cmake_dir}/GazeboUtils.cmake)
+ 
+ ########################################
+ # Find packages
++if(false)
+ if (PKG_CONFIG_FOUND)
+   pkg_check_modules(freeimage freeimage>=${MIN_FREEIMAGE_VERSION})
+   if (NOT freeimage_FOUND)
+     message (STATUS "  freeimage.pc not found, trying freeimage_include_dir and freeimage_library_dir flags.")
+   endif (NOT freeimage_FOUND)
+ endif (PKG_CONFIG_FOUND)
++endif()
+ 
+ if (NOT freeimage_FOUND)
++  if (false)
+   find_path(freeimage_INCLUDE_DIRS FreeImage.h)
+   if (NOT freeimage_INCLUDE_DIRS)
+     message (STATUS "  Looking for FreeImage.h - not found")
+     BUILD_ERROR("Missing: Unable to find FreeImage.h")
+@@ -32,8 +35,13 @@
+        message (STATUS "  Looking for FreeImage.h - found")
+     endif (NOT FREEIMAGE_RUNS)
+   endif (NOT freeimage_INCLUDE_DIRS)
+ 
++  endif()
++ 
++  find_package(freeimage CONFIG REQUIRED)
++  set(freeimage_LIBRARIES freeimage::FreeImage)
++  if (0)
+   if (WIN32)
+     if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+       find_library(freeimage_LIBRARIES FreeImaged)
+     else()
+@@ -48,5 +56,6 @@
+   else (NOT freeimage_LIBRARIES)
+     message (STATUS "  Looking for libfreeimage - found")
+     include_directories(${freeimage_INCLUDE_DIRS})
+   endif (NOT freeimage_LIBRARIES)
++  endif()
+ endif (NOT freeimage_FOUND)
+diff --git a/cmake/SearchForStuff.cmake b/cmake/SearchForStuff.cmake
+index 9777a46..be03eb8 100644
 --- a/cmake/SearchForStuff.cmake
 +++ b/cmake/SearchForStuff.cmake
-@@ -179,7 +179,7 @@ if (PKG_CONFIG_FOUND)
-   # (needed, at least, for MacOS)
+@@ -32,7 +32,9 @@
+ ########################################
+ # The Google Protobuf library for message generation + serialization
+-find_package(Protobuf REQUIRED)
++find_package(PROTOBUF NAMES protobuf REQUIRED)
++set(GZ_PROTOBUF_LIBRARY protobuf::libprotobuf protobuf::libprotobuf-lite)
++set(GZ_PROTOBUF_PROTOC_LIBRARY protobuf::libprotoc)
+ if (NOT PROTOBUF_FOUND)
+   BUILD_ERROR ("Missing: Google Protobuf (libprotobuf-dev)")
+ endif()
+ if (NOT PROTOBUF_PROTOC_EXECUTABLE)
+@@ -45,9 +43,11 @@
++if(0)
+ if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+   set (GZ_PROTOBUF_LIBRARY ${PROTOBUF_LIBRARY_DEBUG})
+   set (GZ_PROTOBUF_PROTOC_LIBRARY ${PROTOBUF_PROTOC_LIBRARY_DEBUG})
+ else()
+   set (GZ_PROTOBUF_LIBRARY ${PROTOBUF_LIBRARY})
+   set (GZ_PROTOBUF_PROTOC_LIBRARY ${PROTOBUF_PROTOC_LIBRARY})
+ endif()
++endif()
  
+ ########################################
+@@ -144,7 +148,12 @@ if (PKG_CONFIG_FOUND)
+   # Find Simbody
+   set(SimTK_INSTALL_DIR ${SimTK_INSTALL_PREFIX})
+   #list(APPEND CMAKE_MODULE_PATH ${SimTK_INSTALL_PREFIX}/share/cmake)
+-  find_package(Simbody)
++  find_package(Simbody CONFIG REQUIRED)
++  if (TARGET SimTKmath_static)
++    set(Simbody_LIBRARIES SimTKmath_static SimTKcommon_static SimTKsimbody_static)
++  else()
++    set(Simbody_LIBRARIES SimTKmath SimTKcommon SimTKsimbody)
++  endif()
+   if (Simbody_FOUND)
+     message (STATUS "Looking for Simbody - found")
+     set (HAVE_SIMBODY TRUE)
+@@ -188,4 +190,4 @@ if (PKG_CONFIG_FOUND)
    # Use system installation on UNIX and Apple, and internal copy on Windows
 -  if (UNIX OR APPLE)
 +  if (true)
-     message (STATUS "Using system tinyxml.")
-     set (USE_EXTERNAL_TINYXML True)
+     set (USE_EXTERNAL_TINYXML_DEFAULT_VALUE ON)
    elseif(WIN32)
-@@ -225,7 +225,7 @@ if (PKG_CONFIG_FOUND)
-   # (needed, at least, for MacOS)
- 
+@@ -237,4 +239,4 @@ if (PKG_CONFIG_FOUND)
    # Use system installation on UNIX and Apple, and internal copy on Windows
 -  if (UNIX OR APPLE)
 +  if (true)
-     message (STATUS "Using system tinyxml2.")
-     set (USE_EXTERNAL_TINYXML2 True)
+     set (USE_EXTERNAL_TINYXML2_DEFAULT_VALUE ON)
    elseif(WIN32)
-@@ -513,7 +513,7 @@ if (PKG_CONFIG_FOUND)
+@@ -341,6 +350,7 @@ if (PKG_CONFIG_FOUND)
+   #################################################
+   # Find OGRE
+ 
++  if (false)
+   pkg_check_modules(OGRE-RTShaderSystem
+                     OGRE-RTShaderSystem>=${MIN_OGRE_VERSION})
+ 
+@@ -387,8 +397,8 @@ if (PKG_CONFIG_FOUND)
+       set (OGRE_PLUGINDIR ${_pkgconfig_invoke_result})
+     endif()
+   endif()
+-
+-  if (NOT OGRE_FOUND)
++  endif()
++  if (true)
+     # Workaround for CMake bug https://gitlab.kitware.com/cmake/cmake/issues/17135,
+     # that prevents to successfully run a find_package(<package>) call if before there
+     # was a failed call to pkg_check_modules(<package> <package>)
+@@ -525,7 +535,7 @@ if (PKG_CONFIG_FOUND)
    endif ()
  
    if (libavutil_FOUND AND libavformat_FOUND AND libavcodec_FOUND AND
@@ -29,7 +123,7 @@ index 4085b5aaeb..f89ac88333 100644
      set (HAVE_FFMPEG TRUE)
    else ()
      set (HAVE_FFMPEG FALSE)
-@@ -538,7 +538,7 @@ if (PKG_CONFIG_FOUND)
+@@ -550,7 +560,7 @@ if (PKG_CONFIG_FOUND)
    ########################################
    # Find GNU Triangulation Surface Library
    pkg_check_modules(gts gts)
@@ -38,7 +132,7 @@ index 4085b5aaeb..f89ac88333 100644
      message (STATUS "Looking for GTS - found")
      set (HAVE_GTS TRUE)
    else ()
-@@ -551,13 +551,14 @@ if (PKG_CONFIG_FOUND)
+@@ -563,13 +573,14 @@ if (PKG_CONFIG_FOUND)
    # First and preferred option is to look for bullet standard pkgconfig,
    # so check it first. if it is not present, check for the OSRF
    # custom bullet2.82.pc file
@@ -54,7 +148,7 @@ index 4085b5aaeb..f89ac88333 100644
      add_definitions( -DLIBBULLET_VERSION=${BULLET_VERSION} )
    else()
      set (HAVE_BULLET FALSE)
-@@ -572,7 +573,7 @@ if (PKG_CONFIG_FOUND)
+@@ -584,7 +595,7 @@ if (PKG_CONFIG_FOUND)
    ########################################
    # Find libusb
    pkg_check_modules(libusb-1.0 libusb-1.0)
@@ -63,7 +157,7 @@ index 4085b5aaeb..f89ac88333 100644
      BUILD_WARNING ("libusb-1.0 not found. USB peripherals support will be disabled.")
      set (HAVE_USB OFF CACHE BOOL "HAVE USB" FORCE)
    else()
-@@ -648,7 +649,7 @@ endif ()
+@@ -660,7 +671,7 @@ endif ()
  ########################################
  # Find gdal
  include (FindGDAL)
@@ -72,7 +166,7 @@ index 4085b5aaeb..f89ac88333 100644
    message (STATUS "Looking for libgdal - not found")
    BUILD_WARNING ("GDAL not found, Digital elevation terrains support will be disabled.")
    set (HAVE_GDAL OFF CACHE BOOL "HAVE GDAL" FORCE)
-@@ -718,7 +719,7 @@ endif()
+@@ -744,7 +755,7 @@ endif()
  ########################################
  # Find graphviz
  include (${gazebo_cmake_dir}/FindGraphviz.cmake)
@@ -82,7 +176,7 @@ index 4085b5aaeb..f89ac88333 100644
    BUILD_WARNING ("Graphviz not found, Model editor's schematic view will be disabled.")
    set (HAVE_GRAPHVIZ OFF CACHE BOOL "HAVE GRAPHVIZ" FORCE)
 diff --git a/cmake/gazebo-config.cmake.in b/cmake/gazebo-config.cmake.in
-index b57a90dd76..63ce97095e 100644
+index b57a90d..63ce970 100644
 --- a/cmake/gazebo-config.cmake.in
 +++ b/cmake/gazebo-config.cmake.in
 @@ -99,12 +99,13 @@ list(APPEND @PKG_NAME@_CFLAGS -I${GAZEBO_INSTALL_INCLUDE_DIR}/gazebo-@GAZEBO_MAJ

--- a/ports/gazebo/add-features.patch
+++ b/ports/gazebo/add-features.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3e0ae3d..eeb1ba7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -384,16 +384,18 @@ else (build_errors)
+     set(TEST_TYPE "UNIT")
+     add_subdirectory(gazebo)
+     add_subdirectory(media)
++    if (BUILD_TOOLS)
+     add_subdirectory(tools)
++    endif()
++    if (BUILD_PLUGINS)
+     add_subdirectory(plugins)
++    endif()
+     add_subdirectory(interfaces)
+     add_subdirectory(worlds)
+     add_subdirectory(models)
+ 
+     if (BUILD_TESTING)
+       add_subdirectory(test)
+-    else()
+-      add_subdirectory(test EXCLUDE_FROM_ALL)
+     endif()
+ 
+   endif (BUILD_GAZEBO)
+diff --git a/gazebo/CMakeLists.txt b/gazebo/CMakeLists.txt
+index 9ad9d02..5c45753 100644
+--- a/gazebo/CMakeLists.txt
++++ b/gazebo/CMakeLists.txt
+@@ -41,7 +41,9 @@ add_subdirectory(gui)
+ add_subdirectory(physics)
+ add_subdirectory(sensors)
+ add_subdirectory(util)
++if (BUILD_TESTING)
+ add_subdirectory(test)
++endif()
+ 
+ add_dependencies(gazebo_physics gazebo_msgs)
+ add_dependencies(gazebo_gui gazebo_msgs)

--- a/ports/gazebo/fix-build-type.patch
+++ b/ports/gazebo/fix-build-type.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/GazeboUtils.cmake b/cmake/GazeboUtils.cmake
+index f1710e9..ace50f9 100644
+--- a/cmake/GazeboUtils.cmake
++++ b/cmake/GazeboUtils.cmake
+@@ -146,13 +146,11 @@ endmacro ()
+ #################################################
+ macro (gz_setup_unix)
+     # Using dynamic linking in UNIX by default
+-    set(BUILD_SHARED_LIBS TRUE)
+ endmacro()
+ 
+ #################################################
+ macro (gz_setup_windows)
+     # Using dynamic linking in Windows by default
+-    set(BUILD_SHARED_LIBS TRUE)
+     add_definitions(-DWIN32_LEAN_AND_MEAN)
+ 
+     # Need for M_PI constant

--- a/ports/gazebo/fix-msgs.patch
+++ b/ports/gazebo/fix-msgs.patch
@@ -1,0 +1,13 @@
+diff --git a/gazebo/msgs/msgs.cc b/gazebo/msgs/msgs.cc
+--- a/gazebo/msgs/msgs.cc
++++ b/gazebo/msgs/msgs.cc
+@@ -16,8 +16,9 @@
+ */
+ 
+ #include <google/protobuf/descriptor.h>
+ #include <algorithm>
++#include <array>
+ #include <ignition/math/MassMatrix3.hh>
+ #include <ignition/math/Rand.hh>
+ 
+ #include "gazebo/common/CommonIface.hh"

--- a/ports/gazebo/fix-opengl-def.patch
+++ b/ports/gazebo/fix-opengl-def.patch
@@ -1,0 +1,13 @@
+diff --git a/gazebo/rendering/RenderEngine.cc b/gazebo/rendering/RenderEngine.cc
+index 87d78ea95d..bd90493266 100644
+--- a/gazebo/rendering/RenderEngine.cc
++++ b/gazebo/rendering/RenderEngine.cc
+@@ -22,6 +22,8 @@
+ 
+ // Not Apple or Windows
+ #if not defined(__APPLE__) && not defined(_WIN32)
++#define GL_GLEXT_LEGACY
++#define GLX_GLXEXT_LEGACY
+ # include <X11/Xlib.h>
+ # include <X11/Xutil.h>
+ # include <GL/glx.h>

--- a/ports/gazebo/portfile.cmake
+++ b/ports/gazebo/portfile.cmake
@@ -1,19 +1,14 @@
-vcpkg_download_distfile(gazebo3211
-    URLS "https://patch-diff.githubusercontent.com/raw/osrf/gazebo/pull/3211.diff"
-    FILENAME "gazebo3211.diff"
-    SHA512 761e254866d4705acc0b81479285f979c436b3b611739a207a575031d8a8daba48de4fc0c8de5edb9a9f89725586c5caeef9e6e1e3d63a2d961ca09df974f7de
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO osrf/gazebo
-    REF 382dcc3f36095a8d79b5bc9c8b8ad346e867c51d
-    SHA512 57638cd0b23b5f2bfd32fdc159d6cd77ca34e3bd695c225591979aef4b7271eac93d3706fa1ffa2340f90013267a4171bebe1e4c142f19ad2bf67963dfed627e
-    HEAD_REF gazebo11
+    REPO gazebosim/gazebo-classic
+    REF gazebo11_${VERSION}
+    SHA512 50a5160dc1fb30cd517bf6937675359e2db01a46eeacad5e1ca5cf61ee36bcb4a9d425d6dabe32fecb705989fb54f2ad807b43b7f39f88a871e1bec9d3f6c70a
     PATCHES
         0001-Fix-deps.patch
-        "${gazebo3211}"
-        fix-tbb.patch # Effectively https://github.com/osrf/gazebo/pull/3174 with merge conflict resolutions
+        fix-build-type.patch
+        fix-opengl-def.patch
+        add-features.patch
+        fix-msgs.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -21,6 +16,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         openal    HAVE_OPENAL
         ffmpeg    FFMPEG_FEATURE
         gts       GTS_FEATURE
+        plugins   BUILD_PLUGINS
+        tools     BUILD_TOOLS
     INVERTED_FEATURES
         simbody   CMAKE_DISABLE_FIND_PACKAGE_Simbody
         dart      CMAKE_DISABLE_FIND_PACKAGE_DART
@@ -33,9 +30,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DUSE_EXTERNAL_TINY_PROCESS_LIBRARY=ON
         "-DPKG_CONFIG_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf${VCPKG_HOST_EXECUTABLE_SUFFIX}"
-        ${FEATURE_OPTIONS}
+        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
         -DBUILD_TESTING=OFF  # Not enabled by default, but to be sure
 )
 
@@ -50,11 +48,15 @@ foreach(postfix "" "-11")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}${postfix}/setup.sh" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../..")
 endforeach()
 
+set(BINARIES_LIST gazebo gzclient gzserver)
+if (BUILD_TOOLS) 
+    set(BINARIES_LIST ${BINARIES_LIST} gz)
+endif()
 vcpkg_copy_tools(
-    TOOL_NAMES gazebo gz gzclient gzserver
+    TOOL_NAMES ${BINARIES_LIST}
     AUTO_CLEAN
 )
-set(EXTRA_OGRE_LIBS Codec_EXR Codec_FreeImage Codec_STBI OgreBites OgreMain OgreMeshLodGenerator OgreOverlay OgrePaging OgreProperty OgreRTShaderSystem OgreTerrain OgreVolume Plugin_BSPSceneManager Plugin_DotScene Plugin_OctreeSceneManager Plugin_OctreeZone Plugin_ParticleFX Plugin_PCZSceneManager RenderSystem_Direct3D11 RenderSystem_GL RenderSystem_GL3Plus)
+set(EXTRA_OGRE_LIBS Codec_FreeImage Codec_STBI OgreBites OgreMain OgreMeshLodGenerator OgreOverlay OgrePaging OgreProperty OgreRTShaderSystem OgreTerrain OgreVolume Plugin_BSPSceneManager Plugin_DotScene Plugin_OctreeSceneManager Plugin_OctreeZone Plugin_ParticleFX Plugin_PCZSceneManager RenderSystem_Direct3D11 RenderSystem_GL RenderSystem_GL3Plus)
 foreach(LIB IN LISTS EXTRA_OGRE_LIBS)
     set(FILE_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}${LIB}${CMAKE_SHARED_LIBRARY_SUFFIX}")
     file(COPY "${CURRENT_INSTALLED_DIR}/bin/${FILE_NAME}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")

--- a/ports/gazebo/vcpkg.json
+++ b/ports/gazebo/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "gazebo",
-  "version-date": "2022-01-20",
-  "port-version": 4,
+  "version": "11.12.0",
   "description": "Open source robotics simulator.",
   "homepage": "http://gazebosim.org",
   "license": "Apache-2.0",
+  "builtin-baseline": "19af97cba8ca48474e4ad15a24ed50271a9ecdac",
   "dependencies": [
     "boost-asio",
     "boost-date-time",
@@ -19,6 +19,7 @@
     "boost-thread",
     "boost-uuid",
     "ccd",
+    "freeimage",
     {
       "name": "hdf5",
       "features": [
@@ -30,12 +31,18 @@
     "ignition-math6",
     "ignition-msgs5",
     "ignition-transport8",
+    {
+      "name": "libtar",
+      "platform": "!windows"
+    },
     "ogre",
+    "opengl",
     {
       "name": "pkgconf",
       "host": true
     },
     "protobuf",
+    "qt5-base",
     "qwt",
     "sdformat9",
     "tbb",
@@ -116,11 +123,35 @@
         "openal-soft"
       ]
     },
+    "plugins": {
+      "description": "Build gazebo plugins",
+      "supports": "!linux"
+    },
     "simbody": {
       "description": "Use the simbody physics engine",
       "dependencies": [
         "simbody"
       ]
+    },
+    "tools": {
+      "description": "Build gazebo tools",
+      "supports": "!(linux & static)"
     }
-  }
+  },
+  "overrides": [
+    {
+      "name": "ogre",
+      "version": "1.12.9",
+      "port-version": 10
+    },
+    {
+      "name": "qwt",
+      "version": "6.1.5"
+    },
+    {
+      "name": "graphviz",
+      "version": "2.49.1",
+      "port-version": 4
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2681,8 +2681,8 @@
       "port-version": 1
     },
     "gazebo": {
-      "baseline": "2022-01-20",
-      "port-version": 4
+      "baseline": "11.12.0",
+      "port-version": 0
     },
     "gcem": {
       "baseline": "1.16.0",

--- a/versions/g-/gazebo.json
+++ b/versions/g-/gazebo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c8ff0ecb8027507bcf3f73787bf749ca7da21c5",
+      "version": "11.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b1f5088e196340aad31ea3700aceae72df1407ae",
       "version-date": "2022-01-20",
       "port-version": 4


### PR DESCRIPTION
This PR is continue from my old PR: 
https://github.com/microsoft/vcpkg/pull/24969
Thank for @JackBoosY and @dg0yt for helping out.

I made a little progress, but still need to patch gazebo to fit the new ogre lib. Also gazebo using private headers from ogre that is problematic. There is open issue on gazebo that they want to compile gazebo with vcpkg on their side, I hope to catch their attention to fix all the problems with you guys.

Gazebo open issue:
https://github.com/gazebosim/gazebo-classic/issues/3202

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

Waiting for:

- [x] https://github.com/microsoft/vcpkg/pull/30435
- [x] https://github.com/microsoft/vcpkg/pull/30421 
- [x] https://github.com/microsoft/vcpkg/pull/30557