### PR TITLE
[llvm] fix feature clang-tools-extra

### DIFF
--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -304,6 +304,7 @@ set(empty_dirs)
 
 if("clang-tools-extra" IN_LIST FEATURES)
     list(APPEND empty_dirs "${CURRENT_PACKAGES_DIR}/include/clang-tidy/plugin")
+    list(APPEND empty_dirs "${CURRENT_PACKAGES_DIR}/include/clang-tidy/misc/ConfusableTable")
 endif()
 
 if("pstl" IN_LIST FEATURES)

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "llvm",
   "version": "15.0.7",
+  "port-version": 1,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4854,7 +4854,7 @@
     },
     "llvm": {
       "baseline": "15.0.7",
-      "port-version": 0
+      "port-version": 1
     },
     "lmdb": {
       "baseline": "0.9.29",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da5caa3f08a5e52f4d46559e0f5be3a73958dd2c",
+      "version": "15.0.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "cb3f603740884034c2a28562e35c47f3c8e45ad6",
       "version": "15.0.7",
       "port-version": 0


### PR DESCRIPTION
Otherwise it fails with 
```
1446/3820 llvm[core,clang-tools-extra]:arm64-osx
Test feature llvm[core,clang-tools-extra]:arm64-osx
Installing 1/1 llvm:arm64-osx...
Building llvm[clang,clang-tools-extra,compiler-rt,core,enable-threads,tools]:arm64-osx...
...
-- Performing post-build validation
warning: There should be no empty directories in /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/packages/llvm_arm64-osx. The following empty directories were found:

    /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/packages/llvm_arm64-osx/include/clang-tidy/misc/ConfusableTable

warning: If a directory should be populated but is not, this might indicate an error in the portfile.
If the directories are not needed and their creation cannot be disabled, use something like this in the portfile to remove them:
    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/clang-tidy/misc/ConfusableTable")

error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/ports/llvm/portfile.cmake
error: building llvm:arm64-osx failed with: POST_BUILD_CHECKS_FAILED
Elapsed time to handle llvm:arm64-osx: 30 min
Total install time: 30 min
```