### PR TITLE
[liblas] Fix missing dependency to boost-foreach

### DIFF
--- a/ports/liblas/fix-crosscompiling.diff
+++ b/ports/liblas/fix-crosscompiling.diff
@@ -1,0 +1,13 @@
+diff --git a/cmake/liblas-config-version.cmake.in b/cmake/liblas-config-version.cmake.in
+index f9b7c7cb..5dd2aba1 100644
+--- a/cmake/liblas-config-version.cmake.in
++++ b/cmake/liblas-config-version.cmake.in
+@@ -22,7 +22,7 @@ elseif (MSVC AND NOT MSVC_VERSION STREQUAL "@MSVC_VERSION@")
+   # Reject if there's a mismatch in MSVC compiler versions
+   set (REASON "_MSC_VER = @MSVC_VERSION@")
+   set (PACKAGE_VERSION_UNSUITABLE TRUE)
+-elseif (NOT CMAKE_CROSSCOMPILING STREQUAL "@CMAKE_CROSSCOMPILING@")
++elseif (0)
+   # Reject if there's a mismatch in ${CMAKE_CROSSCOMPILING}
+   set (REASON "cross-compiling = @CMAKE_CROSSCOMPILING@")
+   set (PACKAGE_VERSION_UNSUITABLE TRUE)

--- a/ports/liblas/portfile.cmake
+++ b/ports/liblas/portfile.cmake
@@ -15,7 +15,9 @@ vcpkg_extract_source_archive(
     PATCHES
         fix-boost-headers.patch
         fix-cmake-config.patch
+        fix-crosscompiling.diff
         misc-fixes.patch
+        remove_unnecessary_boost_dependency.diff
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules")
@@ -44,8 +46,8 @@ else()
 endif()
 
 vcpkg_replace_string ("${CURRENT_PACKAGES_DIR}/share/liblas/liblas-config.cmake" "_DIR}/.." "_DIR}/../..")
-vcpkg_replace_string ("${CURRENT_PACKAGES_DIR}/share/liblas/liblas-config.cmake" "/lib" "$<$<CONFIG:DEBUG>:/debug>/lib")
-vcpkg_replace_string ("${CURRENT_PACKAGES_DIR}/share/liblas/liblas-config.cmake" "/bin" "/tools/${PORT}")
+vcpkg_replace_string ("${CURRENT_PACKAGES_DIR}/share/liblas/liblas-config.cmake" "\${PROJECT_ROOT_DIR}/lib" "\${PROJECT_ROOT_DIR}/$<$<CONFIG:DEBUG>:/debug>/lib")
+vcpkg_replace_string ("${CURRENT_PACKAGES_DIR}/share/liblas/liblas-config.cmake" "\${PROJECT_ROOT_DIR}/bin" "\${PROJECT_ROOT_DIR}/tools/${PORT}")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/liblas/remove_unnecessary_boost_dependency.diff
+++ b/ports/liblas/remove_unnecessary_boost_dependency.diff
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d246a88d..634157c0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -190,11 +190,13 @@ if(WIN32)
+ endif(WIN32)
+ 
+ find_package(Threads)
+-find_package(Boost 1.42 COMPONENTS program_options thread system iostreams filesystem REQUIRED)
++find_package(Boost 1.42 COMPONENTS iostreams program_options serialization thread REQUIRED)
++ 
++# The following header-only and their dependencies are additionally required,
++# but cannot be explicitly requested via find_package, so make sure they exists:
++# - foreach interprocess lambda property_tree uuid
+ 
+-if(Boost_FOUND AND Boost_PROGRAM_OPTIONS_FOUND)
+-  include_directories(${Boost_INCLUDE_DIRS})
+-endif()
++include_directories(${Boost_INCLUDE_DIRS})
+ 
+ # make these available for the user to set.
+ mark_as_advanced(CLEAR Boost_INCLUDE_DIR)

--- a/ports/liblas/usage
+++ b/ports/liblas/usage
@@ -3,7 +3,9 @@ liblas provides CMake targets:
     # C API
     find_package(libLAS CONFIG REQUIRED)
     target_link_libraries(main PRIVATE $<$<PLATFORM_ID:Windows>:lib>las_c)
+    target_include_directories(main SYSTEM PRIVATE ${libLAS_INCLUDE_DIRS})
 
     # C++ API
     find_package(libLAS CONFIG REQUIRED)
     target_link_libraries(main PRIVATE $<$<PLATFORM_ID:Windows>:lib>las)
+    target_include_directories(main SYSTEM PRIVATE ${libLAS_INCLUDE_DIRS})

--- a/ports/liblas/vcpkg.json
+++ b/ports/liblas/vcpkg.json
@@ -1,20 +1,17 @@
 {
   "name": "liblas",
   "version": "1.8.1",
-  "port-version": 12,
+  "port-version": 13,
   "description": "A C/C++ library for reading and writing the very common LAS LiDAR format.",
   "license": null,
   "supports": "!arm & !staticcrt",
   "dependencies": [
-    "boost-detail",
-    "boost-filesystem",
+    "boost-foreach",
     "boost-interprocess",
     "boost-iostreams",
     "boost-lambda",
-    "boost-multi-index",
     "boost-program-options",
-    "boost-system",
-    "boost-thread",
+    "boost-property-tree",
     "boost-uuid",
     "libgeotiff",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4134,7 +4134,7 @@
     },
     "liblas": {
       "baseline": "1.8.1",
-      "port-version": 12
+      "port-version": 13
     },
     "liblbfgs": {
       "baseline": "1.10",

--- a/versions/l-/liblas.json
+++ b/versions/l-/liblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a72a32ce085b262e26bcadc55efd0159fdf00c4f",
+      "version": "1.8.1",
+      "port-version": 13
+    },
+    {
       "git-tree": "c8f90c515041e9c2633daee8e536e8e5e9ce0170",
       "version": "1.8.1",
       "port-version": 12


### PR DESCRIPTION
Tried to update our manifest file and got a compile issue on liblas:

```
...\include\liblas/dimension.hpp(53): fatal error C1083: Cannot open include file: 'boost/foreach.hpp': No such file or directory
```

Also removed unnecessary dependency (searched the code via `#include.*boost` to check which boost modules are really required).

 This issue can reproduced on the current master by calling `vcpkg install liblas`

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.