### PR TITLE
[gstreamer] update to 1.22.1

### DIFF
--- a/ports/gstreamer/fix-clang-cl-bad.patch
+++ b/ports/gstreamer/fix-clang-cl-bad.patch
@@ -1,8 +1,8 @@
 diff --git a/subprojects/gst-plugins-bad/ext/dts/meson.build b/subprojects/gst-plugins-bad/ext/dts/meson.build
-index 8ab3fc917..c19aa2264 100644
+index c4868a4..6b34cb7 100644
 --- a/subprojects/gst-plugins-bad/ext/dts/meson.build
 +++ b/subprojects/gst-plugins-bad/ext/dts/meson.build
-@@ -15,7 +15,7 @@ if not dca_dep.found()
+@@ -20,7 +20,7 @@ if not dca_dep.found()
  endif
  
  no_warn_c_args = []
@@ -12,10 +12,10 @@ index 8ab3fc917..c19aa2264 100644
    # can point to a non-existing location (/usr/include/dca)
    no_warn_c_args = ['-Wno-missing-include-dirs']
 diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
-index 4a844ef75..cd97e8f7a 100644
+index 160080a..6acf110 100644
 --- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
 +++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
-@@ -174,7 +174,7 @@ endif
+@@ -158,7 +158,7 @@ endif
  
  # MinGW 32bits compiler seems to be complaining about redundant-decls
  # when ComPtr is in use. Let's just disable the warning
@@ -25,12 +25,12 @@ index 4a844ef75..cd97e8f7a 100644
      '-Wno-redundant-decls',
    ])
 diff --git a/subprojects/gst-plugins-bad/meson.build b/subprojects/gst-plugins-bad/meson.build
-index 7cab556e0..35531110b 100644
+index 84eeb17..1743f41 100644
 --- a/subprojects/gst-plugins-bad/meson.build
 +++ b/subprojects/gst-plugins-bad/meson.build
-@@ -45,7 +45,7 @@ endif
- 
+@@ -54,7 +54,7 @@ endif
  cdata = configuration_data()
+ cdata.set('ENABLE_NLS', 1)
  
 -if cc.get_id() == 'msvc'
 +if cc.get_argument_syntax() == 'msvc'
@@ -38,7 +38,7 @@ index 7cab556e0..35531110b 100644
        # Ignore several spurious warnings for things gstreamer does very commonly
        # If a warning is completely useless and spammy, use '/wdXXXX' to suppress it
 diff --git a/subprojects/gst-plugins-bad/sys/asio/meson.build b/subprojects/gst-plugins-bad/sys/asio/meson.build
-index 3006d26ce..1afbd0022 100644
+index c61ad4e..b30793c 100644
 --- a/subprojects/gst-plugins-bad/sys/asio/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/asio/meson.build
 @@ -15,7 +15,7 @@ endif
@@ -51,10 +51,10 @@ index 3006d26ce..1afbd0022 100644
      error('asio plugin can only be built with MSVC')
    else
 diff --git a/subprojects/gst-plugins-bad/sys/d3d11/meson.build b/subprojects/gst-plugins-bad/sys/d3d11/meson.build
-index 43f213d9c..9c9e9b535 100644
+index 1368b79..8dd3b30 100644
 --- a/subprojects/gst-plugins-bad/sys/d3d11/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/d3d11/meson.build
-@@ -102,7 +102,7 @@ endif
+@@ -96,7 +96,7 @@ endif
  
  # MinGW 32bits compiler seems to be complaining about redundant-decls
  # when ComPtr is in use. Let's just disable the warning
@@ -64,7 +64,7 @@ index 43f213d9c..9c9e9b535 100644
      '-Wno-redundant-decls',
    ])
 diff --git a/subprojects/gst-plugins-bad/sys/decklink/meson.build b/subprojects/gst-plugins-bad/sys/decklink/meson.build
-index d869e79a4..c7b37a7c6 100644
+index 94a77db..918a209 100644
 --- a/subprojects/gst-plugins-bad/sys/decklink/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/decklink/meson.build
 @@ -18,7 +18,7 @@ decklink_libs = []
@@ -77,10 +77,10 @@ index d869e79a4..c7b37a7c6 100644
      comutil_dep = cxx.find_library('comsuppw', required : get_option('decklink'))
      if comutil_dep.found()
 diff --git a/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build b/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build
-index 828954909..af570f9ff 100644
+index 6b9a059..40713ce 100644
 --- a/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build
