### PR TITLE
[openmama] Fixes

### DIFF
--- a/ports/openmama/fix-dependencies.diff
+++ b/ports/openmama/fix-dependencies.diff
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1332a55..2ed3770 100755
+@@ -123,7 +125,8 @@ find_package(Threads REQUIRED)
+ find_package(APR REQUIRED)
+ 
+ if (WITH_PROTON)
+-    find_package(Proton REQUIRED)
++    find_package(PROTON NAMES Proton REQUIRED)
++    set(PROTON_LIBRARIES Proton::qpid-proton)
+ endif()
+ 
+ if (WITH_UNITTEST)
+diff --git a/cmake/FindUUID.cmake b/cmake/FindUUID.cmake
+index 7a11c70..07f21ed 100644
+--- a/cmake/FindUUID.cmake
++++ b/cmake/FindUUID.cmake
+@@ -90,6 +90,9 @@ else (UUID_LIBRARIES AND UUID_INCLUDE_DIRS)
+ 
+   if (UUID_INCLUDE_DIRS AND UUID_LIBRARIES)
+      set(UUID_FOUND TRUE)
++  elseif(UUID_INCLUDE_DIRS AND APPLE)
++     set(UUID_LIBRARIES "")
++     set(UUID_FOUND TRUE)
+   endif (UUID_INCLUDE_DIRS AND UUID_LIBRARIES)
+ 
+   if (UUID_FOUND)

--- a/ports/openmama/git-no-tags.diff
+++ b/ports/openmama/git-no-tags.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1332a55..2ed3770 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,6 +23,8 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+             COMMAND "${GIT_BIN}" diff-index --quiet HEAD --
+             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+             RESULT_VARIABLE is_current_source_dir_dirty)
++endif()
++if(OPENMAMA_VERSION_GIT)
+     # Strip out unwanted part of version from git
+     message(STATUS "OPENMAMA_VERSION_GIT: ${OPENMAMA_VERSION_GIT}")
+     STRING(REGEX REPLACE "^OpenMAMA-" "" OPENMAMA_VERSION ${OPENMAMA_VERSION_GIT})

--- a/ports/openmama/portfile.cmake
+++ b/ports/openmama/portfile.cmake
@@ -1,41 +1,36 @@
-vcpkg_find_acquire_program(FLEX)
-vcpkg_find_acquire_program(GIT)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO finos/OpenMAMA
-    REF OpenMAMA-${VERSION}-release
+    REF "OpenMAMA-${VERSION}-release"
     SHA512 bf6a9343546ace80b8a72072f97aa85988a3d0d047e2a60d05de638afce89b4e4f2bcae28b8e93ca808e8c0e4a83de9035ff785f69f9b4ac4ccd2616e792fa08
     HEAD_REF next
+    PATCHES
+        git-no-tags.diff
+        fix-dependencies.diff
 )
+
+vcpkg_find_acquire_program(FLEX)
+vcpkg_find_acquire_program(GIT)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DOPENMAMA_DEPENDENCY_ROOT=${CURRENT_INSTALLED_DIR}"
         -DINSTALL_RUNTIME_DEPENDENCIES=OFF
-        -DFLEX_EXECUTABLE=${FLEX}
-        -DGIT_BIN=${GIT}
-        -DOPENMAMA_VERSION=${VERSION}
+        "-DFLEX_EXECUTABLE=${FLEX}"
+        "-DGIT_BIN=${GIT}"
+        "-DOPENMAMA_VERSION=${VERSION}"
         -DWITH_EXAMPLES=OFF
         -DWITH_TESTTOOLS=OFF
 )
-
 vcpkg_cmake_install()
-
-# Copy across license files and copyright
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md" "${SOURCE_PATH}/LICENSE-3RD-PARTY.txt")
-
-# Clean up LICENSE file - vcpkg doesn't expect it to be there
-file(REMOVE "${CURRENT_PACKAGES_DIR}/LICENSE.md" "${CURRENT_PACKAGES_DIR}/debug/LICENSE.md")
-
-# Vcpkg does not expect include files to be in the debug directory
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(
-    PACKAGE_NAME OpenMAMA
-    CONFIG_PATH lib/cmake/OpenMAMA
-    DO_NOT_DELETE_PARENT_CONFIG_PATH
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/OpenMAMA)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/LICENSE.md"
+    "${CURRENT_PACKAGES_DIR}/debug/LICENSE.md"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
 )
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake" "${CURRENT_PACKAGES_DIR}/lib/cmake")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/openmama/vcpkg.json
+++ b/ports/openmama/vcpkg.json
@@ -1,16 +1,29 @@
 {
   "name": "openmama",
   "version-semver": "6.3.2",
+  "port-version": 1,
   "description": "OpenMAMA is a high performance vendor neutral lightweight wrapper that provides a common API interface to different middleware and messaging solutions across a variety of platforms and languages",
   "homepage": "https://github.com/finos/OpenMAMA",
   "license": "LGPL-2.1",
-  "supports": "windows & (x64 | x86)",
   "dependencies": [
     "apr",
     "apr-util",
     "libevent",
-    "qpid-proton",
-    "vcpkg-cmake",
-    "vcpkg-cmake-config"
+    {
+      "name": "libuuid",
+      "platform": "!windows & !osx"
+    },
+    {
+      "name": "qpid-proton",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5826,7 +5826,7 @@
     },
     "openmama": {
       "baseline": "6.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "openmesh": {
       "baseline": "9.0",

--- a/versions/o-/openmama.json
+++ b/versions/o-/openmama.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a928ad97fe18f50da889c2e468f5070d1c4e4b6",
+      "version-semver": "6.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "a385a51389791fdee1a47efdcfec5fffa7c4cbd3",
       "version-semver": "6.3.2",
       "port-version": 0


### PR DESCRIPTION
Amends #30671.

- [x] Restore host property of vcpkg script port dependencies.
- [x] Fix build with git clone which doesn't have upstream tags. (Useful for local vcpkg patch maintenance.)
   - [x] Rewrite for upstream.
- [x] Fix linux (officially supported).
- ~[ ] Build either static or dynamic, not both.~ Not in this PR.
- [x] Portfile cleanup.

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
