### PR TITLE
[vcpkg baseline][qca] Control plugin dependencies

### DIFF
--- a/ports/qca/portfile.cmake
+++ b/ports/qca/portfile.cmake
@@ -45,10 +45,9 @@ vcpkg_execute_required_process(
 )
 message(STATUS "Importing certstore done")
 
+set(PLUGINS gnupg logger softstore wincrypto)
 if("botan" IN_LIST FEATURES)
-    list(APPEND QCA_OPTIONS -DWITH_botan_PLUGIN=yes)
-else()
-    list(APPEND QCA_OPTIONS -DWITH_botan_PLUGIN=no)
+    list(APPEND PLUGINS botan)
 endif()
 
 # Configure and build
@@ -56,13 +55,13 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DUSE_RELATIVE_PATHS=ON
+        "-DBUILD_PLUGINS=${PLUGINS}"
         -DBUILD_TESTS=OFF
         -DBUILD_TOOLS=OFF
         -DBUILD_WITH_QT6=ON
         -DQCA_SUFFIX=OFF
         -DQCA_FEATURE_INSTALL_DIR=share/qca/mkspecs/features
         -DOSX_FRAMEWORK=OFF
-        ${QCA_OPTIONS}
     OPTIONS_DEBUG
         -DQCA_PLUGINS_INSTALL_DIR=${QCA_FEATURE_INSTALL_DIR_DEBUG}
     OPTIONS_RELEASE

--- a/ports/qca/vcpkg.json
+++ b/ports/qca/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qca",
   "version": "2.3.5",
+  "port-version": 1,
   "description": "Qt Cryptographic Architecture (QCA).",
   "homepage": "https://userbase.kde.org/QCA",
   "dependencies": [
@@ -28,7 +29,11 @@
     "botan": {
       "description": "Build with botan",
       "dependencies": [
-        "botan"
+        "botan",
+        {
+          "name": "pkgconf",
+          "host": true
+        }
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6362,7 +6362,7 @@
     },
     "qca": {
       "baseline": "2.3.5",
-      "port-version": 0
+      "port-version": 1
     },
     "qcustomplot": {
       "baseline": "2.1.1",

--- a/versions/q-/qca.json
+++ b/versions/q-/qca.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5af940aef31f91feea8cb12daddb268a7cf4608",
+      "version": "2.3.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "8d7c38d61627baf7ae04a7f069fad8f506e5f82d",
       "version": "2.3.5",
       "port-version": 0


### PR DESCRIPTION
Disables all plugins except for a controlled list. Adding any other plugin requires declaring dependencies.
Fixes some regressions from https://dev.azure.com/vcpkg/public/_build/results?buildId=87700&view=results

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
