### PR TITLE
[qpid-proton] Update, fix dependency control

### DIFF
--- a/ports/qpid-proton/fix-dependencies.patch
+++ b/ports/qpid-proton/fix-dependencies.patch
@@ -1,26 +1,23 @@
 diff --git a/c/CMakeLists.txt b/c/CMakeLists.txt
-index 27b40e7..a3a5d38 100644
+index 27b40e7..81de970 100644
 --- a/c/CMakeLists.txt
 +++ b/c/CMakeLists.txt
-@@ -377,11 +377,15 @@ if (PROACTOR STREQUAL "iocp" OR (NOT PROACTOR AND NOT PROACTOR_OK))
+@@ -377,8 +377,13 @@ if (PROACTOR STREQUAL "iocp" OR (NOT PROACTOR AND NOT PROACTOR_OK))
  endif()
  
  if (PROACTOR STREQUAL "libuv" OR (NOT PROACTOR AND NOT PROACTOR_OK))
 -  find_package(Libuv)
 +  find_package(Libuv NAMES libuv CONFIG)
    if (Libuv_FOUND)
++    if (TARGET uv)
++      add_library(Libuv::Libuv ALIAS uv)
++    else()
++      add_library(Libuv::Libuv ALIAS uv_a)
++    endif()
      set (PROACTOR_OK libuv)
      set (qpid-proton-proactor src/proactor/libuv.c ${qpid-proton-proactor-common})
--    set (PROACTOR_LIBS Libuv::Libuv)
-+    if (TARGET uv)
-+    set (PROACTOR_LIBS uv)
-+    else()
-+    set (PROACTOR_LIBS uv_a)
-+    endif()
-   endif()
- endif()
- 
-@@ -727,11 +731,6 @@ install (FILES
+     set (PROACTOR_LIBS Libuv::Libuv)
+@@ -727,11 +732,6 @@ install (FILES
    ${CMAKE_CURRENT_BINARY_DIR}/ProtonConfig.cmake
    ${CMAKE_CURRENT_BINARY_DIR}/ProtonConfigVersion.cmake
    DESTINATION ${LIB_INSTALL_DIR}/cmake/Proton)
@@ -33,74 +30,48 @@ index 27b40e7..a3a5d38 100644
  if (ENABLE_BENCHMARKS)
    add_subdirectory(benchmarks)
 diff --git a/c/src/ProtonConfig.cmake.in b/c/src/ProtonConfig.cmake.in
-index 6bcc3c0..2f03dc4 100644
+index 3eca7bc..fe27234 100644
 --- a/c/src/ProtonConfig.cmake.in
 +++ b/c/src/ProtonConfig.cmake.in
-@@ -23,7 +23,8 @@
+@@ -23,7 +23,7 @@
  # URL: http://qpid.apache.org/proton/
  
  @PACKAGE_INIT@
 -if (NOT Proton_USE_STATIC_LIBS)
-+include(CMakeFindDependencyMacro)
-+if (1)
++if ("1")
    include("${CMAKE_CURRENT_LIST_DIR}/ProtonTargets.cmake")
  else()
    include("${CMAKE_CURRENT_LIST_DIR}/ProtonTargetsStatic.cmake")
-@@ -32,24 +33,21 @@ endif()
+@@ -32,9 +32,8 @@ endif()
  set(Proton_VERSION @PN_VERSION@)
  
  # find dependencies, because static libs don't transitively pull them
 -if (Proton_USE_STATIC_LIBS)
--    set(CMAKE_MODULE_PATH_OLD ${CMAKE_MODULE_PATH})
++if ("1")
+     set(CMAKE_MODULE_PATH_OLD ${CMAKE_MODULE_PATH})
 -    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-+if (1)
  
      set(CyrusSASL_FOUND @CyrusSASL_FOUND@)
      if (CyrusSASL_FOUND)
--        find_package (CyrusSASL REQUIRED)
-+        find_dependency (CyrusSASL)
-     endif()
- 
-     set(OPENSSL_FOUND @OPENSSL_FOUND@)
-     set(OpenSSL_FOUND @OpenSSL_FOUND@)
-     if (OPENSSL_FOUND OR OpenSSL_FOUND)
--        find_package (OpenSSL REQUIRED)
-+        find_dependency (OpenSSL)
-     endif()
- 
--    find_package (Threads REQUIRED)
-+    find_dependency (Threads)
- 
--    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_OLD})
- endif()
- 
- set (Proton_INCLUDE_DIRS @PACKAGE_INCLUDE_INSTALL_DIR@)
 diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
-index 03fe80a..89c14ed 100644
+index 2049fe9..3dc8a06 100644
 --- a/cpp/CMakeLists.txt
 +++ b/cpp/CMakeLists.txt
