### PR TITLE
[baseline][gz-math7] Control options

### DIFF
--- a/ports/gz-math7/portfile.cmake
+++ b/ports/gz-math7/portfile.cmake
@@ -1,7 +1,12 @@
 set(PACKAGE_NAME math)
 
-ignition_modular_library(NAME ${PACKAGE_NAME}
-                         REF ${PORT}_${VERSION}
-                         VERSION ${VERSION}
-                         SHA512 84617eeb6840b0bad8f94c38e8af11bf010c2e3166042541d0d79c44f60a70ee6fde395b2a1b801abedb36aa024f7fb14bbb993eb7be2949c72d8756ba4b3196
-                         )
+ignition_modular_library(
+    NAME "${PACKAGE_NAME}"
+    REF "${PORT}_${VERSION}"
+    VERSION "${VERSION}"
+    SHA512 84617eeb6840b0bad8f94c38e8af11bf010c2e3166042541d0d79c44f60a70ee6fde395b2a1b801abedb36aa024f7fb14bbb993eb7be2949c72d8756ba4b3196
+    OPTIONS
+        -DSKIP_SWIG=ON
+        -DSKIP_PYBIND11=ON
+        -DBUILD_DOCS=OFF
+)

--- a/ports/gz-math7/vcpkg.json
+++ b/ports/gz-math7/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gz-math7",
   "version": "7.0.2",
+  "port-version": 1,
   "description": "Math API for robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/math",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3026,7 +3026,7 @@
     },
     "gz-math7": {
       "baseline": "7.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gz-tools2": {
       "baseline": "2.0.0",

--- a/versions/g-/gz-math7.json
+++ b/versions/g-/gz-math7.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "687462541825396052367baec48a08e4657d63d4",
+      "version": "7.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "13b399f38d70db748d1babf9296d2a4fc80dc302",
       "version": "7.0.2",
       "port-version": 0


### PR DESCRIPTION
Fixes baseline regression when pybind11 is installed before gz-math7.
Alternative to #31248, without patching. CC @LilyWangLL @Cheney-W 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
