### PR TITLE
[gtk3] Update

### DIFF
--- a/ports/gtk3/0001-build.patch
+++ b/ports/gtk3/0001-build.patch
@@ -8,6 +8,6 @@ index c599843..0cafd79 100644
  
 -if not meson.is_cross_build()
 +if false
-   if meson.version().version_compare('>=0.57.0')
-     gnome.post_install(
-       glib_compile_schemas: true,
+   gnome.post_install(
+     glib_compile_schemas: true,
+     gio_querymodules: gio_module_dirs,

--- a/ports/gtk3/cairo-cpp-linkage.patch
+++ b/ports/gtk3/cairo-cpp-linkage.patch
@@ -55,8 +55,8 @@ index 287f0cb..d35106f 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1,4 +1,4 @@
--project('gtk+-3.0', 'c',
-+project('gtk+-3.0', 'c', 'cpp',
-         version: '3.24.34',
-         default_options: [
-           'buildtype=debugoptimized',
+-project('gtk+', 'c',
++project('gtk+', 'c', 'cpp',
+   version: '3.24.36',
+   default_options: [
+     'buildtype=debugoptimized',

--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gtk3",
-  "version": "3.24.34",
-  "port-version": 2,
+  "version": "3.24.36",
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,
@@ -55,6 +54,7 @@
   "features": {
     "introspection": {
       "description": "build with introspection",
+      "supports": "!windows | !static",
       "dependencies": [
         {
           "name": "atk",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2969,8 +2969,8 @@
       "port-version": 0
     },
     "gtk3": {
-      "baseline": "3.24.34",
-      "port-version": 2
+      "baseline": "3.24.36",
+      "port-version": 0
     },
     "gtkmm": {
       "baseline": "4.6.0",

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93a006967f4d1c6e3ce8409cd1a134f81c2b1288",
+      "version": "3.24.36",
+      "port-version": 0
+    },
+    {
       "git-tree": "0c25a1f1fc2d3f166ea007a97b845fb85769588e",
       "version": "3.24.34",
       "port-version": 2


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
