### PR TITLE
[jasper] fix incorrect library name in jasper.pc

### DIFF
--- a/ports/jasper/fix-library-name.patch
+++ b/ports/jasper/fix-library-name.patch
@@ -1,0 +1,13 @@
+diff --git a/build/jasper.pc.in b/build/jasper.pc.in
+index a4ce38f..a9a7bc4 100644
+--- a/build/jasper.pc.in
++++ b/build/jasper.pc.in
+@@ -6,7 +6,7 @@ Name: JasPer
+ Description: Image Processing/Coding Tool Kit with JPEG-2000 Support
+ Version: @JAS_VERSION@
+ 
+-Libs: -L${libdir} -ljasper
++Libs: -L${libdir} -ljasper@CMAKE_DEBUG_POSTFIX@
+ Requires.private: @JAS_PKGCONFIG_REQUIRES@
+ Cflags: -I${includedir}/jasper -I${includedir}
+ Cflags.private: -DLIBJASPER_STATIC_DEFINE

--- a/ports/jasper/portfile.cmake
+++ b/ports/jasper/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         no_stdc_check.patch
+        fix-library-name.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
@@ -42,4 +43,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE.txt)

--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "jasper",
   "version": "4.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/jasper-software/jasper",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3378,7 +3378,7 @@
     },
     "jasper": {
       "baseline": "4.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "jbig2dec": {
       "baseline": "0.19",

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7f51c26899ba9433a5a3ab92fc5b5887d5c764c",
+      "version": "4.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "1da5fa9a12bf207bf641f903856418e3aed7258d",
       "version": "4.0.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/31146
Added `fix-library-name.patch` to fix incorrect library name in jasper.pc.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
