### PR TITLE
[geos] Update to v3.11.2

### DIFF
--- a/ports/geos/fix-exported-config.patch
+++ b/ports/geos/fix-exported-config.patch
@@ -65,12 +65,12 @@ index 6eff1eb14..8827f6ac6 100644
 +      echo -L${libdir} -lgeos $(if test "@BUILD_SHARED_LIBS@" != "ON"; then echo "@EXTRA_LIBS@"; fi)
        ;;
      --static-clibs)
--      echo -L${libdir} -lgeos_c -lgeos -lm
-+      echo -L${libdir} -lgeos_c -lgeos @EXTRA_LIBS@
+-      echo -L${libdir} -lgeos_c -lgeos -lstdc++ -lm
++      echo -L${libdir} -lgeos_c -lgeos -lstdc++ @EXTRA_LIBS@
        ;;
      --static-cclibs)
--      echo -L${libdir} -lgeos -lm
-+      echo -L${libdir} -lgeos @EXTRA_LIBS@
+-      echo -L${libdir} -lgeos -lstdc++ -lm
++      echo -L${libdir} -lgeos -lstdc++ @EXTRA_LIBS@
        ;;
      --cflags)
        echo -I${includedir}

--- a/ports/geos/gcc-13-fix-backport.patch
+++ b/ports/geos/gcc-13-fix-backport.patch
@@ -1,0 +1,12 @@
+diff --git a/include/geos/shape/fractal/HilbertEncoder.h b/include/geos/shape/fractal/HilbertEncoder.h
+index 61c0010d4..eba5bba8f 100644
+--- a/include/geos/shape/fractal/HilbertEncoder.h
++++ b/include/geos/shape/fractal/HilbertEncoder.h
+@@ -18,6 +18,7 @@
+ #include <geos/export.h>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ // Forward declarations
+ namespace geos {

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
         disable-warning-4996.patch
         fix-exported-config.patch
         fix-dll-builds.patch
+        gcc-13-fix-backport.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.osgeo.org/geos/geos-${VERSION}.tar.bz2"
     FILENAME "geos-${VERSION}.tar.bz2"
-    SHA512 708500aba9b04208ee46a531d55ddf63a213dfaa2922dae937b524300b2b46c95143ed6cd3ff1414e9099f2be95e5df5a2e0b49df43acf93a9478215259f20d3
+    SHA512 b5df5b773bef595335e1be6c6d3325f932f1577e2a4b8bdfa8cf26f09c7d41ed5e0695ca15826d1f95bc4a45b777839c2be8a96a8af5415c8bcf58cc804eb1ec
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"

--- a/ports/geos/vcpkg.json
+++ b/ports/geos/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "geos",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "Geometry Engine Open Source",
   "homepage": "https://libgeos.org/",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2737,7 +2737,7 @@
       "port-version": 0
     },
     "geos": {
-      "baseline": "3.11.1",
+      "baseline": "3.11.2",
       "port-version": 0
     },
     "geotrans": {

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e21f349a41a2ca204eebfb31b75c99bfc8e61c1",
+      "version": "3.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f2b8b7ba62c8e0ca9e17f7ac5a2312c559eb547",
       "version": "3.11.1",
       "port-version": 0

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3e21f349a41a2ca204eebfb31b75c99bfc8e61c1",
+      "git-tree": "6e3173bfbaacdb8fee9ac698f0b6dc668136ed9b",
       "version": "3.11.2",
       "port-version": 0
     },


### PR DESCRIPTION
This PR updates GEOS to version 3.11.2 and backports a fix that allows it to compile with GCC 13.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.