### PR TITLE
[vcpkg baseline][qca] Fix pkgconfig dependency properly

### DIFF
--- a/ports/qca/portfile.cmake
+++ b/ports/qca/portfile.cmake
@@ -19,6 +19,8 @@ vcpkg_from_github(
         0003-Define-NOMINMAX-for-botan-plugin-with-MSVC.patch
 )
 
+vcpkg_find_acquire_program(PKGCONFIG)
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
   set(QCA_FEATURE_INSTALL_DIR_DEBUG ${CURRENT_PACKAGES_DIR}/debug/bin/Qca)
   set(QCA_FEATURE_INSTALL_DIR_RELEASE ${CURRENT_PACKAGES_DIR}/bin/Qca)
@@ -62,6 +64,7 @@ vcpkg_cmake_configure(
         -DQCA_SUFFIX=OFF
         -DQCA_FEATURE_INSTALL_DIR=share/qca/mkspecs/features
         -DOSX_FRAMEWORK=OFF
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
     OPTIONS_DEBUG
         -DQCA_PLUGINS_INSTALL_DIR=${QCA_FEATURE_INSTALL_DIR_DEBUG}
     OPTIONS_RELEASE

--- a/ports/qca/vcpkg.json
+++ b/ports/qca/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qca",
   "version": "2.3.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Cryptographic Architecture (QCA).",
   "homepage": "https://userbase.kde.org/QCA",
   "dependencies": [
@@ -29,11 +29,7 @@
     "botan": {
       "description": "Build with botan",
       "dependencies": [
-        "botan",
-        {
-          "name": "pkgconf",
-          "host": true
-        }
+        "botan"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6362,7 +6362,7 @@
     },
     "qca": {
       "baseline": "2.3.5",
-      "port-version": 1
+      "port-version": 2
     },
     "qcustomplot": {
       "baseline": "2.1.1",

--- a/versions/q-/qca.json
+++ b/versions/q-/qca.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd2cceadc6f23f9c6fc3a77683d4e8bb42ab5105",
+      "version": "2.3.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "a5af940aef31f91feea8cb12daddb268a7cf4608",
       "version": "2.3.5",
       "port-version": 1

--- a/versions/q-/qca.json
+++ b/versions/q-/qca.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fd2cceadc6f23f9c6fc3a77683d4e8bb42ab5105",
+      "git-tree": "32321bfdc0e4563ed40687585b48038d551f6149",
       "version": "2.3.5",
       "port-version": 2
     },


### PR DESCRIPTION
Amends #30686. 
Now using proper `vcpkg_find_aquire_prorgram`, same pattern as in curl.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
