### PR TITLE
[LIBMYSQL] Fix osx build creates invalid nuget package

### DIFF
--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -9,8 +9,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mysql/mysql-server
-    REF 1bfe02bdad6604d54913c62614bde57a055c8332 # 8.0.32
-    SHA512 9a556b783ee978c919ccc0c1c99ab4a84ecc9fe0b75e2e100ad616f3b7c7bd280c8da63eb9e9c98291256ebbd130aef8c6e5c404e93b7cc8b8fe754b055b650f
+    REF mysql-${VERSION}
+    SHA512 1233abe4fe055f62cc28c847e77bcfc37e03e77ee68b8606e5ad722e0b6d1ae30b95bbe623a88cecdfa0b5868b61eabaf4b99e78cb6fbb9cf3627c91d17feb0e
     HEAD_REF master
     PATCHES
         ignore-boost-version.patch
@@ -64,6 +64,7 @@ vcpkg_cmake_configure(
         BUNDLE_RUNTIME_LIBRARIES # only on windows
         LINK_STATIC_RUNTIME_LIBRARIES # only on windows
         WIX_DIR # only on windows
+        WITH_BUILD_ID # only on windows
 )
 
 vcpkg_cmake_install(ADD_BIN_TO_PATH)
@@ -122,11 +123,12 @@ file(RENAME "${CURRENT_PACKAGES_DIR}/include2" "${CURRENT_PACKAGES_DIR}/include/
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/man"
     "${CURRENT_PACKAGES_DIR}/docs"
     "${CURRENT_PACKAGES_DIR}/debug/docs"
     "${CURRENT_PACKAGES_DIR}/lib/debug"
     "${CURRENT_PACKAGES_DIR}/lib/plugin"
-    "${CURRENT_PACKAGES_DIR}/lib/plugin/debug"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/plugin"
 )
 
 # delete dynamic dll on static build
@@ -140,7 +142,6 @@ if (BUILD_STATIC_LIBS)
         "${CURRENT_PACKAGES_DIR}/lib/libmysql.lib"
         "${CURRENT_PACKAGES_DIR}/debug/lib/libmysql.lib"
         "${CURRENT_PACKAGES_DIR}/lib/libmysql.pdb"
-        "${CURRENT_PACKAGES_DIR}/debug/lib/libmysql.pdb"
         "${CURRENT_PACKAGES_DIR}/debug/lib/libmysql.pdb"
     )
 endif()

--- a/ports/libmysql/vcpkg.json
+++ b/ports/libmysql/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmysql",
   "version": "8.0.32",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A MySQL client library for C development",
   "homepage": "https://github.com/mysql/mysql-server",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4246,7 +4246,7 @@
     },
     "libmysql": {
       "baseline": "8.0.32",
-      "port-version": 1
+      "port-version": 2
     },
     "libnice": {
       "baseline": "0.1.21",

--- a/versions/l-/libmysql.json
+++ b/versions/l-/libmysql.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c4f68caa6f20ecfc912028a0f94ef956c154410",
+      "version": "8.0.32",
+      "port-version": 2
+    },
+    {
       "git-tree": "1c2161c6415adf63a68c648172ff414eef484d4e",
       "version": "8.0.32",
       "port-version": 1


### PR DESCRIPTION
Removal of plugins references wrong debug folder.  This causes the NuGet
  package creation to fail on OSX.
Added removal of debug manuals
Tweaked reference to use actual version tag

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
