### PR TITLE
[opencv3] fix webp include dir

### DIFF
--- a/ports/opencv3/0003-force-package-requirements.patch
+++ b/ports/opencv3/0003-force-package-requirements.patch
@@ -72,3 +72,16 @@
    if(NOT GDCM_FOUND)
      set(HAVE_GDCM NO)
      ocv_clear_vars(GDCM_VERSION GDCM_LIBRARIES)
+diff --git a/modules/imgcodecs/CMakeLists.txt b/modules/imgcodecs/CMakeLists.txt
+index 213667a..4052387 100644
+--- a/modules/imgcodecs/CMakeLists.txt
++++ b/modules/imgcodecs/CMakeLists.txt
+@@ -24,7 +24,7 @@ endif()
+
+ if(HAVE_WEBP)
+   add_definitions(-DHAVE_WEBP)
+-  ocv_include_directories(${WEBP_INCLUDE_DIR})
++  ocv_include_directories(${WEBP_INCLUDE_DIRS})
+   list(APPEND GRFMT_LIBS ${WEBP_LIBRARIES})
+ endif()
+

--- a/ports/opencv3/vcpkg.json
+++ b/ports/opencv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv3",
   "version": "3.4.18",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",
@@ -229,6 +229,13 @@
     "python": {
       "description": "Python wrapper support for opencv",
       "dependencies": [
+        {
+          "name": "opencv3",
+          "default-features": false,
+          "features": [
+            "flann"
+          ]
+        },
         "python3"
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5798,7 +5798,7 @@
     },
     "opencv3": {
       "baseline": "3.4.18",
-      "port-version": 8
+      "port-version": 9
     },
     "opencv4": {
       "baseline": "4.7.0",

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "402e9aac0f32db08e2d69f70ba6384f8c7bf4733",
+      "version": "3.4.18",
+      "port-version": 9
+    },
+    {
       "git-tree": "e026bd638aec52f279cbf10d7e75a0f6ca03feb6",
       "version": "3.4.18",
       "port-version": 8


### PR DESCRIPTION
Fixes 
```
[236/382] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DHAVE_IMGCODEC_HDR -DHAVE_IMGCODEC_PXM -DHAVE_IMGCODEC_SUNRASTER -DHAVE_WEBP -D_USE_MATH_DEFINES -D__OPENCV_BUILD=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgcodecs/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg/modules/imgcodecs -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/core/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgproc/include -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg -fPIC   -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wno-delete-non-virtual-dtor -Wno-unnamed-type-template-args -Wno-comment -fdiagnostics-show-option -Qunused-arguments -Wno-semicolon-before-method-body -ffunction-sections -fdata-sections    -fvisibility=hidden -fvisibility-inlines-hidden -Wno-deprecated-declarations -g  -O0 -DDEBUG -D_DEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -std=c++11 -MD -MT modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o -MF modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o.d -o modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgcodecs/src/grfmt_webp.cpp
FAILED: modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DHAVE_IMGCODEC_HDR -DHAVE_IMGCODEC_PXM -DHAVE_IMGCODEC_SUNRASTER -DHAVE_WEBP -D_USE_MATH_DEFINES -D__OPENCV_BUILD=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgcodecs/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg/modules/imgcodecs -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/core/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgproc/include -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg -fPIC   -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wno-delete-non-virtual-dtor -Wno-unnamed-type-template-args -Wno-comment -fdiagnostics-show-option -Qunused-arguments -Wno-semicolon-before-method-body -ffunction-sections -fdata-sections    -fvisibility=hidden -fvisibility-inlines-hidden -Wno-deprecated-declarations -g  -O0 -DDEBUG -D_DEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -std=c++11 -MD -MT modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o -MF modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o.d -o modules/imgcodecs/CMakeFiles/opencv_imgcodecs.dir/src/grfmt_webp.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgcodecs/src/grfmt_webp.cpp
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgcodecs/src/grfmt_webp.cpp:47:10: fatal error: 'webp/decode.h' file not found
#include <webp/decode.h>
         ^~~~~~~~~~~~~~~
1 error generated.
```

Now also fixes the `opencv3[core,python]` build that failed with 
```
[383/385] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -D_USE_MATH_DEFINES -D__OPENCV_BUILD=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Dopencv_python3_EXPORTS -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/python/python3/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg/modules/python3 -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/core/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgproc/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/ml/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/photo/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/video/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/features2d/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgcodecs/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/shape/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/videoio/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/calib3d/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/highgui/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/objdetect/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/superres/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/videostab/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/python/src2 -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg/modules/python_bindings_generator -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg -isystem /opt/homebrew/Frameworks/Python.framework/Versions/3.11/include/python3.11 -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-venv/lib/python3.11/site-packages/numpy/core/include -fPIC   -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wno-delete-non-virtual-dtor -Wno-unnamed-type-template-args -Wno-comment -fdiagnostics-show-option -Qunused-arguments -Wno-semicolon-before-method-body -ffunction-sections -fdata-sections    -fvisibility=hidden -fvisibility-inlines-hidden -Wno-unused-function -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-unused-private-field -Wno-undef -g  -O0 -DDEBUG -D_DEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -std=c++11 -MD -MT modules/python3/CMakeFiles/opencv_python3.dir/__/src2/cv2.cpp.o -MF modules/python3/CMakeFiles/opencv_python3.dir/__/src2/cv2.cpp.o.d -o modules/python3/CMakeFiles/opencv_python3.dir/__/src2/cv2.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/python/src2/cv2.cpp
FAILED: modules/python3/CMakeFiles/opencv_python3.dir/__/src2/cv2.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -D_USE_MATH_DEFINES -D__OPENCV_BUILD=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Dopencv_python3_EXPORTS -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/python/python3/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg/modules/python3 -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/core/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgproc/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/ml/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/photo/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/video/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/features2d/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/imgcodecs/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/shape/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/videoio/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/calib3d/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/highgui/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/objdetect/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/superres/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/videostab/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/python/src2 -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg/modules/python_bindings_generator -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg -isystem /opt/homebrew/Frameworks/Python.framework/Versions/3.11/include/python3.11 -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-venv/lib/python3.11/site-packages/numpy/core/include -fPIC   -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wno-delete-non-virtual-dtor -Wno-unnamed-type-template-args -Wno-comment -fdiagnostics-show-option -Qunused-arguments -Wno-semicolon-before-method-body -ffunction-sections -fdata-sections    -fvisibility=hidden -fvisibility-inlines-hidden -Wno-unused-function -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-unused-private-field -Wno-undef -g  -O0 -DDEBUG -D_DEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -std=c++11 -MD -MT modules/python3/CMakeFiles/opencv_python3.dir/__/src2/cv2.cpp.o -MF modules/python3/CMakeFiles/opencv_python3.dir/__/src2/cv2.cpp.o.d -o modules/python3/CMakeFiles/opencv_python3.dir/__/src2/cv2.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/python/src2/cv2.cpp
In file included from /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/src/3.4.18-b77de20add.clean/modules/python/src2/cv2.cpp:2073:
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opencv3/arm64-osx-dbg/modules/python_bindings_generator/pyopencv_generated_types.h:69:57: error: no member named 'FlannBasedMatcher' in namespace 'cv'
CVPY_TYPE(FlannBasedMatcher, FlannBasedMatcher, Ptr<cv::FlannBasedMatcher>, Ptr, DescriptorMatcher, pyopencv_cv_FlannBasedMatcher_FlannBasedMatcher, "");
                                                    ~~~~^
```