-@@ -48,7 +48,7 @@ if host_system != 'windows' or mf_option.disabled()
+@@ -54,7 +54,7 @@ if host_system != 'windows' or mf_option.disabled()
    subdir_done()
  endif
  
@@ -90,10 +90,10 @@ index 828954909..af570f9ff 100644
      error('mediafoundation plugin can only be built with MSVC')
    endif
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/meson.build b/subprojects/gst-plugins-bad/sys/msdk/meson.build
-index a77160049..7c834d8ed 100644
+index 659b96c..92e6bc4 100644
 --- a/subprojects/gst-plugins-bad/sys/msdk/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/msdk/meson.build
-@@ -139,13 +139,13 @@ if have_mfx_ver134
+@@ -176,12 +176,12 @@ if use_onevpl and have_mfx_ver205
  endif
  
  if host_machine.system() == 'windows'
@@ -102,10 +102,9 @@ index a77160049..7c834d8ed 100644
      error('msdk plugin can only be built with MSVC')
    endif
    legacy_stdio_dep = cc.find_library('legacy_stdio_definitions', required: get_option('msdk'))
-   d3d11_dep = cc.find_library('d3d11', required: get_option('msdk'))
-   msdk_deps = declare_dependency(dependencies: [d3d11_dep, legacy_stdio_dep])
--  msdk_deps_found = d3d11_dep.found() and legacy_stdio_dep.found() and cc.get_id() == 'msvc'
+   msdk_deps = declare_dependency(dependencies: [gstd3d11_dep, legacy_stdio_dep])
+-  msdk_deps_found = gstd3d11_dep.found() and legacy_stdio_dep.found() and cc.get_id() == 'msvc'
 +  msdk_deps_found = d3d11_dep.found() and legacy_stdio_dep.found() and cc.get_argument_syntax() == 'msvc'
  else
-   libva_dep = dependency('libva', required: get_option('msdk'))
-   libva_drm_dep = dependency('libva-drm', required: get_option('msdk'))
+   libdl_dep = cc.find_library('dl', required: get_option('msdk'))
+   libgudev_dep = dependency('gudev-1.0', required: get_option('msdk'))

--- a/ports/gstreamer/fix-clang-cl-base.patch
+++ b/ports/gstreamer/fix-clang-cl-base.patch
@@ -1,8 +1,8 @@
 diff --git a/subprojects/gst-plugins-base/meson.build b/subprojects/gst-plugins-base/meson.build
-index 495671ebb..fff3ea518 100644
+index c040bc9..ce9071c 100644
 --- a/subprojects/gst-plugins-base/meson.build
 +++ b/subprojects/gst-plugins-base/meson.build
-@@ -43,7 +43,7 @@ plugins = []
+@@ -51,7 +51,7 @@ gst_libraries = []
  
  cc = meson.get_compiler('c')
  
