### PR TITLE
[vtk-m] fix openmp on macos

### DIFF
--- a/ports/vtk-m/omp.patch
+++ b/ports/vtk-m/omp.patch
@@ -1,0 +1,26 @@
+diff --git a/CMake/VTKmDeviceAdapters.cmake b/CMake/VTKmDeviceAdapters.cmake
+index e9ac039..c745604 100644
+--- a/CMake/VTKmDeviceAdapters.cmake
++++ b/CMake/VTKmDeviceAdapters.cmake
+@@ -59,20 +59,14 @@ if(VTKm_ENABLE_OPENMP AND NOT TARGET vtkm::openmp)
+   find_package(OpenMP 4.0 REQUIRED COMPONENTS CXX QUIET)
+ 
+   add_library(vtkm::openmp INTERFACE IMPORTED GLOBAL)
++  target_link_libraries(vtkm::openmp INTERFACE OpenMP::OpenMP_CXX)
+   if(OpenMP_CXX_FLAGS)
+-    set_property(TARGET vtkm::openmp
+-      APPEND PROPERTY INTERFACE_COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
+-
+     if(VTKm_ENABLE_CUDA)
+       string(REPLACE ";" "," openmp_cuda_flags "-Xcompiler=${OpenMP_CXX_FLAGS}")
+       set_property(TARGET vtkm::openmp
+         APPEND PROPERTY INTERFACE_COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CUDA>:${openmp_cuda_flags}>)
+     endif()
+   endif()
+-  if(OpenMP_CXX_LIBRARIES)
+-    set_target_properties(vtkm::openmp PROPERTIES
+-      INTERFACE_LINK_LIBRARIES "${OpenMP_CXX_LIBRARIES}")
+-  endif()
+ endif()
+ 
+ if(VTKm_ENABLE_CUDA)

--- a/ports/vtk-m/portfile.cmake
+++ b/ports/vtk-m/portfile.cmake
@@ -42,7 +42,10 @@ vcpkg_from_gitlab(GITLAB_URL "https://gitlab.kitware.com"
                   REPO vtk/vtk-m 
                   REF 902fdac6fafb6358ce88f8747d55e2c0715241f1 # v1.9.0 Upgrading will most likly brake the VTK build
                   SHA512 f83872495ed3dbcea372776c4439a7d224568d144ff602c188fae120026778b1bee681c9e9535cc693e870cbc08ca9896af2bc954935c289f6b9a24f2471a50b
-                  FILE_DISAMBIGUATOR 1)
+                  FILE_DISAMBIGUATOR 1
+                  PATCHES
+                    omp.patch
+)
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS ${OPTIONS}

--- a/ports/vtk-m/vcpkg.json
+++ b/ports/vtk-m/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk-m",
   "version": "1.9.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "VTK-m is a toolkit of scientific visualization algorithms for emerging processor architectures.",
   "homepage": "https://gitlab.kitware.com/vtk/vtk-m/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8330,7 +8330,7 @@
     },
     "vtk-m": {
       "baseline": "1.9.0",
-      "port-version": 1
+      "port-version": 2
     },
     "vulkan": {
       "baseline": "1.1.82.1",

--- a/versions/v-/vtk-m.json
+++ b/versions/v-/vtk-m.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d9c1ecc2af5787432fdebcdf6cd293b7af075bf",
+      "version": "1.9.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "7df5e71334a22b5dc19ffb3c02880554b2838f86",
       "version": "1.9.0",
       "port-version": 1


### PR DESCRIPTION
Fixes:
```
[56/343] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DVTKMDIY_DEBUG -DVTKMDIY_MPI_AS_LIB -DVTKMDIY_MPI_STATIC_BUILD -DVTKMDIY_NO_THREADS -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/arm64-osx-dbg/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/optionparser -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/diy -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/lcl/vtkmlcl -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/loguru -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/diy/vtkmdiy/include -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/arm64-osx-dbg/vtkm/thirdparty/diy/vtkmdiy/include/vtkmdiy/mpi -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fvisibility=hidden -Wno-pass-failed -Wall -Wcast-align -Wextra -Wpointer-arith -Wformat -Wformat-security -Wshadow -Wunused -fno-common -Wno-unused-function -Wconversion -Wodr -ffunction-sections "-Xclang -fopenmp" -std=c++14 -MD -MT vtkm/cont/CMakeFiles/vtkm_cont.dir/CellSetExplicit.cxx.o -MF vtkm/cont/CMakeFiles/vtkm_cont.dir/CellSetExplicit.cxx.o.d -o vtkm/cont/CMakeFiles/vtkm_cont.dir/CellSetExplicit.cxx.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/cont/CellSetExplicit.cxx
FAILED: vtkm/cont/CMakeFiles/vtkm_cont.dir/CellSetExplicit.cxx.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DVTKMDIY_DEBUG -DVTKMDIY_MPI_AS_LIB -DVTKMDIY_MPI_STATIC_BUILD -DVTKMDIY_NO_THREADS -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/arm64-osx-dbg/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/optionparser -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/diy -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/lcl/vtkmlcl -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/loguru -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/thirdparty/diy/vtkmdiy/include -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/arm64-osx-dbg/vtkm/thirdparty/diy/vtkmdiy/include/vtkmdiy/mpi -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fvisibility=hidden -Wno-pass-failed -Wall -Wcast-align -Wextra -Wpointer-arith -Wformat -Wformat-security -Wshadow -Wunused -fno-common -Wno-unused-function -Wconversion -Wodr -ffunction-sections "-Xclang -fopenmp" -std=c++14 -MD -MT vtkm/cont/CMakeFiles/vtkm_cont.dir/CellSetExplicit.cxx.o -MF vtkm/cont/CMakeFiles/vtkm_cont.dir/CellSetExplicit.cxx.o.d -o vtkm/cont/CMakeFiles/vtkm_cont.dir/CellSetExplicit.cxx.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/cont/CellSetExplicit.cxx
clang: warning: argument unused during compilation: '-Xclang -fopenmp' [-Wunused-command-line-argument]
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/cont/CellSetExplicit.cxx:14:
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/cont/Algorithm.h:16:
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/cont/DeviceAdapter.h:20:
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/cont/openmp/DeviceAdapterOpenMP.h:18:
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/cont/openmp/internal/DeviceAdapterAlgorithmOpenMP.h:19:
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vtk-m/src/c0715241f1-a29aef6c50.clean/vtkm/cont/openmp/internal/FunctorsOpenMP.h:25:10: fatal error: 'omp.h' file not found
#include <omp.h>
         ^~~~~~~
1 error generated.
```