### PR TITLE
[vcpkg baseline][qtspeech] Fix target scope promotion

### DIFF
--- a/ports/qtspeech/portfile.cmake
+++ b/ports/qtspeech/portfile.cmake
@@ -22,6 +22,7 @@ qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
                      TOOL_NAMES ${TOOL_NAMES}
                      CONFIGURE_OPTIONS
                         ${FEATURE_OPTIONS}
+                        -DCMAKE_FIND_PACKAGE_TARGETS_GLOBAL=ON
                      CONFIGURE_OPTIONS_MAYBE_UNUSED
                          QT_BUILD_EXAMPLES
                          QT_USE_DEFAULT_CMAKE_OPTIMIZATION_FLAGS

--- a/ports/qtspeech/vcpkg.json
+++ b/ports/qtspeech/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtspeech",
   "version": "6.4.3",
+  "port-version": 1,
   "description": "Qt Speech support",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6738,7 +6738,7 @@
     },
     "qtspeech": {
       "baseline": "6.4.3",
-      "port-version": 0
+      "port-version": 1
     },
     "qtsvg": {
       "baseline": "6.4.3",

--- a/versions/q-/qtspeech.json
+++ b/versions/q-/qtspeech.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e3478f6de5a8d655c7d97e40b158bc7dfdfa39c",
+      "version": "6.4.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "93a6cd65b0db0994bbedef360adbe246b5df6d91",
       "version": "6.4.3",
       "port-version": 0


### PR DESCRIPTION
E.g. for 
#31031 https://dev.azure.com/vcpkg/public/_build/results?buildId=88538&view=results 
#31034 https://dev.azure.com/vcpkg/public/_build/results?buildId=88531&view=results

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
