### PR TITLE
[mesa] fix inter feature deps

### DIFF
--- a/ports/mesa/portfile.cmake
+++ b/ports/mesa/portfile.cmake
@@ -134,4 +134,8 @@ if(VCPKG_TARGET_IS_WINDOWS)
     endif()
 endif()
 
+if(FEATURES STREQUAL "core")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+endif()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/docs/license.rst")

--- a/ports/mesa/vcpkg.json
+++ b/ports/mesa/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mesa",
   "version": "23.0.1",
+  "port-version": 1,
   "description": "Mesa - The 3D Graphics Library",
   "homepage": "https://www.mesa3d.org/",
   "license": "MIT AND BSL-1.0 AND SGI-B-2.0",
@@ -111,7 +112,16 @@
       ]
     },
     "offscreen": {
-      "description": "Build with support for offscreen rendering (OSMesa)"
+      "description": "Build with support for offscreen rendering (OSMesa)",
+      "dependencies": [
+        {
+          "name": "mesa",
+          "default-features": false,
+          "features": [
+            "opengl"
+          ]
+        }
+      ]
     },
     "opengl": {
       "description": "Build support for OpenGL (all versions)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5102,7 +5102,7 @@
     },
     "mesa": {
       "baseline": "23.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "meschach": {
       "baseline": "1.2b",

--- a/versions/m-/mesa.json
+++ b/versions/m-/mesa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d76e69afa98f38f1b3102572a8a5516ce088b9ca",
+      "version": "23.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "87fb0741a264517b99f37f4ff2ba43264cdfe0f9",
       "version": "23.0.1",
       "port-version": 0


### PR DESCRIPTION
Fixes the installation of `mesa[core,offscreen]`
```
[845/846] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -o src/gallium/targets/osmesa/libOSMesa.8.dylib src/gallium/targets/osmesa/libOSMesa.8.dylib.p/target.c.o -L/opt/homebrew/opt/libomp/lib -L/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-undefined,error -fuse-ld=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -shared -install_name @rpath/libOSMesa.8.dylib -compatibility_version 9.0.0 -current_version 9.0.0 -Wl,-force_load src/gallium/frontends/osmesa/libosmesa_st.a -Wl,-force_load src/mapi/glapi/libglapi_static.a -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk src/mesa/libmesa.a src/compiler/glsl/libglsl.a src/compiler/glsl/glcpp/libglcpp.a src/util/libmesa_util.a src/util/format/libmesa_format.a src/util/libmesa_util_sse41.a src/c11/impl/libmesa_util_c11.a src/compiler/nir/libnir.a src/compiler/libcompiler.a src/gallium/auxiliary/libgallium.a src/gallium/winsys/sw/null/libws_null.a src/gallium/drivers/softpipe/libsoftpipe.a /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../lib/libz.a -lm /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../lib/libzstd.a
FAILED: src/gallium/targets/osmesa/libOSMesa.8.dylib 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -o src/gallium/targets/osmesa/libOSMesa.8.dylib src/gallium/targets/osmesa/libOSMesa.8.dylib.p/target.c.o -L/opt/homebrew/opt/libomp/lib -L/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-undefined,error -fuse-ld=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -shared -install_name @rpath/libOSMesa.8.dylib -compatibility_version 9.0.0 -current_version 9.0.0 -Wl,-force_load src/gallium/frontends/osmesa/libosmesa_st.a -Wl,-force_load src/mapi/glapi/libglapi_static.a -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk src/mesa/libmesa.a src/compiler/glsl/libglsl.a src/compiler/glsl/glcpp/libglcpp.a src/util/libmesa_util.a src/util/format/libmesa_format.a src/util/libmesa_util_sse41.a src/c11/impl/libmesa_util_c11.a src/compiler/nir/libnir.a src/compiler/libcompiler.a src/gallium/auxiliary/libgallium.a src/gallium/winsys/sw/null/libws_null.a src/gallium/drivers/softpipe/libsoftpipe.a /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../lib/libz.a -lm /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/debug/lib/pkgconfig/../../lib/libzstd.a
Undefined symbols for architecture arm64:
  "_glAreTexturesResidentEXT", referenced from:
      _static_functions in libglapi_static.a(glapi_getproc.c.o)
  "_glDeleteTexturesEXT", referenced from:
      _static_functions in libglapi_static.a(glapi_getproc.c.o)
  "_glGenTexturesEXT", referenced from:
      _static_functions in libglapi_static.a(glapi_getproc.c.o)
  "_glIsTextureEXT", referenced from:
      _static_functions in libglapi_static.a(glapi_getproc.c.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.

```