### PR TITLE
[openblas] Fix regression on feature dynamic-arch

### DIFF
--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openblas",
   "version": "0.3.21",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/xianyi/OpenBLAS",
   "license": "BSD-3-Clause",
@@ -27,7 +27,7 @@
   "features": {
     "dynamic-arch": {
       "description": "Support for multiple targets in a single library",
-      "supports": "mingw"
+      "supports": "!windows | mingw"
     },
     "simplethread": {
       "description": "Use simple thread",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5730,7 +5730,7 @@
     },
     "openblas": {
       "baseline": "0.3.21",
-      "port-version": 1
+      "port-version": 2
     },
     "opencascade": {
       "baseline": "7.6.2",

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad5694adc46ca2974329e57896d0097e80d65c7d",
+      "version": "0.3.21",
+      "port-version": 2
+    },
+    {
       "git-tree": "86949dd1db1c79ae88f2354225c4363e7200ad66",
       "version": "0.3.21",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix regression introduced by microsoft/vcpkg#30192 wherein the positive lookup made all other valid platform unsupported.

As far as I understood, the original problem seems purely connected to MSVC compiler, so all user-defined triplets using a compatible compiler on Windows (e.g. LLVM/Clang) will have to use --allow-unsupported, unless vcpkg has enabled the possibility to specify compiler/toolset in platform expression.

