### PR TITLE
[shader-slang] Update to v0.27.20

### DIFF
--- a/ports/shader-slang/portfile.cmake
+++ b/ports/shader-slang/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+vcpkg_minimum_required(VERSION 2023-04-07) # for ${VERSION}
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 if (VCPKG_TARGET_IS_WINDOWS)
@@ -11,7 +11,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
 			ARCHIVE
 			URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-win64.zip"
 			FILENAME "slang-${VERSION}-win64.zip"
-			SHA512 a3f9f1a30468588fc5706eacd3a4c2dc41b014a949b34fe8a16dc1a9a2cb3e85edfcabb46473a3599fe9cd95a2ca8cbae5ab39fdf626e6b5b614a94be48e6d4d
+			SHA512 db8404de1e1aa7b4deac258f1d3aed4287d6babc37538c76914da87e1bfcc5919d8013cf9054ae1c0aa32a5a14a25a668fd7f6fb23b8b2e1275bcfc9fe256eac
 		)
 		set(SLANG_BIN_PATH "bin/windows-x64/release")
 	elseif (VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
@@ -19,7 +19,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
 			ARCHIVE
 			URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-win32.zip"
 			FILENAME "slang-${VERSION}-win32.zip"
-			SHA512 06012d3d7004f0565cda01b11fd7236e6828a8ea79ca93ad05e3e1a3e35571daf2cd6558e096dfd97c46c23ce74b802d71287e02eec5d7951c18e16c6c635da6
+			SHA512 1045f37b02ae93c2b8a7b9a7b8c98cd5b7c2d1a86704888c778ae12bc5bd701284d356685010ba4405893c9c0bfec2e117b329c00d8c218e08df578d607a9f80
 		)
 		set(SLANG_BIN_PATH "bin/windows-x86/release")
 	else()
@@ -35,7 +35,7 @@ elseif (VCPKG_TARGET_IS_OSX)
 			ARCHIVE
 			URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-macos-x64.zip"
 			FILENAME "slang-${VERSION}-macos-x64.zip"
-			SHA512 5914caa4ab9867fbceed6f0bb4f83f3b5400c05872baff40456460655efbdccb34b3590663f8ee80e953f3e584d0e729bc1da34ab8f80be33d1233ca4b043d71
+			SHA512 627d77d83eef56e25815c30d0e99ae472c9189c760d1a620daebf49407c97e5e4da4b7880781c7788e85c5ccfba3a9e938e50ede2be0e93c0635050b11ad22a0
 		)
 		set(SLANG_BIN_PATH "bin/macos-x64/release")
 	elseif (VCPKG_TARGET_ARCHITECTURE MATCHES "arm64")
@@ -43,7 +43,7 @@ elseif (VCPKG_TARGET_IS_OSX)
 			ARCHIVE
 			URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-macos-aarch64.zip"
 			FILENAME "slang-${VERSION}-macos-aarch64.zip"
-			SHA512 9e792ba0dec87a892df566b48f4553691f20d48c74c7d111b93c6f55c83790a8857bd82c461746190d8507b4aef440aeadb267da9558692a6113cfda52d12c80
+			SHA512 e898c20c60b4f3e8bbb262fef4cad88fba35b66dafb4784eec8b1603d8ee0293a71faeac1f84a9df96f33e206503ed717f7a068370e40a49bac90c009bbe4336
 		)
 		set(SLANG_BIN_PATH "bin/macos-aarch64/release")
 	else()
@@ -59,7 +59,7 @@ elseif(VCPKG_TARGET_IS_LINUX)
 			ARCHIVE
 			URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-linux-x86_64.tar.gz"
 			FILENAME "slang-${VERSION}-linux-x86_64.tar.gz"
-			SHA512 f6e3d49ddfdb79e0dc8183bd915ee4e2975428f1a6020498062cb54b0f078c86bcdc50d274c8ed22ba2f3ae823cb0b95d719a1067321fb0400c329f8c34149dd
+			SHA512 2291e7ee0e1998eb8cf3725154bade4ebd2873f18ba2dc04e598ffee63298780e6906a6257762a84ba4d81f32b1fb4548b1aaea4a79852f4fc6827faeba4426f
 		)
 		set(SLANG_BIN_PATH "bin/linux-x64/release")
 	else()
@@ -99,7 +99,7 @@ vcpkg_from_github(
 	OUT_SOURCE_PATH SOURCE_PATH
 	REPO shader-slang/slang
 	REF v${VERSION}
-	SHA512 ddb50eb59bebbb826844c4831f721bb40e28edb64d37d7463afb68cd27b653d7d8e1776000eaf70f4b5a882182ac06fa233dfe51167c2a3d170df89987da2cc2
+	SHA512 cc89a8a8eeab494c2558d2699bad75520cb44640d17881b0e35f618df68090a7fcee03e812e77998fe953206790d284fdfa084a0d30d0b4fca33991fe9ec8775
 	HEAD_REF master
 )
 

--- a/ports/shader-slang/portfile.cmake
+++ b/ports/shader-slang/portfile.cmake
@@ -1,4 +1,3 @@
-vcpkg_minimum_required(VERSION 2023-04-07) # for ${VERSION}
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 if (VCPKG_TARGET_IS_WINDOWS)

--- a/ports/shader-slang/vcpkg.json
+++ b/ports/shader-slang/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "shader-slang",
-  "version": "0.24.43",
+  "version": "0.27.20",
   "port-version": 1,
   "description": "Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion, while also maintaining the highest possible performance on modern GPUs and graphics APIs. Slang is based on years of collaboration between researchers at NVIDIA, Carnegie Mellon University, and Stanford.",
   "homepage": "https://github.com/shader-slang/slang",

--- a/ports/shader-slang/vcpkg.json
+++ b/ports/shader-slang/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "shader-slang",
   "version": "0.27.20",
-  "port-version": 1,
   "description": "Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion, while also maintaining the highest possible performance on modern GPUs and graphics APIs. Slang is based on years of collaboration between researchers at NVIDIA, Carnegie Mellon University, and Stanford.",
   "homepage": "https://github.com/shader-slang/slang",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7345,7 +7345,7 @@
       "port-version": 1
     },
     "shader-slang": {
-      "baseline": "0.24.43",
+      "baseline": "0.27.20",
       "port-version": 1
     },
     "shaderc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7346,7 +7346,7 @@
     },
     "shader-slang": {
       "baseline": "0.27.20",
-      "port-version": 1
+      "port-version": 0
     },
     "shaderc": {
       "baseline": "2021.1",

--- a/versions/s-/shader-slang.json
+++ b/versions/s-/shader-slang.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "937b9dc45162056c20aa795bdf6a00deedc3edc5",
+      "git-tree": "1a21463df58c9c2fb4af01bc6c9197ddb98804db",
       "version": "0.27.20",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "b03b5bc45ef502e0ce522ce6fb71eba994348cf2",

--- a/versions/s-/shader-slang.json
+++ b/versions/s-/shader-slang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "937b9dc45162056c20aa795bdf6a00deedc3edc5",
+      "version": "0.27.20",
+      "port-version": 1
+    },
+    {
       "git-tree": "b03b5bc45ef502e0ce522ce6fb71eba994348cf2",
       "version": "0.24.43",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [Yes] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [Yes] SHA512s are updated for each updated download
- [Yes] The "supports" clause reflects platforms that may be fixed by this new version
- [n/a] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [n/a] Any patches that are no longer applied are deleted from the port's directory.
- [Yes] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [Yes] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
