### PR TITLE
[rendergraph] Update to v1.3.0.

### DIFF
--- a/ports/rendergraph/portfile.cmake
+++ b/ports/rendergraph/portfile.cmake
@@ -1,8 +1,10 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO DragonJoker/RenderGraph
-    REF v1.2.0
+    REF v${VERSION}
     HEAD_REF master
-    SHA512 54f2b06931ef912888ae12227b39b17d25969dd5443a37d61cb8072b0137ed6361b03e09ac18e7abe21dfd49b5a5a2ec23f0d2d8e9ede03ddb8fb589d874237c
+    SHA512 48bb3211022499538eebca0051f931ec105af9ccd3fea21d546fcd9cb41bc9d2191c70382e00caaf79fce48303e56d83d7089f7b975f635bcef3645c80abda30
 )
 
 vcpkg_from_github(OUT_SOURCE_PATH CMAKE_SOURCE_PATH
@@ -31,6 +33,7 @@ vcpkg_cmake_configure(
         -DVULKAN_HEADERS_INCLUDE_DIRS=${CURRENT_INSTALLED_DIR}/include
 )
 
+vcpkg_copy_pdbs()
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/RenderGraph)
 

--- a/ports/rendergraph/portfile.cmake
+++ b/ports/rendergraph/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO DragonJoker/RenderGraph
     REF v${VERSION}

--- a/ports/rendergraph/vcpkg.json
+++ b/ports/rendergraph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rendergraph",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Vulkan render graph implementation.",
   "homepage": "https://github.com/DragonJoker/RenderGraph",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6901,7 +6901,7 @@
       "port-version": 1
     },
     "rendergraph": {
-      "baseline": "1.2.0",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "replxx": {

--- a/versions/r-/rendergraph.json
+++ b/versions/r-/rendergraph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9ff6254bb6683673ee3f595d0e4920c297059c6",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "21270b3d8f507068a293df066628704e1de96d82",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/r-/rendergraph.json
+++ b/versions/r-/rendergraph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d9ff6254bb6683673ee3f595d0e4920c297059c6",
+      "git-tree": "189085fb654a90d03e8e1b15971e0b9d6f575270",
       "version": "1.3.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #30522 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
