### PR TITLE
X264 features

### DIFF
--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -77,6 +77,14 @@ else()
     vcpkg_list(APPEND OPTIONS_RELEASE --disable-cli)
 endif()
 
+if("chroma-format-all" IN_LIST FEATURES)
+    vcpkg_list(APPEND OPTIONS --chroma-format=all)
+endif()
+
+if("disable-gpl" IN_LIST FEATURES)
+    vcpkg_list(APPEND OPTIONS --disable-gpl)
+endif()
+
 if(VCPKG_TARGET_IS_UWP)
     list(APPEND OPTIONS --extra-cflags=-D_WIN32_WINNT=0x0A00)
 endif()

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x264",
   "version": "0.164.3095",
-  "port-version": 2,
+  "port-version": 3,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://www.videolan.org/developers/x264.html",
   "license": "GPL-2.0-or-later",
@@ -19,6 +19,9 @@
       "description": "Enable platform-specific assembly optimizations",
       "supports": "x86 | x64 | (arm & !windows) | arm64"
     },
+    "chroma-format-all": {
+      "description": "Output all chroma formats"
+    },
     "default-features": {
       "description": "Default set of features",
       "dependencies": [
@@ -30,6 +33,9 @@
           "platform": "x86 | x64 | (arm & !windows) | arm64"
         }
       ]
+    },
+    "disable-gpl": {
+      "description": "Disable GPL-only features"
     },
     "tool": {
       "description": "Build the command line tool",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8478,7 +8478,7 @@
     },
     "x264": {
       "baseline": "0.164.3095",
-      "port-version": 2
+      "port-version": 3
     },
     "x265": {
       "baseline": "3.4",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18da69fb69b926e7784135262798356e7b1ee5e4",
+      "version": "0.164.3095",
+      "port-version": 3
+    },
+    {
       "git-tree": "4ff53c90cd7222ae9d3e8dc579c1d198715585c2",
       "version": "0.164.3095",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- ~[ ] SHA512s are updated for each updated download~ 
- ~[ ] The "supports" clause reflects platforms that may be fixed by this new version~
- ~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- ~[ ] Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

