### PR TITLE
2023-04-27 ci.baseline.txt fixes

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -42,6 +42,7 @@
 ace:arm-neon-android=fail
 ace:arm64-android=fail
 ace:x64-android=fail
+ace:x64-windows-static-md=fail
 allegro5:arm-neon-android=fail
 allegro5:arm64-android=fail
 allegro5:x64-android=fail
@@ -128,7 +129,7 @@ caf:x64-android=fail
 caf:x64-uwp=fail
 caffe2:x86-windows=fail
 caffe2:arm64-windows=fail
-
+cairo:x64-android=fail
 # file conflict with dbg-macro
 c-dbg-macro:x86-windows=skip
 c-dbg-macro:x64-windows=skip
@@ -203,6 +204,19 @@ civetweb:arm64-windows      = skip
 civetweb:arm-uwp            = skip
 civetweb:x64-uwp            = skip
 clamav:arm64-windows=fail
+
+# clapack is replaced by lapack-reference on the platforms lapack-reference supports
+clapack:x64-linux=skip
+clapack:x64-osx=skip
+clapack:arm64-osx=skip
+clapack:x64-windows-static=skip
+clapack:x64-windows-static-md=skip
+clapack:x64-windows=skip
+clapack:x86-windows=skip
+lapack-reference:arm64-windows=skip
+lapack-reference:arm-uwp=skip
+lapack-reference:x64-uwp=skip
+
 clblas:arm-neon-android=fail
 clblas:arm64-android=fail
 clblas:x64-android=fail
@@ -319,6 +333,11 @@ dcmtk:arm-neon-android=fail
 dcmtk:arm64-android=fail
 dcmtk:x64-android=fail
 dcmtk:x64-uwp=fail
+# VS2019 version 16.9.4's project system changes where PDBs are placed in a way that breaks the
+# upstream build script of this port.
+# See https://developercommunity.visualstudio.com/t/Toolset-169-regression-vcxproj-producin/1356639
+dimcli:x64-windows-static-md=fail
+dimcli:x64-windows-static=fail
 # legacy directxsdk which conflicts with dxsdk-d3dx
 directxsdk:x86-windows=skip
 directxsdk:x64-windows=skip
@@ -371,7 +390,6 @@ fastrtps:arm-uwp=fail
 fastrtps:x64-uwp=fail
 fastrtps:x64-windows-static=fail
 fastrtps:x64-windows-static-md=fail
-fbgemm:x64-android=fail
 fdk-aac:arm-neon-android=fail
 fdk-aac:arm64-android=fail
 fdk-aac:x64-android=fail
@@ -381,6 +399,9 @@ flashlight-cuda:x64-linux=fail
 flint:arm-neon-android=fail
 flint:arm64-android=fail
 flint:x64-android=fail
+fltk:arm-neon-android=fail
+fltk:arm64-android=fail
+fltk:x64-android=fail
 # fluidlite conflicts with fluidsynth; we test fluidsynth rather than fluidlite because
 # fluidlite has no dependencies and thus is less likely to be broken by another package.
 fluidlite:arm-uwp=skip
@@ -400,9 +421,6 @@ fmi4cpp:arm-uwp=fail
 fmi4cpp:x64-uwp=fail
 folly:arm64-android=fail
 folly:x64-android=fail
-fontconfig:arm-neon-android=fail
-fontconfig:arm64-android=fail
-fontconfig:x64-android=fail
 fontconfig:x64-uwp=fail
 fontconfig:arm-uwp=fail
 foonathan-memory:arm-neon-android=fail
@@ -422,6 +440,7 @@ freeopcua:arm-neon-android=fail
 freeopcua:arm64-android=fail
 freeopcua:arm64-windows=fail
 freeopcua:x64-android=fail
+freerdp:x64-android=fail
 fruit:arm-neon-android=fail
 fruit:arm64-android=fail
 fruit:x64-android=fail
