### PR TITLE
[fontconfig] Use system version on linux

### DIFF
--- a/ports/fontconfig/portfile.cmake
+++ b/ports/fontconfig/portfile.cmake
@@ -1,3 +1,9 @@
+if(NOT "force-build" IN_LIST FEATURES)
+    message(WARNING "fontconfig should be provided by your system! Install the required packages or force vcpkg libraries by building with \"force-build\" feature. ")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+    return()
+endif()
+
 set(FONTCONFIG_VERSION 2.14.1)
 
 vcpkg_from_gitlab(

--- a/ports/fontconfig/vcpkg.json
+++ b/ports/fontconfig/vcpkg.json
@@ -1,29 +1,44 @@
 {
   "name": "fontconfig",
   "version": "2.14.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library for configuring and customizing font access.",
   "homepage": "https://www.freedesktop.org/wiki/Software/fontconfig",
   "license": "MIT",
   "dependencies": [
-    "dirent",
-    "expat",
-    "freetype",
-    "getopt",
-    "gettext",
     {
-      "name": "gperf",
-      "host": true
-    },
-    "libiconv",
-    {
-      "name": "libuuid",
-      "platform": "!windows & !osx & !mingw"
-    },
-    "pthread",
-    {
-      "name": "vcpkg-tool-meson",
-      "host": true
+      "name": "fontconfig",
+      "default-features": false,
+      "features": [
+        "force-build"
+      ],
+      "platform": "!linux"
     }
-  ]
+  ],
+  "features": {
+    "force-build": {
+      "description": "Build fontconfig instead of depending on system one",
+      "dependencies": [
+        "dirent",
+        "expat",
+        "freetype",
+        "getopt",
+        "gettext",
+        {
+          "name": "gperf",
+          "host": true
+        },
+        "libiconv",
+        {
+          "name": "libuuid",
+          "platform": "!windows & !osx & !mingw"
+        },
+        "pthread",
+        {
+          "name": "vcpkg-tool-meson",
+          "host": true
+        }
+      ]
+    }
+  }
 }

--- a/ports/qt5-base/patches/gui_configure.patch
+++ b/ports/qt5-base/patches/gui_configure.patch
@@ -14,16 +14,3 @@ index c51e3ceee..7f7e206b6 100644
              ],
              "use": [
                  { "lib": "zlib", "condition": "features.system-zlib" }
-@@ -262,7 +262,10 @@
-             "headers": "fontconfig/fontconfig.h",
-             "sources": [
--                { "type": "pkgConfig", "args": "fontconfig" },
-+                { "type": "pkgConfig", "args": "breakfontconfig" },
--                { "type": "freetype", "libs": "-lfontconfig" }
-+                { "type": "freetype", "libs": "-lbreakautofind" },
-+                { "libs": "-lfontconfig -lexpat" },
-+                { "libs": "-llibfontconfig -llibexpat" },
-+                "-lfontconfig"
-             ],
-             "use": "freetype"
-         },

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.8",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6406,7 +6406,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.8",
-      "port-version": 5
+      "port-version": 6
     },
     "qt5-canvas3d": {
       "baseline": "0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2542,7 +2542,7 @@
     },
     "fontconfig": {
       "baseline": "2.14.1",
-      "port-version": 1
+      "port-version": 2
     },
     "foonathan-lexy": {
       "baseline": "2022.12.1",

--- a/versions/f-/fontconfig.json
+++ b/versions/f-/fontconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5c2a33b545e2362b48a823d39c18008834e70a2b",
+      "version": "2.14.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "8d149d92c9082b4aa83474ae25f2033574a9cd84",
       "version": "2.14.1",
       "port-version": 1

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70714b74553bd35026b59df69cf377a4475c54f1",
+      "version": "5.15.8",
+      "port-version": 6
+    },
+    {
       "git-tree": "51c0d7f3e15a664dba88e8c9891d4a045661f4ec",
       "version": "5.15.8",
       "port-version": 5


### PR DESCRIPTION
There seems to be no proper way to package custom-built fontconfig with a user application. The package relies on paths that are set at build time which is incompatible with vcpkg. It is possible to workaround that by setting config and cache paths to be `/etc/fonts` and `/var/cache`, but it might conflict with system fontconfig (config and cache files might not be compatible with fontconfig that comes from vcpkg).

Given that this port does not really work on linux, and that every other piece of software on linux expects that `fontconfig` comes from system, make it system library (like X11 and wayland).
Fixes #28229

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
