### PR TITLE
[forge] fix wrong dep

### DIFF
--- a/ports/forge/vcpkg.json
+++ b/ports/forge/vcpkg.json
@@ -1,13 +1,13 @@
 {
   "name": "forge",
   "version-semver": "1.0.8",
-  "port-version": 2,
+  "port-version": 3,
   "description": "An OpenGL interop library that can be used with ArrayFire or any other application using CUDA or OpenCL compute backend.",
   "homepage": "https://github.com/arrayfire/forge",
   "license": "BSD-3-Clause",
   "supports": "!(windows & (arm | uwp))",
   "dependencies": [
-    "boost-functional",
+    "boost-container-hash",
     {
       "name": "fontconfig",
       "platform": "!windows"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2570,7 +2570,7 @@
     },
     "forge": {
       "baseline": "1.0.8",
-      "port-version": 2
+      "port-version": 3
     },
     "foxi": {
       "baseline": "2021-12-01",

--- a/versions/f-/forge.json
+++ b/versions/f-/forge.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "020557ffe8bd7c66464eb1a19eb1a67b3151aa25",
+      "version-semver": "1.0.8",
+      "port-version": 3
+    },
+    {
       "git-tree": "9d711924c7973e7f5fe16131a16b90b2317caf9e",
       "version-semver": "1.0.8",
       "port-version": 2


### PR DESCRIPTION
Otherwise it fails with 
```
[1/57] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DOS_MAC -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/arm64-osx-dbg/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend/opengl -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend/opengl/glfw -isystem /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/include -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -fvisibility=hidden -std=gnu++14 -MD -MT src/backend/common/CMakeFiles/forge_common_obj_lib.dir/util.cpp.o -MF src/backend/common/CMakeFiles/forge_common_obj_lib.dir/util.cpp.o.d -o src/backend/common/CMakeFiles/forge_common_obj_lib.dir/util.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend/common/util.cpp
FAILED: src/backend/common/CMakeFiles/forge_common_obj_lib.dir/util.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DOS_MAC -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/arm64-osx-dbg/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend/opengl -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend/opengl/glfw -isystem /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/include -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -fvisibility=hidden -std=gnu++14 -MD -MT src/backend/common/CMakeFiles/forge_common_obj_lib.dir/util.cpp.o -MF src/backend/common/CMakeFiles/forge_common_obj_lib.dir/util.cpp.o.d -o src/backend/common/CMakeFiles/forge_common_obj_lib.dir/util.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend/common/util.cpp
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend/common/util.cpp:10:
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend/common/err_handling.hpp:12:
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/forge/src/v1.0.8-1271a4dc35.clean/src/backend/common/defines.hpp:12:10: fatal error: 'boost/functional/hash.hpp' file not found
#include <boost/functional/hash.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

See also https://stackoverflow.com/questions/60366232/what-is-include-boost-functional-hash-hpp