### PR TITLE
[qt5-declarative] Add d3d12 feature

### DIFF
--- a/ports/qt5-declarative/portfile.cmake
+++ b/ports/qt5-declarative/portfile.cmake
@@ -1,5 +1,12 @@
-include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
-qt_submodule_installation(OUT_SOURCE_PATH SOURCE_PATH)
+include("${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake")
+
+if("d3d12" IN_LIST FEATURES)
+    list(APPEND CORE_OPTIONS -d3d12)
+else()
+    list(APPEND CORE_OPTIONS -no-d3d12)
+endif()
+
+qt_submodule_installation(OUT_SOURCE_PATH SOURCE_PATH BUILD_OPTIONS ${CORE_OPTIONS})
 
 if(NOT QT_UPDATE_VERSION)
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/qt5/QtQml/${QT_MAJOR_MINOR_VER}.${QT_PATCH_VER}/QtQml/private/qqmljsparser_p.h" "${SOURCE_PATH}" "")

--- a/ports/qt5-declarative/vcpkg.json
+++ b/ports/qt5-declarative/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-declarative",
   "version": "5.15.9",
+  "port-version": 1,
   "description": "Qt5 Declarative (Quick 2) Module. Includes QtQuick, QtQuickParticles, QtQuickWidgets, QtQml, and QtPacketProtocol.",
   "license": null,
   "dependencies": [
@@ -10,5 +11,26 @@
     },
     "qt5-imageformats",
     "qt5-svg"
-  ]
+  ],
+  "default-features": [
+    "platform-default-features"
+  ],
+  "features": {
+    "d3d12": {
+      "description": "Provides a Direct3D 12 backend for the scenegraph.",
+      "supports": "windows"
+    },
+    "platform-default-features": {
+      "description": "Enable platform-dependent default features",
+      "dependencies": [
+        {
+          "name": "qt5-declarative",
+          "features": [
+            "d3d12"
+          ],
+          "platform": "windows"
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6494,7 +6494,7 @@
     },
     "qt5-declarative": {
       "baseline": "5.15.9",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-doc": {
       "baseline": "5.15.9",

--- a/versions/q-/qt5-declarative.json
+++ b/versions/q-/qt5-declarative.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3485a7652a098831fc278dd06952308704ed906",
+      "version": "5.15.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "c1e284599a1003dcb722972309215a0e13155f7b",
       "version": "5.15.9",
       "port-version": 0


### PR DESCRIPTION
Towards https://github.com/microsoft/vcpkg/issues/8213 (https://github.com/microsoft/vcpkg/issues/8213#issuecomment-1536983382)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
