### PR TITLE
[libtorch] Fix function not having a default return value

### DIFF
--- a/ports/libtorch/fix_werror.patch
+++ b/ports/libtorch/fix_werror.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8e46275..b505ec5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -788,7 +788,6 @@ if(NOT MSVC)
+   # Details at http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1459
+   string(APPEND CMAKE_CXX_FLAGS " -Wall")
+   string(APPEND CMAKE_CXX_FLAGS " -Wextra")
+-  string(APPEND CMAKE_CXX_FLAGS " -Werror=return-type")
+   string(APPEND CMAKE_CXX_FLAGS " -Wno-missing-field-initializers")
+   string(APPEND CMAKE_CXX_FLAGS " -Wno-type-limits")
+   string(APPEND CMAKE_CXX_FLAGS " -Wno-array-bounds")

--- a/ports/libtorch/portfile.cmake
+++ b/ports/libtorch/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         fix-c10-glog.patch
         use-flatbuffers2.patch # check with codegen-flatc-mobile_bytecode
         fix-windows.patch # https://github.com/pytorch/pytorch/issues/87957
+        fix_werror.patch
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/caffe2/core/macros.h") # We must use generated header files
 

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "1.12.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4566,7 +4566,7 @@
     },
     "libtorch": {
       "baseline": "1.12.1",
-      "port-version": 2
+      "port-version": 3
     },
     "libtorrent": {
       "baseline": "2.0.8",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f8ee520ffcef31a008c2c73b1155b38151ebae4",
+      "version": "1.12.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "1fb6e115393430795e4173a45155e80c5462cd00",
       "version": "1.12.1",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30995

Fix the following issue. Remove the` -Werror=return-type` compile option. When the function needs a default return value when it needs to exit at the end, but the actual situation does not provide it, a warning will be generated at compile time and the warning will not be converted into an error.
```
/data/vcpkg/buildtrees/libtorch/src/v1.12.1-d15308d103.clean/aten/src/ATen/native/Convolution.cpp: In function ‘at::Tensor at::native::_convolution_mode(const at::Tensor&, const at::Tensor&, const c10::optional<at::Tensor>&, at::IntArrayRef, c10::string_view, at::IntArrayRef, int64_t)’:
/data/vcpkg/buildtrees/libtorch/src/v1.12.1-d15308d103.clean/aten/src/ATen/native/Convolution.cpp:920:1: error: control reaches end of non-void function [-Werror=return-type]
  920 | }
      | ^
cc1plus: some warnings being treated as errors
```
The issue https://github.com/pytorch/pytorch/issues/100054 has been submitted upstream, and the added patch can be deleted after waiting for the upstream modification and the release of a new version.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

