### PR TITLE
[gstreamer]: Fixed missing bz2 dependency on Windows in Debug

### DIFF
--- a/ports/gstreamer/fix-bz2-windows-debug-dependency.patch
+++ b/ports/gstreamer/fix-bz2-windows-debug-dependency.patch
@@ -1,0 +1,26 @@
+diff --git a/subprojects/gst-plugins-bad/ext/bz2/meson.build b/subprojects/gst-plugins-bad/ext/bz2/meson.build
+index 08d1596..be5fa02 100644
+--- a/subprojects/gst-plugins-bad/ext/bz2/meson.build
++++ b/subprojects/gst-plugins-bad/ext/bz2/meson.build
+@@ -4,7 +4,7 @@ bz2_sources = [
+   'gstbz2enc.c',
+ ]
+ 
+-bz2_dep = cc.find_library('bz2', required : get_option('bz2'))
++bz2_dep = dependency('bzip2', required : get_option('bz2'))
+ 
+ if bz2_dep.found() and cc.has_header_symbol('bzlib.h', 'BZ2_bzlibVersion')
+   gstbz2 = library('gstbz2',
+diff --git a/subprojects/gst-plugins-good/gst/matroska/meson.build b/subprojects/gst-plugins-good/gst/matroska/meson.build
+index d8a6a96..dd03de2 100644
+--- a/subprojects/gst-plugins-good/gst/matroska/meson.build
++++ b/subprojects/gst-plugins-good/gst/matroska/meson.build
+@@ -12,7 +12,7 @@ matroska_sources = [
+   'lzo.c',
+ ]
+ 
+-bz2_dep = cc.find_library('bz2', required : get_option('bz2'))
++bz2_dep = dependency('bzip2', required : get_option('bz2'))
+ cdata.set('HAVE_BZ2', bz2_dep.found() and cc.has_header('bzlib.h'))
+ 
+ gstmatroska = library('gstmatroska',

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_gitlab(
         fix-clang-cl-ugly.patch
         gstreamer-disable-no-unused.patch
         srtp_fix.patch
+        fix-bz2-windows-debug-dependency.patch
         ${PATCHES}
 )
 
@@ -49,6 +50,12 @@ if("gpl" IN_LIST FEATURES)
     set(LICENSE_GPL enabled)
 else()
     set(LICENSE_GPL disabled)
+endif()
+
+if ("libav" IN_LIST FEATURES)
+    set(LIBAV enabled)
+else()
+    set(LIBAV disabled)
 endif()
 
 if("nls" IN_LIST FEATURES)
@@ -402,7 +409,7 @@ vcpkg_configure_meson(
     OPTIONS
         # General options
         -Dpython=disabled
-        -Dlibav=disabled
+        -Dlibav=${LIBAV}
         -Dlibnice=disabled
         -Ddevtools=disabled
         -Dges=disabled

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.20.5",
-  "port-version": 2,
+  "port-version": 3,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",
@@ -278,6 +278,15 @@
           ]
         },
         "libjpeg-turbo"
+      ]
+    },
+    "libav": {
+      "description": "libav plugins",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false
+        }
       ]
     },
     "libde265": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2946,7 +2946,7 @@
     },
     "gstreamer": {
       "baseline": "1.20.5",
-      "port-version": 2
+      "port-version": 3
     },
     "gtest": {
       "baseline": "1.13.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9724606bfcc594bbdde72fbcba7fbd019312ae6",
+      "version": "1.20.5",
+      "port-version": 3
+    },
+    {
       "git-tree": "6289f1269af159388f8a9cfed08c52acd1a297da",
       "version": "1.20.5",
       "port-version": 2


### PR DESCRIPTION
* Added libav feature

#### update port checklist:
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.