### PR TITLE
[argon2] Major overhaul

### DIFF
--- a/ports/argon2/CMakeLists.txt
+++ b/ports/argon2/CMakeLists.txt
@@ -1,14 +1,14 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25)
 
-project(argon2)
+project(argon2 LANGUAGES C)
 
-set(ARGON2_VERSION 20190702)
+option(WITH_OPTIMIZATIONS "Enable SSE2/AVX2/AVX512 optimizations")
+option(BUILD_TOOL "Build the tool" OFF)
 
-option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
-
-if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang")
- OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+if(BUILD_SHARED_LIBS)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+    endif()
 endif()
 
 find_package(Threads REQUIRED)
@@ -18,66 +18,58 @@ set(ARGON2_HEADERS
 )
 
 set (ARGON2_SRC
-    "src/argon2.c"
-    "src/core.c"
-    "src/blake2/blake2b.c"
-    "src/thread.c"
-    "src/encoding.c"
+    src/argon2.c
+    src/core.c
+    src/blake2/blake2b.c
+    src/thread.c
+    src/encoding.c
 )
-
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-
-message(STATUS "Checking support for hardware optimization:")
-try_compile(WITH_OPTIMIZATIONS
-    ${CMAKE_CURRENT_BINARY_DIR}/optimization
-    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/opt.c
-    CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_CURRENT_SOURCE_DIR}/include
-    OUTPUT_VARIABLE OUTPUT_TEST_SUPPORT_OPTIMIZATION)
-
-message(STATUS "Build with hardware optimization? ${WITH_OPTIMIZATIONS}")
-
 if (WITH_OPTIMIZATIONS)
-    list(APPEND ARGON2_SRC "src/opt.c")
+    list(APPEND ARGON2_SRC src/opt.c)
 else()
-    list(APPEND ARGON2_SRC "src/ref.c")
+    list(APPEND ARGON2_SRC src/ref.c)
 endif()
 
 add_library(libargon2 ${ARGON2_SRC})
-target_include_directories(libargon2 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE src)
-target_link_libraries(libargon2 Threads::Threads)
-target_compile_definitions(libargon2 PUBLIC "A2_VISCTL")
 set_target_properties(libargon2 PROPERTIES OUTPUT_NAME argon2)
+target_include_directories(libargon2 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> PRIVATE src)
+target_link_libraries(libargon2 PRIVATE Threads::Threads)
+if(BUILD_SHARED_LIBS)
+    if(WIN32)
+        target_compile_definitions(libargon2 PRIVATE "BUILDING_ARGON2_DLL" INTERFACE "USING_ARGON2_DLL")
+    else()
+        target_compile_definitions(libargon2 PRIVATE "A2_VISCTL")
+    endif()
+endif()
 
