### PR TITLE
[openmama] Remove the installed config/ directory

### DIFF
--- a/ports/openmama/portfile.cmake
+++ b/ports/openmama/portfile.cmake
@@ -31,6 +31,7 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/LICENSE.md"
     "${CURRENT_PACKAGES_DIR}/debug/LICENSE.md"
     "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/config"
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/openmama/vcpkg.json
+++ b/ports/openmama/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openmama",
   "version-semver": "6.3.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenMAMA is a high performance vendor neutral lightweight wrapper that provides a common API interface to different middleware and messaging solutions across a variety of platforms and languages",
   "homepage": "https://github.com/finos/OpenMAMA",
   "license": "LGPL-2.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5850,7 +5850,7 @@
     },
     "openmama": {
       "baseline": "6.3.2",
-      "port-version": 1
+      "port-version": 2
     },
     "openmesh": {
       "baseline": "9.0",

--- a/versions/o-/openmama.json
+++ b/versions/o-/openmama.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1a0265c65af044c234b3724715e089272679d40",
+      "version-semver": "6.3.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "0a928ad97fe18f50da889c2e468f5070d1c4e4b6",
       "version-semver": "6.3.2",
       "port-version": 1


### PR DESCRIPTION
Remove the directory `config/` which is installed but shouldn't be:
![image](https://user-images.githubusercontent.com/110024546/232660497-a97e92f1-782e-4e01-82c7-5b60971bb20a.png)


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.