### PR TITLE
[vulkan] Fix SDK detection fails for official debian packages

### DIFF
--- a/ports/vulkan/CMakeLists.txt
+++ b/ports/vulkan/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(FIND_VULKAN LANGUAGES C)
+
+set(CMAKE_FIND_DEBUG_MODE ON)
+
+find_package(Vulkan ${VCPKG_VULKAN_VERSION})
+
+set(OUTFILE "${CMAKE_CURRENT_BINARY_DIR}/vulkan-result.cmake" CACHE FILEPATH "")
+configure_file("vulkan-result.cmake.in" "${OUTFILE}" @ONLY ESCAPE_QUOTES)

--- a/ports/vulkan/portfile.cmake
+++ b/ports/vulkan/portfile.cmake
@@ -1,44 +1,36 @@
-# Due to the complexity involved, this package doesn't install the Vulkan SDK.
-# It instead verifies that Vulkan is installed.
-# Other packages can depend on this package to declare a dependency on Vulkan.
-message(STATUS "Querying VULKAN_SDK Enviroment variable")
-file(TO_CMAKE_PATH "$ENV{VULKAN_SDK}" VULKAN_DIR)
-set(VULKAN_INCLUDE "${VULKAN_DIR}/include/vulkan/")
-set(VULKAN_ERROR_DL "Before continuing, please download and install Vulkan from:\n    https://vulkan.lunarg.com/sdk/home\nIf you have already downloaded it, make sure the VULKAN_SDK environment variable is set to vulkan's installation root.")
+# This package just verifies that the Vulkan SDK is installed.
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
-if(NOT DEFINED ENV{VULKAN_SDK})
-    message(FATAL_ERROR "Could not find Vulkan SDK. ${VULKAN_ERROR_DL}")
+if(DEFINED ENV{VULKAN_SDK})
+    message(STATUS "VULKAN_SDK environment variable: $ENV{VULKAN_SDK}")
 endif()
 
-message(STATUS "Searching " ${VULKAN_INCLUDE} " for vulkan.h")
-if(NOT EXISTS "${VULKAN_INCLUDE}/vulkan.h")
-    message(FATAL_ERROR "Could not find vulkan.h. ${VULKAN_ERROR_DL}")
-endif()
-message(STATUS "Found vulkan.h")
+set(vulkan_result_file "${CURRENT_BUILDTREES_DIR}/vulkan-${TARGET_TRIPLET}.cmake.log")
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}"
+    OPTIONS
+        "-DVCPKG_VULKAN_VERSION=${VERSION}"
+    OPTIONS_RELEASE
+        "-DOUTFILE=${vulkan_result_file}"
+)
 
-# Check if the user left the version in the installation directory e.g. c:/vulkanSDK/1.1.82.1/
-if(VULKAN_DIR MATCHES "(([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+))")
-    set(VULKAN_VERSION "${CMAKE_MATCH_1}")
-    set(VULKAN_MAJOR "${CMAKE_MATCH_2}")
-    set(VULKAN_MINOR "${CMAKE_MATCH_3}")
-    set(VULKAN_PATCH "${CMAKE_MATCH_4}")
-    message(STATUS "Found Vulkan SDK version ${VULKAN_VERSION}")
-
-    set(VULKAN_REQUIRED_VERSION "1.1.82.1")
-    if (VULKAN_MAJOR LESS 1 OR VULKAN_MINOR LESS 1 OR VULKAN_PATCH LESS 82)
-        message(FATAL_ERROR "Vulkan ${VULKAN_VERSION} but ${VULKAN_REQUIRED_VERSION} is required. Please download and install a more recent version from:"
-                            "\n    https://vulkan.lunarg.com/sdk/home\n")
-    endif()
-endif()
-
-if (EXISTS ${VULKAN_DIR}/../LICENSE.txt)
-    configure_file(${VULKAN_DIR}/../LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/vulkan/copyright COPYONLY)
-elseif(EXISTS ${VULKAN_DIR}/LICENSE.txt)
-    configure_file(${VULKAN_DIR}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/vulkan/copyright COPYONLY)
+include("${vulkan_result_file}")
+if(DETECTED_Vulkan_FOUND)
+    message(STATUS "Found Vulkan SDK ${DETECTED_Vulkan_VERSION} (${DETECTED_Vulkan_LIBRARIES})")
 else()
