### PR TITLE
[zstd] update to 1.5.5

### DIFF
--- a/ports/zstd/portfile.cmake
+++ b/ports/zstd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/zstd
     REF "v${VERSION}"
-    SHA512 b6f64850ceb6cfed831fff3c43508d2a72338862a96dd9430b1d3ebbfcee40201c8b6dcf8b6b603e252bb96f3f283c9cb07da7f24414187f5f1fea3b51e01863
+    SHA512 356994e0d8188ce97590bf86b602eb50cbcb2f951594afb9c2d6e03cc68f966862505afc4a50e76efd55e4cfb11dbc9b15c7837b7827a961a1311ef72cd23505
     HEAD_REF dev
     PATCHES
         no-static-suffix.patch

--- a/ports/zstd/vcpkg.json
+++ b/ports/zstd/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zstd",
-  "version": "1.5.4",
-  "port-version": 2,
+  "version": "1.5.5",
   "description": "Zstandard - Fast real-time compression algorithm",
   "homepage": "https://facebook.github.io/zstd/",
   "license": "BSD-3-Clause OR GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8785,8 +8785,8 @@
       "port-version": 0
     },
     "zstd": {
-      "baseline": "1.5.4",
-      "port-version": 2
+      "baseline": "1.5.5",
+      "port-version": 0
     },
     "zstr": {
       "baseline": "1.0.7",

--- a/versions/z-/zstd.json
+++ b/versions/z-/zstd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a6d14da5f876e43859950a12a330f8b03cdc327",
+      "version": "1.5.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "fcc4fe2738d903bc347d20d2d4c836699e273509",
       "version": "1.5.4",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/31175

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

