### PR TITLE
[baseline] [gz-math7] Disable python bindings

### DIFF
--- a/ports/gz-math7/disable-python-bindings.patch
+++ b/ports/gz-math7/disable-python-bindings.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 0adbed1..10e82dd 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -18,7 +18,7 @@ gz_build_tests(TYPE UNIT SOURCES ${gtest_sources})
+ add_subdirectory(graph)
+ 
+ # Bindings subdirectories
+-if (pybind11_FOUND AND NOT SKIP_PYBIND11)
++if (0)
+   add_subdirectory(python_pybind11)
+ endif()
+ 

--- a/ports/gz-math7/portfile.cmake
+++ b/ports/gz-math7/portfile.cmake
@@ -4,4 +4,5 @@ ignition_modular_library(NAME ${PACKAGE_NAME}
                          REF ${PORT}_${VERSION}
                          VERSION ${VERSION}
                          SHA512 84617eeb6840b0bad8f94c38e8af11bf010c2e3166042541d0d79c44f60a70ee6fde395b2a1b801abedb36aa024f7fb14bbb993eb7be2949c72d8756ba4b3196
+                         PATCHES disable-python-bindings.patch
                          )

--- a/ports/gz-math7/vcpkg.json
+++ b/ports/gz-math7/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gz-math7",
   "version": "7.0.2",
+  "port-version": 1,
   "description": "Math API for robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/math",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3022,7 +3022,7 @@
     },
     "gz-math7": {
       "baseline": "7.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gz-tools2": {
       "baseline": "2.0.0",

--- a/versions/g-/gz-math7.json
+++ b/versions/g-/gz-math7.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "957a3882802c80e038d5a85a3134173e33798c92",
+      "version": "7.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "13b399f38d70db748d1babf9296d2a4fc80dc302",
       "version": "7.0.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix vcpkg pipeline issues `gz-math7:x86-windows` and `gz-math7:x64-windows` installation failed with following error:
```
LINK : fatal error LNK1104: cannot open file 'python310.lib'
ninja: build stopped: subcommand failed.
```
This issue only occurs when `pybind11` is installed, when `pybind11_FOUND` is ON, `gz-math7` will generate Python bindings via pybind11, `pybind11_add_module` links the incorrect `python3`.

I added patch to disable python bindings.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