@@ -442,45 +461,21 @@ gainput:x64-android=fail
 gamenetworkingsockets:arm-neon-android=fail
 gamenetworkingsockets:arm64-android=fail
 gamenetworkingsockets:x64-android=fail
-
 # VS 2022 Update 3 seems to have broken Gazebo: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1522474
 # gazebo is broken due it depend on old ports that already in the new versions.
 # There is an open PR that try to fix that.
 gazebo:x64-windows=fail
 gazebo:x64-linux=fail
 gazebo:x86-windows=fail
+gdk-pixbuf:arm-neon-android=fail
+gdk-pixbuf:arm64-android=fail
+gdk-pixbuf:x64-android=fail
 gemmlowp:arm-neon-android=fail
 gemmlowp:arm64-android=fail
 gemmlowp:x64-android=fail
 gherkin-c:arm-neon-android=fail
 gherkin-c:arm64-android=fail
 gherkin-c:x64-android=fail
-gl3w:arm-neon-android=fail
-gl3w:arm64-android=fail
-gl3w:x64-android=fail
-glew:arm-neon-android=fail
-glew:arm64-android=fail
-glew:x64-android=fail
-glfw3:arm-neon-android=fail
-glfw3:arm64-android=fail
-glfw3:x64-android=fail
-glib:arm-neon-android=fail
-glib:arm64-android=fail
-glib:x64-android=fail
-gperftools:x64-android=fail
-graphicsmagick:arm-neon-android=fail
-graphicsmagick:arm64-android=fail
-graphicsmagick:x64-android=fail
-graphqlparser:arm-neon-android=fail
-graphqlparser:arm64-android=fail
-graphqlparser:x64-android=fail
-
-# gsoap does not offer stable public source downloads
-gsoap:x64-android=fail
-gsoap:x64-windows        = skip
-gsoap:x86-windows        = skip
-gsoap:x64-windows-static = skip
-gsoap:x64-windows-static-md = skip
 
 # Port geotrans source ftp://ftp.nga.mil server
 # extremely slow may take several hours to download
@@ -502,7 +497,21 @@ gherkin-c:x64-windows           = skip
 gherkin-c:x64-windows-static    = skip
 gherkin-c:x64-windows-static-md = skip
 gherkin-c:x86-windows           = skip
+gl3w:arm-neon-android=fail
+gl3w:arm64-android=fail
+gl3w:x64-android=fail
+glaze:arm-neon-android=fail
+glaze:arm64-android=fail
+glaze:x64-android=fail
+glaze:x64-linux=fail
+glaze:x64-osx=fail
+glew:arm-neon-android=fail
+glew:arm64-android=fail
+glew:x64-android=fail
+glfw3:arm-neon-android=fail
 glfw3:arm-uwp=fail
+glfw3:arm64-android=fail
+glfw3:x64-android=fail
 glfw3:x64-uwp=fail
 glibmm:x64-windows-static-md=fail
 glibmm:x64-windows-static=fail
@@ -516,19 +525,40 @@ gmmlib:x64-windows=fail
 gmmlib:x86-windows=fail
 google-cloud-cpp:arm-uwp=fail
 google-cloud-cpp:x64-uwp=fail
-gperftools:arm64-windows=fail
-gperftools:x64-uwp=fail
 gperftools:arm-uwp=fail
+gperftools:arm64-windows=fail
+gperftools:x64-android=fail
+gperftools:x64-uwp=fail
 graphicsmagick:arm-uwp=fail
 graphicsmagick:x64-uwp=fail
 # graphicsmagick non-uwp trigger an ICE in VS 2022 17.3 https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1557251
-graphicsmagick:x86-windows=fail
-graphicsmagick:x64-windows=fail
-graphicsmagick:x64-windows-static=fail
+graphicsmagick:arm-neon-android=fail
+graphicsmagick:arm64-android=fail
+graphicsmagick:x64-android=fail
 graphicsmagick:x64-windows-static-md=fail
