### PR TITLE
[xapian] update version to 1.4.22

### DIFF
--- a/ports/xapian/portfile.cmake
+++ b/ports/xapian/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS https://oligarchy.co.uk/xapian/1.4.21/xapian-core-1.4.21.tar.xz
-    FILENAME xapian-core-1.4.21.tar.xz
-    SHA512 4071791daf47f5ae77f32f358c6020fcfa9aa81c15c8da25489b055eef30383695e449ab1cb73670f2f5db2b2a5f78056da0e8eea89d83aaad91dfe340a6b13a
+    URLS https://oligarchy.co.uk/xapian/1.4.22/xapian-core-1.4.22.tar.xz
+    FILENAME xapian-core-1.4.22.tar.xz
+    SHA512 60d66adbacbd59622d25e392060984bd1dc6c870f9031765f54cb335fb29f72f6d006d27af82a50c8da2cfbebd08dac4503a8afa8ad51bc4e6fa9cb367a59d29
 )
 
 vcpkg_extract_source_archive(
@@ -12,11 +12,10 @@ vcpkg_extract_source_archive(
 if(WIN32)
     vcpkg_replace_string("${SOURCE_PATH}/configure.ac" "z zlib zdll" "z zlib zdll zlibd")
 
-    # xapian does not support debug lib on Windows
-    # if use `set(VCPKG_BUILD_TYPE release)` ，the vcpkg post check can not passed，
-    # it will throw exception "Mismatching number of debug and release binaries. Found 0 for debug but 1 for release."
-    # that means the `set(VCPKG_BUILD_TYPE release)` can not be used in the WIN32 environment.
-    if(VCPKG_BUILD_TYPE STREQUAL "release")
+    if(MSVC)
+        # xapian.h has _DEBUG macro detection which will make the vcpkg check fail,replace #error with #warning 
+        vcpkg_replace_string("${SOURCE_PATH}/include/xapian/version_h.cc" "#error" "#warning")
+
         set(OPTIONS "CXXFLAGS=-EHsc")
     endif()
 endif()

--- a/ports/xapian/vcpkg.json
+++ b/ports/xapian/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "xapian",
-  "version": "1.4.21",
-  "port-version": 1,
+  "version": "1.4.22",
   "description": "Xapian is an Open Source Search Engine Library, released under the GPL v2+. It's written in C++, with bindings to allow use from Perl, Python 2, Python 3, PHP 5, PHP 7, Java, Tcl, C#, Ruby, Lua, Erlang, Node.js and R (so far!)",
-  "homepage": "https://github.com/xapian/xapian",
+  "homepage": "https://xapian.org/",
   "license": "GPL-2.0-or-later",
   "supports": "!(windows & arm) & !uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8597,8 +8597,8 @@
       "port-version": 0
     },
     "xapian": {
-      "baseline": "1.4.21",
-      "port-version": 1
+      "baseline": "1.4.22",
+      "port-version": 0
     },
     "xaudio2redist": {
       "baseline": "1.2.11",

--- a/versions/x-/xapian.json
+++ b/versions/x-/xapian.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2da71ae6ceb7c0d2317c1d06f11a302f48f89dd",
+      "version": "1.4.22",
+      "port-version": 0
+    },
+    {
       "git-tree": "88d78609c12312fdd2b7260e1c4c1fb3838373b7",
       "version": "1.4.21",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
