### PR TITLE
[qt5compat] add proper error message

### DIFF
--- a/ports/qt5compat/portfile.cmake
+++ b/ports/qt5compat/portfile.cmake
@@ -19,7 +19,12 @@ INVERTED_FEATURES
 
 #For iconv feature to work the following must be true:
 #CONDITION NOT FEATURE_icu AND FEATURE_textcodec AND NOT WIN32 AND NOT QNX AND NOT ANDROID AND NOT APPLE AND WrapIconv_FOUND
-#TODO: check if qtbase was built with ICU and fail if iconv is given here.
+if("iconv" IN_LIST FEATURES)
+    include("${SCRIPT_PATH}/port_status.cmake")
+    if(qtbase_with_icu)
+        message(FATAL_ERROR "qtbase was built with ICU. The iconv feature is not compatible with ICU.")
+    endif()
+endif()
 
 set(TOOL_NAMES)
 qt_install_submodule(PATCHES    ${${PORT}_PATCHES}

--- a/ports/qt5compat/vcpkg.json
+++ b/ports/qt5compat/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5compat",
   "version": "6.4.3",
+  "port-version": 1,
   "description": "The module contains unsupported Qt 5 APIs",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -309,6 +309,8 @@ file(COPY
         "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     )
 
+file(CONFIGURE OUTPUT "${CURRENT_PACKAGES_DIR}/share/${PORT}/port_status.cmake" CONTENT "set(qtbase_with_icu ${FEATURE_icu})\n")
+
 set(other_files qt-cmake
                  qt-cmake-private
                  qt-cmake-standalone-test

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.4.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6598,7 +6598,7 @@
     },
     "qt5compat": {
       "baseline": "6.4.3",
-      "port-version": 0
+      "port-version": 1
     },
     "qt6betablock": {
       "baseline": "6.2.0-beta",
@@ -6614,7 +6614,7 @@
     },
     "qtbase": {
       "baseline": "6.4.3",
-      "port-version": 2
+      "port-version": 3
     },
     "qtcharts": {
       "baseline": "6.4.3",

--- a/versions/q-/qt5compat.json
+++ b/versions/q-/qt5compat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a79c6cfb2113f764e603ee13a4c12493f16b6d5",
+      "version": "6.4.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "df64fa51cb5aaaf59cbe76b91476db4b5c272152",
       "version": "6.4.3",
       "port-version": 0

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc1cc5c1a5d6a7c4c10feebe8d43a069d3a375a7",
+      "version": "6.4.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "b694b6e51c89c8610540165e6e8b3a236acb4301",
       "version": "6.4.3",
       "port-version": 2


### PR DESCRIPTION
The `iconv` feature does not work when qtbase is build with `icu`. Add an explicit error message. 