### PR TITLE
[microsoft-signalr] Fix usage issue

### DIFF
--- a/ports/microsoft-signalr/find-msgpack.patch
+++ b/ports/microsoft-signalr/find-msgpack.patch
@@ -13,3 +13,17 @@ index 676cde2..4562873 100644
  endif()
  
  include_directories (include)
+diff --git a/src/signalrclient/microsoft-signalr-config.in.cmake b/src/signalrclient/microsoft-signalr-config.in.cmake
+index b28235b..09a7d56 100644
+--- a/src/signalrclient/microsoft-signalr-config.in.cmake
++++ b/src/signalrclient/microsoft-signalr-config.in.cmake
+@@ -7,7 +7,7 @@ endif()
+ find_dependency(jsoncpp)
+ 
+ if(@USE_MSGPACK@)
+-  find_dependency(msgpack)
++  find_dependency(msgpack-cxx CONFIG)
+ endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/microsoft-signalr-targets.cmake")
+\ No newline at end of file

--- a/ports/microsoft-signalr/vcpkg.json
+++ b/ports/microsoft-signalr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-signalr",
   "version": "0.1.0-alpha4",
-  "port-version": 4,
+  "port-version": 5,
   "description": "C++ Client for ASP.NET Core SignalR.",
   "homepage": "https://github.com/aspnet/SignalR-Client-Cpp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5166,7 +5166,7 @@
     },
     "microsoft-signalr": {
       "baseline": "0.1.0-alpha4",
-      "port-version": 4
+      "port-version": 5
     },
     "mikktspace": {
       "baseline": "2020-10-06",

--- a/versions/m-/microsoft-signalr.json
+++ b/versions/m-/microsoft-signalr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d404283aa7fbee588db56cbe0a470d82c1f9258",
+      "version": "0.1.0-alpha4",
+      "port-version": 5
+    },
+    {
       "git-tree": "1ea9d11c361ff46b14b9872df5b71b634ff1d709",
       "version": "0.1.0-alpha4",
       "port-version": 4


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/30998

Usage test passed with following triplets:
x64-windows
x86-windows-static
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
