### PR TITLE
[fbthrift]: fix dependency

### DIFF
--- a/ports/fbthrift/0002-fix-dependency.patch
+++ b/ports/fbthrift/0002-fix-dependency.patch
@@ -37,15 +37,20 @@ index beae7d7..0d03162 100644
    add_definitions("-DTHRIFT_HAVE_LIBSNAPPY=0")
    if(lib_only)
 diff --git a/thrift/cmake/FBThriftConfig.cmake.in b/thrift/cmake/FBThriftConfig.cmake.in
-index e1297ed..303c477 100644
+index e1297ed..c7d9d59 100644
 --- a/thrift/cmake/FBThriftConfig.cmake.in
 +++ b/thrift/cmake/FBThriftConfig.cmake.in
-@@ -28,7 +28,9 @@ else()
+@@ -28,7 +28,14 @@ else()
    set_and_check(FBTHRIFT_COMPILER "@PACKAGE_BIN_INSTALL_DIR@/thrift1")
  endif()
  
 -find_dependency(ZLIB REQUIRED)
++find_dependency(fizz CONFIG )
++find_dependency(fmt CONFIG )
++find_dependency(folly CONFIG )
 +find_dependency(gflags CONFIG)
++find_dependency(glog CONFIG )
++find_dependency(wangle CONFIG )
 +find_dependency(ZLIB)
 +find_dependency(zstd CONFIG)
  

--- a/ports/fbthrift/0002-fix-dependency.patch
+++ b/ports/fbthrift/0002-fix-dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index beae7d7..f962a1f 100644
+index beae7d7..0d03162 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -100,7 +100,8 @@ endif ()
@@ -17,7 +17,7 @@ index beae7d7..f962a1f 100644
    find_package(wangle CONFIG REQUIRED)
    find_package(ZLIB REQUIRED)
 -  find_package(Zstd REQUIRED)
-+  find_package(zstd REQUIRED)
++  find_package(zstd CONFIG REQUIRED)
 +  if(TARGET zstd::libzstd_shared)
 +    set(ZSTD_LIBRARIES zstd::libzstd_shared)
 +  elseif(TARGET zstd::libzstd_static)

--- a/ports/fbthrift/0002-fix-dependency.patch
+++ b/ports/fbthrift/0002-fix-dependency.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index beae7d7..f962a1f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -100,7 +100,8 @@ endif ()
+ 
+ # Find required dependencies for thrift/lib
+ if(lib_only OR build_all)
+-  find_package(Gflags REQUIRED)
++  find_package(gflags CONFIG REQUIRED)
++  set(LIBGFLAGS_LIBRARY gflags::gflags)
+   find_package(glog CONFIG REQUIRED)
+   set (GLOG_LIBRARIES glog::glog)
+   find_package(folly CONFIG REQUIRED)
+@@ -108,16 +109,17 @@ if(lib_only OR build_all)
+   find_package(fmt CONFIG REQUIRED)
+   find_package(wangle CONFIG REQUIRED)
+   find_package(ZLIB REQUIRED)
+-  find_package(Zstd REQUIRED)
++  find_package(zstd REQUIRED)
++  if(TARGET zstd::libzstd_shared)
++    set(ZSTD_LIBRARIES zstd::libzstd_shared)
++  elseif(TARGET zstd::libzstd_static)
++    set(ZSTD_LIBRARIES zstd::libzstd_static)
++  endif()
++
+   # https://cmake.org/cmake/help/v3.9/module/FindThreads.html
+   set(THREADS_PREFER_PTHREAD_FLAG ON)
+   find_package(Threads)
+   include_directories(
+-    ${LIBGFLAGS_INCLUDE_DIR}
+-    ${GLOG_INCLUDE_DIRS}
+-    ${OPENSSL_INCLUDE_DIR}
+-    ${ZSTD_INCLUDE_DIRS}
+-    ${Boost_INCLUDE_DIRS}
+   )
+   add_definitions("-DTHRIFT_HAVE_LIBSNAPPY=0")
+   if(lib_only)
+diff --git a/thrift/cmake/FBThriftConfig.cmake.in b/thrift/cmake/FBThriftConfig.cmake.in
+index e1297ed..303c477 100644
+--- a/thrift/cmake/FBThriftConfig.cmake.in
++++ b/thrift/cmake/FBThriftConfig.cmake.in
+@@ -28,7 +28,9 @@ else()
+   set_and_check(FBTHRIFT_COMPILER "@PACKAGE_BIN_INSTALL_DIR@/thrift1")
+ endif()
+ 
+-find_dependency(ZLIB REQUIRED)
++find_dependency(gflags CONFIG)
++find_dependency(ZLIB)
++find_dependency(zstd CONFIG)
+ 
+ if (NOT TARGET FBThrift::thriftcpp2)
+   include("${FBTHRIFT_CMAKE_DIR}/FBThriftTargets.cmake")

