### PR TITLE
[idyntree] Add new port

### DIFF
--- a/ports/idyntree/portfile.cmake
+++ b/ports/idyntree/portfile.cmake
@@ -1,0 +1,56 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO robotology/idyntree
+    REF "v${VERSION}"
+    SHA512 5661fb442fb6d28e71efcb9780c4205b90017e7f4c0bc761c170e59b1cff22b281c5c8c15bf9c4b2cede1e0bbbb05b53f4a22556e0b5b3678abd4d3f47be49d4
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "assimp" IDYNTREE_USES_ASSIMP
+        "irrlicht" IDYNTREE_USES_IRRLICHT
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DIDYNTREE_USES_IPOPT:BOOL=OFF
+        -DIDYNTREE_USES_OSQPEIGEN:BOOL=OFF
+        -DIDYNTREE_USES_MATLAB:BOOL=OFF
+        -DIDYNTREE_USES_PYTHON:BOOL=OFF
+        -DIDYNTREE_USES_OCTAVE:BOOL=OFF
+        -DIDYNTREE_USES_LUA:BOOL=OFF
+        -DIDYNTREE_USES_YARP:BOOL=OFF
+        -DIDYNTREE_USES_ICUB_MAIN:BOOL=OFF
+        -DIDYNTREE_USES_QT5:BOOL=OFF
+        -DIDYNTREE_USES_ALGLIB:BOOL=OFF
+        -DIDYNTREE_USES_WORHP:BOOL=OFF
+        -DIDYNTREE_COMPILE_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME iDynTree
+    CONFIG_PATH lib/cmake/iDynTree)
+vcpkg_copy_pdbs()
+
+set(TOOL_NAMES_LIST idyntree-model-info)
+if ("assimp" IN_LIST FEATURES)
+    list(APPEND TOOL_NAMES_LIST idyntree-model-simplify-shapes)
+endif()
+if ("irrlicht" IN_LIST FEATURES)
+    list(APPEND TOOL_NAMES_LIST idyntree-model-view)
+endif()
+vcpkg_copy_tools(
+    TOOL_NAMES ${TOOL_NAMES_LIST}
+    AUTO_CLEAN
+)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.LGPL2" "${SOURCE_PATH}/LICENSE.LGPL3")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/idyntree/usage
+++ b/ports/idyntree/usage
@@ -1,0 +1,4 @@
+The package idyntree provides CMake targets:
+
+    find_package(iDynTree CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE iDynTree::idyntree-core iDynTree::idyntree-model iDynTree::idyntree-modelio iDynTree::idyntree-modelio iDynTree::idyntree-high-level iDynTree::idyntree-estimation)

--- a/ports/idyntree/vcpkg.json
+++ b/ports/idyntree/vcpkg.json
@@ -1,0 +1,37 @@
+{
+  "name": "idyntree",
+  "version": "8.1.0",
+  "description": "Multibody Dynamics Library designed for Free Floating Robots.",
+  "homepage": "https://github.com/robotology/idyntree",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    "eigen3",
+    "libxml2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "assimp",
+    "irrlicht"
+  ],
+  "features": {
+    "assimp": {
+      "description": "Add support for loading meshes",
+      "dependencies": [
+        "assimp"
+      ]
+    },
+    "irrlicht": {
+      "description": "Add support for irrlicht-based visualizer",
+      "dependencies": [
+        "irrlicht"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3152,6 +3152,10 @@
       "baseline": "1.0.12",
       "port-version": 7
     },
+    "idyntree": {
+      "baseline": "8.1.0",
+      "port-version": 0
+    },
     "if97": {
       "baseline": "2.1.3",
       "port-version": 0

--- a/versions/i-/idyntree.json
+++ b/versions/i-/idyntree.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "65e8740ace938a59b21dc97e30ab531c005ce399",
+      "version": "8.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add a port for the [iDynTree library](https://github.com/robotology/idyntree).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