-add_executable(argon2_tool ${ARGON2_SRC} src/run.c)
-target_include_directories(argon2_tool PRIVATE include src)
-target_compile_definitions(argon2_tool PUBLIC "A2_VISCTL")
-target_link_libraries(argon2_tool Threads::Threads)
+install(TARGETS libargon2
+    EXPORT unofficial-argon2-targets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+if(BUILD_TOOL)
+    add_executable(argon2 src/run.c)
+    target_link_libraries(argon2 PRIVATE libargon2)
+    set_target_properties(argon2 PROPERTIES PDB_NAME "argon2${CMAKE_EXECUTABLE_SUFFIX}.pdb")
+
+    install(TARGETS argon2 RUNTIME DESTINATION bin)
+endif()
 
 install(FILES ${ARGON2_HEADERS} DESTINATION include)
 
-set(PREFIX ${CMAKE_INSTALL_PREFIX})
-set(UPSTREAM_VER 20190702)
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set(EXTRA_LIBS "-lrt -ldl")
-endif ()
-
-configure_file ("${CMAKE_SOURCE_DIR}/libargon2.pc.in" "${PROJECT_BINARY_DIR}/libargon2.pc" @ONLY)
-install (FILES "${CMAKE_CURRENT_BINARY_DIR}/libargon2.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
-
-install(TARGETS libargon2
-    EXPORT unofficial-libargon2
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-)
-
-install(EXPORT unofficial-libargon2
+install(EXPORT unofficial-argon2-targets
   NAMESPACE unofficial::argon2::
-  DESTINATION "share/unofficial-libargon2"
+  DESTINATION "share/unofficial-argon2"
 )
 
-install(TARGETS argon2_tool
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-)
+function(make_pc_file)
+    set(PREFIX "${CMAKE_INSTALL_PREFIX}")
+    set(INCLUDE "include")
+    set(HOST_MULTIARCH "lib")
+    set(EXTRA_LIBS "")
+    configure_file ("${CMAKE_SOURCE_DIR}/libargon2.pc.in" "${PROJECT_BINARY_DIR}/libargon2.pc" @ONLY)
+endfunction()
+make_pc_file()
+install (FILES "${CMAKE_CURRENT_BINARY_DIR}/libargon2.pc" DESTINATION "lib/pkgconfig")

--- a/ports/argon2/unofficial-argon2-config.cmake
+++ b/ports/argon2/unofficial-argon2-config.cmake
@@ -1,0 +1,4 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-argon2-targets.cmake")

--- a/ports/argon2/unofficial-libargon2-config.cmake
+++ b/ports/argon2/unofficial-libargon2-config.cmake
@@ -1,6 +1,4 @@
-if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static" AND NOT WIN32)
-    include(CMakeFindDependencyMacro)
-    find_dependency(Threads)
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/unofficial-libargon2.cmake")
+file(READ "${CMAKE_CURRENT_LIST_DIR}/../argon2/usage" usage)
+message(WARNING "find_package(unofficial-libargon2) is deprecated.\n${usage}")
+include(CMakeFindDependencyMacro)
+find_dependency(unofficial-argon2 CONFIG)

--- a/ports/argon2/usage
+++ b/ports/argon2/usage
@@ -1,0 +1,4 @@
+argon2 provides CMake targets:
+
+    find_package(unofficial-argon2 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::argon2::libargon2)

--- a/ports/argon2/vcpkg.json
+++ b/ports/argon2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "argon2",
   "version": "20190702",
+  "port-version": 1,
   "description": "Password-hashing library.",
   "homepage": "https://github.com/P-H-C/phc-winner-argon2",
   "license": "Apache-2.0 OR CC0-1.0",
@@ -16,7 +17,11 @@
   ],
   "features": {
     "hwopt": {
-      "description": "Enable SSE2/AVX2/AVX512 optimizations if supported on architecture"
+      "description": "Enable SSE2/AVX2/AVX512 optimizations",
+      "supports": "x86 | x64"
+    },
+    "tool": {
+      "description": "Install the argon2 tool"
     }
   }
 }

--- a/ports/argon2/visibility-for-tool.patch
+++ b/ports/argon2/visibility-for-tool.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core.h b/src/core.h
+index 78000ba..91c7bcf 100644
+--- a/src/core.h
++++ b/src/core.h
+@@ -135,7 +135,7 @@ void secure_wipe_memory(void *v, size_t n);
+  * @param mem Pointer to the memory
+  * @param s Memory size in bytes
+  */
+-void clear_internal_memory(void *v, size_t n);
++ARGON2_PUBLIC void clear_internal_memory(void *v, size_t n);
+ 
+ /*
+  * Computes absolute position of reference block in the lane following a skewed

--- a/ports/argon2/visibility.patch
+++ b/ports/argon2/visibility.patch
@@ -1,46 +1,16 @@
-Fix symbol visibility across build triplets.
-Submitted upstream in https://github.com/P-H-C/phc-winner-argon2/pull/262
-
-
 diff --git a/include/argon2.h b/include/argon2.h
-index 3980bb3..2738960 100644
+index fc8682c..1401051 100644
 --- a/include/argon2.h
 +++ b/include/argon2.h
-@@ -27,15 +27,29 @@ extern "C" {
- #endif
- 
- /* Symbols visibility control */
--#ifdef A2_VISCTL
--#define ARGON2_PUBLIC __attribute__((visibility("default")))
--#define ARGON2_LOCAL __attribute__ ((visibility ("hidden")))
+@@ -30,7 +30,10 @@ extern "C" {
+ #ifdef A2_VISCTL
+ #define ARGON2_PUBLIC __attribute__((visibility("default")))
+ #define ARGON2_LOCAL __attribute__ ((visibility ("hidden")))
 -#elif _MSC_VER
--#define ARGON2_PUBLIC __declspec(dllexport)
--#define ARGON2_LOCAL
-+#if defined(_WIN32)
-+  #if defined(A2_VISCTL)
-+    #if defined(_MSC_VER) || defined(__MINGW32__)
-+      #define ARGON2_PUBLIC __declspec(dllexport)
-+    #else
-+      #define ARGON2_PUBLIC __attribute__ ((dllexport))
-+    #endif
-+  #else
-+    #if defined(_MSC_VER) || defined(__MINGW32__)
-+      #define ARGON2_PUBLIC __declspec(dllimport)
-+    #else
-+      #define ARGON2_PUBLIC /*__attribute__ ((dllimport))*/
-+    #endif
-+  #endif
-+  #define ARGON2_LOCAL
++#elif defined(_WIN32) && defined(USING_ARGON2_DLL)
++#define ARGON2_PUBLIC __declspec(dllimport)
++#define ARGON2_LOCAL
++#elif defined(_WIN32) && defined(BUILDING_ARGON2_DLL)
+ #define ARGON2_PUBLIC __declspec(dllexport)
+ #define ARGON2_LOCAL
  #else
--#define ARGON2_PUBLIC
--#define ARGON2_LOCAL
-+  #if defined(A2_VISCTL)
-+    #define ARGON2_PUBLIC __attribute__ ((visibility ("default")))
-+    #define ARGON2_LOCAL  __attribute__ ((visibility ("hidden")))
-+  #else
-+    #define ARGON2_PUBLIC
-+    #define ARGON2_LOCAL
-+  #endif
- #endif
- 
- /*

--- a/versions/a-/argon2.json
+++ b/versions/a-/argon2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08a4ee53f1f5330c8f911dff530810c762551675",
+      "version": "20190702",
+      "port-version": 1
+    },
+    {
       "git-tree": "3a15f9b44e7ae1ef03f6f92a5552bc85951fd3a1",
       "version": "20190702",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -178,7 +178,7 @@
     },
     "argon2": {
       "baseline": "20190702",
-      "port-version": 0
+      "port-version": 1
     },
     "argparse": {
       "baseline": "2.9",


### PR DESCRIPTION
- Cleanup
- Omits visibility modifiers from static builds.
- Fixes installed pkgconfig files (lib dir, include dir)
- Moves the exported config to package `unofficial-argon2`, matching port name and namespace `unofficial::argon2::`. (Migration polyfill provided.)
- Adds `supports`  and an actual effect to the `hwopt` feature.
- Adds a feature `tool`.
- Disables building the tool for the debug config.
- Build tested with static and dynamic triplets for x64 linux and mingw on linux host.

CC @hmoffatt (https://github.com/microsoft/vcpkg/pull/24747).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
