### PR TITLE
[vcpkg baseline][openslide] fix download failed

### DIFF
--- a/ports/openslide/portfile.cmake
+++ b/ports/openslide/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openslide/openslide
     REF "v${VERSION}" 
-    SHA512 1b6bc4722fd6901d7c929ec332177d4892ea15700133c1a1339c6bdcace174064b5e063d3bcb2044e2ca56801c044f7b3d1c774c0b29f9005361a8336e297e4b
+    SHA512 5b0315215f9cada56c85e0068c9493a66c70bae1230cc01dd00ce364414f53bf285728dc860d7de0ac30a10bdc3c1a76f728446b96ca337a62d588f5cc2a971c
     HEAD_REF master
     PATCHES remove-w-flags.patch
             ${PATCHES}

--- a/ports/openslide/vcpkg.json
+++ b/ports/openslide/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openslide",
   "version": "3.4.1",
+  "port-version": 1,
   "description": "OpenSlide is a C library for reading whole slide image files (also known as virtual slides). It provides a consistent and simple API for reading files from multiple vendors.",
   "homepage": "https://openslide.org/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5846,7 +5846,7 @@
     },
     "openslide": {
       "baseline": "3.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "openssl": {
       "baseline": "3.1.0",

--- a/versions/o-/openslide.json
+++ b/versions/o-/openslide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff177e74dacffe2a12dec525304bac97b7f67a9f",
+      "version": "3.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e709084d5ff53f55afd332eac4b43ed9bf79e199",
       "version": "3.4.1",
       "port-version": 0


### PR DESCRIPTION
Fixed CI error, openslide download fails, SHA512 value is wrong.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.