### PR TITLE
[vcpkg-tool-meson] update meson to 1.1.0

### DIFF
--- a/ports/vcpkg-tool-meson/portfile.cmake
+++ b/ports/vcpkg-tool-meson/portfile.cmake
@@ -5,17 +5,16 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
 set(program MESON)
-set(program_version 0.63.0)
+set(program_version 1.1.0)
 set(program_name meson)
 set(search_names meson meson.py)
 set(interpreter PYTHON3)
 set(apt_package_name "meson")
 set(brew_package_name "meson")
-set(ref bb91cea0d66d8d036063dedec1f194d663399cdf)
 set(paths_to_search "${CURRENT_PACKAGES_DIR}/tools/meson")
-set(download_urls "https://github.com/mesonbuild/meson/archive/${ref}.tar.gz")
-set(download_filename "meson-${ref}.tar.gz")
-set(download_sha512 e5888eb35dd4ab5fc0a16143cfbb5a7849f6d705e211a80baf0a8b753e2cf877a4587860a79cad129ec5f3474c12a73558ffe66439b1633d80b8044eceaff2da)
+set(download_urls "https://github.com/mesonbuild/meson/releases/download/${program_version}/meson-${program_version}.tar.gz")
+set(download_filename "meson-${program_version}.tar.gz")
+set(download_sha512 b8968becd1de25d8e92ecbe4c3b50694269a463430b41fcf5206f35ac952507b01f316721fb36f8c7940437e35c3588f6a4504f5b8256fa47fd9b0ceb588ae39)
 set(supported_on_unix ON)
 set(version_command --version)
 set(extra_search_args EXACT_VERSION_MATCH)
@@ -43,7 +42,7 @@ if(NOT "${program}")
                         COMMAND "${CMAKE_COMMAND}" -E tar xzf "${archive_path}"
                         WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools"
                     )
-    file(RENAME "${CURRENT_PACKAGES_DIR}/tools/meson-${ref}" "${CURRENT_PACKAGES_DIR}/tools/meson")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/tools/meson-${program_version}" "${CURRENT_PACKAGES_DIR}/tools/meson")
     z_vcpkg_apply_patches(
         SOURCE_PATH "${CURRENT_PACKAGES_DIR}"
         PATCHES

--- a/ports/vcpkg-tool-meson/vcpkg.json
+++ b/ports/vcpkg-tool-meson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-tool-meson",
-  "version": "0.63",
+  "version": "1.1.0",
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8265,7 +8265,7 @@
       "port-version": 1
     },
     "vcpkg-tool-meson": {
-      "baseline": "0.63",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "vcpkg-tool-mozbuild": {

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a09799b780a3b0cd11d86a0eef170d576fc05a8a",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bee0cb6c5edf45133ebc9643b86c9c775ab36cfe",
       "version": "0.63",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Replaces #28084 with a lot less patches.
