### PR TITLE
Replaced "disable-gpl" feature with "gpl"

### DIFF
--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -81,7 +81,7 @@ if("chroma-format-all" IN_LIST FEATURES)
     vcpkg_list(APPEND OPTIONS --chroma-format=all)
 endif()
 
-if("disable-gpl" IN_LIST FEATURES)
+if(NOT "gpl" IN_LIST FEATURES)
     vcpkg_list(APPEND OPTIONS --disable-gpl)
 endif()
 

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x264",
   "version": "0.164.3095",
-  "port-version": 3,
+  "port-version": 4,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://www.videolan.org/developers/x264.html",
   "license": "GPL-2.0-or-later",
@@ -28,14 +28,15 @@
         {
           "name": "x264",
           "features": [
-            "asm"
+            "asm",
+            "gpl"
           ],
           "platform": "x86 | x64 | (arm & !windows) | arm64"
         }
       ]
     },
-    "disable-gpl": {
-      "description": "Disable GPL-only features"
+    "gpl": {
+      "description": "Allow use of GPL code, the resulting libs and binaries will be under GPL"
     },
     "tool": {
       "description": "Build the command line tool",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8514,7 +8514,7 @@
     },
     "x264": {
       "baseline": "0.164.3095",
-      "port-version": 3
+      "port-version": 4
     },
     "x265": {
       "baseline": "3.4",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0361283be94126cf5e42a4cf765f700f8f209ea5",
+      "version": "0.164.3095",
+      "port-version": 4
+    },
+    {
       "git-tree": "18da69fb69b926e7784135262798356e7b1ee5e4",
       "version": "0.164.3095",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

