### PR TITLE
[urdfdom] update urdfdom

### DIFF
--- a/ports/urdfdom/0006-pc_file_for_windows.patch
+++ b/ports/urdfdom/0006-pc_file_for_windows.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -89,11 +89,11 @@
+ # Make the package config file
+-if (NOT MSVC)
++
+   set(PKG_DESC "Unified Robot Description Format")
+   set(PKG_DEPENDS "urdfdom_headers console_bridge") # make the list separated by spaces instead of ;
+   set(PKG_URDF_LIBS "-lurdfdom_sensor -lurdfdom_model_state -lurdfdom_model -lurdfdom_world")
+   set(pkg_conf_file "cmake/pkgconfig/urdfdom.pc")
+   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${pkg_conf_file}.in" "${CMAKE_BINARY_DIR}/${pkg_conf_file}" @ONLY)
+   install(FILES ${CMAKE_BINARY_DIR}/${pkg_conf_file}
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/ COMPONENT pkgconfig)
+-endif()
++
+

--- a/ports/urdfdom/portfile.cmake
+++ b/ports/urdfdom/portfile.cmake
@@ -3,12 +3,13 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ros/urdfdom
-    REF 99ec1f99f2d175f07cc26e63082502ee62982dac # 3.1.0
-    SHA512 64bd96c6b56c300b92e2bd6a875c4bc3c4c5d2ee332a75a8d98099aee0db3e9c33fa7d75fdc4d013e7b6ac47296f524ef713639b06e66035135dfc2a8cca0276
+    REF ${VERSION}
+    SHA512 6386954bc7883e82d9db7c785ae074b47ca31efb7cc2686101e7813768824bed5b46a774a1296453c39ff76673a9dc77305bb2ac96b86ecf93fab22062ef2258
     HEAD_REF master
     PATCHES
         0001_use_math_defines.patch
         0005-fix-config-and-install.patch
+        0006-pc_file_for_windows.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/urdfdom/vcpkg.json
+++ b/ports/urdfdom/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "urdfdom",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Provides core data structures and a simple XML parsers for populating the class data structures from an URDF file.",
   "homepage": "https://github.com/ros/urdfdom",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8173,7 +8173,7 @@
       "port-version": 0
     },
     "urdfdom": {
-      "baseline": "3.1.0",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "urdfdom-headers": {

--- a/versions/u-/urdfdom.json
+++ b/versions/u-/urdfdom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb1c1a30329b850ac4450d3b1a72166697058bb8",
+      "version": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "35eed492633e8ac2b137093a51d13ad325d9e7c5",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
