### PR TITLE
[ngtcp2] Update, fix config, cleanup

### DIFF
--- a/ports/ngtcp2/export-unofficical-target.patch
+++ b/ports/ngtcp2/export-unofficical-target.patch
@@ -1,49 +1,43 @@
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index d98747f..2bc20d0 100644
+index f822c8e..591a588 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
-@@ -80,12 +80,15 @@ if(ENABLE_SHARED_LIB)
-     C_VISIBILITY_PRESET hidden
-     POSITION_INDEPENDENT_CODE ON
-   )
--  target_include_directories(ngtcp2 PUBLIC ${ngtcp2_INCLUDE_DIRS})
--
--  install(TARGETS ngtcp2
-+  target_include_directories(ngtcp2 PRIVATE ${ngtcp2_INCLUDE_DIRS})
-+  install(TARGETS ngtcp2 EXPORT unofficial-ngtcp2-config
+@@ -69,8 +69,9 @@ set(ngtcp2_SOURCES
+ )
+ 
+ set(ngtcp2_INCLUDE_DIRS
+-  "${CMAKE_CURRENT_SOURCE_DIR}/includes"
+-  "${CMAKE_CURRENT_BINARY_DIR}/includes"
++  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includes>"
++  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/includes>"
++  "$<INSTALL_INTERFACE:include>"
+ )
+ 
+ # Public shared library
+@@ -85,6 +86,7 @@ if(ENABLE_SHARED_LIB)
+   target_include_directories(ngtcp2 PUBLIC ${ngtcp2_INCLUDE_DIRS})
+ 
+   install(TARGETS ngtcp2
++    EXPORT unofficial-ngtcp2-config
      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-+  install(
-+    EXPORT unofficial-ngtcp2-config
-+    NAMESPACE unofficial::ngtcp2::
-+    DESTINATION share/unofficial-ngtcp2)
- endif()
- 
- if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
-@@ -97,10 +100,14 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
-     C_VISIBILITY_PRESET hidden
-   )
+@@ -102,10 +104,18 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
    target_compile_definitions(ngtcp2_static PUBLIC "-DNGTCP2_STATICLIB")
--  target_include_directories(ngtcp2_static PUBLIC ${ngtcp2_INCLUDE_DIRS})
-+  target_include_directories(ngtcp2_static PRIVATE ${ngtcp2_INCLUDE_DIRS})
+   target_include_directories(ngtcp2_static PUBLIC ${ngtcp2_INCLUDE_DIRS})
    if(ENABLE_STATIC_LIB)
--    install(TARGETS ngtcp2_static
-+    install(TARGETS ngtcp2_static EXPORT unofficial-ngtcp2_static-config
++    add_library(ngtcp2 INTERFACE)
++    target_link_libraries(ngtcp2 INTERFACE ngtcp2_static)
+     install(TARGETS ngtcp2_static
++      ngtcp2
++      EXPORT unofficial-ngtcp2-config
        DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-+    install(
-+      EXPORT unofficial-ngtcp2_static-config
-+      NAMESPACE unofficial::ngtcp2_static::
-+      DESTINATION share/unofficial-ngtcp2)
    endif()
  endif()
++install(
++  EXPORT unofficial-ngtcp2-config
++  NAMESPACE unofficial::ngtcp2::
++  DESTINATION share/unofficial-ngtcp2)
  
-diff --git a/lib/includes/CMakeLists.txt b/lib/includes/CMakeLists.txt
-index 5eabf73..78bb715 100644
---- a/lib/includes/CMakeLists.txt
-+++ b/lib/includes/CMakeLists.txt
-@@ -1,3 +1,4 @@
-+configure_file("${CMAKE_CURRENT_LIST_DIR}/ngtcp2/version.h.in" "${CMAKE_CURRENT_BINARY_DIR}/ngtcp2/version.h")
- install(FILES
-     ngtcp2/ngtcp2.h
-     "${CMAKE_CURRENT_BINARY_DIR}/ngtcp2/version.h"
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libngtcp2.pc"
+   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ngtcp2/ngtcp2
     REF "v${VERSION}"
-    SHA512 6bfcae1d7c782931093541156ebd6e736843b5df13362aa5468daa72f74bad33d0f1aa2aafc6f4d138cdd34d6a367e2ff12efedfd6dfa5b8811e4cdebaca0016
+    SHA512 a942ea7789cc306e5a07aaf66bc1af4cb722c0facca7cb2de80e6fb8a30a88cd1beba50dd06164d9547a64d2273fe98d8bb22ab64323b1922002c45d5e714fc7
     HEAD_REF master
     PATCHES
       export-unofficical-target.patch
@@ -16,32 +16,21 @@ vcpkg_cmake_configure(
     OPTIONS
         "-DENABLE_STATIC_LIB=${ENABLE_STATIC_LIB}"
         "-DENABLE_SHARED_LIB=${ENABLE_SHARED_LIB}"
-        -DCMAKE_DISABLE_FIND_PACKAGE_GnuTLS=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_wolfssl=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_Jemalloc=ON
+        -DENABLE_OPENSSL=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_Libev=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Libnghttp3=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_CUnit=ON
-    MAYBE_UNUSED_VARIABLES
-        CMAKE_DISABLE_FIND_PACKAGE_GnuTLS
-        CMAKE_DISABLE_FIND_PACKAGE_Jemalloc
-        CMAKE_DISABLE_FIND_PACKAGE_wolfssl
+        -DCMAKE_INSTALL_DOCDIR=share/ngtcp2
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(CONFIG_PATH "share/unofficial-ngtcp2")
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-ngtcp2)
 
-# Clean
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/doc")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-
-#License
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/ngtcp2/usage
+++ b/ports/ngtcp2/usage
@@ -1,0 +1,4 @@
+ngtcp2 provides CMake targets:
+
+    find_package(unofficial-ngtcp2 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::ngtcp2::ngtcp2)

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ngtcp2",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5521,7 +5521,7 @@
       "port-version": 0
     },
     "ngtcp2": {
-      "baseline": "0.14.0",
+      "baseline": "0.14.1",
       "port-version": 0
     },
     "nifly": {

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae54f702f177016f67025862105af12921ccb325",
+      "version": "0.14.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2ed43a821081be8b08e5e93265f04def890da42f",
       "version": "0.14.0",
       "port-version": 0


### PR DESCRIPTION
Update to 0.14.1.
Install cmake config to a suitable directory. Export include dir. Uniform usage.
Cleanup.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
