### PR TITLE
[ryu] Add support for uwp, arm, x86

### DIFF
--- a/ports/ryu/vcpkg.json
+++ b/ports/ryu/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "ryu",
   "version": "2.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Ryu generates the shortest decimal representation of a floating point number that maintains round-trip safety.",
   "homepage": "https://github.com/ulfjack/ryu",
-  "supports": "!(uwp | arm | x86)",
   "dependencies": [
     {
       "name": "vcpkg-cmake-get-vars",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7098,7 +7098,7 @@
     },
     "ryu": {
       "baseline": "2.0",
-      "port-version": 7
+      "port-version": 8
     },
     "s2geometry": {
       "baseline": "0.10.0",

--- a/versions/r-/ryu.json
+++ b/versions/r-/ryu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "660ffa1a7a15e75dbcff064ac704f53b8a2da880",
+      "version": "2.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "9eef3ab0a0bafea6db1a02920f60b756c3eeabfc",
       "version": "2.0",
       "port-version": 7


### PR DESCRIPTION
Also:
  Remove [the excess setting of the BAZEL_VS](https://github.com/bazelbuild/bazel/blob/release-5.2.0/site/docs/install-compile-source.md?plain=1#L258-L260) environment variable.
  Avoid adding C++ options through the --cxxopt command line option, as these options are [incorrectly applied to C language source files on Windows](https://github.com/bazelbuild/bazel/issues/15073). (Currently, we are only compiling C language source files)

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.