+graphicsmagick:x64-windows-static=fail
+graphicsmagick:x64-windows=fail
+graphicsmagick:x86-windows=fail
+graphqlparser:arm-neon-android=fail
+graphqlparser:arm64-android=fail
 graphqlparser:arm64-osx=fail # python2 required
+graphqlparser:x64-android=fail
+
+# gsoap does not offer stable public source downloads
+gsoap:x64-android=fail
+gsoap:x64-windows        = skip
+gsoap:x86-windows        = skip
+gsoap:x64-windows-static = skip
+gsoap:x64-windows-static-md = skip
+
+gstreamer:arm-neon-android=fail
+gstreamer:arm64-android=fail
+gstreamer:x64-android=fail
 gtk:x64-windows-static=fail
 gtk:x64-windows-static-md=fail
+gts:arm-neon-android=fail
+gts:arm64-android=fail
+gts:x64-android=fail
 gul14:arm-neon-android=fail
 gul14:arm64-android=fail
 gul14:x64-android=fail
@@ -574,16 +604,17 @@ ignition-tools:arm-neon-android=fail
 ignition-tools:arm64-android=fail
 ignition-tools:x64-android=fail
 ijg-libjpeg:arm-neon-android=fail
-ijg-libjpeg:arm64-android=fail
-ijg-libjpeg:arm64-windows      = skip
 ijg-libjpeg:arm-uwp            = skip
+ijg-libjpeg:arm64-android=fail
+ijg-libjpeg:arm64-osx          = skip
+ijg-libjpeg:arm64-windows      = skip
 ijg-libjpeg:x64-android=fail
 ijg-libjpeg:x64-linux          = skip
 ijg-libjpeg:x64-osx            = skip
-ijg-libjpeg:arm64-osx          = skip
 ijg-libjpeg:x64-uwp            = skip
 ijg-libjpeg:x64-windows        = skip
 ijg-libjpeg:x64-windows-static = skip
+ijg-libjpeg:x64-windows-static-md=fail
 ijg-libjpeg:x86-windows        = skip
 infoware:x64-android=fail
 intelrdfpmathlib:arm-neon-android=fail
@@ -608,9 +639,6 @@ jinja2cpplight:arm-uwp=fail
 jinja2cpplight:arm64-android=fail
 jinja2cpplight:x64-android=fail
 jinja2cpplight:x64-uwp=fail
-joltphysics:arm-neon-android=fail
-joltphysics:arm64-android=fail
-joltphysics:x64-android=fail
 json-schema-validator:arm-neon-android=fail
 json-schema-validator:arm64-android=fail
 kfr:arm64-windows=fail
@@ -623,21 +651,22 @@ lastools:arm64-android=fail
 lastools:x64-android=fail
 lcm:x64-windows-static=fail
 lcm:x64-windows-static-md=fail
+lcm:arm-neon-android=fail
+lcm:arm64-android=fail
+lcm:x64-android=fail
 leptonica:x64-uwp=fail
 leptonica:arm-uwp=fail
 leveldb:arm-uwp=fail
 leveldb:x64-uwp=fail
 libaiff:x64-linux=fail
 libarchive:arm-uwp=fail
-libass:arm-neon-android=fail
-libass:arm64-android=fail
-libass:x64-android=fail
 libbson:arm-neon-android=fail
 libbson:arm64-android=fail
 libbson:x64-android=fail
 libcanberra:arm-neon-android=fail
 libcanberra:arm64-android=fail
 libcanberra:x64-android=fail
+libcerf:x64-windows-static-md=fail
 libcpplocate:arm-neon-android=fail
 libcpplocate:arm64-android=fail
 libcpplocate:x64-android=fail
@@ -675,6 +704,9 @@ libgit2:x64-uwp=fail
 libgo:arm-uwp=fail
 libgo:x64-uwp=fail
 libgo:arm64-windows=fail
