### PR TITLE
[libigl] Always install as header-only lib

### DIFF
--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -68,9 +68,6 @@ endif()
 file(REMOVE "${SOURCE_PATH}/cmake/find/FindGMP.cmake")
 file(REMOVE "${SOURCE_PATH}/cmake/find/FindMPFR.cmake")
 
-# static or dynamic build
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LIBIGL_BUILD_STATIC)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
@@ -79,7 +76,7 @@ vcpkg_cmake_configure(
         -DLIBIGL_BUILD_TESTS=OFF
         -DLIBIGL_BUILD_TUTORIALS=OFF
         -DLIBIGL_INSTALL=ON
-        -DLIBIGL_USE_STATIC_LIBRARY=${LIBIGL_BUILD_STATIC}
+        -DLIBIGL_USE_STATIC_LIBRARY=OFF
         -DHUNTER_ENABLED=OFF
         -DLIBIGL_COPYLEFT_COMISO=${LIBIGL_COMISO}
         -DLIBIGL_COPYLEFT_TETGEN=${LIBIGL_TETGEN}

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libigl",
   "version": "2.4.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.",
   "homepage": "https://github.com/libigl/libigl",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4074,7 +4074,7 @@
     },
     "libigl": {
       "baseline": "2.4.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libilbc": {
       "baseline": "3.0.4",

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1f7e5126f4bca6f7d6800bb8eb143d1640f8a80",
+      "version": "2.4.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "7a44d46fb03c0127710107883208300358ad960f",
       "version": "2.4.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

See the discussion here: https://github.com/microsoft/vcpkg/pull/27963#discussion_r1155333866

Pasting the reply again here for completeness:
> > There is clearly something happening here that is not just copying headers. Things like `LIBIGL_USE_STATIC_LIBRARY` suggest that there is in fact a static library and that this thing is not header only. Can you explain why / how this is header only despite the port clearly doing not header only things?
> 
> With this option, the library is explicitly instantiating some templates into a static library, _but_, it also removes all definition of the templated functions... Building with `LIBIGL_USE_STATIC_LIBRARY` is fundamentally different from standard expectation when considering static/shared. It was the case then #14888, it is still applicable now after checking the repo.
> 
> Ultimately this means using libigl after this PR with a static vcpkg triplet would break users relying on types outside the ones allowed by libigl devs.

@BillyONeal @FrankXie05 


