### PR TITLE
[vcpkg baseline][opencv] Let lapack be controlled by the lapack port.

### DIFF
--- a/ports/opencv2/portfile.cmake
+++ b/ports/opencv2/portfile.cmake
@@ -111,6 +111,7 @@ vcpkg_cmake_configure(
         -DWITH_ZLIB=ON
         -WITH_GTK=${WITH_GTK}
         -DWITH_CUBLAS=OFF   # newer libcublas cannot be found by the old cuda cmake script in opencv2, requires a fix
+        -DOPENCV_LAPACK_FIND_PACKAGE_ONLY=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/opencv2/vcpkg.json
+++ b/ports/opencv2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv2",
   "version": "2.4.13.7",
-  "port-version": 17,
+  "port-version": 18,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",

--- a/ports/opencv3/portfile.cmake
+++ b/ports/opencv3/portfile.cmake
@@ -398,6 +398,7 @@ vcpkg_cmake_configure(
         ###### Additional build flags
         ${ADDITIONAL_BUILD_FLAGS}
         -DBUILD_IPP_IW=${WITH_IPP}
+        -DOPENCV_LAPACK_FIND_PACKAGE_ONLY=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/opencv3/vcpkg.json
+++ b/ports/opencv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv3",
   "version": "3.4.18",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -445,6 +445,7 @@ vcpkg_cmake_configure(
         ###### Additional build flags
         ${ADDITIONAL_BUILD_FLAGS}
         -DBUILD_IPP_IW=${WITH_IPP}
+        -DOPENCV_LAPACK_FIND_PACKAGE_ONLY=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.7.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5782,15 +5782,15 @@
     },
     "opencv2": {
       "baseline": "2.4.13.7",
-      "port-version": 17
+      "port-version": 18
     },
     "opencv3": {
       "baseline": "3.4.18",
-      "port-version": 7
+      "port-version": 8
     },
     "opencv4": {
       "baseline": "4.7.0",
-      "port-version": 4
+      "port-version": 5
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv2.json
+++ b/versions/o-/opencv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "246c2e39fa6e117cbea4548446b7f66909de3329",
+      "version": "2.4.13.7",
+      "port-version": 18
+    },
+    {
       "git-tree": "0a9a6ab1907e36f372e3b379dcd1ddc7cfd96980",
       "version": "2.4.13.7",
       "port-version": 17

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e026bd638aec52f279cbf10d7e75a0f6ca03feb6",
+      "version": "3.4.18",
+      "port-version": 8
+    },
+    {
       "git-tree": "e28602bbfb118017bb2bf45795e0bfd9900af4dc",
       "version": "3.4.18",
       "port-version": 7

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c3c175e672cc3a6f0d1465adba8a40a042ff717",
+      "version": "4.7.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "99e88adacfd87e496dddba403025e0fdd3b336b7",
       "version": "4.7.0",
       "port-version": 4


### PR DESCRIPTION
Related: #30570.
Alternative to: #30754.

This fixes the following install path which currently fails:

```
vcpkg install intel-mkl
vcpkg install opencv4[lapack]
vcpkg install openimageio[opencv]
```

because opencv4 ends up picking mkl as the provider for BLAS/LAPACK. Adding `OPENCV_LAPACK_FIND_PACKAGE_ONLY=ON` forces opencv to listen to what the lapack metapackage says is the active lapack implementation, rather than itself choosing mkl while the rest of vcpkg has chosen lapack-reference.