### PR TITLE
[vulkan-headers] Update to v1.3.243

### DIFF
--- a/ports/vulkan-headers/portfile.cmake
+++ b/ports/vulkan-headers/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/Vulkan-Headers
-    REF 2bb0a23104ceffd9a28d5b7401f2cee7dae35bb8
-    SHA512 06eaf7cddf2d8c9487244f3c3adee0a2ebed7f8d53a34409cc19d91847e9b5110cbd9af6b71379ae3e4c310db341cff38fc6978af713aa000e6789f1afec4b03
-    HEAD_REF v1.3.239
+    REF d732b2de303ce505169011d438178191136bfb00
+    SHA512 425d393dec95902af46f182b3d8d5d279efefddc9cbce05c2b3e4f1706fa05ff74db0a3db2adc370bf6ac25c152c66d9a96feaac8a427acdc46b1d27e69c2608
+    HEAD_REF v1.3.243
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port

--- a/ports/vulkan-headers/vcpkg.json
+++ b/ports/vulkan-headers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vulkan-headers",
-  "version": "1.3.239",
+  "version": "1.3.243",
   "port-version": 2,
   "description": "Vulkan header files and API registry",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Headers",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8305,7 +8305,7 @@
       "port-version": 5
     },
     "vulkan-headers": {
-      "baseline": "1.3.239",
+      "baseline": "1.3.243",
       "port-version": 2
     },
     "vulkan-hpp": {

--- a/versions/v-/vulkan-headers.json
+++ b/versions/v-/vulkan-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "535abf6f9fe02ff97da42e5594a4c1fd55190ec1",
+      "version": "1.3.243",
+      "port-version": 2
+    },
+    {
       "git-tree": "d0e10b5347c26f2917d90b107a6177af1c270b65",
       "version": "1.3.239",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.