### PR TITLE
[simd] Use /Z7 instead of /Zi when building static

### DIFF
--- a/ports/simd/portfile.cmake
+++ b/ports/simd/portfile.cmake
@@ -30,6 +30,12 @@ if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPK
     vcpkg_replace_string("${SOURCE_PATH}/prj/${SOLUTION_TYPE}/Simd.vcxproj"
 	     "<ConfigurationType>DynamicLibrary</ConfigurationType>"
 		 "<ConfigurationType>StaticLibrary</ConfigurationType>")
+    file(GLOB_RECURSE PROJ_FILES "${SOURCE_PATH}/prj/${SOLUTION_TYPE}/*.vcxproj")
+    foreach(PROJ_FILE ${PROJ_FILES})
+        vcpkg_replace_string(${PROJ_FILE}
+          "    </ClCompile>"
+          "      <DebugInformationFormat>OldStyle</DebugInformationFormat>\n    </ClCompile>")
+    endforeach()
     if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
 	  file(GLOB_RECURSE PROJ_FILES "${SOURCE_PATH}/prj/${SOLUTION_TYPE}/*.vcxproj")
 	  foreach(PROJ_FILE ${PROJ_FILES})
@@ -48,7 +54,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPK
   	RELEASE_CONFIGURATION "Release"
   	DEBUG_CONFIGURATION "Debug"
   )
-  
+  vcpkg_copy_pdbs()
   file(GLOB SIMD_HEADERS "${SOURCE_PATH}/src/Simd/*.hpp" "${SOURCE_PATH}/src/Simd/*.h")
   file(COPY ${SIMD_HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include/Simd")
 elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")

--- a/ports/simd/vcpkg.json
+++ b/ports/simd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "simd",
   "version": "5.2.123",
+  "port-version": 1,
   "description": "Simd image processing and machine learning library, designed for C and C++ programmers",
   "homepage": "https://github.com/ermig1979/Simd",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7298,7 +7298,7 @@
     },
     "simd": {
       "baseline": "5.2.123",
-      "port-version": 0
+      "port-version": 1
     },
     "simde": {
       "baseline": "0.7.2",

--- a/versions/s-/simd.json
+++ b/versions/s-/simd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "279d96ec1919311cad845670822f7cc376f503e6",
+      "version": "5.2.123",
+      "port-version": 1
+    },
+    {
       "git-tree": "64cfb73836acffe8ff38e25477e0e8332707b4fc",
       "version": "5.2.123",
       "port-version": 0


### PR DESCRIPTION
Fix warnings LNK4099: PDB '*.pdb' was not found with ... linking object as if no debug info

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
~~- [ ] SHA512s are updated for each updated download~~
~~- [ ] The "supports" clause reflects platforms that may be fixed by this new version~~
~~- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
~~- [ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.