### PR TITLE
[sdl2-mixer-ext] add new port

### DIFF
--- a/ports/sdl2-mixer-ext/fix-dependencies.patch
+++ b/ports/sdl2-mixer-ext/fix-dependencies.patch
@@ -1,0 +1,304 @@
+diff --git a/src/codecs/music_ffmpeg.cmake b/src/codecs/music_ffmpeg.cmake
+index c4f69f9dfba4cf77d6f7ba513ff0a6bdb7a7fb71..a6a6bb8cd382ee0cb3d5eb05ed97d2ac430ca50d 100644
+--- a/src/codecs/music_ffmpeg.cmake
++++ b/src/codecs/music_ffmpeg.cmake
+@@ -3,7 +3,7 @@ if(USE_FFMPEG AND MIXERX_LGPL)
+     option(USE_FFMPEG_DYNAMIC "Use dynamical loading of FFMPEG" ON)
+ 
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+-        find_package(FFMPEG QUIET)
++        find_package(FFMPEG REQUIRED)
+         message("FFMPEG: [${FFMPEG_avcodec_FOUND}] ${FFMPEG_INCLUDE_DIRS} ${FFMPEG_swresample_LIBRARY} ${FFMPEG_avformat_LIBRARY} ${FFMPEG_avcodec_LIBRARY} ${FFMPEG_avutil_LIBRARY}")
+         if(USE_FFMPEG_DYNAMIC)
+             list(APPEND SDL_MIXER_DEFINITIONS
+@@ -16,10 +16,7 @@ if(USE_FFMPEG AND MIXERX_LGPL)
+             message("Dynamic FFMPEG: ${FFMPEG_avutil_DYNAMIC_LIBRARY} ${FFMPEG_avcodec_DYNAMIC_LIBRARY} ${FFMPEG_avformat_DYNAMIC_LIBRARY} ${FFMPEG_swresample_DYNAMIC_LIBRARY}")
+         endif()
+         set(FFMPEG_LINK_LIBRARIES
+-            ${FFMPEG_swresample_LIBRARY}
+-            ${FFMPEG_avformat_LIBRARY}
+-            ${FFMPEG_avcodec_LIBRARY}
+-            ${FFMPEG_avutil_LIBRARY}
++            ${FFMPEG_LIBRARIES}
+         )
+     else()
+         message(WARNING "FFMPEG libraries are not a part of AudioCodecs yet. Using any available from the system.")
+@@ -41,7 +38,7 @@ if(USE_FFMPEG AND MIXERX_LGPL)
+         set(FFMPEG_swresample_FOUND 1)
+     endif()
+ 
+-    if(FFMPEG_avcodec_FOUND AND FFMPEG_avformat_FOUND AND FFMPEG_avutil_FOUND AND FFMPEG_swresample_FOUND)
++    if(1)
+         set(FFMPEG_FOUND 1)
+     endif()
+ 
+diff --git a/src/codecs/music_flac.cmake b/src/codecs/music_flac.cmake
+index 8fb69ed54894dc2657e6da326015a606f567eb9d..9caf2b1a817258b957416f20aa57a5cd21f06c3c 100644
+--- a/src/codecs/music_flac.cmake
++++ b/src/codecs/music_flac.cmake
+@@ -3,7 +3,10 @@ if(USE_FLAC)
+     option(USE_FLAC_DYNAMIC "Use dynamical loading of FLAC" OFF)
+ 
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+-        find_package(FLAC QUIET)
++        find_package(FLAC CONFIG REQUIRED)
++        get_target_property(FLAC_INCLUDE_DIRS FLAC::FLAC INTERFACE_INCLUDE_DIRECTORIES)
++        set(FLAC_LIBRARIES FLAC::FLAC)
++        set(FLAC_FOUND 1)
+         message("FLAC: [${FLAC_FOUND}] ${FLAC_INCLUDE_DIRS} ${FLAC_LIBRARIES}")
+         if(USE_FLAC_DYNAMIC)
+             list(APPEND SDL_MIXER_DEFINITIONS -DFLAC_DYNAMIC=\"${FLAC_DYNAMIC_LIBRARY}\")
+diff --git a/src/codecs/music_fluidsynth.cmake b/src/codecs/music_fluidsynth.cmake
+index ee90c2708aa3857514dd4154dcc94ec17a8f22ec..d4d8d921e9863857a4bdce45b87b30e330379b2c 100644
+--- a/src/codecs/music_fluidsynth.cmake
++++ b/src/codecs/music_fluidsynth.cmake
+@@ -6,7 +6,10 @@ if(USE_MIDI_FLUIDSYNTH AND NOT USE_MIDI_FLUIDLITE AND MIXERX_LGPL)
+         message(WARNING "AudioCodecs doesn't ship FluidSynth, it will be recognized from a system!!!")
+     endif()
+ 
+-    find_package(FluidSynth QUIET)
++    find_package(FluidSynth CONFIG REQUIRED)
++    get_target_property(FluidSynth_INCLUDE_DIRS FluidSynth::libfluidsynth INTERFACE_INCLUDE_DIRECTORIES)
++    set(FluidSynth_LIBRARIES FluidSynth::libfluidsynth)
++    set(FluidSynth_FOUND 1)
+     message("FluidSynth: [${FluidSynth_FOUND}] ${FluidSynth_INCLUDE_DIRS} ${FluidSynth_LIBRARIES}")
+     if(USE_MIDI_FLUIDSYNTH_DYNAMIC)
+         list(APPEND SDL_MIXER_DEFINITIONS -DFLUIDSYNTH_DYNAMIC=\"${FluidSynth_DYNAMIC_LIBRARY}\")
+diff --git a/src/codecs/music_gme.cmake b/src/codecs/music_gme.cmake
+index 7e0df24427f4793bd19f2def937853d949957340..a407ccb4c41eb3c900e3a07687e2a15eae166b96 100644
+--- a/src/codecs/music_gme.cmake
++++ b/src/codecs/music_gme.cmake
+@@ -3,7 +3,14 @@ if(USE_GME AND MIXERX_LGPL)
+     option(USE_GME_DYNAMIC "Use dynamical loading of Game Music Emulators library" OFF)
+ 
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+-        find_package(GME QUIET)
++        find_path(GME_INCLUDE_DIRS "gme.h" PATH_SUFFIXES gme)
++        find_library(GME_LIBRARY_RELEASE NAMES gme PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib" NO_DEFAULT_PATH)
++        find_library(GME_LIBRARY_DEBUG NAMES gme PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib" NO_DEFAULT_PATH)
++        include(SelectLibraryConfigurations)
++        select_library_configurations(GME)
++        find_package(ZLIB REQUIRED)
++        list(APPEND GME_LIBRARIES ${ZLIB_LIBRARIES})
++        set(GME_FOUND 1)
+         message("GME: [${GME_FOUND}] ${GME_INCLUDE_DIRS} ${GME_LIBRARIES}")
+         if(USE_GME_DYNAMIC)
+             list(APPEND SDL_MIXER_DEFINITIONS -DGME_DYNAMIC=\"${GME_DYNAMIC_LIBRARY}\")
+diff --git a/src/codecs/music_midi_adl.cmake b/src/codecs/music_midi_adl.cmake
+index 0d3b302f1d73ba01ec6a3b187559f1892f8a4c76..26864407f0e26d2affde07829d28407d8eea1a9f 100644
+--- a/src/codecs/music_midi_adl.cmake
++++ b/src/codecs/music_midi_adl.cmake
+@@ -3,7 +3,15 @@ if(USE_MIDI_ADLMIDI AND MIXERX_GPL)
+     option(USE_MIDI_ADLMIDI_DYNAMIC "Use dynamical loading of libADLMIDI library" OFF)
+ 
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+-        find_package(ADLMIDI QUIET)
++        find_package(libADLMIDI CONFIG REQUIRED)
++        if(SDL_MIXER_X_STATIC)
++            set(_adlmidi libADLMIDI::ADLMIDI_static)
++        else()
++            set(_adlmidi libADLMIDI::ADLMIDI_shared)
++        endif()
++        get_target_property(ADLMIDI_INCLUDE_DIRS ${_adlmidi} INTERFACE_INCLUDE_DIRECTORIES)
++        set(ADLMIDI_LIBRARIES ${_adlmidi})
++        set(ADLMIDI_FOUND 1)
+         message("ADLMIDI: [${ADLMIDI_FOUND}] ${ADLMIDI_INCLUDE_DIRS} ${ADLMIDI_LIBRARIES}")
+         if(USE_MIDI_ADLMIDI_DYNAMIC)
+             list(APPEND SDL_MIXER_DEFINITIONS -DADLMIDI_DYNAMIC=\"${ADLMIDI_DYNAMIC_LIBRARY}\")
+diff --git a/src/codecs/music_midi_opn.cmake b/src/codecs/music_midi_opn.cmake
+index 34169046fe51bd6d1b27d314733b2a13209b7968..3dc4409dc7ea6b6a340f7082c0567bbf946c9132 100644
+--- a/src/codecs/music_midi_opn.cmake
++++ b/src/codecs/music_midi_opn.cmake
+@@ -3,7 +3,15 @@ if(USE_MIDI_OPNMIDI AND MIXERX_GPL)
+     option(USE_MIDI_OPNMIDI_DYNAMIC "Use dynamical loading of libOPNMIDI library" OFF)
+ 
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+-        find_package(OPNMIDI QUIET)
++        find_package(libOPNMIDI CONFIG REQUIRED)
++        if(SDL_MIXER_X_STATIC)
++            set(_opnmidi libOPNMIDI::OPNMIDI_static)
++        else()
++            set(_opnmidi libOPNMIDI::OPNMIDI_shared)
++        endif()
++        get_target_property(OPNMIDI_INCLUDE_DIRS ${_opnmidi} INTERFACE_INCLUDE_DIRECTORIES)
++        set(OPNMIDI_LIBRARIES ${_opnmidi})
++        set(OPNMIDI_FOUND 1)
+         message("OPNMIDI: [${OPNMIDI_FOUND}] ${OPNMIDI_INCLUDE_DIRS} ${OPNMIDI_LIBRARIES}")
+         if(USE_MIDI_OPNMIDI_DYNAMIC)
+             list(APPEND SDL_MIXER_DEFINITIONS -DOPNMIDI_DYNAMIC=\"${OPNMIDI_DYNAMIC_LIBRARY}\")
+diff --git a/src/codecs/music_modplug.cmake b/src/codecs/music_modplug.cmake
+index 555bcd91574d1c65761121648b331715a5fe8dad..ad065be36cd0176aa7f08631a6df48e857f76e42 100644
+--- a/src/codecs/music_modplug.cmake
++++ b/src/codecs/music_modplug.cmake
+@@ -4,7 +4,12 @@ if(USE_MODPLUG)
+     option(USE_MODPLUG_STATIC "Use linking with a static ModPlug" ON)
+ 
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+-        find_package(ModPlug QUIET)
++        find_path(ModPlug_INCLUDE_DIRS "modplug.h" PATH_SUFFIXES libmodplug)
++        find_library(ModPlug_LIBRARY_RELEASE NAMES modplug PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib" NO_DEFAULT_PATH)
++        find_library(ModPlug_LIBRARY_DEBUG NAMES modplug PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib" NO_DEFAULT_PATH)
++        include(SelectLibraryConfigurations)
++        select_library_configurations(ModPlug)
++        set(ModPlug_FOUND 1)
+         message("ModPlug: [${ModPlug_FOUND}] ${ModPlug_INCLUDE_DIRS} ${ModPlug_LIBRARIES}")
+         if(USE_MODPLUG_DYNAMIC)
+             list(APPEND SDL_MIXER_DEFINITIONS -DMODPLUG_DYNAMIC=\"${ModPlug_DYNAMIC_LIBRARY}\")
+diff --git a/src/codecs/music_mpg123.cmake b/src/codecs/music_mpg123.cmake
+index c615896cd95e2854ced2d4188ea8e0d18870ad91..602a7b136ec135d55839cf7ab103df56357a8a4c 100644
+--- a/src/codecs/music_mpg123.cmake
++++ b/src/codecs/music_mpg123.cmake
+@@ -4,7 +4,10 @@ if(USE_MP3_MPG123 AND MIXERX_LGPL)
+     option(USE_MP3_MPG123_DYNAMIC "Use dynamical loading of MPG123" OFF)
+ 
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+-        find_package(Mpg123 QUIET)
++        find_package(MPG123 CONFIG REQUIRED)
++        get_target_property(MPG123_INCLUDE_DIR MPG123::libmpg123 INTERFACE_INCLUDE_DIRECTORIES)
++        set(MPG123_LIBRARIES MPG123::libmpg123)
++        set(MPG123_FOUND 1)
+         message("MPG123 found in ${MPG123_INCLUDE_DIR} folder")
+         if(USE_MP3_MPG123_DYNAMIC)
+             list(APPEND SDL_MIXER_DEFINITIONS -DMPG123_DYNAMIC=\"${MPG123_DYNAMIC_LIBRARY}\")
+diff --git a/src/codecs/music_ogg.cmake b/src/codecs/music_ogg.cmake
+index e7930f9c7e1a583f77306f6838933b991382872f..33a8a59e72e30e3cabd4e834895a23ae7b101324 100644
+--- a/src/codecs/music_ogg.cmake
++++ b/src/codecs/music_ogg.cmake
+@@ -1,4 +1,4 @@
+-if(LIBOGG_NEEDED)
++if(0)
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+         find_package(OGG REQUIRED)
+     else()
+diff --git a/src/codecs/music_ogg_vorbis.cmake b/src/codecs/music_ogg_vorbis.cmake
+index 475c7ea67663d114a4fc0fef243e15fbf66a00c1..66fa87521c91d1f25fc335b026078b384509dc6a 100644
+--- a/src/codecs/music_ogg_vorbis.cmake
++++ b/src/codecs/music_ogg_vorbis.cmake
+@@ -10,7 +10,10 @@ if(USE_OGG_VORBIS)
+                 find_package(Tremor QUIET)
+                 message("Tremor: [${Tremor_FOUND}] ${Tremor_INCLUDE_DIRS} ${Tremor_LIBRARIES}")
+             else()
+-                find_package(Vorbis QUIET)
++                find_package(Vorbis CONFIG REQUIRED)
++                get_target_property(Vorbis_INCLUDE_DIRS Vorbis::vorbisfile INTERFACE_INCLUDE_DIRECTORIES)
++                set(Vorbis_LIBRARIES Vorbis::vorbisfile)
++                set(Vorbis_FOUND 1)
+                 message("Vorbis: [${Vorbis_FOUND}] ${Vorbis_INCLUDE_DIRS} ${Vorbis_LIBRARIES}")
+             endif()
+ 
+diff --git a/src/codecs/music_opus.cmake b/src/codecs/music_opus.cmake
+index 61fb32e7ec1bcb4e21cb77607399f1f36317c481..44e0b5da00146492a2b34a65ab0c16846b1aeb84 100644
+--- a/src/codecs/music_opus.cmake
++++ b/src/codecs/music_opus.cmake
+@@ -3,7 +3,10 @@ if(USE_OPUS)
+     option(USE_OPUS_DYNAMIC "Use dynamical loading of Opus" OFF)
+ 
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+-        find_package(Opus QUIET)
++        find_package(OpusFile CONFIG REQUIRED)
++        get_target_property(Opus_INCLUDE_DIRS OpusFile::opusfile INTERFACE_INCLUDE_DIRECTORIES)
++        set(Opus_LIBRARIES OpusFile::opusfile)
++        set(Opus_FOUND 1)
+         message("Opus: [${Opus_FOUND}] ${Opus_INCLUDE_DIRS} ${Opus_LIBRARIES} ${LIBOPUS_LIB}")
+         if(USE_OPUS_DYNAMIC)
+             list(APPEND SDL_MIXER_DEFINITIONS -DOPUS_DYNAMIC=\"${OpusFile_DYNAMIC_LIBRARY}\")
+diff --git a/src/codecs/music_wavpack.cmake b/src/codecs/music_wavpack.cmake
+index ab841b8c8c9720d50ce15534361cc4ba80e6595d..688f7459789eae14df641e53c003daedc1916c12 100644
+--- a/src/codecs/music_wavpack.cmake
++++ b/src/codecs/music_wavpack.cmake
+@@ -3,7 +3,10 @@ if(USE_WAVPACK)
+     option(USE_WAVPACK_DYNAMIC "Use dynamical loading of WAVPACK" OFF)
+ 
+     if(USE_SYSTEM_AUDIO_LIBRARIES)
+-        find_package(WavPack QUIET)
++        find_package(WavPack CONFIG REQUIRED)
++        get_target_property(WavPack_INCLUDE_DIRS WavPack::WavPack INTERFACE_INCLUDE_DIRECTORIES)
++        set(WavPack_LIBRARIES WavPack::WavPack)
++        set(WavPack_FOUND 1)
+         message("WavPack: [${WavPack_FOUND}] ${WavPack_INCLUDE_DIRS} ${WavPack_LIBRARIES}")
+         if(USE_WAVPACK_DYNAMIC)
+             list(APPEND SDL_MIXER_DEFINITIONS -DWAVPACK_DYNAMIC=\"${WavPack_DYNAMIC_LIBRARY}\")
+diff --git a/src/codecs/music_xmp.cmake b/src/codecs/music_xmp.cmake
+index 2b41037b9cdb4160515982eb8511500baf9961ce..698c34fa2dc8fb8175d8b1ab61255bd0aa7c9d9f 100644
+--- a/src/codecs/music_xmp.cmake
++++ b/src/codecs/music_xmp.cmake
+@@ -19,7 +19,15 @@ if(USE_XMP)
+             set(XMP_LIBRARIES ${XMPLITE_LIBRARIES})
+             set(XMP_FOUND ${XMPLITE_FOUND})
+         else()
+-            find_package(XMP)
++            find_package(libxmp CONFIG REQUIRED)
++            if(SDL_MIXER_X_STATIC)
++                set(_xmp libxmp::xmp_static)
++            else()
++                set(_xmp libxmp::xmp_shared)
++            endif()
++            get_target_property(XMP_INCLUDE_DIRS ${_xmp} INTERFACE_INCLUDE_DIRECTORIES)
++            set(XMP_LIBRARIES ${_xmp})
++            set(XMP_FOUND 1)
+             message("XMP: [${XMP_FOUND}] ${XMP_INCLUDE_DIRS} ${XMP_LIBRARIES}")
+             if(USE_XMP_DYNAMIC)
+                 list(APPEND SDL_MIXER_DEFINITIONS -DXMP_DYNAMIC=\"${XMP_DYNAMIC_LIBRARY}\")
+diff --git a/SDL2_mixer_extConfig.cmake.in b/SDL2_mixer_extConfig.cmake.in
+index 997d4e828150d10fa4113b3341220ca185fc29a5..2d781528151075385a2e837df3863900b8d36573 100644
+--- a/SDL2_mixer_extConfig.cmake.in
++++ b/SDL2_mixer_extConfig.cmake.in
+@@ -6,10 +6,58 @@ set_package_properties(SDL2_mixer_ext PROPERTIES
+ 
+ @PACKAGE_INIT@
+ 
++set(SDL_MIXER_X_USE_OGG_VORBIS              @USE_OGG_VORBIS@)
++set(SDL_MIXER_X_USE_OPUS                    @USE_OPUS@)
++set(SDL_MIXER_X_USE_USE_FLAC                @USE_FLAC@)
++set(SDL_MIXER_X_USE_USE_WAVPACK             @USE_WAVPACK@)
++set(SDL_MIXER_X_USE_MP3_MPG123              @USE_MP3_MPG123@)
++set(SDL_MIXER_X_USE_XMP                     @USE_XMP@)
++set(SDL_MIXER_X_USE_MIDI_ADLMIDI            @USE_MIDI_ADLMIDI@)
++set(SDL_MIXER_X_USE_MIDI_OPNMIDI            @USE_MIDI_OPNMIDI@)
++set(SDL_MIXER_X_USE_MIDI_FLUIDSYNTH         @USE_MIDI_FLUIDSYNTH@)
++
+ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL2_mixer_ext-shared-targets.cmake")
+     include("${CMAKE_CURRENT_LIST_DIR}/SDL2_mixer_ext-shared-targets.cmake")
+ endif()
+ 
+ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL2_mixer_ext-static-targets.cmake")
++    include(CMakeFindDependencyMacro)
++
++    if(SDL_MIXER_X_USE_OGG_VORBIS AND NOT TARGET Vorbis::vorbisfile)
++        find_dependency(Vorbis CONFIG)
++    endif()
++
++    if(SDL_MIXER_X_USE_OPUS AND NOT TARGET OpusFile::opusfile)
++        find_dependency(OpusFile CONFIG)
++    endif()
++
++    if(SDL_MIXER_X_USE_USE_FLAC AND NOT TARGET FLAC::FLAC)
++        find_dependency(FLAC CONFIG)
++    endif()
++
++    if(SDL_MIXER_X_USE_USE_WAVPACK AND NOT TARGET WavPack::WavPack)
++        find_dependency(WavPack CONFIG)
++    endif()
++
++    if(SDL_MIXER_X_USE_MP3_MPG123 AND NOT TARGET MPG123::libmpg123)
++        find_dependency(MPG123 CONFIG)
++    endif()
++
++    if(SDL_MIXER_X_USE_XMP AND NOT TARGET libxmp::xmp_static)
++        find_dependency(libxmp CONFIG)
++    endif()
++
++    if(SDL_MIXER_X_USE_MIDI_ADLMIDI AND NOT TARGET libADLMIDI::ADLMIDI_static)
++        find_dependency(libADLMIDI CONFIG)
++    endif()
++
++    if(SDL_MIXER_X_USE_MIDI_OPNMIDI AND NOT TARGET libOPNMIDI::OPNMIDI_static)
++        find_dependency(libOPNMIDI CONFIG)
++    endif()
++
++    if(SDL_MIXER_X_USE_MIDI_FLUIDSYNTH AND NOT TARGET FluidSynth::libfluidsynth)
++        find_dependency(FluidSynth CONFIG)
++    endif()
++
+     include("${CMAKE_CURRENT_LIST_DIR}/SDL2_mixer_ext-static-targets.cmake")
+ endif()

--- a/ports/sdl2-mixer-ext/portfile.cmake
+++ b/ports/sdl2-mixer-ext/portfile.cmake
@@ -1,0 +1,96 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO WohlSoft/SDL-Mixer-X
+    REF 1bd1111949036645e92cf0f7aa635e904c590318
+    SHA512 b3c87580ff639b015d0e3f00d584878f141896ac812ec036945025416019f7849e952a76135095358f427eb2d04ed8f68fd9721e1869dade78517f7372ad2f9c
+    HEAD_REF master
+    PATCHES
+        fix-dependencies.patch
+)
+
+file(REMOVE
+    "${SOURCE_PATH}/cmake/find/FindOGG.cmake" # Conflicts with official configurations
+    "${SOURCE_PATH}/cmake/find/FindFFMPEG.cmake" # Using FindFFMPEG.cmake provided by vcpkg
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        libvorbis   USE_OGG_VORBIS
+        opusfile    USE_OPUS
+        libflac     USE_FLAC
+        wavpack     USE_WAVPACK
+        mpg123      USE_MP3_MPG123
+        libmodplug  USE_MODPLUG
+        libxmp      USE_XMP
+        libgme      USE_GME
+        ffmpeg      USE_FFMPEG
+        cmd         USE_CMD
+        libadlmidi  USE_MIDI_ADLMIDI
+        libopnmidi  USE_MIDI_OPNMIDI
+        timidity    USE_MIDI_TIMIDITY
+        fluidsynth  USE_MIDI_FLUIDSYNTH
+        nativemidi  USE_MIDI_NATIVE_ALT
+        nativemidi  USE_MIDI_NATIVE
+)
+
+if("libadlmidi"     IN_LIST FEATURES OR 
+    "libopnmidi"    IN_LIST FEATURES OR 
+    "timidity"      IN_LIST FEATURES OR 
+    "fluidsynth"    IN_LIST FEATURES OR 
+    "nativemidi"    IN_LIST FEATURES)
+    set(USE_MIDI ON)
+else()
+    set(USE_MIDI OFF)
+endif()
+
+if("fluidsynth" IN_LIST FEATURES)
+    vcpkg_find_acquire_program(PKGCONFIG)
+    list(APPEND EXTRA_OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        ${EXTRA_OPTIONS}
+        -DMIXERX_ENABLE_GPL=ON
+        -DMIXERX_ENABLE_LGPL=ON
+        -DUSE_SYSTEM_SDL2=ON
+        -DUSE_SYSTEM_AUDIO_LIBRARIES=ON
+        -DUSE_OGG_VORBIS_STB=OFF
+        -DUSE_DRFLAC=OFF
+        -DUSE_MP3_DRMP3=OFF
+        -DUSE_FFMPEG_DYNAMIC=OFF
+        -DUSE_MIDI=${USE_MIDI}
+        -DUSE_MIDI_EDMIDI=OFF
+        -DUSE_MIDI_FLUIDLITE=OFF
+    MAYBE_UNUSED_VARIABLES
+        USE_FFMPEG_DYNAMIC
+        USE_CMD
+        USE_MIDI_NATIVE
+        USE_MIDI_NATIVE_ALT
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME SDL2_mixer_ext
+    CONFIG_PATH lib/cmake/SDL2_mixer_ext)
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+set(LICENSE_FILES
+    "${SOURCE_PATH}/COPYING.txt"
+    "${SOURCE_PATH}/GPLv2.txt"
+    "${SOURCE_PATH}/GPLv3.txt"
+    "${SOURCE_PATH}/SDL2_mixer_ext.License.txt"
+)
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/sdl2-mixer-ext/usage
+++ b/ports/sdl2-mixer-ext/usage
@@ -1,0 +1,4 @@
+sdl2-mixer-ext provides CMake targets:
+
+    find_package(SDL2_mixer_ext CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SDL2_mixer_ext::SDL2_mixer_ext>,SDL2_mixer_ext::SDL2_mixer_ext,SDL2_mixer_ext::SDL2_mixer_ext_Static>)

--- a/ports/sdl2-mixer-ext/vcpkg.json
+++ b/ports/sdl2-mixer-ext/vcpkg.json
@@ -1,0 +1,121 @@
+{
+  "name": "sdl2-mixer-ext",
+  "version-date": "2023-05-04",
+  "description": "An audio mixer library based on the SDL library, a fork of SDL_mixer",
+  "homepage": "https://wohlsoft.github.io/SDL-Mixer-X",
+  "license": "Zlib OR LGPL-2.1-or-later OR GPL-2.0-or-later OR GPL-3.0-or-later",
+  "dependencies": [
+    "sdl2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cmd": {
+      "description": "Use external command for playing music (Linux only).",
+      "supports": "linux"
+    },
+    "ffmpeg": {
+      "description": "Use FFMPEG to play WMA and AAC audio formats.",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false
+        }
+      ]
+    },
+    "fluidsynth": {
+      "description": "Use FluidSynth to play MIDI audio format.",
+      "dependencies": [
+        {
+          "name": "fluidsynth",
+          "default-features": false
+        }
+      ]
+    },
+    "libadlmidi": {
+      "description": "Use libADLMIDI to play XMI, MUS, IMF and regular MIDI audio format with OPL3 (YMF262) emulator.",
+      "dependencies": [
+        {
+          "name": "libadlmidi",
+          "default-features": false
+        }
+      ]
+    },
+    "libflac": {
+      "description": "Use libflac to play FLAC audio format.",
+      "dependencies": [
+        "libflac"
+      ]
+    },
+    "libgme": {
+      "description": "Use libgme to play chip music (AY, GBS, GYM, HES, KSS, NSF/NSFE, SAP, SPC, VGM/VGZ).",
+      "dependencies": [
+        {
+          "name": "libgme",
+          "default-features": false
+        }
+      ]
+    },
+    "libmodplug": {
+      "description": "Use libmodplug to play tracker music including exclusive formats (AMS, DMF, DSM, MT2).",
+      "dependencies": [
+        "libmodplug"
+      ]
+    },
+    "libopnmidi": {
+      "description": "Use libOPNMIDI to play MIDI and RMI audio format with OPN2 (YM2612) emulator.",
+      "dependencies": [
+        {
+          "name": "libopnmidi",
+          "default-features": false
+        }
+      ]
+    },
+    "libvorbis": {
+      "description": "Use libvorbis to play OGG audio format.",
+      "dependencies": [
+        "libvorbis"
+      ]
+    },
+    "libxmp": {
+      "description": "Use libxmp to play tracker music including exclusive formats (ABK, DIGI, DTM, EMOD, FLX, FNK, GDM, IMF, J2B, LIQ, M15, MFP, MGT, MMDC, MTN, RTM, SFX, SPM, STIM, STX, WOW).",
+      "dependencies": [
+        {
+          "name": "libxmp",
+          "default-features": false
+        }
+      ]
+    },
+    "mpg123": {
+      "description": "Use mpg123 to play MP3 audio format.",
+      "dependencies": [
+        "mpg123"
+      ]
+    },
+    "nativemidi": {
+      "description": "Use Native MIDI Player to play MIDI audio format.",
+      "supports": "windows | osx"
+    },
+    "opusfile": {
+      "description": "Use opusfile to play Opus audio format.",
+      "dependencies": [
+        "opusfile"
+      ]
+    },
+    "timidity": {
+      "description": "Use Timidity to play MIDI audio format."
+    },
+    "wavpack": {
+      "description": "Use wavpack to play VW audio format.",
+      "dependencies": [
+        "wavpack"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7216,6 +7216,10 @@
       "baseline": "2.6.3",
       "port-version": 1
     },
+    "sdl2-mixer-ext": {
+      "baseline": "2023-05-04",
+      "port-version": 0
+    },
     "sdl2-net": {
       "baseline": "2.2.0",
       "port-version": 1

--- a/versions/s-/sdl2-mixer-ext.json
+++ b/versions/s-/sdl2-mixer-ext.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "04312072ef4ea392cb39c240e579f06b4d62b955",
+      "version-date": "2023-05-04",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

