### PR TITLE
[alsa] Update to 1.2.8

### DIFF
--- a/ports/alsa/portfile.cmake
+++ b/ports/alsa/portfile.cmake
@@ -1,7 +1,3 @@
-if(NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    message(FATAL_ERROR "Package only supports Linux platform.")
-endif()
-
 message(
 "alsa currently requires the following programs from the system package manager:
     autoconf autoheader aclocal automake libtoolize

--- a/ports/alsa/portfile.cmake
+++ b/ports/alsa/portfile.cmake
@@ -3,16 +3,23 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 message(
-"alsa currently requires the following libraries from the system package manager:
-    autoconf libtool
-These can be installed on Ubuntu systems via sudo apt install autoconf libtool"
+"alsa currently requires the following programs from the system package manager:
+    autoconf autoheader aclocal automake libtoolize
+On Debian and Ubuntu derivatives:
+    sudo apt install autoconf libtool
+On recent Red Hat and Fedora derivatives:
+    sudo dnf install autoconf libtool
+On Arch Linux and derivatives:
+    sudo pacman -S autoconf automake libtool
+On Alpine:
+    apk add autoconf automake libtool"
 )
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alsa-project/alsa-lib
-    REF v1.2.6.1
-    SHA512 d1de9112ec0d600db6e5a20b558811a7a9f34d00a9b1dfb5332669b73732c1c1b8ddda57368edc199e255eba8bcb8a6767b4d9325c9860ade02d84dcaac6eb47
+    REF "v${VERSION}"
+    SHA512 34ebeb64fd43432df779bfd6de08fb26cfd59d75586100cab7308d1ecf60d722cf137f1209426a288bdbaa27c31e963ce09690272b8d85653989a935a6fc50af
     HEAD_REF master
     PATCHES
         "fix-plugin-dir.patch"
@@ -54,10 +61,12 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/tools/alsa/debug")
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/tools/alsa/debug"
+)
 
-configure_file("${SOURCE_PATH}/COPYING" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/alsa/vcpkg.json
+++ b/ports/alsa/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "alsa",
-  "version": "1.2.6.1",
-  "port-version": 2,
+  "version": "1.2.8",
   "description": "The Advanced Linux Sound Architecture (ALSA) - library",
   "homepage": "https://www.alsa-project.org/",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/alsa.json
+++ b/versions/a-/alsa.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c409b636e667ba0bfc181e535818ce36ed471738",
+      "git-tree": "1e4f79a1681c6c40c4b500bf4c8c5d3746916bab",
       "version": "1.2.8",
       "port-version": 0
     },

--- a/versions/a-/alsa.json
+++ b/versions/a-/alsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c409b636e667ba0bfc181e535818ce36ed471738",
+      "version": "1.2.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "658bd201adf1ade8dcfceacc5678f4b790a799c8",
       "version": "1.2.6.1",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -89,8 +89,8 @@
       "port-version": 1
     },
     "alsa": {
-      "baseline": "1.2.6.1",
-      "port-version": 2
+      "baseline": "1.2.8",
+      "port-version": 0
     },
     "amd-amf": {
       "baseline": "1.4.29",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
