### PR TITLE
[vsg] New port (VulkanSceneGraph)

### DIFF
--- a/ports/vsg/devendor-glslang.patch
+++ b/ports/vsg/devendor-glslang.patch
@@ -1,0 +1,68 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 61da709f..472bc6af 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,9 +37,11 @@ find_package(Vulkan ${Vulkan_MIN_VERSION} REQUIRED)
+ 
+ find_package(Threads REQUIRED)
+ 
++find_package(glslang CONFIG REQUIRED)
++
+ # Enable/disable shader compilation support that pulls in glslang
+ set(VSG_SUPPORTS_ShaderCompiler  1 CACHE STRING "Optional shader compiler support, 0 for off, 1 for enabled." )
+-if (VSG_SUPPORTS_ShaderCompiler)
++if (FALSE)
+     if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/glslang/build_vars.cmake)
+ 
+         if (Git_FOUND)
+diff --git a/src/vsg/CMakeLists.txt b/src/vsg/CMakeLists.txt
+index 4154312f..49d63b97 100644
+--- a/src/vsg/CMakeLists.txt
++++ b/src/vsg/CMakeLists.txt
+@@ -226,7 +226,7 @@ set(SOURCES
+     utils/LoadPagedLOD.cpp
+ )
+ 
+-if (${VSG_SUPPORTS_ShaderCompiler})
++if (FALSE)
+ 
+     # include glslang source code directly into the VulkanScenegraph library build.
+     include(../glslang/build_vars.cmake)
+@@ -236,6 +236,14 @@ endif()
+ set(LIBRARIES PUBLIC
+         Vulkan::Vulkan
+         Threads::Threads
++        glslang::glslang
++        glslang::OSDependent
++        glslang::MachineIndependent
++        glslang::GenericCodeGen
++        glslang::glslang-default-resource-limits
++        glslang::OGLCompiler
++        glslang::SPVRemapper
++        glslang::SPIRV
+ )
+ 
+ # Check for std::atomic
+@@ -364,9 +372,6 @@ target_include_directories(vsg
+     PUBLIC
+         $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:${VSG_BINARY_DIR}/include>
+-    PRIVATE
+-        $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/src/glslang>
+-        $<BUILD_INTERFACE:${GLSLANG_GENERATED_INCLUDEDIR}>
+ )
+ 
+ target_link_libraries(vsg ${LIBRARIES})
+diff --git a/src/vsg/utils/ShaderCompiler.cpp b/src/vsg/utils/ShaderCompiler.cpp
+index 71a7f09f..803f26a1 100644
+--- a/src/vsg/utils/ShaderCompiler.cpp
++++ b/src/vsg/utils/ShaderCompiler.cpp
+@@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
+ #include <vsg/utils/ShaderCompiler.h>
+ 
+ #if VSG_SUPPORTS_ShaderCompiler
+-#    include <SPIRV/GlslangToSpv.h>
++#    include <glslang/SPIRV/GlslangToSpv.h>
+ #    include <glslang/Public/ResourceLimits.h>
+ #    include <glslang/Public/ShaderLang.h>
+ #endif

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 da5c9448da6bd2bd6edcb82ed1ac67aded9c3fd957fb7d3c78bb741d8993a5e90b134433237a63bf1a6eb23b30a1e6b4ea2115416f8d32464bd04925d8dbcd34
     HEAD_REF master
+	PATCHES devendor-glslang.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
         -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "vsg" CONFIG_PATH "lib/cmake/vsg")
 vcpkg_copy_pdbs()
 

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -7,11 +7,7 @@ vcpkg_from_github(
 	PATCHES devendor-glslang.patch
 )
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE  #parallel build interferes with cloning glslang in vsg's CMake script
-)
-
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "vsg" CONFIG_PATH "lib/cmake/vsg")
 vcpkg_copy_pdbs()

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO vsg-dev/VulkanSceneGraph
+    REF "v${VERSION}"
+    SHA512 da5c9448da6bd2bd6edcb82ed1ac67aded9c3fd957fb7d3c78bb741d8993a5e90b134433237a63bf1a6eb23b30a1e6b4ea2115416f8d32464bd04925d8dbcd34
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE  #parallel build interferes with cloning glslang in vsg's CMake script
+    OPTIONS
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+)
+
+vcpkg_install_cmake()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "vsg" CONFIG_PATH "lib/cmake/vsg")
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -6,13 +6,9 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE  #parallel build interferes with cloning glslang in vsg's CMake script
-    OPTIONS
-        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
 )
 
 vcpkg_cmake_install()

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -5,6 +5,7 @@
   "homepage": "http://www.vulkanscenegraph.org/",
   "license": "MIT",
   "dependencies": [
+    "glslang",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "vsg",
+  "version": "1.0.5",
+  "description": "A modern, cross platform, high performance scene graph library built upon Vulkan.",
+  "homepage": "http://www.vulkanscenegraph.org/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "vulkan"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8380,6 +8380,10 @@
       "baseline": "0.5.0",
       "port-version": 2
     },
+    "vsg": {
+      "baseline": "1.0.5",
+      "port-version": 0
+    },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",
       "port-version": 6

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cb81d415eca4ddeb23909bee432a76d40922f66d",
+      "git-tree": "69989f2d2bafedcb8b39aa20a327b41dce48c247",
       "version": "1.0.5",
       "port-version": 0
     }

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "69989f2d2bafedcb8b39aa20a327b41dce48c247",
+      "git-tree": "0542d7bb873d65fa6ecbf2c3a02d7a2c7221d34a",
       "version": "1.0.5",
       "port-version": 0
     }

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "58459a188aede98a43571d614f114c64ddda7483",
+      "git-tree": "cb81d415eca4ddeb23909bee432a76d40922f66d",
       "version": "1.0.5",
       "port-version": 0
     }

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5b5289cf93ae5db29e0ba7a980897d868c3d3dd3",
+      "version": "1.0.5",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5b5289cf93ae5db29e0ba7a980897d868c3d3dd3",
+      "git-tree": "58459a188aede98a43571d614f114c64ddda7483",
       "version": "1.0.5",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
