### PR TITLE
[mygui] Fix feature tools build failed on macOS

### DIFF
--- a/ports/mygui/Install-tools.patch
+++ b/ports/mygui/Install-tools.patch
@@ -1,14 +1,16 @@
 diff --git a/CMake/Utils/MyGUIConfigTargets.cmake b/CMake/Utils/MyGUIConfigTargets.cmake
-index 6483339..71710de 100644
+index 6483339..0b35148 100644
 --- a/CMake/Utils/MyGUIConfigTargets.cmake
 +++ b/CMake/Utils/MyGUIConfigTargets.cmake
-@@ -170,6 +170,9 @@ function(mygui_app PROJECTNAME SOLUTIONFOLDER)
+@@ -170,6 +170,11 @@ function(mygui_app PROJECTNAME SOLUTIONFOLDER)
  			set(MYGUI_EXEC_TYPE WIN32)
  		endif ()
  		add_executable(${PROJECTNAME} ${MYGUI_EXEC_TYPE} ${HEADER_FILES} ${SOURCE_FILES})
-+    install(TARGETS ${PROJECTNAME}
-+      RUNTIME DESTINATION bin
-+    )
++		if (APPLE)
++			install(TARGETS ${PROJECTNAME} BUNDLE DESTINATION bin)
++		else ()
++			install(TARGETS ${PROJECTNAME} RUNTIME DESTINATION bin)
++		endif ()
  	endif ()
  	set_target_properties(${PROJECTNAME} PROPERTIES FOLDER ${SOLUTIONFOLDER})
  

--- a/ports/mygui/vcpkg.json
+++ b/ports/mygui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mygui",
   "version": "3.4.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Fast, flexible and simple GUI",
   "homepage": "http://mygui.info",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5390,7 +5390,7 @@
     },
     "mygui": {
       "baseline": "3.4.1",
-      "port-version": 4
+      "port-version": 5
     },
     "mysql-connector-cpp": {
       "baseline": "8.0.30",

--- a/versions/m-/mygui.json
+++ b/versions/m-/mygui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b68ea2f9e7d24c34d86ea4d45050adc7ac29663",
+      "version": "3.4.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "006d47cf87a29b68cbf5f7d1fbbc7e12a38e3cb7",
       "version": "3.4.1",
       "port-version": 4


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #31002 
Fix `mygui[tools]` build failed on macOS with the following error:
```
CMake Error at CMake/Utils/MyGUIConfigTargets.cmake:173 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "SkinEditor".
Call Stack (most recent call first):
  CMake/Utils/MyGUIConfigTargets.cmake:343 (mygui_app)
  Tools/SkinEditor/CMakeLists.txt:1 (mygui_tool)


CMake Error at CMake/Utils/MyGUIConfigTargets.cmake:173 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "ImageEditor".
Call Stack (most recent call first):
  CMake/Utils/MyGUIConfigTargets.cmake:343 (mygui_app)
  Tools/ImageEditor/CMakeLists.txt:1 (mygui_tool)


CMake Error at CMake/Utils/MyGUIConfigTargets.cmake:173 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "FontEditor".
Call Stack (most recent call first):
  CMake/Utils/MyGUIConfigTargets.cmake:343 (mygui_app)
  Tools/FontEditor/CMakeLists.txt:1 (mygui_tool)
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
