### PR TITLE
[sqlcipher] Add fts5 support

### DIFF
--- a/ports/sqlcipher/CMakeLists.txt
+++ b/ports/sqlcipher/CMakeLists.txt
@@ -37,6 +37,11 @@ if(WITH_JSON1)
     add_compile_definitions(SQLITE_ENABLE_JSON1)
 endif()
 
+
+if(WITH_FTS5)
+    add_compile_definitions(SQLITE_ENABLE_FTS5)
+endif()
+
 target_include_directories(sqlcipher INTERFACE $<INSTALL_INTERFACE:include>)
 if(NOT WIN32)
     find_package(Threads REQUIRED)

--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -49,11 +49,11 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION "${SOURCE_PATH}")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-    geopoly WITH_GEOPOLY
-    json1 WITH_JSON1
+        geopoly WITH_GEOPOLY
+        json1 WITH_JSON1
+        fts5 WITH_FTS5
     INVERTED_FEATURES
-    tool SQLITE3_SKIP_TOOLS
-    fts5 WITH_FTS5
+        tool SQLITE3_SKIP_TOOLS
 )
 
 vcpkg_cmake_configure(

--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -53,6 +53,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     json1 WITH_JSON1
     INVERTED_FEATURES
     tool SQLITE3_SKIP_TOOLS
+    fts5 WITH_FTS5
 )
 
 vcpkg_cmake_configure(

--- a/ports/sqlcipher/vcpkg.json
+++ b/ports/sqlcipher/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sqlcipher",
   "version": "4.5.3",
+  "port-version": 1,
   "description": "SQLCipher extends the SQLite database library to add security enhancements that make it more suitable for encrypted local data storage.",
   "homepage": "https://www.zetetic.net/sqlcipher",
   "license": null,
@@ -18,6 +19,9 @@
     }
   ],
   "features": {
+    "fts5": {
+      "description": "enable FTS5 functionality for sqlite3"
+    },
     "geopoly": {
       "description": "enable geopoly functionality for sqlite3"
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7538,7 +7538,7 @@
     },
     "sqlcipher": {
       "baseline": "4.5.3",
-      "port-version": 0
+      "port-version": 1
     },
     "sqlite-modern-cpp": {
       "baseline": "3.2-936cd0c8",

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89dce8e4a1cf09b730d343847043668ac95380ec",
+      "version": "4.5.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "2cbeeef2ddd185d1b41197c8b8abd6fbf0646047",
       "version": "4.5.3",
       "port-version": 0

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89dce8e4a1cf09b730d343847043668ac95380ec",
+      "git-tree": "1debf9d86243c81b196302225f7c382958240a30",
       "version": "4.5.3",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #29671

Add `fts5` feature to enable FTS5 function for sqlite3


All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
