### PR TITLE
[superlu] Update to v6.0.0

### DIFF
--- a/ports/superlu/portfile.cmake
+++ b/ports/superlu/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiaoyeli/superlu
     REF "v${VERSION}"
-    SHA512 1461b52bc18a8b0345beb70fdd46e07df497a13be840bcc061158ea1d0e61c8745806d1ad21cb2723db80f5ed762c3741f9c0ded2b2013df46da0e8bb6b77b83
+    SHA512 8feeb08404cad58724f0f6478bc785b56d8c725b549f1fdc07d3578c4e14bdbdbd8bcda1cdfd366a39417eda60765825e87cf781c68e6723a8246cb357b41439
     HEAD_REF master
     PATCHES
         remove-make.inc.patch

--- a/ports/superlu/portfile.cmake
+++ b/ports/superlu/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         remove-make.inc.patch
+        superfluous-configure.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/superlu/superfluous-configure.patch
+++ b/ports/superlu/superfluous-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d733990..11f429a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -230,7 +230,6 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/superlu.pc
+ 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 	
+ configure_file(${SuperLU_SOURCE_DIR}/SRC/superlu_config.h.in ${SuperLU_BINARY_DIR}/SRC/superlu_config.h)
+-configure_file(${SuperLU_SOURCE_DIR}/SRC/superlu_config.h.in ${SuperLU_SOURCE_DIR}/SRC/superlu_config.h)
+ 
+ # Following is to configure a header file for FORTRAN code
+ configure_file(${SuperLU_SOURCE_DIR}/SRC/superlu_config.h.in ${SuperLU_BINARY_DIR}/FORTRAN/superlu_config.h)

--- a/ports/superlu/vcpkg.json
+++ b/ports/superlu/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "superlu",
-  "version": "5.3.0",
-  "port-version": 1,
+  "version": "6.0.0",
   "description": "Supernodal sparse direct solver.",
   "homepage": "https://github.com/xiaoyeli/superlu",
   "license": "BSD-3-Clause-LBNL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7713,8 +7713,8 @@
       "port-version": 0
     },
     "superlu": {
-      "baseline": "5.3.0",
-      "port-version": 1
+      "baseline": "6.0.0",
+      "port-version": 0
     },
     "symengine": {
       "baseline": "0.9.0",

--- a/versions/s-/superlu.json
+++ b/versions/s-/superlu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8187a877fbae6bdc54d5922753a1d67141576be0",
+      "version": "6.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bcc27a8221ab0323b537025944ebc20ae56c36ac",
       "version": "5.3.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The patch is necessary because it failed on uwp and x86 otherwise (see on [Azure](https://dev.azure.com/vcpkg/public/_build/results?buildId=88693&view=results)). The line tries to write into the source folder which seems to require privileged access on those platforms. 
[failure logs for x86-windows.zip](https://github.com/microsoft/vcpkg/files/11314449/failure.logs.for.x86-windows.zip)
[failure logs for x64-uwp.zip](https://github.com/microsoft/vcpkg/files/11314450/failure.logs.for.x64-uwp.zip)
