### PR TITLE
[libigl] Remove broken features

### DIFF
--- a/ports/libigl/dependencies.patch
+++ b/ports/libigl/dependencies.patch
@@ -1,22 +1,49 @@
-diff --git a/cmake/igl/modules/opengl.cmake b/cmake/igl/modules/opengl.cmake
-index 4580c037..b09d762f 100644
---- a/cmake/igl/modules/opengl.cmake
-+++ b/cmake/igl/modules/opengl.cmake
-@@ -14,11 +14,10 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/*.cpp")
- igl_target_sources(igl_opengl ${INC_FILES} ${SRC_FILES})
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 232bc03..8143963 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,7 +64,7 @@ set(MATLAB_ADDITIONAL_VERSIONS
+ set(LIBIGL_DEFAULT_MATLAB ${LIBIGL_TOPLEVEL_PROJECT})
+ set(LIBIGL_DEFAULT_MOSEK ${LIBIGL_TOPLEVEL_PROJECT})
+ if(LIBIGL_TOPLEVEL_PROJECT)
+-    if(NOT WIN32)
++    if(0)
+         find_package(GMP QUIET)
+         find_package(MPFR QUIET)
+         if(NOT (TARGET gmp::gmp AND TARGET mpfr::mpfr))
+diff --git a/cmake/igl/libigl-config.cmake.in b/cmake/igl/libigl-config.cmake.in
+index 359e314..6e04af6 100644
+--- a/cmake/igl/libigl-config.cmake.in
++++ b/cmake/igl/libigl-config.cmake.in
+@@ -1,3 +1,7 @@
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(Eigen3)
++find_dependency(Threads)
++
+ check_required_components(Libigl)
+diff --git a/cmake/igl/modules/copyleft/cgal.cmake b/cmake/igl/modules/copyleft/cgal.cmake
+index f6abe8c..7ee7d84 100644
+--- a/cmake/igl/modules/copyleft/cgal.cmake
++++ b/cmake/igl/modules/copyleft/cgal.cmake
+@@ -14,13 +14,12 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/cgal/*.cpp")
+ igl_target_sources(igl_copyleft_cgal ${INC_FILES} ${SRC_FILES})
  
  # 4. Dependencies
--include(glad)
- find_package(OpenGL REQUIRED OPTIONAL_COMPONENTS OpenGL)
- target_link_libraries(igl_opengl ${IGL_SCOPE}
+-include(cgal)
++find_package(CGAL CONFIG REQUIRED COMPONENTS Core)
+ igl_include(copyleft core)
+ target_link_libraries(igl_copyleft_cgal ${IGL_SCOPE}
      igl::core
--    glad::glad
-+    glad
-     # Link against OpenGL::OpenGL if available, or fallback to OpenGL::GL
-     $<IF:$<TARGET_EXISTS:OpenGL::OpenGL>,OpenGL::OpenGL,OpenGL::GL>
+     igl_copyleft::core
+     CGAL::CGAL
+-    CGAL::CGAL_Core
  )
+ 
+ # 5. Unit tests
 diff --git a/cmake/igl/modules/core.cmake b/cmake/igl/modules/core.cmake
-index 2aefcd64..137d30bc 100644
+index 2aefcd6..137d30b 100644
 --- a/cmake/igl/modules/core.cmake
 +++ b/cmake/igl/modules/core.cmake
 @@ -20,7 +20,7 @@ igl_target_sources(igl_core ${INC_FILES} ${SRC_FILES})
@@ -29,7 +56,7 @@ index 2aefcd64..137d30bc 100644
  target_link_libraries(igl_core ${IGL_SCOPE}
      Eigen3::Eigen
 diff --git a/cmake/igl/modules/embree.cmake b/cmake/igl/modules/embree.cmake
-index 6f223192..21ce00e3 100644
+index 6f22319..de85066 100644
 --- a/cmake/igl/modules/embree.cmake
 +++ b/cmake/igl/modules/embree.cmake
 @@ -14,10 +14,10 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/embree/*.cpp")
@@ -41,12 +68,12 @@ index 6f223192..21ce00e3 100644
  target_link_libraries(igl_embree ${IGL_SCOPE}
      igl::core
 -    embree::embree
-+    embree
++    $<TARGET_NAME:embree>
  )
  
  # 5. Unit tests
 diff --git a/cmake/igl/modules/glfw.cmake b/cmake/igl/modules/glfw.cmake
-index 151338e4..77c48e58 100644
+index 151338e..f42d22a 100644
 --- a/cmake/igl/modules/glfw.cmake
 +++ b/cmake/igl/modules/glfw.cmake
 @@ -14,10 +14,10 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/glfw/*.cpp")
@@ -60,10 +87,57 @@ index 151338e4..77c48e58 100644
      igl::core
      igl::opengl
 -    glfw::glfw
-+    glfw
++    $<TARGET_NAME:glfw>
  )
+diff --git a/cmake/igl/modules/imgui.cmake b/cmake/igl/modules/imgui.cmake
+index d7ffb9d..f331854 100644
+--- a/cmake/igl/modules/imgui.cmake
++++ b/cmake/igl/modules/imgui.cmake
+@@ -14,14 +14,12 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/glfw/imgui/*.cpp")
+ igl_target_sources(igl_imgui ${INC_FILES} ${SRC_FILES})
+ 
+ # 4. Dependencies
+-include(imgui)
+-include(imguizmo)
+-include(libigl_imgui_fonts)
++find_package(imgui CONFIG REQUIRED)
++find_package(imguizmo CONFIG REQUIRED)
+ igl_include(glfw)
+ target_link_libraries(igl_imgui ${IGL_SCOPE}
+     igl::core
+     igl::glfw
+     imgui::imgui
+     imguizmo::imguizmo
+-    igl::imgui_fonts
+ )
+diff --git a/cmake/igl/modules/opengl.cmake b/cmake/igl/modules/opengl.cmake
+index 4580c03..dfadb38 100644
+--- a/cmake/igl/modules/opengl.cmake
++++ b/cmake/igl/modules/opengl.cmake
+@@ -14,7 +14,7 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/*.cpp")
+ igl_target_sources(igl_opengl ${INC_FILES} ${SRC_FILES})
+ 
+ # 4. Dependencies
+-include(glad)
++find_package(glad CONFIG REQUIRED)
+ find_package(OpenGL REQUIRED OPTIONAL_COMPONENTS OpenGL)
+ target_link_libraries(igl_opengl ${IGL_SCOPE}
+     igl::core
+diff --git a/cmake/igl/modules/png.cmake b/cmake/igl/modules/png.cmake
+index b267deb..8d8decc 100644
+--- a/cmake/igl/modules/png.cmake
++++ b/cmake/igl/modules/png.cmake
+@@ -14,7 +14,7 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/png/*.cpp")
+ igl_target_sources(igl_png ${INC_FILES} ${SRC_FILES})
+ 
+ # 4. Dependencies
+-include(stb)
++find_package(Stb REQUIRED)
+ igl_include(opengl)
+ target_link_libraries(igl_png ${IGL_SCOPE}
+     igl::core
 diff --git a/cmake/igl/modules/xml.cmake b/cmake/igl/modules/xml.cmake
-index 3763b771..31ab979b 100644
+index 3763b77..31ab979 100644
 --- a/cmake/igl/modules/xml.cmake
 +++ b/cmake/igl/modules/xml.cmake
 @@ -14,7 +14,7 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/xml/*.cpp")
@@ -75,46 +149,16 @@ index 3763b771..31ab979b 100644
  target_link_libraries(igl_xml ${IGL_SCOPE}
      igl::core
      tinyxml2::tinyxml2
-
-diff --git a/cmake/igl/modules/imgui.cmake b/cmake/igl/modules/imgui.cmake
-index d7ffb9d4..aac353aa 100644
---- a/cmake/igl/modules/imgui.cmake
-+++ b/cmake/igl/modules/imgui.cmake
-@@ -14,8 +14,8 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/glfw/imgui/*.cpp")
- igl_target_sources(igl_imgui ${INC_FILES} ${SRC_FILES})
- 
- # 4. Dependencies
--include(imgui)
--include(imguizmo)
-+find_package(imgui CONFIG REQUIRED)
-+find_package(imguizmo CONFIG REQUIRED)
- include(libigl_imgui_fonts)
- igl_include(glfw)
- target_link_libraries(igl_imgui ${IGL_SCOPE}
-diff --git a/cmake/igl/modules/copyleft/cgal.cmake b/cmake/igl/modules/copyleft/cgal.cmake
-index f6abe8c3..125dd701 100644
---- a/cmake/igl/modules/copyleft/cgal.cmake
-+++ b/cmake/igl/modules/copyleft/cgal.cmake
-@@ -14,13 +14,18 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/cgal/*.cpp")
- igl_target_sources(igl_copyleft_cgal ${INC_FILES} ${SRC_FILES})
- 
- # 4. Dependencies
--include(cgal)
-+find_package(cgal CONFIG REQUIRED)
-+find_package(PkgConfig REQUIRED)
-+pkg_check_modules(gmp REQUIRED IMPORTED_TARGET gmp)
-+target_link_libraries(igl_copyleft_cgal INTERFACE PkgConfig::gmp)
-+pkg_check_modules(mpfr REQUIRED IMPORTED_TARGET mpfr)
-+target_link_libraries(igl_copyleft_cgal INTERFACE PkgConfig::mpfr)
- igl_include(copyleft core)
- target_link_libraries(igl_copyleft_cgal ${IGL_SCOPE}
-     igl::core
-     igl_copyleft::core
--    CGAL::CGAL
--    CGAL::CGAL_Core
-+    CGAL
-+    CGAL_Core
+diff --git a/cmake/recipes/external/comiso.cmake b/cmake/recipes/external/comiso.cmake
+index d2879cb..5a0bd58 100644
+--- a/cmake/recipes/external/comiso.cmake
++++ b/cmake/recipes/external/comiso.cmake
+@@ -11,7 +11,7 @@ FetchContent_Declare(
+     GIT_TAG 536440e714f412e7ef6c0b96b90ba37b1531bb39
  )
  
- # 5. Unit tests
-
+-include(eigen)
++find_package(Eigen3 CONFIG REQUIRED)
+ 
+ FetchContent_MakeAvailable(comiso)
+ 

--- a/ports/libigl/dependencies.patch
+++ b/ports/libigl/dependencies.patch
@@ -15,12 +15,13 @@ diff --git a/cmake/igl/libigl-config.cmake.in b/cmake/igl/libigl-config.cmake.in
 index 359e314..6e04af6 100644
 --- a/cmake/igl/libigl-config.cmake.in
 +++ b/cmake/igl/libigl-config.cmake.in
-@@ -1,3 +1,7 @@
+@@ -1,3 +1,8 @@
  @PACKAGE_INIT@
  
 +include(CMakeFindDependencyMacro)
 +find_dependency(Eigen3)
 +find_dependency(Threads)
++include("${CMAKE_CURRENT_LIST_DIR}/LibiglConfigTargets.cmake")
 +
  check_required_components(Libigl)
 diff --git a/cmake/igl/modules/copyleft/cgal.cmake b/cmake/igl/modules/copyleft/cgal.cmake

--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -1,4 +1,3 @@
-# Header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libigl/libigl
@@ -9,90 +8,61 @@ vcpkg_from_github(
         dependencies.patch
         upstream_fixes.patch
 )
+file(REMOVE
+    "${SOURCE_PATH}/cmake/find/FindGMP.cmake"
+    "${SOURCE_PATH}/cmake/find/FindMPFR.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/boost.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/catch2.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/cgal.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/eigen.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/embree.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/glad.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/glfw.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/gmp.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/gmp_mpfr.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/imgui.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/imguizmo.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/libigl_imgui_fonts.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/mpfr.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/stb.cmake"
+    "${SOURCE_PATH}/cmake/recipes/external/tinyxml2.cmake"
+)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        cgal            LIBIGL_COPYLEFT_CGAL
         embree          LIBIGL_EMBREE
-        opengl          LIBIGL_OPENGL
         glfw            LIBIGL_GLFW
         imgui           LIBIGL_IMGUI
+        opengl          LIBIGL_OPENGL
         png             LIBIGL_PNG
         xml             LIBIGL_XML
-        cgal            LIBIGL_COPYLEFT_CGAL
+        # Features removed: missing binary libs / separate ports
+        comiso          LIBIGL_COPYLEFT_COMISO
         predicates      LIBIGL_PREDICATES
-        comiso          LIBIGL_COMISO
-        tetgen          LIBIGL_TETGEN
-        triangle        LIBIGL_TRIANGLE
+        tetgen          LIBIGL_COPYLEFT_TETGEN
+        triangle        LIBIGL_RESTRICTED_TRIANGLE
 )
 
-# External dependencies, which are not packaged by vcpkg
-# COMISO
-if(LIBIGL_COMISO)
-    vcpkg_from_github(
-        OUT_SOURCE_PATH COMISO_SOURCE_PATH
-        REPO            libigl/CoMISo
-        REF             536440e714f412e7ef6c0b96b90ba37b1531bb39
-        SHA512          79824ea7f52dc6d59da491a9df763215285955ad2414c508368bcddd227adced72553476ede6d1ff95d4f0c3df8b4854d1d534dc7d2ab648b13c105f948ca2b3
-        HEAD_REF        master
-    )
-    list(APPEND ADDITIONAL_OPTIONS "-DFETCHCONTENT_SOURCE_DIR_COMISO=${COMISO_SOURCE_PATH}")
-endif()
-
-# tetgen
-if(LIBIGL_TETGEN)
-    vcpkg_from_github(
-        OUT_SOURCE_PATH TETGEN_SOURCE_PATH
-        REPO            libigl/tetgen
-        REF             4f3bfba3997f20aa1f96cfaff604313a8c2c85b6
-        SHA512          d847cddd699df4ddca1743d328db8d9f193986f46df668683450b55331d701d6d1f4b9f8aa9d0097856892e3b21bdd5582a41d6ee37f2cf148eb31630e62258e
-        HEAD_REF        master
-    )
-    list(APPEND ADDITIONAL_OPTIONS "-DFETCHCONTENT_SOURCE_DIR_TETGEN=${TETGEN_SOURCE_PATH}")
-endif()
-
-
-# triangle
-if(LIBIGL_TRIANGLE)
-    include(FetchContent)
-    vcpkg_from_github(
-        OUT_SOURCE_PATH TRIANGLE_SOURCE_PATH
-        REPO            libigl/triangle
-        REF             3ee6cac2230f0fe1413879574f741c7b6da11221
-        SHA512          f668836277585068324a208e0cc445ddda569e048ea99e9a77df1e0027e5efa38882c6fcccee242213adf24127db24d018d3b2eea227762eaab9e1b60292a6fd
-        HEAD_REF        master
-    )
-    list(APPEND ADDITIONAL_OPTIONS "-DFETCHCONTENT_SOURCE_DIR_TRIANGLE=${TRIANGLE_SOURCE_PATH}")
-endif()
-
-# remove custom FindGMP and FildMPFR
-file(REMOVE "${SOURCE_PATH}/cmake/find/FindGMP.cmake")
-file(REMOVE "${SOURCE_PATH}/cmake/find/FindMPFR.cmake")
-
+set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    OPTIONS ${FEATURE_OPTIONS}
-        # Build options
+    OPTIONS
+        ${FEATURE_OPTIONS}
         -DLIBIGL_BUILD_TESTS=OFF
         -DLIBIGL_BUILD_TUTORIALS=OFF
         -DLIBIGL_INSTALL=ON
+        -DLIBIGL_RESTRICTED_MATLAB=OFF
+        -DLIBIGL_RESTRICTED_MOSEK=OFF
         -DLIBIGL_USE_STATIC_LIBRARY=OFF
         -DHUNTER_ENABLED=OFF
-        -DLIBIGL_COPYLEFT_COMISO=${LIBIGL_COMISO}
-        -DLIBIGL_COPYLEFT_TETGEN=${LIBIGL_TETGEN}
-        -DLIBIGL_RESTRICTED_TRIANGLE=${LIBIGL_TRIANGLE}
         ${ADDITIONAL_OPTIONS}
-    MAYBE_UNUSED_VARIABLES
-        LIBIGL_COMISO
-        LIBIGL_TETGEN
-        LIBIGL_TRIANGLE
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/igl PACKAGE_NAME libigl)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/igl)
 vcpkg_copy_pdbs()
 
-# libigl is a header-only library.
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-file(INSTALL "${SOURCE_PATH}/LICENSE.GPL" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.GPL")

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -78,7 +78,17 @@
       ]
     },
     "png": {
-      "description": "Install PNG support"
+      "description": "Install PNG support",
+      "dependencies": [
+        {
+          "name": "libigl",
+          "default-features": false,
+          "features": [
+            "opengl"
+          ]
+        },
+        "stb"
+      ]
     },
     "xml": {
       "description": "Build with libxml",

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -1,15 +1,12 @@
 {
   "name": "libigl",
   "version": "2.4.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.",
   "homepage": "https://github.com/libigl/libigl",
   "license": "GPL-3.0-only",
   "dependencies": [
     "eigen3",
-    "gmp",
-    "mpfr",
-    "pkgconf",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -23,15 +20,11 @@
     "cgal": {
       "description": "Build with cgal",
       "dependencies": [
-        "cgal",
         {
           "name": "cgal",
           "default-features": false
         }
       ]
-    },
-    "comiso": {
-      "description": "Build with comiso"
     },
     "embree": {
       "description": "Build with embree",
@@ -84,11 +77,8 @@
         "opengl"
       ]
     },
-    "tetgen": {
-      "description": "Build with tetgen"
-    },
-    "triangle": {
-      "description": "Build with triangle"
+    "png": {
+      "description": "Install PNG support"
     },
     "xml": {
       "description": "Build with libxml",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4082,7 +4082,7 @@
     },
     "libigl": {
       "baseline": "2.4.0",
-      "port-version": 2
+      "port-version": 3
     },
     "libilbc": {
       "baseline": "3.0.4",

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b2c06b829c29fc1bdd36b6f24690dfcf713394ba",
+      "git-tree": "4754633723fc5e93c13f54e405ce0b8662bb570b",
       "version": "2.4.0",
       "port-version": 3
     },

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "64b88d127a5237dbc38c85654ba869cd4a3cccd0",
+      "git-tree": "b2c06b829c29fc1bdd36b6f24690dfcf713394ba",
       "version": "2.4.0",
       "port-version": 3
     },

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64b88d127a5237dbc38c85654ba869cd4a3cccd0",
+      "version": "2.4.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "b1f7e5126f4bca6f7d6800bb8eb143d1640f8a80",
       "version": "2.4.0",
       "port-version": 2


### PR DESCRIPTION
This PR was triggered by the pkgconf dependency missing the host property, but became more radical:
- Some recently added features build and need binary artifacts, but they don't install extra files in the end. How was this meant to work? If these features are desired, they must be added properly, maybe using separate ports for the dependencies. Comiso seems non-trivial.
  CC @iAnyKey This reverts the feature additions from #27963.
- The CMake config didn't actually load the exported targets or dependencies... I fixed the most obvious problems.
- For now, it is really enough to build only release (header-only port).
- I added a png feature.

--

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
