### PR TITLE
[poco] use unofficial pcre2

### DIFF
--- a/ports/poco/0007-find-pcre2.patch
+++ b/ports/poco/0007-find-pcre2.patch
@@ -1,33 +1,14 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8842c76..b887168 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -491,6 +491,11 @@ install(
- 		Devel
- )
- 
-+if(POCO_UNBUNDLED)
-+	install(FILES cmake/FindPCRE2.cmake
-+			DESTINATION "${PocoConfigPackageLocation}")
-+endif()
-+
- message(STATUS "CMake ${CMAKE_VERSION} successfully configured ${PROJECT_NAME} using ${CMAKE_GENERATOR} generator")
- message(STATUS "${PROJECT_NAME} package version: ${PROJECT_VERSION}")
- if(BUILD_SHARED_LIBS)
 diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
 index 226dadb..a3765a7 100644
 --- a/Foundation/CMakeLists.txt
 +++ b/Foundation/CMakeLists.txt
-@@ -35,8 +35,11 @@ POCO_MESSAGES(SRCS Logging src/pocomsg.mc)
+@@ -35,8 +35,8 @@ POCO_MESSAGES(SRCS Logging src/pocomsg.mc)
  # If POCO_UNBUNDLED is enabled we try to find the required packages
  # The configuration will fail if the packages are not found
  if(POCO_UNBUNDLED)
 -	find_package(PCRE2 REQUIRED)
++	find_package(unofficial-pcre2 REQUIRED)
  	find_package(ZLIB REQUIRED)
-+	include(SelectLibraryConfigurations)
-+	find_library(PCRE2_LIBRARY_DEBUG NAMES pcre2-8d pcre2-8-staticd HINTS ${INSTALLED_LIB_PATH})
-+	find_library(PCRE2_LIBRARY_RELEASE NAMES pcre2-8 pcre2-8-static HINTS ${INSTALLED_LIB_PATH})
-+	select_library_configurations(PCRE2)
  
  	#HACK: Unicode.cpp requires functions from these files. The can't be taken from the library
  	POCO_SOURCES(SRCS RegExp
@@ -36,59 +17,21 @@ index 226dadb..a3765a7 100644
  
  if(POCO_UNBUNDLED)
 -	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB)
-+	target_link_libraries(Foundation PUBLIC ${PCRE2_LIBRARY} ZLIB::ZLIB)
++	target_link_libraries(Foundation PUBLIC unofficial::pcre2::pcre2 ZLIB::ZLIB)
  	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
  	add_definitions(
  		-D_pcre2_utf8_table1=_poco_pcre2_utf8_table1
-diff --git a/cmake/FindPCRE2.cmake b/cmake/FindPCRE2.cmake
-index e730f32..6e10df2 100644
---- a/cmake/FindPCRE2.cmake
-+++ b/cmake/FindPCRE2.cmake
-@@ -54,7 +54,7 @@ Hints
- include(FindPackageHandleStandardArgs)
- 
- find_package(PkgConfig QUIET)
--pkg_check_modules(PC_PCRE2 QUIET pcre2)
-+pkg_check_modules(PC_PCRE2 QUIET libpcre2-8)
- 
- find_path(PCRE2_INCLUDE_DIR
-   NAMES pcre2.h
-@@ -66,8 +66,8 @@ find_path(PCRE2_INCLUDE_DIR
-   DOC "Specify the include directory containing pcre2.h"
- )
- 
--find_library(PCRE2_LIBRARY
--  NAMES pcre2-8
-+find_library(PCRE2_LIBRARY_DEBUG
-+  NAMES pcre2-8d pcre2-8-staticd
-   HINTS
-         ${PCRE2_ROOT_DIR}/lib
-         ${PCRE2_ROOT_LIBRARY_DIRS}
-@@ -76,6 +76,19 @@ find_library(PCRE2_LIBRARY
-   DOC "Specify the lib directory containing pcre2"
- )
- 
-+find_library(PCRE2_LIBRARY_RELEASE
-+  NAMES pcre2-8 pcre2-8-static
-+  HINTS
-+        ${PCRE2_ROOT_DIR}/lib
-+        ${PCRE2_ROOT_LIBRARY_DIRS}
-+  PATHS
-+        ${PC_PCRE2_LIBRARY_DIRS}
-+  DOC "Specify the lib directory containing pcre2"
-+)
-+
-+include(SelectLibraryConfigurations)
-+select_library_configurations(PCRE2)
-+
- set(PCRE2_VERSION ${PC_PCRE2_VERSION})
- 
- find_package_handle_standard_args(PCRE2
-@@ -87,7 +100,6 @@ find_package_handle_standard_args(PCRE2
- )
- 
- if(PCRE2_FOUND)
--  set(PCRE2_LIBRARIES ${PCRE2_LIBRARY})
-   set(PCRE2_INCLUDE_DIRS ${PCRE2_INCLUDE_DIR})
-   set(PCRE2_DEFINITIONS ${PC_PCRE2_CFLAGS_OTHER})
+diff --git a/Foundation/cmake/PocoFoundationConfig.cmake b/Foundation/cmake/PocoFoundationConfig.cmake
+index 82c5788..5a3cb23 100644
+--- a/Foundation/cmake/PocoFoundationConfig.cmake
++++ b/Foundation/cmake/PocoFoundationConfig.cmake
+@@ -2,7 +2,7 @@ if(@POCO_UNBUNDLED@)
+        include(CMakeFindDependencyMacro)
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+        find_dependency(ZLIB REQUIRED)
+-       find_dependency(PCRE2 REQUIRED)
++       find_dependency(unofficial-pcre2 REQUIRED)
  endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/PocoFoundationTargets.cmake")
+ 

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -18,8 +18,7 @@ vcpkg_from_github(
 file(REMOVE "${SOURCE_PATH}/Foundation/src/pcre2.h")
 file(REMOVE "${SOURCE_PATH}/cmake/V39/FindEXPAT.cmake")
 file(REMOVE "${SOURCE_PATH}/cmake/V313/FindSQLite3.cmake")
-# vcpkg's PCRE2 does not provide a FindPCRE2, and the bundled one seems to work fine
-# file(REMOVE "${SOURCE_PATH}/cmake/FindPCRE2.cmake")
+file(REMOVE "${SOURCE_PATH}/cmake/FindPCRE2.cmake")
 file(REMOVE "${SOURCE_PATH}/XML/src/expat_config.h")
 file(REMOVE "${SOURCE_PATH}/cmake/FindMySQL.cmake")
 

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "poco",
   "version": "1.12.4",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6194,7 +6194,7 @@
     },
     "poco": {
       "baseline": "1.12.4",
-      "port-version": 4
+      "port-version": 5
     },
     "podofo": {
       "baseline": "0.9.8",

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "378c614aabe267d45a3dee5f665219e579682a69",
+      "version": "1.12.4",
+      "port-version": 5
+    },
+    {
       "git-tree": "5fb22214a00901cbf3697a76442f5f360cbc74ef",
       "version": "1.12.4",
       "port-version": 4


### PR DESCRIPTION
- [poco] use new unofficial-pcre
- ./vcpkg x-add-version --all

Depends on https://github.com/microsoft/vcpkg/pull/30704

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
