### PR TITLE
[g3log] update 2.3

### DIFF
--- a/ports/g3log/portfile.cmake
+++ b/ports/g3log/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KjellKod/g3log
-    REF 6f6da0ed2a8b42b8a5d1a416fe1646fe45e45c99
-    SHA512 65d966e0cb35ae6903619349520f12abf473c98ce6c9ffcb9b196b0be5d2b75ee5b716eeec8285ddc909f65049d8feab9389347c28be376b46cdb0d9246ffbbd
+    REF 4f1224b9d52d7bfe74fde2bf31f88733ce04d19d
+    SHA512 deba3c569dc4b7fc55129b754cd2ba8a9b59f4520014edbbfd316367d7085ac18dd33e354803b4dbe6be982a2e74509d7dc5b36b3b1e0cfcb1033207aaf5c9b2
     HEAD_REF master
 )
 

--- a/ports/g3log/portfile.cmake
+++ b/ports/g3log/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KjellKod/g3log
-    REF 4f1224b9d52d7bfe74fde2bf31f88733ce04d19d
+    REF "${VERSION}"
     SHA512 deba3c569dc4b7fc55129b754cd2ba8a9b59f4520014edbbfd316367d7085ac18dd33e354803b4dbe6be982a2e74509d7dc5b36b3b1e0cfcb1033207aaf5c9b2
     HEAD_REF master
 )

--- a/ports/g3log/vcpkg.json
+++ b/ports/g3log/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "g3log",
-  "version": "2.1",
+  "version": "2.3",
   "description": "Asynchronous logger with Dynamic Sinks",
   "homepage": "https://github.com/KjellKod/g3log",
   "license": "Unlicense",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2134,7 +2134,7 @@
     },
     "drogon": {
       "baseline": "1.8.4",
-      "port-version": 0 
+      "port-version": 0
     },
     "dstorage": {
       "baseline": "1.1.0",
@@ -2637,7 +2637,7 @@
       "port-version": 2
     },
     "g3log": {
-      "baseline": "2.1",
+      "baseline": "2.3",
       "port-version": 0
     },
     "gainput": {

--- a/versions/g-/g3log.json
+++ b/versions/g-/g3log.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1bbc871ee36db0c3ff9d17d0885a151866b4a56",
+      "version": "2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "ce2eee87993ff26684fad107624adebc23e64737",
       "version": "2.1",
       "port-version": 0


### PR DESCRIPTION
Update g3log from 2.1 to 2.3 : https://github.com/KjellKod/g3log/releases/tag/2.3

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
