### PR TITLE
[mimalloc] update to 2.1.1 to build failure

### DIFF
--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/mimalloc
-    REF v2.0.9
-    SHA512 bf6945bfb600ade35dab34c7f570ee4f69a77612547ad874bbbd989a4e594a6a219c222a22c90c5e36f205aae4d5cd1a5e4651caed5433db275d414c6769bf49
+    REF "v${VERSION}"
+    SHA512 01c7bdfd001ebc34bb0918fe4ecff42a4ec316fbbd73d4dda52c93c31e5712595758a595ae7ea436f445ecc0ebbf7f9c63d9c572f1c1c5a9e96f51fc524a4875
     HEAD_REF master
     PATCHES
         fix-cmake.patch
@@ -55,4 +55,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -35,8 +35,6 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_copy_pdbs()
-
 file(COPY
     "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"

--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -35,6 +35,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+vcpkg_copy_pdbs()
+
 file(COPY
     "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mimalloc",
-  "version": "2.0.9",
+  "version": "2.1.1",
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5133,7 +5133,7 @@
       "port-version": 6
     },
     "mimalloc": {
-      "baseline": "2.0.9",
+      "baseline": "2.1.1",
       "port-version": 0
     },
     "minc": {

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f6055b5cb8a3a2d744cac4781fed65cf1da1064f",
+      "version": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "aaa17dfe033cf63a5884ab214e39a790181ae8a3",
       "version": "2.0.9",
       "port-version": 0

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f6055b5cb8a3a2d744cac4781fed65cf1da1064f",
+      "git-tree": "0120c72c8d2ec48a9210549180e2a4fe209af8a9",
       "version": "2.1.1",
       "port-version": 0
     },

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0120c72c8d2ec48a9210549180e2a4fe209af8a9",
+      "git-tree": "f6055b5cb8a3a2d744cac4781fed65cf1da1064f",
       "version": "2.1.1",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #29839

Update mimalloc to the latest version 2.1.1 to fix upstream bug.



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static
