### PR TITLE
[cpp-httplib] update to 0.12.2.

### DIFF
--- a/ports/cpp-httplib/fix-find-brotli.patch
+++ b/ports/cpp-httplib/fix-find-brotli.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 709390a..3fd83aa 100644
+index c98daf5..88d1aad 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -127,9 +127,9 @@ endif()
+@@ -128,9 +128,9 @@ endif()
  # Adds our cmake folder to the search path for find_package
  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
  if(HTTPLIB_REQUIRE_BROTLI)
@@ -14,9 +14,9 @@ index 709390a..3fd83aa 100644
  endif()
  # Just setting this variable here for people building in-tree
  if(Brotli_FOUND)
-@@ -206,9 +206,9 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
- 		$<$<PLATFORM_ID:Windows>:crypt32>
- 		$<$<PLATFORM_ID:Windows>:cryptui>
+@@ -209,9 +209,9 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
+ 		# Needed for API from MacOS Security framework
+ 		"$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>>:-framework CoreFoundation -framework Security>"
  		# Can't put multiple targets in a single generator expression or it bugs out.
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::common>
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>
@@ -27,7 +27,7 @@ index 709390a..3fd83aa 100644
  		$<$<BOOL:${HTTPLIB_IS_USING_ZLIB}>:ZLIB::ZLIB>
  		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL>
  		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::Crypto>
-@@ -265,9 +265,6 @@ install(FILES "${_httplib_build_includedir}/httplib.h" TYPE INCLUDE)
+@@ -266,9 +266,6 @@ install(FILES "${_httplib_build_includedir}/httplib.h" TYPE INCLUDE)
  install(FILES
  		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
  		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"

--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
-    REF v0.11.3
-    SHA512 b0c46bf11c8bc84ab52143559ff1c4682b02504921855e5cd7e82bc65a04b192281ef7a124c7c7dfe928ae3842d5065097b6a4608be1c74dc51b563b15b93d0f
+    REF v0.12.2
+    SHA512 dda47f76eaf5b4daa35f1295e482f1d81dd8823ae06339b9f4c93e4fbe7b54ae28760d3083b5d5cff212f1a679616adfa47dbb9d06c6810fac4b58197f575429
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cpp-httplib",
-  "version": "0.11.3",
-  "port-version": 1,
+  "version": "0.12.2",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1721,8 +1721,8 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.11.3",
-      "port-version": 1
+      "baseline": "0.12.2",
+      "port-version": 0
     },
     "cpp-ipc": {
       "baseline": "1.2.0",

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05e123da2bcd7b05fc8c31fd88e6d3d5aa06d520",
+      "version": "0.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d5bea8aab6eaa201dfd01b054327e3c379ab0864",
       "version": "0.11.3",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30728

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.