### PR TITLE
[angle] Fix crash on macos #29622

### DIFF
--- a/ports/angle/cmake-buildsystem/PlatformMac.cmake
+++ b/ports/angle/cmake-buildsystem/PlatformMac.cmake
@@ -41,8 +41,13 @@ endif()
 
 # OpenGL backend
 if(USE_OPENGL)
+    list(APPEND ANGLE_SOURCES
+        ${angle_translator_glsl_base_sources}
+        ${angle_translator_glsl_sources}
+        ${angle_translator_apple_sources}
+    )
     # Enable GLSL compiler output.
-    list(APPEND ANGLE_DEFINITIONS ANGLE_ENABLE_GLSL)
+    list(APPEND ANGLE_DEFINITIONS ANGLE_ENABLE_GLSL ANGLE_ENABLE_GL_DESKTOP_BACKEND ANGLE_ENABLE_APPLE_WORKAROUNDS)
 endif()
 
 if(USE_ANGLE_EGL OR ENABLE_WEBGL)

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_5414",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "784aa16c1dacc9aedb49de3bd1393bb6ef6b853d",
+      "version-string": "chromium_5414",
+      "port-version": 2
+    },
+    {
       "git-tree": "b9840e4a2d643b94dc27bf1adc2803f16501cadd",
       "version-string": "chromium_5414",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -118,7 +118,7 @@
     },
     "angle": {
       "baseline": "chromium_5414",
-      "port-version": 1
+      "port-version": 2
     },
     "annoy": {
       "baseline": "1.17.2",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix #29622