### PR TITLE
[cdt] fix boost build

### DIFF
--- a/ports/cdt/boost-link.patch
+++ b/ports/cdt/boost-link.patch
@@ -7,7 +7,7 @@ index 555fb4e..86be850 100644
  
  if(CDT_USE_BOOST)
 -    target_link_libraries(${PROJECT_NAME} INTERFACE Boost::boost)
-+    target_link_libraries(${PROJECT_NAME} PUBLIC Boost::boost)
++    target_link_libraries(${PROJECT_NAME} ${cdt_scope} Boost::boost)
  endif()
  
  

--- a/ports/cdt/vcpkg.json
+++ b/ports/cdt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cdt",
   "version": "1.2.0",
+  "port-version": 1,
   "description": "Constrained Delaunay Triangulation",
   "homepage": "https://github.com/artem-ogre/CDT.git",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1410,7 +1410,7 @@
     },
     "cdt": {
       "baseline": "1.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "celero": {
       "baseline": "2.8.5",

--- a/versions/c-/cdt.json
+++ b/versions/c-/cdt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddc92ab3ef284f9643001138f8ed320a2417a80f",
+      "version": "1.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d04985a703ae8b9201876879003d44c84f719a3a",
       "version": "1.2.0",
       "port-version": 0


### PR DESCRIPTION
Otherwise `cdt[core,boost]` fails with
```
CMake Error at CMakeLists.txt:133 (target_link_libraries):
  INTERFACE library can only be used with the INTERFACE keyword of
  target_link_libraries
```