### PR TITLE
[sdformat13] new port

### DIFF
--- a/ports/sdformat13/cmake-config.patch
+++ b/ports/sdformat13/cmake-config.patch
@@ -10,3 +10,14 @@ index 3465a8f..2b57440 100644
  
  if (BUILD_TESTING)
    # Build this test file only if Gazebo Tools is installed.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,6 +58,6 @@
+   if (NOT DEFINED USE_INTERNAL_URDF OR NOT USE_INTERNAL_URDF)
+-    gz_find_package(GzURDFDOM VERSION 1.0 QUIET)
++    gz_find_package(GzURDFDOM)
+     if (NOT GzURDFDOM_FOUND)
+       if (NOT DEFINED USE_INTERNAL_URDF)
+         # fallback to internal urdf
+         set(USE_INTERNAL_URDF ON)

--- a/ports/sdformat13/cmake-config.patch
+++ b/ports/sdformat13/cmake-config.patch
@@ -1,0 +1,12 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 3465a8f..2b57440 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -26,6 +26,7 @@ else()
+   target_link_libraries(using_parser_urdf INTERFACE
+     GzURDFDOM::GzURDFDOM)
+ endif()
++install(TARGETS using_parser_urdf EXPORT ${PROJECT_LIBRARY_TARGET_NAME} COMPONENT libraries)
+ 
+ if (BUILD_TESTING)
+   # Build this test file only if Gazebo Tools is installed.

--- a/ports/sdformat13/no-absolute.patch
+++ b/ports/sdformat13/no-absolute.patch
@@ -1,0 +1,38 @@
+diff --git a/include/sdf/config.hh.in b/include/sdf/config.hh.in
+index d1b3db53..9a9ce91d 100644
+--- a/include/sdf/config.hh.in
++++ b/include/sdf/config.hh.in
+@@ -48,5 +48,3 @@ 
+ #cmakedefine SDFORMAT_DISABLE_CONSOLE_LOGFILE 1
+ 
+-#define SDF_SHARE_PATH "${CMAKE_INSTALL_FULL_DATAROOTDIR}/"
+-#define SDF_VERSION_PATH "${CMAKE_INSTALL_FULL_DATAROOTDIR}/sdformat${SDF_MAJOR_VERSION}/${SDF_PKG_VERSION}"
+ 
+diff --git a/src/SDF.cc b/src/SDF.cc
+index 20dcd4c6..802cbde3 100644
+--- a/src/SDF.cc
++++ b/src/SDF.cc
+@@ -97,22 +97,6 @@ std::string findFile(const std::string &_filename, bool _searchLocalPath,
+     filename = filename.substr(idx + sep.length());
+   }
+ 
+-  // Next check the install path.
+-  std::string path = sdf::filesystem::append(SDF_SHARE_PATH, filename);
+-  if (sdf::filesystem::exists(path))
+-  {
+-    return path;
+-  }
+-
+-  // Next check the versioned install path.
+-  path = sdf::filesystem::append(SDF_SHARE_PATH,
+-                                 "sdformat" SDF_MAJOR_VERSION_STR,
+-                                 sdf::SDF::Version(), filename);
+-  if (sdf::filesystem::exists(path))
+-  {
+-    return path;
+-  }
+-
+   // Next check to see if the given file exists.
+-   path = filename;
++   std::string path = filename;
+   if (sdf::filesystem::exists(path))

--- a/ports/sdformat13/portfile.cmake
+++ b/ports/sdformat13/portfile.cmake
@@ -31,5 +31,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
                     "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sdformat13/portfile.cmake
+++ b/ports/sdformat13/portfile.cmake
@@ -1,0 +1,35 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gazebosim/sdformat
+    REF sdformat13_${VERSION}
+    SHA512 180e28631c02d92bfd17d31ec32edb234e6c56c8fad011d04198481a39bffc26355b9001c598fa63a30ce47ad8abaeaed05e3008957c5e77df3a09b0170f0e6d
+    HEAD_REF sdf13
+    PATCHES
+        no-absolute.patch
+)
+
+# Ruby is required by the sdformat build process
+vcpkg_find_acquire_program(RUBY)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        -DBUILD_TESTING=OFF
+        -DUSE_INTERNAL_URDF=OFF
+        -DUSE_EXTERNAL_TINYXML=ON
+        "-DRUBY=${RUBY}"
+)
+
+vcpkg_cmake_install()
+
+# Fix cmake targets and pkg-config file location
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sdformat12")
+vcpkg_fixup_pkgconfig()
+
+# Remove debug files
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/sdformat13/portfile.cmake
+++ b/ports/sdformat13/portfile.cmake
@@ -1,12 +1,12 @@
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gazebosim/sdformat
-    REF sdformat13_${VERSION}
-    SHA512 180e28631c02d92bfd17d31ec32edb234e6c56c8fad011d04198481a39bffc26355b9001c598fa63a30ce47ad8abaeaed05e3008957c5e77df3a09b0170f0e6d
+    REF "sdformat13_${VERSION}"
+    SHA512 adc555527aadaede84d6fde11555bf4872028d9e895fc47c89f4077452fde9a52b233d60d0cbff5a098e261c7810aa2dc38a6275ec9f37ba4d0161af98e2aade
     HEAD_REF sdf13
     PATCHES
         no-absolute.patch
