### PR TITLE
[opencv4] fix webp include dir

### DIFF
--- a/ports/opencv4/0003-force-package-requirements.patch
+++ b/ports/opencv4/0003-force-package-requirements.patch
@@ -81,3 +81,16 @@
    if(NOT GDCM_FOUND)
      set(HAVE_GDCM NO)
      ocv_clear_vars(GDCM_VERSION GDCM_LIBRARIES)
+diff --git a/modules/imgcodecs/CMakeLists.txt b/modules/imgcodecs/CMakeLists.txt
+index 213667a..4052387 100644
+--- a/modules/imgcodecs/CMakeLists.txt
++++ b/modules/imgcodecs/CMakeLists.txt
+@@ -24,7 +24,7 @@ endif()
+ 
+ if(HAVE_WEBP)
+   add_definitions(-DHAVE_WEBP)
+-  ocv_include_directories(${WEBP_INCLUDE_DIR})
++  ocv_include_directories(${WEBP_INCLUDE_DIRS})
+   list(APPEND GRFMT_LIBS ${WEBP_LIBRARIES})
+ endif()
+ 

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.7.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5802,7 +5802,7 @@
     },
     "opencv4": {
       "baseline": "4.7.0",
-      "port-version": 5
+      "port-version": 6
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d435a87c7a3f4dd38d623503d5200abe65c249d1",
+      "version": "4.7.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "0c3c175e672cc3a6f0d1465adba8a40a042ff717",
       "version": "4.7.0",
       "port-version": 5


### PR DESCRIPTION
Fixes
```
[287/422] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DHAVE_IMGCODEC_HDR -DHAVE_IMGCODEC_PFM -DHAVE_IMGCODEC_PXM -DHAVE_IMGCODEC_SUNRASTER -DHAVE_WEBP -D_USE_MATH_DEFINES -D__OPENCV_BUILD=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/src/4.7.0-34a2240496.clean/modules/imgcodecs/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/arm64-osx-dbg/modules/imgcodecs -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/src/4.7.0-34a2240496.clean/modules/core/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/src/4.7.0-34a2240496.clean/modules/imgproc/include -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/arm64-osx-dbg -fPIC   -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wno-delete-non-virtual-dtor -Wno-unnamed-type-template-args -Wno-comment -fdiagnostics-show-option -Qunused-arguments -Wno-semicolon-before-method-body -ffunction-sections -fdata-sections    -fvisibility=hidden -fvisibility-inlines-hidden -Wno-deprecated-declarations -g  -O0 -DDEBUG -D_DEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -std=c++11 -MD -MT modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o -MF modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o.d -o modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/src/4.7.0-34a2240496.clean/modules/imgcodecs/src/grfmt_webp.cpp
FAILED: modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DHAVE_IMGCODEC_HDR -DHAVE_IMGCODEC_PFM -DHAVE_IMGCODEC_PXM -DHAVE_IMGCODEC_SUNRASTER -DHAVE_WEBP -D_USE_MATH_DEFINES -D__OPENCV_BUILD=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/src/4.7.0-34a2240496.clean/modules/imgcodecs/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/arm64-osx-dbg/modules/imgcodecs -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/src/4.7.0-34a2240496.clean/modules/core/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/src/4.7.0-34a2240496.clean/modules/imgproc/include -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/arm64-osx-dbg -fPIC   -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wno-delete-non-virtual-dtor -Wno-unnamed-type-template-args -Wno-comment -fdiagnostics-show-option -Qunused-arguments -Wno-semicolon-before-method-body -ffunction-sections -fdata-sections    -fvisibility=hidden -fvisibility-inlines-hidden -Wno-deprecated-declarations -g  -O0 -DDEBUG -D_DEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -std=c++11 -MD -MT modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o -MF modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o.d -o modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/src/4.7.0-34a2240496.clean/modules/imgcodecs/src/grfmt_webp.cpp
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv4/src/4.7.0-34a2240496.clean/modules/imgcodecs/src/grfmt_webp.cpp:47:10: fatal error: 'webp/decode.h' file not found
#include <webp/decode.h>
         ^~~~~~~~~~~~~~~
1 error generated.
```