### PR TITLE
[visit-struct] Update to 1.1.0 and prefix targets with unofficial 

### DIFF
--- a/ports/visit-struct/CMakeLists.txt
+++ b/ports/visit-struct/CMakeLists.txt
@@ -4,13 +4,13 @@ project(visit_struct)
 add_library(visit_struct INTERFACE)
 
 install(TARGETS visit_struct
-    EXPORT visit_struct-targets
+    EXPORT unofficial-visit_struct-targets
     INCLUDES DESTINATION include)
 
-install(EXPORT visit_struct-targets
-    FILE visit_struct-config.cmake
-    NAMESPACE visit_struct::
-    DESTINATION share/visit_struct)
+install(EXPORT unofficial-visit_struct-targets
+    FILE unofficial-visit_struct-config.cmake
+    NAMESPACE unofficial::visit_struct::
+    DESTINATION share/unofficial-visit_struct)
 
 install(DIRECTORY
     include/visit_struct

--- a/ports/visit-struct/portfile.cmake
+++ b/ports/visit-struct/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cbeck88/visit_struct
-    REF v1.0
-    SHA512 1396d0d4c4d37f48434361d1e0ab4cb02c397aff1134678b26de713a27a4fcfa1c352890845502be645ba01e20314bf67731893fc6410b93e4521c1261d63c06
+    REF "v${VERSION}"
+    SHA512 8d1f93344ef13320bc7967cbe2696bf49d6773fe3c89ba10bcf8ee9c33be165f14086828f6195bad742fbe75fee9c0995827c455c777950df583ff8f13c21338
     HEAD_REF master
 )
 
@@ -13,7 +13,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME visit_struct)
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-visit_struct)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/visit-struct/vcpkg.json
+++ b/ports/visit-struct/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "visit-struct",
-  "version": "1.0",
-  "port-version": 4,
+  "version": "1.1.0",
   "description": "A header-only library providing structure visitors for C++11 and C++14",
+  "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8289,8 +8289,8 @@
       "port-version": 1
     },
     "visit-struct": {
-      "baseline": "1.0",
-      "port-version": 4
+      "baseline": "1.1.0",
+      "port-version": 0
     },
     "vk-bootstrap": {
       "baseline": "0.5",

--- a/versions/v-/visit-struct.json
+++ b/versions/v-/visit-struct.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59296ff30012685f7c9c1d7b0723fc940997a2b1",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a803da3fde987d8abc319748c6a599e6ace6e650",
       "version": "1.0",
       "port-version": 4


### PR DESCRIPTION
This PR updates visit-struct to 1.1.0 after the recent tag: https://github.com/cbeck88/visit_struct/releases/tag/v1.1.0 . As I also noticed that the targets installed were not complaint with the mantainer guide, I also fixed those.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
