### PR TITLE
[blingfire] Use Ninja rather than MSBuild in BlingFire to support UWP.

### DIFF
--- a/ports/blingfire/ninja.patch
+++ b/ports/blingfire/ninja.patch
@@ -1,0 +1,9 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 818a3da..e8b3bed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,3 +19,3 @@ IF (WIN32 AND MSVC)
+   set (CMAKE_CXX_FLAGS " -DNDEBUG")
+-  add_compile_options("/O2" "/W4" "/GS" "/Gy" "/guard:cf" "/Gm-" "/Zc:inline" "/fp:precise" "/GF" "/EHsc" "/ZH:SHA_256")
++  add_compile_options("/W4" "/GS" "/Gy" "/guard:cf" "/Gm-" "/Zc:inline" "/fp:precise" "/GF" "/EHsc" "/ZH:SHA_256")
+   add_compile_options("$<$<CONFIG:Debug>:/Od>")

--- a/ports/blingfire/portfile.cmake
+++ b/ports/blingfire/portfile.cmake
@@ -4,11 +4,12 @@ vcpkg_from_github(
     REF c0381c68b6aa6d1b4e569888bae1642e40494a99
     SHA512 0fa15791fc815a992023bae6f30c84dda1d477bcdedcf1343d4dbe4b09b51e17fd87bf130d58e50f378ca94982a6306d7f980e3ff4522091be036428684bdcbb
     HEAD_REF master
+    PATCHES
+        ninja.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    WINDOWS_USE_MSBUILD
     OPTIONS
         ${ADDITIONAL_OPTIONS}
     )

--- a/ports/blingfire/vcpkg.json
+++ b/ports/blingfire/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "blingfire",
   "version": "0.1.8.1",
+  "port-version": 1,
   "description": "BlingFire is a lightning fast Finite State machine and REgular expression manipulation library.",
   "license": "MIT",
-  "supports": "windows & !static & !uwp",
+  "supports": "windows & !static",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/b-/blingfire.json
+++ b/versions/b-/blingfire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70822350369b68d60a5640eca1b668e1829c8054",
+      "version": "0.1.8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "8352e7a158da2568b5c67c973b3692681be8b0d6",
       "version": "0.1.8.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -598,7 +598,7 @@
     },
     "blingfire": {
       "baseline": "0.1.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "blitz": {
       "baseline": "2020-03-25",


### PR DESCRIPTION
Fixes #31330.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.