### PR TITLE
[ltla-umappp|ltla-*] new ports

### DIFF
--- a/ports/ltla-aarand/portfile.cmake
+++ b/ports/ltla-aarand/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LTLA/aarand
+    REF 84d48b65d49ce8b844398f11aff3015b86e17197
+    SHA512 78b175055768dd8b0abab421b66d0d16ad9bc23f1d1406d774874d4ea12b11e199554ccf6a6ef02d10ef96ad5f652863e403aa3ec9522211958c78d243821ee5
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE "release") # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DAARAND_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME ltla_aarand
+    CONFIG_PATH lib/cmake/ltla_aarand
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ltla-aarand/vcpkg.json
+++ b/ports/ltla-aarand/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "ltla-aarand",
+  "version-date": "2023-03-19",
+  "description": "Aaron's random distributions for C++",
+  "homepage": "https://github.com/LTLA/aarand",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/ltla-cppirlba/portfile.cmake
+++ b/ports/ltla-cppirlba/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LTLA/CppIrlba
+    REF d23a4c12b95563907cf8ca7584b7bb6625ff886b
+    SHA512 1fdc9552ab00c7c541b4cd34326075f257a30ebcf73dd633dd088b20a20cb0dd704be0c3295ab96d5a573cb1a783c19f34a3e5d860c719e413c098fd9df4cb3a
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE "release") # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DIRLBA_FETCH_EXTERN=OFF
+        -DIRLBA_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME ltla_irlba
+    CONFIG_PATH lib/cmake/ltla_irlba
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ltla-cppirlba/vcpkg.json
+++ b/ports/ltla-cppirlba/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "ltla-cppirlba",
+  "version-date": "2023-04-07",
+  "description": "A C++ port of the IRLBA algorithm, based on the C code in the R package.",
+  "homepage": "https://github.com/LTLA/CppIrlba",
+  "license": "MIT",
+  "dependencies": [
+    "eigen3",
+    "ltla-aarand",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/ltla-cppkmeans/portfile.cmake
+++ b/ports/ltla-cppkmeans/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LTLA/CppKmeans
+    REF 4c5aca44bffd8ed7d7243b2451105b572028e9d4
+    SHA512 c56147bc89ab50aa4d738c1392dffcf32771ad4995cbb206a83af05294dbfe640a1da265d46e108816486374fe0e6fa45c1b1da770cdc4367a69195c3510ecd4
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE "release") # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DKMEANS_FETCH_EXTERN=OFF
+        -DKMEANS_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME ltla_kmeans
+    CONFIG_PATH lib/cmake/ltla_kmeans
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ltla-cppkmeans/vcpkg.json
+++ b/ports/ltla-cppkmeans/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "ltla-cppkmeans",
+  "version-date": "2023-03-20",
+  "description": "C++ port of R's Hartigan-Wong implementation",
+  "homepage": "https://github.com/LTLA/CppKmeans",
+  "license": "MIT",
+  "dependencies": [
+    "ltla-aarand",
+    "ltla-powerit",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/ltla-knncolle/portfile.cmake
+++ b/ports/ltla-knncolle/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LTLA/knncolle
+    REF 3ad6b8cdbd281d78c77390d5a6ded4513bdf3860
+    SHA512 c6e66d8ea5501cb511fd88155d18b57b31661ad0e20f3289d9a7ec8fc558f91dd409487b53d41171111fdaa2baa11fe9548f01daf307a90121d17dc398203676
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE "release") # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DKNNCOLLE_FETCH_EXTERN=OFF
+        -DKNNCOLLE_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME ltla_knncolle
+    CONFIG_PATH lib/cmake/ltla_knncolle
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ltla-knncolle/vcpkg.json
+++ b/ports/ltla-knncolle/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "ltla-knncolle",
+  "version-date": "2023-05-09",
+  "description": "Collection of KNN algorithms in C++",
+  "homepage": "https://github.com/LTLA/knncolle",
+  "license": "MIT",
+  "dependencies": [
+    "annoy",
+    "hnswlib",
+    "ltla-cppkmeans",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/ltla-powerit/portfile.cmake
+++ b/ports/ltla-powerit/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LTLA/powerit
+    REF 705c4a6209baeaf4a246c8a61c46ecd0d3473511
+    SHA512 e45172baf90fe2e76152a53feb2a3b613a355482b657e5bc71f0eca4199dff947da70b44edd87efbdc4929eb39ec4455300edaf8f95eb394f61213657c97c321
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE "release") # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DPOWERIT_FETCH_EXTERN=OFF
+        -DPOWERIT_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME ltla_powerit
+    CONFIG_PATH lib/cmake/ltla_powerit
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ltla-powerit/vcpkg.json
+++ b/ports/ltla-powerit/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "ltla-powerit",
+  "version-date": "2023-03-19",
+  "description": "Lightweight C++ library for power iterations",
+  "homepage": "https://github.com/LTLA/powerit",
+  "license": "MIT",
+  "dependencies": [
+    "ltla-aarand",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/ltla-umappp/portfile.cmake
+++ b/ports/ltla-umappp/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LTLA/umappp
+    REF d18095ea8b6d62aa740a566411e439eaab16b71f
+    SHA512 5f05c9cd7eeac2c16e8dbb0e747c84bc5209e91e37cf8a120273b01f681e19afa69d52e03a6862386c75d9f4d62d925135087c69b835257764aa1f490d92ef3d
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE "release") # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DUMAPPP_FETCH_EXTERN=OFF
+        -DUMAPPP_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME ltla_umappp
+    CONFIG_PATH lib/cmake/ltla_umappp
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ltla-umappp/vcpkg.json
+++ b/ports/ltla-umappp/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "ltla-umappp",
+  "version-date": "2023-05-11",
+  "description": "UMAP C++ implementation",
+  "homepage": "https://github.com/LTLA/umappp",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    "ltla-aarand",
+    "ltla-cppirlba",
+    "ltla-knncolle",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4932,6 +4932,30 @@
       "baseline": "1.0.2",
       "port-version": 4
     },
