### PR TITLE
[pdal] Fix GCC 13 compatibility

### DIFF
--- a/ports/pdal/fix-gcc-13-build.patch
+++ b/ports/pdal/fix-gcc-13-build.patch
@@ -1,0 +1,24 @@
+diff --git a/plugins/e57/libE57Format/include/E57Format.h b/plugins/e57/libE57Format/include/E57Format.h
+index 267d8c77b..66b5a62d1 100644
+--- a/plugins/e57/libE57Format/include/E57Format.h
++++ b/plugins/e57/libE57Format/include/E57Format.h
+@@ -34,6 +34,7 @@
+ #include <cfloat>
+ #include <memory>
+ #include <vector>
++#include <cstdint>
+ 
+ #include "E57Exception.h"
+ 
+diff --git a/vendor/lazperf/Extractor.hpp b/vendor/lazperf/Extractor.hpp
+index 02c7d2cef..3b26dc310 100644
+--- a/vendor/lazperf/Extractor.hpp
++++ b/vendor/lazperf/Extractor.hpp
+@@ -36,6 +36,7 @@
+ 
+ #include <cstring>
+ #include <vector>
++#include <cstdint>
+ 
+ #include "portable_endian.hpp"
+ 

--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         no-pkgconfig-requires.patch
         no-rpath.patch
         fix-gcc8-compatibility.patch #Upstream PR: https://github.com/PDAL/PDAL/pull/3864
+        fix-gcc-13-build.patch
 )
 
 # Prefer pristine CMake find modules + wrappers and config files from vcpkg.

--- a/ports/pdal/vcpkg.json
+++ b/ports/pdal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pdal",
   "version": "2.4.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.",
   "homepage": "https://pdal.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6098,7 +6098,7 @@
     },
     "pdal": {
       "baseline": "2.4.3",
-      "port-version": 3
+      "port-version": 4
     },
     "pdal-c": {
       "baseline": "2.1",

--- a/versions/p-/pdal.json
+++ b/versions/p-/pdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a5c7ee725760b1dfb189a65869b595766403439",
+      "version": "2.4.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "e0e82c8480da2e69cc7532911895844095466aad",
       "version": "2.4.3",
       "port-version": 3


### PR DESCRIPTION
This PR adds a patch which fixes some missing standard library headers that cause PDAL to fail to compile in GCC 13.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.