### PR TITLE
[opentelemetry-cpp] Fixes #31218

### DIFF
--- a/ports/opentelemetry-cpp/add-missing-find-dependency.patch
+++ b/ports/opentelemetry-cpp/add-missing-find-dependency.patch
@@ -1,11 +1,12 @@
 diff --git a/cmake/opentelemetry-cpp-config.cmake.in b/cmake/opentelemetry-cpp-config.cmake.in
-index adae58d..21baab7 100644
+index adae58dd..26427722 100644
 --- a/cmake/opentelemetry-cpp-config.cmake.in
 +++ b/cmake/opentelemetry-cpp-config.cmake.in
-@@ -69,6 +69,7 @@ set(OPENTELEMETRY_VERSION
+@@ -69,6 +69,8 @@ set(OPENTELEMETRY_VERSION
  # ##############################################################################
  
  find_package(Threads)
++include(CMakeFindDependencyMacro)
 +find_dependency(absl)
  
  set_and_check(OPENTELEMETRY_CPP_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.8.3",
-  "port-version": 5,
+  "port-version": 6,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5926,7 +5926,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.8.3",
-      "port-version": 5
+      "port-version": 6
     },
     "opentracing": {
       "baseline": "1.6.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfd999f93f24e916631d57bf73c0bf02f8c2da0a",
+      "version-semver": "1.8.3",
+      "port-version": 6
+    },
+    {
       "git-tree": "d01c3006eaa3db92a643c8b6e275e5275561d443",
       "version-semver": "1.8.3",
       "port-version": 5


### PR DESCRIPTION
Fixes #31218

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
