### PR TITLE
[luajit] Fix special path on MSVC

### DIFF
--- a/ports/luajit/006-fix-special-path-MSVC.patch
+++ b/ports/luajit/006-fix-special-path-MSVC.patch
@@ -1,0 +1,13 @@
+diff --git a/src/msvcbuild.bat b/src/msvcbuild.bat
+index 27f3953..a912b3e 100644
+--- a/src/msvcbuild.bat
++++ b/src/msvcbuild.bat
+@@ -44,7 +44,7 @@ if exist minilua.exe.manifest^
+ @set LJARCH=x86
+ @set LJCOMPILE=%LJCOMPILE% /arch:SSE2
+ :X64
+-@if "%1" neq "nogc64" goto :GC64
++@if "%~1" neq "nogc64" goto :GC64
+ @shift
+ @set DASC=%SOURCEDIR%\vm_x86.dasc
+ @set LJCOMPILE=%LJCOMPILE% /DLUAJIT_DISABLE_GC64

--- a/ports/luajit/portfile.cmake
+++ b/ports/luajit/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
     PATCHES
         003-do-not-set-macosx-deployment-target.patch
         004-fix-build-path-and-crt-linkage.patch
+        006-fix-special-path-MSVC.patch
         ${LJIT_PATCHES}
 )
 

--- a/ports/luajit/vcpkg.json
+++ b/ports/luajit/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "luajit",
   "version-date": "2023-01-04",
+  "port-version": 1,
   "description": "LuaJIT is a Just-In-Time (JIT) compiler for the Lua programming language.",
   "homepage": "https://github.com/LuaJIT/LuaJIT",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4882,7 +4882,7 @@
     },
     "luajit": {
       "baseline": "2023-01-04",
-      "port-version": 0
+      "port-version": 1
     },
     "luasec": {
       "baseline": "1.1.0",

--- a/versions/l-/luajit.json
+++ b/versions/l-/luajit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "425bc654c3d01c4b88a22dff60d816c27479c492",
+      "version-date": "2023-01-04",
+      "port-version": 1
+    },
+    {
       "git-tree": "3c7f639efd41b49e93c61ae54fd99bb332d80bf9",
       "version-date": "2023-01-04",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/30524
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: 
In the extended syntax of the windows command, if `"%1"` needs to be escaped or treated specially when dealing with paths with spaces or special characters.  Otherwise, it will be parsed into multiple parameters.
```
@if "%1" neq "nogc64" goto :GC64
```

Using `"%~1"` solves the problem of quotes in the parameter, while still preserving spaces and other special characters in the parameter value.
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
