### PR TITLE
[proxygen]:fix deps

### DIFF
--- a/ports/proxygen/fix-dependency.patch
+++ b/ports/proxygen/fix-dependency.patch
@@ -1,0 +1,84 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6bf0f17..343ec2b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,13 +66,13 @@ endif()
+ #
+ # IMPORTANT: If you change this, make the analogous update in:
+ #   cmake/proxygen-config.cmake.in
+-find_package(fmt REQUIRED)
+-find_package(folly REQUIRED)
+-find_package(wangle REQUIRED)
++find_package(fmt CONFIG REQUIRED)
++find_package(folly CONFIG REQUIRED)
++find_package(wangle CONFIG REQUIRED)
+ if (BUILD_QUIC)
+-  find_package(mvfst REQUIRED)
++  find_package(mvfst CONFIG REQUIRED)
+ else()
+- find_package(Fizz REQUIRED)
++  find_package(fizz CONFIG REQUIRED)
+ endif()
+ find_package(zstd CONFIG REQUIRED)
+ find_package(ZLIB REQUIRED)
+@@ -128,27 +128,8 @@ SET(GFLAG_DEPENDENCIES "")
+ SET(PROXYGEN_EXTRA_LINK_LIBRARIES "")
+ SET(PROXYGEN_EXTRA_INCLUDE_DIRECTORIES "")
+ 
+-find_package(gflags CONFIG QUIET)
+-if (gflags_FOUND)
+-  message("module path: ${CMAKE_MODULE_PATH}")
+-  message(STATUS "Found gflags from package config")
+-  if (TARGET gflags-shared)
+-    list(APPEND GFLAG_DEPENDENCIES gflags-shared)
+-  elseif (TARGET gflags)
+-    list(APPEND GFLAG_DEPENDENCIES gflags)
+-  else()
+-    message(FATAL_ERROR
+-            "Unable to determine the target name for the GFlags package.")
+-  endif()
+-  list(APPEND CMAKE_REQUIRED_LIBRARIES ${GFLAGS_LIBRARIES})
+-  list(APPEND CMAKE_REQUIRED_INCLUDES ${GFLAGS_INCLUDE_DIR})
+-else()
+-  find_package(Gflags REQUIRED MODULE)
+-  list(APPEND PROXYGEN_EXTRA_LINK_LIBRARIES ${LIBGFLAGS_LIBRARY})
+-  list(APPEND PROXYGEN_EXTRA_INCLUDE_DIRECTORIES ${LIBGFLAGS_INCLUDE_DIR})
+-  list(APPEND CMAKE_REQUIRED_LIBRARIES ${LIBGFLAGS_LIBRARY})
+-  list(APPEND CMAKE_REQUIRED_INCLUDES ${LIBGFLAGS_INCLUDE_DIR})
+-endif()
++find_package(gflags CONFIG REQUIRED)
++list(APPEND CMAKE_REQUIRED_LIBRARIES gflags::gflags)
+ 
+ include(ProxygenTest)
+ 
+diff --git a/cmake/proxygen-config.cmake.in b/cmake/proxygen-config.cmake.in
+index 8c1426d..f8b89a4 100644
+--- a/cmake/proxygen-config.cmake.in
++++ b/cmake/proxygen-config.cmake.in
+@@ -17,19 +17,20 @@
+ @PACKAGE_INIT@
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(fmt)
+-find_dependency(folly)
+-find_dependency(wangle)
++find_dependency(fmt CONFIG)
++find_dependency(folly CONFIG)
++find_dependency(wangle CONFIG)
+ if ("@BUILD_QUIC@")
+-  find_dependency(mvfst)
++  find_dependency(mvfst CONFIG)
+ endif()
+-find_dependency(Fizz)
++find_dependency(fizz CONFIG)
++find_dependency(gflags CONFIG)
+ # For now, anything that depends on Proxygen has to copy its FindZstd.cmake
+ # and issue a `find_package(Zstd)`.  Uncommenting this won't work because
+ # this Zstd module exposes a library called `zstd`.  The right fix is
+ # discussed on D24686032.
+ #
+-# find_dependency(Zstd)
++find_dependency(zstd CONFIG)
+ find_dependency(ZLIB)
+ find_dependency(OpenSSL)
+ find_dependency(Threads)

--- a/ports/proxygen/portfile.cmake
+++ b/ports/proxygen/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         remove-register.patch
         fix-zstd-zlib-dependency.patch
+        fix-dependency.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/proxygen/vcpkg.json
+++ b/ports/proxygen/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "proxygen",
   "version-string": "2022.07.11.00",
+  "port-version": 1,
   "description": "It comprises the core C++ HTTP abstractions used at Facebook.",
   "homepage": "https://github.com/facebook/proxygen",
   "license": "BSD-3-Clause",
@@ -16,6 +17,7 @@
     "boost-thread",
     "fizz",
     "folly",
+    "gflags",
     {
       "name": "gperf",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6314,7 +6314,7 @@
     },
     "proxygen": {
       "baseline": "2022.07.11.00",
-      "port-version": 0
+      "port-version": 1
     },
     "psimd": {
       "baseline": "2021-02-21",

--- a/versions/p-/proxygen.json
+++ b/versions/p-/proxygen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e66bcd352675efbaf2ff458ae1709c165ed26696",
+      "version-string": "2022.07.11.00",
+      "port-version": 1
+    },
+    {
       "git-tree": "7f8e28d0d1ec8591df5cdfa602d60e0efaa8ee7a",
       "version-string": "2022.07.11.00",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
