### PR TITLE
[rubberband] Update to version 3.2.0

### DIFF
--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -1,19 +1,33 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO breakfastquay/rubberband
-    REF v3.1.1
-    SHA512 aef4de02b6fe250ab43d627d30720dab8aea3587b428ce76fe339d0b1f0e50da6ba7fa7c76f61306704dd2cfc24241f3d4108b6c155c3d12624eac859672f86c
+    REF "v${VERSION}"
+    SHA512 953d705e4a69ed40732644b8039dae02ddf596216e484ce8625fdde796e0de35fe6ac6c4f180eabc457c98b63c3fba212afa74b731eac570bea1902b667f506f
     HEAD_REF default
 )
+
+
+if("cli" IN_LIST FEATURES)
+    set(CLI_FEATURE enabled)
+else()    
+    set(CLI_FEATURE disabled)
+endif()
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -Dfft=fftw                 # 'auto', 'builtin', 'kissfft', 'fftw', 'vdsp', 'ipp' 'FFT library to use. The default (auto) will use vDSP if available, the builtin implementation otherwise.')
-        -Dresampler=libsamplerate  # 'auto', 'builtin', 'libsamplerate', 'speex', 'ipp' 'Resampler library to use. The default (auto) simply uses the builtin implementation.'
+        -Dfft=fftw                 # 'auto', 'builtin', 'kissfft', 'fftw', sleef', 'vdsp', 'ipp' 'FFT library to use. The default (auto) will use vDSP if available, the builtin implementation otherwise.')
+        -Dresampler=libsamplerate  # 'auto', 'builtin', 'libsamplerate', 'speex', 'libspeexdsp', 'ipp' 'Resampler library to use. The default (auto) simply uses the builtin implementation.'
         -Dipp_path=                # 'Path to Intel IPP libraries, if selected for any of the other options.'
         -Dextra_include_dirs=      # 'Additional local header directories to search for dependencies.'
         -Dextra_lib_dirs=          # 'Additional local library directories to search for dependencies.'
+        -Djni=disabled             # 'auto', 'disabled', 'enabled'
+        -Dladspa=disabled          # 'auto', 'disabled', 'enabled'
+        -Dlv2=disabled             # 'auto', 'disabled', 'enabled' lv2 feature is not yet supported yet because vcpkg can't isntall to 
+                                   # %APPDATA%\LV2 or %COMMONPROGRAMFILES%\LV2 but also complains about dlls in "${CURRENT_PACKAGES_DIR}/lib/lv2"
+        -Dvamp=disabled           # 'auto', 'disabled', 'enabled'
+        -Dcmdline=${CLI_FEATURE}   # 'auto', 'disabled', 'enabled'
+        -Dtests=disabled           # 'auto', 'disabled', 'enabled'
     )
 
 vcpkg_install_meson()
@@ -29,17 +43,10 @@ else()
   set(RUBBERBAND_PROGRAM_NAMES rubberband rubberband-r3)
 endif()
 
-# Features cli and lv2 are build whenever suficient dependencies are installed,
 # Remove them when not enabled.
 if("cli" IN_LIST FEATURES)
   vcpkg_copy_tools(TOOL_NAMES ${RUBBERBAND_PROGRAM_NAMES} AUTO_CLEAN)
-else()
-  vcpkg_clean_executables_in_bin(FILE_NAMES ${RUBBERBAND_PROGRAM_NAMES})
 endif()
-
-# lv2 feature is not supported yet because vcpkg can't isntall to
-# %APPDATA%\LV2 or %COMMONPROGRAMFILES%\LV2 but also complains about dlls in "${CURRENT_PACKAGES_DIR}/lib/lv2"
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/lv2" "${CURRENT_PACKAGES_DIR}/debug/lib/lv2")
 
 file(
   INSTALL "${SOURCE_PATH}/COPYING"

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rubberband",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "A high quality software library for audio time-stretching and pitch-shifting.",
   "homepage": "https://www.breakfastquay.com/rubberband/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7041,7 +7041,7 @@
       "port-version": 0
     },
     "rubberband": {
-      "baseline": "3.1.1",
+      "baseline": "3.2.0",
       "port-version": 0
     },
     "rxcpp": {

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2cdedb774d373326dd7b2f2d138280653f97c89b",
+      "version": "3.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ce88046ebe45fa738789a3bf6dd843392bcb6fd2",
       "version": "3.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

