### PR TITLE
[gstreamer] fix inter feature deps

### DIFF
--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.20.5",
-  "port-version": 5,
+  "port-version": 6,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",
@@ -312,6 +312,13 @@
         {
           "name": "ffmpeg",
           "default-features": false
+        },
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "features": [
+            "plugins-base"
+          ]
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2958,7 +2958,7 @@
     },
     "gstreamer": {
       "baseline": "1.20.5",
-      "port-version": 5
+      "port-version": 6
     },
     "gtest": {
       "baseline": "1.13.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "631b03d07848f5a632168da7e3f9e1bc753d4085",
+      "version": "1.20.5",
+      "port-version": 6
+    },
+    {
       "git-tree": "86757cb6fd9f50813cadb3779f1096fe1377eef9",
       "version": "1.20.5",
       "port-version": 5


### PR DESCRIPTION
Otherwise `gstreamer[core,libav]` fails with:
```
...
../src/1.20.5-7f605f43d3.clean/subprojects/gst-libav/meson.build:98:0: ERROR: Subproject "subprojects/gst-plugins-base" required but not found.
```
