### PR TITLE
[gstreamer] Added feature to enable bzip2 support in plugins

### DIFF
--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -142,6 +142,12 @@ endif()
 
 # Good optional plugins
 
+if("bzip2-good" IN_LIST FEATURES)
+    set(PLUGIN_GOOD_BZ2 enabled)
+else()
+    set(PLUGIN_GOOD_BZ2 disabled)
+endif()
+
 if("cairo" IN_LIST FEATURES)
     set(PLUGIN_GOOD_CAIRO enabled)
 else()
@@ -224,6 +230,12 @@ if("assrender" IN_LIST FEATURES)
     set(PLUGIN_BAD_ASSRENDER enabled)
 else()
     set(PLUGIN_BAD_ASSRENDER disabled)
+endif()
+
+if("bzip2-bad" IN_LIST FEATURES)
+    set(PLUGIN_BAD_BZ2 enabled)
+else()
+    set(PLUGIN_BAD_BZ2 disabled)
 endif()
 
 if("chromaprint" IN_LIST FEATURES)
@@ -459,7 +471,7 @@ vcpkg_configure_meson(
         # gst-plugins-good
         -Dgood=${PLUGIN_GOOD_SUPPORT}
         -Dgst-plugins-good:aalib=disabled
-        -Dgst-plugins-good:bz2=disabled
+        -Dgst-plugins-good:bz2=${PLUGIN_GOOD_BZ2}
         -Dgst-plugins-good:directsound=auto
         -Dgst-plugins-good:dv=disabled
         -Dgst-plugins-good:dv1394=disabled
@@ -508,7 +520,7 @@ vcpkg_configure_meson(
         -Dgst-plugins-bad:assrender=${PLUGIN_BAD_ASSRENDER}
         -Dgst-plugins-bad:bluez=disabled
         -Dgst-plugins-bad:bs2b=disabled
-        -Dgst-plugins-bad:bz2=disabled # Error during plugin configuration
+        -Dgst-plugins-bad:bz2=${PLUGIN_BAD_BZ2}
         -Dgst-plugins-bad:chromaprint=${PLUGIN_BAD_CHROMAPRINT}
         -Dgst-plugins-bad:closedcaption=${PLUGIN_BAD_CLOSEDCAPTION}
         -Dgst-plugins-bad:colormanagement=${PLUGIN_BAD_COLORMANAGEMENT}
@@ -550,7 +562,7 @@ vcpkg_configure_meson(
         -Dgst-plugins-bad:msdk=disabled
         -Dgst-plugins-bad:musepack=disabled
         -Dgst-plugins-bad:neon=disabled
-        -Dgst-plugins-bad:nvcodec=disabled
+        -Dgst-plugins-bad:nvcodec=enabled
         -Dgst-plugins-bad:onnx=disabled # libonnxruntime not found
         -Dgst-plugins-bad:openal=${PLUGIN_BAD_OPENAL}
         -Dgst-plugins-bad:openaptx=disabled

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.20.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",
@@ -81,6 +81,32 @@
           ]
         },
         "libass"
+      ]
+    },
+    "bzip2-bad": {
+      "description": "Enable bzip2 stream compression in bad plugins",
+      "dependencies": [
+        "bzip2",
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "features": [
+            "plugins-bad"
+          ]
+        }
+      ]
+    },
+    "bzip2-good": {
+      "description": "Enable bzip2 stream compression in good plugins",
+      "dependencies": [
+        "bzip2",
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "features": [
+            "plugins-good"
+          ]
+        }
       ]
     },
     "cairo": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2950,7 +2950,7 @@
     },
     "gstreamer": {
       "baseline": "1.20.5",
-      "port-version": 3
+      "port-version": 4
     },
     "gtest": {
       "baseline": "1.13.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "084ea66aed42ba882e19b103de4042d676be1530",
+      "version": "1.20.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "e9724606bfcc594bbdde72fbcba7fbd019312ae6",
       "version": "1.20.5",
       "port-version": 3


### PR DESCRIPTION
* Enabled nvcodec plugins

#### update port checklist:
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.