### PR TITLE
[stlab] fix core build

### DIFF
--- a/ports/stlab/portfile.cmake
+++ b/ports/stlab/portfile.cmake
@@ -6,10 +6,17 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cpp17shims   STLAB_USE_BOOST_CPP17_SHIMS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
+        ${FEATURE_OPTIONS}
+        -DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/stlab/vcpkg.json
+++ b/ports/stlab/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "stlab",
   "version": "1.7.1",
+  "port-version": 1,
   "description": [
     "stlab is the ongoing work of what was Adobe Software Technology Lab.",
     "The Concurrency library provides futures and channels, high level constructs for implementing algorithms that eases the use of multiple CPU cores while minimizing contention. This library solves several problems of the C++11 and C++17 TS futures."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7642,7 +7642,7 @@
     },
     "stlab": {
       "baseline": "1.7.1",
-      "port-version": 0
+      "port-version": 1
     },
     "stormlib": {
       "baseline": "2019-05-10",

--- a/versions/s-/stlab.json
+++ b/versions/s-/stlab.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "abb069e17e53344d850ff3b01ebf636a1734a6e0",
+      "version": "1.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "82ee8586032e3eb89368644e78fe4a4726a17774",
       "version": "1.7.1",
       "port-version": 0


### PR DESCRIPTION
Previously the core build failed with 
```
CMake Error at CMakeLists.txt:37 (message):
  STLAB_USE_BOOST_CPP17_SHIMS is enabled, but a Boost installation was not
  found.
```