### PR TITLE
[glaze] bump to 1.2.3 to disable dev mode

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,13 +6,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 8016328a347dac7c4826cb5ff944d38b1b32dd2fbfe9080f73e3351d2f3682c06c5500f05b2f2dfda5925af8605469b26f78f2522ff498a2131867edceb7b709
+    SHA512 456b49a86dddb5949991050daa8dcfbe47ca55db6746539e14995a19bd2623ab46ac72e08af29f64cb1f3ff79265fb8d824bf9b7744f3cf94e568f27467b6185
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-      -DBUILD_TESTING=OFF
+      -Dglaze_DEVELOPER_MODE=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2805,7 +2805,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "1.2.2",
+      "baseline": "1.2.3",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ccae5c60306415e7f7bd44e4ebb91b972b550c10",
+      "version": "1.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "16c37a75de3f8e60dca6acec5bb868b869cb7e76",
       "version": "1.2.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The primary purpose of this update is to avoid building unnecessary executable targets that are used for "developer mode". glaze 1.2.3 allows this mode to be disabled, and this port update adopts this.