### PR TITLE
[gstreamer, gst-rtsp-server, libnice-gst] Move installed plugins into plugins/gstreamer

### DIFF
--- a/ports/gst-rtsp-server/portfile.cmake
+++ b/ports/gst-rtsp-server/portfile.cmake
@@ -24,16 +24,21 @@ vcpkg_configure_meson(
 
 vcpkg_install_meson()
 
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    file(GLOB DBG_BINS ${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.dll
-                       ${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.pdb
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    if(NOT VCPKG_BUILD_TYPE)
+        file(GLOB DBG_BINS "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/${CMAKE_SHARED_LIBRARY_PREFIX}*${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                           "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.pdb"
+        )
+        file(COPY ${DBG_BINS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/plugins/gstreamer")
+    endif()
+    file(GLOB REL_BINS "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/${CMAKE_SHARED_LIBRARY_PREFIX}*${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                       "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/*.pdb"
     )
-    file(COPY ${DBG_BINS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(GLOB REL_BINS ${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/*.dll
-                       ${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/*.pdb
-    )
-    file(COPY ${REL_BINS} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+    file(COPY ${REL_BINS} DESTINATION "${CURRENT_PACKAGES_DIR}/plugins/gstreamer")
     file(REMOVE ${DBG_BINS} ${REL_BINS})
+    if(NOT VCPKG_TARGET_IS_WINDOWS)
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0" "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0")
+    endif()
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/gst-rtsp-server/vcpkg.json
+++ b/ports/gst-rtsp-server/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gst-rtsp-server",
   "version": "1.20.5",
+  "port-version": 1,
   "description": "gst-rtsp-server is a library on top of GStreamer for building an RTSP server",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.1-only",

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -702,18 +702,21 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/gstreamer-1.0/gst/gstconfig.h" "!defined(GST_STATIC_COMPILATION)" "0")
 endif()
 
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     if(NOT VCPKG_BUILD_TYPE)
-        file(GLOB DBG_BINS "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.dll"
+        file(GLOB DBG_BINS "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/${CMAKE_SHARED_LIBRARY_PREFIX}*${CMAKE_SHARED_LIBRARY_SUFFIX}"
                            "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.pdb"
         )
-        file(COPY ${DBG_BINS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(COPY ${DBG_BINS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/plugins/${PORT}")
     endif()
-    file(GLOB REL_BINS "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/*.dll"
+    file(GLOB REL_BINS "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/${CMAKE_SHARED_LIBRARY_PREFIX}*${CMAKE_SHARED_LIBRARY_SUFFIX}"
                        "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/*.pdb"
     )
-    file(COPY ${REL_BINS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(COPY ${REL_BINS} DESTINATION "${CURRENT_PACKAGES_DIR}/plugins/${PORT}")
     file(REMOVE ${DBG_BINS} ${REL_BINS})
+    if(NOT VCPKG_TARGET_IS_WINDOWS)
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0" "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0")
+    endif()
 endif()
 
 vcpkg_fixup_pkgconfig()

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.20.5",
-  "port-version": 4,
+  "port-version": 5,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/ports/libnice-gst/portfile.cmake
+++ b/ports/libnice-gst/portfile.cmake
@@ -59,28 +59,33 @@ file(WRITE "${USAGE_FILE}" "${PORT} usage:\n\n")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)
-    file(APPEND "${USAGE_FILE}" "\tIf the plugin isn't found by the default paths add one of the following paths to the 'GST_PLUGIN_PATH' environment variable\n")
+    file(APPEND "${USAGE_FILE}" "\tMake sure one of the following paths is added to the 'GST_PLUGIN_PATH' environment variable\n")
     file(APPEND "${USAGE_FILE}" "\tFor more information on GStreamer environment variables see https://gstreamer.freedesktop.org/documentation/gstreamer/running.html?gi-language=c#environment-variables\n")
-
-    if(VCPKG_TARGET_IS_WINDOWS)
-
-        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-            file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/gstnice.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/gstnice.dll")
-            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/gstnice.pdb" "${CURRENT_PACKAGES_DIR}/debug/bin/gstnice.pdb")
-
-            file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_PACKAGES_DIR}/debug/bin/'\n")
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/plugins/gstreamer")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/${CMAKE_SHARED_LIBRARY_PREFIX}gstnice${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                    "${CURRENT_PACKAGES_DIR}/debug/plugins/gstreamer/${CMAKE_SHARED_LIBRARY_PREFIX}gstnice${CMAKE_SHARED_LIBRARY_SUFFIX}")
+        if(VCPKG_TARGET_IS_WINDOWS)
+            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/gstnice.pdb"
+                        "${CURRENT_PACKAGES_DIR}/debug/plugins/gstreamer/gstnice.pdb")
+        else()
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
         endif()
-        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-            file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
-            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/gstnice.dll" "${CURRENT_PACKAGES_DIR}/bin/gstnice.dll")
-            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/gstnice.pdb" "${CURRENT_PACKAGES_DIR}/bin/gstnice.pdb")
 
-            file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_PACKAGES_DIR}/bin/'\n")
+        file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_INSTALLED_DIR}/debug/plugins/gstreamer/'\n")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/plugins/gstreamer")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/${CMAKE_SHARED_LIBRARY_PREFIX}gstnice${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                    "${CURRENT_PACKAGES_DIR}/plugins/gstreamer/${CMAKE_SHARED_LIBRARY_PREFIX}gstnice${CMAKE_SHARED_LIBRARY_SUFFIX}")
+        if(VCPKG_TARGET_IS_WINDOWS)
+            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/gstnice.pdb"
+                        "${CURRENT_PACKAGES_DIR}/plugins/gstreamer/gstnice.pdb")
+        else()
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
         endif()
-    else()
-        file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/'\n")
-        file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/'\n")
+
+        file(APPEND "${USAGE_FILE}" "\t\t* '${CURRENT_INSTALLED_DIR}/plugins/gstreamer/'\n")
     endif()
 else()
     file(APPEND "${USAGE_FILE}" "\tRegister static plugin with gst_plugin_register_static()\n")

--- a/ports/libnice-gst/vcpkg.json
+++ b/ports/libnice-gst/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libnice-gst",
   "version": "0.1.21",
+  "port-version": 1,
   "description": "Gstreamer Libnice plugins.",
   "homepage": "https://nice.freedesktop.org",
   "license": "LGPL-2.1-only AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2950,11 +2950,11 @@
     },
     "gst-rtsp-server": {
       "baseline": "1.20.5",
-      "port-version": 0
+      "port-version": 1
     },
     "gstreamer": {
       "baseline": "1.20.5",
-      "port-version": 4
+      "port-version": 5
     },
     "gtest": {
       "baseline": "1.13.0",
@@ -4246,7 +4246,7 @@
     },
     "libnice-gst": {
       "baseline": "0.1.21",
-      "port-version": 0
+      "port-version": 1
     },
     "libnoise": {
       "baseline": "1.0.0",

--- a/versions/g-/gst-rtsp-server.json
+++ b/versions/g-/gst-rtsp-server.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85ca43c538fdb1f41292003c458eb209a1478906",
+      "version": "1.20.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "6bde18badd06f4466ca4cb75b83aa98b1f24f3bd",
       "version": "1.20.5",
       "port-version": 0

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86757cb6fd9f50813cadb3779f1096fe1377eef9",
+      "version": "1.20.5",
+      "port-version": 5
+    },
+    {
       "git-tree": "084ea66aed42ba882e19b103de4042d676be1530",
       "version": "1.20.5",
       "port-version": 4

--- a/versions/l-/libnice-gst.json
+++ b/versions/l-/libnice-gst.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9ea8f77a4a4f70cceb4d65650ee5de24e14e8190",
+      "version": "0.1.21",
+      "port-version": 1
+    },
+    {
       "git-tree": "3d7072d7e0810ec844b7f4b3ecaa1e325e407be6",
       "version": "0.1.21",
       "port-version": 0


### PR DESCRIPTION
This aligns with the behaviour of other ports like QT and GStreamer deadlocks when trying to load glib shared libraries if they are in the plugin directory.

#### Update existing port checklist:
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