+    "ltla-aarand": {
+      "baseline": "2023-03-19",
+      "port-version": 0
+    },
+    "ltla-cppirlba": {
+      "baseline": "2023-04-07",
+      "port-version": 0
+    },
+    "ltla-cppkmeans": {
+      "baseline": "2023-03-20",
+      "port-version": 0
+    },
+    "ltla-knncolle": {
+      "baseline": "2023-05-09",
+      "port-version": 0
+    },
+    "ltla-powerit": {
+      "baseline": "2023-03-19",
+      "port-version": 0
+    },
+    "ltla-umappp": {
+      "baseline": "2023-05-11",
+      "port-version": 0
+    },
     "lua": {
       "baseline": "5.4.4",
       "port-version": 7

--- a/versions/l-/ltla-aarand.json
+++ b/versions/l-/ltla-aarand.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "78cd0fcfb69b096fb2f4261e02c0b0dbaa85b89a",
+      "version-date": "2023-03-19",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/ltla-cppirlba.json
+++ b/versions/l-/ltla-cppirlba.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a1a4fe3742a5fecbadcb34155df9230a279a3e1c",
+      "version-date": "2023-04-07",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/ltla-cppkmeans.json
+++ b/versions/l-/ltla-cppkmeans.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "98167fd1d30ddefc1bbb44a321af164cf59aee31",
+      "version-date": "2023-03-20",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/ltla-knncolle.json
+++ b/versions/l-/ltla-knncolle.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "543f312cf96c53b41e8501bf473e5e8a336d8b12",
+      "version-date": "2023-05-09",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/ltla-powerit.json
+++ b/versions/l-/ltla-powerit.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "522b483967df42ac83d0876893d81becf3e88ab6",
+      "version-date": "2023-03-19",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/ltla-umappp.json
+++ b/versions/l-/ltla-umappp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b96e4bc54041c787e0c15d884c0968aade97cfae",
+      "version-date": "2023-05-11",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This adds the port ltla-umappp and all required dependencies. I included them in a single PR, because all 6 libraries are using the same project layout, same CMake handling, are all header only and overall relative small libraries without any patches or other edge cases and have many dependencies on each other. I assume reviewing will be very similar for all of them, so maybe it is easier to look at them at once. However, if you want a single port per PR I could split it up.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.