### PR TITLE
[zeromq] fix feature websockets

### DIFF
--- a/ports/zeromq/include-dir-gnutls.patch
+++ b/ports/zeromq/include-dir-gnutls.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 124cbb7..16f0c81 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1382,6 +1382,9 @@ else()
+   if(NOT MINGW)
+     add_library(objects OBJECT ${sources})
+     set_property(TARGET objects PROPERTY POSITION_INDEPENDENT_CODE ON)
++    if(GNUTLS_FOUND)
++      target_include_directories(objects PRIVATE "${GNUTLS_INCLUDE_DIR}")
++    endif()
+   endif()
+ 
+   if(BUILD_SHARED)
+@@ -1469,6 +1472,7 @@ if(BUILD_SHARED)
+   target_link_libraries(libzmq ${CMAKE_THREAD_LIBS_INIT})
+   if(GNUTLS_FOUND)
+     target_link_libraries(libzmq ${GNUTLS_LIBRARIES})
++    target_include_directories(libzmq PRIVATE "${GNUTLS_INCLUDE_DIR}")
+   endif()
+ 
+   if(NSS3_FOUND)
+@@ -1518,6 +1522,7 @@ if(BUILD_STATIC)
+   target_link_libraries(libzmq-static ${CMAKE_THREAD_LIBS_INIT})
+   if(GNUTLS_FOUND)
+     target_link_libraries(libzmq-static ${GNUTLS_LIBRARIES})
++    target_include_directories(libzmq-static PRIVATE "${GNUTLS_INCLUDE_DIR}")
+   endif()
+ 
+   if(LIBBSD_FOUND)
+@@ -1590,6 +1595,7 @@ if(BUILD_SHARED)
+ 
+       if(GNUTLS_FOUND)
+         target_link_libraries(${perf-tool} ${GNUTLS_LIBRARIES})
++        target_include_directories(${perf-tool} PRIVATE "${GNUTLS_INCLUDE_DIR}")
+       endif()
+ 
+       if(LIBBSD_FOUND)

--- a/ports/zeromq/portfile.cmake
+++ b/ports/zeromq/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 e204db3e40d99df2206f9537bf7dbc9bb8994174f4f9c4770dcc7a92622e6ff0e2b1be537d7fff96cfbdb0cdd0174bfd11ba60d08c4bab0ccb4db3ec25c06593
     PATCHES 
         fix-arm.patch
+        include-dir-gnutls.patch # from https://github.com/zeromq/libzmq/pull/4533
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
@@ -15,7 +16,8 @@ vcpkg_check_features(
     FEATURES
         sodium          WITH_LIBSODIUM
         draft           ENABLE_DRAFTS
-        websockets-sha1 ENABLE_WS
+        websockets      ENABLE_WS
+        websockets-secure WITH_TLS
 )
 
 set(PLATFORM_OPTIONS "")
@@ -32,6 +34,7 @@ vcpkg_cmake_configure(
         -DWITH_PERF_TOOL=OFF
         -DWITH_DOCS=OFF
         -DWITH_NSS=OFF
+        -DCMAKE_FIND_PACKAGE_REQUIRE_GnuTLS=ON
         -DWITH_LIBSODIUM_STATIC=${BUILD_STATIC}
         ${FEATURE_OPTIONS}
         ${PLATFORM_OPTIONS}

--- a/ports/zeromq/vcpkg.json
+++ b/ports/zeromq/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zeromq",
   "version-date": "2023-01-31",
+  "port-version": 1,
   "description": "The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products",
   "homepage": "https://github.com/zeromq/libzmq",
   "license": "LGPL-3.0-only",
@@ -25,8 +26,21 @@
         "libsodium"
       ]
     },
-    "websockets-sha1": {
-      "description": "Enable WebSocket transport through builtin sha1 (libzmq#3676)"
+    "websockets": {
+      "description": "Enable WebSocket transport"
+    },
+    "websockets-secure": {
+      "description": "Enable WebSocket transport with TSL (wss)",
+      "dependencies": [
+        "libgnutls",
+        {
+          "name": "zeromq",
+          "default-features": false,
+          "features": [
+            "websockets"
+          ]
+        }
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2134,7 +2134,7 @@
     },
     "drogon": {
       "baseline": "1.8.4",
-      "port-version": 0 
+      "port-version": 0
     },
     "dstorage": {
       "baseline": "1.1.0",
@@ -8662,7 +8662,7 @@
     },
     "zeromq": {
       "baseline": "2023-01-31",
-      "port-version": 0
+      "port-version": 1
     },
     "zfp": {
       "baseline": "1.0.0",

--- a/versions/z-/zeromq.json
+++ b/versions/z-/zeromq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "faad6e9fea08c6740bc27652b7d3df33ee693a41",
+      "version-date": "2023-01-31",
+      "port-version": 1
+    },
+    {
       "git-tree": "ea8e483d88e81e7472323575f5bfe28c6fc74e2e",
       "version-date": "2023-01-31",
       "port-version": 0


### PR DESCRIPTION
The old feature was non functional. It needs a dependency on GnuTLS. Split the websockets support into _With_ and _Without_ TLS support. 