### PR TITLE
[eve] update to 2023.2.15

### DIFF
--- a/ports/eve/portfile.cmake
+++ b/ports/eve/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/eve-${VERSION}")
 if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/share/eve/eve-config.cmake")
-    message(FATAL_ERROR "CMake config is missing for ${CURRENT_PACKAGES_DIR}/share/eve/eve-config.cmake")
+    message(FATAL_ERROR "CMake config is missing")
 endif()
 
 file(REMOVE_RECURSE

--- a/ports/eve/portfile.cmake
+++ b/ports/eve/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jfalcou/eve
     REF "${git_ref}"
-    SHA512 5623587de77c3e321555ca99326829928f69c5ac499d2abedfb18860e8c2a4c7dd5b408afef3ae2f8681cb363ffbfbc869dbf28c90e62e2b0abca62e03d08d12
+    SHA512 20b55996465fa5016d43cee95541510b6470b2358635b0e269965d3fb43731e83b92bc2df0502fcdfadd31de47f877f22b1c6ae84638f1f3db92c70315cc1b29
     HEAD_REF main
 )
 
@@ -17,7 +17,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/eve-${VERSION}")
 if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/share/eve/eve-config.cmake")
-    message(FATAL_ERROR "CMake config is missing")
+    message(FATAL_ERROR "CMake config is missing for ${CURRENT_PACKAGES_DIR}/share/eve/eve-config.cmake")
 endif()
 
 file(REMOVE_RECURSE

--- a/ports/eve/vcpkg.json
+++ b/ports/eve/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "eve",
-  "version-string": "2023.02.15",
+  "version": "2023.2.15",
   "description": "EVE - the Expressive Vector Engine : C++20 SIMD Programming Library",
   "homepage": "https://github.com/jfalcou/eve",
   "documentation": "https://jfalcou.github.io/eve/",

--- a/ports/eve/vcpkg.json
+++ b/ports/eve/vcpkg.json
@@ -1,10 +1,7 @@
 {
   "name": "eve",
   "version-string": "2023.02.15",
-  "description": [
-    "EVE - the Expressive Vector Engine",
-    "A header-only C++20 and onward implementation of a type based wrapper around SIMD extensions sets for most current architectures."
-  ],
+  "description": "EVE - the Expressive Vector Engine : C++20 SIMD Programming Library",
   "homepage": "https://github.com/jfalcou/eve",
   "documentation": "https://jfalcou.github.io/eve/",
   "license": "BSL-1.0",

--- a/ports/eve/vcpkg.json
+++ b/ports/eve/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "eve",
-  "version": "2022.9.1",
+  "version-string": "2023.02.15",
   "description": [
     "EVE - the Expressive Vector Engine",
     "A header-only C++20 and onward implementation of a type based wrapper around SIMD extensions sets for most current architectures."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2281,7 +2281,7 @@
       "port-version": 0
     },
     "eve": {
-      "baseline": "2022.9.1",
+      "baseline": "2023.02.15",
       "port-version": 0
     },
     "eventpp": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2281,7 +2281,7 @@
       "port-version": 0
     },
     "eve": {
-      "baseline": "2023.02.15",
+      "baseline": "2023.2.15",
       "port-version": 0
     },
     "eventpp": {

--- a/versions/e-/eve.json
+++ b/versions/e-/eve.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "157e93052350e733c5bd775ea6e6e62ca9e35ef9",
-      "version-string": "2023.02.15",
+      "version": "2023.2.15",
       "port-version": 0
     },
     {

--- a/versions/e-/eve.json
+++ b/versions/e-/eve.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "157e93052350e733c5bd775ea6e6e62ca9e35ef9",
+      "git-tree": "f76e41a1a878a665a45ca3b3eef2c8ec8d406778",
       "version": "2023.2.15",
       "port-version": 0
     },

--- a/versions/e-/eve.json
+++ b/versions/e-/eve.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "607becd3e04efa096c075ff8547b845f3a67e39c",
+      "version-string": "2023.02.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "701ec863d463d1a8c570336d3c5bd672f540793c",
       "version": "2022.9.1",
       "port-version": 0

--- a/versions/e-/eve.json
+++ b/versions/e-/eve.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e202dab270b132c57276d3458d728005d907d58d",
+      "git-tree": "157e93052350e733c5bd775ea6e6e62ca9e35ef9",
       "version-string": "2023.02.15",
       "port-version": 0
     },

--- a/versions/e-/eve.json
+++ b/versions/e-/eve.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "607becd3e04efa096c075ff8547b845f3a67e39c",
+      "git-tree": "e202dab270b132c57276d3458d728005d907d58d",
       "version-string": "2023.02.15",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