+libgpod:arm-neon-android=fail
+libgpod:arm64-android=fail
+libgpod:x64-android=fail
 libgxps:x64-windows-static=fail
 libgxps:x64-windows-static-md=fail
 libhdfs3:arm-neon-android=fail
@@ -730,6 +762,7 @@ libmesh:x64-linux=skip
 # Build fails since PIC is not enabled and some configuration tests do not work properly on UWP
 libmicrodns:arm-uwp=fail
 libmicrodns:x64-uwp=fail
+libmicrohttpd:x64-windows-static-md=fail
 libmikmod:arm-neon-android=fail
 libmikmod:arm64-android=fail
 libmikmod:x64-android=fail
@@ -853,6 +886,7 @@ licensepp:arm-uwp=fail
 licensepp:x64-uwp=fail
 linenoise-ng:arm-uwp=fail
 linenoise-ng:x64-uwp=fail
+linenoise-ng:x64-windows-static-md=fail
 live555:arm-neon-android=fail
 live555:arm-uwp=fail
 live555:arm64-android=fail
@@ -947,6 +981,10 @@ mp3lame:arm-neon-android=fail
 mp3lame:arm64-android=fail
 mp3lame:x64-android=fail
 mpir:x64-android=fail
+# these ports require the Microsoft GDK with Xbox Extensions which is not installed on the CI pipeline machines
+ms-gdkx:x64-windows=fail
+ms-gdkx:x64-windows-static=fail
+ms-gdkx:x64-windows-static-md=fail
 ms-gltf:arm-neon-android=fail
 ms-gltf:arm64-android=fail
 ms-gltf:x64-android=fail
@@ -997,7 +1035,10 @@ munit:x64-uwp=fail
 mysql-connector-cpp:arm-neon-android=fail
 mysql-connector-cpp:arm64-android=fail
 mysql-connector-cpp:x64-android=fail
+nana:arm-neon-android=fail
 nana:arm-uwp=fail
+nana:arm64-android=fail
+nana:x64-android=fail
 nana:x64-linux=fail
 nana:x64-osx=fail
 nana:x64-uwp=fail
@@ -1006,6 +1047,7 @@ nanodbc:x64-uwp=fail
 nanodbc:x64-linux=skip
 nativefiledialog:arm-uwp=fail
 nativefiledialog:x64-uwp=fail
+netcdf-cxx4:x64-windows-static-md=fail
 nettle:arm-uwp=fail
 nettle:arm64-windows=fail
 ngspice:x64-android=fail
@@ -1072,9 +1114,7 @@ ompl:x64-linux=fail
 omplapp:arm64-android=fail
 omplapp:x64-android=fail
 onednn:x64-android=fail
-open62541:arm-neon-android=fail
-open62541:arm64-android=fail
-open62541:x64-android=fail
+open62541:x64-windows-static-md=fail
 openblas:arm-neon-android=fail
 openblas:arm64-android=fail
 openblas:x64-android=fail
@@ -1124,8 +1164,12 @@ openmesh:x64-uwp=fail
 openmpi:arm-neon-android=fail
 openmpi:arm64-android=fail
 openmpi:x64-android=fail
-openscap:x64-windows-static=fail
+openscap:arm-neon-android=fail
+openscap:arm64-android=fail
+openscap:x64-android=fail
 openscap:x64-osx=fail
+openscap:x64-windows-static-md=fail
+openscap:x64-windows-static=fail
 opensubdiv:x64-android=fail
 # osx needs bison 3.4 installed
 openturns:x64-osx=fail
@@ -1212,8 +1256,10 @@ qpid-proton:arm64-android=fail
 qpid-proton:x64-android=fail
 qpid-proton:x64-uwp=fail
 qpid-proton:x64-windows-static=fail
+qt5-base:arm-neon-android=fail
+qt5-base:arm64-android=fail
 qt5-base:arm64-windows=fail
