### PR TITLE
[halide] fix core build

### DIFF
--- a/ports/halide/portfile.cmake
+++ b/ports/halide/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_check_features(
         target-amdgpu TARGET_AMDGPU
         target-arm TARGET_ARM
         target-d3d12compute TARGET_D3D12COMPUTE
+        target-opengl-compute TARGET_OPENGLCOMPUTE
         target-hexagon TARGET_HEXAGON
         target-metal TARGET_METAL
         target-mips TARGET_MIPS

--- a/ports/halide/vcpkg.json
+++ b/ports/halide/vcpkg.json
@@ -1,11 +1,43 @@
 {
   "name": "halide",
   "version": "15.0.0",
+  "port-version": 1,
   "description": "Halide is a programming language designed to make it easier to write high-performance image and array processing code on modern machines.",
   "homepage": "https://github.com/halide/Halide",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
+    {
+      "name": "halide",
+      "default-features": false,
+      "features": [
+        "target-arm"
+      ],
+      "platform": "arm32"
+    },
+    {
+      "name": "halide",
+      "default-features": false,
+      "features": [
+        "target-aarch64"
+      ],
+      "platform": "arm64"
+    },
+    {
+      "name": "halide",
+      "default-features": false,
+      "features": [
+        "target-x86"
+      ],
+      "platform": "x86 | x64"
+    },
+    {
+      "name": "halide",
+      "features": [
+        "target-all"
+      ],
+      "platform": "!x86 & !x64 & !arm"
+    },
     {
       "name": "llvm",
       "default-features": false,
@@ -24,46 +56,7 @@
       "host": true
     }
   ],
-  "default-features": [
-    "jit"
-  ],
   "features": {
-    "jit": {
-      "description": "Include targets required for jit compilation",
-      "dependencies": [
-        {
-          "name": "halide",
-          "default-features": false,
-          "features": [
-            "target-aarch64"
-          ],
-          "platform": "arm64"
-        },
-        {
-          "name": "halide",
-          "default-features": false,
-          "features": [
-            "target-x86"
-          ],
-          "platform": "x86 | x64"
-        },
-        {
-          "name": "halide",
-          "default-features": false,
-          "features": [
-            "target-arm"
-          ],
-          "platform": "arm & !arm64"
-        },
-        {
-          "name": "halide",
-          "features": [
-            "target-all"
-          ],
-          "platform": "!x86 & !x64 & !arm & !arm64"
-        }
-      ]
-    },
     "target-aarch64": {
       "description": "Include AArch64 target",
       "dependencies": [
@@ -92,6 +85,7 @@
             "target-mips",
             "target-nvptx",
             "target-opencl",
+            "target-opengl-compute",
             "target-powerpc",
             "target-riscv",
             "target-x86"
@@ -167,6 +161,9 @@
     },
     "target-opencl": {
       "description": "Include OpenCL-C target"
+    },
+    "target-opengl-compute": {
+      "description": "Include OpenGL Compute target"
     },
     "target-powerpc": {
       "description": "Include PowerPC target",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3006,7 +3006,7 @@
     },
     "halide": {
       "baseline": "15.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "happly": {
       "baseline": "2021-03-19",

--- a/versions/h-/halide.json
+++ b/versions/h-/halide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "747567f07492ad16950a115456d31ba746a3bd10",
+      "version": "15.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1d7e84604e36eb833964af361772ebcf5e3953c5",
       "version": "15.0.0",
       "port-version": 0


### PR DESCRIPTION
The core build did not work. The `jit` feature was the default and required to get a successful build => merge `jit` feature into `core`. This also adds the `target-opengl-compute` target/feature. 