### PR TITLE
[amqpcpp] Update to 4.3.23

### DIFF
--- a/ports/amqpcpp/fix-max_min_macros.patch
+++ b/ports/amqpcpp/fix-max_min_macros.patch
@@ -1,0 +1,31 @@
+diff --git a/include/amqpcpp/message.h b/include/amqpcpp/message.h
+index 0a35838..96b43e1 100644
+--- a/include/amqpcpp/message.h
++++ b/include/amqpcpp/message.h
+@@ -80,7 +80,7 @@ protected:
+         // safety-check: on 32-bit platforms size_t is obviously also a 32-bit dword
+         // in which case casting the uint64_t to a size_t could result in truncation
+         // here we check whether the given size fits inside a size_t
+-        if (std::numeric_limits<size_t>::max() < size) throw std::runtime_error("message is too big for this system");
++        if ((std::numeric_limits<size_t>::max)() < size) throw std::runtime_error("message is too big for this system");
+ 
+         // store the new size
+         _bodySize = size;
+@@ -98,7 +98,7 @@ protected:
+         if (_mutableBody)
+         {
+             // prevent overflow
+-            size = std::min(size, _bodySize - _filled);
++            size = (std::min)(size, _bodySize - _filled);
+             
+             // append more data
+             memcpy(_mutableBody + _filled, buffer, (size_t)size);
+@@ -121,7 +121,7 @@ protected:
+             _body = _mutableBody;
+             
+             // store the initial data
+-            _filled = std::min((size_t)size, (size_t)_bodySize);
++            _filled = (std::min)((size_t)size, (size_t)_bodySize);
+             memcpy(_mutableBody, buffer, _filled);
+         }
+             

--- a/ports/amqpcpp/portfile.cmake
+++ b/ports/amqpcpp/portfile.cmake
@@ -4,10 +4,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CopernicaMarketingSoftware/AMQP-CPP
     REF "v${VERSION}"
-    SHA512 6220d6cdd3114cf02f08f1d8599d1f6de94df204384f9da7db1c18f74732a5c23063cd50066b7d32906af0a968d600daf0d59f1649d9674fa67446197c6e4988
+    SHA512 3af0c0a9aeb98e349cedc7144bfc4ef1b63270d3b20d240b98b990c048402d5d4ea3a2ba28a468aab24ad45544b111809a0692716dc33af493ea5160f132834b
     HEAD_REF master
     PATCHES
         find-openssl.patch
+        fix-max_min_macros.patch
 )
 
 if(VCPKG_TARGET_IS_LINUX)

--- a/ports/amqpcpp/vcpkg.json
+++ b/ports/amqpcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "amqpcpp",
-  "version": "4.3.19",
+  "version": "4.3.23",
   "description": "AMQP-CPP is a C++ library for communicating with a RabbitMQ message broker",
   "homepage": "https://github.com/CopernicaMarketingSoftware/AMQP-CPP",
   "license": "Apache-2.0",

--- a/versions/a-/amqpcpp.json
+++ b/versions/a-/amqpcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a0661ec390526889afac4ba693c92ab00a4937c",
+      "version": "4.3.23",
+      "port-version": 0
+    },
+    {
       "git-tree": "cdf5751364452365ad13aeecc8a74bc6ab15076a",
       "version": "4.3.19",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -105,7 +105,7 @@
       "port-version": 4
     },
     "amqpcpp": {
-      "baseline": "4.3.19",
+      "baseline": "4.3.23",
       "port-version": 0
     },
     "anax": {


### PR DESCRIPTION
Fixes #31177.

* Update `amqpcpp` to 4.3.23.
* Errors C2589 and C2059 occurred during testing usage, add `fix-max_min_macros.patch` to fix it. Reported upstream: [AMQP-CPP/issues/498](https://github.com/CopernicaMarketingSoftware/AMQP-CPP/issues/498).
  ```
  E:\vcpkg01\installed\x64-windows\include\amqpcpp\message.h(85,42): error C2589: '(': illegal token on right side of '::' 
  E:\vcpkg01\installed\x64-windows\include\amqpcpp\message.h(85,42): error C2059: syntax error: ')' 
  ```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

No feature needs to be tested. The usage test passed (header files found):
```
amqpcpp provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(amqpcpp CONFIG REQUIRED)
    target_link_libraries(main PRIVATE amqpcpp)
```