-
+qt5-base:x64-android=fail
 # Skip deprecated Qt module
 # (remove after 1 year or longer due to vcpkg upgrade not handling removed ports correctly)
 qt5-canvas3d:x64-linux=skip
@@ -1388,6 +1434,7 @@ sdl2-net:x64-uwp=fail
 sentencepiece:arm-neon-android=fail
 sentencepiece:arm64-android=fail
 sentencepiece:x64-android=fail
+sentencepiece:x64-windows-static-md=fail
 septag-sx:arm64-windows=fail
 septag-sx:arm-uwp=fail
 septag-sx:x64-android=fail
@@ -1509,6 +1556,7 @@ stxxl:x64-windows=skip
 stxxl:x64-windows-static=skip
 stxxl:x64-windows-static-md=skip
 symengine:arm-uwp=fail
+symengine:x64-windows-static-md=fail
 systemc:arm64-windows=fail
 systemc:arm-uwp=fail
 systemc:x64-uwp=fail
@@ -1525,15 +1573,15 @@ teemo:x64-android=fail
 telnetpp:arm-uwp=fail
 telnetpp:x64-uwp=fail
 
-tensorflow-cc:x64-android=fail
-tensorflow:x64-android=fail
 # tensorflow does not support VS2022
-tensorflow:x64-windows=fail
-tensorflow:x64-windows-static=fail
+tensorflow:x64-android=fail
 tensorflow:x64-windows-static-md=fail
-tensorflow-cc:x64-windows=fail
-tensorflow-cc:x64-windows-static=fail
+tensorflow:x64-windows-static=fail
+tensorflow:x64-windows=fail
+tensorflow-cc:x64-android=fail
 tensorflow-cc:x64-windows-static-md=fail
+tensorflow-cc:x64-windows-static=fail
+tensorflow-cc:x64-windows=fail
 
 tesseract:arm-neon-android=fail
 tesseract:arm64-android=fail
@@ -1571,12 +1619,14 @@ tvision:arm64-android=fail
 tvision:x64-android=fail
 unicorn-lib:arm-uwp=fail
 unicorn-lib:x64-uwp=fail
+unicorn:x64-windows-static-md=fail
 unittest-cpp:arm-neon-android=fail
 unittest-cpp:arm64-android=fail
 unittest-cpp:arm64-windows=fail
 unittest-cpp:arm-uwp=fail
 unittest-cpp:x64-android=fail
 unittest-cpp:x64-uwp=fail
+usbmuxd:x64-windows-static-md=fail
 # USD has set official policy that they will not update to be compatible with TBB in the near term (https://github.com/PixarAnimationStudios/USD/issues/1600)
 usd:arm64-windows=skip
 usd:arm-uwp=skip
@@ -1589,11 +1639,16 @@ usd:x64-osx=skip
 usd:x86-windows=skip
 uthenticode:arm-uwp=fail
 uthenticode:x64-uwp=fail
-v8:arm64-windows=fail
+# the version of v8 we have in the repo doesn't support VS2022
 v8:arm-uwp=fail
+v8:arm64-windows=fail
 v8:x64-android=fail
 v8:x64-osx=fail
 v8:x64-uwp=fail
+v8:x64-windows-static-md=fail
+v8:x64-windows-static=fail
+v8:x64-windows=fail
+v8:x86-windows=fail
 vectorclass:arm64-windows=fail
 vectorclass:arm-uwp=fail
 vowpal-wabbit:arm-neon-android=fail
@@ -1646,8 +1701,10 @@ wordnet:arm-neon-android=fail
 wordnet:arm64-android=fail
 wordnet:x64-android=fail
 workflow:arm-neon-android=fail
+workflow:arm-uwp=fail
 workflow:arm64-android=fail
 workflow:x64-android=fail
+workflow:x64-uwp=fail
 wpilib:arm-neon-android=fail
 wpilib:arm64-android=fail
 wpilib:arm64-windows=fail
