### PR TITLE
[fluidsynth] Add pulseaudio feature for Linux

### DIFF
--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -1,3 +1,11 @@
+if("pulseaudio" IN_LIST FEATURES)
+    message(
+    "${PORT} with pulseaudio feature currently requires the following from the system package manager:
+        libpulse-dev pulseaudio
+    These can be installed on Ubuntu systems via sudo apt install libpulse-dev pulseaudio"
+    )
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FluidSynth/fluidsynth

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_check_features(
     FEATURES
         buildtools  VCPKG_BUILD_MAKE_TABLES
         sndfile     enable-libsndfile
+        pulseaudio  enable-pulseaudio
 )
 
 # enable platform-specific features, force the build to fail if the required libraries are not found,
@@ -23,7 +24,7 @@ set(LINUX_OPTIONS enable-alsa ALSA_FOUND)
 set(ANDROID_OPTIONS enable-opensles OpenSLES_FOUND)
 set(IGNORED_OPTIONS enable-coverage enable-dbus enable-floats enable-fpe-check enable-framework enable-jack enable-lash
     enable-libinstpatch enable-midishare enable-oboe enable-openmp enable-oss enable-pipewire enable-portaudio
-    enable-profiling enable-pulseaudio enable-readline enable-sdl2 enable-systemd enable-trap-on-fpe enable-ubsan)
+    enable-profiling enable-readline enable-sdl2 enable-systemd enable-trap-on-fpe enable-ubsan)
 
 if(VCPKG_TARGET_IS_WINDOWS)
     set(OPTIONS_TO_ENABLE ${WINDOWS_OPTIONS})

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -32,6 +32,10 @@
     "buildtools": {
       "description": "Build tools gentables"
     },
+    "pulseaudio": {
+      "description": "Build with PulseAudio support",
+      "supports": "linux"
+    },
     "sndfile": {
       "description": "Enable rendering to file and SF3 support",
       "dependencies": [
@@ -43,10 +47,6 @@
           ]
         }
       ]
-    },
-    "pulseaudio": {
-      "description": "Build with PulseAudio support",
-      "supports": "linux"
     }
   }
 }

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fluidsynth",
   "version": "2.3.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -43,6 +43,10 @@
           ]
         }
       ]
+    },
+    "pulseaudio": {
+      "description": "Build with PulseAudio support",
+      "supports": "linux"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2522,7 +2522,7 @@
     },
     "fluidsynth": {
       "baseline": "2.3.2",
-      "port-version": 1
+      "port-version": 2
     },
     "fmem": {
       "baseline": "c-libs-2ccee3d2fb",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c402772dcfb4c29941bc61b1709e54d2368f17da",
+      "git-tree": "eb9b815d5af8da59d2cb5a42361a9c88e7d6a1f4",
       "version": "2.3.2",
       "port-version": 2
     },

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c402772dcfb4c29941bc61b1709e54d2368f17da",
+      "version": "2.3.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "0deaa03650b97bd28bcaa13d05fb3502f8651e48",
       "version": "2.3.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

This PR adds a pulseaudio feature for Linux for fluidsynth. This is so that fluidsynth can be built with pulseaudio support. Followed https://github.com/microsoft/vcpkg/pull/30679/files as an example for adding a similar feature.