### PR TITLE
[vcpkg baseline][portsmf] fix download failed

### DIFF
--- a/ports/portsmf/portfile.cmake
+++ b/ports/portsmf/portfile.cmake
@@ -1,9 +1,12 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO tenacityteam/portsmf
-    REF 238
-    SHA512 af619d1b0a656361af8f8b8b65d7f98047613ac8e9ea51354031629c1732ad02755f84d63ac7c4ed24cdf0ad3db46381061bf32d9afe29b7be3226dc814ef552
-    HEAD_REF main
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://codeberg.org/tenacityteam/portsmf/archive/${VERSION}.tar.gz"
+    FILENAME "${VERSION}.tar.gz"
+    SHA512 522ef6e92de6497c66d6b9adf2b6b4e419024d26fac421096718b024ea0e183d322d3f0cd9fc357e0ba983371cf313d7a0b93b8b24aff5c9cb1ab61c915725ff
+)
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+
 )
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
@@ -13,5 +16,5 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/PortSMF)
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license.txt")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/portsmf/vcpkg.json
+++ b/ports/portsmf/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "portsmf",
-  "version": "0.238",
-  "port-version": 1,
+  "version": "239",
   "description": "Portsmf is 'Port Standard MIDI File', a cross-platform, C++ library for reading and writing Standard MIDI Files.",
-  "homepage": "https://github.com/tenacityteam/portsmf",
+  "homepage": "https://codeberg.org/tenacityteam/portsmf",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6237,8 +6237,8 @@
       "port-version": 1
     },
     "portsmf": {
-      "baseline": "0.238",
-      "port-version": 1
+      "baseline": "239",
+      "port-version": 0
     },
     "ppconsul": {
       "baseline": "0.5",

--- a/versions/p-/portsmf.json
+++ b/versions/p-/portsmf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fb3e1fa8a02794b84b7a9d15171886845c91474",
+      "version": "239",
+      "port-version": 0
+    },
+    {
       "git-tree": "60b00990b46bbac28e91a94533d212be1af49ffb",
       "version": "0.238",
       "port-version": 1


### PR DESCRIPTION
Fixes vcpkg pipeline issue:
Downloading https://github.com/tenacityteam/portsmf/archive/238.tar.gz error: Failed to download from mirror set



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
