### PR TITLE
[cuda-api-wrappers] New port

### DIFF
--- a/ports/cuda-api-wrappers/portfile.cmake
+++ b/ports/cuda-api-wrappers/portfile.cmake
@@ -1,0 +1,34 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO eyalroz/cuda-api-wrappers
+    REF v0.6.2
+    SHA512 4365b052d761d4ab0a840e084b64227348bb97d51826791442672afc4648f7b782fd2b862d91a0b5e88b140e5857e4a1a0a44686fa2c7b4fb380bb2f53adef91
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+	SOURCE_PATH "${SOURCE_PATH}"
+	OPTIONS
+	-DCAW_BUILD_EXAMPLES=OFF
+	)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+PACKAGE_NAME cuda-api-wrappers
+CONFIG_PATH lib/cmake
+)
+
+set(CAW_CMAKE_PACKAGE_FILES_DIR ${CURRENT_PACKAGES_DIR}/share/cuda-api-wrappers)
+
+file(GLOB packageFiles ${CAW_CMAKE_PACKAGE_FILES_DIR}/cuda-api-wrappers/*)
+foreach(pkgFile ${packageFiles})
+	get_filename_component(fileName ${pkgFile} NAME)
+    file(RENAME ${pkgFile} ${CAW_CMAKE_PACKAGE_FILES_DIR}/${fileName})
+endforeach()
+
+file(REMOVE_RECURSE "${CAW_CMAKE_PACKAGE_FILES_DIR}/cuda-api-wrappers")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/cuda-api-wrappers/vcpkg.json
+++ b/ports/cuda-api-wrappers/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "cuda-api-wrappers",
+  "version": "0.6.2",
+  "description": "header-only library of integrated wrappers around the core parts of NVIDIA's CUDA execution ecosystem",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1912,6 +1912,10 @@
       "baseline": "10.1",
       "port-version": 13
     },
+	"cuda-api-wrappers" : {
+	  "baseline": "0.6.2",
+	  "port-version": 0
+	},
     "cudnn": {
       "baseline": "7.6.5",
       "port-version": 9

--- a/versions/c-/cuda-api-wrappers.json
+++ b/versions/c-/cuda-api-wrappers.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "36221e42d8828dc8824ebb937ad9612d5644caf9",
+      "version": "0.6.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
