### PR TITLE
[microsoft-signalr] Fix msgpackConfig.cmake is not found

### DIFF
--- a/ports/microsoft-signalr/find-msgpack.patch
+++ b/ports/microsoft-signalr/find-msgpack.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 676cde2..4562873 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,8 +45,8 @@ set(JSONCPP_LIB "jsoncpp_static" CACHE STRING "jsoncpp target name")
+ endif()
+ 
+ if(USE_MSGPACK)
+-  find_package(msgpack CONFIG REQUIRED)
+-  set(MSGPACK_LIB "msgpackc-cxx")
++  find_package(msgpack-cxx CONFIG REQUIRED)
++  set(MSGPACK_LIB "msgpack-cxx")
+ endif()
+ 
+ include_directories (include)

--- a/ports/microsoft-signalr/portfile.cmake
+++ b/ports/microsoft-signalr/portfile.cmake
@@ -1,9 +1,10 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aspnet/SignalR-Client-Cpp
-    REF v0.1.0-alpha4
+    REF "v${VERSION}"
     SHA512 b87c94e8bc81781c1cfb4292f1fe3ce046a5f192a25c02104f454b533349c1c0ed965570bd749b496bb316ccb89ae51c5e7461ffa06055e71dac659fbde79456
     HEAD_REF main
+    PATCHES find-msgpack.patch
 )
 
 vcpkg_check_features(
@@ -31,7 +32,8 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/share/microsoft-signalr)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/share" "${CURRENT_PACKAGES_DIR}/lib/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+
 file(COPY "${SOURCE_PATH}/third-party-notices.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_copy_pdbs()

--- a/ports/microsoft-signalr/portfile.cmake
+++ b/ports/microsoft-signalr/portfile.cmake
@@ -33,7 +33,6 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/share" "${CURRENT_PACKAGE
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
-
 file(COPY "${SOURCE_PATH}/third-party-notices.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_copy_pdbs()

--- a/ports/microsoft-signalr/vcpkg.json
+++ b/ports/microsoft-signalr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-signalr",
   "version": "0.1.0-alpha4",
-  "port-version": 3,
+  "port-version": 4,
   "description": "C++ Client for ASP.NET Core SignalR.",
   "homepage": "https://github.com/aspnet/SignalR-Client-Cpp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5138,7 +5138,7 @@
     },
     "microsoft-signalr": {
       "baseline": "0.1.0-alpha4",
-      "port-version": 3
+      "port-version": 4
     },
     "mikktspace": {
       "baseline": "2020-10-06",

--- a/versions/m-/microsoft-signalr.json
+++ b/versions/m-/microsoft-signalr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c806011dd25a94c01725a265b93955cfad47fc4d",
+      "git-tree": "1ea9d11c361ff46b14b9872df5b71b634ff1d709",
       "version": "0.1.0-alpha4",
       "port-version": 4
     },

--- a/versions/m-/microsoft-signalr.json
+++ b/versions/m-/microsoft-signalr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c806011dd25a94c01725a265b93955cfad47fc4d",
+      "version": "0.1.0-alpha4",
+      "port-version": 4
+    },
+    {
       "git-tree": "756cbce0122778f80b0029e5efbec95f76e04457",
       "version": "0.1.0-alpha4",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/30998.

Since https://github.com/microsoft/vcpkg/pull/30401 and https://github.com/microsoft/vcpkg/pull/30389, vcpkg provides two `msgpack` packages, one for C++ (`msgpack`) and one for C (`msgpack-c`). This causes the previous usage of `msgpack` to no longer be available, leading to `microsoft-signalr[messagepack]` installation failures for the following error:
```
Could not find a package configuration file provided by "msgpack" with any
of the following names:
  msgpackConfig.cmake
  msgpack-config.cmake
```
To fix this issue, we need to use the new usage. And because there is code like this in `microsoft-signalr`:
```
#include <msgpack.hpp>
```
Therefore, we should use the usage provided by `msgpack` instead of `msgpack-c`.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
