### PR TITLE
[proj] windows: fix sqlite3 tool not finding deps

### DIFF
--- a/ports/proj/portfile.cmake
+++ b/ports/proj/portfile.cmake
@@ -25,6 +25,10 @@ if("tools" IN_LIST FEATURES AND NOT "net" IN_LIST FEATURES)
 endif()
 
 find_program(EXE_SQLITE3 NAMES "sqlite3" PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools" NO_DEFAULT_PATH REQUIRED)
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    # sqlite3 needs to find it's dependency libraries
+    vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/bin")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/proj/vcpkg.json
+++ b/ports/proj/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "proj",
   "version": "9.2.0",
+  "port-version": 1,
   "description": "PROJ library for cartographic projections",
   "homepage": "https://proj.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6286,7 +6286,7 @@
     },
     "proj": {
       "baseline": "9.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "proj4": {
       "baseline": "8.9.9",

--- a/versions/p-/proj.json
+++ b/versions/p-/proj.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40a1772a7ddfd4afa85dc5b292d076b11b553bd3",
+      "version": "9.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "24665244df24460f20293fc879787852554b16c7",
       "version": "9.2.0",
       "port-version": 0


### PR DESCRIPTION
In a dynamic build, sqlite3.exe doesn't find libz.dll, which causes an error when building proj during proj.db generation. Fix this by adding the installed bin dir to the path before building proj.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [n/a ] SHA512s are updated for each updated download
- [n/a] The "supports" clause reflects platforms that may be fixed by this new version
- [n/a] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [n/a] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [n/a] Only one version is added to each modified port's versions file.

---

Package: proj[core,net,tiff,tools]:x64-windows -> 9.2.0

**Host Environment**

- Host: x64-windows
- Compiler: MSVC 19.29.30148.0
-    vcpkg-tool version: 2023-04-07-bedcba5172f5e4b91caac660ab7afe92c27a9895
    vcpkg-scripts version: dcf61b206 2023-04-15 (6 days ago)

**To Reproduce**

`vcpkg install `

**Failure logs**

```
-- Using cached OSGeo-PROJ-9.2.0.tar.gz.
-- Extracting source D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/downloads/OSGeo-PROJ-9.2.0.tar.gz
-- Applying patch fix-win-output-name.patch
-- Applying patch fix-proj4-targets-cmake.patch
-- Applying patch remove-doc.patch
-- Using source at D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/src/9.2.0-07ca3b7ec6.clean
-- Found external ninja('1.10.2').
-- Configuring x64-windows
-- Building x64-windows-rel
CMake Error at scripts/cmake/vcpkg_execute_build_process.cmake:134 (message):
    Command failed: D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/downloads/tools/cmake-3.25.1-windows/cmake-3.25.1-windows-i386/bin/cmake.exe --build . --config Release --target install -- -v -j5
    Working Directory: D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel
    See logs for more information:
      D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\install-x64-windows-rel-out.log

Call Stack (most recent call first):
  D:/Users/rcoup/kart/build/vcpkg_installed/x64-windows/share/vcpkg-cmake/vcpkg_cmake_build.cmake:74 (vcpkg_execute_build_process)
  D:/Users/rcoup/kart/build/vcpkg_installed/x64-windows/share/vcpkg-cmake/vcpkg_cmake_install.cmake:16 (vcpkg_cmake_build)
  D:/Users/rcoup/kart/vcpkg-vendor/vcpkg-overlay-ports/proj/portfile.cmake:44 (vcpkg_cmake_install)
  scripts/ports.cmake:147 (include)



```
<details><summary>D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\install-x64-windows-rel-out.log</summary>

```
[1/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\aasincos.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\aasincos.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[2/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\auth.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\auth.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[3/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\adjlon.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\adjlon.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[4/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\datum_set.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\datum_set.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[5/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\4D_api.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\4D_api.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[6/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\deriv.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\deriv.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[7/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\datums.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\datums.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[8/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\init.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\init.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[9/241] cmd.exe /C "cd /D D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\data && D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\downloads\tools\cmake-3.25.1-windows\cmake-3.25.1-windows-i386\bin\cmake.exe -E remove -f D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/proj.db && D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\downloads\tools\cmake-3.25.1-windows\cmake-3.25.1-windows-i386\bin\cmake.exe -DALL_SQL_IN=D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/all.sql.in -DEXE_SQLITE3=D:/Users/rcoup/kart/build/vcpkg_installed/x64-windows/tools/sqlite3.exe -DPROJ_DB=D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/proj.db -DPROJ_VERSION=9.2.0 -P D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/src/9.2.0-07ca3b7ec6.clean/data/generate_proj_db.cmake && D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\downloads\tools\cmake-3.25.1-windows\cmake-3.25.1-windows-i386\bin\cmake.exe -E copy D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/proj.db D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/for_tests"
FAILED: data/proj.db D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/proj.db 
cmd.exe /C "cd /D D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\data && D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\downloads\tools\cmake-3.25.1-windows\cmake-3.25.1-windows-i386\bin\cmake.exe -E remove -f D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/proj.db && D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\downloads\tools\cmake-3.25.1-windows\cmake-3.25.1-windows-i386\bin\cmake.exe -DALL_SQL_IN=D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/all.sql.in -DEXE_SQLITE3=D:/Users/rcoup/kart/build/vcpkg_installed/x64-windows/tools/sqlite3.exe -DPROJ_DB=D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/proj.db -DPROJ_VERSION=9.2.0 -P D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/src/9.2.0-07ca3b7ec6.clean/data/generate_proj_db.cmake && D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\downloads\tools\cmake-3.25.1-windows\cmake-3.25.1-windows-i386\bin\cmake.exe -E copy D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/proj.db D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/buildtrees/proj/x64-windows-rel/data/for_tests"
CMake Error at generate_proj_db.cmake:22 (message):
  SQLite3 failed


[10/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\dmstor.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\dmstor.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[11/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\ell_set.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\ell_set.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[12/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\fwd.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\fwd.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[13/241] C:\PROGRA~2\MICROS~1\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DCURL_ENABLED -DEXTERNAL_NLOHMANN_JSON -DNOMINMAX -DPROJ_DATA=\"D:/Users/rcoup/kart/vcpkg-vendor/vcpkg/packages/proj_x64-windows/share/proj\" -DPROJ_MSVC_DLL_EXPORT=1 -DTIFF_ENABLED -D_CRT_SECURE_NO_WARNINGS -Dproj_EXPORTS -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\include -ID:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\x64-windows-rel\src -external:ID:\Users\rcoup\kart\build\vcpkg_installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /MD /O2 /Oi /Gy /DNDEBUG /Z7  /EHsc /W4 /wd4706 /wd4996 /showIncludes /Fosrc\CMakeFiles\proj.dir\ctx.cpp.obj /Fdsrc\CMakeFiles\proj.dir\ /FS -c D:\Users\rcoup\kart\vcpkg-vendor\vcpkg\buildtrees\proj\src\9.2.0-07ca3b7ec6.clean\src\ctx.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
ninja: build stopped: subcommand failed.
```
</details>

**Additional context**

<details><summary>vcpkg.json</summary>

```
{
  "name": "kart-vendor",
  "version-string": "0.1.2",
  "builtin-baseline": "dcf61b206c60b08940192220d38394b1a5029598",
  "dependencies": [
    {
      "name": "sqlite3",
      "features": [
        "json1",
        "rtree",
        "tool",
        "zlib"
      ]
    },
    {
      "name": "libpq",
      "features": [
        "client"
      ]
    },
    {
      "name": "libgit2"
    },
    {
      "name": "unixodbc",
      "platform": "!windows"
    },
    {
      "name": "curl",
      "default-features": false,
      "features": [
        "ssl",
        "http2"
      ]
    },
    {
      "name": "proj",
      "features": [
        "tools"
      ]
    },
    {
      "name": "gdal",
      "default-features": false,
      "version>=": "3.5.1",
      "features": [
        "recommended-features",
        "tools",
        "postgresql",
        "geos",
        "curl"
      ]
    },
    {
      "name": "pdal",
      "default-features": false
    },
    {
      "name": "libspatialite",
      "default-features": false
    },
    {
      "name": "pcre2"
    },
    {
      "name": "openssl"
    },
    {
      "name": "libffi"
    },
    {
      "name": "python3",
      "platform": "linux"
    }
  ]
}

```
</details>


Some spelunking reveals:
- running that command from the MSVC command prompt works fine
- it doesn't work under cmake+vcpkg, with an exit code of `0xc0000135` (`STATUS_DLL_NOT_FOUND`)
- examining the `${CURRENT_HOST_INSTALLED_DIR}/tools/sqlite3.exe` binary shows it loads `zlib1.dll`
- which should be found from `${CURRENT_HOST_INSTALLED_DIR}/bin/`
