### PR TITLE
[nanopb] fix install location

### DIFF
--- a/ports/nanopb/fix-install-location.patch
+++ b/ports/nanopb/fix-install-location.patch
@@ -1,0 +1,41 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0ce05ea..1e8c4ed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,18 +34,11 @@ if(NOT DEFINED CMAKE_INSTALL_CMAKEDIR)
+     set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/nanopb")
+ endif()
+ 
+-execute_process(
+-    COMMAND ${Python_EXECUTABLE} -c
+-        "import os.path, sys, sysconfig; print(os.path.relpath(sysconfig.get_path('purelib'), start=sys.prefix))"
+-    OUTPUT_VARIABLE PYTHON_INSTDIR
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-)
+-
+ if(nanopb_BUILD_GENERATOR)
+     set(generator_protos nanopb)
+-    if(NOT DEFINED nanopb_PROTOC_PATH)
+-        message(FATAL_ERROR "nanopb_PROTOC_PATH not defined")
+-    endif()
++    if(NOT DEFINED nanopb_PROTOC_PATH)
++        message(FATAL_ERROR "nanopb_PROTOC_PATH not defined")
++    endif()
+     foreach(generator_proto IN LISTS generator_protos)
+         string(REGEX REPLACE "([^;]+)" "${PROJECT_SOURCE_DIR}/generator/proto/\\1.proto" generator_proto_file "${generator_proto}")
+         string(REGEX REPLACE "([^;]+)" "\\1_pb2.py" generator_proto_py_file "${generator_proto}")
+@@ -58,12 +51,12 @@ if(nanopb_BUILD_GENERATOR)
+         install(
+             FILES ${PROJECT_BINARY_DIR}/${generator_proto_py_file}
+                   ${generator_proto_file}
+-            DESTINATION ${PYTHON_INSTDIR}/proto/
++            DESTINATION ${CMAKE_INSTALL_DATADIR}/proto/
+         )
+     endforeach()
+ 
+     install( FILES generator/proto/_utils.py
+-             DESTINATION ${PYTHON_INSTDIR}/proto/ )
++             DESTINATION ${CMAKE_INSTALL_DATADIR}/proto/ )
+ endif()
+ 
+ if(WIN32)

--- a/ports/nanopb/portfile.cmake
+++ b/ports/nanopb/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES 
         fix-cmakelist-and-pb-header.patch
+        fix-install-location.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" nanopb_BUILD_STATIC_LIBS)
@@ -30,6 +31,7 @@ vcpkg_cmake_configure(
         -Dnanopb_MSVC_STATIC_RUNTIME=${nanopb_STATIC_LINKING}
         -Dnanopb_PROTOC_PATH="${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
         ${FEATURE_OPTIONS}
+        -DCMAKE_INSTALL_DATADIR=share/${PORT}
 )
 vcpkg_cmake_install()
 
@@ -37,7 +39,7 @@ vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 if(nanopb_BUILD_GENERATOR)
     file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/nanopb_generator.py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")

--- a/ports/nanopb/vcpkg.json
+++ b/ports/nanopb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nanopb",
   "version-semver": "0.4.7",
+  "port-version": 1,
   "description": "A small code-size Protocol Buffers implementation in ANSI C.",
   "homepage": "https://jpa.kapsi.fi/nanopb/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2134,7 +2134,7 @@
     },
     "drogon": {
       "baseline": "1.8.4",
-      "port-version": 0 
+      "port-version": 0
     },
     "dstorage": {
       "baseline": "1.1.0",
@@ -5374,7 +5374,7 @@
     },
     "nanopb": {
       "baseline": "0.4.7",
-      "port-version": 0
+      "port-version": 1
     },
     "nanoprintf": {
       "baseline": "2020-05-27",

--- a/versions/n-/nanopb.json
+++ b/versions/n-/nanopb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d78bf2dbff06f0540e971677c39641b9057dc57",
+      "version-semver": "0.4.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "230c55c9370ee3756674be33a6d5740ff04fccda",
       "version-semver": "0.4.7",
       "port-version": 0


### PR DESCRIPTION
Before this change I got
```
CMake Error at cmake_install.cmake:41 (file):
  file cannot create directory:
  /Users/leanderSchulten/git_projekte/vcpkg/packages/nanopb_arm64-osx/debug/../../../../../../lib/python3.11/site-packages/proto.
  Maybe need administrative privileges.
```
`/Users/leanderSchulten/git_projekte/vcpkg/packages/nanopb_arm64-osx/debug/../../../../../../lib/python3.11/site-packages/proto` is `/Users/lib/python3.11/site-packages/proto`