### PR TITLE
[libzen] update to v0.4.40

### DIFF
--- a/ports/libzen/portfile.cmake
+++ b/ports/libzen/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MediaArea/ZenLib
-    REF 13b9d3dbd2088390fbdccab32ae4560526389fbc # v0.4.39
-    SHA512 ec63af7ea60be2548d45702518a9b638b4f424044ecaebfbca97d9872b3ecafddc9c59aed4a5bae7bd5bbdffbd543c4ed9e106e5c406ec576a9c0970f0aadcac
+    REF ecb548043a6dbee15a07a43d4d3388509d849570 # v0.4.40
+    SHA512 9be9dfa20f4bf7e1f450b2ab19391ea091a091d242e98797652aa74ae595365e25f44ccca915b8889bc46245abf523949d22a012805a2f4f55742ae3c0e8932d
     HEAD_REF master
 )
 

--- a/ports/libzen/vcpkg.json
+++ b/ports/libzen/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "libzen",
-  "version": "0.4.39",
-  "port-version": 1,
+  "version": "0.4.40",
   "description": "ZenLib is a C++ utility library for easiest cross-platform development",
+  "license": "Zlib",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4765,8 +4765,8 @@
       "port-version": 0
     },
     "libzen": {
-      "baseline": "0.4.39",
-      "port-version": 1
+      "baseline": "0.4.40",
+      "port-version": 0
     },
     "libzip": {
       "baseline": "1.9.2",

--- a/versions/l-/libzen.json
+++ b/versions/l-/libzen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e3635609bd53140cc191a65b168d1a131f84366a",
+      "version": "0.4.40",
+      "port-version": 0
+    },
+    {
       "git-tree": "37c7d9f6e950b43bc62ed633bc8fc1964bb2ada3",
       "version": "0.4.39",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
