### PR TITLE
[gstreamer]: fix pkgconfig parameters of gstreamer

### DIFF
--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -703,6 +703,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    # move plugins to ${prefix}/plugins/${PORT} instead of ${prefix}/lib/gstreamer-1.0
     if(NOT VCPKG_BUILD_TYPE)
         file(GLOB DBG_BINS "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/${CMAKE_SHARED_LIBRARY_PREFIX}*${CMAKE_SHARED_LIBRARY_SUFFIX}"
                            "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.pdb"
@@ -716,6 +717,24 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     file(REMOVE ${DBG_BINS} ${REL_BINS})
     if(NOT VCPKG_TARGET_IS_WINDOWS)
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0" "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0")
+    endif()
+
+    set(_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gstreamer-1.0.pc")
+    if(EXISTS "${_file}")
+        file(READ "${_file}" _contents)
+        string(REPLACE [[toolsdir=${exec_prefix}/bin]] "toolsdir=\${prefix}/../tools/${PORT}" _contents "${_contents}")
+        string(REPLACE [[pluginscannerdir=${libexecdir}/gstreamer-1.0]] "pluginscannerdir=\${prefix}/../tools/${PORT}" _contents "${_contents}")
+        string(REPLACE [[pluginsdir=${libdir}/gstreamer-1.0]] "pluginsdir=\${prefix}/plugins/${PORT}" _contents "${_contents}")
+        file(WRITE "${_file}" "${_contents}")
+    endif()
+
+    set(_file "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gstreamer-1.0.pc")
+    if(EXISTS "${_file}")
+        file(READ "${_file}" _contents)
+        string(REPLACE [[toolsdir=${exec_prefix}/bin]] "toolsdir=\${prefix}/tools/${PORT}" _contents "${_contents}")
+        string(REPLACE [[pluginscannerdir=${libexecdir}/gstreamer-1.0]] "pluginscannerdir=\${prefix}/tools/${PORT}" _contents "${_contents}")
+        string(REPLACE [[pluginsdir=${libdir}/gstreamer-1.0]] "pluginsdir=\${prefix}/plugins/${PORT}" _contents "${_contents}")
+        file(WRITE "${_file}" "${_contents}")
     endif()
 endif()
 

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.20.5",
-  "port-version": 6,
+  "port-version": 7,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2970,7 +2970,7 @@
     },
     "gstreamer": {
       "baseline": "1.20.5",
-      "port-version": 6
+      "port-version": 7
     },
     "gtest": {
       "baseline": "1.13.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "877a4687de4ef7b958624b55a558f91b4b34c32b",
+      "version": "1.20.5",
+      "port-version": 7
+    },
+    {
       "git-tree": "631b03d07848f5a632168da7e3f9e1bc753d4085",
       "version": "1.20.5",
       "port-version": 6


### PR DESCRIPTION
I build gstreamer using vcpkg, and use these parameters to package my application. This fix correctly sets the values of the following parameters in pkgconfig file:
1. toolsdir
2. pluginscannerdir
3. pluginsdir

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