-@@ -26,12 +26,15 @@ find_package(Threads)
+@@ -26,10 +26,10 @@ find_package(Threads)
  include(versions.cmake)
  
  # Check for JSON-CPP support for connection configuration
 -find_package(JsonCpp)
--option(ENABLE_JSONCPP "Use jsoncpp parser for connection configuration" ${JsonCpp_FOUND})
-+option(ENABLE_JSONCPP "Use jsoncpp parser for connection configuration" OFF)
+ option(ENABLE_JSONCPP "Use jsoncpp parser for connection configuration" ${JsonCpp_FOUND})
  if (ENABLE_JSONCPP)
 -  include_directories(${JsonCpp_INCLUDE_DIRS})
-+  find_package(jsoncpp CONFIG REQUIRED)
++  find_package(JsonCpp NAMES jsoncpp CONFIG REQUIRED)
++  set(JsonCpp_LIBRARY JsonCpp::JsonCpp)
    set(CONNECT_CONFIG_SRC src/connect_config.cpp)
--  set(CONNECT_CONFIG_LIBS ${JsonCpp_LIBRARY})
-+  if (TARGET jsoncpp_lib)
-+    set(CONNECT_CONFIG_LIBS jsoncpp_lib)
-+  elseif (TARGET jsoncpp_static)
-+    set(CONNECT_CONFIG_LIBS jsoncpp_static)
-+  endif()
+   set(CONNECT_CONFIG_LIBS ${JsonCpp_LIBRARY})
  else()
-   set(CONNECT_CONFIG_SRC src/connect_config_dummy.cpp)
- endif()
 diff --git a/cpp/ProtonCppConfig.cmake.in b/cpp/ProtonCppConfig.cmake.in
-index 74ddfaa..2fece73 100644
+index aaa1bf9..e1be025 100644
 --- a/cpp/ProtonCppConfig.cmake.in
 +++ b/cpp/ProtonCppConfig.cmake.in
 @@ -23,7 +23,9 @@

--- a/ports/qpid-proton/portfile.cmake
+++ b/ports/qpid-proton/portfile.cmake
@@ -3,10 +3,11 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/qpid-proton
-    REF fee5e94afb83b92ffa60a6f815d5102a67915166 # 0.37.0
-    SHA512 e9fbd02444dd073908186e6873b4e230e0a5971929e9b1a49758240d166f6da4e6c88d701c66d5e5539bea0beca380c763bffcef5b0e1ed5f9fc2691f5f86559 
+    REF "${VERSION}"
+    SHA512 05c3fded3db1fae0e6a7b9fbe34fe17af41a676a584ee916cbbeb82e957d7da74861524c5db06634326c403fabc82fddf938d018d9383745a6ce0cbc7a9eada3 
     HEAD_REF next
-    PATCHES fix-dependencies.patch
+    PATCHES
+        fix-dependencies.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/tools/cmake/Modules/FindPython.cmake")
@@ -24,10 +25,13 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE # It may cause call CHECK_LIBRARY_EXISTS before call project to set the language
     OPTIONS
-        -DBUILD_GO=no
+        -DBUILD_BINDINGS=cpp
         -DCMAKE_DISABLE_FIND_PACKAGE_CyrusSASL=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_SWIG=ON
         -DENABLE_JSONCPP=ON
         -DENABLE_LINKTIME_OPTIMIZATION=OFF
+        -DENABLE_OPENTELEMETRYCPP=OFF
         -DLIB_SUFFIX=
         -DENABLE_WARNING_ERROR=OFF
         -DENABLE_BENCHMARKS=OFF
@@ -39,28 +43,27 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 
 # qpid-proton installs tests into share/proton; this is not desireable
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/proton")
 
-vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME Proton
+    PACKAGE_NAME proton
     CONFIG_PATH lib/cmake/Proton
     DO_NOT_DELETE_PARENT_CONFIG_PATH
 )
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME ProtonCpp
+    PACKAGE_NAME protoncpp
     CONFIG_PATH lib/cmake/ProtonCpp
 )
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/proton/version.h" "#define PN_INSTALL_PREFIX \"${CURRENT_PACKAGES_DIR}\"" "")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-    RENAME copyright
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qpid-proton",
-  "version": "0.37.0",
-  "port-version": 3,
+  "version": "0.38.0",
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
   "homepage": "https://github.com/apache/qpid-proton",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6381,8 +6381,8 @@
       "port-version": 3
     },
     "qpid-proton": {
-      "baseline": "0.37.0",
-      "port-version": 3
+      "baseline": "0.38.0",
+      "port-version": 0
     },
     "qscintilla": {
       "baseline": "2.13.4",

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "848bfbdf75b68fadddcddd6c501d095a8f21f63d",
+      "version": "0.38.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "32527f3a05b41a04ad42ab2e0827dfee69b18ec0",
       "version": "0.37.0",
       "port-version": 3


### PR DESCRIPTION
Fixes build error with swig installed locally.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
