### PR TITLE
[vcpkg baseline][infoware][pciids] Update infoware and add new port pciids

### DIFF
--- a/ports/infoware/cross-build.diff
+++ b/ports/infoware/cross-build.diff
@@ -1,8 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 580df83..b0d2553 100644
+index 580df83..ac89904 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -122,11 +122,17 @@ set_target_properties(infoware_pci_generator PROPERTIES CXX_STANDARD 14
+@@ -93,6 +93,8 @@ if(INFOWARE_PCI_IDS_PATH)
+ 		message(WARNING "The specified pci.ids file INFOWARE_PCI_IDS_PATH=${INFOWARE_PCI_IDS_PATH} doesn't seem to exist.")
+ 	endif()
+ 	set(infoware_pci_ids_file "${INFOWARE_PCI_IDS_PATH}")
++elseif(HOST_PCI_DATA)
++	# git unused
+ elseif(NOT Git_FOUND)
+ 	message(SEND_ERROR "Couldn't find a usable git executable in the environment, and the CMake variable INFOWARE_PCI_IDS_PATH is empty.\n${infoware_pci_ids_error}")
+ else()
+@@ -122,11 +124,17 @@ set_target_properties(infoware_pci_generator PROPERTIES CXX_STANDARD 14
  set(INFOWARE_PCI_DATA_HPP pci_data.hpp)
  set(INFOWARE_PCI_DATA_GEN "infoware_generated/${INFOWARE_PCI_DATA_HPP}")
  

--- a/ports/infoware/cross-build.diff
+++ b/ports/infoware/cross-build.diff
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 580df83..b0d2553 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -122,11 +122,17 @@ set_target_properties(infoware_pci_generator PROPERTIES CXX_STANDARD 14
+ set(INFOWARE_PCI_DATA_HPP pci_data.hpp)
+ set(INFOWARE_PCI_DATA_GEN "infoware_generated/${INFOWARE_PCI_DATA_HPP}")
+ 
++if(HOST_PCI_DATA)
++	set_target_properties(infoware_pci_generator PROPERTIES EXCLUDE_FROM_ALL 1)
++	configure_file("${HOST_PCI_DATA}" "${CMAKE_CURRENT_BINARY_DIR}/${INFOWARE_PCI_DATA_GEN}" COPYONLY)
++else()
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${INFOWARE_PCI_DATA_GEN}" DESTINATION "share/infoware")
+ add_custom_command(OUTPUT ${INFOWARE_PCI_DATA_GEN}
+                    COMMAND ${CMAKE_COMMAND} -E make_directory infoware_generated/
+                    COMMAND $<TARGET_FILE:infoware_pci_generator> "${infoware_pci_ids_file}" > "infoware_generated/pci_data.hpp"
+                    DEPENDS "${infoware_pci_ids_file}"
+                    COMMENT "Generating ${INFOWARE_PCI_DATA_HPP}")
++endif()
+ 
+ add_custom_target(infoware_generate_pcis DEPENDS "${INFOWARE_PCI_DATA_GEN}")
+ add_dependencies(infoware infoware_generate_pcis)

--- a/ports/infoware/portfile.cmake
+++ b/ports/infoware/portfile.cmake
@@ -1,36 +1,33 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ThePhD/infoware
-    REF 50cb0982aceb32c8eb57aa6bc5011aced2c379df
-    SHA512 fe8182998a9e9dbed3dc3985a1161da11b340562628a71da8840aa4d4c56382ddc3ddef3d094e5d9c7c06481a2076dcff7fdb561bd169dd9d1849da4b4c6a064
+    REF d64a0c948593c0555115f60c79225c0b9ae09510
+    SHA512 3794cb78a1422bfc065037abbae81259e6061ba7b12ebd7b88581118e8eeebaf92d80cf7793b0f9f1da6754baf52835a6891663593dd0b0a38009a9cb141082b
     HEAD_REF master
 )
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        x11 INFOWARE_USE_X11
-        d3d INFOWARE_USE_D3D
-        opencl INFOWARE_USE_OPENCL
-        opengl INFOWARE_USE_OPENGL
+        d3d     INFOWARE_USE_D3D
+        opencl  INFOWARE_USE_OPENCL
+        opengl  INFOWARE_USE_OPENGL
+        x11     INFOWARE_USE_X11
 )
 
-# git must be injected, because vcpkg isolates the build
-# from the environment entirely to have reproducible builds
 vcpkg_find_acquire_program(GIT)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
         -DINFOWARE_EXAMPLES=OFF
         -DINFOWARE_TESTS=OFF
-        -DGIT_EXECUTABLE=${GIT}
-        -DGIT_FOUND=true
+        "-DGIT_EXECUTABLE=${GIT}"
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/infoware/portfile.cmake
+++ b/ports/infoware/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF d64a0c948593c0555115f60c79225c0b9ae09510
     SHA512 3794cb78a1422bfc065037abbae81259e6061ba7b12ebd7b88581118e8eeebaf92d80cf7793b0f9f1da6754baf52835a6891663593dd0b0a38009a9cb141082b
     HEAD_REF master
+    PATCHES
+        cross-build.diff
 )
 
 vcpkg_check_features(
@@ -14,6 +16,10 @@ vcpkg_check_features(
         opengl  INFOWARE_USE_OPENGL
         x11     INFOWARE_USE_X11
 )
+
+if(VCPKG_CROSSCOMPILING)
+    list(APPEND FEATURE_OPTIONS "-DHOST_PCI_DATA=${CURRENT_HOST_INSTALLED_DIR}/share/${PORT}/pci_data.hpp")
+endif()
 
 vcpkg_find_acquire_program(GIT)
 
@@ -29,5 +35,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/infoware/portfile.cmake
+++ b/ports/infoware/portfile.cmake
@@ -19,9 +19,10 @@ vcpkg_check_features(
 
 if(VCPKG_CROSSCOMPILING)
     list(APPEND FEATURE_OPTIONS "-DHOST_PCI_DATA=${CURRENT_HOST_INSTALLED_DIR}/share/${PORT}/pci_data.hpp")
+else()
+    acquire_pciids(pciids_path)
+    list(APPEND FEATURE_OPTIONS "-DINFOWARE_PCI_IDS_PATH=${pciids_path}")
 endif()
-
-vcpkg_find_acquire_program(GIT)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -29,7 +30,7 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DINFOWARE_EXAMPLES=OFF
         -DINFOWARE_TESTS=OFF
-        "-DGIT_EXECUTABLE=${GIT}"
+        -DCMAKE_DISABLE_FIND_PACKAGE_Git=1
 )
 
 vcpkg_cmake_install()

--- a/ports/infoware/vcpkg.json
+++ b/ports/infoware/vcpkg.json
@@ -5,6 +5,7 @@
   "description": "C++ Library for pulling system and hardware information, without hitting the command line.",
   "homepage": "https://github.com/ThePhD/infoware",
   "license": "CC0-1.0",
+  "supports": "!android & !uwp & !(windows & arm)",
   "dependencies": [
     {
       "name": "infoware",

--- a/ports/infoware/vcpkg.json
+++ b/ports/infoware/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "$reason": "Note that independent usage and testing may work, but it seems to fail in CI environments for potential cross-compilation, and is thusly noted here to note break how vcpkg builds things!",
   "name": "infoware",
-  "version-date": "2021-06-16",
-  "port-version": 1,
+  "version-date": "2023-04-12",
   "description": "C++ Library for pulling system and hardware information, without hitting the command line.",
   "homepage": "https://github.com/ThePhD/infoware",
-  "supports": "!(arm | uwp)",
+  "license": "CC0-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -18,16 +17,31 @@
   ],
   "features": {
     "d3d": {
-      "description": "Prefer usage of Direct3D to find graphical capabilities (typically only works on Windows systems)."
+      "description": [
+        "Use Direct3D for GPU detection.",
+        "This choice has priority over opencl and opengl."
+      ],
+      "supports": "windows"
     },
     "opencl": {
-      "description": "Prefer usage of OpenCL to find graphical capabilities of the system."
+      "description": [
+        "Use OpenCL for GPU detection.",
+        "This choice has priority over opengl."
+      ],
+      "dependencies": [
+        "opencl"
+      ]
     },
     "opengl": {
-      "description": "Prefer usage of OpenGL to find graphical capabilities (may require additional libraries to be available for linking depending on the system)."
+      "description": "Use OpenGL for GPU detection.",
+      "supports": "!osx & !ios",
+      "dependencies": [
+        "opengl"
+      ]
     },
     "x11": {
-      "description": "Prefer usage of X11 to find graphical capabilities."
+      "description": "Use X11 for display detection.",
+      "supports": "!windows"
     }
   }
 }

--- a/ports/infoware/vcpkg.json
+++ b/ports/infoware/vcpkg.json
@@ -1,5 +1,4 @@
 {
-  "$reason": "Note that independent usage and testing may work, but it seems to fail in CI environments for potential cross-compilation, and is thusly noted here to note break how vcpkg builds things!",
   "name": "infoware",
   "version-date": "2023-04-12",
   "description": "C++ Library for pulling system and hardware information, without hitting the command line.",

--- a/ports/infoware/vcpkg.json
+++ b/ports/infoware/vcpkg.json
@@ -7,6 +7,10 @@
   "license": "CC0-1.0",
   "dependencies": [
     {
+      "name": "infoware",
+      "host": true
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },

--- a/ports/infoware/vcpkg.json
+++ b/ports/infoware/vcpkg.json
@@ -12,6 +12,10 @@
       "host": true
     },
     {
+      "name": "pciids",
+      "platform": "native"
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },

--- a/ports/pciids/acquire_pciids.cmake
+++ b/ports/pciids/acquire_pciids.cmake
@@ -1,0 +1,9 @@
+function(acquire_pciids out_var)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO pciutils/pciids
+        REF 4e3f51b4b7ba7ffd3cca463d6a19daf0f4270252
+        SHA512 952b56affffdf9ecf78f6125cf4216bd01d85c55e49ec4b2dfb3a77bae2258dec6b4e2d28824d6408f072667480ef7e5f7279fd69bae65c071b7b3816fe9f504
+    )
+    set(${out_var} "${SOURCE_PATH}/pci.ids" PARENT_SCOPE)
+endfunction()

--- a/ports/pciids/portfile.cmake
+++ b/ports/pciids/portfile.cmake
@@ -1,0 +1,15 @@
+# This package doesn't "install" the pciids data file but
+# provides a maintainer function which does the download.
+
+set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
+
+include("${CMAKE_CURRENT_LIST_DIR}/acquire_pciids.cmake")
+acquire_pciids(pciids_path)
+cmake_path(GET pciids_path PARENT_PATH pciids_dir)
+
+file(INSTALL
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/acquire_pciids.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+vcpkg_install_copyright(FILE_LIST "${pciids_dir}/README")

--- a/ports/pciids/vcpkg-port-config.cmake
+++ b/ports/pciids/vcpkg-port-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/acquire_pciids.cmake")

--- a/ports/pciids/vcpkg.json
+++ b/ports/pciids/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "pciids",
+  "version-date": "2023-04-11",
+  "description": "Maintainer function to acquire a PCI ID Repository database snapshot",
+  "homepage": "https://pci-ids.ucw.cz/",
+  "license": "GPL-2.0-or-later OR BSD-3-Clause",
+  "supports": "native"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6100,6 +6100,10 @@
       "baseline": "2021-04-06",
       "port-version": 2
     },
+    "pciids": {
+      "baseline": "2023-04-11",
+      "port-version": 0
+    },
     "pcl": {
       "baseline": "1.13.0",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3325,8 +3325,8 @@
       "port-version": 0
     },
     "infoware": {
-      "baseline": "2021-06-16",
-      "port-version": 1
+      "baseline": "2023-04-12",
+      "port-version": 0
     },
     "inih": {
       "baseline": "56",

--- a/versions/i-/infoware.json
+++ b/versions/i-/infoware.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88766705f123cd31492901cd2ff96b1cb53cbf78",
+      "version-date": "2023-04-12",
+      "port-version": 0
+    },
+    {
       "git-tree": "5501ab1b5d5391ca168856f073f6a46d5ea83268",
       "version-date": "2021-06-16",
       "port-version": 1

--- a/versions/i-/infoware.json
+++ b/versions/i-/infoware.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9dfaaa4693703c3d38b3e4bde78c4daa5c4d6796",
+      "git-tree": "72277bf30eb8332608961105d64dbe092e187de6",
       "version-date": "2023-04-12",
       "port-version": 0
     },

--- a/versions/i-/infoware.json
+++ b/versions/i-/infoware.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "72277bf30eb8332608961105d64dbe092e187de6",
+      "git-tree": "6c63257b423fb978ef3b355b50351bcc0f7e1dd8",
       "version-date": "2023-04-12",
       "port-version": 0
     },

