### PR TITLE
[vcpkg baseline][live555] Update to 2023-03-30

### DIFF
--- a/ports/live555/fix-RTSPClient.patch
+++ b/ports/live555/fix-RTSPClient.patch
@@ -1,13 +1,13 @@
 diff --git a/liveMedia/RTSPClient.cpp b/liveMedia/RTSPClient.cpp
-index 130baa9..8e1ea10 100644
+index 66e0c79..13255af 100644
 --- a/liveMedia/RTSPClient.cpp
 +++ b/liveMedia/RTSPClient.cpp
-@@ -2022,7 +2022,7 @@ int RTSPClient::write(const char* data, unsigned count) {
+@@ -2029,7 +2029,7 @@ int RTSPClient::write(const char* data, unsigned count) {
        if (fOutputTLS->isNeeded) {
  	return fOutputTLS->write(data, count);
        } else {
--	return send(fOutputSocketNum, data, count, 0);
-+	return send(fOutputSocketNum, (const char *)data, count, 0);
+-	return send(fOutputSocketNum, data, count, MSG_NOSIGNAL);
++	return send(fOutputSocketNum, (const char *)data, count, MSG_NOSIGNAL);
        }
  }
  

--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://live555.com/liveMedia/public/live.2023.01.19.tar.gz"
-    FILENAME "live.2023.01.19.tar.gz"
-    SHA512 155c38097d37864978d6b68bf0a7268a9cc88160ebbe679ca5654bd925c5400ef5f74aa6307f53c9584a4611d914d0c8edd275b66b7ca9a66be6591a5b5a8f4f
+    URLS "http://live555.com/liveMedia/public/live.2023.03.30.tar.gz"
+    FILENAME "live.2023.03.30.tar.gz"
+    SHA512 84dcc9af7fcfd565342b913e8420e2cca9b45e9a8ff74c04ef8e32449f6bbf35eb594ba48ae06d93efe6ec4c3d7c6812ce5989d02676398cdbd63f2ec0042b68
 )
 
 vcpkg_extract_source_archive(

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "live555",
-  "version-date": "2023-01-19",
+  "version-date": "2023-03-30",
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4809,7 +4809,7 @@
       "port-version": 2
     },
     "live555": {
-      "baseline": "2023-01-19",
+      "baseline": "2023-03-30",
       "port-version": 0
     },
     "llfio": {

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a8b18570460ba3155d5c6cba9f5c05c95d876e2",
+      "version-date": "2023-03-30",
+      "port-version": 0
+    },
+    {
       "git-tree": "43dd99ed461fd0fef750ceb08527b761fd8ba384",
       "version-date": "2023-01-19",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes vcpkg pipeline issue:
`Downloading http://live555.com/liveMedia/public/live.2023.01.19.tar.gz error: Failed to download from mirror set`

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
