### PR TITLE
[soxr] generate a CMake export file

### DIFF
--- a/ports/soxr/0001-generate-a-CMake-config-file.patch
+++ b/ports/soxr/0001-generate-a-CMake-config-file.patch
@@ -1,0 +1,80 @@
+From d1799b6bb06925f46888cc420afaa51d55ab3f10 Mon Sep 17 00:00:00 2001
+From: Steve Lhomme <robux4@ycbcr.xyz>
+Date: Mon, 10 Apr 2023 16:00:39 +0200
+Subject: [PATCH] generate a CMake config file
+
+---
+ src/CMakeLists.txt       | 28 ++++++++++++++++++++++++++--
+ src/soxr-config.cmake.in |  5 +++++
+ 2 files changed, 31 insertions(+), 2 deletions(-)
+ create mode 100644 src/soxr-config.cmake.in
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 24ecd5d..a1bf962 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -82,7 +82,6 @@ set_target_properties (${PROJECT_NAME} PROPERTIES
+   VERSION "${SO_VERSION}"
+   SOVERSION ${SO_VERSION_MAJOR}
+   INSTALL_NAME_DIR ${LIB_INSTALL_DIR}
+-  LINK_INTERFACE_LIBRARIES ""
+   PUBLIC_HEADER "${PROJECT_NAME}.h")
+ if (BUILD_FRAMEWORK)
+   set_target_properties (${PROJECT_NAME} PROPERTIES FRAMEWORK TRUE)
+@@ -106,7 +105,6 @@ if (WITH_LSR_BINDINGS)
+     VERSION "${LSR_SO_VERSION}"
+     SOVERSION ${LSR_SO_VERSION_MAJOR}
+     INSTALL_NAME_DIR ${LIB_INSTALL_DIR}
+-    LINK_INTERFACE_LIBRARIES ""
+     PUBLIC_HEADER "${LSR}.h")
+   if (BUILD_FRAMEWORK)
+     set_target_properties (${LSR} PROPERTIES FRAMEWORK TRUE)
+@@ -122,8 +120,34 @@ endif ()
+ # Installation (from build from source):
+ 
+ install (TARGETS ${PROJECT_NAME} ${LSR}
++  EXPORT soxr
+   FRAMEWORK DESTINATION ${FRAMEWORK_INSTALL_DIR}
+   LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+   RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+   ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+   PUBLIC_HEADER DESTINATION ${INCLUDE_INSTALL_DIR})
++
++include(CMakePackageConfigHelpers)
++include(GNUInstallDirs)
++
++install(EXPORT soxr 
++  FILE soxr.cmake
++  NAMESPACE Soxr::
++  DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}" )
++
++configure_package_config_file(
++  "${CMAKE_CURRENT_SOURCE_DIR}/soxr-config.cmake.in"
++  "${CMAKE_CURRENT_BINARY_DIR}/soxr-config.cmake"
++  INSTALL_DESTINATION "share/soxr"
++)
++write_basic_package_version_file(
++  "${CMAKE_CURRENT_BINARY_DIR}/soxr-config-version.cmake"
++  VERSION "${CMAKE_PROJECT_VERSION}"
++  COMPATIBILITY SameMajorVersion
++)
++install(
++  FILES 
++    "${CMAKE_CURRENT_BINARY_DIR}/soxr-config.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/soxr-config-version.cmake"
++  DESTINATION "share/soxr"
++)
+diff --git a/src/soxr-config.cmake.in b/src/soxr-config.cmake.in
+new file mode 100644
+index 0000000..64dd1c5
+--- /dev/null
++++ b/src/soxr-config.cmake.in
+@@ -0,0 +1,5 @@
++@PACKAGE_INIT@
++
++include("${CMAKE_CURRENT_LIST_DIR}/soxr.cmake")
++
++check_required_components(soxr)
+-- 
+2.38.1.windows.1
+

--- a/ports/soxr/portfile.cmake
+++ b/ports/soxr/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_sourceforge(
         001_initialize-resampler.patch
         002_disable_warning.patch
         003_detect_arm.patch
+        0001-generate-a-CMake-config-file.patch
 )
 
 vcpkg_check_features(

--- a/ports/soxr/vcpkg.json
+++ b/ports/soxr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "soxr",
   "version": "0.1.3",
-  "port-version": 7,
+  "port-version": 8,
   "description": "High quality audio resampling",
   "homepage": "https://sourceforge.net/projects/soxr/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7458,7 +7458,7 @@
     },
     "soxr": {
       "baseline": "0.1.3",
-      "port-version": 7
+      "port-version": 8
     },
     "spaceland": {
       "baseline": "7.8.2",

--- a/versions/s-/soxr.json
+++ b/versions/s-/soxr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae64dc4e79f545f99b68136fa6b33f615c2939b6",
+      "version": "0.1.3",
+      "port-version": 8
+    },
+    {
       "git-tree": "9eaa72e750312e0bacbd2a02e1a16fcc680489dd",
       "version": "0.1.3",
       "port-version": 7


### PR DESCRIPTION
So it's easier to use from other CMake packages.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
