### PR TITLE
[libgit2] fix support expressions

### DIFF
--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libgit2",
   "version-semver": "1.4.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Git linkable library",
   "homepage": "https://github.com/libgit2/libgit2",
   "supports": "!uwp",
@@ -49,7 +49,7 @@
     },
     "sectransp": {
       "description": "SSL support (sectransp)",
-      "supports": "!osx"
+      "supports": "osx"
     },
     "ssh": {
       "description": "SSH support via libssh2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4034,7 +4034,7 @@
     },
     "libgit2": {
       "baseline": "1.4.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libgme": {
       "baseline": "0.6.3",

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5c636f8eb77d7d68c2a4b41fcd7d68759fb9ad0",
+      "version-semver": "1.4.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "53a1a7485857995d3b4cc5a2b6eaa22d6c6b036c",
       "version-semver": "1.4.2",
       "port-version": 1


### PR DESCRIPTION
Fixes my PR merged yesterday (https://github.com/microsoft/vcpkg/pull/31278). 

`sectransp` is of cause only available on `osx` and not the other way around 