### PR TITLE
[libphonenumber] Update to 8.13.11

### DIFF
--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/libphonenumber
     REF "v${VERSION}"
-    SHA512 b864f0ff25ed32813dfa7db5d92ada501566b4d6c366f6ee856dff82680631b88acf24def742015d112e20d4e8aa7c6312c04afb846d492d1f5bef93099775ec
+    SHA512 e685bb9501104527ceec9af7ac424a5f642f6960454fe5a6f10f5e6555bb6d52b68a0465c5475162e8a1ac20a0b1bfb68bd4587ffae64dc017a5c8a5efc5b09f
     HEAD_REF master
     PATCHES 
         fix-re2-identifiers.patch

--- a/ports/libphonenumber/vcpkg.json
+++ b/ports/libphonenumber/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libphonenumber",
-  "version": "8.13.9",
+  "version": "8.13.11",
   "description": "Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.",
   "license": "Apache-2.0",
   "supports": "!linux & !osx",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4361,7 +4361,7 @@
       "port-version": 1
     },
     "libphonenumber": {
-      "baseline": "8.13.9",
+      "baseline": "8.13.11",
       "port-version": 0
     },
     "libplist": {

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f6bcac3d621a03907f69278cb2a1e303fa414f1",
+      "version": "8.13.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "c67ed43ff7bcb68e7d676e1a3be1139e7f5bdc2f",
       "version": "8.13.9",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/31188

The usage and feature has been tested successfully locally.
```
find_package(libphonenumber CONFIG REQUIRED)
target_link_libraries(main PRIVATE libphonenumber::phonenumber)
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
