### PR TITLE
[omniorb] new port

### DIFF
--- a/ports/omniorb/add_win_into_autotools.patch
+++ b/ports/omniorb/add_win_into_autotools.patch
@@ -1,0 +1,334 @@
+diff --git a/configure.ac b/configure.ac
+index d485463..2ba9c82 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -231,6 +231,7 @@ case "$host" in
+   *-*-openbsd*)  plat_name="OpenBSD";  plat_def="__openbsd__";  os_v="3";;
+   *-*-sco*)      plat_name="OSR5";     plat_def="__osr5__";     os_v="5";;
+   *-*-gnu*)      plat_name="GNU";      plat_def="__hurd__" ;    os_v="0";;
++  *-*-mingw*)    plat_name="Win32Platform";      plat_def="__WIN32__" ;    os_v="4";;
+ esac
+ 
+ AC_SUBST(PLATFORM_NAME, $plat_name)
+diff --git a/mk/beforeauto.mk.in b/mk/beforeauto.mk.in
+index f078912..9aef646 100644
+--- a/mk/beforeauto.mk.in
++++ b/mk/beforeauto.mk.in
+@@ -1311,3 +1314,7 @@ endif
+ 
+ lib_depend := $(patsubst %,$(LibPattern),omnithread)
+ OMNITHREAD_LIB_DEPEND := $(GENERATE_LIB_DEPEND)
++
++ifdef Win32Platform
++include $(THIS_IMPORT_TREE)/mk/platforms/vcpkg.mk
++endif
+\ No newline at end of file
+diff --git a/mk/win32.mk b/mk/win32.mk
+index 94c9aad..f788d41 100644
+--- a/mk/win32.mk
++++ b/mk/win32.mk
+@@ -81,7 +81,6 @@ endif
+ 
+ 
+ ifndef WINVER
+-WINVER = 0x0400
+ endif
+ 
+ IMPORT_CPPFLAGS += -D__WIN32__ -D_WIN32_WINNT=$(WINVER)
+@@ -179,7 +179,7 @@ define CXXExecutable
+  $(RM) $@; \
+  $(CXXLINK) -out:$@ $(CXXLINKOPTIONS) -PDB:$@.pdb $(IMPORT_LIBRARY_FLAGS) \
+       $(filter-out $(LibPattern),$^) $$libs; \
+- $(MANIFESTTOOL) /outputresource:"$@;#1" /manifest $@.manifest; \
++ $(MANIFESTTOOL) -outputresource:"$@;#1" -manifest $@.manifest; \
+ )
+ endef
+ 
+@@ -187,7 +187,7 @@ define CExecutable
+ (set -x; \
+  $(RM) $@; \
+  $(CLINK) -out:$@ $(CLINKOPTIONS) -PDB:$@.pdb $(IMPORT_LIBRARY_FLAGS) $(filter-out $(LibPattern),$^) $$libs; \
+- $(MANIFESTTOOL) /outputresource:"$@;#1" /manifest $@.manifest; \
++ $(MANIFESTTOOL) -outputresource:"$@;#1" -manifest $@.manifest; \
+ )
+ endef
+ 
+@@ -356,18 +356,18 @@ extralinkoption="$(MSVC_DLL_CXXLINKDEBUGOPTIONS)"; \
+ else \
+ extralinkoption="$(MSVC_DLL_CXXLINKNODEBUGOPTIONS)"; \
+ fi; \
+ if [ -z "$$nodeffile" ]; then \
+ $(MakeCXXExportSymbolDefinitionFile) \
+ defflag="-def:$$defname"; \
+ fi; \
+ $(MakeResourceDefinitionFile) \
+ set -x; \
+ $(RM) $@; \
+ $(CXXLINK) -out:$$dllname -DLL $$extralinkoption \
+ $$defflag -IMPLIB:$@ $(IMPORT_LIBRARY_FLAGS) \
+ $^ $$extralibs $$resname; \
+-$(MANIFESTTOOL) /outputresource:"$$dllname;#2" /manifest $$dllname.manifest; \
++$(MANIFESTTOOL) -outputresource:"$$dllname;#2" -manifest $$dllname.manifest; \
+ $(CP) $@ $$slibname;
+ endef
+ 
+ # Export SharedLibrary
+diff --git a/acinclude.m4 b/acinclude.m4
+index cef87f8bd..cf61556bd 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -433,8 +433,8 @@ AC_SUBST(ENABLE_LONGDOUBLE, $omni_cv_enable_longdouble)
+ 
+ dnl Enable ZIOP
+ AC_DEFUN([OMNI_ENABLE_ZIOP],
+-[AC_CHECK_LIB(z,compressBound,omni_cv_enable_ziop_zlib=yes,omni_cv_enable_ziop_zlib=no)
+-AC_CHECK_LIB(zstd,ZSTD_compress,omni_cv_enable_ziop_zstd=yes,omni_cv_enable_ziop_zstd=no)
++[AC_SEARCH_LIBS(compressBound,[z zlib zlibd],omni_cv_enable_ziop_zlib=yes,omni_cv_enable_ziop_zlib=no)
++AC_SEARCH_LIBS(ZSTD_compress,[zstd zstdd],omni_cv_enable_ziop_zstd=yes,omni_cv_enable_ziop_zstd=no)
+ omni_cv_enable_ziop="no"
+ if test "$omni_cv_enable_ziop_zlib" = "yes"; then
+   omni_cv_enable_ziop="yes"
+diff --git a/mk/win32.mk b/mk/win32.mk
+index 741835b4b..7a5bff934 100644
+--- a/mk/win32.mk
++++ b/mk/win32.mk
+@@ -580,8 +580,7 @@ OMNIORB_IDL = $(OMNIORB_IDL_ONLY) $(OMNIORB_IDL_ANY_FLAGS)
+ OMNIORB_CPPFLAGS = -D__OMNIORB4__ -I$(CORBA_STUB_DIR) $(OMNITHREAD_CPPFLAGS)
+ OMNIORB_IDL_OUTPUTDIR_PATTERN = -C%
+ 
+-msvc_work_around_stub = $(patsubst %,$(LibPattern),msvcstub) \
+-                        -NODEFAULTLIB:libcmt.lib -NODEFAULTLIB:libcmtd.lib 
++msvc_work_around_stub = $(patsubst %,$(LibPattern),msvcstub) 
+ 
+ OMNIORB_LIB = $(omniorb_dll_name) \
+ 		$(omnidynamic_dll_name) \
+diff --git a/src/tool/dir.mk b/src/tool/dir.mk
+index c6cb127d9..d75ba288a 100644
+--- a/src/tool/dir.mk
++++ b/src/tool/dir.mk
+@@ -11,7 +11,7 @@ SUBDIRS = omkdepend omniidl
+ endif
+ 
+ ifdef Win32Platform
+-SUBDIRS = omniidl
++SUBDIRS = omkdepend omniidl
+ endif
+ 
+ 
+diff --git a/mk/win32.mk b/mk/win32.mk
+index 6d320a2bd..3983eba5c 100644
+--- a/mk/win32.mk
++++ b/mk/win32.mk
+@@ -8,7 +8,7 @@ Win32Platform = 1
+ # Define macro for path of wrapper executables
+ #
+ ifndef EmbeddedSystem
+-WRAPPER_FPATH = $(BINDIR)
++WRAPPER_FPATH = bin
+ else
+ WRAPPER_FPATH = $(HOSTBINDIR)
+ endif
+@@ -40,12 +40,12 @@ SORT = sort
+ endif
+ 
+ 
+-AR = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/libwrapper $(XLN)
+-CXX = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
+-CXXLINK	= $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
++#AR = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/libwrapper $(XLN)
++#CXX = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
++#CXXLINK	= $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
+ CXXMAKEDEPEND = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/omkdepend $(MKDEPOPT) -D__cplusplus -D_MSC_VER
+-CC = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
+-CLINK = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
++#CC = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
++#CLINK = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
+ CMAKEDEPEND = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/omkdepend $(MKDEPOPT) -D_MSC_VER
+ 
+ RCTOOL          = rc.exe
+@@ -83,7 +83,7 @@ endif
+ ifndef WINVER
+ endif
+ 
+-IMPORT_CPPFLAGS += -D__WIN32__ -D_WIN32_WINNT=$(WINVER)
++IMPORT_CPPFLAGS += -D__WIN32__
+ 
+ SOCKET_LIB = ws2_32.lib mswsock.lib
+ 
+diff --git a/mk/beforeauto.mk.in b/mk/beforeauto.mk.in
+index b7087ea36..d7a826fa9 100644
+--- a/mk/beforeauto.mk.in
++++ b/mk/beforeauto.mk.in
+@@ -36,6 +36,8 @@ BINDIR  = bin
+ 
+ prefix        	 := @prefix@
+ exec_prefix   	 := @exec_prefix@
++includedir   	   := @includedir@
++libdir   	       := @libdir@
+ INSTALLTARGET 	 := 1
+ INSTALLINCDIR 	 := $(DESTDIR)@includedir@
+ INSTALLBINDIR 	 := $(DESTDIR)@bindir@
+@@ -362,6 +364,9 @@ endef
+ #
+ # Patterns for various file types
+ #
++
++ifndef Win32Platform
++
+ LibPathPattern    = -L%
+ LibNoDebugPattern = lib%.a
+ LibDebugPattern = lib%.a
+@@ -371,6 +376,37 @@ LibSearchPattern = -l%
+ BinPattern = %
+ TclScriptPattern = %
+ 
++else
++
++LibPathPattern = -libpath:%
++LibNoDebugPattern = %.lib
++LibDebugPattern = %d.lib
++DLLNoDebugPattern = %_rt.lib
++DLLDebugPattern = %_rtd.lib
++LibNoDebugSearchPattern = %.lib
++LibDebugSearchPattern = %d.lib
++DLLNoDebugSearchPattern = %_rt.lib
++DLLDebugSearchPattern = %_rtd.lib
++
++
++ifndef BuildDebugBinary
++
++LibPattern = $(LibNoDebugPattern)
++DLLPattern = $(DLLNoDebugPattern)
++LibSearchPattern = $(LibNoDebugSearchPattern)
++DLLSearchPattern = $(DLLNoDebugSearchPattern)
++
++else
++
++LibPattern = $(LibDebugPattern)
++DLLPattern = $(DLLDebugPattern)
++LibSearchPattern = $(LibDebugSearchPattern)
++DLLSearchPattern = $(DLLDebugSearchPattern)
++endif
++
++endif
++
++
+ 
+ #
+ # Stuff to generate statically-linked libraries.
+diff --git a/src/services/mklib/dynstublib/dir.mk b/src/services/mklib/dynstublib/dir.mk
+index e128aa87a..f2e1448b3 100644
+--- a/src/services/mklib/dynstublib/dir.mk
++++ b/src/services/mklib/dynstublib/dir.mk
+@@ -17,6 +17,14 @@ ifdef Win32Platform
+   MSVC_STATICLIB_CXXDEBUGFLAGS += -D_WINSTATIC
+ endif
+ 
++ifdef Win32Platform
++# in case of Win32 lossage:
++dynimps := COS$(OMNIORB_MAJOR_VERSION)$(OMNIORB_MINOR_VERSION)$(OMNIORB_MICRO_VERSION)_rt.lib \
++           $(patsubst $(DLLDebugSearchPattern),$(DLLNoDebugSearchPattern), $(OMNIORB_LIB))
++else
++dynimps := $(OMNIORB_COS_LIB) $(OMNIORB_LIB)
++endif
++
+ ifndef NoReleaseBuild
+ all:: mkstatic mkshared
+ 
+@@ -75,14 +83,6 @@ dynskshared   = shared/$(shell $(SharedLibraryFullName) $(dynsknamespec))
+ 
+ MDFLAGS += -p shared/
+ 
+-ifdef Win32Platform
+-# in case of Win32 lossage:
+-dynimps := COS$(OMNIORB_MAJOR_VERSION)$(OMNIORB_MINOR_VERSION)$(OMNIORB_MICRO_VERSION)_rt.lib \
+-           $(patsubst $(DLLDebugSearchPattern),$(DLLNoDebugSearchPattern), $(OMNIORB_LIB))
+-else
+-dynimps := $(OMNIORB_COS_LIB) $(OMNIORB_LIB)
+-endif
+-
+ mkshared::
+ 	@(dir=shared; $(CreateDir))
+ 
+diff --git a/mk/win32.mk b/mk/win32.mk
+index 83f1b1687..741835b4b 100644
+--- a/mk/win32.mk
++++ b/mk/win32.mk
+@@ -43,10 +43,10 @@ endif
+ #AR = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/libwrapper $(XLN)
+ #CXX = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
+ #CXXLINK	= $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
+-CXXMAKEDEPEND = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/omkdepend $(MKDEPOPT) -D__cplusplus -D_MSC_VER
++CXXMAKEDEPEND = $(OMKDEPEND) -D__cplusplus -D_MSC_VER
+ #CC = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
+ #CLINK = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
+-CMAKEDEPEND = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/omkdepend $(MKDEPOPT) -D_MSC_VER
++CMAKEDEPEND = $(OMKDEPEND) $(MKDEPOPT) -D_MSC_VER
+ 
+ RCTOOL          = rc.exe
+ MANIFESTTOOL    = true
+@@ -145,7 +145,7 @@ BinPattern = %.exe
+ define StaticLinkLibrary
+ (set -x; \
+  $(RM) $@; \
+- $(AR) $@ $^; \
++ $(AR) -OUT:$@ $^; \
+ )
+ endef
+ 
+@@ -439,12 +444,11 @@ endef
+ # The pattern rules below ensured that the right compiler flags are used
+ # to compile the source for the library.
+ 
++ifndef NoReleaseBuild
++
+ static/%.o: %.cc
+ 	$(CXX) -c $(CXXDEBUGFLAGS) $(MSVC_STATICLIB_CXXNODEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fdstatic\\$(LIB_NAME)$(major).pdb $<
+ 
+-debug/%.o: %.cc
+-	$(CXX) -c  $(MSVC_STATICLIB_CXXDEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fddebug\\$(LIB_NAME)$(major)d.pdb $<
+-
+ shared/%DynSK.o: %DynSK.cc
+ 	$(CXX) -c $(CXXDEBUGFLAGS) -DUSE_core_stub_in_nt_dll $(MSVC_DLL_CXXNODEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fdshared\\ $<
+ 
+@@ -454,6 +458,18 @@ shared/%SK.o: %SK.cc
+ shared/%.o: %.cc
+ 	$(CXX) -c $(CXXDEBUGFLAGS) $(MSVC_DLL_CXXNODEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fdshared\\ $<
+ 
++static/%.o: %.c
++	$(CC) -c $(CDEBUGFLAGS) $(MSVC_STATICLIB_CXXNODEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fdstatic\\$(LIB_NAME)$(major).pdb $<
++
++shared/%.o: %.c
++	$(CC) -c $(CDEBUGFLAGS) $(MSVC_DLL_CXXNODEBUGFLAGS) $(CPPFLAGS) -Fo$@ $<
++
++endif
++
++ifndef NoDebugBuild
++
++debug/%.o: %.cc
++	$(CXX) -c  $(MSVC_STATICLIB_CXXDEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fddebug\\$(LIB_NAME)$(major)d.pdb $<
+ 
+ shareddebug/%DynSK.o: %DynSK.cc
+ 	$(CXX) -c  -DUSE_core_stub_in_nt_dll $(MSVC_DLL_CXXDEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fdshareddebug\\ $<
+@@ -464,19 +480,14 @@ shareddebug/%SK.o: %SK.cc
+ shareddebug/%.o: %.cc
+ 	$(CXX) -c  $(MSVC_DLL_CXXDEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fdshareddebug\\ $<
+ 
+-static/%.o: %.c
+-	$(CC) -c $(CDEBUGFLAGS) $(MSVC_STATICLIB_CXXNODEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fdstatic\\$(LIB_NAME)$(major).pdb $<
+-
+ debug/%.o: %.c
+ 	$(CC) -c $(MSVC_STATICLIB_CXXDEBUGFLAGS) $(CPPFLAGS) -Fo$@ -Fdstatic\\$(LIB_NAME)$(major)d.pdb $<
+ 
+-shared/%.o: %.c
+-	$(CC) -c $(CDEBUGFLAGS) $(MSVC_DLL_CXXNODEBUGFLAGS) $(CPPFLAGS) -Fo$@ $<
+-
+-
+ shareddebug/%.o: %.c
+ 	$(CC) -c  $(MSVC_DLL_CXXDEBUGFLAGS) $(CPPFLAGS) -Fo$@ $<
+ 
++endif
++
+ 
+ #
+ # Replacements for implicit rules

--- a/ports/omniorb/add_win_into_autotools.patch
+++ b/ports/omniorb/add_win_into_autotools.patch
@@ -119,30 +119,16 @@ diff --git a/mk/win32.mk b/mk/win32.mk
 index 6d320a2bd..3983eba5c 100644
 --- a/mk/win32.mk
 +++ b/mk/win32.mk
-@@ -8,7 +8,7 @@ Win32Platform = 1
- # Define macro for path of wrapper executables
- #
- ifndef EmbeddedSystem
--WRAPPER_FPATH = $(BINDIR)
-+WRAPPER_FPATH = bin
- else
- WRAPPER_FPATH = $(HOSTBINDIR)
- endif
-@@ -40,12 +40,12 @@ SORT = sort
+@@ -40,12 +40,7 @@ SORT = sort
  endif
  
  
 -AR = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/libwrapper $(XLN)
 -CXX = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
 -CXXLINK	= $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
-+#AR = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/libwrapper $(XLN)
-+#CXX = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
-+#CXXLINK	= $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
  CXXMAKEDEPEND = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/omkdepend $(MKDEPOPT) -D__cplusplus -D_MSC_VER
 -CC = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
 -CLINK = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
-+#CC = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
-+#CLINK = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
  CMAKEDEPEND = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/omkdepend $(MKDEPOPT) -D_MSC_VER
  
  RCTOOL          = rc.exe
@@ -254,14 +240,9 @@ diff --git a/mk/win32.mk b/mk/win32.mk
 index 83f1b1687..741835b4b 100644
 --- a/mk/win32.mk
 +++ b/mk/win32.mk
-@@ -43,10 +43,10 @@ endif
- #AR = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/libwrapper $(XLN)
- #CXX = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
- #CXXLINK	= $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
+@@ -43,5 +43,5 @@ endif
 -CXXMAKEDEPEND = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/omkdepend $(MKDEPOPT) -D__cplusplus -D_MSC_VER
 +CXXMAKEDEPEND = $(OMKDEPEND) -D__cplusplus -D_MSC_VER
- #CC = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/clwrapper $(XLN)
- #CLINK = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/linkwrapper $(XLN)
 -CMAKEDEPEND = $(BASE_OMNI_TREE)/$(WRAPPER_FPATH)/omkdepend $(MKDEPOPT) -D_MSC_VER
 +CMAKEDEPEND = $(OMKDEPEND) $(MKDEPOPT) -D_MSC_VER
  

--- a/ports/omniorb/def_gen_fix.patch
+++ b/ports/omniorb/def_gen_fix.patch
@@ -1,0 +1,18 @@
+diff --git a/mk/win32.mk b/mk/win32.mk
+index fc179563e..15903919a 100644
+--- a/mk/win32.mk
++++ b/mk/win32.mk
+@@ -264,12 +264,12 @@ endef
+ define MakeCXXExportSymbolDefinitionFile
+ symrefdir=$${debug:+debug}; \
+ symreflib=$(SharedLibrarySymbolRefLibraryTemplate); \
+ if [ ! -f $$symreflib ]; then echo "Cannot find reference static library $$symreflib"; return 1; fi;  \
+ set -x; \
+ echo "LIBRARY $$dllbase" > $$defname; \
+ echo "VERSION $$version" >> $$defname; \
+ echo "EXPORTS" >> $$defname; \
+-DUMPBIN.EXE /SYMBOLS $$symreflib | \
++DUMPBIN.EXE $$symreflib -SYMBOLS | \
+ egrep '^[^ ]+ +[^ ]+ +SECT[^ ]+ +[^ ]+ +\(\) +External +\| +\?[^ ]*|^[^ ]+ +[^ ]+ +SECT[^ ]+ +[^ ]+ +External +\| +\?[^?][^ ]*'|\
+ egrep -v 'deleting destructor[^(]+\(unsigned int\)' | \
+ egrep -v 'anonymous namespace' | \

--- a/ports/omniorb/fix_dependency.patch
+++ b/ports/omniorb/fix_dependency.patch
@@ -1,0 +1,78 @@
+diff --git a/mk/mklib.mk b/mk/mklib.mk
+index fb83cf391..9b28a314b 100644
+--- a/mk/mklib.mk
++++ b/mk/mklib.mk
+@@ -100,6 +100,10 @@ $(shlib): $(patsubst %, shared/%, $(LIB_OBJS) $(LIB_SHARED_ONLY_OBJS))
+ 	@(namespec="$(namespec)" extralibs="$(imps) $(extralibs)"; \
+          $(MakeCXXSharedLibrary))
+ 
++ifdef Win32Platform
++$(shlib): | $(staticlib)
++endif
++
+ export:: $(shlib)
+ 	@(namespec="$(namespec)"; \
+           $(ExportSharedLibrary))
+@@ -209,6 +211,10 @@ $(dbugshlib): $(patsubst %, shareddebug/%, $(LIB_OBJS) $(LIB_SHARED_ONLY_OBJS))
+ 	(namespec="$(namespec)" debug=1 extralibs="$(dbugimps) $(extralibs)"; \
+          $(MakeCXXSharedLibrary))
+ 
++ifdef Win32Platform
++$(dbugshlib): | $(dbuglib)
++endif
++
+ export:: $(dbugshlib)
+ 	@(namespec="$(namespec)" debug=1; \
+           $(ExportSharedLibrary))
+diff --git a/src/services/mklib/stublib/dir.mk b/src/services/mklib/stublib/dir.mk
+index ce46f6c5f..eb619e5c5 100644
+--- a/src/services/mklib/stublib/dir.mk
++++ b/src/services/mklib/stublib/dir.mk
+@@ -92,6 +92,10 @@ $(skshared): $(patsubst %, shared/%, $(COS_SK_OBJS))
+ 	@(namespec="$(sknamespec)"; extralibs="$(imps) $(extralibs)"; \
+          $(MakeCXXSharedLibrary))
+ 
++ifdef Win32Platform
++$(skshared): | $(sk)
++endif
++
+ export:: $(skshared)
+ 	@(namespec="$(sknamespec)"; \
+          $(ExportSharedLibrary))
+@@ -168,6 +170,10 @@ $(skshareddbug): $(patsubst %, shareddebug/%, $(COS_SK_OBJS))
+ 	(namespec="$(sknamespec)"; debug=1; extralibs="$(dbugimps) $(extralibs)"; \
+          $(MakeCXXSharedLibrary))
+ 
++ifdef Win32Platform
++$(skshareddbug): | $(skdbug)
++endif
++
+ export:: $(skshareddbug)
+ 	@(namespec="$(sknamespec)" debug=1; \
+          $(ExportSharedLibrary))
+diff --git a/src/services/mklib/dynstublib/dir.mk b/src/services/mklib/dynstublib/dir.mk
+index f2e1448b3..9134e8aba 100644
+--- a/src/services/mklib/dynstublib/dir.mk
++++ b/src/services/mklib/dynstublib/dir.mk
+@@ -92,6 +92,10 @@ $(dynskshared): $(skshared) $(patsubst %, shared/%, $(COS_DYNSK_OBJS))
+ 	@(namespec="$(dynsknamespec)"; extralibs="$(dynimps)"; \
+          $(MakeCXXSharedLibrary))
+ 
++ifdef Win32Platform
++$(dynskshared): | $(dynsk)
++endif
++
+ export:: $(dynskshared)
+ 	@(namespec="$(dynsknamespec)"; \
+          $(ExportSharedLibrary))
+@@ -169,6 +171,10 @@ $(dynskshareddbug): $(patsubst %, shareddebug/%, $(COS_DYNSK_OBJS))
+ 	@(namespec="$(dynsknamespec)"; debug=1; extralibs="$(skshareddbug) $(dbugimps) $(extralibs)"; \
+          $(MakeCXXSharedLibrary))
+ 
++ifdef Win32Platform
++$(dynskshareddbug): | $(dynskdbug)
++endif
++
+ export:: $(dynskshareddbug)
+ 	@(namespec="$(dynsknamespec)" debug=1; \
+          $(ExportSharedLibrary))

--- a/ports/omniorb/hardcode_vaargs_for_msvc.patch
+++ b/ports/omniorb/hardcode_vaargs_for_msvc.patch
@@ -1,0 +1,97 @@
+diff --git a/src/tool/omniidl/cxx/cccp/cccp.c b/src/tool/omniidl/cxx/cccp/cccp.c
+index 507c330..5651b3e 100644
+--- a/src/tool/omniidl/cxx/cccp/cccp.c
++++ b/src/tool/omniidl/cxx/cccp/cccp.c
+@@ -182,15 +182,24 @@ my_bzero (b, length)
+ # endif
+ #endif
+ 
+-#if defined (__STDC__) && defined (OMNI_HAVE_VPRINTF)
++#if defined(_MSC_VER)
++#define OMNI_HAVE_VPRINTF
++#define __STDC__
++#endif
++
++#if (defined (__STDC__) && defined (OMNI_HAVE_VPRINTF))
+ # include <stdarg.h>
+-# define VA_START(va_list, var) va_start (va_list, var)
++# define VA_START(va_list, var) va_start(va_list, var)
+ # define PRINTF_ALIST(msg) char *msg, ...
+ # define PRINTF_DCL(msg)
+ # define PRINTF_PROTO(ARGS, m, n) PROTO (ARGS) __attribute__ ((format (__printf__, m, n)))
+ #else
++#ifdef _MSC_VER
++# include <stdarg.h>
++#else
+ # include <varargs.h>
+-# define VA_START(va_list, var) va_start (va_list)
++#endif
++# define VA_START(va_list, var) va_start(va_list)
+ # define PRINTF_ALIST(msg) msg, va_alist
+ # define PRINTF_DCL(msg) char *msg; va_dcl
+ # define PRINTF_PROTO(ARGS, m, n) () __attribute__ ((format (__printf__, m, n)))
+diff --git a/src/tool/omniidl/cxx/cccp/cexp.c b/src/tool/omniidl/cxx/cccp/cexp.c
+index 4b4679c..b534fb3 100644
+--- a/src/tool/omniidl/cxx/cccp/cexp.c
++++ b/src/tool/omniidl/cxx/cccp/cexp.c
+@@ -152,15 +152,25 @@ struct arglist {
+ # endif
+ #endif
+ 
+-#if defined (__STDC__) && defined (OMNI_HAVE_VPRINTF)
++#if defined(_MSC_VER)
++#define OMNI_HAVE_VPRINTF
++#define __STDC__
++#endif
++
++
++#if ( defined (__STDC__) && defined (OMNI_HAVE_VPRINTF))
+ # include <stdarg.h>
+-# define VA_START(va_list, var) va_start (va_list, var)
++# define VA_START(va_list, var) VA_START(va_list, var)
+ # define PRINTF_ALIST(msg) char *msg, ...
+ # define PRINTF_DCL(msg)
+ # define PRINTF_PROTO(ARGS, m, n) PROTO (ARGS) __attribute__ ((format (__printf__, m, n)))
+ #else
++#ifdef _MSC_VER
++# include <stdarg.h>
++#else
+ # include <varargs.h>
+-# define VA_START(va_list, var) va_start (va_list)
++#endif
++# define VA_START(va_list, var) VA_START(va_list)
+ # define PRINTF_ALIST(msg) msg, va_alist
+ # define PRINTF_DCL(msg) char *msg; va_dcl
+ # define PRINTF_PROTO(ARGS, m, n) () __attribute__ ((format (__printf__, m, n)))
+diff --git a/src/tool/omniidl/cxx/cccp/cexp.y.source b/src/tool/omniidl/cxx/cccp/cexp.y.source
+index 6fc69f5..6f59873 100644
+--- a/src/tool/omniidl/cxx/cccp/cexp.y.source
++++ b/src/tool/omniidl/cxx/cccp/cexp.y.source
+@@ -111,15 +111,24 @@ struct arglist {
+ # endif
+ #endif
+ 
+-#if defined (__STDC__) && defined (HAVE_VPRINTF)
++#if defined(_MSC_VER)
++#define OMNI_HAVE_VPRINTF
++#define __STDC__
++#endif
++
++#if ( defined (__STDC__) && defined (HAVE_VPRINTF) )
+ # include <stdarg.h>
+-# define VA_START(va_list, var) va_start (va_list, var)
++# define VA_START(va_list, var) VA_START(va_list, var)
+ # define PRINTF_ALIST(msg) char *msg, ...
+ # define PRINTF_DCL(msg)
+ # define PRINTF_PROTO(ARGS, m, n) PROTO (ARGS) __attribute__ ((format (__printf__, m, n)))
+ #else
++#ifdef _MSC_VER
++# include <stdarg.h>
++#else
+ # include <varargs.h>
+-# define VA_START(va_list, var) va_start (va_list)
++#endif
++# define VA_START(va_list, var) VA_START(va_list)
+ # define PRINTF_ALIST(msg) msg, va_alist
+ # define PRINTF_DCL(msg) char *msg; va_dcl
+ # define PRINTF_PROTO(ARGS, m, n) () __attribute__ ((format (__printf__, m, n)))

--- a/ports/omniorb/hardcode_vaargs_for_msvc.patch
+++ b/ports/omniorb/hardcode_vaargs_for_msvc.patch
@@ -2,31 +2,24 @@ diff --git a/src/tool/omniidl/cxx/cccp/cccp.c b/src/tool/omniidl/cxx/cccp/cccp.c
 index 507c330..5651b3e 100644
 --- a/src/tool/omniidl/cxx/cccp/cccp.c
 +++ b/src/tool/omniidl/cxx/cccp/cccp.c
-@@ -182,15 +182,24 @@ my_bzero (b, length)
+@@ -182,15 +182,20 @@ my_bzero (b, length)
  # endif
  #endif
  
--#if defined (__STDC__) && defined (OMNI_HAVE_VPRINTF)
 +#if defined(_MSC_VER)
 +#define OMNI_HAVE_VPRINTF
 +#define __STDC__
 +#endif
 +
-+#if (defined (__STDC__) && defined (OMNI_HAVE_VPRINTF))
+ #if defined (__STDC__) && defined (OMNI_HAVE_VPRINTF)
  # include <stdarg.h>
--# define VA_START(va_list, var) va_start (va_list, var)
-+# define VA_START(va_list, var) va_start(va_list, var)
+ # define VA_START(va_list, var) va_start (va_list, var)
  # define PRINTF_ALIST(msg) char *msg, ...
  # define PRINTF_DCL(msg)
  # define PRINTF_PROTO(ARGS, m, n) PROTO (ARGS) __attribute__ ((format (__printf__, m, n)))
  #else
-+#ifdef _MSC_VER
-+# include <stdarg.h>
-+#else
  # include <varargs.h>
--# define VA_START(va_list, var) va_start (va_list)
-+#endif
-+# define VA_START(va_list, var) va_start(va_list)
+ # define VA_START(va_list, var) va_start (va_list)
  # define PRINTF_ALIST(msg) msg, va_alist
  # define PRINTF_DCL(msg) char *msg; va_dcl
  # define PRINTF_PROTO(ARGS, m, n) () __attribute__ ((format (__printf__, m, n)))
@@ -34,32 +27,24 @@ diff --git a/src/tool/omniidl/cxx/cccp/cexp.c b/src/tool/omniidl/cxx/cccp/cexp.c
 index 4b4679c..b534fb3 100644
 --- a/src/tool/omniidl/cxx/cccp/cexp.c
 +++ b/src/tool/omniidl/cxx/cccp/cexp.c
-@@ -152,15 +152,25 @@ struct arglist {
+@@ -152,15 +152,20 @@ struct arglist {
  # endif
  #endif
  
--#if defined (__STDC__) && defined (OMNI_HAVE_VPRINTF)
 +#if defined(_MSC_VER)
 +#define OMNI_HAVE_VPRINTF
 +#define __STDC__
 +#endif
 +
-+
-+#if ( defined (__STDC__) && defined (OMNI_HAVE_VPRINTF))
+ #if defined (__STDC__) && defined (OMNI_HAVE_VPRINTF)
  # include <stdarg.h>
--# define VA_START(va_list, var) va_start (va_list, var)
-+# define VA_START(va_list, var) VA_START(va_list, var)
+ # define VA_START(va_list, var) va_start (va_list, var)
  # define PRINTF_ALIST(msg) char *msg, ...
  # define PRINTF_DCL(msg)
  # define PRINTF_PROTO(ARGS, m, n) PROTO (ARGS) __attribute__ ((format (__printf__, m, n)))
  #else
-+#ifdef _MSC_VER
-+# include <stdarg.h>
-+#else
  # include <varargs.h>
--# define VA_START(va_list, var) va_start (va_list)
-+#endif
-+# define VA_START(va_list, var) VA_START(va_list)
+ # define VA_START(va_list, var) va_start (va_list)
  # define PRINTF_ALIST(msg) msg, va_alist
  # define PRINTF_DCL(msg) char *msg; va_dcl
  # define PRINTF_PROTO(ARGS, m, n) () __attribute__ ((format (__printf__, m, n)))
@@ -67,31 +52,25 @@ diff --git a/src/tool/omniidl/cxx/cccp/cexp.y.source b/src/tool/omniidl/cxx/cccp
 index 6fc69f5..6f59873 100644
 --- a/src/tool/omniidl/cxx/cccp/cexp.y.source
 +++ b/src/tool/omniidl/cxx/cccp/cexp.y.source
-@@ -111,15 +111,24 @@ struct arglist {
+@@ -111,15 +111,20 @@ struct arglist {
  # endif
  #endif
  
--#if defined (__STDC__) && defined (HAVE_VPRINTF)
 +#if defined(_MSC_VER)
 +#define OMNI_HAVE_VPRINTF
 +#define __STDC__
 +#endif
 +
-+#if ( defined (__STDC__) && defined (HAVE_VPRINTF) )
+-#if defined (__STDC__) && defined (HAVE_VPRINTF)
++#if defined (__STDC__) && defined (OMNI_HAVE_VPRINTF)
  # include <stdarg.h>
--# define VA_START(va_list, var) va_start (va_list, var)
-+# define VA_START(va_list, var) VA_START(va_list, var)
+ # define VA_START(va_list, var) va_start (va_list, var)
  # define PRINTF_ALIST(msg) char *msg, ...
  # define PRINTF_DCL(msg)
  # define PRINTF_PROTO(ARGS, m, n) PROTO (ARGS) __attribute__ ((format (__printf__, m, n)))
  #else
-+#ifdef _MSC_VER
-+# include <stdarg.h>
-+#else
  # include <varargs.h>
--# define VA_START(va_list, var) va_start (va_list)
-+#endif
-+# define VA_START(va_list, var) VA_START(va_list)
+ # define VA_START(va_list, var) va_start (va_list)
  # define PRINTF_ALIST(msg) msg, va_alist
  # define PRINTF_DCL(msg) char *msg; va_dcl
  # define PRINTF_PROTO(ARGS, m, n) () __attribute__ ((format (__printf__, m, n)))

--- a/ports/omniorb/msvc-src-build-fixes.patch
+++ b/ports/omniorb/msvc-src-build-fixes.patch
@@ -1,0 +1,13 @@
+diff --git a/include/omnithread/atomic.h b/include/omnithread/atomic.h
+index 3fed8df..e1b6a71 100644
+--- a/include/omnithread/atomic.h
++++ b/include/omnithread/atomic.h
+@@ -27,7 +27,7 @@
+ #define __omnithread_atomic_h_
+ 
+ 
+-#ifdef OMNI_HAVE_SYNC_ADD_AND_FETCH
++#if defined(OMNI_HAVE_SYNC_ADD_AND_FETCH) && !defined(_MSC_VER)
+ 
+ #  define OMNI_REFCOUNT_DEFINED
+ 

--- a/ports/omniorb/portfile.cmake
+++ b/ports/omniorb/portfile.cmake
@@ -33,10 +33,10 @@ vcpkg_extract_source_archive(
 vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/python3") # port ask python distutils for info.
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
   set(pythonpathbase "${CURRENT_HOST_INSTALLED_DIR}/tools/python3/Lib")
+  set(ENV{PYTHONPATH} "${pythonpathbase}${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/python${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib/python")
 else()
   set(pythonpathbase "${CURRENT_HOST_INSTALLED_DIR}/lib/python3.10")
 endif()
-set(ENV{PYTHONPATH} "${pythonpathbase}${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/python${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib/python")
 
 vcpkg_find_acquire_program(FLEX)
 cmake_path(GET FLEX PARENT_PATH FLEX_DIR)

--- a/ports/omniorb/portfile.cmake
+++ b/ports/omniorb/portfile.cmake
@@ -32,10 +32,7 @@ vcpkg_extract_source_archive(
 
 vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/python3") # port ask python distutils for info.
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-  set(pythonpathbase "${CURRENT_HOST_INSTALLED_DIR}/tools/python3/Lib")
-  set(ENV{PYTHONPATH} "${pythonpathbase}${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/python${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib/python")
-else()
-  set(pythonpathbase "${CURRENT_HOST_INSTALLED_DIR}/lib/python3.10")
+  set(ENV{PYTHONPATH} "${CURRENT_HOST_INSTALLED_DIR}/tools/python3/Lib${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/python${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib/python")
 endif()
 
 vcpkg_find_acquire_program(FLEX)

--- a/ports/omniorb/portfile.cmake
+++ b/ports/omniorb/portfile.cmake
@@ -1,0 +1,216 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://netcologne.dl.sourceforge.net/project/omniorb/omniORB/omniORB-4.3.0/omniORB-4.3.0.tar.bz2"
+    FILENAME "omniORB-${VERSION}.tar.bz2"
+    SHA512 b081c1acbea3c7bee619a288fec209a0705b7d436f8e5fd4743675046356ef271a8c75882334fcbde4ff77d15f54d2da55f6cfcd117b01e42919d04fd29bfe2f
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+set (PATCHES 
+      hardcode_vaargs_for_msvc.patch
+    )
+set (OPTIONS 
+      ac_cv_prog_cc_g=yes
+      ac_cv_prog_cxx_11=no
+      ac_cv_prog_cxx_g=yes
+      omni_cv_sync_add_and_fetch=no
+    )
+endif()
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES 
+      fix_dependency.patch
+      def_gen_fix.patch
+      msvc-src-build-fixes.patch
+      release-debug-static.patch
+      add_win_into_autotools.patch
+      python-fixes.patch
+      ${PATCHES}
+)
+
+
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/python3") # port ask python distutils for info.
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+  set(pythonpathbase "${CURRENT_HOST_INSTALLED_DIR}/tools/python3/Lib")
+else()
+  set(pythonpathbase "${CURRENT_HOST_INSTALLED_DIR}/lib/python3.10")
+endif()
+set(ENV{PYTHONPATH} "${pythonpathbase}${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/python${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib/python")
+
+vcpkg_find_acquire_program(FLEX)
+cmake_path(GET FLEX PARENT_PATH FLEX_DIR)
+vcpkg_add_to_path("${FLEX_DIR}")
+
+vcpkg_find_acquire_program(BISON)
+cmake_path(GET BISON PARENT_PATH BISON_DIR)
+vcpkg_add_to_path("${BISON_DIR}")
+
+#string(APPEND VCPKG_C_FLAGS_DEBUG " -D_DEBUG") # for python to autolink the correct lib
+#string(APPEND VCPKG_CXX_FLAGS_DEBUG " -D_DEBUG")
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+  set(z_vcpkg_org_linkage "${VCPKG_LIBRARY_LINKAGE}") 
+  # convoluted build system; shared builds requires 
+  # static library to create def file for symbol export
+  # tools seem to only dynamically link on windows due to make rules!
+  # zlib/zstd deps for ZIOP seem to not work on windows. At least configure
+  # won't run the required checks for some reasons.
+  set(VCPKG_LIBRARY_LINKAGE dynamic)
+  z_vcpkg_get_cmake_vars(cmake_vars_file)
+  include("${cmake_vars_file}")
+  if(VCPKG_BUILD_TYPE)
+    string(APPEND build_info "NoDebugBuild=1\n")
+  endif()
+  string(APPEND build_info "replace-with-per-config-text\n")
+  set(progs C_COMPILER CXX_COMPILER AR
+            LINKER RANLIB OBJDUMP MT
+            STRIP NM DLLTOOL RC_COMPILER)
+  list(TRANSFORM progs PREPEND "VCPKG_DETECTED_CMAKE_")
+  foreach(prog IN LISTS progs)
+      if(${prog})
+          set(path "${${prog}}")
+          unset(prog_found CACHE)
+          get_filename_component(${prog} "${${prog}}" NAME)
+          find_program(prog_found ${${prog}} PATHS ENV PATH NO_DEFAULT_PATH)
+          if(NOT path STREQUAL prog_found)
+              get_filename_component(path "${path}" DIRECTORY)
+              vcpkg_add_to_path(PREPEND ${path})
+          endif()
+      endif()
+  endforeach()
+  configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg.mk" "${SOURCE_PATH}/mk/platforms/vcpkg.mk" @ONLY NEWLINE_STYLE UNIX)
+  file(GLOB_RECURSE wrappers "${SOURCE_PATH}/bin/x86_win32/*")
+  file(COPY ${wrappers} DESTINATION "${SOURCE_PATH}/bin")
+endif()
+
+vcpkg_configure_make(
+  SOURCE_PATH "${SOURCE_PATH}"
+  AUTOCONFIG
+  NO_WRAPPERS
+  COPY_SOURCE
+  OPTIONS
+    ${OPTIONS}
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+  vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel//mk/platforms/vcpkg.mk" "replace-with-per-config-text" "NoDebugBuild=1")
+  if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/mk/platforms/vcpkg.mk" "replace-with-per-config-text" "NoReleaseBuild=1\nBuildDebugBinary=1")
+    vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/tool/omniidl/cxx/dir.mk" "python$(subst .,,$(PYVERSION)).lib" "python$(subst .,,$(PYVERSION))_d.lib")
+  endif()
+endif()
+
+vcpkg_install_make(
+  MAKEFILE "GNUMakefile"
+  ADD_BIN_TO_PATH
+)
+
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+  file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/msvcstub.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+  file(GLOB all_libs "${CURRENT_PACKAGES_DIR}/lib/*.lib")
+  set(import_libs "${all_libs}")
+  list(FILTER import_libs INCLUDE REGEX "(_rt.lib$|msvcstub)")
+  if(z_vcpkg_org_linkage STREQUAL "static")
+    file(REMOVE ${import_libs})
+  else()
+    list(REMOVE_ITEM all_libs ${import_libs})
+    file(REMOVE ${all_libs}) # remove installed static libs
+    set(to_copy_and_rename ${import_libs})
+    list(FILTER to_copy_and_rename INCLUDE REGEX "3(0)?_rt.lib")
+    foreach(cp IN LISTS to_copy_and_rename)
+      string(REGEX REPLACE "3(0)?_rt" "" new_name "${cp}")
+      string(REGEX REPLACE "thread4" "thread" new_name "${new_name}")
+      configure_file("${cp}" "${new_name}" COPYONLY)
+    endforeach()
+    file(GLOB dll_files "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/*.dll")
+    file(COPY ${dll_files} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(GLOB pc_files "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/*.pc")
+    foreach(pc_file IN LISTS pc_files)
+      get_filename_component(filename "${pc_file}" NAME_WE)
+      if(filename STREQUAL "omnithread3")
+        vcpkg_replace_string("${pc_file}" "-lomnithread" "-lomnithread_rt")
+      else()
+        vcpkg_replace_string("${pc_file}" "-l${filename}" "-l${filename}_rt")
+      endif()
+    endforeach()
+  endif()
+
+  if(NOT VCPKG_BUILD_TYPE) # dbg libs have no install rules so manually copy them.
+    file(GLOB all_libs "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib/*.lib")
+    set(install_libs "${all_libs}")
+    if(z_vcpkg_org_linkage STREQUAL "static")
+      list(FILTER install_libs EXCLUDE REGEX "(_rtd.lib$|msvcstub)")
+    else() # dynamic lib
+      list(FILTER install_libs INCLUDE REGEX "(_rtd.lib$|msvcstub)")
+      set(to_copy_and_rename ${install_libs})
+      list(FILTER to_copy_and_rename INCLUDE REGEX "3(0)?_rtd.lib")
+      #list(REMOVE_ITEM install_libs ${to_copy_and_rename})
+      foreach(cp IN LISTS to_copy_and_rename)
+        string(REGEX REPLACE "3(0)?_rt" "" new_name "${cp}")
+        string(REGEX REPLACE "thread4" "thread" new_name "${new_name}")
+        configure_file("${cp}" "${new_name}" COPYONLY)
+        list(APPEND install_libs "${new_name}")
+      endforeach()
+      file(GLOB dll_files "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/*.dll")
+      file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+      file(COPY ${dll_files} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+      file(GLOB pc_files "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
+      foreach(pc_file IN LISTS pc_files)
+        get_filename_component(filename "${pc_file}" NAME_WE)
+        if(filename STREQUAL "omnithread3")
+          vcpkg_replace_string("${pc_file}" "-lomnithread" "-lomnithread_rtd")
+        else()
+          vcpkg_replace_string("${pc_file}" "-l${filename}" "-l${filename}_rtd")
+        endif()
+      endforeach()
+    endif()
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib")
+    file(COPY ${install_libs} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+  endif()
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LIB") # Lib is LGPL
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin" RENAME copyright) # Tools etc are GPL
+
+vcpkg_copy_pdbs()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+file(COPY
+      "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/omnicpp${VCPKG_TARGET_EXECUTABLE_SUFFIX}"
+    DESTINATION
+      "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin"
+    )
+endif()
+
+file(COPY
+      "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/omniidl${VCPKG_TARGET_EXECUTABLE_SUFFIX}"
+    DESTINATION
+      "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin"
+    )
+
+vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
+
+# Restore old linkage info. 
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+   set(VCPKG_LIBRARY_LINKAGE ${z_vcpkg_org_linkage})
+endif()
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/omniidl" "${CURRENT_INSTALLED_DIR}" "\"os.path.dirname(__file__)+\"/../../../")
+endif()
+
+set(del_files "")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+  file(GLOB del_files "${CURRENT_PACKAGES_DIR}/lib/*.a" "${CURRENT_PACKAGES_DIR}/debug/lib/*.a")
+  file(REMOVE ${del_files})
+else()
+  file(GLOB del_files "${CURRENT_PACKAGES_DIR}/lib/*.so*" "${CURRENT_PACKAGES_DIR}/debug/lib/*.so*")
+  file(REMOVE ${del_files})
+endif()
+
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/omniorb/portfile.cmake
+++ b/ports/omniorb/portfile.cmake
@@ -29,7 +29,6 @@ vcpkg_extract_source_archive(
       ${PATCHES}
 )
 
-
 vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/python3") # port ask python distutils for info.
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
   set(ENV{PYTHONPATH} "${CURRENT_HOST_INSTALLED_DIR}/tools/python3/Lib${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/python${VCPKG_HOST_PATH_SEPARATOR}${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib/python")
@@ -42,9 +41,6 @@ vcpkg_add_to_path("${FLEX_DIR}")
 vcpkg_find_acquire_program(BISON)
 cmake_path(GET BISON PARENT_PATH BISON_DIR)
 vcpkg_add_to_path("${BISON_DIR}")
-
-#string(APPEND VCPKG_C_FLAGS_DEBUG " -D_DEBUG") # for python to autolink the correct lib
-#string(APPEND VCPKG_CXX_FLAGS_DEBUG " -D_DEBUG")
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
   set(z_vcpkg_org_linkage "${VCPKG_LIBRARY_LINKAGE}") 
@@ -116,12 +112,12 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
   else()
     list(REMOVE_ITEM all_libs ${import_libs})
     file(REMOVE ${all_libs}) # remove installed static libs
-    set(to_copy_and_rename ${import_libs})
+    set(to_copy_and_rename "${import_libs}")
     list(FILTER to_copy_and_rename INCLUDE REGEX "3(0)?_rt.lib")
     foreach(cp IN LISTS to_copy_and_rename)
       string(REGEX REPLACE "3(0)?_rt" "" new_name "${cp}")
       string(REGEX REPLACE "thread4" "thread" new_name "${new_name}")
-      configure_file("${cp}" "${new_name}" COPYONLY)
+      file(COPY_FILE "${cp}" "${new_name}")
     endforeach()
     file(GLOB dll_files "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/*.dll")
     file(COPY ${dll_files} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
@@ -143,13 +139,12 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
       list(FILTER install_libs EXCLUDE REGEX "(_rtd.lib$|msvcstub)")
     else() # dynamic lib
       list(FILTER install_libs INCLUDE REGEX "(_rtd.lib$|msvcstub)")
-      set(to_copy_and_rename ${install_libs})
+      set(to_copy_and_rename "${install_libs}")
       list(FILTER to_copy_and_rename INCLUDE REGEX "3(0)?_rtd.lib")
-      #list(REMOVE_ITEM install_libs ${to_copy_and_rename})
       foreach(cp IN LISTS to_copy_and_rename)
         string(REGEX REPLACE "3(0)?_rt" "" new_name "${cp}")
         string(REGEX REPLACE "thread4" "thread" new_name "${new_name}")
-        configure_file("${cp}" "${new_name}" COPYONLY)
+        file(COPY_FILE "${cp}" "${new_name}")
         list(APPEND install_libs "${new_name}")
       endforeach()
       file(GLOB dll_files "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/*.dll")
@@ -193,7 +188,7 @@ vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
 
 # Restore old linkage info. 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-   set(VCPKG_LIBRARY_LINKAGE ${z_vcpkg_org_linkage})
+   set(VCPKG_LIBRARY_LINKAGE "${z_vcpkg_org_linkage}")
 endif()
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
@@ -212,7 +207,6 @@ else()
     file(REMOVE ${del_files})
   endif()
 endif()
-
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/omniorb/portfile.cmake
+++ b/ports/omniorb/portfile.cmake
@@ -98,11 +98,12 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
   if(NOT VCPKG_BUILD_TYPE)
     vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/mk/platforms/vcpkg.mk" "replace-with-per-config-text" "NoReleaseBuild=1\nBuildDebugBinary=1")
     vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/tool/omniidl/cxx/dir.mk" "python$(subst .,,$(PYVERSION)).lib" "python$(subst .,,$(PYVERSION))_d.lib")
+    vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/tool/omniidl/cxx/dir.mk" "zlib.lib" "zlibd.lib")
   endif()
 endif()
 
 vcpkg_install_make(
-  MAKEFILE "GNUMakefile"
+  MAKEFILE "GNUmakefile"
   ADD_BIN_TO_PATH
 )
 
@@ -205,10 +206,14 @@ endif()
 set(del_files "")
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
   file(GLOB del_files "${CURRENT_PACKAGES_DIR}/lib/*.a" "${CURRENT_PACKAGES_DIR}/debug/lib/*.a")
-  file(REMOVE ${del_files})
+  if(del_files)
+    file(REMOVE ${del_files})
+  endif()
 else()
   file(GLOB del_files "${CURRENT_PACKAGES_DIR}/lib/*.so*" "${CURRENT_PACKAGES_DIR}/debug/lib/*.so*")
-  file(REMOVE ${del_files})
+  if(del_files)
+    file(REMOVE ${del_files})
+  endif()
 endif()
 
 

--- a/ports/omniorb/python-fixes.patch
+++ b/ports/omniorb/python-fixes.patch
@@ -1,0 +1,46 @@
+diff --git a/mk/python.mk b/mk/python.mk
+index 1380018..fb321a5 100644
+--- a/mk/python.mk
++++ b/mk/python.mk
+@@ -4,7 +4,7 @@
+ 
+ PYVERSION := $(shell $(PYTHON) -c 'import sys; sys.stdout.write(".".join(sys.version.split(".")[:2]))')
+ PYPREFIX  := $(shell $(PYTHON) -c 'import sys; sys.stdout.write(sys.exec_prefix.replace("\\","/"))')
+-PYINCDIR  := $(shell $(PYTHON) -c 'import sys, distutils.sysconfig; sys.stdout.write(distutils.sysconfig.get_python_inc().replace("\\","/"))')
++PYINCDIR  := $(includedir)/python3.10
+ 
+ PythonSHAREDLIB_SUFFIX = $(shell $(PYTHON) -c 'import sys, distutils.sysconfig; sys.stdout.write((distutils.sysconfig.get_config_var("SO") or ".so").lstrip("."))')
+ 
+diff --git a/src/tool/omniidl/cxx/idlpython.cc b/src/tool/omniidl/cxx/idlpython.cc
+index 639515105..27ad3ee0e 100644
+--- a/src/tool/omniidl/cxx/idlpython.cc
++++ b/src/tool/omniidl/cxx/idlpython.cc
+@@ -27,8 +27,6 @@
+ 
+ // On Windows, if _DEBUG is defined, some Python versions try to force
+ // use of _d.lib libraries that are not actually present.
+-#undef _DEBUG
+-
+ #include <Python.h>
+ 
+ #include <idlsysdep.h>
+diff --git a/src/tool/omniidl/cxx/dir.mk b/src/tool/omniidl/cxx/dir.mk
+index 84f10ac03..3b5a60b87 100644
+--- a/src/tool/omniidl/cxx/dir.mk
++++ b/src/tool/omniidl/cxx/dir.mk
+@@ -190,13 +190,13 @@ ifdef Win32Platform
+ 
+ DIR_CPPFLAGS += -DMSDOS -DOMNIIDL_EXECUTABLE
+ 
+-PYLIBDIR := $(PYPREFIX)/libs $(PYPREFIX)/lib/x86_win32
++PYLIBDIR := $(libdir)
+ 
+ ifdef MinGW32Build
+ PYLIB     := -lpython$(subst .,,$(PYVERSION))
+ CXXLINKOPTIONS += $(patsubst %,-L%,$(PYLIBDIR))
+ else
+-PYLIB     := python$(subst .,,$(PYVERSION)).lib
++PYLIB     = python$(subst .,,$(PYVERSION)).lib Advapi32.lib
+ CXXLINKOPTIONS += $(patsubst %,-libpath:%,$(PYLIBDIR))
+ endif
+ 

--- a/ports/omniorb/python-fixes.patch
+++ b/ports/omniorb/python-fixes.patch
@@ -40,7 +40,7 @@ index 84f10ac03..3b5a60b87 100644
  CXXLINKOPTIONS += $(patsubst %,-L%,$(PYLIBDIR))
  else
 -PYLIB     := python$(subst .,,$(PYVERSION)).lib
-+PYLIB     = python$(subst .,,$(PYVERSION)).lib Advapi32.lib
++PYLIB     = python$(subst .,,$(PYVERSION)).lib zlib.lib Advapi32.lib
  CXXLINKOPTIONS += $(patsubst %,-libpath:%,$(PYLIBDIR))
  endif
  

--- a/ports/omniorb/release-debug-static.patch
+++ b/ports/omniorb/release-debug-static.patch
@@ -1,0 +1,319 @@
+diff --git a/mk/mklib.mk b/mk/mklib.mk
+index 8f64b14dd..1d73cfdbe 100644
+--- a/mk/mklib.mk
++++ b/mk/mklib.mk
+@@ -16,6 +16,8 @@
+ # are called libfoo.a and libfoo.so.1.3 etc.
+ #
+ 
++ifndef NoReleaseBuild
++
+ all:: mkstatic mkshared
+ 
+ export:: mkstatic mkshared
+@@ -147,9 +149,13 @@ mkshared::
+ 
+ endif
+ 
++endif
++
+ ##############################################################################
+ # Build debug libraries for Win32
+ ##############################################################################
++ifndef NoDebugBuild
++
+ ifdef Win32Platform
+ 
+ ifdef BuildSharedLibrary
+@@ -231,3 +237,4 @@ veryclean::
+ 
+ endif
+ endif
++endif
+\ No newline at end of file
+diff --git a/src/lib/dir.mk b/src/lib/dir.mk
+index 732f8457c..bff3144f8 100644
+--- a/src/lib/dir.mk
++++ b/src/lib/dir.mk
+@@ -17,9 +17,14 @@ ciao::
+ ifndef EmbeddedSystem
+ ifdef Win32Platform
+ ifndef MinGW32Build
++ifndef NoReleaseBuild
+ export::
+ 	(cd $(EXPORT_TREE)/$(BINDIR); editbin /REBASE:BASE=0x68000000,DOWN *_rt.dll; )
++endif
++ifndef NoDebugBuild
++export::
+ 	(cd $(EXPORT_TREE)/$(BINDIR); editbin /REBASE:BASE=0x68000000,DOWN *_rtd.dll; )
+ endif
+ endif
+ endif
++endif
+diff --git a/src/lib/omnithread/dir.mk b/src/lib/omnithread/dir.mk
+index ed2194c98..adb87adba 100644
+--- a/src/lib/omnithread/dir.mk
++++ b/src/lib/omnithread/dir.mk
+@@ -32,14 +32,6 @@ LIB_VERSION  := $(OMNITHREAD_VERSION)
+ LIB_OBJS     := $(CXXSRCS:.cc=.o)
+ LIB_IMPORTS  := $(OMNITHREAD_PLATFORM_LIB)
+ 
+-all:: mkstatic mkshared
+-
+-export:: mkstatic mkshared
+-
+-ifdef INSTALLTARGET
+-install:: mkstatic mkshared
+-endif
+-
+ vers := $(subst ., ,$(LIB_VERSION))
+ ifeq ($(words $(vers)), 2)
+   vers  := _ $(vers)
+@@ -50,6 +42,16 @@ endif
+ 
+ namespec := $(LIB_NAME) $(vers)
+ 
++ifndef NoReleaseBuild
++
++all:: mkstatic mkshared
++
++export:: mkstatic mkshared
++
++ifdef INSTALLTARGET
++install:: mkstatic mkshared
++endif
++
+ ##############################################################################
+ # Build Static library
+ ##############################################################################
+@@ -158,9 +160,12 @@ mkshared::
+ 
+ endif
+ 
++endif
+ ##############################################################################
+ # Build debug libraries for Win32
+ ##############################################################################
++ifndef NoDebugBuild
++
+ ifdef Win32Platform
+ 
+ ifdef BuildSharedLibrary
+@@ -239,4 +244,4 @@ veryclean::
+ 
+ endif
+ endif
+-
++endif
+diff --git a/src/services/mklib/dynstublib/dir.mk b/src/services/mklib/dynstublib/dir.mk
+index 23573345d..e128aa87a 100644
+--- a/src/services/mklib/dynstublib/dir.mk
++++ b/src/services/mklib/dynstublib/dir.mk
+@@ -12,15 +12,18 @@ COS_DYNSK_SRCS = $(COS_INTERFACES:%=%DynSK.cc)
+ 
+ CXXSRCS = $(COS_DYNSK_SRCS)
+ 
+-all:: mkstatic mkshared
+-
+-export:: mkstatic mkshared
+-
+ ifdef Win32Platform
+   MSVC_STATICLIB_CXXNODEBUGFLAGS += -D_WINSTATIC
+   MSVC_STATICLIB_CXXDEBUGFLAGS += -D_WINSTATIC
+ endif
+ 
++ifndef NoReleaseBuild
++all:: mkstatic mkshared
++
++export:: mkstatic mkshared
++
++
++
+ 
+ ##############################################################################
+ # Build Static library
+@@ -108,10 +111,11 @@ else
+ mkshared::
+ 
+ endif
+-
++endif
+ ##############################################################################
+ # Build debug libraries for Win32
+ ##############################################################################
++ifndef NoDebugBuild
+ ifdef Win32Platform
+ 
+ all:: mkstaticdbug mkshareddbug
+@@ -145,6 +149,7 @@ clean::
+ #####################################################
+ #      DLL debug libraries
+ #####################################################
++
+ shareddbugversion = $(OMNIORB_VERSION)
+ 
+ dynsknamespec   = $(subst ., ,$(COS_DYNSKLIB_NAME).$(shareddbugversion))
+@@ -173,3 +178,4 @@ clean::
+ 	@(dir=shareddebug; $(CleanSharedLibrary))
+ 
+ endif
++endif
+\ No newline at end of file
+diff --git a/src/services/mklib/mkBOAlib/dir.mk b/src/services/mklib/mkBOAlib/dir.mk
+index 1869d083d..18cc38764 100644
+--- a/src/services/mklib/mkBOAlib/dir.mk
++++ b/src/services/mklib/mkBOAlib/dir.mk
+@@ -16,6 +16,8 @@ COS_SK_OBJS = $(COS_INTERFACES:%=%SK.o)
+ COS_SK_SRCS = $(COS_INTERFACES:%=%SK.cc)
+ CXXSRCS = $(COS_SK_SRCS) 
+ 
++ifndef NoReleaseBuild
++
+ all:: mkstatic mkshared
+ 
+ export:: mkstatic mkshared
+@@ -124,10 +126,11 @@ else
+ mkshared::
+ 
+ endif
+-
++endif
+ ##############################################################################
+ # Build debug libraries for Win32
+ ##############################################################################
++ifndef NoDebugBuild
+ ifdef Win32Platform
+ 
+ all:: mkstaticdbug mkshareddbug
+@@ -190,4 +193,4 @@ clean::
+ 
+ endif
+ 
+-
++endif
+diff --git a/src/services/mklib/stublib/dir.mk b/src/services/mklib/stublib/dir.mk
+index d58027d84..87f7ec22b 100644
+--- a/src/services/mklib/stublib/dir.mk
++++ b/src/services/mklib/stublib/dir.mk
+@@ -12,15 +12,18 @@ COS_SK_SRCS = $(COS_INTERFACES:%=%SK.cc)
+ 
+ CXXSRCS = $(COS_SK_SRCS)
+ 
+-all:: mkstatic mkshared
+-
+-export:: mkstatic mkshared
+-
+ ifdef Win32Platform
+   MSVC_STATICLIB_CXXNODEBUGFLAGS += -D_WINSTATIC
+   MSVC_STATICLIB_CXXDEBUGFLAGS += -D_WINSTATIC
+ endif
+ 
++ifndef NoReleaseBuild
++
++all:: mkstatic mkshared
++
++export:: mkstatic mkshared
++
++
+ 
+ ##############################################################################
+ # Build Static library
+@@ -108,10 +111,11 @@ else
+ mkshared::
+ 
+ endif
+-
++endif
+ ##############################################################################
+ # Build debug libraries for Win32
+ ##############################################################################
++ifdef NoDebugBuild
+ ifdef Win32Platform
+ 
+ all:: mkstaticdbug mkshareddbug
+@@ -173,3 +177,4 @@ clean::
+ 	@(dir=shareddebug; $(CleanSharedLibrary))
+ 
+ endif
++endif
+diff --git a/src/lib/omniORB/orbcore/dir.mk b/src/lib/omniORB/orbcore/dir.mk
+index 634e6b1e2..4370fed07 100644
+--- a/src/lib/omniORB/orbcore/dir.mk
++++ b/src/lib/omniORB/orbcore/dir.mk
+@@ -220,6 +220,7 @@ include $(BASE_OMNI_TREE)/mk/mklib.mk
+ 
+ #########################################################################
+ ifdef Win32Platform
++ifndef NoReleaseBuild
+ 
+ stublib = static/$(patsubst %,$(LibNoDebugPattern),msvcstub)
+ 
+@@ -236,6 +237,8 @@ clean::
+ 
+ veryclean::
+ 	$(RM) $(stublib)
++endif
++ifndef NoDebugBuild
+ 
+ stubdblib = debug/$(patsubst %,$(LibDebugPattern),msvcstub)
+ 
+@@ -254,6 +257,7 @@ veryclean::
+ 	$(RM) $(stubdblib)
+ 
+ endif
++endif
+ 
+ #########################################################################
+ ifdef OPEN_SSL_ROOT
+diff --git a/src/services/mklib/stublib/dir.mk b/src/services/mklib/stublib/dir.mk
+index 87f7ec22b..ce46f6c5f 100644
+--- a/src/services/mklib/stublib/dir.mk
++++ b/src/services/mklib/stublib/dir.mk
+@@ -115,7 +115,7 @@ endif
+ ##############################################################################
+ # Build debug libraries for Win32
+ ##############################################################################
+-ifdef NoDebugBuild
++ifndef NoDebugBuild
+ ifdef Win32Platform
+ 
+ all:: mkstaticdbug mkshareddbug
+diff --git a/mk/mklib.mk b/mk/mklib.mk
+index 1d73cfdbe..e6e8d65fe 100644
+--- a/mk/mklib.mk
++++ b/mk/mklib.mk
+@@ -16,16 +16,6 @@
+ # are called libfoo.a and libfoo.so.1.3 etc.
+ #
+ 
+-ifndef NoReleaseBuild
+-
+-all:: mkstatic mkshared
+-
+-export:: mkstatic mkshared
+-
+-ifdef INSTALLTARGET
+-install:: mkstatic mkshared
+-endif
+-
+ vers := $(subst ., ,$(LIB_VERSION))
+ ifeq ($(words $(vers)), 2)
+   vers  := _ $(vers)
+@@ -36,6 +26,16 @@ endif
+ 
+ namespec := $(LIB_NAME) $(vers)
+ 
++ifndef NoReleaseBuild
++
++all:: mkstatic mkshared
++
++export:: mkstatic mkshared
++
++ifdef INSTALLTARGET
++install:: mkstatic mkshared
++endif
++
+ ##############################################################################
+ # Build Static library
+ ##############################################################################
+

--- a/ports/omniorb/vcpkg.json
+++ b/ports/omniorb/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "4.3.0",
   "description": "omniORB is a robust high performance CORBA ORB for C++",
   "license": "LGPL-2.1-or-later",
-  "supports": "!uwp, (!(arm & windows), !osx)",
+  "supports": "!uwp & !(arm & windows) & !osx",
   "dependencies": [
     "openssl",
     "python3",

--- a/ports/omniorb/vcpkg.json
+++ b/ports/omniorb/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "4.3.0",
   "description": "omniORB is a robust high performance CORBA ORB for C++",
   "license": "LGPL-2.1-or-later",
-  "supports": "!uwp, !(arm & windows)",
+  "supports": "!uwp, !(arm & windows), !osx",
   "dependencies": [
     "openssl",
     "python3",

--- a/ports/omniorb/vcpkg.json
+++ b/ports/omniorb/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "omniorb",
+  "version": "4.3.0",
+  "description": "omniORB is a robust high performance CORBA ORB for C++",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!uwp",
+  "dependencies": [
+    "openssl",
+    "python3",
+    {
+      "name": "python3",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    "zlib",
+    "zstd"
+  ]
+}

--- a/ports/omniorb/vcpkg.json
+++ b/ports/omniorb/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "4.3.0",
   "description": "omniORB is a robust high performance CORBA ORB for C++",
   "license": "LGPL-2.1-or-later",
-  "supports": "!uwp, !(arm & windows), !osx",
+  "supports": "!uwp, (!(arm & windows), !osx)",
   "dependencies": [
     "openssl",
     "python3",

--- a/ports/omniorb/vcpkg.json
+++ b/ports/omniorb/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "4.3.0",
   "description": "omniORB is a robust high performance CORBA ORB for C++",
   "license": "LGPL-2.1-or-later",
+  "homepage": "https://omniorb.sourceforge.io/",
   "supports": "!uwp & !((arm | x86) & windows) & !osx",
   "dependencies": [
     "openssl",

--- a/ports/omniorb/vcpkg.json
+++ b/ports/omniorb/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "4.3.0",
   "description": "omniORB is a robust high performance CORBA ORB for C++",
   "license": "LGPL-2.1-or-later",
-  "supports": "!uwp & !(arm & windows) & !osx",
+  "supports": "!uwp & !((arm | x86) & windows) & !osx",
   "dependencies": [
     "openssl",
     "python3",

--- a/ports/omniorb/vcpkg.json
+++ b/ports/omniorb/vcpkg.json
@@ -2,8 +2,8 @@
   "name": "omniorb",
   "version": "4.3.0",
   "description": "omniORB is a robust high performance CORBA ORB for C++",
-  "license": "LGPL-2.1-or-later",
   "homepage": "https://omniorb.sourceforge.io/",
+  "license": "LGPL-2.1-or-later",
   "supports": "!uwp & !((arm | x86) & windows) & !osx",
   "dependencies": [
     "openssl",

--- a/ports/omniorb/vcpkg.json
+++ b/ports/omniorb/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "4.3.0",
   "description": "omniORB is a robust high performance CORBA ORB for C++",
   "license": "LGPL-2.1-or-later",
-  "supports": "!uwp",
+  "supports": "!uwp, !(arm & windows)",
   "dependencies": [
     "openssl",
     "python3",

--- a/ports/omniorb/vcpkg.mk
+++ b/ports/omniorb/vcpkg.mk
@@ -1,0 +1,90 @@
+#
+# vcpkg.mk - make variables and rules specific to
+#                     Visual Studio 16 / 2019
+#
+
+WindowsNT=1
+x86Processor=1
+
+BINDIR = bin
+LIBDIR = lib
+
+ABSTOP = $(shell cd $(TOP); pwd)
+
+# Windows builds require a shared library build
+BuildSharedLibrary=1
+# This will be replaced
+
+ThreadSystem=NT
+undefine UnixPlatform
+# Windows build requires static lib to generate symbol def file
+undefine NoStaticLibrary
+platform = Win32Platform
+
+@build_info@
+
+# Use the following set of flags to build and use multithreaded DLLs
+#
+MSVC_DLL_CXXNODEBUGFLAGS       = @VCPKG_DETECTED_CMAKE_CXX_FLAGS_RELEASE@
+MSVC_DLL_CXXLINKNODEBUGOPTIONS = @VCPKG_DETECTED_CMAKE_SHARED_LINKER_FLAGS_RELEASE@ -manifest
+MSVC_DLL_CNODEBUGFLAGS         = @VCPKG_DETECTED_CMAKE_C_FLAGS_RELEASE@
+MSVC_DLL_CLINKNODEBUGOPTIONS   = @VCPKG_DETECTED_CMAKE_SHARED_LINKER_FLAGS_RELEASE@ -manifest
+#
+MSVC_DLL_CXXDEBUGFLAGS         = @VCPKG_DETECTED_CMAKE_CXX_FLAGS_DEBUG@ -D_DEBUG
+MSVC_DLL_CXXLINKDEBUGOPTIONS   = @VCPKG_DETECTED_CMAKE_SHARED_LINKER_FLAGS_DEBUG@ -manifest
+MSVC_DLL_CDEBUGFLAGS           = @VCPKG_DETECTED_CMAKE_C_FLAGS_DEBUG@ -D_DEBUG
+MSVC_DLL_CLINKDEBUGOPTIONS     = @VCPKG_DETECTED_CMAKE_SHARED_LINKER_FLAGS_DEBUG@ -manifest
+#
+# Or
+#
+# Use the following set of flags to build and use multithread static libraries
+#
+MSVC_STATICLIB_CXXNODEBUGFLAGS       = @VCPKG_DETECTED_CMAKE_CXX_FLAGS_RELEASE@
+MSVC_STATICLIB_CXXLINKNODEBUGOPTIONS = @VCPKG_DETECTED_CMAKE_STATIC_LINKER_FLAGS_RELEASE@ -manifest
+MSVC_STATICLIB_CNODEBUGFLAGS         = @VCPKG_DETECTED_CMAKE_CXX_FLAGS_RELEASE@
+MSVC_STATICLIB_CLINKNODEBUGOPTIONS   = @VCPKG_DETECTED_CMAKE_STATIC_LINKER_FLAGS_RELEASE@ -manifest
+
+MSVC_STATICLIB_CXXDEBUGFLAGS         = @VCPKG_DETECTED_CMAKE_CXX_FLAGS_DEBUG@ -D_DEBUG
+MSVC_STATICLIB_CXXLINKDEBUGOPTIONS   = @VCPKG_DETECTED_CMAKE_STATIC_LINKER_FLAGS_DEBUG@ -manifest
+MSVC_STATICLIB_CDEBUGFLAGS           = @VCPKG_DETECTED_CMAKE_C_FLAGS_DEBUG@ -D_DEBUG
+MSVC_STATICLIB_CLINKDEBUGOPTIONS     = @VCPKG_DETECTED_CMAKE_STATIC_LINKER_FLAGS_DEBUG@ -manifest
+
+#
+# Include general win32 things
+#
+
+include $(THIS_IMPORT_TREE)/mk/win32.mk
+
+MANIFESTTOOL = @VCPKG_DETECTED_CMAKE_MT@
+RCTOOL       = @VCPKG_DETECTED_CMAKE_RC_COMPILER@
+CLINK        = @VCPKG_DETECTED_CMAKE_LINKER@
+CXXLINK      = @VCPKG_DETECTED_CMAKE_LINKER@
+AR           = @VCPKG_DETECTED_CMAKE_AR@
+RANLIB       = true
+
+# To build ZIOP support, EnableZIOP must be defined and one or both of
+# the zlib and zstd sections must be defined.
+
+#EnableZIOP = 1
+
+#EnableZIOPZLib = 1
+#ZLIB_ROOT = /cygdrive/c/zlib-1.2.11
+#ZLIB_CPPFLAGS = -DOMNI_ENABLE_ZIOP_ZLIB -I$(ZLIB_ROOT)
+#ZLIB_LIB = $(patsubst %,$(LibPathPattern),$(ZLIB_ROOT)) zdll.lib
+
+#EnableZIOPZStd = 1
+#ZSTD_ROOT = /cygdrive/c/zstd
+#ZSTD_CPPFLAGS = -DOMNI_ENABLE_ZIOP_ZSTD -I$(ZSTD_ROOT)/include
+#ZSTD_LIB = $(patsubst %,$(LibPathPattern),$(ZSTD_ROOT)/lib) zstd.lib
+LN_S=cp -pR 
+
+define ExportSharedLibraryToDir
+ $(ExportLibraryToDir); \
+ $(ParseNameSpec); \
+ soname=$(SharedLibraryShortLibName); \
+ libname=$(SharedLibraryLibNameTemplate); \
+ set -x; \
+ cd $$dir; \
+ $(RM) $$soname; \
+ $(LN_S) $(<F) $$soname;
+endef

--- a/ports/omniorb/vcpkg.mk
+++ b/ports/omniorb/vcpkg.mk
@@ -1,6 +1,5 @@
 #
-# vcpkg.mk - make variables and rules specific to
-#                     Visual Studio 16 / 2019
+# vcpkg.mk - make variables and rules specific to Visual Studio
 #
 
 WindowsNT=1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5704,6 +5704,10 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
+    "omniorb": {
+      "baseline": "4.3.0",
+      "port-version": 0
+    },
     "ompl": {
       "baseline": "1.5.1",
       "port-version": 5

--- a/versions/o-/omniorb.json
+++ b/versions/o-/omniorb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f8deeefa2d8ccd53fc888a7074ed313a5a7e16bf",
+      "git-tree": "3f227eb568760155c60e38ff5491089b4af94cbf",
       "version": "4.3.0",
       "port-version": 0
     }

--- a/versions/o-/omniorb.json
+++ b/versions/o-/omniorb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d394651b8040262572f12df376b7a463385fc69",
+      "git-tree": "0a7fa3d4332c405df05897fb2b7bdc2ce64e6ab4",
       "version": "4.3.0",
       "port-version": 0
     }

--- a/versions/o-/omniorb.json
+++ b/versions/o-/omniorb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0a7fa3d4332c405df05897fb2b7bdc2ce64e6ab4",
+      "git-tree": "51fa63a0e4615dd806fd5ac4cd532f81123ddd4d",
       "version": "4.3.0",
       "port-version": 0
     }

--- a/versions/o-/omniorb.json
+++ b/versions/o-/omniorb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3f227eb568760155c60e38ff5491089b4af94cbf",
+      "git-tree": "6d394651b8040262572f12df376b7a463385fc69",
       "version": "4.3.0",
       "port-version": 0
     }

--- a/versions/o-/omniorb.json
+++ b/versions/o-/omniorb.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c15908aca4843dc95ffd0f200bd379e04ebe6f35",
+      "version": "4.3.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/o-/omniorb.json
+++ b/versions/o-/omniorb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c15908aca4843dc95ffd0f200bd379e04ebe6f35",
+      "git-tree": "f8deeefa2d8ccd53fc888a7074ed313a5a7e16bf",
       "version": "4.3.0",
       "port-version": 0
     }


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] ~~The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

(i feel like deleting the above if I put in x everywhere anyway)

supersedes #7071; #8609
removes tag from #3346