### PR TITLE
[hyperscan] Update to 5.4.2

### DIFF
--- a/ports/hyperscan/portfile.cmake
+++ b/ports/hyperscan/portfile.cmake
@@ -1,12 +1,10 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(HYPERSCAN_VERSION 5.4.0)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/hyperscan
-    REF v${HYPERSCAN_VERSION}
-    SHA512 cfec3f43b9e8b3fbb2e761927f3a173c1230f2688da710ec7708f2941ce6f550a1d3cb48b0b0e2ccf709807390117a7e40047cb99190bcc341f37eb3da13ae62
+    REF "v${VERSION}"
+    SHA512 328f21133161d16b36ebdc7f8b80a7afe7ca9e7e7433348e9bfa9acb5f3641522e8314beea1b219891f4e95f1392ff8036ebb87780fe808b8b4bd15a535e9509
     HEAD_REF master
     PATCHES
         0001-remove-Werror.patch
@@ -24,6 +22,6 @@ vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/hyperscan/vcpkg.json
+++ b/ports/hyperscan/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperscan",
-  "version": "5.4.0",
+  "version": "5.4.2",
   "description": "A regular expression library with O(length of input) match times that takes advantage of Intel hardware to provide blazing speed.",
   "homepage": "https://www.hyperscan.io",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3129,7 +3129,7 @@
       "port-version": 0
     },
     "hyperscan": {
-      "baseline": "5.4.0",
+      "baseline": "5.4.2",
       "port-version": 0
     },
     "hypodermic": {

--- a/versions/h-/hyperscan.json
+++ b/versions/h-/hyperscan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "174fd7953b696f08703b580901a840cc53157439",
+      "version": "5.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "72c36aba3fff7cd403bdf02ad8f691ced9da30a9",
       "version": "5.4.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #30976. No feature needs to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.