### PR TITLE
[mio] Update to 2023-03-03

### DIFF
--- a/ports/mio/portfile.cmake
+++ b/ports/mio/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mandreyel/mio
-    REF 3f86a95c0784d73ce6815237ec33ed25f233b643
-    SHA512 18bbc41d5c3b29ecafe19cef29687380d8f4f27279af08edb0d5e65ee1d71162f3cf75d8efaa324cd11301f3f49fadaec3e4c1514607d5065ddd7a65bf32ee2a
+    REF 8b6b7d878c89e81614d05edca7936de41ccdd2da
+    SHA512 444131d4839f2244dd88722f5bfad2cfa47336e2a4405518a2ff8f0d80f2755321d7d627f8d5b890864a5dc3f3f810a1c7dd6588ff3e9039a6ef7d010e0f2f06
     HEAD_REF master
 )
 
@@ -20,4 +20,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/mio)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mio/vcpkg.json
+++ b/ports/mio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mio",
-  "version-date": "2023-01-25",
+  "version-date": "2023-03-03",
   "description": "Cross-platform header-only C++11 library for memory mapped file IO.",
   "homepage": "https://github.com/mandreyel/mio",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5165,7 +5165,7 @@
       "port-version": 0
     },
     "mio": {
-      "baseline": "2023-01-25",
+      "baseline": "2023-03-03",
       "port-version": 0
     },
     "mlpack": {

--- a/versions/m-/mio.json
+++ b/versions/m-/mio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32e1d9bb77df214fec0e6ea240671114e3d3df30",
+      "version-date": "2023-03-03",
+      "port-version": 0
+    },
+    {
       "git-tree": "a71deb82d263c979ed9077747778cc2295baee36",
       "version-date": "2023-01-25",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/29370
No feature need to test.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
