### PR TITLE
[libconfig] Export correct cmake config

### DIFF
--- a/ports/libconfig/Export-correct-cmake-config.patch
+++ b/ports/libconfig/Export-correct-cmake-config.patch
@@ -1,30 +1,18 @@
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index 709a1b5..f4d59a4 100644
+index 709a1b5..bd3085f 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
-@@ -141,7 +141,8 @@ install(TARGETS ${libname}++
- 
- 
- include(CMakePackageConfigHelpers)
--foreach(target_name libconfig libconfig++)
-+set(name_list "libconfig" "libconfig++")
-+foreach(target_name IN LISTS name_list)
-   write_basic_package_version_file("${target_name}ConfigVersion.cmake"
-     VERSION ${PACKAGE_VERSION}
-     COMPATIBILITY SameMajorVersion
-@@ -149,12 +150,12 @@ foreach(target_name libconfig libconfig++)
- 
+@@ -150,11 +150,11 @@ foreach(target_name libconfig libconfig++)
    install(EXPORT ${target_name}Targets
      FILE "${target_name}Config.cmake"
--    NAMESPACE libconfig::
+     NAMESPACE libconfig::
 -    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libconfig
-+    NAMESPACE ${target_name}::
 +    DESTINATION share/${target_name}
      )
  
    install(FILES
      "${CMAKE_CURRENT_BINARY_DIR}/${target_name}ConfigVersion.cmake"
 -    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libconfig"
-+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/share/${target_name}"
++    DESTINATION share/${target_name}
      )
  endforeach()

--- a/ports/libconfig/Export-correct-cmake-config.patch
+++ b/ports/libconfig/Export-correct-cmake-config.patch
@@ -1,0 +1,30 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 709a1b5..f4d59a4 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -141,7 +141,8 @@ install(TARGETS ${libname}++
+ 
+ 
+ include(CMakePackageConfigHelpers)
+-foreach(target_name libconfig libconfig++)
++set(name_list "libconfig" "libconfig++")
++foreach(target_name IN LISTS name_list)
+   write_basic_package_version_file("${target_name}ConfigVersion.cmake"
+     VERSION ${PACKAGE_VERSION}
+     COMPATIBILITY SameMajorVersion
+@@ -149,12 +150,12 @@ foreach(target_name libconfig libconfig++)
+ 
+   install(EXPORT ${target_name}Targets
+     FILE "${target_name}Config.cmake"
+-    NAMESPACE libconfig::
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libconfig
++    NAMESPACE ${target_name}::
++    DESTINATION share/${target_name}
+     )
+ 
+   install(FILES
+     "${CMAKE_CURRENT_BINARY_DIR}/${target_name}ConfigVersion.cmake"
+-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libconfig"
++    DESTINATION "${CMAKE_INSTALL_LIBDIR}/share/${target_name}"
+     )
+ endforeach()

--- a/ports/libconfig/portfile.cmake
+++ b/ports/libconfig/portfile.cmake
@@ -1,9 +1,15 @@
+if(VCPKG_USE_HEAD_VERSION)
+    list(APPEND PATCHES Export-correct-cmake-config.patch)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hyperrealm/libconfig
     REF v1.7.3
     SHA512 3749bf9eb29bab0f6b14f4fc759f0c419ed27a843842aaabed1ec1fbe0faa8c93322ff875ca1291d69cb28a39ece86d512aec42c2140d566c38c56dc616734f4
     HEAD_REF master
+    PATCHES
+        ${PATCHES}
 )
 
 if (NOT VCPKG_USE_HEAD_VERSION)
@@ -31,7 +37,8 @@ vcpkg_copy_pdbs()
 
 if (VCPKG_USE_HEAD_VERSION)
   file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-  vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libconfig)
+  vcpkg_cmake_config_fixup()
+  vcpkg_cmake_config_fixup(PACKAGE_NAME libconfig++)
 endif()
 
 foreach(FILE ${CURRENT_PACKAGES_DIR}/include/libconfig.h++ ${CURRENT_PACKAGES_DIR}/include/libconfig.h)

--- a/ports/libconfig/vcpkg.json
+++ b/ports/libconfig/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libconfig",
   "version": "1.7.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "C/C++ library for processing configuration files",
   "homepage": "https://github.com/hyperrealm/libconfig",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3842,7 +3842,7 @@
     },
     "libconfig": {
       "baseline": "1.7.3",
-      "port-version": 2
+      "port-version": 3
     },
     "libconfuse": {
       "baseline": "2019-07-14",

--- a/versions/l-/libconfig.json
+++ b/versions/l-/libconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8f4c44243b663ca295a0b2a2638357b1411a256",
+      "version": "1.7.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "cf6ab494ef19e4fb5bf1effcd86246cb758000af",
       "version": "1.7.3",
       "port-version": 2

--- a/versions/l-/libconfig.json
+++ b/versions/l-/libconfig.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c8f4c44243b663ca295a0b2a2638357b1411a256",
+      "git-tree": "1f823ddea02ee97b6f74f4ee3aeefc11c7c8b94e",
       "version": "1.7.3",
       "port-version": 3
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/30906
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: Export correct cmake config files and usage:
```
libconfig provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(libconfig CONFIG REQUIRED)
    target_link_libraries(main PRIVATE libconfig::libconfig)
    
    find_package(libconfig++ CONFIG REQUIRED)
    target_link_libraries(main PRIVATE libconfig++::libconfig++)
```
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
