### PR TITLE
[libkml] explicitly set C++ standard as it uses removed features

### DIFF
--- a/ports/libkml/portfile.cmake
+++ b/ports/libkml/portfile.cmake
@@ -28,6 +28,9 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCMAKE_POLICY_DEFAULT_CMP0022=NEW
+        # libkml uses std::unary_function that was deprecated in C++11 and removed in C++17
+        # compilers are starting to ship C++17 as the defualt so explicitly set C++11
+        -DCMAKE_CXX_STANDARD=11
 )
 
 vcpkg_cmake_install()

--- a/ports/libkml/vcpkg.json
+++ b/ports/libkml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libkml",
   "version": "1.3.0",
-  "port-version": 11,
+  "port-version": 12,
   "description": "Reference implementation of OGC KML 2.2",
   "homepage": "https://github.com/libkml/libkml",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4098,7 +4098,7 @@
     },
     "libkml": {
       "baseline": "1.3.0",
-      "port-version": 11
+      "port-version": 12
     },
     "liblas": {
       "baseline": "1.8.1",

--- a/versions/l-/libkml.json
+++ b/versions/l-/libkml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "84ea1bd884a5d5afee127b15e73ef5bb7ba638dc",
+      "version": "1.3.0",
+      "port-version": 12
+    },
+    {
       "git-tree": "4969a3e81df3ef13b5e3f2f94e652311df8bbafe",
       "version": "1.3.0",
       "port-version": 11


### PR DESCRIPTION
- [libkml] explicitly set C++ standard as it uses features that were removed in C++17
- ./vcpkg x-add-version --all

Clang 16 now defaults to C++ 17, and libkml uses `std::unary_function`, which was removed in C++17, so this can fail to compile. `libstdc++` seems fine with it, but libc++ does not. To reproduce the error, install libkml with this triplet:

```cmake
set(VCPKG_TARGET_ARCHITECTURE x64)
set(VCPKG_CRT_LINKAGE dynamic)
set(VCPKG_LIBRARY_LINKAGE static)

set(VCPKG_CMAKE_SYSTEM_NAME Linux)

set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DCMAKE_CXX_COMPILER=clang++-16 -DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_FLAGS=-stdlib=libc++)
```

(after installing clang 16 and libc++). The error message is

```
/workspaces/ars/ext/vcpkg/buildtrees/libkml/src/1.3.0-a67b3b4bbe.clean/src/kml/xsd/xsd_file.cc:53:33: error: no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
```

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
