### PR TITLE
[vcpkg baseline][libusb] Remove libusb:arm64-windows in ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -479,7 +479,6 @@ libtomcrypt:arm64-windows=fail
 libtomcrypt:arm-uwp=fail
 libusb:arm-uwp=fail
 libusb:x64-uwp=fail
-libusb:arm64-windows=fail
 libusb-win32:arm-uwp=fail
 libusb-win32:x64-linux=fail
 libusb-win32:x64-osx=fail


### PR DESCRIPTION
Fixed [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=87799&view=results) issue:
````
PASSING, REMOVE FROM FAIL LIST: libusb:arm64-windows
````
`libusb:arm64-windows=fail` was added into the `ci.baseline.txt` by PR https://github.com/microsoft/vcpkg/pull/9203, it was fixed in PR https://github.com/microsoft/vcpkg/pull/30335, so remove the records from `ci.baseline.txt`.