### PR TITLE
[directxtex] update port with omp feature

### DIFF
--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -15,10 +15,11 @@ vcpkg_check_features(
     FEATURES
         dx11 BUILD_DX11
         dx12 BUILD_DX12
-        omp BC_USE_OPENMP
         openexr ENABLE_OPENEXR_SUPPORT
         spectre ENABLE_SPECTRE_MITIGATION
         tools BUILD_TOOLS
+    INVERTED_FEATURES
+        no-omp BC_USE_OPENMP
 )
 
 if(VCPKG_TARGET_IS_MINGW AND ("dx11" IN_LIST FEATURES))

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_check_features(
     FEATURES
         dx11 BUILD_DX11
         dx12 BUILD_DX12
+        omp BC_USE_OPENMP
         openexr ENABLE_OPENEXR_SUPPORT
         spectre ENABLE_SPECTRE_MITIGATION
         tools BUILD_TOOLS
@@ -30,7 +31,7 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS} -DBUILD_SAMPLE=OFF -DBUILD_TESTING=OFF -DBC_USE_OPENMP=ON
+    OPTIONS ${FEATURE_OPTIONS} -DBUILD_SAMPLE=OFF -DBUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directxtex",
   "version-date": "2023-03-30",
+  "port-version": 1,
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",
@@ -26,7 +27,8 @@
     }
   ],
   "default-features": [
-    "dx11"
+    "dx11",
+    "omp"
   ],
   "features": {
     "dx11": {
@@ -34,6 +36,9 @@
     },
     "dx12": {
       "description": "Build with DirectX12 support for Windows 10/Windows 11"
+    },
+    "omp": {
+      "description": "Build using OpenMP support for the BC6H/BC7 software codec"
     },
     "openexr": {
       "description": "Enable OpenEXR support",

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -27,8 +27,7 @@
     }
   ],
   "default-features": [
-    "dx11",
-    "omp"
+    "dx11"
   ],
   "features": {
     "dx11": {
@@ -37,8 +36,8 @@
     "dx12": {
       "description": "Build with DirectX12 support for Windows 10/Windows 11"
     },
-    "omp": {
-      "description": "Build using OpenMP support for the BC6H/BC7 software codec"
+    "no-omp": {
+      "description": "Build without using OpenMP support for the BC6H/BC7 software codec"
     },
     "openexr": {
       "description": "Enable OpenEXR support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2078,7 +2078,7 @@
     },
     "directxtex": {
       "baseline": "2023-03-30",
-      "port-version": 0
+      "port-version": 1
     },
     "directxtk": {
       "baseline": "2023-03-30",

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "047d30fb76568b30342feedeeb51baf6d9fbb66f",
+      "version-date": "2023-03-30",
+      "port-version": 1
+    },
+    {
       "git-tree": "49ac22c74d82cd2a67dc98755d3bd78d1ff3be45",
       "version-date": "2023-03-30",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "047d30fb76568b30342feedeeb51baf6d9fbb66f",
+      "git-tree": "14daf71a3dffda45222d771968e399ec56e1c0e1",
       "version-date": "2023-03-30",
       "port-version": 1
     },


### PR DESCRIPTION
The library has a build option for using OpenMP to make the software BC6H/BC7 codec use multiple cores. This feature has been on by default for some time, but there are some build contexts where I need to be able to disable it.

Therefore, this port adds an ``omp`` feature for controlling that build option, and this is a 'default' feature.
