### PR TITLE
[vcpkg baseline][qwt] Remove qwt in ci.baseline.txt 

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -773,7 +773,6 @@ qt5-webengine:x86-windows=skip
 # Missing system libraries
 qt5-x11extras:x64-osx=fail
 qt5-x11extras:arm64-osx=fail
-qwt:x64-osx=fail
 qwt:arm64-osx=fail
 qwt-qt6:x64-osx=fail
 rabit:arm64-osx=fail


### PR DESCRIPTION
Fixes vcpkg pipeline issue: `PASSING, REMOVE FROM FAIL LIST: qwt:x64-osx`

`qwt:x64-osx=ignore` was added for the first time by #9203, and later changed to `qwt:x64-osx=fail` by #12197.

Remove it now, because it was fixed by #30337.