### PR TITLE
Capstone remove non functional features

### DIFF
--- a/ports/capstone/portfile.cmake
+++ b/ports/capstone/portfile.cmake
@@ -18,20 +18,14 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "m680x"       CAPSTONE_M680X_SUPPORT
         "m68k"        CAPSTONE_M68K_SUPPORT
         "mips"        CAPSTONE_MIPS_SUPPORT
-        "osxkernel"   CAPSTONE_OSXKERNEL_SUPPORT
         "ppc"         CAPSTONE_PPC_SUPPORT
         "sparc"       CAPSTONE_SPARC_SUPPORT
         "sysz"        CAPSTONE_SYSZ_SUPPORT
         "tms320c64x"  CAPSTONE_TMS320C64X_SUPPORT
         "x86"         CAPSTONE_X86_SUPPORT
-        "x86-reduce"  CAPSTONE_X86_REDUCE
         "xcore"       CAPSTONE_XCORE_SUPPORT
         "diet"        CAPSTONE_BUILD_DIET
 )
-
-if ("osxkernel" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_OSX)
-    message(FATAL_ERROR "Feature 'osxkernel' only supported in OSX")
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/capstone/vcpkg.json
+++ b/ports/capstone/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "capstone",
   "version": "5.0.0-rc2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Multi-architecture disassembly framework",
   "homepage": "https://github.com/capstone-engine/capstone",
   "dependencies": [
@@ -36,9 +36,6 @@
     "mips": {
       "description": "Capstone disassembly support for MIPS"
     },
-    "osxkernel": {
-      "description": "Support for embedding Capstone into OSX Kernel extensions"
-    },
     "ppc": {
       "description": "Capstone disassembly support for PowerPC"
     },
@@ -53,17 +50,6 @@
     },
     "x86": {
       "description": "Capstone disassembly support for x86"
-    },
-    "x86-reduce": {
-      "description": "Capstone disassembly support for x86 without support for less used instructions",
-      "dependencies": [
-        {
-          "name": "capstone",
-          "features": [
-            "x86"
-          ]
-        }
-      ]
     },
     "xcore": {
       "description": "Capstone disassembly support for XCore"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1366,7 +1366,7 @@
     },
     "capstone": {
       "baseline": "5.0.0-rc2",
-      "port-version": 1
+      "port-version": 2
     },
     "cargs": {
       "baseline": "1.0.3",

--- a/versions/c-/capstone.json
+++ b/versions/c-/capstone.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c9184889dd21d609401fe4ea34fa5320a9443a2",
+      "version": "5.0.0-rc2",
+      "port-version": 2
+    },
+    {
       "git-tree": "f31ba3baba34c74dea464d864cca666c8793b1e7",
       "version": "5.0.0-rc2",
       "port-version": 1


### PR DESCRIPTION
The `osxkernel` feature was non functional from the beginning and `x86-reduce` is not additive and also broken: https://github.com/capstone-engine/capstone/issues/1955 