### PR TITLE
[ffmpeg] Osx cross fix

### DIFF
--- a/ports/ffmpeg/build.sh.in
+++ b/ports/ffmpeg/build.sh.in
@@ -130,7 +130,7 @@ build_ffmpeg() {
 
 cd "$PATH_TO_BUILD_DIR"
 
-if [ $OSX_ARCH_COUNT -gt 1 ]; then
+if [ $OSX_ARCH_COUNT -gt 0 ]; then
     for ARCH in $OSX_ARCHS; do
         echo "=== CLEANING FOR $ARCH ==="
 

--- a/ports/ffmpeg/build.sh.in
+++ b/ports/ffmpeg/build.sh.in
@@ -136,7 +136,7 @@ if [ $OSX_ARCH_COUNT -gt 0 ]; then
 
         make clean && make distclean
 
-        build_ffmpeg $ARCH --enable-cross-compile --extra-cflags=-arch --extra-cflags=$ARCH --extra-ldflags=-arch --extra-ldflags=$ARCH
+        build_ffmpeg $ARCH --extra-cflags=-arch --extra-cflags=$ARCH --extra-ldflags=-arch --extra-ldflags=$ARCH
 
         echo "=== COLLECTING BINARIES FOR $ARCH ==="
 

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -513,7 +513,7 @@ else()
     set(OPTIONS "${OPTIONS} --disable-libmfx")
 endif()
 
-set(OPTIONS_CROSS " --enable-cross-compile")
+set(OPTIONS_CROSS "--enable-cross-compile")
 
 # ffmpeg needs --cross-prefix option to use appropriate tools for cross-compiling.
 if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "([^\/]*-)gcc$")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "5.1.2",
-  "port-version": 5,
+  "port-version": 6,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2450,7 +2450,7 @@
     },
     "ffmpeg": {
       "baseline": "5.1.2",
-      "port-version": 5
+      "port-version": 6
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7e0c378cd0a6564b28c28d6d970e3d633b4382e",
+      "version": "5.1.2",
+      "port-version": 6
+    },
+    {
       "git-tree": "14577b12f56accfce4428caf17e4b47542f365ec",
       "version": "5.1.2",
       "port-version": 5


### PR DESCRIPTION
Fixes #30659

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
