### PR TITLE
[opencascade] Add samples feature 

### DIFF
--- a/ports/opencascade/portfile.cmake
+++ b/ports/opencascade/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "freeimage"  USE_FREEIMAGE
         "tbb"        USE_TBB
         "rapidjson"  USE_RAPIDJSON
+        "samples"    INSTALL_SAMPLES 
 )
 
 # VTK option in opencascade not currently supported because only 6.1.0 is supported but vcpkg has >= 9.0
@@ -40,7 +41,6 @@ vcpkg_cmake_configure(
         -DBUILD_SAMPLES_QT=OFF
         -DBUILD_DOC_Overview=OFF
         -DINSTALL_TEST_CASES=OFF
-        -DINSTALL_SAMPLES=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/opencascade/vcpkg.json
+++ b/ports/opencascade/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencascade",
   "version": "7.6.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Open CASCADE Technology (OCCT) is an open-source software development platform for 3D CAD, CAM, CAE.",
   "homepage": "https://github.com/Open-Cascade-SAS/OCCT",
   "license": "LGPL-2.1",
@@ -36,6 +36,9 @@
       "dependencies": [
         "tbb"
       ]
+    },
+    "samples":{
+      "description": "Enable optional samples"    
     }
   }
 }

--- a/ports/opencascade/vcpkg.json
+++ b/ports/opencascade/vcpkg.json
@@ -31,14 +31,14 @@
         "rapidjson"
       ]
     },
+    "samples": {
+      "description": "Enable optional samples"
+    },
     "tbb": {
       "description": "Enable optional usage of tbb",
       "dependencies": [
         "tbb"
       ]
-    },
-    "samples":{
-      "description": "Enable optional samples"    
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5770,7 +5770,7 @@
     },
     "opencascade": {
       "baseline": "7.6.2",
-      "port-version": 1
+      "port-version": 2
     },
     "opencc": {
       "baseline": "1.1.6",

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "58939d51b0f33a014e48f1d7100ab8888d068c2d",
+      "version": "7.6.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "137097588b2328c3d7f66c4f0e46e6e4fe1559cf",
       "version": "7.6.2",
       "port-version": 1


### PR DESCRIPTION
Fixes #16619.

Add feature opencascade install samples


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature `samples` tested successfully in the following triplet:

- x86-windows
- x64-windows
- x64-windows-static

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
