### PR TITLE
[dartsim] Compile dartsim in windows x86

### DIFF
--- a/ports/dartsim/vcpkg.json
+++ b/ports/dartsim/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "dartsim",
   "version": "6.12.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Dynamic Animation and Robotics Toolkit",
   "homepage": "https://dartsim.github.io/",
   "license": "BSD-2-Clause",
-  "supports": "!x86",
   "dependencies": [
     "assimp",
     "boost-algorithm",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -249,8 +249,11 @@ ftgl:x64-uwp=fail
 ftgl:arm-uwp=fail
 
 # VS 2022 Update 3 seems to have broken Gazebo: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1522474
+# gazebo is broken due it depend on old ports that already in the new versions.
+# There is an open PR that try to fix that.
 gazebo:x64-windows=fail
 gazebo:x64-linux=fail
+gazebo:x86-windows=fail
 
 # gsoap does not offer stable public source downloads
 gsoap:x64-windows        = skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1958,7 +1958,7 @@
     },
     "dartsim": {
       "baseline": "6.12.2",
-      "port-version": 1
+      "port-version": 2
     },
     "dataframe": {
       "baseline": "1.22.0",

--- a/versions/d-/dartsim.json
+++ b/versions/d-/dartsim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af3970efb060832f60efe9ad00eef7bc0e824a90",
+      "version": "6.12.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "746ffa24744bf10e2ce9b04332c8dcde2222ba39",
       "version": "6.12.2",
       "port-version": 1


### PR DESCRIPTION
Compile dartsim in windows x86:

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
