### PR TITLE
[vcpkg] lld-link workaround should be used with ClangCl MSBuild platform toolset

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.props
+++ b/scripts/buildsystems/msbuild/vcpkg.props
@@ -32,7 +32,7 @@
     <VcpkgAutoLink Condition="'$(VcpkgAutoLink)' == ''">true</VcpkgAutoLink>
     <!-- Deactivate Autolinking if lld is used as a linker. (Until a better way to solve the problem is found!).
     Tried to add /lib as a parameter to the linker call but was unable to find a way to pass it as the first parameter. -->
-    <VcpkgAutoLink Condition="'$(UseLldLink)' == 'true'">false</VcpkgAutoLink>
+    <VcpkgAutoLink Condition="'$(UseLldLink)' == 'true' OR '$(PlatformToolset.ToLower())' == 'clangcl'">false</VcpkgAutoLink>
     <VcpkgApplocalDeps Condition="'$(VcpkgApplocalDeps)' == ''">true</VcpkgApplocalDeps>
 
     <!-- Classic Mode: The following line is edited by the mint standalone bundle script to be false for standlone copies -->


### PR DESCRIPTION
The 'temporary fix' for lld-link done in [4573](https://github.com/microsoft/vcpkg/pull/4573) does not work for VS 2022 when using the clangcl integrated MSBuild platform.

This applies the fix to the newer scenario as well.

You still need to use 'manual link' with lld-llvm, but at least the experience isn't broken out of the box for header-only libs.
