### PR TITLE
[Thorvg] Update to 0.9.0

### DIFF
--- a/ports/thorvg/install-tools.patch
+++ b/ports/thorvg/install-tools.patch
@@ -1,22 +1,22 @@
 diff --git a/src/bin/svg2png/meson.build b/src/bin/svg2png/meson.build
-index 8011410..40cf3f9 100644
+index ed21489e..c3fb3188 100644
 --- a/src/bin/svg2png/meson.build
 +++ b/src/bin/svg2png/meson.build
-@@ -3,4 +3,5 @@ svg2png_src  = files('svg2png.cpp', 'lodepng.cpp')
- executable('svg2png',
+@@ -4,4 +4,5 @@ executable('svg2png',
             svg2png_src,
             include_directories : headers,
+            cpp_args: compiler_flags,
 -           link_with : thorvg_lib)
 +           link_with : thorvg_lib,
 +           install : true, install_dir : get_option('bindir'))
 diff --git a/src/bin/svg2tvg/meson.build b/src/bin/svg2tvg/meson.build
-index 2df9fac..ffd5a20 100644
+index a40111aa..a02f4b8a 100644
 --- a/src/bin/svg2tvg/meson.build
 +++ b/src/bin/svg2tvg/meson.build
-@@ -3,4 +3,5 @@ svg2tvg_src  = files('svg2tvg.cpp')
- executable('svg2tvg',
+@@ -4,4 +4,5 @@ executable('svg2tvg',
             svg2tvg_src,
             include_directories : headers,
+            cpp_args: compiler_flags,
 -           link_with : thorvg_lib)
 +           link_with : thorvg_lib,
 +           install : true, install_dir : get_option('bindir'))

--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO thorvg/thorvg
-    REF v0.8.4
-    SHA512 8e885a8c56efb129fb3ab90b9a7b765b84f5f520a9c7a5c92af4ffe61bac1b928165801b64ebc7db77046e1aaf2918ed0ffdf98cb9572dc6d46ed6de3f96b9b7
+    REF v0.9.0
+    SHA512 c0294a60f0b2e432bec62e1c44f0cb632420ec5c9390df210c8b8db5507fa8f5946bdc8a7879007e4e54865dc4538f4bf1e26d76f90a324cc5edd5cdf61c0fc0
     HEAD_REF master
     PATCHES
         install-tools.patch

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "thorvg",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7889,7 +7889,7 @@
       "port-version": 6
     },
     "thorvg": {
-      "baseline": "0.8.4",
+      "baseline": "0.9.0",
       "port-version": 0
     },
     "threadpool": {

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e0dd9030c6e211cbf558dae00ea87e9591a09f8",
+      "version": "0.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "09d722c7f2cb784d571af9a6f46abb83aa907d2b",
       "version": "0.8.4",
       "port-version": 0


### PR DESCRIPTION
Update Thorvg from 0.8,4 to 0.9.0 : https://github.com/thorvg/thorvg/releases/tag/v0.9.0

Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
SHA512s are updated for each updated download
The "supports" clause reflects platforms that may be fixed by this new version
Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
Any patches that are no longer applied are deleted from the port's directory.
The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
Only one version is added to each modified port's versions file.