--- a/versions/i-/infoware.json
+++ b/versions/i-/infoware.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6c63257b423fb978ef3b355b50351bcc0f7e1dd8",
+      "git-tree": "10ceed518afc0c84b79aa36c1263a034b320511e",
       "version-date": "2023-04-12",
       "port-version": 0
     },

--- a/versions/i-/infoware.json
+++ b/versions/i-/infoware.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "88766705f123cd31492901cd2ff96b1cb53cbf78",
+      "git-tree": "9dfaaa4693703c3d38b3e4bde78c4daa5c4d6796",
       "version-date": "2023-04-12",
       "port-version": 0
     },

--- a/versions/p-/pciids.json
+++ b/versions/p-/pciids.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ffc7c82fb249347c25b294b6c8131e1f3b2156c2",
+      "version-date": "2023-04-11",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
To fix flaky vcpkg CI, https://dev.azure.com/vcpkg/public/_build/results?buildId=89266

# infoware

- Update
- Update supported platforms.
- Add dependencies to optional features.
- Fix cross builds (for supported targets)
- Stop cloning pciids git repo in project mode

# pciids

New script port for fetching pciids data
- Script port. Actual data is only cached in assets, not artifacts
- Versioning can vary independently from infoware.
- Data might be used e.g. by a future pciutils port.
- Name: most frequent match in repology.
  https://repology.org/project/pciids/information

# ...
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