--- a/ports/fbthrift/portfile.cmake
+++ b/ports/fbthrift/portfile.cmake
@@ -10,8 +10,18 @@ vcpkg_from_github(
     PATCHES 
         0001-fix-compatibility-with-boost-1.79.0.patch
         fix-glog.patch
+        0002-fix-dependency.patch
 )
 
+file(REMOVE "${SOURCE_PATH}/thrift/cmake/FindGMock.cmake")
+file(REMOVE "${SOURCE_PATH}/thrift/cmake/FindOpenSSL.cmake")
+file(REMOVE "${SOURCE_PATH}/thrift/cmake/FindZstd.cmake")
+file(REMOVE "${SOURCE_PATH}/build/fbcode_builder/CMake/FindGflags.cmake")
+file(REMOVE "${SOURCE_PATH}/build/fbcode_builder/CMake/FindGlog.cmake")
+file(REMOVE "${SOURCE_PATH}/build/fbcode_builder/CMake/FindGMock.cmake")
+file(REMOVE "${SOURCE_PATH}/build/fbcode_builder/CMake/FindLibEvent.cmake")
+file(REMOVE "${SOURCE_PATH}/build/fbcode_builder/CMake/FindSodium.cmake")
+file(REMOVE "${SOURCE_PATH}/build/fbcode_builder/CMake/FindZstd.cmake")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/fbthrift/vcpkg.json
+++ b/ports/fbthrift/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fbthrift",
   "version-string": "2022.03.21.00",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Facebook's branch of Apache Thrift, including a new C++ server.",
   "homepage": "https://github.com/facebook/fbthrift",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2438,7 +2438,7 @@
     },
     "fbthrift": {
       "baseline": "2022.03.21.00",
-      "port-version": 2
+      "port-version": 3
     },
     "fcl": {
       "baseline": "0.7.0",

--- a/versions/f-/fbthrift.json
+++ b/versions/f-/fbthrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b574cd22e85718b498dd1103dd3c915cb9090791",
+      "version-string": "2022.03.21.00",
+      "port-version": 3
+    },
+    {
       "git-tree": "60135cc9f7a4bf698b67d275e1ad66a542d9acb4",
       "version-string": "2022.03.21.00",
       "port-version": 2

--- a/versions/f-/fbthrift.json
+++ b/versions/f-/fbthrift.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fd4683b3d6950cb569e21c57716cb1b9d66e592c",
+      "git-tree": "74805d5c9147b3255703cdce511d9082cdfee016",
       "version-string": "2022.03.21.00",
       "port-version": 3
     },

--- a/versions/f-/fbthrift.json
+++ b/versions/f-/fbthrift.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b574cd22e85718b498dd1103dd3c915cb9090791",
+      "git-tree": "fd4683b3d6950cb569e21c57716cb1b9d66e592c",
       "version-string": "2022.03.21.00",
       "port-version": 3
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [*] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
