### PR TITLE
Track CI baseline change effect

### DIFF
--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -136,7 +136,7 @@ if ($LASTEXITCODE -ne 0)
 $parentHashes = @()
 if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
 {
-    $headBaseline = Get-Content "$PSScriptRoot/../ci.baseline.txt"
+    $headBaseline = Get-Content "$PSScriptRoot/../ci.baseline.txt" -Raw
 
     # Prefetch tools for better output
     foreach ($tool in @('cmake', 'ninja', 'git')) {
@@ -149,7 +149,7 @@ if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
 
     Write-Host "Comparing with HEAD~1"
     & git revert -n -m 1 HEAD | Out-Null
-    $parentBaseline = Get-Content "$PSScriptRoot/../ci.baseline.txt"
+    $parentBaseline = Get-Content "$PSScriptRoot/../ci.baseline.txt" -Raw
     if ($parentBaseline -eq $headBaseline)
     {
         Write-Host "CI baseline unchanged, determining parent hashes"

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -133,11 +133,11 @@ if ($LASTEXITCODE -ne 0)
     throw "vcpkg clean failed"
 }
 
-$baseline = Get-Content "$PSScriptRoot/../ci.baseline.txt"
-
 $parentHashes = @()
 if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
 {
+    $headBaseline = Get-Content "$PSScriptRoot/../ci.baseline.txt"
+
     # Prefetch tools for better output
     foreach ($tool in @('cmake', 'ninja', 'git')) {
         & "./vcpkg$executableExtension" fetch $tool
@@ -150,7 +150,7 @@ if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
     Write-Host "Comparing with HEAD~1"
     & git revert -n -m 1 HEAD | Out-Null
     $parentBaseline = Get-Content "$PSScriptRoot/../ci.baseline.txt"
-    if ($parentBaseline -eq $baseline)
+    if ($parentBaseline -eq $headBaseline)
     {
         Write-Host "CI baseline unchanged, determining parent hashes"
         $parentHashesFile = Join-Path $ArtifactStagingDirectory 'parent-hashes.json'

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -133,6 +133,8 @@ if ($LASTEXITCODE -ne 0)
     throw "vcpkg clean failed"
 }
 
+$baseline = Get-Content "$PSScriptRoot/../ci.baseline.txt"
+
 $parentHashes = @()
 if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
 {
@@ -145,17 +147,25 @@ if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
         }
     }
 
-    Write-Host "Determining parent hashes using HEAD~1"
-    $parentHashesFile = Join-Path $ArtifactStagingDirectory 'parent-hashes.json'
-    $parentHashes = @("--parent-hashes=$parentHashesFile")
+    Write-Host "Comparing with HEAD~1"
     & git revert -n -m 1 HEAD | Out-Null
-    # The vcpkg.cmake toolchain file is not part of ABI hashing,
-    # but changes must trigger at least some testing.
-    Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake"
-    Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake-user"
-    & "./vcpkg$executableExtension" ci "--triplet=$Triplet" --dry-run "--ci-baseline=$PSScriptRoot/../ci.baseline.txt" @commonArgs --no-binarycaching "--output-hashes=$parentHashesFile"
-
-    Write-Host "Running CI using parent hashes"
+    $parentBaseline = Get-Content "$PSScriptRoot/../ci.baseline.txt"
+    if ($parentBaseline -eq $baseline)
+    {
+        Write-Host "CI baseline unchanged, determining parent hashes"
+        $parentHashesFile = Join-Path $ArtifactStagingDirectory 'parent-hashes.json'
+        $parentHashes = @("--parent-hashes=$parentHashesFile")
+        # The vcpkg.cmake toolchain file is not part of ABI hashing,
+        # but changes must trigger at least some testing.
+        Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake"
+        Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake-user"
+        & "./vcpkg$executableExtension" ci "--triplet=$Triplet" --dry-run "--ci-baseline=$PSScriptRoot/../ci.baseline.txt" @commonArgs --no-binarycaching "--output-hashes=$parentHashesFile"
+    }
+    else
+    {
+        Write-Host "CI baseline was modified, not using parent hashes"
+    }
+    Write-Host "Running CI for HEAD"
     & git reset --hard HEAD
 }
 

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -241,6 +241,7 @@ fmi4cpp:x64-uwp=fail
 fontconfig:x64-uwp=fail
 fontconfig:arm-uwp=fail
 foonathan-memory:arm64-windows=fail
+foonathan-memory:arm-uwp=fail
 foonathan-memory:x64-uwp=fail
 freeglut:arm-uwp=fail
 freeglut:x64-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -241,7 +241,6 @@ fmi4cpp:x64-uwp=fail
 fontconfig:x64-uwp=fail
 fontconfig:arm-uwp=fail
 foonathan-memory:arm64-windows=fail
-foonathan-memory:arm-uwp=fail
 foonathan-memory:x64-uwp=fail
 freeglut:arm-uwp=fail
 freeglut:x64-uwp=fail


### PR DESCRIPTION
Recurring pattern of introducing baseline regressions due to the cone of destruction being untested on changes to `ci.baseline.txt`:
1. PR 1 unexpectedly fixes a failure of port A for triplet T which is recorded as `fail` in CI baseline. Unnoticed in PR CI. 
   Example: #30335 fixing arm64-windows.
2. Nightly CI notices that port A now succeeds. 
   https://dev.azure.com/vcpkg/public/_build/results?buildId=87799&view=results
5. PR 2 removes port A `fail` from CI baseline. No changes to parent hashes, so no CI action. Merged quickly. (No side effects expected.)
    Example: #30714
7. PRs 3, 4 ... n fail because the cone of destruction now contains ports B, C, ... which were never tested for T, and fail now.
   Examples: The libcaer:arm64-windows baseline regression hits #30724, #30754, ...

This PR now disables the use of parent hashes when a pull request carries changes with regard to the current state of `ci.baseline.txt`. This improves CI correctness and stability at the price of installing more ports for very few PRs (and even mitigated by artifact caching).

Commits in this PR: 
a5e7a5c Simulated change to `ci.baseline.txt` before the fix, CI green
9162d30 Actual fix, CI now listing *all* current baseline regressions.
f077e63 Revert simulated change

CC @BillyONeal @ras0219-msft