### PR TITLE
[wangle]:fix dependency

### DIFF
--- a/ports/folly/fix-deps.patch
+++ b/ports/folly/fix-deps.patch
@@ -57,7 +57,7 @@ index 4b78e9f..ac83c99 100644
      thread
    REQUIRED
  )
-+set (Boost_LIBRARIES Boost::context Boost::filesystem Boost::program_options Boost::regex  Boost::system Boost::thread
++set (Boost_LIBRARIES Boost::boost Boost::context Boost::filesystem Boost::program_options Boost::regex  Boost::system Boost::thread
 +  )
  list(APPEND FOLLY_LINK_LIBRARIES ${Boost_LIBRARIES})
 -list(APPEND FOLLY_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "folly",
   "version-string": "2022.10.31.00",
-  "port-version": 5,
+  "port-version": 6,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/ports/wangle/fix_dependency.patch
+++ b/ports/wangle/fix_dependency.patch
@@ -1,8 +1,8 @@
 diff --git a/wangle/CMakeLists.txt b/wangle/CMakeLists.txt
-index 977bbe4..658eb63 100644
+index 977bbe4..831090b 100644
 --- a/wangle/CMakeLists.txt
 +++ b/wangle/CMakeLists.txt
-@@ -64,18 +64,11 @@ set(CMAKE_INSTALL_DIR lib/cmake/wangle CACHE STRING
+@@ -64,18 +64,17 @@ set(CMAKE_INSTALL_DIR lib/cmake/wangle CACHE STRING
  find_package(folly CONFIG REQUIRED)
  
  find_package(fizz CONFIG REQUIRED)
@@ -10,58 +10,52 @@ index 977bbe4..658eb63 100644
  find_package(OpenSSL REQUIRED)
 -find_package(Glog REQUIRED)
 -find_package(gflags CONFIG QUIET)
--if (gflags_FOUND)
--  message(STATUS "Found gflags from package config")
--  message(STATUS "gflags_CONFIG=${gflags_CONFIG}")
--else()
--  find_package(Gflags REQUIRED)
--endif()
--find_package(LibEvent MODULE REQUIRED)
--find_package(DoubleConversion REQUIRED)
 +find_package(glog CONFIG REQUIRED)
 +find_package(gflags CONFIG REQUIRED)
+ if (gflags_FOUND)
+   message(STATUS "Found gflags from package config")
+   message(STATUS "gflags_CONFIG=${gflags_CONFIG}")
+ else()
+   find_package(Gflags REQUIRED)
+ endif()
+-find_package(LibEvent MODULE REQUIRED)
+-find_package(DoubleConversion REQUIRED)
 +find_package(Libevent CONFIG REQUIRED)
 +find_package(double-conversion CONFIG REQUIRED)
  find_package(Threads REQUIRED)
  if (UNIX AND NOT APPLE)
    find_package(Librt)
-@@ -157,24 +150,18 @@ target_include_directories(
+@@ -152,6 +151,14 @@ if (BUILD_SHARED_LIBS)
+     PROPERTIES VERSION ${PACKAGE_VERSION})
+ endif()
+ 
++set(FIZZ_INCLUDE_DIR "")
++set(FOLLY_INCLUDE_DIR "")
++set(Boost_INCLUDE_DIR "")
++set(GLOG_INCLUDE_DIRS "")
++set(GFLAGS_INCLUDE_DIRS "")
++set(LIBEVENT_INCLUDE_DIR "")
++set(DOUBLE_CONVERSION_INCLUDE_DIRS "")
++set(OPENSSL_INCLUDE_DIR "")
+ target_include_directories(
+   wangle
    PUBLIC
-     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/..>
-     $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
--    ${FIZZ_INCLUDE_DIR}
--    ${FOLLY_INCLUDE_DIR}
--    ${Boost_INCLUDE_DIR}
--    ${OPENSSL_INCLUDE_DIR}
--    ${GLOG_INCLUDE_DIRS}
--    ${GFLAGS_INCLUDE_DIRS}
--    ${LIBEVENT_INCLUDE_DIR}
--    ${DOUBLE_CONVERSION_INCLUDE_DIRS}
-+  PRIVATE
+@@ -166,6 +173,13 @@ target_include_directories(
+     ${LIBEVENT_INCLUDE_DIR}
+     ${DOUBLE_CONVERSION_INCLUDE_DIRS}
  )
++set(FOLLY_LIBRARIES             Folly::folly)
++set(FIZZ_LIBRARIES              fizz::fizz)
++set(GLOG_LIBRARIES              glog::glog)
++set(GFLAGS_LIBRARIES            gflags::gflags)
++set(LIBEVENT_LIB                libevent::core libevent::extra)
++set(DOUBLE_CONVERSION_LIBRARIES double-conversion::double-conversion)
++
  target_link_libraries(wangle PUBLIC
--  ${FOLLY_LIBRARIES}
--  ${FIZZ_LIBRARIES}
--  ${Boost_LIBRARIES}
--  ${OPENSSL_LIBRARIES}
--  ${GLOG_LIBRARIES}
--  ${GFLAGS_LIBRARIES}
--  ${LIBEVENT_LIB}
--  ${DOUBLE_CONVERSION_LIBRARIES}
-+  Folly::folly
-+  fizz::fizz
-+  OpenSSL::SSL
-+  OpenSSL::Crypto
-+  glog::glog
-+  gflags::gflags
-+  libevent::core
-+  libevent::extra
-+  double-conversion::double-conversion
-   ${CMAKE_DL_LIBS}
-   ${LIBRT_LIBRARIES}
-   Threads::Threads)
+   ${FOLLY_LIBRARIES}
+   ${FIZZ_LIBRARIES}
 diff --git a/wangle/cmake/wangle-config.cmake.in b/wangle/cmake/wangle-config.cmake.in
-index e0fd0dc..0aef27b 100644
+index e0fd0dc..52b50d1 100644
 --- a/wangle/cmake/wangle-config.cmake.in
 +++ b/wangle/cmake/wangle-config.cmake.in
 @@ -15,13 +15,14 @@ set_and_check(WANGLE_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
@@ -77,8 +71,8 @@ index e0fd0dc..0aef27b 100644
 -find_dependency(double-conversion REQUIRED)
 +find_dependency(folly CONFIG)
 +find_dependency(fizz CONFIG)
-+find_dependency(glog CONFIG)
 +find_dependency(gflags CONFIG)
++find_dependency(glog CONFIG)
 +find_dependency(Threads)
 +find_dependency(Libevent CONFIG)
 +find_dependency(OpenSSL)

--- a/ports/wangle/fix_dependency.patch
+++ b/ports/wangle/fix_dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/wangle/CMakeLists.txt b/wangle/CMakeLists.txt
-index 977bbe4..3c2bb4a 100644
+index 977bbe4..5a092d4 100644
 --- a/wangle/CMakeLists.txt
 +++ b/wangle/CMakeLists.txt
 @@ -64,18 +64,17 @@ set(CMAKE_INSTALL_DIR lib/cmake/wangle CACHE STRING
@@ -25,20 +25,7 @@ index 977bbe4..3c2bb4a 100644
  find_package(Threads REQUIRED)
  if (UNIX AND NOT APPLE)
    find_package(Librt)
-@@ -152,6 +151,12 @@ if (BUILD_SHARED_LIBS)
-     PROPERTIES VERSION ${PACKAGE_VERSION})
- endif()
- 
-+set(FIZZ_INCLUDE_DIR "")
-+set(FOLLY_INCLUDE_DIR "")
-+set(GLOG_INCLUDE_DIRS "")
-+set(GFLAGS_INCLUDE_DIRS "")
-+set(LIBEVENT_INCLUDE_DIR "")
-+set(DOUBLE_CONVERSION_INCLUDE_DIRS "")
- target_include_directories(
-   wangle
-   PUBLIC
-@@ -166,6 +171,13 @@ target_include_directories(
+@@ -166,6 +165,13 @@ target_include_directories(
      ${LIBEVENT_INCLUDE_DIR}
      ${DOUBLE_CONVERSION_INCLUDE_DIRS}
  )

--- a/ports/wangle/fix_dependency.patch
+++ b/ports/wangle/fix_dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/wangle/CMakeLists.txt b/wangle/CMakeLists.txt
-index 977bbe4..9009572 100644
+index 977bbe4..3c2bb4a 100644
 --- a/wangle/CMakeLists.txt
 +++ b/wangle/CMakeLists.txt
 @@ -64,18 +64,17 @@ set(CMAKE_INSTALL_DIR lib/cmake/wangle CACHE STRING
@@ -25,13 +25,12 @@ index 977bbe4..9009572 100644
  find_package(Threads REQUIRED)
  if (UNIX AND NOT APPLE)
    find_package(Librt)
-@@ -152,6 +151,13 @@ if (BUILD_SHARED_LIBS)
+@@ -152,6 +151,12 @@ if (BUILD_SHARED_LIBS)
      PROPERTIES VERSION ${PACKAGE_VERSION})
  endif()
  
 +set(FIZZ_INCLUDE_DIR "")
 +set(FOLLY_INCLUDE_DIR "")
-+set(Boost_INCLUDE_DIR "")
 +set(GLOG_INCLUDE_DIRS "")
 +set(GFLAGS_INCLUDE_DIRS "")
 +set(LIBEVENT_INCLUDE_DIR "")
@@ -39,7 +38,7 @@ index 977bbe4..9009572 100644
  target_include_directories(
    wangle
    PUBLIC
-@@ -166,6 +172,13 @@ target_include_directories(
+@@ -166,6 +171,13 @@ target_include_directories(
      ${LIBEVENT_INCLUDE_DIR}
      ${DOUBLE_CONVERSION_INCLUDE_DIRS}
  )

--- a/ports/wangle/fix_dependency.patch
+++ b/ports/wangle/fix_dependency.patch
@@ -1,56 +1,88 @@
 diff --git a/wangle/CMakeLists.txt b/wangle/CMakeLists.txt
-index 8df7c76..f605f25 100644
+index 977bbe4..658eb63 100644
 --- a/wangle/CMakeLists.txt
 +++ b/wangle/CMakeLists.txt
-@@ -62,7 +62,7 @@ find_package(folly CONFIG REQUIRED)
+@@ -64,18 +64,11 @@ set(CMAKE_INSTALL_DIR lib/cmake/wangle CACHE STRING
+ find_package(folly CONFIG REQUIRED)
+ 
  find_package(fizz CONFIG REQUIRED)
- find_package(fmt CONFIG REQUIRED)
+-find_package(fmt CONFIG REQUIRED)
  find_package(OpenSSL REQUIRED)
 -find_package(Glog REQUIRED)
-+find_package(glog CONFIG REQUIRED)
- find_package(gflags CONFIG QUIET)
- if (gflags_FOUND)
-   message(STATUS "Found gflags from package config")
-@@ -70,8 +70,8 @@ if (gflags_FOUND)
- else()
-   find_package(Gflags REQUIRED)
- endif()
+-find_package(gflags CONFIG QUIET)
+-if (gflags_FOUND)
+-  message(STATUS "Found gflags from package config")
+-  message(STATUS "gflags_CONFIG=${gflags_CONFIG}")
+-else()
+-  find_package(Gflags REQUIRED)
+-endif()
 -find_package(LibEvent MODULE REQUIRED)
 -find_package(DoubleConversion REQUIRED)
++find_package(glog CONFIG REQUIRED)
++find_package(gflags CONFIG REQUIRED)
 +find_package(Libevent CONFIG REQUIRED)
 +find_package(double-conversion CONFIG REQUIRED)
  find_package(Threads REQUIRED)
  if (UNIX AND NOT APPLE)
    find_package(Librt)
-@@ -153,24 +153,23 @@ target_include_directories(
+@@ -157,24 +150,18 @@ target_include_directories(
    PUBLIC
      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/..>
      $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
-+  PRIVATE
-     ${FIZZ_INCLUDE_DIR}
-     ${FOLLY_INCLUDE_DIR}
-     ${Boost_INCLUDE_DIR}
+-    ${FIZZ_INCLUDE_DIR}
+-    ${FOLLY_INCLUDE_DIR}
+-    ${Boost_INCLUDE_DIR}
 -    ${OPENSSL_INCLUDE_DIR}
 -    ${GLOG_INCLUDE_DIRS}
-     ${GFLAGS_INCLUDE_DIRS}
+-    ${GFLAGS_INCLUDE_DIRS}
 -    ${LIBEVENT_INCLUDE_DIR}
 -    ${DOUBLE_CONVERSION_INCLUDE_DIRS}
++  PRIVATE
  )
  target_link_libraries(wangle PUBLIC
-   ${FOLLY_LIBRARIES}
-   ${FIZZ_LIBRARIES}
-   ${Boost_LIBRARIES}
+-  ${FOLLY_LIBRARIES}
+-  ${FIZZ_LIBRARIES}
+-  ${Boost_LIBRARIES}
 -  ${OPENSSL_LIBRARIES}
 -  ${GLOG_LIBRARIES}
+-  ${GFLAGS_LIBRARIES}
+-  ${LIBEVENT_LIB}
+-  ${DOUBLE_CONVERSION_LIBRARIES}
++  Folly::folly
++  fizz::fizz
 +  OpenSSL::SSL
 +  OpenSSL::Crypto
 +  glog::glog
-   ${GFLAGS_LIBRARIES}
--  ${LIBEVENT_LIB}
--  ${DOUBLE_CONVERSION_LIBRARIES}
++  gflags::gflags
 +  libevent::core
 +  libevent::extra
 +  double-conversion::double-conversion
    ${CMAKE_DL_LIBS}
    ${LIBRT_LIBRARIES}
    Threads::Threads)
+diff --git a/wangle/cmake/wangle-config.cmake.in b/wangle/cmake/wangle-config.cmake.in
+index e0fd0dc..0aef27b 100644
+--- a/wangle/cmake/wangle-config.cmake.in
++++ b/wangle/cmake/wangle-config.cmake.in
+@@ -15,13 +15,14 @@ set_and_check(WANGLE_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+ set_and_check(WANGLE_CMAKE_DIR "${PACKAGE_PREFIX_DIR}/share/wangle")
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(folly REQUIRED)
+-find_dependency(fizz REQUIRED)
+-find_dependency(glog REQUIRED)
+-find_dependency(Threads REQUIRED)
+-find_dependency(Libevent REQUIRED)
+-find_dependency(OpenSSL REQUIRED)
+-find_dependency(double-conversion REQUIRED)
++find_dependency(folly CONFIG)
++find_dependency(fizz CONFIG)
++find_dependency(glog CONFIG)
++find_dependency(gflags CONFIG)
++find_dependency(Threads)
++find_dependency(Libevent CONFIG)
++find_dependency(OpenSSL CONFIG)
++find_dependency(double-conversion CONFIG)
+ 
+ if (NOT TARGET wangle::wangle)
+   include("${WANGLE_CMAKE_DIR}/wangle-targets.cmake")

--- a/ports/wangle/fix_dependency.patch
+++ b/ports/wangle/fix_dependency.patch
@@ -1,8 +1,8 @@
 diff --git a/wangle/CMakeLists.txt b/wangle/CMakeLists.txt
-index 977bbe4..5a092d4 100644
+index 977bbe4..155f9cc 100644
 --- a/wangle/CMakeLists.txt
 +++ b/wangle/CMakeLists.txt
-@@ -64,18 +64,17 @@ set(CMAKE_INSTALL_DIR lib/cmake/wangle CACHE STRING
+@@ -64,18 +64,23 @@ set(CMAKE_INSTALL_DIR lib/cmake/wangle CACHE STRING
  find_package(folly CONFIG REQUIRED)
  
  find_package(fizz CONFIG REQUIRED)
@@ -12,6 +12,12 @@ index 977bbe4..5a092d4 100644
 -find_package(gflags CONFIG QUIET)
 +find_package(glog CONFIG REQUIRED)
 +find_package(gflags CONFIG REQUIRED)
++find_package(Boost REQUIRED
++  COMPONENTS
++	filesystem
++	thread
++)
++
  if (gflags_FOUND)
    message(STATUS "Found gflags from package config")
    message(STATUS "gflags_CONFIG=${gflags_CONFIG}")
@@ -25,10 +31,11 @@ index 977bbe4..5a092d4 100644
  find_package(Threads REQUIRED)
  if (UNIX AND NOT APPLE)
    find_package(Librt)
-@@ -166,6 +165,13 @@ target_include_directories(
+@@ -166,6 +171,14 @@ target_include_directories(
      ${LIBEVENT_INCLUDE_DIR}
      ${DOUBLE_CONVERSION_INCLUDE_DIRS}
  )
++set(Boost_LIBRARIES             Boost::boost Boost::filesystem  Boost::thread )
 +set(FOLLY_LIBRARIES             Folly::folly)
 +set(FIZZ_LIBRARIES              fizz::fizz)
 +set(GLOG_LIBRARIES              glog::glog)
@@ -40,10 +47,10 @@ index 977bbe4..5a092d4 100644
    ${FOLLY_LIBRARIES}
    ${FIZZ_LIBRARIES}
 diff --git a/wangle/cmake/wangle-config.cmake.in b/wangle/cmake/wangle-config.cmake.in
-index e0fd0dc..52b50d1 100644
+index e0fd0dc..5f6cf14 100644
 --- a/wangle/cmake/wangle-config.cmake.in
 +++ b/wangle/cmake/wangle-config.cmake.in
-@@ -15,13 +15,14 @@ set_and_check(WANGLE_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+@@ -15,13 +15,19 @@ set_and_check(WANGLE_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
  set_and_check(WANGLE_CMAKE_DIR "${PACKAGE_PREFIX_DIR}/share/wangle")
  
  include(CMakeFindDependencyMacro)
@@ -62,6 +69,11 @@ index e0fd0dc..52b50d1 100644
 +find_dependency(Libevent CONFIG)
 +find_dependency(OpenSSL)
 +find_dependency(double-conversion CONFIG)
++find_dependency(Boost
++  COMPONENTS
++    filesystem
++    thread
++)
  
  if (NOT TARGET wangle::wangle)
    include("${WANGLE_CMAKE_DIR}/wangle-targets.cmake")

--- a/ports/wangle/fix_dependency.patch
+++ b/ports/wangle/fix_dependency.patch
@@ -81,7 +81,7 @@ index e0fd0dc..0aef27b 100644
 +find_dependency(gflags CONFIG)
 +find_dependency(Threads)
 +find_dependency(Libevent CONFIG)
-+find_dependency(OpenSSL CONFIG)
++find_dependency(OpenSSL)
 +find_dependency(double-conversion CONFIG)
  
  if (NOT TARGET wangle::wangle)

--- a/ports/wangle/fix_dependency.patch
+++ b/ports/wangle/fix_dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/wangle/CMakeLists.txt b/wangle/CMakeLists.txt
-index 977bbe4..831090b 100644
+index 977bbe4..9009572 100644
 --- a/wangle/CMakeLists.txt
 +++ b/wangle/CMakeLists.txt
 @@ -64,18 +64,17 @@ set(CMAKE_INSTALL_DIR lib/cmake/wangle CACHE STRING
@@ -25,7 +25,7 @@ index 977bbe4..831090b 100644
  find_package(Threads REQUIRED)
  if (UNIX AND NOT APPLE)
    find_package(Librt)
-@@ -152,6 +151,14 @@ if (BUILD_SHARED_LIBS)
+@@ -152,6 +151,13 @@ if (BUILD_SHARED_LIBS)
      PROPERTIES VERSION ${PACKAGE_VERSION})
  endif()
  
@@ -36,11 +36,10 @@ index 977bbe4..831090b 100644
 +set(GFLAGS_INCLUDE_DIRS "")
 +set(LIBEVENT_INCLUDE_DIR "")
 +set(DOUBLE_CONVERSION_INCLUDE_DIRS "")
-+set(OPENSSL_INCLUDE_DIR "")
  target_include_directories(
    wangle
    PUBLIC
-@@ -166,6 +173,13 @@ target_include_directories(
+@@ -166,6 +172,13 @@ target_include_directories(
      ${LIBEVENT_INCLUDE_DIR}
      ${DOUBLE_CONVERSION_INCLUDE_DIRS}
  )

--- a/ports/wangle/portfile.cmake
+++ b/ports/wangle/portfile.cmake
@@ -11,6 +11,17 @@ vcpkg_from_github(
         fix_dependency.patch
 )
 
+file(REMOVE
+  "${SOURCE_PATH}/wangle/cmake/FindDoubleConversion.cmake"
+  "${SOURCE_PATH}/build/fbcode_builder/CMake/FindGflags.cmake"
+  "${SOURCE_PATH}/build/fbcode_builder/CMake/FindGlog.cmake"
+  "${SOURCE_PATH}/build/fbcode_builder/CMake/FindGMock.cmake"
+  "${SOURCE_PATH}/build/fbcode_builder/CMake/FindLibEvent.cmake"
+  "${SOURCE_PATH}/build/fbcode_builder/CMake/FindSodium.cmake"
+  "${SOURCE_PATH}/build/fbcode_builder/CMake/FindZstd.cmake"
+)
+
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/wangle"
     OPTIONS

--- a/ports/wangle/vcpkg.json
+++ b/ports/wangle/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wangle",
   "version-string": "2022.03.21.00",
+  "port-version": 1,
   "description": "Wangle is a framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.",
   "homepage": "https://github.com/facebook/wangle",
   "license": "Apache-2.0",
@@ -13,6 +14,7 @@
     "double-conversion",
     "fizz",
     "folly",
+    "gflags",
     "glog",
     "libevent",
     "openssl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8382,7 +8382,7 @@
     },
     "wangle": {
       "baseline": "2022.03.21.00",
-      "port-version": 0
+      "port-version": 1
     },
     "wasmedge": {
       "baseline": "0.12.0-alpha.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2542,7 +2542,7 @@
     },
     "folly": {
       "baseline": "2022.10.31.00",
-      "port-version": 5
+      "port-version": 6
     },
     "font-chef": {
       "baseline": "1.1.0",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2be8536b3faaf9f907284548e4db1f49b77054c1",
+      "git-tree": "6ecf09c10ff94b6e9eb8b28560bca7e623e277df",
       "version-string": "2022.10.31.00",
       "port-version": 5
     },

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "204d88dbc53dc5ff37c58459c1af0c6f19f446db",
+      "version-string": "2022.10.31.00",
+      "port-version": 6
+    },
+    {
       "git-tree": "6ecf09c10ff94b6e9eb8b28560bca7e623e277df",
       "version-string": "2022.10.31.00",
       "port-version": 5

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -6,7 +6,7 @@
       "port-version": 6
     },
     {
-      "git-tree": "6ecf09c10ff94b6e9eb8b28560bca7e623e277df",
+      "git-tree": "2be8536b3faaf9f907284548e4db1f49b77054c1",
       "version-string": "2022.10.31.00",
       "port-version": 5
     },

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3991681f9b546246d78a475aa4f5dea99a4abe0e",
+      "git-tree": "6ca5554af76f56f5f19a8a5bfaee03461cfa4a1a",
       "version-string": "2022.03.21.00",
       "port-version": 1
     },

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2e35c1e149756ecb7825a45aa27fe125ea2877fa",
+      "version-string": "2022.03.21.00",
+      "port-version": 1
+    },
+    {
       "git-tree": "6f0fec69eddf934964ee77b9923f68da2c3c7724",
       "version-string": "2022.03.21.00",
       "port-version": 0

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ca2dcb7645cd7b0b6af605063eb6d7ac428c3b49",
+      "git-tree": "3991681f9b546246d78a475aa4f5dea99a4abe0e",
       "version-string": "2022.03.21.00",
       "port-version": 1
     },

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2e35c1e149756ecb7825a45aa27fe125ea2877fa",
+      "git-tree": "2daca233f1a24ff0631816f0183bbe2b9e233c33",
       "version-string": "2022.03.21.00",
       "port-version": 1
     },

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6ca5554af76f56f5f19a8a5bfaee03461cfa4a1a",
+      "git-tree": "dbd4602c679e4cb530b3b6dc515eb6b10737c834",
       "version-string": "2022.03.21.00",
       "port-version": 1
     },

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dbd4602c679e4cb530b3b6dc515eb6b10737c834",
+      "git-tree": "e79739dcf42e3dd4d0e32c595b27ece48c762bdd",
       "version-string": "2022.03.21.00",
       "port-version": 1
     },

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2daca233f1a24ff0631816f0183bbe2b9e233c33",
+      "git-tree": "ca2dcb7645cd7b0b6af605063eb6d7ac428c3b49",
       "version-string": "2022.03.21.00",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
