### PR TITLE
[hnswlib] backport CMake targets

### DIFF
--- a/ports/hnswlib/cmake.patch
+++ b/ports/hnswlib/cmake.patch
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7cebe60..b2aecc8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,11 +1,36 @@
+-cmake_minimum_required (VERSION 2.6)
+-project(hnsw_lib
++cmake_minimum_required(VERSION 3.0...3.26)
++
++project(hnswlib
+     LANGUAGES CXX)
+ 
++include(GNUInstallDirs)
++
+ add_library(hnswlib INTERFACE)
+-target_include_directories(hnswlib INTERFACE .) 
++add_library(hnswlib::hnswlib ALIAS hnswlib)
++
++target_include_directories(hnswlib INTERFACE
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++
++# Install
++install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/hnswlib
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ 
++install(TARGETS hnswlib
++    EXPORT hnswlibTargets)
++
++install(EXPORT hnswlibTargets
++    FILE hnswlibConfig.cmake
++    NAMESPACE hnswlib::
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hnswlib)
++
++# Examples and tests
+ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
++    option(HNSWLIB_EXAMPLES "Build examples and tests." ON)
++else()
++    option(HNSWLIB_EXAMPLES "Build examples and tests." OFF)
++endif()
++if(HNSWLIB_EXAMPLES)
+     set(CMAKE_CXX_STANDARD 11)
+ 
+     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/ports/hnswlib/portfile.cmake
+++ b/ports/hnswlib/portfile.cmake
@@ -1,11 +1,3 @@
-# Backport CMake targets from develop
-vcpkg_download_distfile(
-    CMAKE_TARGETS_PATCH
-    URLS "https://github.com/nmslib/hnswlib/commit/dccd4f98acb9da404b7439606a97c4e3077a8d44.patch"
-    FILENAME dccd4f98acb9da404b7439606a97c4e3077a8d44.patch
-    SHA512 e514feaf9b5138627aa9847c12cba111acd6ae7315acff14aabe151e3339600418473f805053bb3b28ed92b32751ccac675feaa95cc3881090de672b70983140
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nmslib/hnswlib
@@ -13,7 +5,7 @@ vcpkg_from_github(
     SHA512 fd74c23040598973d7e0b5a6af73eb884ee2d30703187d1702fdd48eaf8f7f96d8fbb125d3763f90111d9fb7c5ab3434ebdb818da8717d35c5571e99083c812b
     HEAD_REF master
     PATCHES
-        ${CMAKE_TARGETS_PATCH}
+        cmake.patch # Backport CMake targets from nmslib/hnswlib #446 to 0.7.0 release.
 )
 
 set(VCPKG_BUILD_TYPE "release") # header-only port

--- a/ports/hnswlib/portfile.cmake
+++ b/ports/hnswlib/portfile.cmake
@@ -1,12 +1,22 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nmslib/hnswlib
-    REF 359b2ba87358224963986f709e593d799064ace6 # v0.7.0
-    SHA512 59a0c02bbe8f7389a2ecad9188a76eb3847b719a213d306093753c04e4eeb11d95e8e310aa03888364be475a2f2e6e7976bd81117517eef81eff2983379ac743
+    REF dccd4f98acb9da404b7439606a97c4e3077a8d44 # v0.7.0 + CMake targets from develop
+    SHA512 4faa7c3dc75e45c506a14bd2932b62d42e919e7b6c6e275513ae5162ee6b203d63edbd9d0ce6cfb67c3b935460c2ea200a69beafa2b426eccb4b969d269e34bb
     HEAD_REF master
 )
 
-file(COPY "${SOURCE_PATH}/hnswlib" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+set(VCPKG_BUILD_TYPE "release") # header-only port
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DHNSWLIB_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/hnswlib)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hnswlib/portfile.cmake
+++ b/ports/hnswlib/portfile.cmake
@@ -1,9 +1,19 @@
+# Backport CMake targets from develop
+vcpkg_download_distfile(
+    CMAKE_TARGETS_PATCH
+    URLS "https://github.com/nmslib/hnswlib/commit/dccd4f98acb9da404b7439606a97c4e3077a8d44.patch"
+    FILENAME dccd4f98acb9da404b7439606a97c4e3077a8d44.patch
+    SHA512 e514feaf9b5138627aa9847c12cba111acd6ae7315acff14aabe151e3339600418473f805053bb3b28ed92b32751ccac675feaa95cc3881090de672b70983140
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nmslib/hnswlib
-    REF dccd4f98acb9da404b7439606a97c4e3077a8d44 # v0.7.0 + CMake targets from develop
-    SHA512 4faa7c3dc75e45c506a14bd2932b62d42e919e7b6c6e275513ae5162ee6b203d63edbd9d0ce6cfb67c3b935460c2ea200a69beafa2b426eccb4b969d269e34bb
+    REF "v${VERSION}"
+    SHA512 fd74c23040598973d7e0b5a6af73eb884ee2d30703187d1702fdd48eaf8f7f96d8fbb125d3763f90111d9fb7c5ab3434ebdb818da8717d35c5571e99083c812b
     HEAD_REF master
+    PATCHES
+        ${CMAKE_TARGETS_PATCH}
 )
 
 set(VCPKG_BUILD_TYPE "release") # header-only port

--- a/ports/hnswlib/usage
+++ b/ports/hnswlib/usage
@@ -1,4 +1,0 @@
-hnswlib is header-only and can be used from CMake via:
-
-    find_path(HNSWLIB_INCLUDE_DIRS "hnswlib/hnswlib.h")
-    target_include_directories(main PRIVATE ${HNSWLIB_INCLUDE_DIRS})

--- a/ports/hnswlib/vcpkg.json
+++ b/ports/hnswlib/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "hnswlib",
   "version": "0.7.0",
+  "port-version": 1,
   "description": "Header-only library for fast approximate nearest neighbors",
   "homepage": "https://github.com/nmslib/hnswlib",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3130,7 +3130,7 @@
     },
     "hnswlib": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "hps": {
       "baseline": "2022-01-18",

--- a/versions/h-/hnswlib.json
+++ b/versions/h-/hnswlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b5cd65685aa5197d9c0cb58db6f3b59594e703fe",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7053d263445d46410589894d921fa6c85fbf107c",
       "version": "0.7.0",
       "port-version": 0

--- a/versions/h-/hnswlib.json
+++ b/versions/h-/hnswlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b5cd65685aa5197d9c0cb58db6f3b59594e703fe",
+      "git-tree": "e7c7e3675fbc55d4cd206189893ac31c5ea83797",
       "version": "0.7.0",
       "port-version": 1
     },

--- a/versions/h-/hnswlib.json
+++ b/versions/h-/hnswlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e7c7e3675fbc55d4cd206189893ac31c5ea83797",
+      "git-tree": "497030f03d37d63ff86c9e99d24d9e8f048ea067",
       "version": "0.7.0",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Upstream added CMake targets in develop branch, backport these changes to have CMake targets available in vcpkg.
Here are the changes between 0.7.0 release and the downloaded commit from develop branch:
https://github.com/nmslib/hnswlib/compare/v0.7.0..dccd4f98acb9da404b7439606a97c4e3077a8d44
The changes (except that CMake targets are added) should be absolutely minimal and not change any library behaviour, therefore I did not change the version.