### PR TITLE
[libmad] Add dynamic support

### DIFF
--- a/ports/libmad/CMakeLists.txt
+++ b/ports/libmad/CMakeLists.txt
@@ -30,23 +30,15 @@ set(SOURCES
     version.h
 )
 
-if (BUILD_DYNAMIC)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libmad.pc.in" "${PROJECT_BINARY_DIR}/libmad.pc" @ONLY)
-    install(
-        FILES "${PROJECT_BINARY_DIR}/libmad.pc"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    )
-    add_library(
-        mad
-        SHARED
-        ${SOURCES}
-    )
-else()
-    add_library(
-        mad
-        ${SOURCES}
-    )
-endif()
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libmad.pc.in" "${PROJECT_BINARY_DIR}/libmad.pc" @ONLY)
+install(
+    FILES "${PROJECT_BINARY_DIR}/libmad.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+add_library(
+    mad
+    ${SOURCES}
+)
 
 target_compile_definitions(mad
     PRIVATE _LIB _MBCS ASO_ZEROCHECK HAVE_CONFIG_H FPM_DEFAULT

--- a/ports/libmad/CMakeLists.txt
+++ b/ports/libmad/CMakeLists.txt
@@ -30,10 +30,23 @@ set(SOURCES
     version.h
 )
 
-add_library(
-    mad
-    ${SOURCES}
-)
+if (BUILD_DYNAMIC)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libmad.pc.in" "${PROJECT_BINARY_DIR}/libmad.pc" @ONLY)
+    install(
+        FILES "${PROJECT_BINARY_DIR}/libmad.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    )
+    add_library(
+        mad
+        SHARED
+        ${SOURCES}
+    )
+else()
+    add_library(
+        mad
+        ${SOURCES}
+    )
+endif()
 
 target_compile_definitions(mad
     PRIVATE _LIB _MBCS ASO_ZEROCHECK HAVE_CONFIG_H FPM_DEFAULT

--- a/ports/libmad/CMakeLists.txt
+++ b/ports/libmad/CMakeLists.txt
@@ -30,9 +30,9 @@ set(SOURCES
     version.h
 )
 
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libmad.pc.in" "${PROJECT_BINARY_DIR}/libmad.pc" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mad.pc.in" "${PROJECT_BINARY_DIR}/mad.pc" @ONLY)
 install(
-    FILES "${PROJECT_BINARY_DIR}/libmad.pc"
+    FILES "${PROJECT_BINARY_DIR}/mad.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
 add_library(

--- a/ports/libmad/libmad.pc.in
+++ b/ports/libmad/libmad.pc.in
@@ -1,0 +1,9 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libmad
+Description: MPEG audio decoder library
+Version: @VERSION@
+Libs: -L${libdir} -lmad

--- a/ports/libmad/mad.pc.in
+++ b/ports/libmad/mad.pc.in
@@ -3,7 +3,8 @@ exec_prefix=${prefix}
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
-Name: libmad
+Name: mad
 Description: MPEG audio decoder library
 Version: @VERSION@
 Libs: -L${libdir} -lmad
+Cflags: -I${includedir}

--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -21,6 +21,8 @@ file(COPY "${SOURCE_PATH}/msvc++/config.h" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DVERSION=${VERSION}"
 )
 
 vcpkg_cmake_install()

--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_from_sourceforge(
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 # Adds pkgconfig template
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/libmad.pc.in" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/mad.pc.in" DESTINATION "${SOURCE_PATH}")
 
 #Use the msvc++ config.h header
 file(COPY "${SOURCE_PATH}/msvc++/config.h" DESTINATION "${SOURCE_PATH}")

--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mad/libmad
@@ -12,14 +10,24 @@ vcpkg_from_sourceforge(
 #The archive only contains a Visual Studio 6.0 era DSP project file, so use a custom CMakeLists.txt
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
+# Adds pkgconfig template if dynamic
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(COPY "${CMAKE_CURRENT_LIST_DIR}/libmad.pc.in" DESTINATION "${SOURCE_PATH}")
+endif()
+
 #Use the msvc++ config.h header
 file(COPY "${SOURCE_PATH}/msvc++/config.h" DESTINATION "${SOURCE_PATH}")
 
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_DYNAMIC)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_DYNAMIC=${BUILD_DYNAMIC}
 )
 
 vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -1,4 +1,4 @@
-if(NOT VCPKG_TARGET_IS_LINUX)
+if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
@@ -14,7 +14,6 @@ vcpkg_from_sourceforge(
 #The archive only contains a Visual Studio 6.0 era DSP project file, so use a custom CMakeLists.txt
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-# Adds pkgconfig template
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/mad.pc.in" DESTINATION "${SOURCE_PATH}")
 
 #Use the msvc++ config.h header

--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -1,3 +1,7 @@
+if(NOT VCPKG_TARGET_IS_LINUX)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mad/libmad
@@ -10,20 +14,14 @@ vcpkg_from_sourceforge(
 #The archive only contains a Visual Studio 6.0 era DSP project file, so use a custom CMakeLists.txt
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-# Adds pkgconfig template if dynamic
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    file(COPY "${CMAKE_CURRENT_LIST_DIR}/libmad.pc.in" DESTINATION "${SOURCE_PATH}")
-endif()
+# Adds pkgconfig template
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/libmad.pc.in" DESTINATION "${SOURCE_PATH}")
 
 #Use the msvc++ config.h header
 file(COPY "${SOURCE_PATH}/msvc++/config.h" DESTINATION "${SOURCE_PATH}")
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_DYNAMIC)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DBUILD_DYNAMIC=${BUILD_DYNAMIC}
 )
 
 vcpkg_cmake_install()

--- a/ports/libmad/vcpkg.json
+++ b/ports/libmad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmad",
   "version": "0.15.1",
-  "port-version": 11,
+  "port-version": 12,
   "description": "high-quality MPEG audio decoder",
   "homepage": "http://www.mars.org/home/rob/proj/mpeg/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4202,7 +4202,7 @@
     },
     "libmad": {
       "baseline": "0.15.1",
-      "port-version": 11
+      "port-version": 12
     },
     "libmagic": {
       "baseline": "5.40",

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "860e1453c883170d11c5fb01c9a8dde4ef584402",
+      "git-tree": "a813eefd9b2491f4e1e99703bdb771ea1ea2209f",
       "version": "0.15.1",
       "port-version": 12
     },

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "14f65f4bad7e1d97f47fe5053d2612ae1f5c3c93",
+      "git-tree": "eaed142825775ca972204c5c2d7720043eef3c2b",
       "version": "0.15.1",
       "port-version": 12
     },

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08ae0dd9c7bc223c73747289382f89488edb9028",
+      "version": "0.15.1",
+      "port-version": 12
+    },
+    {
       "git-tree": "c4393712733ce1f3078a4ec0a042736e5862efa7",
       "version": "0.15.1",
       "port-version": 11

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "447b47b9ddbe02cb4a72121495fef8975cddcb14",
+      "git-tree": "860e1453c883170d11c5fb01c9a8dde4ef584402",
       "version": "0.15.1",
       "port-version": 12
     },

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a813eefd9b2491f4e1e99703bdb771ea1ea2209f",
+      "git-tree": "14f65f4bad7e1d97f47fe5053d2612ae1f5c3c93",
       "version": "0.15.1",
       "port-version": 12
     },

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "08ae0dd9c7bc223c73747289382f89488edb9028",
+      "git-tree": "447b47b9ddbe02cb4a72121495fef8975cddcb14",
       "version": "0.15.1",
       "port-version": 12
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This adds support for building in dynamic mode for libmad.