### PR TITLE
[magnum-integration] fix eigen feature

### DIFF
--- a/ports/magnum-integration/portfile.cmake
+++ b/ports/magnum-integration/portfile.cmake
@@ -44,6 +44,12 @@ if("${FEATURES}" STREQUAL "core")
         "${CURRENT_PACKAGES_DIR}/debug"
     )
     set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+else()
+    file(GLOB FILES "${CURRENT_PACKAGES_DIR}/debug/*")
+    list(LENGTH FILES COUNT)
+    if(COUNT EQUAL 0)
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+    endif()
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)

--- a/ports/magnum-integration/vcpkg.json
+++ b/ports/magnum-integration/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "magnum-integration",
   "version-string": "2020.06",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Integrations for magnum, C++11/C++14 graphics middleware for games and data visualization",
   "homepage": "https://magnum.graphics/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4978,7 +4978,7 @@
     },
     "magnum-integration": {
       "baseline": "2020.06",
-      "port-version": 2
+      "port-version": 3
     },
     "magnum-plugins": {
       "baseline": "2020.06",

--- a/versions/m-/magnum-integration.json
+++ b/versions/m-/magnum-integration.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "191049e602f776d41b02b21f74df5c36393f8de0",
+      "version-string": "2020.06",
+      "port-version": 3
+    },
+    {
       "git-tree": "7485cdf34b865de5cca00d40ee315a0504e226f1",
       "version-string": "2020.06",
       "port-version": 2


### PR DESCRIPTION
Fixes `magnum-integration[core,eigen]`
```
-- Performing post-build validation
warning: There should be no empty directories in /Users/leanderSchulten/git_projekte/vcpkg/packages/magnum-integration_arm64-osx. The following empty directories were found:

    /Users/leanderSchulten/git_projekte/vcpkg/packages/magnum-integration_arm64-osx/debug

warning: If a directory should be populated but is not, this might indicate an error in the portfile.
If the directories are not needed and their creation cannot be disabled, use something like this in the portfile to remove them:
    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
```