### PR TITLE
[vcpkg baseline][xeus] Fix libuuid dependency

### DIFF
--- a/ports/xeus/vcpkg.json
+++ b/ports/xeus/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "xeus",
   "version": "0.24.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "C++ implementation of the Jupyter kernel protocol",
   "homepage": "https://github.com/jupyter-xeus/xeus",
   "license": "BSD-3-Clause",
@@ -9,7 +9,7 @@
     "cppzmq",
     {
       "name": "libuuid",
-      "platform": "linux"
+      "platform": "!windows & !osx"
     },
     "nlohmann-json",
     "openssl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8594,7 +8594,7 @@
     },
     "xeus": {
       "baseline": "0.24.3",
-      "port-version": 2
+      "port-version": 3
     },
     "xframe": {
       "baseline": "0.3.0",

--- a/versions/x-/xeus.json
+++ b/versions/x-/xeus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b36c5dea30b1657552313a07c10623753918b1bf",
+      "version": "0.24.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "58ccbb03903ad023da77a9a53225dc4bd25df600",
       "version": "0.24.3",
       "port-version": 2


### PR DESCRIPTION
Fixes error in Android builds, #31098.

(Didn't I recently insist on mirroring libuuid's `supports` in another PR? This is why...)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
