### PR TITLE
[libheif] Update to 1.16.1

### DIFF
--- a/ports/libheif/gdk-pixbuf.patch
+++ b/ports/libheif/gdk-pixbuf.patch
@@ -1,13 +1,9 @@
-diff --git a/gdk-pixbuf/CMakeLists.txt b/gdk-pixbuf/CMakeLists.txt
-index 85ad59708..d6aa4a5f9 100644
---- a/gdk-pixbuf/CMakeLists.txt
-+++ b/gdk-pixbuf/CMakeLists.txt
-@@ -1,13 +1,10 @@
- if(UNIX OR MINGW)
-   find_package(PkgConfig)
-   find_package(Threads)
--  pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0)
-+  pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0 IMPORTED_TARGET)
+diff --git "a/gdk-pixbuf/CMakeLists.txt" "b/gdk-pixbuf/CMakeLists.txt"
+index eeb2727..100a323 100644
+--- "a/gdk-pixbuf/CMakeLists.txt"
++++ "b/gdk-pixbuf/CMakeLists.txt"
+@@ -3,10 +3,7 @@ if(UNIX OR MINGW)
+   pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0)
  
    if(GDKPIXBUF2_FOUND)
 -    execute_process(
@@ -18,7 +14,7 @@ index 85ad59708..d6aa4a5f9 100644
  
      add_library(pixbufloader-heif MODULE pixbufloader-heif.c)
  
-@@ -15,7 +12,7 @@ if(UNIX)
+@@ -14,7 +11,7 @@ if(UNIX OR MINGW)
  
      target_link_directories(pixbufloader-heif PRIVATE ${GDKPIXBUF2_LIBRARY_DIRS})
  
@@ -27,4 +23,3 @@ index 85ad59708..d6aa4a5f9 100644
  
      install(TARGETS pixbufloader-heif DESTINATION ${GDKPIXBUF2_MODULE_DIR})
    endif()
-

--- a/ports/libheif/gdk-pixbuf.patch
+++ b/ports/libheif/gdk-pixbuf.patch
@@ -1,9 +1,12 @@
 diff --git "a/gdk-pixbuf/CMakeLists.txt" "b/gdk-pixbuf/CMakeLists.txt"
-index eeb2727..100a323 100644
+index eeb2727..20a6b16 100644
 --- "a/gdk-pixbuf/CMakeLists.txt"
 +++ "b/gdk-pixbuf/CMakeLists.txt"
-@@ -3,10 +3,7 @@ if(UNIX OR MINGW)
-   pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0)
+@@ -1,12 +1,9 @@
+ if(UNIX OR MINGW)
+   find_package(PkgConfig)
+-  pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0)
++  pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0 IMPORTED_TARGET)
  
    if(GDKPIXBUF2_FOUND)
 -    execute_process(

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  strukturag/libheif 
     REF "v${VERSION}"
-    SHA512 966a95dacc12722d2dd37d449125c3df08f9e9be76ec2dc6762866bf285442c33836046df884b50cc14c799dfdcc1d5c9b16e4f9f36a2dbaf422df089756a234
+    SHA512 d81f841ac63d58f56414bf8d799a12af0c846148d2c245cd0c0cc3133edd0b3e08e5018efbc82b83fbab00209a6e0806133f63283bf7244cc4e9cf37b4fa8110
     HEAD_REF master
     PATCHES
         gdk-pixbuf.patch

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libheif",
-  "version": "1.15.1",
-  "port-version": 1,
+  "version": "1.16.1",
   "description": "Open h.265 video codec implementation.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4081,8 +4081,8 @@
       "port-version": 4
     },
     "libheif": {
-      "baseline": "1.15.1",
-      "port-version": 1
+      "baseline": "1.16.1",
+      "port-version": 0
     },
     "libhsplasma": {
       "baseline": "2022-05-19",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "24cbaa1d9105c3018ad3c8b87271f2536caf8ac7",
+      "version": "1.16.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e2b6e5599374567a1f1f61821adc8064fcfaaa0f",
       "version": "1.15.1",
       "port-version": 1

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "24cbaa1d9105c3018ad3c8b87271f2536caf8ac7",
+      "git-tree": "30bfad0af10297606d1687eba9fabe7b5eda60e8",
       "version": "1.16.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
