### PR TITLE
[starlink-ast] Update, fix

### DIFF
--- a/ports/starlink-ast/cminpack.diff
+++ b/ports/starlink-ast/cminpack.diff
@@ -1,0 +1,13 @@
+diff --git a/src/polymap.c b/src/polymap.c
+index 0b436cc..1aee268 100644
+--- a/src/polymap.c
++++ b/src/polymap.c
+@@ -165,7 +165,7 @@ f     - AST_POLYTRAN: Fit a PolyMap inverse or forward transformation
+ #include "cmpmap.h"              /* Compound mappings */
+ #include "polymap.h"             /* Interface definition for this class */
+ #include "unitmap.h"             /* Unit mappings */
+-#include "cminpack/cminpack.h"   /* Levenberg - Marquardt minimization */
++#include "cminpack-1/cminpack.h"   /* Levenberg - Marquardt minimization */
+ #include "pal.h"                 /* SLALIB function definitions */
+ 
+ /* Error code definitions. */

--- a/ports/starlink-ast/portfile.cmake
+++ b/ports/starlink-ast/portfile.cmake
@@ -57,7 +57,6 @@ vcpkg_install_make()
 # Avoid vcpkg artifact issues with symlinks
 foreach(ast_lib IN ITEMS "${CURRENT_PACKAGES_DIR}/lib/libast" "${CURRENT_PACKAGES_DIR}/debug/lib/libast")
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND EXISTS "${ast_lib}${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
-        message(STATUS "${ast_lib}${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
         file(REMOVE "${ast_lib}_pass2${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
         file(COPY_FILE "${ast_lib}${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}" "${ast_lib}_pass2${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
     endif()

--- a/ports/starlink-ast/portfile.cmake
+++ b/ports/starlink-ast/portfile.cmake
@@ -1,19 +1,35 @@
+# There is no 9.2.10 tarball with generated `configure`.
+# Reconfiguration needs a custom starlink autoconf.
+# Cf. https://github.com/Starlink/ast/issues/21
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/Starlink/ast/releases/download/v9.2.7/ast-9.2.7.tar.gz"
-    FILENAME "ast-9.2.7.tar.gz"
-    SHA512 4778658fe6b08af29b51807e2d988f8425d99d630a14d8fef9ca4ea43016d676df419a93c4b2fdecc0549c28c0665f61e366bd4e7aa896ebb8e47f56d5af1887
+    # regular: "https://github.com/Starlink/ast/releases/download/v${VERSION}/ast-${VERSION}.tar.gz"
+    URLS "https://github.com/Starlink/ast/files/8843897/ast-9.2.9.tar.gz" # not a release asset or tarball
+    FILENAME "starlink-ast-${VERSION}.tar.gz"
+    SHA512 af19cdf41e20d9e92850d90ea760bd21bc9a53ca5bb181a6e27322a610fd13cd6cef30aaf8de6193a2c3fe3c66428b3bd46492a6b22ac22f18cd9be712aa357b
 )
+vcpkg_download_distfile(UPDATE_DIFF
+    URLS "https://github.com/Starlink/ast/compare/v9.2.9...v${VERSION}.diff"
+    FILENAME "starlink-ast-v9.2.9...v${VERSION}.diff"
+    SHA512 fd1255eaefcfdb57273ba241fc604e3ab5eabd2212c17f10daac8fd23436f6d50272bfa35bac292097441ff5334e3d28d12ea6d7d90838f6058e05fc7067c966
+)
+file(READ "${UPDATE_DIFF}" diff)
+set(files_to_ignore "(configure\\.ac|Makefile|\\.gitignore|component\\.xml)")
+string(REGEX REPLACE "diff --git a/${files_to_ignore}[^\n]*\n([-+@ i][^\n]*\n)*" "" diff "${diff}")
+file(WRITE "${CURRENT_BUILDTREES_DIR}/update-${VERSION}.diff" "${diff}")
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        cminpack.diff
+        "${CURRENT_BUILDTREES_DIR}/update-${VERSION}.diff"
 )
+file(REMOVE_RECURSE "${SOURCE_PATH}/cminpack")
+vcpkg_replace_string("${SOURCE_PATH}/configure" "9.2.9" "9.2.10")
 
 set(CONFIGURE_OPTIONS
     --without-fortran
     --with-external-cminpack
-    star_cv_cnf_trail_type=long
-    star_cv_cnf_f2c_compatible=no
 )
 
 if ("yaml" IN_LIST FEATURES)
@@ -33,22 +49,44 @@ vcpkg_configure_make(
     USE_WRAPPERS
     DETERMINE_BUILD_TRIPLET
     ADDITIONAL_MSYS_PACKAGES perl
-    OPTIONS ${CONFIGURE_OPTIONS}
+    OPTIONS
+        ${CONFIGURE_OPTIONS}
 )
-
 vcpkg_install_make()
 
-# libast_pass2 is a hyperlink / symbol link
-if (EXISTS "{CURRENT_PACKAGES_DIR}/lib/libast_pass2${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
-    file(REMOVE "{CURRENT_PACKAGES_DIR}/lib/libast_pass2${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
-endif()
+# Avoid vcpkg artifact issues with symlinks
+foreach(ast_lib IN ITEMS "${CURRENT_PACKAGES_DIR}/lib/libast" "${CURRENT_PACKAGES_DIR}/debug/lib/libast")
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND EXISTS "${ast_lib}${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+        message(STATUS "${ast_lib}${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+        file(REMOVE "${ast_lib}_pass2${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+        file(COPY_FILE "${ast_lib}${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}" "${ast_lib}_pass2${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+    endif()
+endforeach()
 
-if (EXISTS "{CURRENT_PACKAGES_DIR}/debug/lib/libast_pass2${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
-    file(REMOVE "{CURRENT_PACKAGES_DIR}/debug/lib/libast_pass2${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
-endif()
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/docs"
+    "${CURRENT_PACKAGES_DIR}/debug/help"
+    "${CURRENT_PACKAGES_DIR}/debug/manifests"
+    "${CURRENT_PACKAGES_DIR}/debug/news"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/docs"
+    "${CURRENT_PACKAGES_DIR}/help"
+    "${CURRENT_PACKAGES_DIR}/manifests"
+    "${CURRENT_PACKAGES_DIR}/news"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/ast"
+)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/COPYING.LESSER"
+        "${SOURCE_PATH}/COPYING"
+        "${SOURCE_PATH}/erfa/LICENSE"
+    COMMENT [[
+AST is distributed under the Lesser GPL licence (LGPL).
 
-# # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+The AST distribution includes a cut down subset of the C version of the SLALIB library written
+by Pat Wallace. This subset contains only the functions needed by the AST library. It is built as
+part of the process of building AST and is distributed under GPL.
+
+The AST distribution includes the ERFA library. See LICENSE below.
+]])

--- a/ports/starlink-ast/vcpkg.json
+++ b/ports/starlink-ast/vcpkg.json
@@ -1,22 +1,21 @@
 {
   "name": "starlink-ast",
-  "version": "9.2.7",
-  "port-version": 3,
+  "version": "9.2.10",
   "description": "The AST library provides a comprehensive range of facilities for attaching world coordinate systems to astronomical data, for retrieving and interpreting that information and for generating graphical output based on it",
   "homepage": "https://starlink.eao.hawaii.edu/starlink/AST",
-  "supports": "windows",
+  "license": null,
   "dependencies": [
     "cminpack"
   ],
   "features": {
     "pthreads": {
-      "description": "build with POSIX threads support",
+      "description": "Build with POSIX threads support",
       "dependencies": [
         "pthreads"
       ]
     },
     "yaml": {
-      "description": "build with YAML support",
+      "description": "Build with YAML support",
       "dependencies": [
         "libyaml"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7649,8 +7649,8 @@
       "port-version": 0
     },
     "starlink-ast": {
-      "baseline": "9.2.7",
-      "port-version": 3
+      "baseline": "9.2.10",
+      "port-version": 0
     },
     "staticjson": {
       "baseline": "1.0.0",

--- a/versions/s-/starlink-ast.json
+++ b/versions/s-/starlink-ast.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "80540b0cc40c7b79714ea0f2d9775c6554ccb10c",
+      "git-tree": "f79db80b697effc13bf43a3d370701e0e7a244c4",
       "version": "9.2.10",
       "port-version": 0
     },

--- a/versions/s-/starlink-ast.json
+++ b/versions/s-/starlink-ast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80540b0cc40c7b79714ea0f2d9775c6554ccb10c",
+      "version": "9.2.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "88677a462cafe1aea0ff773adb4b57ea1e89c9c5",
       "version": "9.2.7",
       "port-version": 3


### PR DESCRIPTION
Update to 9.2.10. But note https://github.com/Starlink/ast/issues/21.
Fixes vcpkg baseline issue.
Removes `supports` restrictons.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
