### PR TITLE
[easyloggingpp] Features to support multithreading

### DIFF
--- a/ports/easyloggingpp/0001_add_cmake_options.patch
+++ b/ports/easyloggingpp/0001_add_cmake_options.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 538cc8a..9221dab 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,6 +25,10 @@ option(test "Build all tests" OFF)
+ option(build_static_lib "Build easyloggingpp as a static library" OFF)
+ option(lib_utc_datetime "Build library with UTC date/time logging" OFF)
+ 
++option(no_default_logfile "Do not write to default log file \"myeasylog.log\" (define ELPP_NO_DEFAULT_LOG_FILE)" OFF)
++option(thread_safe "Build easyloggingpp thread safe (define ELPP_THREAD_SAFE)" OFF)
++option(use_std_threads "Use standard library thread synchronization (define ELPP_FORCE_USE_STD_THREAD)" OFF)
++
+ set(ELPP_MAJOR_VERSION "9")
+ set(ELPP_MINOR_VERSION "96")
+ set(ELPP_PATCH_VERSION "7")
+@@ -57,6 +61,18 @@ if (build_static_lib)
+                 add_definitions(-DELPP_UTC_DATETIME)
+         endif()
+ 
++        if (no_default_logfile)
++                add_definitions(-DELPP_NO_DEFAULT_LOG_FILE)
++        endif()
++
++        if (thread_safe)
++                add_definitions(-DELPP_THREAD_SAFE)
++        endif()
++
++        if (use_std_threads)
++                add_definitions(-DELPP_FORCE_USE_STD_THREAD)
++        endif()
++
+         require_cpp11()
+         add_library(easyloggingpp STATIC src/easylogging++.cc)
+         set_property(TARGET easyloggingpp PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/ports/easyloggingpp/portfile.cmake
+++ b/ports/easyloggingpp/portfile.cmake
@@ -6,11 +6,21 @@ vcpkg_from_github(
     REF v9.97.0
     SHA512 e45789edaf7a43ad6a73861840d24ccce9b9d6bba1aaacf93c6ac26ff7449957251d2ca322c9da85130b893332dd305b13a2499eaffc65ecfaaafa3e11f8d63d
     HEAD_REF master
+    PATCHES
+        0001_add_cmake_options.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+		std-locking     use_std_threads
+		thread-safe     thread_safe
+		no-defaultfile  no_default_logfile
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -Dbuild_static_lib=ON
 )
 vcpkg_cmake_install()

--- a/ports/easyloggingpp/vcpkg.json
+++ b/ports/easyloggingpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "easyloggingpp",
   "version": "9.97.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Easylogging++ is a single header efficient logging library for C++ applications.",
   "homepage": "https://github.com/amrayn/easyloggingpp",
   "dependencies": [
@@ -13,5 +13,16 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "no-defaultfile": {
+      "description": "Do not write to default log file \"myeasylog.log\" (compile with ELPP_NO_DEFAULT_LOG_FILE)"
+    },
+    "std-locking": {
+      "description": "Use std::mutex for thread synchronization (compile with ELPP_FORCE_USE_STD_THREAD)"
+    },
+    "thread-safe": {
+      "description": "Make easyloggingpp thread safe (compile with ELPP_THREAD_SAFE)"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2234,7 +2234,7 @@
     },
     "easyloggingpp": {
       "baseline": "9.97.0",
-      "port-version": 2
+      "port-version": 3
     },
     "eathread": {
       "baseline": "1.32.09",

--- a/versions/e-/easyloggingpp.json
+++ b/versions/e-/easyloggingpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69f6b238899967e671f818a164f21de0219546bc",
+      "version": "9.97.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "40ca985ab8030ca0daf7c902e413423801d3e3d4",
       "version": "9.97.0",
       "port-version": 2


### PR DESCRIPTION
This pull request adds the following features to easyloggingpp

- 'thread-safe': Build library with working thread synchronization. The current port uses dummy lock objects.
- 'std-locking': Use std::recursive_mutex and std::lock_guard instead of platform-specific mechanisms.
- 'no-defaultfile': Supresses logging to default "myeasylog.log" when logger isn't yet configured.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
