### PR TITLE
[fastrtps] Replace xtime with _timespec64 for fixing error C2065

### DIFF
--- a/ports/fastrtps/fix-xtime.patch
+++ b/ports/fastrtps/fix-xtime.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7ca47ae..1e54249 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,6 +42,18 @@ message(STATUS "Version: ${PROJECT_VERSION}")
+ ###############################################################################
+ option(EPROSIMA_BUILD "Activate internal building" OFF)
+ 
++###############################################################################
++# As a workround of the unreleased version of msvc, it will be deleted after release.
++###############################################################################
++if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
++	message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
++    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.36.32528.95")
++        file(READ "${PROJECT_SOURCE_DIR}/include/fastrtps/utils/TimedMutex.hpp" _contents)
++        string(REPLACE "xtime*" "_timespec64*" _contents "${_contents}")
++        file(WRITE "${PROJECT_SOURCE_DIR}/include/fastrtps/utils/TimedMutex.hpp" "${_contents}")
++    endif()
++endif()
++
+ ###############################################################################
+ # Warning level
+ ###############################################################################

--- a/ports/fastrtps/fix-xtime.patch
+++ b/ports/fastrtps/fix-xtime.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7ca47ae..1e54249 100644
+index 7ca47ae..632c38b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -42,6 +42,18 @@ message(STATUS "Version: ${PROJECT_VERSION}")
@@ -7,10 +7,10 @@ index 7ca47ae..1e54249 100644
  option(EPROSIMA_BUILD "Activate internal building" OFF)
  
 +###############################################################################
-+# As a workround of the unreleased version of msvc, it will be deleted after release.
++# Replace xtime with _timespec64. As a workround of the unreleased version of 
++# MSVC, it will be deleted after release.
 +###############################################################################
 +if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-+	message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
 +    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.36.32528.95")
 +        file(READ "${PROJECT_SOURCE_DIR}/include/fastrtps/utils/TimedMutex.hpp" _contents)
 +        string(REPLACE "xtime*" "_timespec64*" _contents "${_contents}")

--- a/ports/fastrtps/portfile.cmake
+++ b/ports/fastrtps/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-find-package-asio.patch
         disable-symlink.patch
+        fix-xtime.patch
 )
 
 vcpkg_cmake_configure(
@@ -69,4 +70,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/tools")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fastrtps/vcpkg.json
+++ b/ports/fastrtps/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fastrtps",
   "version": "2.7.0",
+  "port-version": 1,
   "description": "Eprosima Fast RTPS is a C++ implementation of the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2426,7 +2426,7 @@
     },
     "fastrtps": {
       "baseline": "2.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "fawdlstty-libfv": {
       "baseline": "0.0.8",

--- a/versions/f-/fastrtps.json
+++ b/versions/f-/fastrtps.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "02c43398e4ad215da0fe69fb212c76dd35878187",
+      "git-tree": "b2d64bc038a30ea7ad49dc5cb923c0e13618281c",
       "version": "2.7.0",
       "port-version": 1
     },

--- a/versions/f-/fastrtps.json
+++ b/versions/f-/fastrtps.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02c43398e4ad215da0fe69fb212c76dd35878187",
+      "version": "2.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7a1b9df69d8a4219b390a65056d837dc6c0f385c",
       "version": "2.7.0",
       "port-version": 0


### PR DESCRIPTION
In MSVC internal testing we found that `xtime` has been changed to `_timespec64` since https://github.com/microsoft/STL/pull/3594, causing the following errors:
```
D:\buildtrees\fastrtps\src\v2.7.0-5b113921c9.clean\include\fastrtps/utils/TimedMutex.hpp(93): error C2065: 'xtime': undeclared identifier
D:\buildtrees\fastrtps\src\v2.7.0-5b113921c9.clean\include\fastrtps/utils/TimedMutex.hpp(93): error C2059: syntax error: ')'
```

This issue can be fixed by replacing `xtime` with `_timespec64` as a temporary workaround for upcoming releases.


I've opened an issue upstream to notify: https://github.com/eProsima/Fast-DDS/issues/3451


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.