### PR TITLE
[mp-units] Does not build on clang

### DIFF
--- a/ports/mp-units/mp_units_clang.patch
+++ b/ports/mp-units/mp_units_clang.patch
@@ -1,0 +1,86 @@
+diff --git a/src/core/CMakeLists.txt b/src/core/CMakeLists.txt
+index d4f4f06c..59e155b6 100644
+--- a/src/core/CMakeLists.txt
++++ b/src/core/CMakeLists.txt
+@@ -45,7 +45,7 @@ target_include_directories(mp-units-core ${units_as_system} INTERFACE
+ )
+ 
+ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+-    if(UNITS_LIBCXX)
++    if(UNITS_LIBCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14")
+         find_package(range-v3 CONFIG REQUIRED)
+         target_link_libraries(mp-units-core INTERFACE range-v3::range-v3)
+     endif()
+diff --git a/src/core/include/units/bits/external/hacks.h b/src/core/include/units/bits/external/hacks.h
+index 847293f5..5f76bd5f 100644
+--- a/src/core/include/units/bits/external/hacks.h
++++ b/src/core/include/units/bits/external/hacks.h
+@@ -99,7 +99,7 @@ namespace std {
+ template<class T>
+ concept default_constructible = constructible_from<T>;
+ 
+-#elif UNITS_COMP_CLANG && UNITS_LIBCXX
++#elif UNITS_COMP_CLANG <= 13 && UNITS_LIBCXX
+ 
+ // concepts
+ using concepts::common_with;
+@@ -164,13 +164,13 @@ constexpr bool cmp_equal(T t, U u) noexcept
+   else
+       return u < 0 ? false : t == UU(u);
+ }
+- 
++
+ template<class T, class U>
+ constexpr bool cmp_not_equal(T t, U u) noexcept
+ {
+   return !cmp_equal(t, u);
+ }
+- 
++
+ template<class T, class U>
+ constexpr bool cmp_less(T t, U u) noexcept
+ {
+@@ -183,19 +183,19 @@ constexpr bool cmp_less(T t, U u) noexcept
+   else
+       return u < 0 ? false : t < UU(u);
+ }
+- 
++
+ template<class T, class U>
+ constexpr bool cmp_greater(T t, U u) noexcept
+ {
+   return cmp_less(u, t);
+ }
+- 
++
+ template<class T, class U>
+ constexpr bool cmp_less_equal(T t, U u) noexcept
+ {
+   return !cmp_greater(t, u);
+ }
+- 
++
+ template<class T, class U>
+ constexpr bool cmp_greater_equal(T t, U u) noexcept
+ {
+@@ -208,7 +208,6 @@ constexpr bool in_range(T t) noexcept
+   return std::cmp_greater_equal(t, std::numeric_limits<R>::min()) &&
+         std::cmp_less_equal(t, std::numeric_limits<R>::max());
+ }
+-
+ #endif
+ 
+ } // namespace std
+diff --git a/src/mp-unitsConfig.cmake b/src/mp-unitsConfig.cmake
+index a6360a6d..afe3f7a1 100644
+--- a/src/mp-unitsConfig.cmake
++++ b/src/mp-unitsConfig.cmake
+@@ -45,7 +45,7 @@ find_dependency(gsl-lite)
+ # add range-v3 dependency only for clang + libc++
+ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+     __check_libcxx_in_use(__units_libcxx)
+-    if(__units_libcxx)
++    if(__units_libcxx AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14")
+         find_dependency(range-v3)
+     endif()
+     unset(__units_libcxx)

--- a/ports/mp-units/portfile.cmake
+++ b/ports/mp-units/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 72175f34f358d0741650ce9c8a7b28fced90cc45ddd3f1662ae1cb9ff7d31403ff742ee07ab4c96bd2d95af714d9111a888cf6acccb91e568e12d1ef663b2f64
     PATCHES
         config.patch
+        mp_units_clang.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mp-units",
   "version-semver": "0.7.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "mp-units - A Units Library for C++",
   "homepage": "https://github.com/mpusz/units",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5302,7 +5302,7 @@
     },
     "mp-units": {
       "baseline": "0.7.0",
-      "port-version": 1
+      "port-version": 2
     },
     "mp3lame": {
       "baseline": "3.100",

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc20d3ebf5ed6051689bae1a2905fe0a86e3954a",
+      "version-semver": "0.7.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b4bce95b7e67f66db9d613e7e3601c2b90cec665",
       "version-semver": "0.7.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/mpusz/units/issues/453 for clang versions that do not require ranges-v3

I added a draft pull request on vcpkg that patches away the ranges-v3 requirement from mp-units if using clang 14 or newer. This has the downside that ranges-v3 is still not marked as a dependency and this will
therefor fail for clang <= 13 where ranges-v3 is required.