### PR TITLE
[zlib-ng] Add compat feature

### DIFF
--- a/ports/zlib-ng/portfile.cmake
+++ b/ports/zlib-ng/portfile.cmake
@@ -1,9 +1,7 @@
-set(ZLIB_FULL_VERSION 2.0.6)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/zlib-ng
-    REF "${ZLIB_FULL_VERSION}"
+    REF "${VERSION}"
     SHA512 4888f17160d0a87a9b349704047ae0d0dc57237a10e11adae09ace957afa9743cce5191db67cb082991421fc961ce68011199621034d2369c0e7724fad58b4c5
     HEAD_REF develop
 )
@@ -11,7 +9,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DZLIB_FULL_VERSION=${ZLIB_FULL_VERSION}"
+        "-DZLIB_FULL_VERSION=${VERSION}"
         -DZLIB_ENABLE_TESTS=OFF
         -DWITH_NEW_STRATEGIES=ON
     OPTIONS_RELEASE
@@ -25,7 +23,7 @@ if ("compat" IN_LIST FEATURES)
    vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DZLIB_FULL_VERSION=${ZLIB_FULL_VERSION}"
+        "-DZLIB_FULL_VERSION=${VERSION}"
         -DZLIB_ENABLE_TESTS=OFF
         -DWITH_NEW_STRATEGIES=ON
         -DZLIB_COMPAT=ON

--- a/ports/zlib-ng/portfile.cmake
+++ b/ports/zlib-ng/portfile.cmake
@@ -21,6 +21,22 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
+if ("compat" IN_LIST FEATURES)
+   vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DZLIB_FULL_VERSION=${ZLIB_FULL_VERSION}"
+        -DZLIB_ENABLE_TESTS=OFF
+        -DWITH_NEW_STRATEGIES=ON
+        -DZLIB_COMPAT=ON
+    OPTIONS_RELEASE
+        -DWITH_OPTIM=ON
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
                     "${CURRENT_PACKAGES_DIR}/debug/include"
 )

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -10,5 +10,10 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "compat": {
+      "description": "Create an additional zlib-ng build that runs in compatibility mode.\nPackages that depends on the old zlib can then reference this build and take advantage of next gen instructions with no change to source code."
+    }
+  }
 }

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -13,7 +13,7 @@
   ],
   "features": {
     "compat": {
-      "description": "Create an additional zlib-ng build that runs in compatibility mode.\nPackages that depends on the old zlib can then reference this build and take advantage of next gen instructions with no change to source code."
+      "description": "Create an additional zlib-ng build that runs in compatibility mode (ZLIB_COMPAT). With an overlay port, packages that depends on the old zlib can directly reference zlib-ng and take advantage of next gen instructions with no change to the source code."
     }
   }
 }

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zlib-ng",
   "version": "2.0.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "zlib replacement with optimizations for 'next generation' systems",
   "homepage": "https://github.com/zlib-ng/zlib-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8738,7 +8738,7 @@
     },
     "zlib-ng": {
       "baseline": "2.0.6",
-      "port-version": 1
+      "port-version": 2
     },
     "zookeeper": {
       "baseline": "3.5.6",

--- a/versions/z-/zlib-ng.json
+++ b/versions/z-/zlib-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e2cb9bbfda91c55296e897cb4dadba934d67c05",
+      "version": "2.0.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "60e9a6f12ede4c5e87d2b3077c25e83991a02eea",
       "version": "2.0.6",
       "port-version": 1


### PR DESCRIPTION
@Neumann-A  [suggested](https://github.com/microsoft/vcpkg/pull/30918#issuecomment-1511219443) the possibility to create a feature rather than a separate port:
> This can either be solved by adding a new port or providing a feature to `zlib-ng` which just builds the source twice with different configure options.

This seems to me a better option because (I believe) it requires no additional maintenance. So, this is going to replace my original pull [request](https://github.com/microsoft/vcpkg/pull/30918).

### Description
With `zlib-ng[compat]` and an overlay port, user can automatically replace `zlib` dependency with `zlib-ng` and take advantage of the speed provided by next gen instructions with no change to the source code. Running `zlib-ng` natively is still the preferred way, but requires changes to the source code and this is not something that all developers are willing to do and here is where `zlib-ng[compat]` comes in handy.


### Please note
I'm new to vcpkg and even to pull requests in general. So, this is to be intended as a prototype that needs to be checked and corrected by experts.


### Issues and concerns
1 - This is the only way I have been able to get both the builds:
```
if ("compat" IN_LIST FEATURES)
   vcpkg_cmake_configure(
    SOURCE_PATH "${SOURCE_PATH}"
    OPTIONS
        "-DZLIB_FULL_VERSION=${ZLIB_FULL_VERSION}"
        -DZLIB_ENABLE_TESTS=OFF
        -DWITH_NEW_STRATEGIES=ON
        -DZLIB_COMPAT=ON
    OPTIONS_RELEASE
        -DWITH_OPTIM=ON
)
vcpkg_cmake_install()
vcpkg_copy_pdbs()
vcpkg_fixup_pkgconfig()
endif()
```
...and with the following warning:
```
CMake Warning at installed/x64-windows/share/vcpkg-cmake/vcpkg_cmake_configure.cmake:19 (message):
  vcpkg_cmake_configure already called; this function should only be called
  once.
```
Any attempt to replace the function with `set(VCPKG_CMAKE_CONFIGURE_OPTIONS ...` or `set(ZLIB_COMPAT ON)` result in no output. This is probably something that vcpkg staff can easily fix in no time while I cannot even after hours of trials.

2 - With an empty overlay port (`"dependencies": [ { "name": "zlib-ng", "features": [ "compat" ] } ]`) a package that depends on `zlib` successfully compiles even with the above. However I feel this happens just because "compat' has been the last compiled build. It's unclear how a package determine the correct linkage. I expect that, in the same process, a package can reference `zlib-ng` and another one `zlib-ng[compat]` with no issues as happens with my original pull request.
Unfortunately I cannot test a port that depends on the default `zlib-ng` because there is none in the repo.

Thanks