### PR TITLE
[ChakraCore] enable building without dotnet sdk installed

### DIFF
--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -10,14 +10,6 @@ vcpkg_from_github(
         add-missing-reference.patch # https://github.com/chakra-core/ChakraCore/pull/6862
 )
 
-if(WIN32)
-    find_path(COR_H_PATH cor.h)
-    if(COR_H_PATH MATCHES "NOTFOUND")
-        message(FATAL_ERROR "Could not find <cor.h>. Ensure the NETFXSDK is installed.")
-    endif()
-    get_filename_component(NETFXSDK_PATH "${COR_H_PATH}/../.." ABSOLUTE)
-endif()
-
 set(BUILDTREE_PATH ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET})
 file(REMOVE_RECURSE ${BUILDTREE_PATH})
 file(COPY ${SOURCE_PATH}/ DESTINATION ${BUILDTREE_PATH})
@@ -31,7 +23,6 @@ if(WIN32)
         SOURCE_PATH "${BUILDTREE_PATH}"
         PROJECT_SUBPATH "Build/Chakra.Core.sln"
         OPTIONS
-            "/p:DotNetSdkRoot=${NETFXSDK_PATH}/"
             "/p:CustomBeforeMicrosoftCommonTargets=${CMAKE_CURRENT_LIST_DIR}/no-warning-as-error.props"
             "/p:RuntimeLib=${CHAKRA_RUNTIME_LIB}"
         ${PLATFORM_ARG}

--- a/ports/chakracore/vcpkg.json
+++ b/ports/chakracore/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "chakracore",
   "version-date": "2022-11-09",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Core part of the Chakra Javascript engine",
   "homepage": "https://github.com/Microsoft/ChakraCore",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1458,7 +1458,7 @@
     },
     "chakracore": {
       "baseline": "2022-11-09",
-      "port-version": 2
+      "port-version": 3
     },
     "charls": {
       "baseline": "2.4.1",

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "11111145c68adfe4a6164f368027093dffb79ab6",
+      "git-tree": "0e3461099e02572100a3a6731b04fa0c3d12b223",
       "version-date": "2022-11-09",
       "port-version": 3
     },

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11111145c68adfe4a6164f368027093dffb79ab6",
+      "version-date": "2022-11-09",
+      "port-version": 3
+    },
+    {
       "git-tree": "637e8045c68adfe4a6164f368027093dffb79ab6",
       "version-date": "2022-11-09",
       "port-version": 2


### PR DESCRIPTION
I checked on a fresh Windows 11 VM with only VS2022 and C++ native tools installed

Before this change, this port gave me an error

After this change, I was able to install this port successfully

triplet x64-windows