### PR TITLE
[openimageio] Skip building tests

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -48,6 +48,7 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         -DBUILD_TESTING=OFF
+        -DOIIO_BUILD_TESTS=OFF
         -DUSE_DCMTK=OFF
         -DUSE_NUKE=OFF
         -DUSE_OpenVDB=OFF

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openimageio",
   "version": "2.4.9.0",
+  "port-version": 1,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5794,7 +5794,7 @@
     },
     "openimageio": {
       "baseline": "2.4.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openjpeg": {
       "baseline": "2.5.0",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34493d776df3b1fee4ba5e01c882d1237a135362",
+      "version": "2.4.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "82fe27ff1713dd3f0fbaaa7399257fc4d56cf1b0",
       "version": "2.4.9.0",
       "port-version": 0


### PR DESCRIPTION
Disable the option `OIIO_BUILD_TESTS` to fix the following errors: 
```
FAILED: bin/imagebufalgo_test 
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/lib/intel64/libmkl_core.a(_avx_d__trmm_rut.o): in function `mkl_blas_avx_dtrmm_rut':
_trmm_rut.f:(.text+0x818f): undefined reference to `mkl_blas_daxpy'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/lib/intel64/libmkl_core.a(_avx_s__trmm_rut.o): in function `mkl_blas_avx_strmm_rut':
_trmm_rut.f:(.text+0x7c1c): undefined reference to `mkl_blas_saxpy'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/lib/intel64/libmkl_core.a(_avx512_domatcopy.o): in function `mkl_trans_avx512_mkl_domatcopy':
domatcopy.c:(.text+0x61): undefined reference to `mkl_trans_mkl_domatcopy2_par'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/lib/intel64/libmkl_core.a(_def_somatcopy.o): in function `mkl_trans_def_mkl_somatcopy':
somatcopy.c:(.text+0x61): undefined reference to `mkl_trans_mkl_somatcopy2_par'
collect2: error: ld returned 1 exit status
```

**Repro steps:**
1.	./vcpkg install intel-mkl:x64-linux
2.	./vcpkg install opencv4[lapack]:x64-linux
3.	./vcpkg install openimageio[opencv]:x64-linux



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.