### PR TITLE
[vcpkg baseline][opencv4] Control intel-mkl dependency

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -72,6 +72,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  "webp"      WITH_WEBP
  "world"     BUILD_opencv_world
  "dc1394"    WITH_1394
+ INVERTED_FEATURES
+ "mkl"       OPENCV_LAPACK_DISABLE_MKL
 )
 
 # Cannot use vcpkg_check_features() for "dnn", "gtk", ipp", "openmp", "ovis", "python", "qt", "tbb"

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.7.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -217,6 +217,19 @@
       "dependencies": [
         "blas",
         "lapack"
+      ]
+    },
+    "mkl": {
+      "description": "MKL LAPACK support for opencv",
+      "dependencies": [
+        "intel-mkl",
+        {
+          "name": "opencv4",
+          "default-features": false,
+          "features": [
+            "lapack"
+          ]
+        }
       ]
     },
     "nonfree": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5786,7 +5786,7 @@
     },
     "opencv4": {
       "baseline": "4.7.0",
-      "port-version": 3
+      "port-version": 4
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51c88689b73bab9c8e21266c5172b670baa07009",
+      "version": "4.7.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "ca4b616630bef409960661592549086539a7e28e",
       "version": "4.7.0",
       "port-version": 3


### PR DESCRIPTION
Assumed to fix the openimagio:x64-linux CI baseline regression, given the `<opencv4 libs> <intel-mkl libs>` argument sequence of the failing link step.

(This PR is just to resolve the baseline regression without completely disabling intel-mkl for opencv4, not to ensure that opencv4[mkl] correctly exports link libraries for downstream usage as in openimagio.)

Related: #30570.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
