### PR TITLE
[halide] update to 15.0.0

### DIFF
--- a/ports/halide/portfile.cmake
+++ b/ports/halide/portfile.cmake
@@ -48,15 +48,6 @@ vcpkg_cmake_configure(
 # which use Halide.dll (and deps) during the build.
 vcpkg_cmake_install(ADD_BIN_TO_PATH)
 
-vcpkg_copy_tools(
-    TOOL_NAMES
-        featurization_to_sample
-        get_host_target
-        retrain_cost_model
-        weightsdir_to_weightsfile
-    AUTO_CLEAN
-)
-
 # Release mode MODULE targets in CMake don't get PDBs.
 # Exclude those to avoid warning with default globs.
 vcpkg_copy_pdbs(

--- a/ports/halide/portfile.cmake
+++ b/ports/halide/portfile.cmake
@@ -42,6 +42,8 @@ vcpkg_cmake_configure(
         "-DHalide_INSTALL_CMAKEDIR=share/${PORT}"
         -DHalide_INSTALL_HELPERSDIR=share/HalideHelpers
         -DHalide_INSTALL_PLUGINDIR=bin
+        -DCMAKE_DISABLE_FIND_PACKAGE_PNG=TRUE
+        -DCMAKE_DISABLE_FIND_PACKAGE_JPEG=JPEG
 )
 
 # ADD_BIN_TO_PATH needed to compile autoschedulers, 

--- a/ports/halide/portfile.cmake
+++ b/ports/halide/portfile.cmake
@@ -1,13 +1,13 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
-set(HALIDE_VERSION_TAG v14.0.0)
+set(HALIDE_VERSION_TAG v${VERSION})
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO halide/Halide
     REF ${HALIDE_VERSION_TAG}
-    SHA512 c7b1186cca545f30d038f1e9bb28ca7231023869d191c50722213da4c7e9adfd4a53129fe395cd7938cb7cb3fb1bf80f9cd3b4b8473a0246f15b9ad8d3e40fe2
-    HEAD_REF release/14.x
+    SHA512 0
+    HEAD_REF release/15.x
 )
 
 vcpkg_check_features(

--- a/ports/halide/portfile.cmake
+++ b/ports/halide/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO halide/Halide
     REF ${HALIDE_VERSION_TAG}
-    SHA512 0
+    SHA512 918cd0a7e69e4414b98f17c5ec5cdb543ce3ae68ed07c9a80b7c0378c247a4a4fde62ade79b402e9ffcfce30c066a3fa662ea46c3a2a5b93eb5ec4e05b3fd808
     HEAD_REF release/15.x
 )
 

--- a/ports/halide/vcpkg.json
+++ b/ports/halide/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "halide",
-  "version": "14.0.0",
-  "port-version": 1,
+  "version": "15.0.0",
   "description": "Halide is a programming language designed to make it easier to write high-performance image and array processing code on modern machines.",
   "homepage": "https://github.com/halide/Halide",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2989,8 +2989,8 @@
       "port-version": 1
     },
     "halide": {
-      "baseline": "14.0.0",
-      "port-version": 1
+      "baseline": "15.0.0",
+      "port-version": 0
     },
     "happly": {
       "baseline": "2021-03-19",

--- a/versions/h-/halide.json
+++ b/versions/h-/halide.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "475f30815b430d17ee0f1367128f0c7f09df776f",
+      "git-tree": "1d7e84604e36eb833964af361772ebcf5e3953c5",
       "version": "15.0.0",
       "port-version": 0
     },

--- a/versions/h-/halide.json
+++ b/versions/h-/halide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "475f30815b430d17ee0f1367128f0c7f09df776f",
+      "version": "15.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "958cd321f20007534db5859498f8153017271b2f",
       "version": "14.0.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [x] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
