### PR TITLE
[miniply] fix shared folder name

### DIFF
--- a/ports/miniply/portfile.cmake
+++ b/ports/miniply/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/unofficial-miniply)
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-miniply)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/miniply/vcpkg.json
+++ b/ports/miniply/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "miniply",
   "version-date": "2022-09-15",
+  "port-version": 1,
   "description": "A fast and easy-to-use PLY parsing library in a single c++11 header and cpp file",
   "homepage": "https://github.com/vilya/miniply",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5178,7 +5178,7 @@
     },
     "miniply": {
       "baseline": "2022-09-15",
-      "port-version": 0
+      "port-version": 1
     },
     "minisat-master-keying": {
       "baseline": "2.3.6",

--- a/versions/m-/miniply.json
+++ b/versions/m-/miniply.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20ddfb09455e95fa20fcebc8d9e0d99409526a35",
+      "version-date": "2022-09-15",
+      "port-version": 1
+    },
+    {
       "git-tree": "648516b62e07a6e5c6387f110f9f4bce0d6c67e9",
       "version-date": "2022-09-15",
       "port-version": 0


### PR DESCRIPTION
Fixes miniply integration, `vcpkg_cmake_config_fixup` was set to copy the cmake files inside share/miniply instead of share/unofficial-miniply