### PR TITLE
[xtensor] update to 0.24.6

### DIFF
--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xsimd
-    REF 9.0.1
-    SHA512 ed56287f608ccdf5bc5d5fc2918e313e7c4cecdd9ef2c9993a72ea900d9ff662c57ac5326c7a809eb11505c6f39d4599f3f161b97b6e03c65783b824b8d700d2
+    REF "${VERSION}"
+    SHA512 bd7a363bbebc9196954c8c87271f14f05ca177569fcf080dac91be06ad2801c43fccbb385afd700b80d58c83d77f26ba199a7105672e4a1e55c517d15dd6e8e3
     HEAD_REF master
 )
 
@@ -28,4 +28,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xsimd/vcpkg.json
+++ b/ports/xsimd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xsimd",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "Modern, portable C++ wrappers for SIMD intrinsics",
   "homepage": "https://github.com/xtensor-stack/xsimd",
   "license": "BSD-3-Clause",

--- a/ports/xtensor/fix-find-tbb-and-install-destination.patch
+++ b/ports/xtensor/fix-find-tbb-and-install-destination.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7535649..5c93655 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -75,8 +75,8 @@ if(XTENSOR_USE_XSIMD)
+ endif()
+ 
+ if(XTENSOR_USE_TBB)
+-    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+-    find_package(TBB REQUIRED)
++    #set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
++    find_package(TBB CONFIG REQUIRED)
+     message(STATUS "Found intel TBB: ${TBB_INCLUDE_DIRS}")
+ endif()
+ 
+@@ -261,7 +261,7 @@ export(EXPORT ${PROJECT_NAME}-targets
+ install(FILES ${XTENSOR_HEADERS}
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xtensor)
+ 
+-set(XTENSOR_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}" CACHE
++set(XTENSOR_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE
+     STRING "install path for xtensorConfig.cmake")
+ 
+ configure_package_config_file(${PROJECT_NAME}Config.cmake.in
+@@ -288,7 +288,7 @@ configure_file(${PROJECT_NAME}.pc.in
+                "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+                 @ONLY)
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig/")
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+ 
+ # Write single include
+ # ====================

--- a/ports/xtensor/portfile.cmake
+++ b/ports/xtensor/portfile.cmake
@@ -3,9 +3,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtensor
-    REF 0.24.3
-    SHA512 3519541ce659d800dca386cdbb4c7aa5331e5297779239230cbfb78b22c541af22a98aae30a9e8604ee855378fa8e67be720dab1e0005135575d9738e64797c8
+    REF "${VERSION}"
+    SHA512 6284fb5de5d61c87a8599baad86b6c8c95d06d3753698a3a49efe9a87c291965e4a2439c84abf0722ce97ca7e48c5fdb0b64141f1bc8de7a7d06b7de9ec06cb6
     HEAD_REF master
+    PATCHES
+        fix-find-tbb-and-install-destination.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -34,4 +36,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xtensor/vcpkg.json
+++ b/ports/xtensor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xtensor",
-  "version": "0.24.3",
+  "version": "0.24.6",
   "description": "C++ tensors with broadcasting and lazy computing",
   "homepage": "https://github.com/xtensor-stack/xtensor",
   "license": "BSD-3-Clause",

--- a/ports/xtl/portfile.cmake
+++ b/ports/xtl/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtl
-    REF e0f00666d90086bb245ae73abb6123d0e2c1b30b # 0.7.2
-    SHA512 d7a552dc4e43a3270a56c57fde8fdc48a108909d4fa1e3fdd7ab12b178b3e271ed4d89aac9fd184e2739ddacfb3b5cb248538ed50a0ba56e740875c0faf5aa62
+    REF "${VERSION}"
+    SHA512 fb447334f68f255d7d28c9202eee2cec70d007c1031f3756a6acd0cc019c0d95ed1d12ec63f2e9fb3df184f9ec305e6a3c808bb88c1e3eb922916ad059d2e856
     HEAD_REF master
     PATCHES
         fix-fixup-cmake.patch
@@ -25,4 +25,4 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xtl/vcpkg.json
+++ b/ports/xtl/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "xtl",
-  "version": "0.7.2",
-  "port-version": 1,
+  "version": "0.7.5",
   "description": "The x template library",
   "homepage": "https://github.com/xtensor-stack/xtl",
+  "license": "BSD-3-Clause",
   "dependencies": [
     "nlohmann-json",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8705,11 +8705,11 @@
       "port-version": 2
     },
     "xsimd": {
-      "baseline": "9.0.1",
+      "baseline": "10.0.0",
       "port-version": 0
     },
     "xtensor": {
-      "baseline": "0.24.3",
+      "baseline": "0.24.6",
       "port-version": 0
     },
     "xtensor-blas": {
@@ -8725,8 +8725,8 @@
       "port-version": 1
     },
     "xtl": {
-      "baseline": "0.7.2",
-      "port-version": 1
+      "baseline": "0.7.5",
+      "port-version": 0
     },
     "xtrans": {
       "baseline": "1.4.0",

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c67f06803f30a45e0dc0db77378869d4c3067a0",
+      "version": "10.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "be6cd49ae57f84d0d66692b388c2ee0ce25cd0e0",
       "version": "9.0.1",
       "port-version": 0

--- a/versions/x-/xtensor.json
+++ b/versions/x-/xtensor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aeb0efc2bdf326191f5dff18bb2506690902b162",
+      "version": "0.24.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "474191556a342fc77b9defef9ba63a4dcf2205c4",
       "version": "0.24.3",
       "port-version": 0

--- a/versions/x-/xtl.json
+++ b/versions/x-/xtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5cad9625b1b7459135265c4f8647b2bcae0e252",
+      "version": "0.7.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "8255a333f114b449c2578ec70e91970eace40598",
       "version": "0.7.2",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/31348

- The latest `xtensor` requires the `0.7.5` version of `xtl`, so I update `xtl` to `0.7.5`.
- The latest `xtensor` requires the `10.0.0` version of `xsimd`, so I update `xsimd` to `10.0.0`.
- Add patch to find the `tbb` provided by vcpkg and use `${CMAKE_INSTALL_LIBDIR}` path。

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

All features passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```

Usage test pass with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```
<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
