### PR TITLE
[libxlsxwriter] Fix pc file, de-vendor minizip

### DIFF
--- a/ports/libxlsxwriter/dependencies.diff
+++ b/ports/libxlsxwriter/dependencies.diff
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e656184..776c88a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -225,8 +225,8 @@ message("zlib version: " ${ZLIB_VERSION})
+ 
+ # MINIZIP
+ if (USE_SYSTEM_MINIZIP)
+-    find_package(MINIZIP REQUIRED "1.0")
+-    list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${MINIZIP_INCLUDE_DIRS})
++    find_package(MINIZIP NAMES unofficial-minizip REQUIRED)
++    set(MINIZIP_LIBRARIES unofficial::minizip::minizip)
+ endif()
+ 
+ # LIBRARY
+diff --git a/dev/release/pkg-config.txt b/dev/release/pkg-config.txt
+index a87d080..fa58047 100644
+--- a/dev/release/pkg-config.txt
++++ b/dev/release/pkg-config.txt
+@@ -7,4 +7,5 @@ Name: libxlsxwriter
+ Description: A C library for creating Excel XLSX files
+ Version: @VERSION@
+ Cflags: -I${includedir}
+-Libs: -L${libdir} -lxlsxwriter -lz
++Libs: -L${libdir} -lxlsxwriter
++Requires.private: minizip zlib

--- a/ports/libxlsxwriter/portfile.cmake
+++ b/ports/libxlsxwriter/portfile.cmake
@@ -1,20 +1,23 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jmcnamara/libxlsxwriter
-    REF RELEASE_1.1.5
+    REF "RELEASE_${VERSION}"
     SHA512 bd7db0fcf25ebf492b4d8f7da8fdb6cc79400d7d0fa5856ddae259cb24817034fc97d4828cbde42434f41198dcfb6732ac63c756abd962689f4249ca64bf19c6
     HEAD_REF master
+    PATCHES
+        dependencies.diff
 )
+file(REMOVE_RECURSE "${SOURCE_PATH}/third_party/minizip")
 
+set(USE_WINDOWSSTORE OFF)
 if (VCPKG_TARGET_IS_UWP)
-  set(USE_WINDOWSSTORE ON)
-else()
-  set(USE_WINDOWSSTORE OFF)
+    set(USE_WINDOWSSTORE ON)
 endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
+        -DUSE_SYSTEM_MINIZIP=1
         -DWINDOWSSTORE=${USE_WINDOWSSTORE}
 )
 
@@ -24,5 +27,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")

--- a/ports/libxlsxwriter/vcpkg.json
+++ b/ports/libxlsxwriter/vcpkg.json
@@ -1,10 +1,12 @@
 {
   "name": "libxlsxwriter",
   "version": "1.1.5",
+  "port-version": 1,
   "description": "Libxlsxwriter is a C library that can be used to write text, numbers, formulas and hyperlinks to multiple worksheets in an Excel 2007+ XLSX file.",
   "homepage": "https://github.com/jmcnamara/libxlsxwriter",
   "license": null,
   "dependencies": [
+    "minizip",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4746,7 +4746,7 @@
     },
     "libxlsxwriter": {
       "baseline": "1.1.5",
-      "port-version": 0
+      "port-version": 1
     },
     "libxml2": {
       "baseline": "2.10.3",

--- a/versions/l-/libxlsxwriter.json
+++ b/versions/l-/libxlsxwriter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2769eadc216de088f724efd09edce1c73f9e8b4b",
+      "version": "1.1.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "1fec6d7beb6dff8486fb16b04849725ac466d409",
       "version": "1.1.5",
       "port-version": 0


### PR DESCRIPTION
Alternative to #31246.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.