### PR TITLE
[gtkmm] update to 4.10.0

### DIFF
--- a/ports/gtkmm/portfile.cmake
+++ b/ports/gtkmm/portfile.cmake
@@ -1,7 +1,8 @@
+string(REGEX MATCH "^([0-9]*[.][0-9]*)" GTKMM_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnome.org/pub/GNOME/sources/gtkmm/4.6/gtkmm-4.6.0.tar.xz"
-    FILENAME "gtkmm-4.6.0.tar.xz"
-    SHA512 d1040be44d133cfa016efc581b79c5303806d0d441b57dcc22bd84a05c3e7934f9b7b894e71d7f4a0be332daba3dd58ef558f58070b83bf8a9de7d1027d92199
+    URLS "https://ftp.gnome.org/pub/GNOME/sources/gtkmm/${GTKMM_MAJOR_MINOR}/gtkmm-${VERSION}.tar.xz"
+    FILENAME "gtkmm-${VERSION}.tar.xz"
+    SHA512 ee40cce37c34814884ffc06e614013d23fa31cac51ea9d98ea5689a08acc2ff58bb2ca80ba822d6fe3c0f3bdcb9ce2596ede3c05c69a702b524c4e38afc3d9ab
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gtkmm/vcpkg.json
+++ b/ports/gtkmm/vcpkg.json
@@ -1,27 +1,16 @@
 {
   "name": "gtkmm",
-  "version": "4.6.0",
-  "port-version": 2,
+  "version": "4.10.0",
   "description": "gtkmm is the official C++ interface for the popular GUI library GTK+.",
   "homepage": "https://www.gtkmm.org/",
   "license": "LGPL-3.0-or-later",
   "supports": "!uwp",
   "dependencies": [
-    "atk",
-    "atkmm",
-    "cairo",
     "cairomm",
     "gdk-pixbuf",
-    "gettext",
-    "glib",
-    {
-      "name": "glib",
-      "host": true
-    },
     "glibmm",
     "gtk",
     "libepoxy",
-    "pango",
     "pangomm",
     {
       "name": "vcpkg-tool-meson",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2973,8 +2973,8 @@
       "port-version": 0
     },
     "gtkmm": {
-      "baseline": "4.6.0",
-      "port-version": 2
+      "baseline": "4.10.0",
+      "port-version": 0
     },
     "gtl": {
       "baseline": "1.1.5",

--- a/versions/g-/gtkmm.json
+++ b/versions/g-/gtkmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5bede7b8a7ab28981640b17d73708e710c5e8701",
+      "version": "4.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c20c4893b7e0aada402db3895d38d840123ae8c5",
       "version": "4.6.0",
       "port-version": 2


### PR DESCRIPTION
Fixes #31121.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.