### PR TITLE
[xxhash] Fix the installation path of the xxhsum.1 file

### DIFF
--- a/ports/xxhash/fix_xxhsum1_path.patch
+++ b/ports/xxhash/fix_xxhsum1_path.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake_unofficial/CMakeLists.txt b/cmake_unofficial/CMakeLists.txt
+index d5456b0..aed0db5 100644
+--- a/cmake_unofficial/CMakeLists.txt
++++ b/cmake_unofficial/CMakeLists.txt
+@@ -122,7 +122,7 @@ if(NOT XXHASH_BUNDLED_MODE)
+     install(TARGETS xxhsum
+       EXPORT xxHashTargets
+       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+-    install(FILES "${XXHASH_DIR}/xxhsum.1"
++    install(FILES "${XXHASH_DIR}/cli/xxhsum.1"
+       DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
+   endif(XXHASH_BUILD_XXHSUM)
+ 

--- a/ports/xxhash/portfile.cmake
+++ b/ports/xxhash/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v0.8.1
     SHA512 12feedd6a1859ef55e27218dbd6dcceccbb5a4da34cd80240d2f7d44cd246c7afdeb59830c2d5b90189bb5159293532208bf5bb622250102e12d6e1bad14a193
     HEAD_REF dev
+    PATCHES
+        fix_xxhsum1_path.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/xxhash/vcpkg.json
+++ b/ports/xxhash/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "xxhash",
   "version": "0.8.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Extremely fast hash algorithm",
   "homepage": "https://github.com/Cyan4973/xxHash",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8658,7 +8658,7 @@
     },
     "xxhash": {
       "baseline": "0.8.1",
-      "port-version": 1
+      "port-version": 2
     },
     "yajl": {
       "baseline": "2.1.0",

--- a/versions/x-/xxhash.json
+++ b/versions/x-/xxhash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c45988bd467674cb21961646a9379645a235ba5",
+      "version": "0.8.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "895a0039b3cd40c7f66725608d07dc851e0d54b6",
       "version": "0.8.1",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30831
Fix the following problem, the installation path of `xxhsum.1` file in `CMakeLists.txt` is changed from `${XXHASH_DIR}/xxhsum.1` to `${XXHASH_DIR}/cli/xxhsum.1`.
```
CMake Error at cmake_install.cmake:56 (file):
  file INSTALL cannot find
  "C:/Users/admin/git_projects/vcpkg2/buildtrees/xxhash/src/v0.8.1-c171284619.clean/cmake_unofficial/../xxhsum.1":
  File exists.
```
The usage has been tested successfully locally.
```
find_package(xxHash CONFIG REQUIRED)
target_link_libraries(main PRIVATE xxHash::xxhash)
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
