### PR TITLE
[pe-parse] no Werror

### DIFF
--- a/ports/pe-parse/no-werror.patch
+++ b/ports/pe-parse/no-werror.patch
@@ -1,0 +1,26 @@
+diff --git a/cmake/compilation_flags.cmake b/cmake/compilation_flags.cmake
+index 395f1b5..bb10165 100644
+--- a/cmake/compilation_flags.cmake
++++ b/cmake/compilation_flags.cmake
+@@ -26,7 +26,7 @@ else ()
+     -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization
+     -Wformat=2 -Winit-self -Wlong-long -Wmissing-declarations -Wmissing-include-dirs -Wcomment
+     -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion
+-    -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Werror -Wunused -Wuninitialized
++    -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Wunused -Wuninitialized
+     -Wno-missing-declarations -Wno-strict-overflow
+   )
+ 
+diff --git a/examples/peaddrconv/CMakeLists.txt b/examples/peaddrconv/CMakeLists.txt
+index fbad06a..02c8bcf 100644
+--- a/examples/peaddrconv/CMakeLists.txt
++++ b/examples/peaddrconv/CMakeLists.txt
+@@ -26,7 +26,7 @@ else ()
+     -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization
+     -Wformat=2 -Winit-self -Wlong-long -Wmissing-declarations -Wmissing-include-dirs -Wcomment
+     -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion
+-    -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Werror -Wunused -Wuninitialized
++    -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Wunused -Wuninitialized
+     -Wno-missing-declarations
+   )
+ 

--- a/ports/pe-parse/portfile.cmake
+++ b/ports/pe-parse/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         arm64-windows-fix.patch
+        no-werror.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/pe-parse/vcpkg.json
+++ b/ports/pe-parse/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pe-parse",
   "version": "2.1.0",
+  "port-version": 1,
   "description": "pe-parse is a principled, lightweight C/C++ PE parser",
   "homepage": "https://github.com/trailofbits/pe-parse",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6050,7 +6050,7 @@
     },
     "pe-parse": {
       "baseline": "2.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "pegtl": {
       "baseline": "3.2.6",

--- a/versions/p-/pe-parse.json
+++ b/versions/p-/pe-parse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3e0e5dcb11738632d8eba03e22e4f0530ae5445",
+      "version": "2.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "94a994b08f738c94aa751def532be843595ebf62",
       "version": "2.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes the arm64-osx build:
```
[1/5] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DPEPARSE_VERSION=\"2.0.0\" -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/pe-parse/src/v2.1.0-35d7e8a7d3.clean/pe-parser-library/include -fPIC -O3 -DNDEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wlong-long -Wmissing-declarations -Wmissing-include-dirs -Wcomment -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Werror -Wunused -Wuninitialized -Wno-missing-declarations -Wno-strict-overflow -std=c++17 -MD -MT pe-parser-library/CMakeFiles/pe-parse.dir/src/unicode_codecvt.cpp.o -MF pe-parser-library/CMakeFiles/pe-parse.dir/src/unicode_codecvt.cpp.o.d -o pe-parser-library/CMakeFiles/pe-parse.dir/src/unicode_codecvt.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/pe-parse/src/v2.1.0-35d7e8a7d3.clean/pe-parser-library/src/unicode_codecvt.cpp
FAILED: pe-parser-library/CMakeFiles/pe-parse.dir/src/unicode_codecvt.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DPEPARSE_VERSION=\"2.0.0\" -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/pe-parse/src/v2.1.0-35d7e8a7d3.clean/pe-parser-library/include -fPIC -O3 -DNDEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wlong-long -Wmissing-declarations -Wmissing-include-dirs -Wcomment -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Werror -Wunused -Wuninitialized -Wno-missing-declarations -Wno-strict-overflow -std=c++17 -MD -MT pe-parser-library/CMakeFiles/pe-parse.dir/src/unicode_codecvt.cpp.o -MF pe-parser-library/CMakeFiles/pe-parse.dir/src/unicode_codecvt.cpp.o.d -o pe-parser-library/CMakeFiles/pe-parse.dir/src/unicode_codecvt.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/pe-parse/src/v2.1.0-35d7e8a7d3.clean/pe-parser-library/src/unicode_codecvt.cpp
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/pe-parse/src/v2.1.0-35d7e8a7d3.clean/pe-parser-library/src/unicode_codecvt.cpp:33:29: error: 'codecvt_utf8<char16_t, 1114111, 0>' is deprecated [-Werror,-Wdeprecated-declarations]
  std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> convert;
```