### PR TITLE
[ogre] fix feature tools on osx

### DIFF
--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
         cfg-rel-paths.patch
         swig-python-polyfill.patch
         pkgconfig.patch
+        same-install-rules-all-platforms.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/CMake/Packages/FindOpenEXR.cmake")

--- a/ports/ogre/same-install-rules-all-platforms.patch
+++ b/ports/ogre/same-install-rules-all-platforms.patch
@@ -1,0 +1,14 @@
+diff --git a/CMake/Utils/OgreConfigTargets.cmake b/CMake/Utils/OgreConfigTargets.cmake
+index c4e6de8..e92da59 100644
+--- a/CMake/Utils/OgreConfigTargets.cmake
++++ b/CMake/Utils/OgreConfigTargets.cmake
+@@ -56,9 +56,6 @@ elseif (UNIX)
+   set(OGRE_LIB_RELEASE_PATH "")
+   set(OGRE_LIB_RELWDBG_PATH "")
+   set(OGRE_LIB_DEBUG_PATH "")
+-  if(APPLE AND NOT APPLE_IOS)
+-    set(OGRE_RELEASE_PATH "/${PLATFORM_NAME}")
+-  endif()
+   if(APPLE AND APPLE_IOS)
+     set(OGRE_LIB_RELEASE_PATH "/Release")
+   endif(APPLE AND APPLE_IOS)

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ogre",
   "version": "13.6.2",
+  "port-version": 1,
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5698,7 +5698,7 @@
     },
     "ogre": {
       "baseline": "13.6.2",
-      "port-version": 0
+      "port-version": 1
     },
     "ogre-next": {
       "baseline": "2.3.1",

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b7ec525c0cd854d1da91a5a11cd05109693b9333",
+      "version": "13.6.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "dda1cee749cebb6fc251073a702e6a698fd4521e",
       "version": "13.6.2",
       "port-version": 0


### PR DESCRIPTION
On macos the tools are otherwise inside the folder `macosx` and then not found by `vcpkg_copy_tools`