### PR TITLE
[pcre2] add unofficial-pcre2 cmake config

### DIFF
--- a/ports/pcre2/pcre2-config.in.cmake
+++ b/ports/pcre2/pcre2-config.in.cmake
@@ -1,9 +1,3 @@
-
-if(NOT WIN32)
-    include(CMakeFindDependencyMacro)
-    find_dependency(Threads)
-endif()
-
 include(${CMAKE_CURRENT_LIST_DIR}/unofficial-pcre2-targets.cmake)
 
 if ("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static" AND TARGET unofficial::pcre2::pcre2-8-static)

--- a/ports/pcre2/pcre2-config.in.cmake
+++ b/ports/pcre2/pcre2-config.in.cmake
@@ -1,0 +1,13 @@
+
+if(NOT WIN32)
+    include(CMakeFindDependencyMacro)
+    find_dependency(Threads)
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/unofficial-pcre2-targets.cmake)
+
+if ("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static" AND TARGET unofficial::pcre2::pcre2-8-static)
+    add_library(unofficial::pcre2::pcre2 ALIAS unofficial::pcre2::pcre2-8-static)
+elseif("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "dynamic" AND TARGET unofficial::pcre2::pcre2-8-shared)
+    add_library(unofficial::pcre2::pcre2 ALIAS unofficial::pcre2::pcre2-8-shared)
+endif()

--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         pcre2-10.35_fix-uwp.patch
         no-static-suffix.patch
+        unofficial_cmake.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
@@ -49,6 +50,7 @@ endif()
 file(WRITE "${CURRENT_PACKAGES_DIR}/include/pcre2.h" "${PCRE2_H}")
 
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH share/unofficial-${PORT})
 
 # The cmake file provided by pcre2 has some problems, so don't use it for now.
 #vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
@@ -68,5 +70,11 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/bin/pcre2-config" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../..")
     endif()
 endif()
+
+configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/${PORT}-config.in.cmake"
+    "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-${PORT}-config.cmake"
+    @ONLY
+)
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/pcre2/unofficial_cmake.patch
+++ b/ports/pcre2/unofficial_cmake.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3bf5317..e02ec5f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1024,10 +1024,13 @@ ENDIF(PCRE2_BUILD_TESTS)
+ 
+ SET(CMAKE_INSTALL_ALWAYS 1)
+ 
++
+ INSTALL(TARGETS ${targets}
++        EXPORT unofficial-pcre2-targets
+         RUNTIME DESTINATION bin
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(EXPORT unofficial-pcre2-targets NAMESPACE unofficial::pcre2:: FILE unofficial-pcre2-targets.cmake DESTINATION share/unofficial-pcre2)
+ INSTALL(FILES ${pkg_config_files} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/pcre2-config"
+   DESTINATION bin

--- a/ports/pcre2/vcpkg.json
+++ b/ports/pcre2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pcre2",
   "version": "10.40",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Regular Expression pattern matching using the same syntax and semantics as Perl 5.",
   "homepage": "https://github.com/PCRE2Project/pcre2",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6042,7 +6042,7 @@
     },
     "pcre2": {
       "baseline": "10.40",
-      "port-version": 1
+      "port-version": 2
     },
     "pdal": {
       "baseline": "2.4.3",

--- a/versions/p-/pcre2.json
+++ b/versions/p-/pcre2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7381ef80a9e51b71b3c31584f81673e7042332d7",
+      "git-tree": "a0e237452146b7449735fe0a396c4250c4b5746d",
       "version": "10.40",
       "port-version": 2
     },

--- a/versions/p-/pcre2.json
+++ b/versions/p-/pcre2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7381ef80a9e51b71b3c31584f81673e7042332d7",
+      "version": "10.40",
+      "port-version": 2
+    },
+    {
       "git-tree": "941f187c16a9385815fd353a9b79abf55bd2a7ec",
       "version": "10.40",
       "port-version": 1


### PR DESCRIPTION
- [pcre2] add unoffical-pcre cmake config
- ./vcpkg x-add-version --all

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
