### PR TITLE
[cpp-httplib] Update to 0.12.3

### DIFF
--- a/ports/cpp-httplib/fix-find-brotli.patch
+++ b/ports/cpp-httplib/fix-find-brotli.patch
@@ -1,8 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c98daf5..88d1aad 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -128,9 +128,9 @@ endif()
+@@ -131,9 +131,9 @@ endif()
  # Adds our cmake folder to the search path for find_package
  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
  if(HTTPLIB_REQUIRE_BROTLI)
@@ -14,9 +13,9 @@ index c98daf5..88d1aad 100644
  endif()
  # Just setting this variable here for people building in-tree
  if(Brotli_FOUND)
-@@ -209,9 +209,9 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
+@@ -216,9 +216,9 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
  		# Needed for API from MacOS Security framework
- 		"$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>>:-framework CoreFoundation -framework Security>"
+ 		"$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>,$<BOOL:${HTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN}>>:-framework CoreFoundation -framework Security>"
  		# Can't put multiple targets in a single generator expression or it bugs out.
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::common>
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>
@@ -27,7 +26,7 @@ index c98daf5..88d1aad 100644
  		$<$<BOOL:${HTTPLIB_IS_USING_ZLIB}>:ZLIB::ZLIB>
  		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL>
  		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::Crypto>
-@@ -266,9 +266,6 @@ install(FILES "${_httplib_build_includedir}/httplib.h" TYPE INCLUDE)
+@@ -274,9 +274,6 @@ install(FILES "${_httplib_build_includedir}/httplib.h" TYPE INCLUDE)
  install(FILES
  		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
  		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"

--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
-    REF v0.12.2
-    SHA512 dda47f76eaf5b4daa35f1295e482f1d81dd8823ae06339b9f4c93e4fbe7b54ae28760d3083b5d5cff212f1a679616adfa47dbb9d06c6810fac4b58197f575429
+    REF v0.12.3
+    SHA512 3465e5c843ad4087bababadf8fe9f3e6961213301540053bb47f242f958280f43c85b03b8cf6f955a6b91bf9511a81669feeb9989344caf2a1e42ff587b3a460
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch

--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
-    REF v0.12.3
+    REF "v${VERSION}"
     SHA512 3465e5c843ad4087bababadf8fe9f3e6961213301540053bb47f242f958280f43c85b03b8cf6f955a6b91bf9511a81669feeb9989344caf2a1e42ff587b3a460
     HEAD_REF master
     PATCHES

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-httplib",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1733,7 +1733,7 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.12.2",
+      "baseline": "0.12.3",
       "port-version": 0
     },
     "cpp-ipc": {

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22a86943554c594a43df13b0c4f225764be570db",
+      "version": "0.12.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "05e123da2bcd7b05fc8c31fd88e6d3d5aa06d520",
       "version": "0.12.2",
       "port-version": 0

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "22a86943554c594a43df13b0c4f225764be570db",
+      "git-tree": "570d0fcd52fa9bb8048dfe84df6a31b2473949b5",
       "version": "0.12.3",
       "port-version": 0
     },


### PR DESCRIPTION
Updates cpp-httplib to 0.12.3

* [x]  Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
* [x]  SHA512s are updated for each updated download
* [ ]  The "supports" clause reflects platforms that may be fixed by this new version
* [ ]  Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
* [ ]  Any patches that are no longer applied are deleted from the port's directory.
* [x]  The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
* [x]  Only one version is added to each modified port's versions file.