### PR TITLE
[bond] Update to 10.0.0

### DIFF
--- a/ports/bond/portfile.cmake
+++ b/ports/bond/portfile.cmake
@@ -1,21 +1,19 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(BOND_VER 9.0.3)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/bond
-    REF  ${BOND_VER}
-    SHA512 3a7884eb00e6d0ab40c688f4a40cb2d3f356c48b38d48a9a08c756047a94b82619ef345483f42c3240732f5da06816b65a61acb83bfebb3c2c6b44099ce71bf9
+    REF  "${VERSION}"
+    SHA512 a5475d3f988928fc3d03b69fc34b33ada35bd790138a0f4a733642558c72945e79c5dcde88b656cbc1cafbc3cb2dd4ba28031e09e507d730056876148ef65014
     HEAD_REF master
     PATCHES fix-install-path.patch skip-grpc-compilation.patch
 )
 
 if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_download_distfile(GBC_ARCHIVE
-        URLS "https://github.com/microsoft/bond/releases/download/${BOND_VER}/gbc-${BOND_VER}-amd64.zip"
-        FILENAME "gbc-${BOND_VER}-amd64.zip"
-        SHA512 41a4e01a9a0f6246a3c07f516f2c0cfc8a837eff2166c2bb787877e409d6f55eeb6084e63aabc3502492775a3fa7e381bf37fde0bdfced50a9d0b39dfaca7dfd
+        URLS "https://github.com/microsoft/bond/releases/download/${VERSION}/gbc-${VERSION}-amd64.zip"
+        FILENAME "gbc-${VERSION}-amd64.zip"
+        SHA512 590b051aa47ad161f8a8a5f782e22d2201ad536e0772c9e528f98df1d1fd2b154723d21587d35c8b948805ab229dfb3b515273ae37d05028554fd49b39dc5418
     )
 
     # Clear the generator to prevent it from updating
@@ -24,7 +22,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_extract_source_archive(extracted_tool_dir ARCHIVE "${GBC_ARCHIVE}" NO_REMOVE_ONE_LEVEL)
     file(RENAME "${extracted_tool_dir}" "${CURRENT_BUILDTREES_DIR}/tools")
 
-    set(FETCHED_GBC_PATH "${CURRENT_BUILDTREES_DIR}/tools/gbc-${BOND_VER}-amd64.exe")
+    set(FETCHED_GBC_PATH "${CURRENT_BUILDTREES_DIR}/tools/gbc-${VERSION}-amd64.exe")
     if(NOT EXISTS "${FETCHED_GBC_PATH}")
         message(FATAL_ERROR "Fetching GBC failed. Expected '${FETCHED_GBC_PATH}' to exist, but it doesn't.")
     endif()
@@ -71,4 +69,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Put the license file where vcpkg expects it
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bond/skip-grpc-compilation.patch
+++ b/ports/bond/skip-grpc-compilation.patch
@@ -1,11 +1,15 @@
 diff --git a/thirdparty/CMakeLists.txt b/thirdparty/CMakeLists.txt
-index f8c7bf3..e69de29 100644
+index 8c1f368..8b13789 100644
 --- a/thirdparty/CMakeLists.txt
 +++ b/thirdparty/CMakeLists.txt
-@@ -1,6 +0,0 @@
+@@ -1,10 +1 @@
 -include (Compiler)
--
+ 
 -if (BOND_ENABLE_GRPC)
--    cxx_add_compile_options (Clang -Wno-unused-value)
--    add_subdirectory(grpc)
--endif()
+-    if (BOND_FIND_GRPC)
+-        find_package(grpc CONFIG REQUIRED)
+-    else ()
+-        cxx_add_compile_options(Clang -Wno-unused-value)
+-        add_subdirectory(grpc)
+-    endif ()
+-endif ()

--- a/ports/bond/vcpkg.json
+++ b/ports/bond/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "bond",
-  "version": "9.0.3",
-  "port-version": 3,
+  "version": "10.0.0",
   "description": "Bond is a cross-platform framework for working with schematized data. It supports cross-language de/serialization and powerful generic mechanisms for efficiently manipulating data. Bond is broadly used at Microsoft in high scale services.",
   "homepage": "https://github.com/Microsoft/bond",
   "dependencies": [

--- a/versions/b-/bond.json
+++ b/versions/b-/bond.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ce8875d8de21ca31d61b521c2e84a974e325436",
+      "version": "10.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "96ecc1c6ea2a8fabfbdfd7d0a8535821446af89f",
       "version": "9.0.3",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -613,8 +613,8 @@
       "port-version": 0
     },
     "bond": {
-      "baseline": "9.0.3",
-      "port-version": 3
+      "baseline": "10.0.0",
+      "port-version": 0
     },
     "boolinq": {
       "baseline": "3.0.4",


### PR DESCRIPTION
Fixes #31167. 

* Update `bond` to 10.0.0.
* All features are tested successfully in the following triplet:
  ```
  x86-windows
  x64-windows
  x64-windows-static
  ```


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
