### PR TITLE
[ace] Update to 7.1.0

### DIFF
--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -10,14 +10,14 @@ if("tao" IN_LIST FEATURES)
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE%2BTAO-src-${VERSION}.tar.gz"
         FILENAME "ACE-TAO-${VERSION}.tar.gz"
-        SHA512 7210091f0512fa9c7ba2ea9e3f805a2ba0aab4d848a8e9e5651a824dcac65ddd50b95c98f4da86900487fa0a79aede126d021f4eb109f224224fc88a58133f79
+        SHA512 a40a4761d396f1e7dc96287075810a3d874794f56057cf1f18b2bd27fbb89e024c2926890fd0a8efe825c31865c382b91e90477d78cba64877b93ba9909b7da2
     )
 else()
     # Don't change to vcpkg_from_github! This points to a release and not an archive
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE-src-${VERSION}.tar.gz"
         FILENAME "ACE-src-${VERSION}.tar.gz"
-        SHA512 6e8b63ee8fa691656544a7a9e5887b499a8791f25766a8081df1d64e911f667a95fed26c1eb6355f6ce1233694f8ef11c1a986ca16a686e21fb1e375035a29ed
+        SHA512 716b27e347e013b866fa08f7ab182c60faf108e8000089b90717db86d6dd92d8c7e776d4850be27c5f50c8e31543f573ce19466efcd9b4b7bc8836eec5447860
     )
 endif()
 

--- a/ports/ace/vcpkg.json
+++ b/ports/ace/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ace",
   "version": "7.1.0",
-  "port-version": 0,
   "maintainers": "Johnny Willemsen <jwillemsen@remedy.nl>",
   "description": "The ADAPTIVE Communication Environment",
   "homepage": "https://github.com/DOCGroup/ACE_TAO",

--- a/ports/ace/vcpkg.json
+++ b/ports/ace/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ace",
-  "version": "7.0.11",
-  "port-version": 2,
+  "version": "7.1.0",
+  "port-version": 0,
   "maintainers": "Johnny Willemsen <jwillemsen@remedy.nl>",
   "description": "The ADAPTIVE Communication Environment",
   "homepage": "https://github.com/DOCGroup/ACE_TAO",

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a2a1876f2f625494b16da42b27ace343255d691",
+      "version": "7.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "25ea14090fceba8ae684e0c6ab047a719250ef56",
       "version": "7.0.11",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -25,8 +25,8 @@
       "port-version": 3
     },
     "ace": {
-      "baseline": "7.0.11",
-      "port-version": 2
+      "baseline": "7.1.0",
+      "port-version": 0
     },
     "acl": {
       "baseline": "2.3.1",


### PR DESCRIPTION


If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


