### PR TITLE
[Scenepic] Update to 1.1.0

### DIFF
--- a/ports/scenepic/portfile.cmake
+++ b/ports/scenepic/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  microsoft/scenepic 
     REF "v${VERSION}"
-    SHA512 2d9dfcefa7a054cf0addb12113ab65cb7dd3a8a6f7b42f60558a5d47a6de45a9e801be3266b81358ff8ac075dd9e9e2b9369905d62f2383531d6e28e93406ac9
+    SHA512 2ec8cdaa54a4432386175c545c4114d0682015cb34f77968622eac0b9ef6ccd8a5f14ba663339995bf109b472958407f694d40adf6025c02e464e94ef4fe5bd0
     HEAD_REF main
     PATCHES
         "fix_dependencies.patch"

--- a/ports/scenepic/vcpkg.json
+++ b/ports/scenepic/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "scenepic",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "port-version": 1,
   "description": "A Powerful, easy to use, and portable visualization toolkit for mixed 3D and 2D content",
   "homepage": "https://microsoft.github.io/scenepic/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7141,8 +7141,8 @@
       "port-version": 1
     },
     "scenepic": {
-      "baseline": "1.0.16",
-      "port-version": 1
+      "baseline": "1.1.0",
+      "port-version": 0
     },
     "scintilla": {
       "baseline": "4.4.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7142,7 +7142,7 @@
     },
     "scenepic": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "scintilla": {
       "baseline": "4.4.6",

--- a/versions/s-/scenepic.json
+++ b/versions/s-/scenepic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70b1207796dcdf599a5ede346b4a1748106d2c02",
+      "version": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "57d4ac99e32e53ed59ea56871fefb332a01e7481",
       "version": "1.0.16",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



