### PR TITLE
Updated CMake Targets as per libjpeg-turbo 2.0.90

### DIFF
--- a/ports/libjpeg-turbo/usage
+++ b/ports/libjpeg-turbo/usage
@@ -1,5 +1,6 @@
 The package libjpeg-turbo is compatible with built-in CMake targets:
 
-    find_package(JPEG REQUIRED)
-    target_link_libraries(main PRIVATE ${JPEG_LIBRARIES})
-    target_include_directories(main PRIVATE ${JPEG_INCLUDE_DIR})
+    find_package(libjpeg-turbo REQUIRED)
+    target_link_libraries(main PRIVATE libjpeg-turbo::jpeg)
+    target_link_libraries(main PRIVATE libjpeg-turbo::turbojpeg)
+    target_include_directories(main PRIVATE ${JPEG_INCLUDE_DIRS})


### PR DESCRIPTION
There were no libjpeg-turbo linker targets when these instructions were last updated. As of https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.0.90 (Point 10) there are now, letting you link to the libjpeg-turbo symbols (and not just the jpeg symbols as before). Also, JPEG_INCLUDE_DIR should be JPEG_INCLUDE_DIRS, as per FindJPEG.cmake .

I'm not sure both target_link_libraries lines should be in there, as one is for the standard jpeg libraries also included in libjpeg-turbo, but I put them both there, since most users would want to use both.
