### PR TITLE
[stlab] Update to 1.7.1

### DIFF
--- a/ports/stlab/portfile.cmake
+++ b/ports/stlab/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stlab/libraries
-    REF 9819ce0d5cf13d5a561dc1ca02a0a6e81f1002b3 # V1.7.1
-    SHA512 f55d04c6ba93386db847cad8aa6d2d4c1ec74be96800ad54e29fc47592d7aff7ef534b1370541f0fece629741743ff0d0d5013e872f85683266d99507b875e87
-    HEAD_REF develop
+    REF "v${VERSION}"
+    SHA512 ceed4fffc381bebd5456d56e8f9d84094da2a9994c8be60e9c1fe4a72ae5f2c398448169927af1439615b55c549332dfe4c38a2b3b8bdf84e3c550fd14bf125c
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/stlab/portfile.cmake
+++ b/ports/stlab/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stlab/libraries
-    REF 0a7232a4120c2daf8ddb6621ec13f313a029e495 # V1.6.2
-    SHA512 6e03a5370d02accd798fc14fd256ab593b9a33b4a9b9cda8f2233eeafacf70c389c2999d1834b7ffef6968008921d28d88bcf728a322ba7943106ddc9d8e6f16
+    REF 9819ce0d5cf13d5a561dc1ca02a0a6e81f1002b3 # V1.7.1
+    SHA512 f55d04c6ba93386db847cad8aa6d2d4c1ec74be96800ad54e29fc47592d7aff7ef534b1370541f0fece629741743ff0d0d5013e872f85683266d99507b875e87
     HEAD_REF develop
 )
 
@@ -19,7 +19,7 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/share/cmake")
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/stlabConfig.cmake"
-    "find_dependency(Boost 1.60.0)"
+    "find_dependency(Boost 1.74.0)"
     "if(APPLE)\nfind_dependency(Boost)\nendif()"
 )
 

--- a/ports/stlab/vcpkg.json
+++ b/ports/stlab/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "stlab",
-  "version-string": "1.6.2",
-  "port-version": 2,
+  "version-semver": "1.7.1",
+  "port-version": 3,
   "description": [
     "stlab is the ongoing work of what was Adobe Software Technology Lab.",
     "The Concurrency library provides futures and channels, high level constructs for implementing algorithms that eases the use of multiple CPU cores while minimizing contention. This library solves several problems of the C++11 and C++17 TS futures."

--- a/ports/stlab/vcpkg.json
+++ b/ports/stlab/vcpkg.json
@@ -7,11 +7,17 @@
   ],
   "homepage": "https://github.com/stlab/libraries",
   "license": "BSL-1.0",
+  "default-features": [ "cpp17shims" ],
+  "features": {
+    "cpp17shims": {
+      "description": "Support C++11/14 by polyfilling stlab's use of `optional` and `variant` with boost. On by default.",
+      "dependencies": [
+        "boost-variant",
+        "boost-optional"
+      ]
+    }
+  },
   "dependencies": [
-    {
-      "name": "boost-variant",
-      "platform": "osx"
-    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/stlab/vcpkg.json
+++ b/ports/stlab/vcpkg.json
@@ -7,16 +7,6 @@
   ],
   "homepage": "https://github.com/stlab/libraries",
   "license": "BSL-1.0",
-  "default-features": [ "cpp17shims" ],
-  "features": {
-    "cpp17shims": {
-      "description": "Support C++11/14 by polyfilling stlab's use of `optional` and `variant` with boost. On by default.",
-      "dependencies": [
-        "boost-variant",
-        "boost-optional"
-      ]
-    }
-  },
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -26,5 +16,17 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "cpp17shims"
+  ],
+  "features": {
+    "cpp17shims": {
+      "description": "Support C++11/14 by polyfilling stlab's use of `optional` and `variant` with boost. On by default.",
+      "dependencies": [
+        "boost-optional",
+        "boost-variant"
+      ]
+    }
+  }
 }

--- a/ports/stlab/vcpkg.json
+++ b/ports/stlab/vcpkg.json
@@ -1,10 +1,12 @@
 {
   "name": "stlab",
-  "version-semver": "1.7.1",
-  "port-version": 3,
+  "version": "1.7.1",
   "description": [
     "stlab is the ongoing work of what was Adobe Software Technology Lab.",
     "The Concurrency library provides futures and channels, high level constructs for implementing algorithms that eases the use of multiple CPU cores while minimizing contention. This library solves several problems of the C++11 and C++17 TS futures."
+  ],
+  "homepage": "https://github.com/stlab/libraries",
+  "license": "BSL-1.0",
   ],
   "dependencies": [
     {

--- a/ports/stlab/vcpkg.json
+++ b/ports/stlab/vcpkg.json
@@ -7,7 +7,6 @@
   ],
   "homepage": "https://github.com/stlab/libraries",
   "license": "BSL-1.0",
-  ],
   "dependencies": [
     {
       "name": "boost-variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7614,7 +7614,7 @@
     },
     "stlab": {
       "baseline": "1.7.1",
-      "port-version": 3
+      "port-version": 0
     },
     "stormlib": {
       "baseline": "2019-05-10",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7613,8 +7613,8 @@
       "port-version": 0
     },
     "stlab": {
-      "baseline": "1.6.2",
-      "port-version": 2
+      "baseline": "1.7.1",
+      "port-version": 3
     },
     "stormlib": {
       "baseline": "2019-05-10",

--- a/versions/s-/stlab.json
+++ b/versions/s-/stlab.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4669df09319dc32e75f6f16a052c75b1bdc17bec",
+      "version-semver": "1.7.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "8e7a8c754181f223c69b2b67ed3cf928db44e4b9",
       "version-string": "1.6.2",
       "port-version": 2

--- a/versions/s-/stlab.json
+++ b/versions/s-/stlab.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "4669df09319dc32e75f6f16a052c75b1bdc17bec",
-      "version-semver": "1.7.1",
-      "port-version": 3
-    },
-    {
       "git-tree": "8e7a8c754181f223c69b2b67ed3cf928db44e4b9",
       "version-string": "1.6.2",
       "port-version": 2

--- a/versions/s-/stlab.json
+++ b/versions/s-/stlab.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0edc954c81b5cf340e699edb425dfcf1629a8120",
+      "git-tree": "82ee8586032e3eb89368644e78fe4a4726a17774",
       "version": "1.7.1",
       "port-version": 0
     },

--- a/versions/s-/stlab.json
+++ b/versions/s-/stlab.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0edc954c81b5cf340e699edb425dfcf1629a8120",
+      "version": "1.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4669df09319dc32e75f6f16a052c75b1bdc17bec",
       "version-semver": "1.7.1",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.