### PR TITLE
[libxmp] add new port

### DIFF
--- a/ports/libxmp/fix-cmake-config-dir.patch
+++ b/ports/libxmp/fix-cmake-config-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1794cb2c1534d53d502785e0446d302e5439216a..c960405632c0d1b4797470424fce4ff8a7ec1aef 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -170,7 +170,7 @@ add_subdirectory(docs)
+ 
+ include(CMakePackageConfigHelpers)
+ 
+-if(WIN32)
++if(0)
+     set(cmake_install_cmakdir "cmake")
+ else()
+     set(cmake_install_cmakdir "${CMAKE_INSTALL_LIBDIR}/cmake/libxmp")

--- a/ports/libxmp/fix-uwp-build.patch
+++ b/ports/libxmp/fix-uwp-build.patch
@@ -1,0 +1,26 @@
+diff --git a/src/depackers/ptpopen.c b/src/depackers/ptpopen.c
+index 421faf08c6bf83e38fbb795595f1a8cf79691b16..a11ade9d81267346a0a3970723de2dc12f62c189 100644
+--- a/src/depackers/ptpopen.c
++++ b/src/depackers/ptpopen.c
+@@ -12,7 +12,7 @@
+  * useful. -- Kurt Keller, Aug 2013
+  */
+ 
+-#ifdef _WIN32
++#if defined(_WIN32 ) && !(defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP))
+ 
+ #include "ptpopen.h"
+ 
+diff --git a/src/depackers/depacker.c b/src/depackers/depacker.c
+index 7ff76513781d7daf79135ddf578db94f826f6e19..429a421e29fe1c17ed1d79a5e0d376dbfe04e7b9 100644
+--- a/src/depackers/depacker.c
++++ b/src/depackers/depacker.c
+@@ -28,7 +28,7 @@
+ #include "../tempfile.h"
+ #include "xfnmatch.h"
+ 
+-#ifdef _WIN32
++#if defined(_WIN32 ) && !(defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP))
+ /* Note: The _popen function returns an invalid file opaque, if
+  * used in a Windows program, that will cause the program to hang
+  * indefinitely. _popen works properly in a Console application.

--- a/ports/libxmp/portfile.cmake
+++ b/ports/libxmp/portfile.cmake
@@ -1,0 +1,42 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libxmp/libxmp
+    REF 2c339d0f7517e464d3f2f743212ca76c8c6fe1f1
+    SHA512 6c8eca7e37ad9b51b4d9aea08f253c6c4c34f01bfc44b2be4066450b8e34c4bc96a1d1129edc761de4d2e281f718f8d969ce86273af23e37ee172072af8b0a2c
+    PATCHES
+        fix-cmake-config-dir.patch
+        fix-uwp-build.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        depackers  LIBXMP_DISABLE_DEPACKERS
+        prowizard  LIBXMP_DISABLE_PROWIZARD
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DBUILD_STATIC=${BUILD_STATIC}
+        -DBUILD_SHARED=${BUILD_SHARED}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "libxmp"
+    CONFIG_PATH "lib/cmake/libxmp"
+)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(INSTALL "${SOURCE_PATH}/docs/COPYING.LIB" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libxmp/usage
+++ b/ports/libxmp/usage
@@ -1,0 +1,4 @@
+libxmp provides CMake targets:
+
+    find_package(libxmp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:libxmp::xmp_shared>,libxmp::xmp_shared,libxmp::xmp_static>)

--- a/ports/libxmp/vcpkg.json
+++ b/ports/libxmp/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "libxmp",
+  "version-date": "2023-04-13",
+  "description": "Libxmp is a library that renders module files to PCM data.",
+  "homepage": "https://sourceforge.net/projects/xmp/",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "depackers",
+    "prowizard"
+  ],
+  "features": {
+    "depackers": {
+      "description": "Enable archive depackers."
+    },
+    "prowizard": {
+      "description": "Enable ProWizard format loaders."
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4728,6 +4728,10 @@
       "baseline": "5.0.0",
       "port-version": 2
     },
+    "libxmp": {
+      "baseline": "2023-04-13",
+      "port-version": 0
+    },
     "libxmp-lite": {
       "baseline": "4.4.1",
       "port-version": 8

--- a/versions/l-/libxmp.json
+++ b/versions/l-/libxmp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2773b355a7b3a41ab6739548277b9b828d163242",
+      "version-date": "2023-04-13",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

