### PR TITLE
[matroska] update to 1.7.1 and enable UWP builds

### DIFF
--- a/ports/matroska/portfile.cmake
+++ b/ports/matroska/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Matroska-Org/libmatroska
-    REF release-1.6.3
-    SHA512 f4b4cd5b5e76c452fb559ead28c4bcb5ec4e28d74898f13c1709a6ab75d95cf82b319118445d7a7f895708bb0d5d1f3c09040d3e3263c6a2f2a27ffc92d35c2f
+    REF release-1.7.1
+    SHA512 abb4fb4b527266944b1a59516866462498675c5e71bb679758894dff6156169d7132dddaa2e2ef6187a6dbce4a4aa377eeb75dd869268fd44933c769b34be5b9
     HEAD_REF master
 )
 

--- a/ports/matroska/portfile.cmake
+++ b/ports/matroska/portfile.cmake
@@ -1,7 +1,3 @@
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "matroska does not currently support UWP")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Matroska-Org/libmatroska

--- a/ports/matroska/vcpkg.json
+++ b/ports/matroska/vcpkg.json
@@ -1,11 +1,14 @@
 {
   "name": "matroska",
-  "version": "1.6.3",
+  "version": "1.7.1",
   "description": "a C++ library to parse Matroska files (.mkv and .mka)",
   "homepage": "https://github.com/Matroska-Org/libmatroska",
   "supports": "!uwp",
   "dependencies": [
-    "ebml",
+    {
+      "name": "ebml",
+      "version>=": "1.4.3"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/matroska/vcpkg.json
+++ b/ports/matroska/vcpkg.json
@@ -3,7 +3,6 @@
   "version": "1.7.1",
   "description": "a C++ library to parse Matroska files (.mkv and .mka)",
   "homepage": "https://github.com/Matroska-Org/libmatroska",
-  "supports": "!uwp",
   "dependencies": [
     {
       "name": "ebml",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5049,7 +5049,7 @@
       "port-version": 6
     },
     "matroska": {
-      "baseline": "1.6.3",
+      "baseline": "1.7.1",
       "port-version": 0
     },
     "mbedtls": {

--- a/versions/m-/matroska.json
+++ b/versions/m-/matroska.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "041bae8554d02be4ce2909d9a01a8fd2bced588b",
+      "version": "1.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4f42c70e6e7b730f43e59e3dd7e0b4b8e7e7abd8",
       "version": "1.6.3",
       "port-version": 0


### PR DESCRIPTION
~Draft as it requires #30750 to be at least 1.4.3~

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.