### PR TITLE
[rtaudio] Add 'pulse' feature

### DIFF
--- a/ports/rtaudio/portfile.cmake
+++ b/ports/rtaudio/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         asio  RTAUDIO_API_ASIO
         alsa  RTAUDIO_API_ALSA
+        pulse RTAUDIO_API_PULSE
 )
 
 vcpkg_cmake_configure(
@@ -20,7 +21,6 @@ vcpkg_cmake_configure(
     OPTIONS
         -DRTAUDIO_STATIC_MSVCRT=${RTAUDIO_STATIC_MSVCRT}
         -DRTAUDIO_API_JACK=OFF
-        -DRTAUDIO_API_PULSE=OFF
         ${FEATURE_OPTIONS}
 )
 
@@ -31,4 +31,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rtaudio/vcpkg.json
+++ b/ports/rtaudio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rtaudio",
   "version-date": "2021-11-16",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A set of C++ classes that provide a common API for realtime audio input/output across Linux (native ALSA, JACK, PulseAudio and OSS), Macintosh OS X (CoreAudio and JACK), and Windows (DirectSound, ASIO and WASAPI) operating systems.",
   "homepage": "https://github.com/thestk/rtaudio",
   "license": null,
@@ -27,6 +27,10 @@
     "asio": {
       "description": "Build with ASIO backend",
       "supports": "windows"
+    },
+    "pulse": {
+      "description": "Build with PulseAudio backend",
+      "supports": "linux"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7034,7 +7034,7 @@
     },
     "rtaudio": {
       "baseline": "2021-11-16",
-      "port-version": 1
+      "port-version": 2
     },
     "rtlsdr": {
       "baseline": "2020-04-16",

--- a/versions/r-/rtaudio.json
+++ b/versions/r-/rtaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "989c7dceafbd4ea849445d86bdc1b4bbf7133960",
+      "version-date": "2021-11-16",
+      "port-version": 2
+    },
+    {
       "git-tree": "f1adbba529fbfd9b66a7951556a088e0834baa09",
       "version-date": "2021-11-16",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Rationale:
Instead of always disabling PulseAudio backend, add a feature st. users have the option to build this backend on Linux. Especially useful if one doesn't want to use Alsa backend.