### PR TITLE
[Thorvg] Update to 0.8.4

### DIFF
--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO Samsung/thorvg
-    REF v0.8.3
-    SHA512 df2662b89e72608bd635ff18e7a56562e046421eb7152f11e9796df8cd0d964e34d1ffdba742a838e46f9a27f3d69ba81fb3e08a3ff3f21eac951476bdc72848
+    REPO thorvg/thorvg
+    REF v0.8.4
+    SHA512 8e885a8c56efb129fb3ab90b9a7b765b84f5f520a9c7a5c92af4ffe61bac1b928165801b64ebc7db77046e1aaf2918ed0ffdf98cb9572dc6d46ed6de3f96b9b7
     HEAD_REF master
     PATCHES
         install-tools.patch

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "thorvg",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2134,7 +2134,7 @@
     },
     "drogon": {
       "baseline": "1.8.4",
-      "port-version": 0 
+      "port-version": 0
     },
     "dstorage": {
       "baseline": "1.1.0",
@@ -7769,7 +7769,7 @@
       "port-version": 6
     },
     "thorvg": {
-      "baseline": "0.8.3",
+      "baseline": "0.8.4",
       "port-version": 0
     },
     "threadpool": {

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09d722c7f2cb784d571af9a6f46abb83aa907d2b",
+      "version": "0.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "0ca8e329f991f2fc88a65508cd83401882aac41c",
       "version": "0.8.3",
       "port-version": 0


### PR DESCRIPTION
Update Thorvg from 0.8,3 to 0.8.4 : https://github.com/thorvg/thorvg/releases/tag/v0.8.4

 Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
 SHA512s are updated for each updated download
 The "supports" clause reflects platforms that may be fixed by this new version
 Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
 Any patches that are no longer applied are deleted from the port's directory.
 The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
 Only one version is added to each modified port's versions file.