### PR TITLE
[vcpkg baseline][backward-cpp,ignition-tools] Fix include dir and dependencies

### DIFF
--- a/ports/backward-cpp/include-dir.diff
+++ b/ports/backward-cpp/include-dir.diff
@@ -1,0 +1,16 @@
+diff --git a/BackwardConfig.cmake b/BackwardConfig.cmake
+index a982adc..0c549f3 100644
+--- a/BackwardConfig.cmake
++++ b/BackwardConfig.cmake
+@@ -198,6 +198,11 @@ if(WIN32)
+ endif()
+ 
+ set(BACKWARD_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}")
++if(NOT PROJECT_NAME STREQUAL "backward")
++	get_filename_component(BACKWARD_INCLUDE_DIR "${BACKWARD_INCLUDE_DIR}" DIRECTORY)
++	get_filename_component(BACKWARD_INCLUDE_DIR "${BACKWARD_INCLUDE_DIR}" DIRECTORY)
++	set(BACKWARD_INCLUDE_DIR "${BACKWARD_INCLUDE_DIR}/include")
++endif()
+ 
+ set(BACKWARD_HAS_EXTERNAL_LIBRARIES FALSE)
+ set(FIND_PACKAGE_REQUIRED_VARS BACKWARD_INCLUDE_DIR)

--- a/ports/backward-cpp/portfile.cmake
+++ b/ports/backward-cpp/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 db0256a54819952ff1d92e05d6ab81fe979d4826ebb6651b6b08c30e7a0091879dfeff33d81f9599462152ce68e61e2c8c42bf039129bc6b28d1e68b1eab039b
     HEAD_REF master
+    PATCHES
+        include-dir.diff
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only
@@ -12,7 +14,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME Backward CONFIG_PATH lib/backward)
+vcpkg_cmake_config_fixup(PACKAGE_NAME backward CONFIG_PATH lib/backward)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/ports/backward-cpp/vcpkg.json
+++ b/ports/backward-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "backward-cpp",
   "version": "1.6",
+  "port-version": 1,
   "description": "A beautiful stack trace pretty printer for C++",
   "homepage": "https://github.com/bombela/backward-cpp",
   "supports": "!uwp & !(windows & arm)",

--- a/ports/ignition-tools/portfile.cmake
+++ b/ports/ignition-tools/portfile.cmake
@@ -12,6 +12,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
         -DBUILD_TESTING=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
+        -DUSE_SYSTEM_BACKWARDCPP=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/ignition-tools/vcpkg.json
+++ b/ports/ignition-tools/vcpkg.json
@@ -1,11 +1,13 @@
 {
   "name": "ignition-tools",
   "version": "1.5.0",
+  "port-version": 1,
   "description": "Gazebo tools provide the ign command line tool that accepts multiple subcommands.",
   "homepage": "https://gazebosim.org",
   "license": "Apache-2.0",
   "supports": "!(arm & windows) & !uwp",
   "dependencies": [
+    "backward-cpp",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/b-/backward-cpp.json
+++ b/versions/b-/backward-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "748c91a2ed90cad10b92d4c527dc855ec8f15db0",
+      "version": "1.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "9f204819a5063dea81b56369e5ce424219e56ca5",
       "version": "1.6",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3202,7 +3202,7 @@
     },
     "ignition-tools": {
       "baseline": "1.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ignition-transport4": {
       "baseline": "4.0.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -470,7 +470,7 @@
     },
     "backward-cpp": {
       "baseline": "1.6",
-      "port-version": 0
+      "port-version": 1
     },
     "basisu": {
       "baseline": "1.11",

--- a/versions/i-/ignition-tools.json
+++ b/versions/i-/ignition-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b47d5830dfaf7b6f136f5b26002b50adb0804bde",
+      "version": "1.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5567f256c2183bacba71d78d26362a1b76021bcf",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
Amends #30101.
Fixes some regressions from https://dev.azure.com/vcpkg/public/_build/results?buildId=87700&view=results

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
