### PR TITLE
[libavif] add missing find_dependency

### DIFF
--- a/ports/libavif/find-dependency.patch
+++ b/ports/libavif/find-dependency.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 29d7d60..7e28ba4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -555,7 +555,7 @@ endif()
+ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+     install(
+         TARGETS avif
+-        EXPORT ${PROJECT_NAME}-config
++        EXPORT ${PROJECT_NAME}-targets
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+@@ -563,7 +563,7 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+ 
+     # Enable CMake configs in VCPKG mode
+     if(BUILD_SHARED_LIBS OR VCPKG_TARGET_TRIPLET)
+-        install(EXPORT ${PROJECT_NAME}-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
++        install(EXPORT ${PROJECT_NAME}-targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+ 
+         include(CMakePackageConfigHelpers)
+         write_basic_package_version_file(
+@@ -572,6 +572,28 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+                 DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+         )
++        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake.in "@PACKAGE_INIT@\n")
++        if(UNIX AND NOT BUILD_SHARED_LIBS)
++            file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake.in "
++                include(CMakeFindDependencyMacro)
++                set(CMAKE_THREAD_PREFER_PTHREADS ON)
++                set(THREADS_PREFER_PTHREAD_FLAG ON)
++                find_dependency(Threads)
++                ")
++        endif()
++        file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake.in "include(\${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}-targets.cmake)")
++
++        # Install CMake configuration export file.
++        configure_package_config_file(
++            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake.in
++            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
++            INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
++            NO_SET_AND_CHECK_MACRO NO_CHECK_REQUIRED_COMPONENTS_MACRO
++        )
++        install(
++            FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
++            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
++        )
+     endif()
+ 
+     configure_file(libavif.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libavif.pc @ONLY)

--- a/ports/libavif/portfile.cmake
+++ b/ports/libavif/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         disable-source-utf8.patch
         fix-compiler-warnings.patch
+        find-dependency.patch # from https://github.com/AOMediaCodec/libavif/pull/1339
 )
 
 vcpkg_cmake_configure(
@@ -14,6 +15,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DAVIF_CODEC_AOM=ON
         -DAVIF_BUILD_APPS=OFF
+        -DCMAKE_REQUIRE_FIND_PACKAGE_libyuv=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/libavif/vcpkg.json
+++ b/ports/libavif/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libavif",
   "version-semver": "0.11.1",
+  "port-version": 1,
   "description": "Library for encoding and decoding AVIF files",
   "homepage": "https://github.com/AOMediaCodec/libavif",
   "license": "BSD-2-Clause AND Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3794,7 +3794,7 @@
     },
     "libavif": {
       "baseline": "0.11.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libb2": {
       "baseline": "0.98.1",

--- a/versions/l-/libavif.json
+++ b/versions/l-/libavif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "775b04db12d2353cc6e69d54faef89b857dd32eb",
+      "version-semver": "0.11.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "11db2c9c2c399768d55d5b54f203e1f789d06936",
       "version-semver": "0.11.1",
       "port-version": 0


### PR DESCRIPTION
Fixes `sail[avif]`:
```
CMake Error at /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/share/libavif/libavif-config.cmake:61 (set_target_properties):
  The link interface of target "avif" contains:

    Threads::Threads

  but the target was not found.
```