### PR TITLE
[dstorage] update for version 1.2.0 release

### DIFF
--- a/ports/dstorage/portfile.cmake
+++ b/ports/dstorage/portfile.cmake
@@ -1,3 +1,5 @@
+# Set VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY instead of using `vcpkg_check_linkage` because
+# these DLLs don't link with a CRT.
 set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/dstorage/portfile.cmake
+++ b/ports/dstorage/portfile.cmake
@@ -1,5 +1,5 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/${VERSION}"

--- a/ports/dstorage/portfile.cmake
+++ b/ports/dstorage/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/${VERSION}"
     FILENAME "directstorage.${VERSION}.zip"
-    SHA512 2c2cf6486220f99e7447c1a4406cea6fcaea69edccf790df6887acfde9a684e102547016adadd1ca23f17f8f02bfbd39095892ed63fba3e806bfa44ca9fe0fe6
+    SHA512 5be6219888c89c5f590709d1528b3e6854eabd7b733af5c8f665aa9d7e987fa3bac34472362f845eb902b88d2d6e8afbbcead15e892d72678861a14b0bc13c41
 )
 
 vcpkg_extract_source_archive(

--- a/ports/dstorage/portfile.cmake
+++ b/ports/dstorage/portfile.cmake
@@ -1,4 +1,3 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/dstorage/vcpkg.json
+++ b/ports/dstorage/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "dstorage",
-  "version": "1.1.0",
-  "port-version": 2,
+  "version": "1.2.0",
   "description": "DirectStorage for Windows",
   "homepage": "https://aka.ms/directstorage/",
   "documentation": "https://github.com/microsoft/DirectStorage",
   "license": null,
-  "supports": "windows & !uwp & !xbox & !staticcrt"
+  "supports": "windows & !uwp & !xbox"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2161,8 +2161,8 @@
       "port-version": 0
     },
     "dstorage": {
-      "baseline": "1.1.0",
-      "port-version": 2
+      "baseline": "1.2.0",
+      "port-version": 0
     },
     "dtl": {
       "baseline": "1.20",

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e53576c00a63741ad5b2a08914404f85feb08424",
+      "git-tree": "18440695231677ed659b391e4a31c0100996cdb6",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e531da3026b6419a66690f9d4a8f4ed6fa10e9f4",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "065715cb0fcd3b94934da5de3db5e2341cf1912c",
       "version": "1.1.0",
       "port-version": 2

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e531da3026b6419a66690f9d4a8f4ed6fa10e9f4",
+      "git-tree": "b6a35b4c329fabbc7c7bf62b39db7e880eccd73d",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b6a35b4c329fabbc7c7bf62b39db7e880eccd73d",
+      "git-tree": "e53576c00a63741ad5b2a08914404f85feb08424",
       "version": "1.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
### New Features
- Add support for enabling buffered file IO for use on HDDs that may benefit from OS file caching behaviors.
- Add IDStorageQueue2::GetCompressionSupport API to indicate what path the DirectStorage runtime will take when decompressing a supported GPU decompression format.
- Update dstorage.h and dstorageerr.h to be covered by the MIT License.
- Add Microsoft.Direct3D.DirectStorage.winmd, to ease generation of non-C++ bindings to the API.

### Bug Fixes
- Add "Reserved1" field to DSTORAGE_REQUEST_OPTIONS.  This makes the in-memory layout of the structure more explicit, but doesn't actually change the layout from previous versions.
- Fix DSTORAGE_REQUEST_DESTINATION_TEXTURE_REGION for 3D textures.
- Fix scheduling issue that manifested when transferring uncompressed data from memory to buffers

### Performance improvements
- Move the copy after GPU decompression onto the compute queue for GPUs where this is faster.
