### PR TITLE
[libzip] Fix zstd feature

### DIFF
--- a/ports/libzip/fix-dependency.patch
+++ b/ports/libzip/fix-dependency.patch
@@ -1,23 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d00a4f9f..586123b9 100644
+index d00a4f9f..cf85fc4b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -197,12 +197,12 @@ if(ENABLE_LZMA)
+@@ -197,7 +197,7 @@ if(ENABLE_LZMA)
  endif(ENABLE_LZMA)
  
  if(ENABLE_ZSTD)
 -  find_package(Zstd 1.3.6)
--  if(Zstd_FOUND)
-+  find_package(zstd 1.3.6)
-+  if(zstd_FOUND)
++  find_package(Zstd NAMES zstd 1.3.6)
+   if(Zstd_FOUND)
      set(HAVE_LIBZSTD 1)
    else()
-     message(WARNING "-- zstd library not found; zstandard support disabled")
--  endif(Zstd_FOUND)
-+  endif(zstd_FOUND)
- endif(ENABLE_ZSTD)
- 
- if (COMMONCRYPTO_FOUND)
 @@ -301,7 +301,7 @@ foreach(LIB ${LIBS_PRIVATE})
  endforeach()
  string(REGEX REPLACE "-lBZip2::BZip2" "-lbz2" LIBS ${LIBS})

--- a/ports/libzip/fix-dependency.patch
+++ b/ports/libzip/fix-dependency.patch
@@ -1,5 +1,47 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d00a4f9f..586123b9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -197,12 +197,12 @@ if(ENABLE_LZMA)
+ endif(ENABLE_LZMA)
+ 
+ if(ENABLE_ZSTD)
+-  find_package(Zstd 1.3.6)
+-  if(Zstd_FOUND)
++  find_package(zstd 1.3.6)
++  if(zstd_FOUND)
+     set(HAVE_LIBZSTD 1)
+   else()
+     message(WARNING "-- zstd library not found; zstandard support disabled")
+-  endif(Zstd_FOUND)
++  endif(zstd_FOUND)
+ endif(ENABLE_ZSTD)
+ 
+ if (COMMONCRYPTO_FOUND)
+@@ -301,7 +301,7 @@ foreach(LIB ${LIBS_PRIVATE})
+ endforeach()
+ string(REGEX REPLACE "-lBZip2::BZip2" "-lbz2" LIBS ${LIBS})
+ string(REGEX REPLACE "-lLibLZMA::LibLZMA" "-llzma" LIBS ${LIBS})
+-string(REGEX REPLACE "-lZstd::Zstd" "-lzstd" LIBS ${LIBS})
++string(REGEX REPLACE "-l$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>" "-lzstd" LIBS ${LIBS})
+ string(REGEX REPLACE "-lOpenSSL::Crypto" "-lssl -lcrypto" LIBS ${LIBS})
+ string(REGEX REPLACE "-lZLIB::ZLIB" "-lz" LIBS ${LIBS})
+ string(REGEX REPLACE "-lGnuTLS::GnuTLS" "-lgnutls" LIBS ${LIBS})
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 1213fa0a..b6446cbd 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -147,7 +147,7 @@ endif()
+ 
+ if(HAVE_LIBZSTD)
+   target_sources(zip PRIVATE zip_algorithm_zstd.c)
+-  target_link_libraries(zip PRIVATE Zstd::Zstd)
++  target_link_libraries(zip PRIVATE $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
+ endif()
+ 
+ if(HAVE_COMMONCRYPTO)
 diff --git a/libzip-config.cmake.in b/libzip-config.cmake.in
-index 5b9aa55..0723f3c 100644
+index 5b9aa558..f9adc538 100644
 --- a/libzip-config.cmake.in
 +++ b/libzip-config.cmake.in
 @@ -1,8 +1,20 @@
@@ -16,7 +58,7 @@ index 5b9aa55..0723f3c 100644
 +    find_dependency(LibLZMA)
 +endif()
 +if(@ENABLE_ZSTD@)
-+    find_dependency(Zstd)
++    find_dependency(zstd)
 +endif()
 +if(@ENABLE_OPENSSL@)
 +    find_dependency(OpenSSL)

--- a/ports/libzip/vcpkg.json
+++ b/ports/libzip/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libzip",
   "version": "1.9.2",
+  "port-version": 1,
   "description": "A library for reading, creating, and modifying zip archives.",
   "homepage": "https://github.com/nih-at/libzip",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4766,7 +4766,7 @@
     },
     "libzip": {
       "baseline": "1.9.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libzippp": {
       "baseline": "6.0-1.9.2",

--- a/versions/l-/libzip.json
+++ b/versions/l-/libzip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc3c054612370e663262903884eb253f4d261704",
+      "version": "1.9.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "ec8e48c035f43c65ce9f0f5b455affaa92aa477e",
       "version": "1.9.2",
       "port-version": 0

--- a/versions/l-/libzip.json
+++ b/versions/l-/libzip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dc3c054612370e663262903884eb253f4d261704",
+      "git-tree": "42ad3093c3b335f0ae0bf54179faa30bd751d00c",
       "version": "1.9.2",
       "port-version": 1
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

When building with the `zstd` feature, calling `find_package(libzip)` fails due to `Zstd` being not found.

`libzip` uses a custom Find module for `zstd` that does not use the same package name as upstream `zstd`. But since the Find module is not installed, it is unable to find the package.

The updated patch uses the upstream package and targets name.