### PR TITLE
[vcpkg baseline][cmake] fix bad hash

### DIFF
--- a/scripts/test_ports/cmake/portfile.cmake
+++ b/scripts/test_ports/cmake/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_gitlab(
     REF
         8428e39ed9cddb3b7f1a6f7a58cb8617503183d2
     SHA512
-        4a40656efe5854bd6b893d0b2b86eed5df42992d080edb9c0cb2da2c55ad8dd489a85072b138947933d94ef5ba90c7a59f0a4460e3722d0f898ceefbbf74d226 
+        12df5d68aad6bf1bfa34c3a83b428e1ecdc0b2b746e92bf71157eec4b4c114c86f21e91509f26f5da6e8916941563750e63cc3218970eaba33d6de231599de34
     HEAD_REF master
     PATCHES fix-dependency-libuv.patch
 )

--- a/scripts/test_ports/cmake/vcpkg.json
+++ b/scripts/test_ports/cmake/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cmake",
   "version": "3.22.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "CMake is an open-source, cross-platform family of tools designed to build, test and package software.",
   "homepage": "https://cmake.org/",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes vcpkg pipeline issue:
```
error: File does not have the expected hash:
url: https://gitlab.kitware.com//cmake/cmake/-/archive/8428e39ed9cddb3b7f1a6f7a58cb8617503183d2/cmake-8428e39ed9cddb3b7f1a6f7a58cb8617503183d2.tar.gz
File: /mnt/vcpkg-ci/downloads/cmake-cmake-8428e39ed9cddb3b7f1a6f7a58cb8617503183d2.tar.gz.1582213.part
Expected hash: 4a40656efe5854bd6b893d0b2b86eed5df42992d080edb9c0cb2da2c55ad8dd489a85072b138947933d94ef5ba90c7a59f0a4460e3722d0f898ceefbbf74d226
Actual hash: 12df5d68aad6bf1bfa34c3a83b428e1ecdc0b2b746e92bf71157eec4b4c114c86f21e91509f26f5da6e8916941563750e63cc3218970eaba33d6de231599de34
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
