### PR TITLE
[aklomp-base64] New Port

### DIFF
--- a/ports/aklomp-base64/portfile.cmake
+++ b/ports/aklomp-base64/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO aklomp/base64
+    REF e77bd70bdd860c52c561568cffb251d88bba064c
+    SHA512 bc0cf64f6a24226a64c51983e8b73b4d4e893b8242bc6ac39361d977996de453d9f95ed0ab68a7544f21b0be1d76ae53af96521207a651c95673b02954cc5bbe
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_cmake_config_fixup(
+	CONFIG_PATH "lib/cmake/base64"
+)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/aklomp-base64/vcpkg.json
+++ b/ports/aklomp-base64/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "aklomp-base64",
+  "version-string": "2023-01-06",
+  "description": "Implementation of a base64 stream encoding/decoding library in C99 with SIMD (AVX2, NEON, AArch64/NEON, SSSE3, SSE4.1, SSE4.2, AVX) and OpenMP acceleration",
+  "dependencies": [
+		{
+			"name": "vcpkg-cmake",
+			"host": true
+		},
+		{
+			"name": "vcpkg-cmake-config",
+			"host": true
+		}
+	]
+}

--- a/ports/aklomp-base64/vcpkg.json
+++ b/ports/aklomp-base64/vcpkg.json
@@ -1,7 +1,9 @@
 {
   "name": "aklomp-base64",
   "version-string": "2023-01-06",
-  "description": "Implementation of a base64 stream encoding/decoding library in C99 with SIMD (AVX2, NEON, AArch64/NEON, SSSE3, SSE4.1, SSE4.2, AVX) and OpenMP acceleration",
+  "description": "Implementation of a base64 stream encoding/decoding library in C99 with SIMD (AVX2, AVX512, NEON, AArch64/NEON, SSSE3, SSE4.1, SSE4.2, AVX) and OpenMP acceleration",
+  "homepage": "https://github.com/aklomp/base64",
+  "license": "BSD 2-Clause",
   "dependencies": [
 		{
 			"name": "vcpkg-cmake",

--- a/ports/aklomp-base64/vcpkg.json
+++ b/ports/aklomp-base64/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "2023-01-06",
   "description": "Implementation of a base64 stream encoding/decoding library in C99 with SIMD (AVX2, AVX512, NEON, AArch64/NEON, SSSE3, SSE4.1, SSE4.2, AVX) and OpenMP acceleration",
   "homepage": "https://github.com/aklomp/base64",
-  "license": "BSD 2-Clause",
+  "license": "BSD-2-Clause",
   "dependencies": [
 		{
 			"name": "vcpkg-cmake",

--- a/ports/aklomp-base64/vcpkg.json
+++ b/ports/aklomp-base64/vcpkg.json
@@ -1,17 +1,17 @@
 {
   "name": "aklomp-base64",
-  "version-string": "2023-01-06",
+  "version-date": "2023-01-06",
   "description": "Implementation of a base64 stream encoding/decoding library in C99 with SIMD (AVX2, AVX512, NEON, AArch64/NEON, SSSE3, SSE4.1, SSE4.2, AVX) and OpenMP acceleration",
   "homepage": "https://github.com/aklomp/base64",
   "license": "BSD-2-Clause",
   "dependencies": [
-		{
-			"name": "vcpkg-cmake",
-			"host": true
-		},
-		{
-			"name": "vcpkg-cmake-config",
-			"host": true
-		}
-	]
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/a-/aklomp-base64.json
+++ b/versions/a-/aklomp-base64.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f73a4f50ab2a515962e939dad478916a5f44842f",
+      "version-date": "2023-01-06",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -60,6 +60,10 @@
       "baseline": "1.43",
       "port-version": 1
     },
+    "aklomp-base64": {
+      "baseline": "2023-01-06",
+      "port-version": 0
+    },
     "alac": {
       "baseline": "2017-11-03-c38887c5",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.