### PR TITLE
[simdjson] Update to 3.1.6

### DIFF
--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO simdjson/simdjson
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 e2a8c3b21b134c96158f8a6f209ea4c9c7bd63205ad967860a99ad24bc607b857f3a952ab84cdf927322ddcc6a549555d32c163751fe4ff2b5776de918685b40
+    SHA512 72f27b010e659025f9c8842daf79364d0d0f40cddd66858956ab4fa4f3f3a631fe342f440201d58ed9af42a4356aafafaac8d3caf3317dd1a6314dad3a71081a
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "A extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7293,7 +7293,7 @@
       "port-version": 1
     },
     "simdjson": {
-      "baseline": "3.1.5",
+      "baseline": "3.1.6",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d4926521a5e488d316ec612c5cca368ae842cc9",
+      "version": "3.1.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "6694abe5993ac1fc09466303507bb0eccca53911",
       "version": "3.1.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] <del>The "supports" clause reflects platforms that may be fixed by this new version</del>
- [ ] <del>Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.</del>
- [ ] <del>Any patches that are no longer applied are deleted from the port's directory.</del>
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
