### PR TITLE
[imgui] imgui[glfw-binding]:wasm32-emscripten build fix

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -53,8 +53,10 @@ if(IMGUI_BUILD_DX12_BINDING)
 endif()
 
 if(IMGUI_BUILD_GLFW_BINDING)
-    find_package(glfw3 CONFIG REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PUBLIC glfw)
+    if(NOT EMSCRIPTEN)
+        find_package(glfw3 CONFIG REQUIRED)
+        target_link_libraries(${PROJECT_NAME} PUBLIC glfw)
+    endif()
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glfw.cpp)
 endif()
 

--- a/ports/imgui/imgui-config.cmake.in
+++ b/ports/imgui/imgui-config.cmake.in
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0012 NEW)
 include(CMakeFindDependencyMacro)
 
 if (@IMGUI_BUILD_GLFW_BINDING@)
-    if (NOT EMSCRIPTEN)
+    if (NOT "@EMSCRIPTEN@")
         find_dependency(glfw3 CONFIG)
     endif()
 endif()

--- a/ports/imgui/imgui-config.cmake.in
+++ b/ports/imgui/imgui-config.cmake.in
@@ -5,7 +5,9 @@ cmake_policy(SET CMP0012 NEW)
 include(CMakeFindDependencyMacro)
 
 if (@IMGUI_BUILD_GLFW_BINDING@)
-    find_dependency(glfw3 CONFIG)
+    if (NOT EMSCRIPTEN)
+        find_dependency(glfw3 CONFIG)
+    endif()
 endif()
 
 if (@IMGUI_BUILD_GLUT_BINDING@)

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui",
   "version": "1.89.4",
+  "port-version": 1,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",
@@ -49,7 +50,10 @@
     "glfw-binding": {
       "description": "Make available GLFW binding",
       "dependencies": [
-        "glfw3"
+        {
+          "name": "glfw3",
+          "platform": "!emscripten"
+        }
       ]
     },
     "glut-binding": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3262,7 +3262,7 @@
     },
     "imgui": {
       "baseline": "1.89.4",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui-sfml": {
       "baseline": "2.5",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0a970aacfef236315c6b4f33f1585fb9ebbe91f",
+      "version": "1.89.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "337ea84e098e85d4706ecdd807fe292933d9e6f8",
       "version": "1.89.4",
       "port-version": 0

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a0a970aacfef236315c6b4f33f1585fb9ebbe91f",
+      "git-tree": "68cf6847418f27dbd3ae70c557b1ef1357875fa1",
       "version": "1.89.4",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #30790

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
~SHA512s are updated for each updated download~
~The "supports" clause reflects platforms that may be fixed by this new version~
~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.