### PR TITLE
[libigl] allow arm and uwp

### DIFF
--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "libigl",
   "version": "2.4.0",
+  "port-version": 1,
   "description": "libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.",
   "homepage": "https://github.com/libigl/libigl",
   "license": "GPL-3.0-only",
-  "supports": "!(arm | uwp)",
   "dependencies": [
     "eigen3",
     "gmp",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -390,9 +390,6 @@ libgxps:x64-windows-static-md=fail
 libhdfs3:x64-linux=fail
 libhdfs3:x64-osx=fail
 libhdfs3:arm64-osx=fail
-libigl:arm64-windows=fail
-libigl:arm-uwp=fail
-libigl:x64-uwp=fail
 libirecovery:x64-windows-static-md=fail
 # 120 min build time for libjxl arm-uwp-rel, reason unknown
 libjxl:arm-uwp=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4066,7 +4066,7 @@
     },
     "libigl": {
       "baseline": "2.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libilbc": {
       "baseline": "3.0.4",

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a44d46fb03c0127710107883208300358ad960f",
+      "version": "2.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f3426c36bc18bb524834ef9f4482964a3d980fb9",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/27084. 

Counter PR against #30333 but without a support expression at all. I have tested `arm64-osx`, `arm-windows`, `arm64-windows`, `x64-uwp`, `arm-uwp` and `arm64-uwp`