### PR TITLE
[orocos-kdl] update to v1.5.1

### DIFF
--- a/ports/orocos-kdl/portfile.cmake
+++ b/ports/orocos-kdl/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orocos/orocos_kinematics_dynamics
-    REF v1.4.0
-    SHA512 7156465e2aff02f472933617512069355836a03a02d4587cfe03c1b1d667a9762a4e3ed6e055b2a44f1fce1b6746179203c7204389626a7b458dcab1b28930d8
+    REF "v${VERSION}"
+    SHA512 9774b76b755ea81168390643813789783f60d0b1cdb46cd250e3e0d27f75a6cf2fd3bfd2081c04e30a14ff4fc70d0080c9b43b82ee181c2dda82f23f052b338d
     HEAD_REF master
     PATCHES export-include-dir.patch
 )

--- a/ports/orocos-kdl/vcpkg.json
+++ b/ports/orocos-kdl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "orocos-kdl",
-  "version": "1.4",
-  "port-version": 6,
+  "version": "1.5.1",
   "description": "Kinematics and Dynamics Library.",
   "homepage": "https://github.com/orocos/orocos_kinematics_dynamics",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5953,8 +5953,8 @@
       "port-version": 0
     },
     "orocos-kdl": {
-      "baseline": "1.4",
-      "port-version": 6
+      "baseline": "1.5.1",
+      "port-version": 0
     },
     "osg": {
       "baseline": "3.6.5",

--- a/versions/o-/orocos-kdl.json
+++ b/versions/o-/orocos-kdl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "409939e301654f22afd5c71f3bbd8edb88cefc3d",
+      "version": "1.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c2ee586866fcf7a9f3c3930bd1af16763047aa4",
       "version": "1.4",
       "port-version": 6

--- a/versions/o-/orocos-kdl.json
+++ b/versions/o-/orocos-kdl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "409939e301654f22afd5c71f3bbd8edb88cefc3d",
+      "git-tree": "e9fdf57afeb547c9e5fdad47dff693fe8f96f4b5",
       "version": "1.5.1",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #31067

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
 - [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
