### PR TITLE
[vcpkg baseline][zeroc-ice] Remove zeroc-ice in ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1088,10 +1088,6 @@ workflow:arm-uwp=fail
 dimcli:x64-windows-static-md=fail
 dimcli:x64-windows-static=fail
 
-zeroc-ice:x86-windows=fail
-zeroc-ice:x64-windows=fail
-zeroc-ice:x64-windows-static-md=fail
-
 # Ports which needs to pass in CI
 cmake:x64-windows=pass
 cmake:x64-windows-static=pass

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1088,6 +1088,9 @@ workflow:arm-uwp=fail
 dimcli:x64-windows-static-md=fail
 dimcli:x64-windows-static=fail
 
+zeroc-ice:x86-windows=fail
+zeroc-ice:x64-windows=fail
+
 # Ports which needs to pass in CI
 cmake:x64-windows=pass
 cmake:x64-windows-static=pass


### PR DESCRIPTION
zeroc-ice:x64-windows-static-md=fail was added by https://github.com/microsoft/vcpkg/pull/28522 due to the following post-check problem:
```
zeroc-ice:x64-windows-static-md install failed with following error on CI pipeline run:
error MSB6006: "slice2cpp.exe" exited with code -1073741515
```
This problem was random in compilation, in new CI the problem is gone. Later, I will track the error code and continue to analyze the cause of the problem.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~
