### PR TITLE
[gdal] Update to 3.7.0

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/gdal
     REF "v${VERSION}"
-    SHA512 e2e01c1181ab604766119be63449239000314a3042a4a30f2b8d2794f23ec4b1d1f255699d7d723238a8b5bed25d0dcfd63c37066a03188be02c8e2f5e9b0853
+    SHA512 dfc7ccf5c1a3184fa93be762a880b7631faa4cd178cd72df8f5fd8a6296edafc56de2594617bebcb75ddf19ed4471dafcb574b22d7e9217dedfd7ea72c9247f2
     HEAD_REF master
     PATCHES
         find-link-libraries.patch

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gdal",
-  "version-semver": "3.6.4",
+  "version-semver": "3.7.0",
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/ports/pdal/gdal-3.7.patch
+++ b/ports/pdal/gdal-3.7.patch
@@ -1,0 +1,22 @@
+diff --git a/pdal/Geometry.cpp b/pdal/Geometry.cpp
+index 608bf86..8b010d3 100644
+--- a/pdal/Geometry.cpp
++++ b/pdal/Geometry.cpp
+@@ -153,7 +153,7 @@ Geometry& Geometry::operator=(const Geometry& input)
+ 
+ bool Geometry::srsValid() const
+ {
+-    OGRSpatialReference *srs = m_geom->getSpatialReference();
++    const OGRSpatialReference *srs = m_geom->getSpatialReference();
+     return srs && srs->GetRoot();
+ }
+ 
+@@ -172,7 +172,7 @@ Utils::StatusWithReason Geometry::transform(SpatialReference out)
+         return StatusWithReason(-2,
+             "Geometry::transform() failed.  NULL target SRS.");
+ 
+-    OGRSpatialReference *inSrs = m_geom->getSpatialReference();
++    const OGRSpatialReference *inSrs = m_geom->getSpatialReference();
+     SrsTransform transform(*inSrs, OGRSpatialReference(out.getWKT().data()));
+     if (m_geom->transform(transform.get()) != OGRERR_NONE)
+         return StatusWithReason(-1, "Geometry::transform() failed.");

--- a/ports/pdal/mingw.patch
+++ b/ports/pdal/mingw.patch
@@ -1,0 +1,13 @@
+diff --git a/io/OptechReader.cpp b/io/OptechReader.cpp
+index bd12e70..2b7846b 100644
+--- a/io/OptechReader.cpp
++++ b/io/OptechReader.cpp
+@@ -60,7 +60,7 @@ std::string OptechReader::getName() const
+     return s_info.name;
+ }
+ 
+-#ifndef _WIN32
++#ifndef _MSC_VER
+ const size_t OptechReader::MaximumNumberOfReturns;
+ const size_t OptechReader::MaxNumRecordsInBuffer;
+ const size_t OptechReader::NumBytesInRecord;

--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -13,6 +13,8 @@ vcpkg_from_github(
         no-pkgconfig-requires.patch
         no-rpath.patch
         fix-gcc-13-build.patch  #upstream PR: https://github.com/PDAL/PDAL/pull/4039
+        gdal-3.7.patch
+        mingw.patch
 )
 
 # Prefer pristine CMake find modules + wrappers and config files from vcpkg.

--- a/ports/pdal/vcpkg.json
+++ b/ports/pdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pdal",
   "version": "2.5.3",
+  "port-version": 1,
   "description": "PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.",
   "homepage": "https://pdal.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2709,7 +2709,7 @@
       "port-version": 0
     },
     "gdal": {
-      "baseline": "3.6.4",
+      "baseline": "3.7.0",
       "port-version": 0
     },
     "gdcm": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6114,7 +6114,7 @@
     },
     "pdal": {
       "baseline": "2.5.3",
-      "port-version": 0
+      "port-version": 1
     },
     "pdal-c": {
       "baseline": "2.2.0",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "befcd2fe67a87498bfdaea5601b58f120e984038",
+      "version-semver": "3.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f83039e70646a59b782781b3c805f276fb4c72be",
       "version-semver": "3.6.4",
       "port-version": 0

--- a/versions/p-/pdal.json
+++ b/versions/p-/pdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a8618eb3877634f95eb6edbbba64f3e4cccb1d58",
+      "version": "2.5.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "36cec2be04df8ba1771c374ccc8ae3c8a0cc96f3",
       "version": "2.5.3",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

