### PR TITLE
[nu-book-zxing-cpp] Enable stack protector, UWP

### DIFF
--- a/ports/nu-book-zxing-cpp/portfile.cmake
+++ b/ports/nu-book-zxing-cpp/portfile.cmake
@@ -1,25 +1,27 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+vcpkg_download_distfile(
+    STACK_PROTECTOR_FIX_PATCH
+    URLS https://github.com/zxing-cpp/zxing-cpp/commit/accced21bae23320aad47b295de1085ab4e561b5.patch
+    FILENAME accced21bae23320aad47b295de1085ab4e561b5.patch
+    SHA512 c787f7cd313d80fcaa39c171a59021453a98936a66b842b3d83389104c8398417eed42151b8f5649e339e83b7261e9caa3423d9fa7b47e1fd00c933d8b11447c
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zxing-cpp/zxing-cpp
     REF v2.0.0
     SHA512 fa22164f834a42194eafd0d3e9c09d953233c69843ac6e79c8d6513314be28d8082382b436c379368e687e0eed05cb5e566d2893ec6eb29233a36643904ae083
     HEAD_REF master
+    PATCHES
+        "${STACK_PROTECTOR_FIX_PATCH}"
 )
 
-if (VCPKG_TARGET_IS_UWP)
-   set(ENV{CL} "$ENV{CL} -wd4996")
-endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_BLACKBOX_TESTS=OFF
         -DBUILD_EXAMPLES=OFF
-        -DBUILD_SYSTEM_DEPS=ALWAYS
-    MAYBE_UNUSED_VARIABLES
-        # Currently no dependencies, but this defends against future additions
-        BUILD_SYSTEM_DEPS
 )
 
 vcpkg_cmake_install()

--- a/ports/nu-book-zxing-cpp/vcpkg.json
+++ b/ports/nu-book-zxing-cpp/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "nu-book-zxing-cpp",
   "version": "2.0.0",
+  "port-version": 1,
   "description": "Barcode detection and decoding library.",
   "homepage": "https://github.com/zxing-cpp/zxing-cpp",
   "license": "Apache-2.0",
-  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5606,7 +5606,7 @@
     },
     "nu-book-zxing-cpp": {
       "baseline": "2.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nuklear": {
       "baseline": "2022-05-12",

--- a/versions/n-/nu-book-zxing-cpp.json
+++ b/versions/n-/nu-book-zxing-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4cd1e936d33ae825fc57284f37bd29b1b0b08c5",
+      "version": "2.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "78c8636186395a676c941dc214b01d4576d643b6",
       "version": "2.0.0",
       "port-version": 0


### PR DESCRIPTION
Applies upstream commit https://github.com/zxing-cpp/zxing-cpp/commit/accced21bae23320aad47b295de1085ab4e561b5 which appears to fix UWP and enables the stack protector.

Alternative to: https://github.com/microsoft/vcpkg/pull/29311

Resolves: https://github.com/microsoft/vcpkg/issues/29310
