### PR TITLE
[glibmm] update to 2.76.0

### DIFF
--- a/ports/glibmm/portfile.cmake
+++ b/ports/glibmm/portfile.cmake
@@ -1,9 +1,9 @@
 # Glib uses winapi functions not available in WindowsStore
-
+string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIBMM_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIBMM_ARCHIVE
-    URLS "https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.74/glibmm-2.74.0.tar.xz"
-    FILENAME "glibmm-2.74.0.tar.xz"
-    SHA512 29c16a6c921fb135721c39b5328e0b45e09c500c65175199c1ec5ee75bdd5fb907072389c6980da3bf8fac0846235af5580f692706eb00d26947804daa1c99c9
+    URLS "https://ftp.gnome.org/pub/GNOME/sources/glibmm/${GLIBMM_MAJOR_MINOR}/glibmm-${VERSION}.tar.xz"
+    FILENAME "glibmm-${VERSION}.tar.xz"
+    SHA512 be49599f5eb8eb5a1cef015cdb37af2564fcd1ea845aa4344804ca5f0f61468949711e25cefebb93219e1be37128ebfdd2a816324e752ac4395b4b87c072fc78
 )
 
 vcpkg_extract_source_archive(

--- a/ports/glibmm/vcpkg.json
+++ b/ports/glibmm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glibmm",
-  "version": "2.74.0",
+  "version": "2.76.0",
   "description": "This is glibmm, a C++ API for parts of glib that are useful for C++.",
   "homepage": "https://www.gtkmm.org.",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2813,7 +2813,7 @@
       "port-version": 1
     },
     "glibmm": {
-      "baseline": "2.74.0",
+      "baseline": "2.76.0",
       "port-version": 0
     },
     "glm": {

--- a/versions/g-/glibmm.json
+++ b/versions/g-/glibmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "16125400e378b3a45ff56a2f26573d9312ead0d1",
+      "version": "2.76.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d633ca7a15a77e20cdf515ba74448d59f4e49021",
       "version": "2.74.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #30806 .

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