@@ -1681,43 +1738,6 @@ yara:arm-uwp=fail
 yara:x64-uwp=fail
 z3:arm-uwp=fail
 z3:x64-uwp=fail
-
-# clapack is replaced by lapack-reference on the platforms lapack-reference supports
-clapack:x64-linux=skip
-clapack:x64-osx=skip
-clapack:arm64-osx=skip
-clapack:x64-windows-static=skip
-clapack:x64-windows-static-md=skip
-clapack:x64-windows=skip
-clapack:x86-windows=skip
-lapack-reference:arm64-windows=skip
-lapack-reference:arm-uwp=skip
-lapack-reference:x64-uwp=skip
-
-# failures for x64-windows-static-md
-ace:x64-windows-static-md=fail
-ijg-libjpeg:x64-windows-static-md=fail
-libcerf:x64-windows-static-md=fail
-libmicrohttpd:x64-windows-static-md=fail
-linenoise-ng:x64-windows-static-md=fail
-netcdf-cxx4:x64-windows-static-md=fail
-open62541:x64-windows-static-md=fail
-openscap:x64-windows-static-md=fail
-sentencepiece:x64-windows-static-md=fail
-symengine:x64-windows-static-md=fail
-unicorn:x64-windows-static-md=fail
-
-# these ports require the Microsoft GDK with Xbox Extensions which is not installed on the CI pipeline machines
-ms-gdkx:x64-windows=fail
-ms-gdkx:x64-windows-static=fail
-ms-gdkx:x64-windows-static-md=fail
-
-# the version of v8 we have in the repo doesn't support VS2022
-v8:x86-windows=fail
-v8:x64-windows=fail
-v8:x64-windows-static=fail
-v8:x64-windows-static-md=fail
-
 zeroc-ice:arm-neon-android=fail
 zeroc-ice:arm64-android=fail
 zeroc-ice:x64-android=fail
@@ -1725,16 +1745,6 @@ ztd-text:arm-neon-android=fail
 ztd-text:arm64-android=fail
 ztd-text:x64-android=fail
 zyre:x64-windows-static-md=fail
-usbmuxd:x64-windows-static-md=fail
-workflow:x64-uwp=fail
-workflow:arm-uwp=fail
-
-# VS2019 version 16.9.4's project system changes where PDBs are placed in a way that breaks the
-# upstream build script of this port.
-# See https://developercommunity.visualstudio.com/t/Toolset-169-regression-vcxproj-producin/1356639
-dimcli:x64-windows-static-md=fail
-dimcli:x64-windows-static=fail
-
 zeroc-ice:x86-windows=fail
 zeroc-ice:x64-windows=fail
 
@@ -1817,8 +1827,3 @@ vcpkg-ci-wxwidgets:x64-windows-static-md=pass
 vcpkg-ci-wxwidgets:x64-windows-static=pass
 vcpkg-ci-wxwidgets:x64-windows=pass
 vcpkg-ci-wxwidgets:x86-windows=pass
-glaze:x64-linux=fail
-glaze:x64-osx=fail
-glaze:arm-neon-android=fail
-glaze:x64-android=fail
-glaze:arm64-android=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1741,12 +1741,12 @@ z3:x64-uwp=fail
 zeroc-ice:arm-neon-android=fail
 zeroc-ice:arm64-android=fail
 zeroc-ice:x64-android=fail
+zeroc-ice:x64-windows=fail
+zeroc-ice:x86-windows=fail
 ztd-text:arm-neon-android=fail
 ztd-text:arm64-android=fail
 ztd-text:x64-android=fail
 zyre:x64-windows-static-md=fail
-zeroc-ice:x86-windows=fail
-zeroc-ice:x64-windows=fail
 
 # Ports which needs to pass in CI
 cmake:x64-windows=pass


### PR DESCRIPTION
Also fixed ordering issues:
* Entries at the end reordered to where they go.
* Entries starting with 'g' were scrambled.

