### PR TITLE
[alsa] Add cmake wrapper

### DIFF
--- a/ports/alsa/portfile.cmake
+++ b/ports/alsa/portfile.cmake
@@ -57,6 +57,8 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
 file(REMOVE_RECURSE 
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"

--- a/ports/alsa/vcpkg-cmake-wrapper.cmake
+++ b/ports/alsa/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,96 @@
+find_path(
+  ALSA_INCLUDE_DIR
+  NAMES alsa/asoundlib.h
+  PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include"
+  NO_DEFAULT_PATH
+)
+
+find_library(
+  ALSA_LIBRARY_DEBUG
+  NAMES asound
+  PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib"
+  NO_DEFAULT_PATH
+)
+
+find_library(
+  ALSA_LIBRARY_RELEASE
+  NAMES asound
+  PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib"
+  NO_DEFAULT_PATH
+)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(ALSA)
+unset(ALSA_FOUND)
+
+if(NOT ALSA_INCLUDE_DIR OR NOT ALSA_LIBRARY)
+  message(FATAL_ERROR "Broken installation of the alsa vcpkg port")
+endif()
+
+_find_package(${ARGS})
+
+if(TARGET ALSA::ALSA)
+  if(ALSA_LIBRARY_DEBUG)
+    set_property(
+      TARGET ALSA::ALSA
+      APPEND
+      PROPERTY IMPORTED_CONFIGURATIONS DEBUG
+    )
+    set_target_properties(
+      ALSA::ALSA
+      PROPERTIES
+        IMPORTED_LOCATION_DEBUG "${ALSA_LIBRARY_DEBUG}"
+    )
+  endif()
+  if(ALSA_LIBRARY_RELEASE)
+    set_property(
+      TARGET ALSA::ALSA
+      APPEND
+      PROPERTY IMPORTED_CONFIGURATIONS RELEASE
+    )
+    set_target_properties(
+      ALSA::ALSA
+      PROPERTIES
+        IMPORTED_LOCATION_RELEASE "${ALSA_LIBRARY_RELEASE}"
+    )
+  endif()
+
+  find_library(Z_VCPKG_HAS_LIBM NAMES m)
+  if(Z_VCPKG_HAS_LIBM)
+    list(APPEND ALSA_LIBRARIES m)
+    set_property(
+      TARGET ALSA::ALSA
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES m
+    )
+  endif()
+
+  if(CMAKE_DL_LIBS)
+    list(APPEND ALSA_LIBRARIES ${CMAKE_DL_LIBS})
+    set_property(
+      TARGET ALSA::ALSA
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS}
+    )
+  endif()
+
+  find_package(Threads)
+  if(TARGET Threads::Threads)
+    list(APPEND ALSA_LIBRARIES Threads::Threads)
+    set_property(
+      TARGET ALSA::ALSA
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads
+    )
+  endif()
+
+  find_library(Z_VCPKG_HAS_LIBRT NAMES rt)
+  if(Z_VCPKG_HAS_LIBRT)
+    list(APPEND ALSA_LIBRARIES rt)
+    set_property(
+      TARGET ALSA::ALSA
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES rt
+    )
+  endif()
+endif()

--- a/ports/alsa/vcpkg.json
+++ b/ports/alsa/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "alsa",
   "version": "1.2.8",
+  "port-version": 1,
   "description": "The Advanced Linux Sound Architecture (ALSA) - library",
   "homepage": "https://www.alsa-project.org/",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/alsa.json
+++ b/versions/a-/alsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18d67806b319dea0e3c2e9c921a1864901af1d22",
+      "version": "1.2.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "1e4f79a1681c6c40c4b500bf4c8c5d3746916bab",
       "version": "1.2.8",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -90,7 +90,7 @@
     },
     "alsa": {
       "baseline": "1.2.8",
-      "port-version": 0
+      "port-version": 1
     },
     "amd-amf": {
       "baseline": "1.4.29",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

The [FindALSA module](https://github.com/Kitware/CMake/blob/master/Modules/FindALSA.cmake) provided by Kitware does not search for the transitive usage requirements (namely libm, libdl, pthread, and librt). Depending on the system, it may lead to failures when linking statically (see https://github.com/microsoft/vcpkg/pull/30625#issuecomment-1493453735).

This PR checks for each library in the order they typically appear in the pkg-config file and adds them to the `ALSA_LIBRARIES` list and `ALSA::ALSA`'s `INTERFACE_LINK_LIBRARIES`.

Additionally, the wrapper sets the available configurations (debug/release) for the target.

cc @BillyONeal 