### PR TITLE
[vcpkg baseline][stdexec] fix bad hash

### DIFF
--- a/ports/stdexec/portfile.cmake
+++ b/ports/stdexec/portfile.cmake
@@ -27,7 +27,7 @@ file(COPY "${RAPIDS_cmake}" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIP
 vcpkg_download_distfile(execution_bs
     URLS "https://raw.githubusercontent.com/brycelelbach/wg21_p2300_execution/main/execution.bs"
     FILENAME "execution.bs"
-    SHA512 8b976ab932019794d356cf36744af09e027a78488b44d70772675e2c23de0a6fac4e5aaa2ed339d2975b04c75ad27c06c4c3ed95bc2bd9d13370682a019656f2
+    SHA512 22493329bcc26d4c30950df632349daf632adee87bdc904167afcdbb1f9398da2ca3ce9aad1d1c9dab961a2946b0fb9e5b66619b8a529f7cf04fe6aec01c5bb8
 )
 file(COPY "${execution_bs}" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
 

--- a/ports/stdexec/vcpkg.json
+++ b/ports/stdexec/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "stdexec",
   "version-date": "2023-03-05",
+  "port-version": 1,
   "description": "stdexec is an experimental reference implementation of the Senders model of asynchronous programming proposed by P2300 - std::execution for adoption into the C++ Standard.",
   "homepage": "https://github.com/NVIDIA/stdexec",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7610,7 +7610,7 @@
     },
     "stdexec": {
       "baseline": "2023-03-05",
-      "port-version": 0
+      "port-version": 1
     },
     "stduuid": {
       "baseline": "1.2.2",

--- a/versions/s-/stdexec.json
+++ b/versions/s-/stdexec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3435db06cfe7eb2aa08dd32988c2360017bb66f1",
+      "version-date": "2023-03-05",
+      "port-version": 1
+    },
+    {
       "git-tree": "f0dea0ac2888c1fe01a7521f5cddabfc86d6fd8d",
       "version-date": "2023-03-05",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes vcpkg pipeline issue:
```
"error: File does not have the expected hash:
url: https://raw.githubusercontent.com/brycelelbach/wg21_p2300_execution/main/execution.bs
File: D:\downloads\execution.bs.15352.part
Expected hash: 8b976ab932019794d356cf36744af09e027a78488b44d70772675e2c23de0a6fac4e5aaa2ed339d2975b04c75ad27c06c4c3ed95bc2bd9d13370682a019656f2
Actual hash: be58193daeef686b69e6ccbfd5e6bdbcb303647cd7a60f59d252f1ab93e63ba1a9513f421e9c7e76143026fec98fcb21db85a089fc2ead04da55d25837b411a0
"
```

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
