### PR TITLE
[liburing] Fix installation of shared libraries

### DIFF
--- a/ports/liburing/fix-configure.patch
+++ b/ports/liburing/fix-configure.patch
@@ -2,15 +2,15 @@ diff --git a/configure b/configure
 index 2c2441b..620c443 100644
 --- a/configure
 +++ b/configure
-@@ -14,7 +14,7 @@ for opt do
-   ;;
-   --includedir=*) includedir="$optarg"
-   ;;
--  --libdir=*) libdir="$optarg"
-+  --datarootdir=*) libdir="$optarg"
-   ;;
-   --libdevdir=*) libdevdir="$optarg"
-   ;;
+@@ -20,7 +20,7 @@ for opt do
+  ;;
+  --mandir=*) mandir="$optarg"
+  ;;
+-  --datadir=*) datadir="$optarg"
++  --datarootdir=*) datadir="$optarg"
+  ;;
+  --cc=*) cc="$optarg"
+  ;;
 @@ -28,10 +28,12 @@ for opt do
    ;;
    --nolibc) liburing_nolibc="yes"

--- a/ports/liburing/vcpkg.json
+++ b/ports/liburing/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "liburing",
   "version": "2.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Linux-native io_uring I/O access library",
   "homepage": "https://github.com/axboe/liburing",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4558,7 +4558,7 @@
     },
     "liburing": {
       "baseline": "2.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libusb": {
       "baseline": "1.0.26",

--- a/versions/l-/liburing.json
+++ b/versions/l-/liburing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92a2fd81331f9b6ad3119a166ed18159499fa403",
+      "version": "2.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "e41ee56c7ceb8925a59b8d427a63990f581c0328",
       "version": "2.2",
       "port-version": 1


### PR DESCRIPTION
I've attempted to also update this port in #30406, but couldn't figure out how to properly fix `libunifex` regression.
Lets fix the port bug first.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.