### PR TITLE
[fizz]: fix library dependency

### DIFF
--- a/ports/fizz/0003-fix-deps.patch
+++ b/ports/fizz/0003-fix-deps.patch
@@ -1,0 +1,193 @@
+diff --git a/fizz/CMakeLists.txt b/fizz/CMakeLists.txt
+index 64bf93b..39af257 100644
+--- a/fizz/CMakeLists.txt
++++ b/fizz/CMakeLists.txt
+@@ -50,10 +50,9 @@ find_package(folly CONFIG REQUIRED)
+ find_package(fmt CONFIG REQUIRED)
+ 
+ find_package(OpenSSL REQUIRED)
+-find_package(Glog REQUIRED)
+-find_package(DoubleConversion REQUIRED)
++find_package(glog CONFIG REQUIRED)
++find_package(double-conversion CONFIG REQUIRED)
+ find_package(Threads REQUIRED)
+-find_package(Zstd REQUIRED)
+ if (UNIX AND NOT APPLE)
+   find_package(Librt)
+ endif()
+@@ -66,37 +65,17 @@ SET(FIZZ_SHINY_DEPENDENCIES "")
+ SET(FIZZ_LINK_LIBRARIES "")
+ SET(FIZZ_INCLUDE_DIRECTORIES "")
+ 
+-find_package(gflags CONFIG QUIET)
+-if (gflags_FOUND)
+-  message(STATUS "Found gflags from package config")
+-  if (TARGET gflags-shared)
+-    list(APPEND FIZZ_SHINY_DEPENDENCIES gflags-shared)
+-  elseif (TARGET gflags)
+-    list(APPEND FIZZ_SHINY_DEPENDENCIES gflags)
+-  else()
+-    message(FATAL_ERROR "Unable to determine the target name for the GFlags package.")
+-  endif()
+-  list(APPEND CMAKE_REQUIRED_LIBRARIES ${GFLAGS_LIBRARIES})
+-  list(APPEND CMAKE_REQUIRED_INCLUDES ${GFLAGS_INCLUDE_DIR})
+-else()
+-  find_package(Gflags REQUIRED MODULE)
+-  list(APPEND FIZZ_LINK_LIBRARIES ${LIBGFLAGS_LIBRARY})
+-  list(APPEND FIZZ_INCLUDE_DIRECTORIES ${LIBGFLAGS_INCLUDE_DIR})
+-  list(APPEND CMAKE_REQUIRED_LIBRARIES ${LIBGFLAGS_LIBRARY})
+-  list(APPEND CMAKE_REQUIRED_INCLUDES ${LIBGFLAGS_INCLUDE_DIR})
++find_package(zstd CONFIG REQUIRED)
++if(TARGET zstd::libzstd_shared)
++  list(APPEND FIZZ_LINK_LIBRARIES zstd::libzstd_shared)
++elseif(TARGET zstd::libzstd_static)
++  list(APPEND FIZZ_LINK_LIBRARIES zstd::libzstd_static)
+ endif()
+ 
++find_package(gflags CONFIG REQUIRED)
+ find_package(ZLIB REQUIRED)
+ 
+ find_package(Libevent CONFIG REQUIRED)
+-if(TARGET libevent::core)
+-  message(STATUS "Found libevent from package config")
+-  list(APPEND FIZZ_SHINY_DEPENDENCIES libevent::core)
+-else()
+-  find_package(Libevent MODULE REQUIRED)
+-  list(APPEND FIZZ_LINK_LIBRARIES ${LIBEVENT_LIB})
+-  list(APPEND FIZZ_INCLUDE_DIRECTORIES ${LIBEVENT_INCLUDE_DIR})
+-endif()
+ 
+ set(FIZZ_HEADER_DIRS
+   client
+@@ -237,30 +216,25 @@ target_include_directories(
+   PUBLIC
+     $<BUILD_INTERFACE:${FIZZ_BASE_DIR}>
+     $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
+-    ${FOLLY_INCLUDE_DIR}
+-    ${OPENSSL_INCLUDE_DIR}
+-    ${sodium_INCLUDE_DIR}
+-    ${ZSTD_INCLUDE_DIR}
+   PRIVATE
+-    ${GLOG_INCLUDE_DIRS}
+     ${FIZZ_INCLUDE_DIRECTORIES}
+-    ${DOUBLE_CONVERSION_INCLUDE_DIR}
+ )
+ 
+ 
+ target_link_libraries(fizz
+   PUBLIC
+-    ${FOLLY_LIBRARIES}
+-    ${OPENSSL_LIBRARIES}
++		Folly::folly
++		OpenSSL::SSL
++		OpenSSL::Crypto
+     unofficial-sodium::sodium
+     Threads::Threads
+     ZLIB::ZLIB
+-    ${ZSTD_LIBRARY}
+   PRIVATE
+-    ${GLOG_LIBRARIES}
+-    ${GFLAGS_LIBRARIES}
++    glog::glog
++    gflags::gflags
+     ${FIZZ_LINK_LIBRARIES}
+-    ${DOUBLE_CONVERSION_LIBRARY}
++		libevent::core
++    double-conversion::double-conversion
+     ${CMAKE_DL_LIBS}
+     ${LIBRT_LIBRARIES})
+ 
+@@ -317,8 +291,7 @@ ENDIF(CMAKE_CROSSCOMPILING)
+ SET(FIZZ_TEST_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+ 
+ if(BUILD_TESTS)
+-  find_package(GMock 1.8.0 MODULE REQUIRED)
+-  find_package(GTest 1.8.0 MODULE REQUIRED)
++   find_package(GTest CONFIG REQUIRED)
+ endif()
+ 
+ add_library(fizz_test_support
+@@ -331,21 +304,9 @@ add_library(fizz_test_support
+ target_link_libraries(fizz_test_support
+   PUBLIC
+     fizz
+-    ${LIBGMOCK_LIBRARIES}
+-    ${GLOG_LIBRARY}
++		glog::glog
+ )
+ 
+-target_compile_definitions(fizz_test_support
+-  PUBLIC
+-    ${LIBGMOCK_DEFINES}
+-)
+-
+-target_include_directories(fizz_test_support
+-  SYSTEM
+-  PUBLIC
+-    ${LIBGMOCK_INCLUDE_DIR}
+-    ${LIBGTEST_INCLUDE_DIRS}
+-)
+ 
+ # export fizz headers and targets for unit tests utils
+ # since other projects such as mvfst and proxygen use them
+@@ -369,14 +330,13 @@ macro(add_gtest test_source test_name)
+   add_executable(${test_name} ${test_source} test/CMakeTestMain.cpp)
+ 
+   set_property(TARGET ${test_name} PROPERTY ENABLE_EXPORTS true)
+-  target_include_directories(
+-    ${test_name} PUBLIC ${LIBGMOCK_INCLUDE_DIR} ${LIBGTEST_INCLUDE_DIR})
+-  target_compile_definitions(${test_name} PUBLIC ${LIBGMOCK_DEFINES})
+   target_link_libraries(
+     ${test_name}
+     fizz
+     fizz_test_support
+-    ${LIBGMOCK_LIBRARIES})
++    GTest::gtest
++    GTest::gmock
++    )
+ 
+   if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+     # GMOCK_MOCK_METHOD() will complain otherwise
+@@ -462,7 +422,7 @@ option(BUILD_EXAMPLES "BUILD_EXAMPLES" ON)
+ 
+ if(BUILD_EXAMPLES)
+   add_executable(BogoShim test/BogoShim.cpp)
+-  target_link_libraries(BogoShim fizz sodium)
++  target_link_libraries(BogoShim fizz)
+   set_target_properties(BogoShim PROPERTIES OUTPUT_NAME fizz-bogoshim)
+   install(
+     TARGETS BogoShim
+@@ -476,7 +436,7 @@ if(BUILD_EXAMPLES)
+       tool/FizzGenerateDelegatedCredentialCommand.cpp
+       tool/FizzServerBenchmarkCommand.cpp
+       tool/FizzServerCommand.cpp)
+-  target_link_libraries(FizzTool fizz sodium)
++  target_link_libraries(FizzTool fizz)
+   set_target_properties(FizzTool PROPERTIES OUTPUT_NAME fizz)
+   install(
+     TARGETS FizzTool
+diff --git a/fizz/cmake/fizz-config.cmake.in b/fizz/cmake/fizz-config.cmake.in
+index 3fb48b2..baa43a6 100644
+--- a/fizz/cmake/fizz-config.cmake.in
++++ b/fizz/cmake/fizz-config.cmake.in
+@@ -26,10 +26,19 @@ endif()
+ set(FIZZ_LIBRARIES fizz::fizz)
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(unofficial-sodium CONFIG REQUIRED)
++find_dependency(unofficial-sodium CONFIG)
+ find_dependency(folly CONFIG)
+ find_dependency(ZLIB)
+ find_dependency(Libevent CONFIG)
++find_dependency(fmt CONFIG)
++find_dependency(OpenSSL)
++find_dependency(glog CONFIG)
++find_dependency(double-conversion CONFIG)
++find_dependency(Threads)
++find_dependency(gflags CONFIG)
++find_dependency(zstd CONFIG)
++find_dependency(GTest CONFIG)
++
+ 
+ if (NOT fizz_FIND_QUIETLY)
+   message(STATUS "Found fizz: ${PACKAGE_PREFIX_DIR}")

--- a/ports/fizz/0003-fix-deps.patch
+++ b/ports/fizz/0003-fix-deps.patch
@@ -1,5 +1,5 @@
 diff --git a/fizz/CMakeLists.txt b/fizz/CMakeLists.txt
-index 64bf93b..39af257 100644
+index 64bf93b..843b035 100644
 --- a/fizz/CMakeLists.txt
 +++ b/fizz/CMakeLists.txt
 @@ -50,10 +50,9 @@ find_package(folly CONFIG REQUIRED)
@@ -78,9 +78,9 @@ index 64bf93b..39af257 100644
    PUBLIC
 -    ${FOLLY_LIBRARIES}
 -    ${OPENSSL_LIBRARIES}
-+		Folly::folly
-+		OpenSSL::SSL
-+		OpenSSL::Crypto
++    Folly::folly
++    OpenSSL::SSL
++    OpenSSL::Crypto
      unofficial-sodium::sodium
      Threads::Threads
      ZLIB::ZLIB
@@ -92,7 +92,7 @@ index 64bf93b..39af257 100644
 +    gflags::gflags
      ${FIZZ_LINK_LIBRARIES}
 -    ${DOUBLE_CONVERSION_LIBRARY}
-+		libevent::core
++    libevent::core
 +    double-conversion::double-conversion
      ${CMAKE_DL_LIBS}
      ${LIBRT_LIBRARIES})
@@ -113,7 +113,7 @@ index 64bf93b..39af257 100644
      fizz
 -    ${LIBGMOCK_LIBRARIES}
 -    ${GLOG_LIBRARY}
-+		glog::glog
++    glog::glog
  )
  
 -target_compile_definitions(fizz_test_support
@@ -148,24 +148,6 @@ index 64bf93b..39af257 100644
  
    if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
      # GMOCK_MOCK_METHOD() will complain otherwise
-@@ -462,7 +422,7 @@ option(BUILD_EXAMPLES "BUILD_EXAMPLES" ON)
- 
- if(BUILD_EXAMPLES)
-   add_executable(BogoShim test/BogoShim.cpp)
--  target_link_libraries(BogoShim fizz sodium)
-+  target_link_libraries(BogoShim fizz)
-   set_target_properties(BogoShim PROPERTIES OUTPUT_NAME fizz-bogoshim)
-   install(
-     TARGETS BogoShim
-@@ -476,7 +436,7 @@ if(BUILD_EXAMPLES)
-       tool/FizzGenerateDelegatedCredentialCommand.cpp
-       tool/FizzServerBenchmarkCommand.cpp
-       tool/FizzServerCommand.cpp)
--  target_link_libraries(FizzTool fizz sodium)
-+  target_link_libraries(FizzTool fizz)
-   set_target_properties(FizzTool PROPERTIES OUTPUT_NAME fizz)
-   install(
-     TARGETS FizzTool
 diff --git a/fizz/cmake/fizz-config.cmake.in b/fizz/cmake/fizz-config.cmake.in
 index 3fb48b2..baa43a6 100644
 --- a/fizz/cmake/fizz-config.cmake.in

--- a/ports/fizz/portfile.cmake
+++ b/ports/fizz/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     PATCHES
         0001-fix-libsodium.patch
         0002-fix-libevent.patch
-				0003-fix-deps.patch
+        0003-fix-deps.patch
 )
 
 # Prefer installed config files

--- a/ports/fizz/portfile.cmake
+++ b/ports/fizz/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         0001-fix-libsodium.patch
         0002-fix-libevent.patch
+				0003-fix-deps.patch
 )
 
 # Prefer installed config files

--- a/ports/fizz/vcpkg.json
+++ b/ports/fizz/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fizz",
   "version-string": "2022.10.31.00",
+  "port-version": 1,
   "description": "a TLS 1.3 implementation by Facebook",
   "homepage": "https://github.com/facebookincubator/fizz",
   "license": "BSD-3-Clause",
@@ -8,6 +9,9 @@
     "double-conversion",
     "fmt",
     "folly",
+    "gflags",
+    "glog",
+    "gtest",
     "libevent",
     "libsodium",
     "openssl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2474,7 +2474,7 @@
     },
     "fizz": {
       "baseline": "2022.10.31.00",
-      "port-version": 0
+      "port-version": 1
     },
     "flann": {
       "baseline": "2019-04-07",

--- a/versions/f-/fizz.json
+++ b/versions/f-/fizz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9aa17880e736261a0e9efc5a7dbeb5820f41be2b",
+      "version-string": "2022.10.31.00",
+      "port-version": 1
+    },
+    {
       "git-tree": "aa78418cc3a270fb236d03b946e1658feabd19dc",
       "version-string": "2022.10.31.00",
       "port-version": 0

--- a/versions/f-/fizz.json
+++ b/versions/f-/fizz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9aa17880e736261a0e9efc5a7dbeb5820f41be2b",
+      "git-tree": "df45ebd305a5416215667058e31729d6f28f7b64",
       "version-string": "2022.10.31.00",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [*] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [*] Any patches that are no longer applied are deleted from the port's directory.
- [*] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [*] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
