### PR TITLE
[ogre] Fix function override problem in macos system.

### DIFF
--- a/ports/ogre/fix_override.patch
+++ b/ports/ogre/fix_override.patch
@@ -1,0 +1,33 @@
+diff --git a/PlugIns/EXRCodec/src/O_IStream.cpp b/PlugIns/EXRCodec/src/O_IStream.cpp
+index 6f668d5..eba9ac7 100644
+--- a/PlugIns/EXRCodec/src/O_IStream.cpp
++++ b/PlugIns/EXRCodec/src/O_IStream.cpp
+@@ -39,11 +39,11 @@ bool O_IStream::read(char c[], int n) {
+     return _stream.eof();
+ }
+ 
+-Int64 O_IStream::tellg() {
++uint64_t O_IStream::tellg() {
+     return _stream.getCurrentPtr() - _stream.getPtr();
+ }
+ 
+-void O_IStream::seekg(Int64 pos) {
++void O_IStream::seekg(uint64_t pos) {
+     _stream.seek(pos);
+ }
+ 
+diff --git a/PlugIns/EXRCodec/src/O_IStream.h b/PlugIns/EXRCodec/src/O_IStream.h
+index 8eb09d8..dc301ae 100644
+--- a/PlugIns/EXRCodec/src/O_IStream.h
++++ b/PlugIns/EXRCodec/src/O_IStream.h
+@@ -46,8 +46,8 @@ public:
+         IStream (file_name), _stream(stream) {}
+ 
+     bool    read (char c[], int n) override;
+-    Imf::Int64   tellg () override;
+-    void    seekg (Imf::Int64 pos) override;
++    virtual uint64_t   tellg () override;
++    virtual void    seekg (uint64_t pos) override;
+     void    clear () override;
+ 
+ private:

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -10,10 +10,9 @@ if(VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_EMSCRIPTEN)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
+set(PATCHLIB fix-dependencies.patch cfg-rel-paths.patch swig-python-polyfill.patch pkgconfig.patch same-install-rules-all-platforms.patch)
 if(VCPKG_TARGET_IS_OSX)
-    set(PATCHLIB fix_override.patch fix-dependencies.patch cfg-rel-paths.patch swig-python-polyfill.patch pkgconfig.patch same-install-rules-all-platforms.patch)
-else()
-    set(PATCHLIB fix-dependencies.patch cfg-rel-paths.patch swig-python-polyfill.patch pkgconfig.patch same-install-rules-all-platforms.patch)
+    set(APPEND PATCHLIB fix_override.patch) # upstream PR:https://github.com/OGRECave/ogre/pull/2831
 endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -10,6 +10,11 @@ if(VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_EMSCRIPTEN)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
+if(VCPKG_TARGET_IS_OSX)
+    set(PATCHLIB fix_override.patch fix-dependencies.patch cfg-rel-paths.patch swig-python-polyfill.patch pkgconfig.patch same-install-rules-all-platforms.patch)
+else()
+    set(PATCHLIB fix-dependencies.patch cfg-rel-paths.patch swig-python-polyfill.patch pkgconfig.patch same-install-rules-all-platforms.patch)
+endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OGRECave/ogre
@@ -17,11 +22,7 @@ vcpkg_from_github(
     SHA512 d4022a454e0649a01182545f24094ba1f72127099a9b096e1b438238659629e93b1d79277d02acc0aceebdc3969aab0031de7f86390077bafc66ccfd86755430
     HEAD_REF master
     PATCHES
-        fix-dependencies.patch
-        cfg-rel-paths.patch
-        swig-python-polyfill.patch
-        pkgconfig.patch
-        same-install-rules-all-platforms.patch
+        ${PATCHLIB}       
 )
 
 file(REMOVE "${SOURCE_PATH}/CMake/Packages/FindOpenEXR.cmake")

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -12,7 +12,7 @@ endif()
 
 set(PATCHLIB fix-dependencies.patch cfg-rel-paths.patch swig-python-polyfill.patch pkgconfig.patch same-install-rules-all-platforms.patch)
 if(VCPKG_TARGET_IS_OSX)
-    set(APPEND PATCHLIB fix_override.patch) # upstream PR:https://github.com/OGRECave/ogre/pull/2831
+    list(APPEND PATCHLIB fix_override.patch) # upstream PR:https://github.com/OGRECave/ogre/pull/2831
 endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ogre",
   "version": "13.6.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5702,7 +5702,7 @@
     },
     "ogre": {
       "baseline": "13.6.2",
-      "port-version": 1
+      "port-version": 2
     },
     "ogre-next": {
       "baseline": "2.3.1",

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2e8af868f20f2fa384a1e270404e3d63f04e2052",
+      "git-tree": "9a0701fa116eca04bd8a2446f6e44c732084857b",
       "version": "13.6.2",
       "port-version": 2
     },

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "460052e3baa8641015f11764ca42647716fbe72b",
+      "version": "13.6.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "b7ec525c0cd854d1da91a5a11cd05109693b9333",
       "version": "13.6.2",
       "port-version": 1

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "460052e3baa8641015f11764ca42647716fbe72b",
+      "git-tree": "2e8af868f20f2fa384a1e270404e3d63f04e2052",
       "version": "13.6.2",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/31006

Fix the following issue to keep the return value and parameter types of the override function and the inherited function consistent.
```
/Users/vcpkg/Jim/vcpkg/buildtrees/ogre/src/v13.6.2-57c75b3e04/PlugIns/EXRCodec/src/O_IStream.cpp:42:18: error: return type of out-of-line definition of 'Ogre::O_IStream::tellg' differs from that in the declaration
Int64 O_IStream::tellg() {
~~~~~            ^
/Users/vcpkg/Jim/vcpkg/buildtrees/ogre/src/v13.6.2-57c75b3e04/PlugIns/EXRCodec/src/O_IStream.h:49:16: note: previous declaration is here
    uint64_t   tellg () override;
    ~~~~~~~~   ^
/Users/vcpkg/Jim/vcpkg/buildtrees/ogre/src/v13.6.2-57c75b3e04/PlugIns/EXRCodec/src/O_IStream.cpp:46:17: error: out-of-line definition of 'seekg' does not match any declaration in 'Ogre::O_IStream'
void O_IStream::seekg(Int64 pos) {
                ^~~~~
2 errors generated.
```
The usage and feature has been tested successfully locally.
A PR https://github.com/OGRECave/ogre/pull/2831 has been submitted upstream to fix this issue. Subsequent waiting for the upstream integration to release a new version can delete the patch submitted this time.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

