### PR TITLE
[openmama] Update to version 6.3.2

### DIFF
--- a/ports/openmama/portfile.cmake
+++ b/ports/openmama/portfile.cmake
@@ -1,20 +1,22 @@
 vcpkg_find_acquire_program(FLEX)
+vcpkg_find_acquire_program(GIT)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO finos/OpenMAMA
-    REF c4925ee103add1a51c1d27be45b46d97af347f36 # https://github.com/finos/OpenMAMA/releases/tag/OpenMAMA-6.3.1-release
-    SHA512 e2773d082dd28e073fe81223fc113b1a5db7cd0d95e150e9f3f02c8c9483b9219b5d10682a125dd792c3a7877e15b90fd908084a4c89af4ec8d8c0389c282de2
+    REF OpenMAMA-${VERSION}-release
+    SHA512 bf6a9343546ace80b8a72072f97aa85988a3d0d047e2a60d05de638afce89b4e4f2bcae28b8e93ca808e8c0e4a83de9035ff785f69f9b4ac4ccd2616e792fa08
     HEAD_REF next
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DPROTON_ROOT=${CURRENT_INSTALLED_DIR}"
-        "-DAPR_ROOT=${CURRENT_INSTALLED_DIR}"
+        "-DOPENMAMA_DEPENDENCY_ROOT=${CURRENT_INSTALLED_DIR}"
         -DINSTALL_RUNTIME_DEPENDENCIES=OFF
         -DFLEX_EXECUTABLE=${FLEX}
+        -DGIT_BIN=${GIT}
+        -DOPENMAMA_VERSION=${VERSION}
         -DWITH_EXAMPLES=OFF
         -DWITH_TESTTOOLS=OFF
 )
@@ -29,25 +31,13 @@ file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/sh
 # Clean up LICENSE file - vcpkg doesn't expect it to be there
 file(REMOVE "${CURRENT_PACKAGES_DIR}/LICENSE.MD" "${CURRENT_PACKAGES_DIR}/debug/LICENSE.MD")
 
-# Temporary workaround until upstream project puts dll in right place
-if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/libmamaplugindqstrategymd.dll")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/lib/libmamaplugindqstrategymd.dll" "${CURRENT_PACKAGES_DIR}/bin/libmamaplugindqstrategymd.dll")
-endif()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/libmamaplugindqstrategymd.dll")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/libmamaplugindqstrategymd.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/libmamaplugindqstrategymd.dll")
-endif()
-
 # Vcpkg does not expect include files to be in the debug directory
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-foreach(OPENMAMA_ROOT_HEADER destroyhandle.h platform.h list.h lookup2.h property.h timers.h wlock.h windows)
-    if(EXISTS "${CURRENT_PACKAGES_DIR}/include/${OPENMAMA_ROOT_HEADER}")
-        file(RENAME "${CURRENT_PACKAGES_DIR}/include/${OPENMAMA_ROOT_HEADER}" "${CURRENT_PACKAGES_DIR}/include/wombat/${OPENMAMA_ROOT_HEADER}")
-    endif()
-endforeach()
-
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/transport.h" "list.h" "wombat/list.h")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/types.h" "list.h" "wombat/list.h")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/mama.h" "property.h" "wombat/property.h")
-
 vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME OpenMAMA
+    CONFIG_PATH lib/cmake/OpenMAMA
+    DO_NOT_DELETE_PARENT_CONFIG_PATH
+)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake" "${CURRENT_PACKAGES_DIR}/lib/cmake")

--- a/ports/openmama/portfile.cmake
+++ b/ports/openmama/portfile.cmake
@@ -24,12 +24,10 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 # Copy across license files and copyright
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(COPY "${SOURCE_PATH}/LICENSE-3RD-PARTY.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/")
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md" "${SOURCE_PATH}/LICENSE-3RD-PARTY.txt")
 
 # Clean up LICENSE file - vcpkg doesn't expect it to be there
-file(REMOVE "${CURRENT_PACKAGES_DIR}/LICENSE.MD" "${CURRENT_PACKAGES_DIR}/debug/LICENSE.MD")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/LICENSE.md" "${CURRENT_PACKAGES_DIR}/debug/LICENSE.md")
 
 # Vcpkg does not expect include files to be in the debug directory
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/openmama/vcpkg.json
+++ b/ports/openmama/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "OpenMAMA is a high performance vendor neutral lightweight wrapper that provides a common API interface to different middleware and messaging solutions across a variety of platforms and languages",
   "homepage": "https://github.com/finos/OpenMAMA",
   "supports": "windows & (x64 | x86)",
+  "license": "LGPL-2.1",
   "dependencies": [
     "apr",
     "apr-util",

--- a/ports/openmama/vcpkg.json
+++ b/ports/openmama/vcpkg.json
@@ -3,8 +3,8 @@
   "version-semver": "6.3.2",
   "description": "OpenMAMA is a high performance vendor neutral lightweight wrapper that provides a common API interface to different middleware and messaging solutions across a variety of platforms and languages",
   "homepage": "https://github.com/finos/OpenMAMA",
-  "supports": "windows & (x64 | x86)",
   "license": "LGPL-2.1",
+  "supports": "windows & (x64 | x86)",
   "dependencies": [
     "apr",
     "apr-util",

--- a/ports/openmama/vcpkg.json
+++ b/ports/openmama/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openmama",
   "version-semver": "6.3.2",
-  "port-version": 0,
   "description": "OpenMAMA is a high performance vendor neutral lightweight wrapper that provides a common API interface to different middleware and messaging solutions across a variety of platforms and languages",
   "homepage": "https://github.com/finos/OpenMAMA",
   "supports": "windows & (x64 | x86)",

--- a/ports/openmama/vcpkg.json
+++ b/ports/openmama/vcpkg.json
@@ -1,17 +1,16 @@
 {
   "name": "openmama",
-  "version-semver": "6.3.1",
-  "port-version": 2,
+  "version-semver": "6.3.2",
+  "port-version": 0,
   "description": "OpenMAMA is a high performance vendor neutral lightweight wrapper that provides a common API interface to different middleware and messaging solutions across a variety of platforms and languages",
   "homepage": "https://github.com/finos/OpenMAMA",
   "supports": "windows & (x64 | x86)",
   "dependencies": [
     "apr",
+    "apr-util",
     "libevent",
     "qpid-proton",
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    }
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5821,8 +5821,8 @@
       "port-version": 0
     },
     "openmama": {
-      "baseline": "6.3.1",
-      "port-version": 2
+      "baseline": "6.3.2",
+      "port-version": 0
     },
     "openmesh": {
       "baseline": "9.0",

--- a/versions/o-/openmama.json
+++ b/versions/o-/openmama.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a385a51389791fdee1a47efdcfec5fffa7c4cbd3",
+      "version-semver": "6.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e5f4f2e62bf5825132077e6abf19b99014a91755",
       "version-semver": "6.3.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
