### PR TITLE
[crashpad] Fetch missing dependency for crashpad on linux

### DIFF
--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -30,6 +30,15 @@ checkout_in_path(
     "5654edb4225bcad13901155c819febb5748e502b"
 )
 
+if(VCPKG_TARGET_IS_LINUX)
+    # fetch lss
+    checkout_in_path(
+        "${SOURCE_PATH}/third_party/lss/lss"
+        https://chromium.googlesource.com/linux-syscall-support
+        9719c1e1e676814c456b55f5f070eabad6709d31
+    )
+endif()
+
 function(replace_gn_dependency INPUT_FILE OUTPUT_FILE LIBRARY_NAMES)
     unset(_LIBRARY_DEB CACHE)
     find_library(_LIBRARY_DEB NAMES ${LIBRARY_NAMES}

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,14 +1,14 @@
 {
   "name": "crashpad",
   "version-date": "2022-09-05",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."
   ],
   "homepage": "https://chromium.googlesource.com/crashpad/crashpad/+/master/README.md",
   "license": "Apache-2.0",
-  "supports": "osx | (windows & !uwp)",
+  "supports": "linux | osx | (windows & !uwp)",
   "dependencies": [
     {
       "name": "vcpkg-cmake-get-vars",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -175,6 +175,7 @@ cppcoro:x64-uwp=fail
 # This is known to work on x64-linux as of gcc 10.3.0.
 cppgraphqlgen:x64-linux=fail
 crashpad:arm-uwp=fail
+crashpad:x64-linux=fail
 cuda:x64-osx=fail
 # Since pipeline cannot automatically install dbghelp dependency, skip this detection
 dbghelp:arm-uwp=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1846,7 +1846,7 @@
     },
     "crashpad": {
       "baseline": "2022-09-05",
-      "port-version": 3
+      "port-version": 4
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63c757af964d6d69f6abdeb0a3849889ad3531a9",
+      "version-date": "2022-09-05",
+      "port-version": 4
+    },
+    {
       "git-tree": "699f5caaac594c10928ddf73ba45e64ad764252f",
       "version-date": "2022-09-05",
       "port-version": 3


### PR DESCRIPTION
Note that this does not change the fact that crashpad is marked as unsupported, but it makes the build work now with
`--allow-unsupported`.

The build seems to work fine if the default compiler is set to clang, it does not build with gcc, which is probably why it's marked as unsupported.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.