@@ -11,12 +11,3 @@ index 495671ebb..fff3ea518 100644
    msvc_args = [
        # Ignore several spurious warnings for things gstreamer does very commonly
        # If a warning is completely useless and spammy, use '/wdXXXX' to suppress it
-@@ -75,7 +75,7 @@ endif
- core_conf = configuration_data()
- 
- # Symbol visibility
--if cc.get_id() == 'msvc'
-+if cc.get_argument_syntax() == 'msvc'
-   export_define = '__declspec(dllexport) extern'
- elif cc.has_argument('-fvisibility=hidden')
-   add_project_arguments('-fvisibility=hidden', language: 'c')

--- a/ports/gstreamer/fix-clang-cl-good.patch
+++ b/ports/gstreamer/fix-clang-cl-good.patch
@@ -1,8 +1,8 @@
 diff --git a/subprojects/gst-plugins-good/meson.build b/subprojects/gst-plugins-good/meson.build
-index 64705379f..0c55b9732 100644
+index 90fb33d..d0ae0d8 100644
 --- a/subprojects/gst-plugins-good/meson.build
 +++ b/subprojects/gst-plugins-good/meson.build
-@@ -30,7 +30,7 @@ plugins = []
+@@ -40,7 +40,7 @@ static_build = get_option('default_library') == 'static'
  cc = meson.get_compiler('c')
  host_system = host_machine.system()
  
@@ -11,7 +11,7 @@ index 64705379f..0c55b9732 100644
    msvc_args = [
        # Ignore several spurious warnings for things gstreamer does very commonly
        # If a warning is completely useless and spammy, use '/wdXXXX' to suppress it
-@@ -183,7 +183,7 @@ cdata.set('SIZEOF_OFF_T', cc.sizeof('off_t'))
+@@ -224,7 +224,7 @@ cdata.set('HAVE_RTLD_NOLOAD', have_rtld_noload)
  # Here be fixmes.
  # FIXME: check if this is correct
  cdata.set('HAVE_CPU_X86_64', host_machine.cpu() == 'amd64')

--- a/ports/gstreamer/fix-clang-cl-gstreamer.patch
+++ b/ports/gstreamer/fix-clang-cl-gstreamer.patch
@@ -1,5 +1,5 @@
 diff --git a/subprojects/gstreamer/gst/parse/meson.build b/subprojects/gstreamer/gst/parse/meson.build
-index 35ed6f2f4..5e38e49ea 100644
+index b79a07c..891f907 100644
 --- a/subprojects/gstreamer/gst/parse/meson.build
 +++ b/subprojects/gstreamer/gst/parse/meson.build
 @@ -16,7 +16,7 @@ else
@@ -12,10 +12,10 @@ index 35ed6f2f4..5e38e49ea 100644
  else
    flex_cdata.set('FLEX_ARGS', '')
 diff --git a/subprojects/gstreamer/meson.build b/subprojects/gstreamer/meson.build
-index 772809e15..70b1eafc5 100644
+index 9e90872..cd37a40 100644
 --- a/subprojects/gstreamer/meson.build
 +++ b/subprojects/gstreamer/meson.build
-@@ -36,7 +36,7 @@ cc = meson.get_compiler('c')
+@@ -47,7 +47,7 @@ endif
  
  cdata = configuration_data()
  
@@ -24,16 +24,7 @@ index 772809e15..70b1eafc5 100644
    msvc_args = [
        # Ignore several spurious warnings for things gstreamer does very commonly
        # If a warning is completely useless and spammy, use '/wdXXXX' to suppress it
-@@ -61,7 +61,7 @@ endif
- 
- # Symbol visibility
- have_visibility_hidden = false
--if cc.get_id() == 'msvc'
-+if cc.get_argument_syntax() == 'msvc'
-   export_define = '__declspec(dllexport) extern'
- elif cc.has_argument('-fvisibility=hidden')
-   add_project_arguments('-fvisibility=hidden', language: 'c')
-@@ -313,8 +313,10 @@ static __uint128_t v2 = 10;
+@@ -347,8 +347,10 @@ static __uint128_t v2 = 10;
  static __uint128_t u;
  u = v1 / v2;
  }'''
@@ -46,12 +37,12 @@ index 772809e15..70b1eafc5 100644
  endif
  
  # All supported platforms have long long now
-@@ -322,7 +324,7 @@ cdata.set('HAVE_LONG_LONG', 1)
+@@ -484,7 +486,7 @@ if cc.has_header('execinfo.h')
+ endif
  
- # We only want to use the __declspec(dllexport/import) dance in GST_EXPORT when
- # building with MSVC
--if cc.get_id() == 'msvc'
-+if cc.get_argument_syntax() == 'msvc'
-   cdata.set('GSTCONFIG_BUILT_WITH_MSVC', 1)
- else
-   cdata.set('GSTCONFIG_BUILT_WITH_MSVC', 0)
+ gst_debug = get_option('gst_debug')
+-if not gst_debug
++if not gst_debug and cc.has_argument('-Wno-unused')
+   add_project_arguments(['-Wno-unused'], language: 'c')
+ endif
+ 

--- a/ports/gstreamer/fix-clang-cl-ugly.patch
+++ b/ports/gstreamer/fix-clang-cl-ugly.patch
@@ -1,8 +1,8 @@
 diff --git a/subprojects/gst-plugins-ugly/meson.build b/subprojects/gst-plugins-ugly/meson.build
-index 14be48c4c..83d019874 100644
+index 937d8c3..b1f3e37 100644
 --- a/subprojects/gst-plugins-ugly/meson.build
 +++ b/subprojects/gst-plugins-ugly/meson.build
-@@ -31,7 +31,7 @@ if have_cxx
+@@ -38,7 +38,7 @@ if have_cxx
    cxx = meson.get_compiler('cpp')
  endif
  

--- a/ports/gstreamer/plugin-base-disable-no-unused.patch
+++ b/ports/gstreamer/plugin-base-disable-no-unused.patch
@@ -1,8 +1,8 @@
 diff --git a/subprojects/gst-plugins-base/meson.build b/subprojects/gst-plugins-base/meson.build
-index 9b00253..495671e 100644
+index c040bc9..b434315 100644
 --- a/subprojects/gst-plugins-base/meson.build
 +++ b/subprojects/gst-plugins-base/meson.build
-@@ -388,10 +388,11 @@ int32x4_t testfunc(int16_t *a, int16_t *b) {
+@@ -403,10 +403,11 @@ int32x4_t testfunc(int16_t *a, int16_t *b) {
    endif
  endif
  
@@ -15,7 +15,7 @@ index 9b00253..495671e 100644
          message('GStreamer debug system is disabled')
          add_project_arguments('-Wno-unused', language: 'c')
      else
-@@ -404,7 +405,7 @@ else
+@@ -419,7 +420,7 @@ else
  #include <gst/gstconfig.h>
  #ifdef GST_DISABLE_GST_DEBUG
  #error "debugging disabled, make compiler fail"

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -5,22 +5,20 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/
+    GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gstreamer/gstreamer
-    REF 1.20.5
-    SHA512 2a996d8ac0f70c34dbbc02c875026df6e89346f0844fbaa25475075bcb6e57c81ceb7d71e729c3259eace851e3d7222cb3fe395e375d93eb45b1262a6ede1fdb
-    HEAD_REF master
+    REF 1.22.1
+    SHA512 738eaedc653ea52a4d134bdd7f74518afd3c3f267a5558e7533fb196904169b9ebe0baebc7c652af99f021a3d7315c680faf5b1d0e3c190d88534b60788d188d
+    HEAD_REF main
     PATCHES
         fix-clang-cl.patch
         fix-clang-cl-gstreamer.patch
         fix-clang-cl-base.patch
         fix-clang-cl-good.patch
         fix-clang-cl-bad.patch
-        fix-clang-cl-ugly.patch
-        gstreamer-disable-no-unused.patch
+        fix-clang-cl-ugly.patch 
         srtp_fix.patch
-        fix-bz2-windows-debug-dependency.patch
         ${PATCHES}
 )
 
@@ -50,12 +48,6 @@ if("gpl" IN_LIST FEATURES)
     set(LICENSE_GPL enabled)
 else()
     set(LICENSE_GPL disabled)
-endif()
-
-if ("libav" IN_LIST FEATURES)
-    set(LIBAV enabled)
-else()
-    set(LIBAV disabled)
 endif()
 
 if("nls" IN_LIST FEATURES)
@@ -142,12 +134,6 @@ endif()
 
 # Good optional plugins
 
-if("bzip2-good" IN_LIST FEATURES)
-    set(PLUGIN_GOOD_BZ2 enabled)
-else()
-    set(PLUGIN_GOOD_BZ2 disabled)
-endif()
-
 if("cairo" IN_LIST FEATURES)
     set(PLUGIN_GOOD_CAIRO enabled)
 else()
@@ -230,12 +216,6 @@ if("assrender" IN_LIST FEATURES)
     set(PLUGIN_BAD_ASSRENDER enabled)
 else()
     set(PLUGIN_BAD_ASSRENDER disabled)
-endif()
-
-if("bzip2-bad" IN_LIST FEATURES)
-    set(PLUGIN_BAD_BZ2 enabled)
-else()
-    set(PLUGIN_BAD_BZ2 disabled)
 endif()
 
 if("chromaprint" IN_LIST FEATURES)
@@ -421,7 +401,7 @@ vcpkg_configure_meson(
     OPTIONS
         # General options
         -Dpython=disabled
-        -Dlibav=${LIBAV}
+        -Dlibav=disabled
         -Dlibnice=disabled
         -Ddevtools=disabled
         -Dges=disabled
@@ -471,7 +451,7 @@ vcpkg_configure_meson(
         # gst-plugins-good
         -Dgood=${PLUGIN_GOOD_SUPPORT}
         -Dgst-plugins-good:aalib=disabled
-        -Dgst-plugins-good:bz2=${PLUGIN_GOOD_BZ2}
+        -Dgst-plugins-good:bz2=disabled
         -Dgst-plugins-good:directsound=auto
         -Dgst-plugins-good:dv=disabled
         -Dgst-plugins-good:dv1394=disabled
@@ -520,7 +500,7 @@ vcpkg_configure_meson(
         -Dgst-plugins-bad:assrender=${PLUGIN_BAD_ASSRENDER}
         -Dgst-plugins-bad:bluez=disabled
         -Dgst-plugins-bad:bs2b=disabled
-        -Dgst-plugins-bad:bz2=${PLUGIN_BAD_BZ2}
+        -Dgst-plugins-bad:bz2=disabled # Error during plugin configuration
         -Dgst-plugins-bad:chromaprint=${PLUGIN_BAD_CHROMAPRINT}
         -Dgst-plugins-bad:closedcaption=${PLUGIN_BAD_CLOSEDCAPTION}
         -Dgst-plugins-bad:colormanagement=${PLUGIN_BAD_COLORMANAGEMENT}
@@ -562,7 +542,7 @@ vcpkg_configure_meson(
         -Dgst-plugins-bad:msdk=disabled
         -Dgst-plugins-bad:musepack=disabled
         -Dgst-plugins-bad:neon=disabled
-        -Dgst-plugins-bad:nvcodec=enabled
+        -Dgst-plugins-bad:nvcodec=disabled
         -Dgst-plugins-bad:onnx=disabled # libonnxruntime not found
         -Dgst-plugins-bad:openal=${PLUGIN_BAD_OPENAL}
         -Dgst-plugins-bad:openaptx=disabled

--- a/ports/gstreamer/srtp_fix.patch
+++ b/ports/gstreamer/srtp_fix.patch
@@ -1,8 +1,8 @@
 diff --git a/subprojects/gst-plugins-bad/ext/srtp/meson.build b/subprojects/gst-plugins-bad/ext/srtp/meson.build
-index 7f947191ae..b4a8e9c2a8 100644
+index 49eed5b..db5aed0 100644
 --- a/subprojects/gst-plugins-bad/ext/srtp/meson.build
 +++ b/subprojects/gst-plugins-bad/ext/srtp/meson.build
-@@ -6,12 +6,14 @@ srtp_sources = [
+@@ -6,13 +6,15 @@ srtp_sources = [
    'gstsrtpenc.c',
  ]
  
@@ -10,6 +10,7 @@ index 7f947191ae..b4a8e9c2a8 100644
 +
  srtp_cargs = []
  if get_option('srtp').disabled()
+   srtp_dep = dependency('', required : false)
    subdir_done()
  endif
  
@@ -18,12 +19,12 @@ index 7f947191ae..b4a8e9c2a8 100644
  if srtp_dep.found()
    srtp_cargs += ['-DHAVE_SRTP2']
  else
-@@ -37,7 +39,7 @@ if srtp_dep.found()
+@@ -38,7 +40,7 @@ if srtp_dep.found()
      include_directories : [configinc],
      dependencies : [gstrtp_dep, gstvideo_dep, srtp_dep],
      install : true,
 -    install_dir : plugins_install_dir,
 +    install_dir : gst_plugins_install_dir,
    )
-   pkgconfig.generate(gstsrtp, install_dir : plugins_pkgconfig_install_dir)
    plugins += [gstsrtp]
+ endif

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gstreamer",
-  "version": "1.20.5",
-  "port-version": 4,
+  "version": "1.22.1",
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",
@@ -81,32 +80,6 @@
           ]
         },
         "libass"
-      ]
-    },
-    "bzip2-bad": {
-      "description": "Enable bzip2 stream compression in bad plugins",
-      "dependencies": [
-        "bzip2",
-        {
-          "name": "gstreamer",
-          "default-features": false,
-          "features": [
-            "plugins-bad"
-          ]
-        }
-      ]
-    },
-    "bzip2-good": {
-      "description": "Enable bzip2 stream compression in good plugins",
-      "dependencies": [
-        "bzip2",
-        {
-          "name": "gstreamer",
-          "default-features": false,
-          "features": [
-            "plugins-good"
-          ]
-        }
       ]
     },
     "cairo": {
@@ -304,15 +277,6 @@
           ]
         },
         "libjpeg-turbo"
-      ]
-    },
-    "libav": {
-      "description": "libav plugins",
-      "dependencies": [
-        {
-          "name": "ffmpeg",
-          "default-features": false
-        }
       ]
     },
     "libde265": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2949,8 +2949,8 @@
       "port-version": 0
     },
     "gstreamer": {
-      "baseline": "1.20.5",
-      "port-version": 4
+      "baseline": "1.22.1",
+      "port-version": 0
     },
     "gtest": {
       "baseline": "1.13.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e9abbd4db56a3c8405da96c06313946461ca14d",
+      "version": "1.22.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "084ea66aed42ba882e19b103de4042d676be1530",
       "version": "1.20.5",
       "port-version": 4


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30734
The modification has the main branch switched to `main`. 
Update the version to 1.22.1.
Merge the changes from patch `gstreamer-disable-no-unused.patch` into patch `fix-clang-cl-gstreamer.patch`.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