-    configure_file(${CURRENT_PORT_DIR}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/vulkan/copyright COPYONLY)
+    set(message "The Vulkan SDK wasn't found. ")
+    if(VCPKG_TARGET_IS_WINDOWS)
+        string(APPEND message "Refer to Getting Started with the Windows Vulkan SDK: https://vulkan.lunarg.com/doc/sdk/latest/windows/getting_started.html")
+    elseif(VCPKG_TARGET_IS_OSX)
+        string(APPEND message "Refer to Getting Started with the MacOS Vulkan SDK: https://vulkan.lunarg.com/doc/sdk/latest/mac/getting_started.html")
+    elseif(VCPKG_TARGET_IS_LINUX)
+        string(APPEND message "Refer to Getting Started with the Linux Vulkan SDK: https://vulkan.lunarg.com/doc/sdk/latest/linux/getting_started.html")
+    endif()
+    message(FATAL_ERROR "${message}")
 endif()
 
-SET(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+find_file(vulkan_license NAMES LICENSE.txt PATHS ${DETECTED_Vulkan_INCLUDE_DIRS} "${CURRENT_PORT_DIR}" PATH_SUFFIXES "..")
+vcpkg_install_copyright(FILE_LIST "${vulkan_license}")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/vulkan/usage
+++ b/ports/vulkan/usage
@@ -1,9 +1,8 @@
-The package vulkan does not provide cmake or visual studio integration directly.
-However, it can still easily be used.
+vulkan is compatible with built-in CMake targets:
 
-    Visual Studio:
-    Include $(VULKAN_SDK)/include to your include path.
-
-    CMake:
+    # https://cmake.org/cmake/help/latest/module/FindVulkan.html
     find_package(Vulkan REQUIRED)
     target_link_libraries(main PRIVATE Vulkan::Vulkan)
+
+The vulkan package does not provide direct Visual Studio integration.
+For manual integration, add $(VULKAN_SDK)/include to your include path.

--- a/ports/vulkan/vcpkg.json
+++ b/ports/vulkan/vcpkg.json
@@ -1,8 +1,14 @@
 {
   "name": "vulkan",
   "version": "1.1.82.1",
-  "port-version": 5,
-  "description": "A graphics and compute API that provides high-efficiency, cross-platform access to modern GPUs on a wide variety of devices.",
+  "port-version": 6,
+  "description": "A stub package that ensures that the Vulkan SDK is installed.",
   "license": null,
-  "supports": "!uwp & !xbox"
+  "supports": "!uwp & !xbox",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/ports/vulkan/vulkan-result.cmake.in
+++ b/ports/vulkan/vulkan-result.cmake.in
@@ -1,0 +1,4 @@
+set(DETECTED_Vulkan_FOUND "@Vulkan_FOUND@")
+set(DETECTED_Vulkan_VERSION "@Vulkan_VERSION@")
+set(DETECTED_Vulkan_INCLUDE_DIRS "@Vulkan_INCLUDE_DIRS@")
+set(DETECTED_Vulkan_LIBRARIES "@Vulkan_LIBRARIES@")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8342,7 +8342,7 @@
     },
     "vulkan": {
       "baseline": "1.1.82.1",
-      "port-version": 5
+      "port-version": 6
     },
     "vulkan-headers": {
       "baseline": "1.3.243",

--- a/versions/v-/vulkan.json
+++ b/versions/v-/vulkan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea62236a3c91051f5ccb340442b60a026bf160c6",
+      "version": "1.1.82.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "80d4793fe3882fca0afcb470183f404d97c22981",
       "version": "1.1.82.1",
       "port-version": 5


### PR DESCRIPTION
Fixes #13331

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
