### PR TITLE
[fluidlite] update version; add SF3 feature; shared library support

### DIFF
--- a/ports/fluidlite/fix-dependencies.patch
+++ b/ports/fluidlite/fix-dependencies.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4aead6c369f129f50d79d77e6ac8f58afba91fa5..83f3f5026861dd904060293be8754c9e265047ab 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -113,7 +113,7 @@ endif()
+ 
+ set(FLUIDLITE_VENDORED FALSE)
+ if (ENABLE_SF3 AND NOT STB_VORBIS)
+-    find_package(Vorbis QUIET)
++    find_package(Vorbis CONFIG REQUIRED)
+     if (NOT TARGET Vorbis::vorbisfile)
+         message(WARNING "Using vendored libogg/libvorbis")
+ 
+diff --git a/fluidlite-config.cmake.in b/fluidlite-config.cmake.in
+index 8c40ff0eb077fc0fd530f052500214d75e96899d..46940e4cd218d245014f40f1097f7193cc8952b3 100644
+--- a/fluidlite-config.cmake.in
++++ b/fluidlite-config.cmake.in
+@@ -15,7 +15,7 @@ endif()
+ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-static-targets.cmake")
+    include(CMakeFindDependencyMacro)
+    if("${FLUIDLITE_SF3_SUPPORT}" STREQUAL "SF3_XIPH_VORBIS" AND NOT FLUIDLITE_VENDORED AND NOT TARGET Vorbis::vorbisfile)
+-      find_dependency(Vorbis)
++      find_dependency(Vorbis CONFIG)
+    endif()
+ 
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-static-targets.cmake")

--- a/ports/fluidlite/portfile.cmake
+++ b/ports/fluidlite/portfile.cmake
@@ -1,32 +1,38 @@
-if(EXISTS "${CURRENT_PACKAGES_DIR}/share/fluidsynth/copyright")
-    message(FATAL_ERROR "Can't build fluidlite if fluidsynth is installed. Please remove fluidsynth, and try to install fluidlite again if you need it.")
-endif()
-
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO divideconcept/FluidLite
-    REF fdd05bad03cdb24d1f78b5fe3453842890c1b0e8
-    SHA512 8118bec2cb5ee48b8064ed2111610f1917ee8e6f1dc213121b2311d056da21d7f618ef50735e7653d2cccf1e96652f3ccf026101fccb9863448008918add53e0
-    HEAD_REF master
+    REF d59d2328818f913b7d1a6a59aed695c47a8ce388
+    SHA512 d08ddd0b61dc16c26e5ebc8e54e2efef163f8d0b4da6ce4a040b49756feb105220d48ec6238568b00c68dfa244fac0ab53e3c59c066d4b92dc248df3715c388c
+    PATCHES
+        fix-dependencies.patch
 )
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" FLUIDLITE_BUILD_STATIC)
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" FLUIDLITE_BUILD_SHARED)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        sf3     ENABLE_SF3
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DFLUIDLITE_BUILD_STATIC=${FLUIDLITE_BUILD_STATIC}
-        -DFLUIDLITE_BUILD_SHARED=${FLUIDLITE_BUILD_SHARED}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME fluidlite
+    CONFIG_PATH lib/cmake/fluidlite
+)
+
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fluidlite/usage
+++ b/ports/fluidlite/usage
@@ -1,0 +1,4 @@
+fluidlite provides CMake targets:
+
+    find_package(fluidlite CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:fluidlite::fluidlite>,fluidlite::fluidlite,fluidlite::fluidlite-static>)

--- a/ports/fluidlite/vcpkg.json
+++ b/ports/fluidlite/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fluidlite",
-  "version-date": "2020-08-27",
-  "port-version": 3,
+  "version-date": "2023-04-18",
   "description": "FluidLite is a very light version of FluidSynth designed to be hardware, platform and external dependency independant.",
   "homepage": "https://github.com/divideconcept/FluidLite",
   "license": "LGPL-2.1-or-later",
@@ -9,6 +8,21 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "sf3"
+  ],
+  "features": {
+    "sf3": {
+      "description": "Enable SF3 files (ogg/vorbis compressed samples)",
+      "dependencies": [
+        "libvorbis"
+      ]
+    }
+  }
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -222,18 +222,6 @@ fastrtps:x64-windows-static=fail
 fastrtps:x64-windows-static-md=fail
 flashlight-cpu:x64-linux=fail
 flashlight-cuda:x64-linux=fail
-# fluidlite conflicts with fluidsynth; we test fluidsynth rather than fluidlite because
-# fluidlite has no dependencies and thus is less likely to be broken by another package.
-fluidlite:arm-uwp=skip
-fluidlite:arm64-windows=skip
-fluidlite:x64-linux=skip
-fluidlite:x64-osx=skip
-fluidlite:arm64-osx=skip
-fluidlite:x64-uwp=skip
-fluidlite:x64-windows-static=skip
-fluidlite:x64-windows-static-md=skip
-fluidlite:x64-windows=skip
-fluidlite:x86-windows=skip
 fmi4cpp:arm-uwp=fail
 fmi4cpp:x64-uwp=fail
 fontconfig:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2517,8 +2517,8 @@
       "port-version": 5
     },
     "fluidlite": {
-      "baseline": "2020-08-27",
-      "port-version": 3
+      "baseline": "2023-04-18",
+      "port-version": 0
     },
     "fluidsynth": {
       "baseline": "2.3.1",

--- a/versions/f-/fluidlite.json
+++ b/versions/f-/fluidlite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2cb547c733a48a1c7448c6db9e22432bca431ea6",
+      "version-date": "2023-04-18",
+      "port-version": 0
+    },
+    {
       "git-tree": "280ded5f814d25cc6db5336f016ed4e26b704ffe",
       "version-date": "2020-08-27",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
