### PR TITLE
[raylib] Fix incorrect version in raylib-config-version.cmake

### DIFF
--- a/ports/raylib/fix-project-version.patch
+++ b/ports/raylib/fix-project-version.patch
@@ -1,0 +1,14 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9087f8e..5092bdf 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # Setup the project and settings
+ project(raylib C)
+-set(PROJECT_VERSION 4.2.0)
+-set(API_VERSION 420)
++set(PROJECT_VERSION 4.5.0)
++set(API_VERSION 450)
+ 
+ include(GNUInstallDirs)
+ include(JoinPaths)

--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -15,16 +15,18 @@ if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
 endif()
 
 if(VCPKG_TARGET_IS_EMSCRIPTEN)
-	set(ADDITIONAL_OPTIONS "-DPLATFORM=Web")
+    set(ADDITIONAL_OPTIONS "-DPLATFORM=Web")
 endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO raysan5/raylib
-    REF ${VERSION}
+    REF "${VERSION}"
     SHA512 a959abbb577a8951251a469d6505093fd20988444dcf055e26cb0b484ef4024211b2cca45187accbd465c56bc50e02d450b6f7f7cfde2cdaedcdce422f80dcbc
     HEAD_REF master
-    PATCHES ${patches}
+    PATCHES
+        fix-project-version.patch #Upstream change https://github.com/raysan5/raylib/commit/0d4db7ad7f6fd442ed165ebf8ab8b3f4033b04e7, please remove in next update.
+        ${patches}
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SHARED)
@@ -59,6 +61,10 @@ vcpkg_cmake_configure(
         -DENABLE_ASAN=OFF
         -DENABLE_UBSAN=OFF
         -DENABLE_MSAN=OFF
+    MAYBE_UNUSED_VARIABLES
+        SHARED
+        STATIC
+        SUPPORT_HIGH_DPI
 )
 
 vcpkg_cmake_install()
@@ -81,4 +87,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     )
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/raylib/vcpkg.json
+++ b/ports/raylib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "raylib",
   "version-semver": "4.5.0",
+  "port-version": 1,
   "description": "A simple and easy-to-use library to enjoy videogames programming",
   "homepage": "https://github.com/raysan5/raylib",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6874,7 +6874,7 @@
     },
     "raylib": {
       "baseline": "4.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "rbdl": {
       "baseline": "3.2.0",

--- a/versions/r-/raylib.json
+++ b/versions/r-/raylib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ae048ec33152df88804d243fd6e89691d5712d2",
+      "version-semver": "4.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f8a98453d76631d6a8f4f8d762646808cc3e9e1a",
       "version-semver": "4.5.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/30908
This issue has been fixed by upstream commit https://github.com/raysan5/raylib/commit/0d4db7ad7f6fd442ed165ebf8ab8b3f4033b04e7, because this commit was made 3 days after the current version was released and there is no new version release from upstream yet, I am using a patch to apply these changes.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
