### PR TITLE
[libnice-gst] Added libnice-gst port at 0.1.18

### DIFF
--- a/ports/libnice-gst/portfile.cmake
+++ b/ports/libnice-gst/portfile.cmake
@@ -1,0 +1,88 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libnice/libnice
+    REF 0.1.21
+    SHA512 8808523d663da5974e81ffeef10812b758792b1f762edc1f3713d09962598a8a30d17ac1985438361d2a284b9bc82b5ba1e8d73c6e1ca86c93901bc06b634e9a
+    HEAD_REF master
+    PATCHES
+    skip_libnice.patch
+)
+
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dgtk_doc=disabled #Enable generating the API reference (depends on GTK-Doc)
+        -Dintrospection=disabled #Enable GObject Introspection (depends on GObject)'
+        -Dtests=disabled
+        -Dexamples=disabled
+        -Dgstreamer=enabled
+        -Dcrypto-library=openssl
+    ADDITIONAL_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+                        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+)
+
+# Could be features:
+# option('gupnp', type: 'feature', value: 'auto',
+  # description: 'Enable or disable GUPnP IGD support')
+# option('ignored-network-interface-prefix', type: 'array', value: ['docker', 'veth', 'virbr', 'vnet'],
+  # description: 'Ignore network interfaces whose name starts with a string from this list in the ICE connection check algorithm. For example, "virbr" to ignore virtual bridge interfaces added by virtd, which do not help in finding connectivity.')
+# option('crypto-library', type: 'combo', choices : ['auto', 'gnutls', 'openssl'], value : 'auto')
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    # Move plugin pkg-config file
+    file(COPY           "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/pkgconfig/gstnice.pc"
+         DESTINATION    "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(COPY           "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/pkgconfig/gstnice.pc"
+         DESTINATION    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/pkgconfig/"
+                        "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/pkgconfig/")
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(
+  FILE_LIST
+    "${SOURCE_PATH}/COPYING"
+    "${SOURCE_PATH}/COPYING.LGPL"
+    "${SOURCE_PATH}/COPYING.MPL"
+)
+
+set(USAGE_FILE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage")
+file(WRITE "${USAGE_FILE}" "${PORT} usage:\n\n")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)
+    file(APPEND "${USAGE_FILE}" "\tIf the plugin isn't found by the default paths add one of the following paths to the 'GST_PLUGIN_PATH' environment variable\n")
+    file(APPEND "${USAGE_FILE}" "\tFor more information on GStreamer environment variables see https://gstreamer.freedesktop.org/documentation/gstreamer/running.html?gi-language=c#environment-variables\n")
+
+    if(VCPKG_TARGET_IS_WINDOWS)
+
+        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+            file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/gstnice.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/gstnice.dll")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/gstnice.pdb" "${CURRENT_PACKAGES_DIR}/debug/bin/gstnice.pdb")
+
+            file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_PACKAGES_DIR}/debug/bin/'\n")
+        endif()
+        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+            file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/gstnice.dll" "${CURRENT_PACKAGES_DIR}/bin/gstnice.dll")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/gstnice.pdb" "${CURRENT_PACKAGES_DIR}/bin/gstnice.pdb")
+
+            file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_PACKAGES_DIR}/bin/'\n")
+        endif()
+    else()
+        file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/'\n")
+        file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/'\n")
+    endif()
+else()
+    file(APPEND "${USAGE_FILE}" "\tRegister static plugin with gst_plugin_register_static()\n")
+    file(APPEND "${USAGE_FILE}" "\thttps://gstreamer.freedesktop.org/documentation/application-development/appendix/compiling.html#embedding-static-elements-in-your-application\n")
+endif()