+        cmake-config.patch
 )
 
 # Ruby is required by the sdformat build process
@@ -14,22 +14,22 @@ vcpkg_find_acquire_program(RUBY)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS 
-        -DBUILD_TESTING=OFF
-        -DUSE_INTERNAL_URDF=OFF
-        -DUSE_EXTERNAL_TINYXML=ON
+    OPTIONS
         "-DRUBY=${RUBY}"
+        -DBUILD_TESTING=OFF
+        -DSKIP_PYBIND11=ON
+        -DUSE_INTERNAL_URDF=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
+        -DCMAKE_REQUIRE_FIND_PACKAGE_GzURDFDOM=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_Python3=ON
 )
 
 vcpkg_cmake_install()
-
-# Fix cmake targets and pkg-config file location
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sdformat12")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sdformat13")
 vcpkg_fixup_pkgconfig()
 
-# Remove debug files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
                     "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sdformat13/usage
+++ b/ports/sdformat13/usage
@@ -1,4 +1,0 @@
-sdformat13 provides CMake targets:
-
-    find_package(sdformat13 CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE sdformat13::sdformat13)

--- a/ports/sdformat13/usage
+++ b/ports/sdformat13/usage
@@ -1,0 +1,4 @@
+sdformat13 provides CMake targets:
+
+    find_package(sdformat13 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE sdformat13::sdformat13)

--- a/ports/sdformat13/vcpkg.json
+++ b/ports/sdformat13/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "sdformat13",
+  "version": "13.0.0",
+  "description": "Simulation Description Format (SDF) parser and description files.",
+  "homepage": "http://sdformat.org/",
+  "license": "Apache-2.0",
+  "supports": "!uwp",
+  "dependencies": [
+    "gz-math7",
+    "gz-tools2",
+    "gz-utils2",
+    "tinyxml2",
+    "urdfdom",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/sdformat13/vcpkg.json
+++ b/ports/sdformat13/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "sdformat13",
-  "version": "13.0.0",
+  "version": "13.5.0",
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "license": "Apache-2.0",
-  "supports": "!uwp",
+  "supports": "!uwp & !windows",
   "dependencies": [
     "gz-math7",
     "gz-tools2",

--- a/ports/sdformat13/vcpkg.json
+++ b/ports/sdformat13/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "license": "Apache-2.0",
-  "supports": "!uwp & !windows",
+  "supports": "!uwp",
   "dependencies": [
     "gz-math7",
     "gz-tools2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7445,7 +7445,7 @@
       "port-version": 3
     },
     "sdformat13": {
-      "baseline": "13.0.0",
+      "baseline": "13.5.0",
       "port-version": 0
     },
     "sdformat6": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7444,6 +7444,10 @@
       "baseline": "10.0.0",
       "port-version": 3
     },
+    "sdformat13": {
+      "baseline": "13.0.0",
+      "port-version": 0
+    },
     "sdformat6": {
       "baseline": "6.2.0",
       "port-version": 6

--- a/versions/s-/sdformat13.json
+++ b/versions/s-/sdformat13.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "11d5648e7def31d3cf811839545a8f13f7e36f49",
-      "version": "13.0.0",
+      "git-tree": "b005db07273efd4913f040594b791b89a4e0094a",
+      "version": "13.5.0",
       "port-version": 0
     }
   ]

--- a/versions/s-/sdformat13.json
+++ b/versions/s-/sdformat13.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b005db07273efd4913f040594b791b89a4e0094a",
+      "git-tree": "b8f7d3bdbefa0795808f6c9a42764584d6e96f2c",
       "version": "13.5.0",
       "port-version": 0
     }

--- a/versions/s-/sdformat13.json
+++ b/versions/s-/sdformat13.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "11d5648e7def31d3cf811839545a8f13f7e36f49",
+      "version": "13.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add sdformat13 port:

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
