### PR TITLE
[libgit2] Add GIT_OPENSSL OPTION to fix setting certificate location fail

### DIFF
--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -29,10 +29,8 @@ function(set_tls_backend VALUE)
     set(USE_HTTPS ${VALUE} PARENT_SCOPE)
 endfunction()
 
-if(UNIX)
-    if("openssl" IN_LIST FEATURES)
-        list(APPEND GIT_OPTIONS "-DGIT_OPENSSL=1")  
-    endif()
+if("openssl" IN_LIST FEATURES)
+    list(APPEND GIT_OPTIONS "-DGIT_OPENSSL=1")  
 endif()
 
 foreach(GIT2_FEATURE ${FEATURES})

--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -30,7 +30,9 @@ function(set_tls_backend VALUE)
 endfunction()
 
 if(UNIX)
-    list(APPEND GIT_OPTIONS "-DGIT_OPENSSL=1")  
+    if("openssl" IN_LIST FEATURES)
+        list(APPEND GIT_OPTIONS "-DGIT_OPENSSL=1")  
+    endif()
 endif()
 
 foreach(GIT2_FEATURE ${FEATURES})

--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -29,6 +29,10 @@ function(set_tls_backend VALUE)
     set(USE_HTTPS ${VALUE} PARENT_SCOPE)
 endfunction()
 
+if(UNIX)
+    list(APPEND GIT_OPTIONS "-DGIT_OPENSSL=1")  
+endif()
+
 foreach(GIT2_FEATURE ${FEATURES})
     if(GIT2_FEATURE STREQUAL "pcre")
         set_regex_backend("pcre")
@@ -64,6 +68,7 @@ vcpkg_cmake_configure(
         -DREGEX_BACKEND=${REGEX_BACKEND}
         -DSTATIC_CRT=${STATIC_CRT}
         ${GIT2_FEATURES}
+        ${GIT_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libgit2",
   "version-semver": "1.4.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Git linkable library",
   "homepage": "https://github.com/libgit2/libgit2",
   "supports": "!uwp",
@@ -49,7 +49,7 @@
     },
     "sectransp": {
       "description": "SSL support (sectransp)",
-      "supports": "!osx"
+      "supports": "osx"
     },
     "ssh": {
       "description": "SSH support via libssh2",

--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -49,7 +49,7 @@
     },
     "sectransp": {
       "description": "SSL support (sectransp)",
-      "supports": "osx"
+      "supports": "!osx"
     },
     "ssh": {
       "description": "SSH support via libssh2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4034,7 +4034,7 @@
     },
     "libgit2": {
       "baseline": "1.4.2",
-      "port-version": 2
+      "port-version": 3
     },
     "libgme": {
       "baseline": "0.6.3",

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "944f3816f44a0f986367c78d2f64bcf34c020058",
+      "version-semver": "1.4.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "434c99053ca23cda1b58796ac7d42a66b3f84a44",
       "version-semver": "1.4.2",
       "port-version": 2

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d5c636f8eb77d7d68c2a4b41fcd7d68759fb9ad0",
+      "git-tree": "434c99053ca23cda1b58796ac7d42a66b3f84a44",
       "version-semver": "1.4.2",
       "port-version": 2
     },

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "944f3816f44a0f986367c78d2f64bcf34c020058",
+      "git-tree": "3f1811eb638a2ce5661fc7b714eca1114a2af798",
       "version-semver": "1.4.2",
       "port-version": 3
     },

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -6,7 +6,7 @@
       "port-version": 3
     },
     {
-      "git-tree": "434c99053ca23cda1b58796ac7d42a66b3f84a44",
+      "git-tree": "d5c636f8eb77d7d68c2a4b41fcd7d68759fb9ad0",
       "version-semver": "1.4.2",
       "port-version": 2
     },

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3f1811eb638a2ce5661fc7b714eca1114a2af798",
+      "git-tree": "7c2173f86743e6e3c6759d5c781f236c08adbec4",
       "version-semver": "1.4.2",
       "port-version": 3
     },


### PR DESCRIPTION
Fixes #14048

Add GIT_OPENSSL OPTION for linux targets to fix setting certificate location fail.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
