### PR TITLE
[libgpiod] update version to 2.0.1

### DIFF
--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
-    HEAD_REF master
+    FETCH_REF master
     REF ae275c375477f207912113e5cf190fada78f3f90 # v2.0.1
 )
 

--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -1,6 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
+    HEAD_REF master
     REF ae275c375477f207912113e5cf190fada78f3f90 # v2.0.1
 )
 

--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
-    FETCH_REF master
+    FETCH_REF "v${VERSION}"
     REF ae275c375477f207912113e5cf190fada78f3f90 # v2.0.1
 )
 

--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -1,8 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
-    REF dfc5d361e6748d5f48b706e5c4ac949d133b5470 # v1.6.3
-    PATCHES
+    REF ae275c375477f207912113e5cf190fada78f3f90 # v2.0.1
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/libgpiod/vcpkg.json
+++ b/ports/libgpiod/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libgpiod",
-  "version": "1.6.3",
-  "port-version": 2,
+  "version": "2.0.1",
   "description": "C library and tools for interacting with the linux GPIO character device",
   "homepage": "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4025,8 +4025,8 @@
       "port-version": 0
     },
     "libgpiod": {
-      "baseline": "1.6.3",
-      "port-version": 2
+      "baseline": "2.0.1",
+      "port-version": 0
     },
     "libgpod": {
       "baseline": "2019-08-29",

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "508b9c094abecc766d9a10caa1bd3e34695db9b6",
+      "git-tree": "d5fde793827568c4be74cb76793650e37e3e5354",
       "version": "2.0.1",
       "port-version": 0
     },

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7160dbf1daa63e65d17a45b51f21d105c23168c1",
+      "git-tree": "508b9c094abecc766d9a10caa1bd3e34695db9b6",
       "version": "2.0.1",
       "port-version": 0
     },

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5623a0dbfe49badbe59f7a3bd54afb65030d19fd",
+      "git-tree": "7160dbf1daa63e65d17a45b51f21d105c23168c1",
       "version": "2.0.1",
       "port-version": 0
     },

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5623a0dbfe49badbe59f7a3bd54afb65030d19fd",
+      "version": "2.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "effc79de6dafb6ef6762bd2863a222c6090881e8",
       "version": "1.6.3",
       "port-version": 2


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


FYI, there are breaking API changes between those two versions, I am not sure it needs to be handled any differently.