### PR TITLE
[functions-framework-cpp] fixup package name

### DIFF
--- a/ports/functions-framework-cpp/portfile.cmake
+++ b/ports/functions-framework-cpp/portfile.cmake
@@ -19,7 +19,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install(ADD_BIN_TO_PATH)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+vcpkg_cmake_config_fixup(PACKAGE_NAME functions_framework_cpp CONFIG_PATH lib/cmake/functions_framework_cpp)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(

--- a/ports/functions-framework-cpp/vcpkg.json
+++ b/ports/functions-framework-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "functions-framework-cpp",
   "version": "1.1.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Functions Framework for C++.",
   "homepage": "https://github.com/GoogleCloudPlatform/functions-framework-cpp/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2650,7 +2650,7 @@
     },
     "functions-framework-cpp": {
       "baseline": "1.1.0",
-      "port-version": 3
+      "port-version": 4
     },
     "fuzzylite": {
       "baseline": "6.0",

--- a/versions/f-/functions-framework-cpp.json
+++ b/versions/f-/functions-framework-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4ad257a93efebb34ffabde85fa4a548d5038706",
+      "version": "1.1.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "61df7f37f44d59355e0ded6bb1241924a44143c8",
       "version": "1.1.0",
       "port-version": 3


### PR DESCRIPTION
When using `find_package()` the package needs to be called `functions_framework_cpp` (with underscores).  Probably my mistake to use a mismatched package name for vcpkg when contributing the port.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
