### PR TITLE
[nanobind] New port

### DIFF
--- a/ports/nanobind/portfile.cmake
+++ b/ports/nanobind/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wjakob/nanobind
+    REF v${VERSION}
+    SHA512 8c8f2ef41ac27acf46e495910aa149a6b46c2cdac40274cced5346381a1a06bfd41f6d892eca8b6053dd62a9113e40971d3e33a7898084969404bfbe93b6d70d
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/nanobind/vcpkg.json
+++ b/ports/nanobind/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "nanobind",
+  "version": "1.2.0",
+  "port-version": 0,
+  "description": "tiny and efficient C++/Python bindings",
+  "homepage": "https://nanobind.readthedocs.io/en/latest/",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "python3",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5440,6 +5440,10 @@
       "baseline": "4.3.10",
       "port-version": 1
     },
+    "nanobind": {
+      "baseline": "1.2.0",
+      "port-version": 0
+    },
     "nanodbc": {
       "baseline": "2.13.0",
       "port-version": 6

--- a/versions/n-/nanobind.json
+++ b/versions/n-/nanobind.json
@@ -1,0 +1,9 @@
+{
+    "versions": [
+        {
+            "git-tree": "0e332df4b8a04fe96437a3cdd77f0e3a607f5d92",
+            "version": "1.2.0",
+            "port-version": 0
+        }
+    ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

