### PR TITLE
[qt5-imageformats] Move deps to features

### DIFF
--- a/ports/qt5-imageformats/portfile.cmake
+++ b/ports/qt5-imageformats/portfile.cmake
@@ -1,47 +1,49 @@
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
-include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
 
+include("${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake")
 
 list(APPEND CORE_OPTIONS
-    -system-tiff
-    -system-webp
-    -jasper 
     -no-mng # must be explicitly disabled to not automatically pick up mng
-    -verbose)
-    
-x_vcpkg_pkgconfig_get_modules(PREFIX tiff MODULES libtiff-4 LIBS)
+    -verbose
+)
 
-find_library(JPEG_RELEASE NAMES jpeg jpeg-static PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
-find_library(JPEG_DEBUG NAMES jpeg jpeg-static jpegd jpeg-staticd PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
-find_library(ZLIB_RELEASE NAMES z zlib PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
-find_library(ZLIB_DEBUG NAMES z zlib zd zlibd PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
+if("jasper" IN_LIST FEATURES)
+    list(APPEND CORE_OPTIONS -jasper)
 
-find_library(JASPER_RELEASE NAMES jasper PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
-find_library(JASPER_DEBUG NAMES jasperd jasper libjasperd libjasper PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
+    x_vcpkg_pkgconfig_get_modules(PREFIX jasper MODULES jasper LIBS)
 
-if(NOT VCPKG_TARGET_IS_OSX AND NOT (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64"))
-    set(FREEGLUT_NEEDED ON)
+    file(READ "${CURRENT_INSTALLED_DIR}/share/jasper/vcpkg_abi_info.txt" jasper_abi_info)
+    if(jasper_abi_info MATCHES "(^|;)opengl(;|$)")
+        find_library(FREEGLUT_RELEASE NAMES freeglut glut PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
+        find_library(FREEGLUT_DEBUG NAMES freeglutd freeglut glutd glut PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
+    endif()
+
+    list(APPEND OPT_REL "JASPER_LIBS=${jasper_LIBS_RELEASE} ${FREEGLUT_RELEASE}")
+    list(APPEND OPT_DBG "JASPER_LIBS=${jasper_LIBS_DEBUG} ${FREEGLUT_DEBUG}")
+else()
+    list(APPEND CORE_OPTIONS -no-jasper)
 endif()
 
-if(FREEGLUT_NEEDED)
-    find_library(FREEGLUT_RELEASE NAMES freeglut glut PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
-    find_library(FREEGLUT_DEBUG NAMES freeglutd freeglut glutd glut PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
+if("tiff" IN_LIST FEATURES)
+    list(APPEND CORE_OPTIONS -system-tiff)
+
+    x_vcpkg_pkgconfig_get_modules(PREFIX tiff MODULES libtiff-4 LIBS)
+    list(APPEND OPT_REL "TIFF_LIBS=${tiff_LIBS_RELEASE}")
+    list(APPEND OPT_DBG "TIFF_LIBS=${tiff_LIBS_DEBUG}")
+else()
+    list(APPEND CORE_OPTIONS -no-tiff)
 endif()
 
-x_vcpkg_pkgconfig_get_modules(PREFIX webp MODULES libwebp libwebpdemux libwebpmux libwebpdecoder LIBS)
+if("webp" IN_LIST FEATURES)
+    list(APPEND CORE_OPTIONS -system-webp)
 
-set(OPT_REL "TIFF_LIBS=${tiff_LIBS_RELEASE}"
-            "WEBP_LIBS=${webp_LIBS_RELEASE}"
-            "JASPER_LIBS=${JASPER_RELEASE} ${JPEG_RELEASE} ${ZLIB_RELEASE}") # This will still fail if LIBWEBP is installed with all available features due to the missing additional dependencies
-set(OPT_DBG "TIFF_LIBS=${tiff_LIBS_DEBUG}"
-            "WEBP_LIBS=${webp_LIBS_DEBUG}"
-            "JASPER_LIBS=${JASPER_DEBUG}  ${JPEG_DEBUG} ${ZLIB_DEBUG}")
-
-if(FREEGLUT_NEEDED)
-    set(OPT_REL "${OPT_REL} ${FREEGLUT_RELEASE}")
-    set(OPT_DBG "${OPT_DBG} ${FREEGLUT_DEBUG}")
+    x_vcpkg_pkgconfig_get_modules(PREFIX webp MODULES libwebp libwebpdemux libwebpmux libwebpdecoder LIBS)
+    list(APPEND CORE_OPTIONS "WEBP_INCDIR=${CURRENT_INSTALLED_DIR}/include") # Requires libwebp[all]
+    # This will still fail if LIBWEBP is installed with all available features due to the missing additional dependencies
+    list(APPEND OPT_REL "WEBP_LIBS=${webp_LIBS_RELEASE}")
+    list(APPEND OPT_DBG "WEBP_LIBS=${webp_LIBS_DEBUG}")
+else()
+    list(APPEND CORE_OPTIONS -no-webp)
 endif()
-
-list(APPEND CORE_OPTIONS "WEBP_INCDIR=${CURRENT_INSTALLED_DIR}/include") # Requires libwebp[all]
 
 qt_submodule_installation(BUILD_OPTIONS ${CORE_OPTIONS} BUILD_OPTIONS_RELEASE ${OPT_REL} BUILD_OPTIONS_DEBUG ${OPT_DBG})

--- a/ports/qt5-imageformats/vcpkg.json
+++ b/ports/qt5-imageformats/vcpkg.json
@@ -1,19 +1,52 @@
 {
   "name": "qt5-imageformats",
   "version": "5.15.9",
+  "port-version": 1,
   "description": "Qt5 Image Formats Module - Plugins for additional image formats: TIFF, MNG, TGA, WBMP",
   "license": null,
   "dependencies": [
-    "jasper",
-    "libwebp",
     {
       "name": "qt5-base",
       "default-features": false
-    },
-    "tiff",
-    {
-      "name": "vcpkg-pkgconfig-get-modules",
-      "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "tiff",
+    "webp"
+  ],
+  "features": {
+    "jasper": {
+      "description": "Enable JPEG-2000 support using the JasPer library",
+      "dependencies": [
+        {
+          "name": "jasper",
+          "default-features": false
+        },
+        {
+          "name": "vcpkg-pkgconfig-get-modules",
+          "host": true
+        }
+      ]
+    },
+    "tiff": {
+      "description": "Enable TIFF support",
+      "dependencies": [
+        "tiff",
+        {
+          "name": "vcpkg-pkgconfig-get-modules",
+          "host": true
+        }
+      ]
+    },
+    "webp": {
+      "description": "Enable WEBP support",
+      "dependencies": [
+        "libwebp",
+        {
+          "name": "vcpkg-pkgconfig-get-modules",
+          "host": true
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6510,7 +6510,7 @@
     },
     "qt5-imageformats": {
       "baseline": "5.15.9",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-location": {
       "baseline": "5.15.9",

--- a/versions/q-/qt5-imageformats.json
+++ b/versions/q-/qt5-imageformats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f076f78b7733120039477509c1472f270ad3e88",
+      "version": "5.15.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "889e130592f375153e49fc8d334204ccdaf6010d",
       "version": "5.15.9",
       "port-version": 0


### PR DESCRIPTION
Towards #8213

Jasper is no longer installed by default. Not sure whether freeglut detection should stay (upstream bug?).
Also not sure whether libwebp comment is still relevant.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
