### PR TITLE
[json-c] Update to 2023-03-28

### DIFF
--- a/ports/json-c/portfile.cmake
+++ b/ports/json-c/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO json-c/json-c
-    REF d28ac67dde77566f53a97f22b4ea7cb36afe6582
-    SHA512 30063c8e32eb82e170647363055119f2f7eab19e1c3152673b966f41ed07e0349c3d6141b215b9912f9e84c2e06677b3d7ac949f720c7ebc2c95d692dc3881fe
+    REF d0f32a5a43d1b9dc0b2cd6af310e5f09b97c3423
+    SHA512 c4d4bb1a54ae95f47223636c51c8ad611d2a8d698e9dbdc2d3fd06946b23d34b78af930762eb7f98cb49ae0a78948a668b1c44e1bb590069d5dd90dbcbb078ab
     HEAD_REF master
     PATCHES pkgconfig.patch
             fix-clang-cl.patch

--- a/ports/json-c/vcpkg.json
+++ b/ports/json-c/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "json-c",
-  "version-date": "2022-06-26",
-  "port-version": 2,
+  "version-date": "2023-03-28",
   "description": "A JSON implementation in C",
   "homepage": "https://github.com/json-c/json-c",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3393,8 +3393,8 @@
       "port-version": 1
     },
     "json-c": {
-      "baseline": "2022-06-26",
-      "port-version": 2
+      "baseline": "2023-03-28",
+      "port-version": 0
     },
     "json-dto": {
       "baseline": "0.3.1",

--- a/versions/j-/json-c.json
+++ b/versions/j-/json-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "311b30650779d18fa8d42829a92616895b8f806b",
+      "version-date": "2023-03-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "2090ebb6a6e0be1d0f6331c266bd0bc6eef1cd57",
       "version-date": "2022-06-26",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
