### PR TITLE
[netcdf-c] fix feature nczarr-zip

### DIFF
--- a/ports/netcdf-c/fix-dependency-libzip.patch
+++ b/ports/netcdf-c/fix-dependency-libzip.patch
@@ -9,7 +9,7 @@ index b93a141..c3763a7 100644
 -FIND_PACKAGE(Zip)
 +if(ENABLE_NCZARR_ZIP)
 +  find_package(libzip CONFIG REQUIRED)
-+  set(Zip_LIBRARIES libzip::zip)
++  set(Zip_LIBRARIES zip)
 +  set(Zip_FOUND TRUE)
 +else()
 +  set(Zip_LIBRARIES "")
@@ -32,3 +32,62 @@ index b3be259..72b4b25 100644
  include("${CMAKE_CURRENT_LIST_DIR}/netCDFTargets.cmake")
  
  # Compiling Options
+diff --git a/liblib/CMakeLists.txt b/liblib/CMakeLists.txt
+index 1363d35..31dbbda 100644
+--- a/liblib/CMakeLists.txt
++++ b/liblib/CMakeLists.txt
+@@ -134,6 +134,10 @@ ENDIF()
+ 
+ TARGET_LINK_LIBRARIES(netcdf ${TLL_LIBS})
+ 
++if(ENABLE_NCZARR_ZIP)
++  target_link_libraries(netcdf libzip::zip)
++endif()
++
+ SET(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${TLL_LIBS})
+ IF(MSVC)
+   SET_TARGET_PROPERTIES(netcdf PROPERTIES
+diff --git a/libnczarr/CMakeLists.txt b/libnczarr/CMakeLists.txt
+index 86e093b..d7edaf6 100644
+--- a/libnczarr/CMakeLists.txt
++++ b/libnczarr/CMakeLists.txt
+@@ -58,6 +58,10 @@ ENDIF()
+ 
+ add_library(nczarr OBJECT ${libnczarr_SOURCES})
+ 
++IF(ENABLE_NCZARR_ZIP)
++    target_link_libraries(nczarr PRIVATE libzip::zip)
++ENDIF()
++
+ IF(MPI_C_INCLUDE_PATH)
+     target_include_directories(nczarr PUBLIC ${MPI_C_INCLUDE_PATH})
+ ENDIF(MPI_C_INCLUDE_PATH)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6357965..3de76cd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2123,6 +2123,10 @@ replace_pkgconfig_module("-lzip"       "libzip")
+ replace_pkgconfig_module("-lCURL[^ ]*" "libcurl")
+ replace_pkgconfig_module("-lZLIB[^ ]*" "zlib")
+ 
++IF(ENABLE_NCZARR_ZIP)
++  string(APPEND NC_REQUIRES_PRIVATE " libzip")
++ENDIF()
++
+ configure_file(
+   ${netCDF_SOURCE_DIR}/netcdf.pc.in
+   ${netCDF_BINARY_DIR}/netcdf.pc @ONLY)
+diff --git a/liblib/CMakeLists.txt b/liblib/CMakeLists.txt
+index 31dbbda..eb497cc 100644
+--- a/liblib/CMakeLists.txt
++++ b/liblib/CMakeLists.txt
+@@ -120,9 +120,6 @@ IF(ENABLE_PNETCDF AND PNETCDF)
+   SET(TLL_LIBS ${TLL_LIBS} ${PNETCDF})
+ ENDIF()
+ 
+-IF(ENABLE_NCZARR_ZIP)
+-  SET(TLL_LIBS ${TLL_LIBS} ${Zip_LIBRARIES})
+-ENDIF()
+ 
+ IF(ENABLE_S3_SDK)
+   TARGET_LINK_DIRECTORIES(netcdf PUBLIC ${AWSSDK_LIB_DIR})

--- a/ports/netcdf-c/vcpkg.json
+++ b/ports/netcdf-c/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "netcdf-c",
   "version": "4.8.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.",
   "homepage": "https://github.com/Unidata/netcdf-c",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5482,7 +5482,7 @@
     },
     "netcdf-c": {
       "baseline": "4.8.1",
-      "port-version": 2
+      "port-version": 3
     },
     "netcdf-cxx4": {
       "baseline": "4.3.1",

--- a/versions/n-/netcdf-c.json
+++ b/versions/n-/netcdf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d17052df3479de37b4c756f4e90661c9fa85e7d",
+      "version": "4.8.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "f4d487e2f7e093b2406887023bb3a0856735bad5",
       "version": "4.8.1",
       "port-version": 2


### PR DESCRIPTION
Otherwise the build fails with 
```
[100/105] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DENABLE_SET_LOG_LEVEL -DHAVE_CONFIG_H -DRELAX_COORD_BOUND -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/arm64-osx-dbg/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/src/83aa5b8e47-7f6988dec5.clean/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/src/83aa5b8e47-7f6988dec5.clean/oc2 -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/src/83aa5b8e47-7f6988dec5.clean/libsrc -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/arm64-osx-dbg -fPIC -fno-strict-aliasing -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -g -Wall -Wshorten-64-to-32 -Wconversion -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -MD -MT libnczarr/CMakeFiles/nczarr.dir/zmap_zip.c.o -MF libnczarr/CMakeFiles/nczarr.dir/zmap_zip.c.o.d -o libnczarr/CMakeFiles/nczarr.dir/zmap_zip.c.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/src/83aa5b8e47-7f6988dec5.clean/libnczarr/zmap_zip.c
FAILED: libnczarr/CMakeFiles/nczarr.dir/zmap_zip.c.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DENABLE_SET_LOG_LEVEL -DHAVE_CONFIG_H -DRELAX_COORD_BOUND -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/arm64-osx-dbg/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/src/83aa5b8e47-7f6988dec5.clean/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/src/83aa5b8e47-7f6988dec5.clean/oc2 -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/src/83aa5b8e47-7f6988dec5.clean/libsrc -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/arm64-osx-dbg -fPIC -fno-strict-aliasing -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -g -Wall -Wshorten-64-to-32 -Wconversion -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -MD -MT libnczarr/CMakeFiles/nczarr.dir/zmap_zip.c.o -MF libnczarr/CMakeFiles/nczarr.dir/zmap_zip.c.o.d -o libnczarr/CMakeFiles/nczarr.dir/zmap_zip.c.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/src/83aa5b8e47-7f6988dec5.clean/libnczarr/zmap_zip.c
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/netcdf-c/src/83aa5b8e47-7f6988dec5.clean/libnczarr/zmap_zip.c:15:10: fatal error: 'zip.h' file not found
#include <zip.h>
         ^~~~~~~
1 error generated.
```