--- a/ports/libnice-gst/skip_libnice.patch
+++ b/ports/libnice-gst/skip_libnice.patch
@@ -1,0 +1,43 @@
+diff --git a/gst/meson.build b/gst/meson.build
+index 572c6ab..325a3d5 100644
+--- a/gst/meson.build
++++ b/gst/meson.build
+@@ -13,12 +13,12 @@ libgstnice = library('gstnice',
+   c_args : gst_nice_args,
+   include_directories: nice_incs,
+   dependencies: [nice_deps, gst_dep],
+-  link_with: libnice,
+   install_dir: gst_plugins_install_dir,
+   install: true)
+ plugins = [libgstnice]
+ 
+ # Generate pc files for static plugins if we build static plugins
+ if get_option('default_library') != 'shared'
++  pkg = import('pkgconfig')
+   pkg.generate(libgstnice, install_dir: join_paths(gst_plugins_install_dir, 'pkgconfig'))
+ endif
+diff --git a/meson.build b/meson.build
+index 60ca250..05fc8c7 100644
+--- a/meson.build
++++ b/meson.build
+@@ -90,6 +90,7 @@ version_conf.set('NICE_VERSION_MINOR', version_minor)
+ version_conf.set('NICE_VERSION_MICRO', version_micro)
+ version_conf.set('NICE_VERSION_NANO', version_nano)
+ nice_version_h = configure_file(output: 'nice-version.h',
++  install: false,
+   install_dir: get_option('includedir') / 'nice',
+   configuration: version_conf)
+ 
+@@ -298,11 +299,7 @@ endif
+ 
+ gir = find_program('g-ir-scanner', required : get_option('introspection'))
+ 
+-subdir('agent')
+-subdir('stun')
+-subdir('socket')
+-subdir('random')
+-subdir('nice')
++nice_deps += [dependency('nice', version: '= @0@'.format(meson.project_version()), required: true)]
+ 
+ if gst_dep.found()
+   subdir('gst')

--- a/ports/libnice-gst/vcpkg.json
+++ b/ports/libnice-gst/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "libnice-gst",
+  "version": "0.1.21",
+  "description": "Gstreamer Libnice plugins.",
+  "homepage": "https://nice.freedesktop.org",
+  "license": "LGPL-2.1-only AND MPL-1.1",
+  "dependencies": [
+    "gstreamer",
+    "libnice"
+  ]
+}

--- a/ports/libnice/portfile.cmake
+++ b/ports/libnice/portfile.cmake
@@ -2,10 +2,10 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libnice/libnice
-    REF 55b71d47f2b427b3baa8812818ed3f059acc748d # 0.1.18
-    SHA512 78575c487d74734d2dff1c04103fd55c76cf5e78edde03ffd68050348881a3efc985513cfd30553bfce0568c8edfcd61be7dea8991731efc749ee4fee2f503d6
+    REF 0.1.21
+    SHA512 8808523d663da5974e81ffeef10812b758792b1f762edc1f3713d09962598a8a30d17ac1985438361d2a284b9bc82b5ba1e8d73c6e1ca86c93901bc06b634e9a
     HEAD_REF master
-) 
+)
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -16,13 +16,11 @@ vcpkg_configure_meson(
         -Dexamples=disabled
         -Dgstreamer=disabled
         -Dcrypto-library=openssl
-    ADDITIONAL_NATIVE_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-                               glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
-    ADDITIONAL_CROSS_BINARIES  glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
-                               glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+    ADDITIONAL_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+                        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
 )
 
-# Could be features: 
+# Could be features:
 # option('gupnp', type: 'feature', value: 'auto',
   # description: 'Enable or disable GUPnP IGD support')
 # option('ignored-network-interface-prefix', type: 'array', value: ['docker', 'veth', 'virbr', 'vnet'],

--- a/ports/libnice/vcpkg.json
+++ b/ports/libnice/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libnice",
-  "version": "0.1.18",
-  "port-version": 1,
+  "version": "0.1.21",
   "description": "Libnice is an implementation of the IETF's Interactive Connectivity Establishment (ICE) standard (RFC 5245) and the Session Traversal Utilities for NAT (STUN) standard (RFC 5389).",
   "homepage": "https://nice.freedesktop.org",
   "license": "LGPL-2.1-only AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4229,8 +4229,12 @@
       "port-version": 10
     },
     "libnice": {
-      "baseline": "0.1.18",
-      "port-version": 1
+      "baseline": "0.1.21",
+      "port-version": 0
+    },
+    "libnice-gst": {
+      "baseline": "0.1.21",
+      "port-version": 0
     },
     "libnoise": {
       "baseline": "1.0.0",

--- a/versions/l-/libnice-gst.json
+++ b/versions/l-/libnice-gst.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3d7072d7e0810ec844b7f4b3ecaa1e325e407be6",
+      "version": "0.1.21",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libnice.json
+++ b/versions/l-/libnice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6efccae4d0017390516e28abce03705114131b16",
+      "version": "0.1.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "e15c3356146049f0dffd9aef46786677bb4b007e",
       "version": "0.1.18",
       "port-version": 1


### PR DESCRIPTION
This port primarily works around the following dependency cycle where libnice enables the GStreamer plugin:
* libnice -> gstreamer
* gstreamer -> libnice

##### New port checklist:
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
