### PR TITLE
[Vulkan] Ensure minimum Vulkan SDK of 1.2

### DIFF
--- a/ports/vulkan/vcpkg.json
+++ b/ports/vulkan/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vulkan",
-  "version": "1.1.82.1",
+  "version": "1.2",
   "port-version": 6,
   "description": "A stub package that ensures that the Vulkan SDK is installed.",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8349,7 +8349,7 @@
       "port-version": 1
     },
     "vulkan": {
-      "baseline": "1.1.82.1",
+      "baseline": "1.2",
       "port-version": 6
     },
     "vulkan-headers": {

--- a/versions/v-/vulkan.json
+++ b/versions/v-/vulkan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14e7546bb3bc43c1589378ae142e17027e57daa4",
+      "version": "1.2",
+      "port-version": 6
+    },
+    {
       "git-tree": "ea62236a3c91051f5ccb340442b60a026bf160c6",
       "version": "1.1.82.1",
       "port-version": 6


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Currently the latest version of the vulkan sdk is `1.3`. So `1.2` as a minimum isn't too restricting. When `1.4` comes out, I'll update the version to `1.3` accordingly.

The Vulkan SDK follows semantic versioning so there shouldn't be any issues with this approach.

Also it makes the version number more useful and less confusing than `1.1.82.1` to developers.