### PR TITLE
[folly] fix missing dep

### DIFF
--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "folly",
   "version-string": "2022.10.31.00",
-  "port-version": 4,
+  "port-version": 5,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",
@@ -19,6 +19,7 @@
     "boost-smart-ptr",
     "boost-system",
     "boost-thread",
+    "boost-variant",
     "double-conversion",
     "fmt",
     "gflags",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2542,7 +2542,7 @@
     },
     "folly": {
       "baseline": "2022.10.31.00",
-      "port-version": 4
+      "port-version": 5
     },
     "font-chef": {
       "baseline": "1.1.0",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2be8536b3faaf9f907284548e4db1f49b77054c1",
+      "version-string": "2022.10.31.00",
+      "port-version": 5
+    },
+    {
       "git-tree": "9f031566a728d2a7adf76c1026324cfc993b02a6",
       "version-string": "2022.10.31.00",
       "port-version": 4


### PR DESCRIPTION
Otherwise it fails with:
```
[28/303] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DFOLLY_XLOG_STRIP_PREFIXES=\"/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/src/183f5c2249-2e653483fb.clean:/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/arm64-osx-dbg\" -DGFLAGS_IS_A_DLL=0 -D_GNU_SOURCE -D_REENTRANT -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/src/183f5c2249-2e653483fb.clean -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/arm64-osx-dbg -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/include -fPIC -g -g -Wall -Wextra -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -g -std=gnu++1z -finput-charset=UTF-8 -fsigned-char -Wall -Wno-deprecated -Wno-deprecated-declarations -Wno-sign-compare -Wno-unused -Wuninitialized -Wunused-label -Wunused-result -Wno-noexcept-type -Wno-nullability-completeness -Wno-inconsistent-missing-override -faligned-new -std=gnu++17 -MD -MT CMakeFiles/folly_base.dir/folly/Singleton.cpp.o -MF CMakeFiles/folly_base.dir/folly/Singleton.cpp.o.d -o CMakeFiles/folly_base.dir/folly/Singleton.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/src/183f5c2249-2e653483fb.clean/folly/Singleton.cpp
FAILED: CMakeFiles/folly_base.dir/folly/Singleton.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DFOLLY_XLOG_STRIP_PREFIXES=\"/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/src/183f5c2249-2e653483fb.clean:/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/arm64-osx-dbg\" -DGFLAGS_IS_A_DLL=0 -D_GNU_SOURCE -D_REENTRANT -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/src/183f5c2249-2e653483fb.clean -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/arm64-osx-dbg -I/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/include -fPIC -g -g -Wall -Wextra -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -g -std=gnu++1z -finput-charset=UTF-8 -fsigned-char -Wall -Wno-deprecated -Wno-deprecated-declarations -Wno-sign-compare -Wno-unused -Wuninitialized -Wunused-label -Wunused-result -Wno-noexcept-type -Wno-nullability-completeness -Wno-inconsistent-missing-override -faligned-new -std=gnu++17 -MD -MT CMakeFiles/folly_base.dir/folly/Singleton.cpp.o -MF CMakeFiles/folly_base.dir/folly/Singleton.cpp.o.d -o CMakeFiles/folly_base.dir/folly/Singleton.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/src/183f5c2249-2e653483fb.clean/folly/Singleton.cpp
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/src/183f5c2249-2e653483fb.clean/folly/Singleton.cpp:35:
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/src/183f5c2249-2e653483fb.clean/folly/experimental/symbolizer/Symbolizer.h:30:
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/folly/src/183f5c2249-2e653483fb.clean/folly/experimental/symbolizer/Dwarf.h:21:10: fatal error: 'boost/variant.hpp' file not found
#include <boost/variant.hpp>
         ^~~~~~~~~~~~~~~~~~~
1 error generated.
```