Partially complete CI run results: https://dev.azure.com/vcpkg/public/_build/results?buildId=88831

PASSING, REMOVE FROM FAIL LIST: fbgemm:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: fontconfig:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: fontconfig:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: fontconfig:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: glib:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: glib:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: glib:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: joltphysics:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: joltphysics:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: joltphysics:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: libass:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: libass:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: libass:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: open62541:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: open62541:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: open62541:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).

I'm not going to bother figuring out specifically which commit fixed these because this is the first normal full CI run including Android, and it could be any amount of skew that happened while https://github.com/microsoft/vcpkg/pull/29406 was in development.

REGRESSION: cairo:x64-android failed with BUILD_FAILED. If expected, add cairo:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: fltk:arm-neon-android failed with BUILD_FAILED. If expected, add fltk:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: fltk:arm64-android failed with BUILD_FAILED. If expected, add fltk:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: fltk:x64-android failed with BUILD_FAILED. If expected, add fltk:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: nana:arm-neon-android failed with BUILD_FAILED. If expected, add nana:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: nana:arm64-android failed with BUILD_FAILED. If expected, add nana:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: nana:x64-android failed with BUILD_FAILED. If expected, add nana:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.

Previously blocked by fontconfig.

REGRESSION: freerdp:x64-android failed with BUILD_FAILED. If expected, add freerdp:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: gdk-pixbuf:arm-neon-android failed with BUILD_FAILED. If expected, add gdk-pixbuf:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: gdk-pixbuf:arm64-android failed with BUILD_FAILED. If expected, add gdk-pixbuf:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: gdk-pixbuf:x64-android failed with BUILD_FAILED. If expected, add gdk-pixbuf:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: gstreamer:arm-neon-android failed with BUILD_FAILED. If expected, add gstreamer:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: gstreamer:arm64-android failed with BUILD_FAILED. If expected, add gstreamer:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: gstreamer:x64-android failed with BUILD_FAILED. If expected, add gstreamer:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: gts:arm-neon-android failed with BUILD_FAILED. If expected, add gts:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: gts:arm64-android failed with BUILD_FAILED. If expected, add gts:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: gts:x64-android failed with BUILD_FAILED. If expected, add gts:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: lcm:arm-neon-android failed with BUILD_FAILED. If expected, add lcm:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: lcm:arm64-android failed with BUILD_FAILED. If expected, add lcm:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: lcm:x64-android failed with BUILD_FAILED. If expected, add lcm:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: libgpod:arm-neon-android failed with BUILD_FAILED. If expected, add libgpod:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: libgpod:arm64-android failed with BUILD_FAILED. If expected, add libgpod:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: libgpod:x64-android failed with BUILD_FAILED. If expected, add libgpod:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: openscap:arm-neon-android failed with BUILD_FAILED. If expected, add openscap:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: openscap:arm64-android failed with BUILD_FAILED. If expected, add openscap:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: openscap:x64-android failed with BUILD_FAILED. If expected, add openscap:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.

Previously blocked by glib

REGRESSION: qt5-base:arm-neon-android failed with BUILD_FAILED. If expected, add qt5-base:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: qt5-base:arm64-android failed with BUILD_FAILED. If expected, add qt5-base:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: qt5-base:x64-android failed with BUILD_FAILED. If expected, add qt5-base:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.

In the PR that added Android to ci, qt5-base was a cascade because harfbuzz was a cascade: https://dev.azure.com/vcpkg/public/_build/results?buildId=88710 . Possible stealth merge conflict with https://github.com/microsoft/vcpkg/pull/30852 which might have fixed harfbuzz?

REGRESSION: urho3d:x64-linux failed with BUILD_FAILED. If expected, add urho3d:x64-linux=fail to /agent/_work/1/s/scripts/azure-pipelines/../ci.baseline.txt.

Fixed by https://github.com/microsoft/vcpkg/pull/31147
