### PR TITLE
[spdlog] Add upstream patch for fmt 10

### DIFF
--- a/ports/spdlog/fmt-10-support.patch
+++ b/ports/spdlog/fmt-10-support.patch
@@ -1,0 +1,39 @@
+From 0ca574ae168820da0268b3ec7607ca7b33024d05 Mon Sep 17 00:00:00 2001
+From: H1X4 <10332146+H1X4Dev@users.noreply.github.com>
+Date: Fri, 31 Mar 2023 20:39:32 +0300
+Subject: [PATCH] fix build for master fmt (non-bundled) (#2694)
+
+* fix build for master fmt (non-bundled)
+
+* update fmt_runtime_string macro
+
+* fix build of updated macro
+---
+ include/spdlog/common.h | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/include/spdlog/common.h b/include/spdlog/common.h
+index e69201a81..5f671c5c6 100644
+--- a/include/spdlog/common.h
++++ b/include/spdlog/common.h
+@@ -173,12 +173,19 @@ using format_string_t = fmt::format_string<Args...>;
+ template<class T>
+ using remove_cvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+ 
++template <typename Char>
++#if FMT_VERSION >= 90101
++using fmt_runtime_string = fmt::runtime_format_string<Char>;
++#else
++using fmt_runtime_string = fmt::basic_runtime<Char>;
++#endif
++
+ // clang doesn't like SFINAE disabled constructor in std::is_convertible<> so have to repeat the condition from basic_format_string here,
+ // in addition, fmt::basic_runtime<Char> is only convertible to basic_format_string<Char> but not basic_string_view<Char>
+ template<class T, class Char = char>
+ struct is_convertible_to_basic_format_string
+     : std::integral_constant<bool,
+-          std::is_convertible<T, fmt::basic_string_view<Char>>::value || std::is_same<remove_cvref_t<T>, fmt::basic_runtime<Char>>::value>
++          std::is_convertible<T, fmt::basic_string_view<Char>>::value || std::is_same<remove_cvref_t<T>, fmt_runtime_string<Char>>::value>
+ {};
+ 
+ #    if defined(SPDLOG_WCHAR_FILENAMES) || defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT)

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gabime/spdlog
-    REF v1.11.0
+    REF "v${VERSION}"
     SHA512 210f3135c7af3ec774ef9a5c77254ce172a44e2fa720bf590e1c9214782bf5c8140ff683403a85b585868bc308286fbdeb1c988e4ed1eb3c75975254ffe75412
     HEAD_REF v1.x
     PATCHES
@@ -19,12 +19,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 if(NOT DEFINED SPDLOG_WCHAR_FILENAMES)
     set(SPDLOG_WCHAR_FILENAMES OFF)
 endif()
-if(NOT VCPKG_TARGET_IS_WINDOWS)
-    if("wchar" IN_LIST FEATURES)
-        message(WARNING "Feature 'wchar' is only supported for Windows and has no effect on other platforms.")
-    elseif(SPDLOG_WCHAR_FILENAMES)
-        message(FATAL_ERROR "Build option 'SPDLOG_WCHAR_FILENAMES' is for Windows.")
-    endif()
+if(NOT VCPKG_TARGET_IS_WINDOWS AND SPDLOG_WCHAR_FILENAMES)
+    message(FATAL_ERROR "Build option 'SPDLOG_WCHAR_FILENAMES' is for Windows.")
 endif()
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SPDLOG_BUILD_SHARED)
@@ -45,15 +41,12 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/spdlog)
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
-# use vcpkg-provided fmt library (see also option SPDLOG_FMT_EXTERNAL above)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/spdlog/fmt/bundled")
-
 # add support for integration other than cmake
 vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/tweakme.h
     "// #define SPDLOG_FMT_EXTERNAL"
     "#ifndef SPDLOG_FMT_EXTERNAL\n#define SPDLOG_FMT_EXTERNAL\n#endif"
 )
-if(SPDLOG_WCHAR_SUPPORT AND VCPKG_TARGET_IS_WINDOWS)
+if(SPDLOG_WCHAR_SUPPORT)
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/tweakme.h
         "// #define SPDLOG_WCHAR_TO_UTF8_SUPPORT"
         "#ifndef SPDLOG_WCHAR_TO_UTF8_SUPPORT\n#define SPDLOG_WCHAR_TO_UTF8_SUPPORT\n#endif"
@@ -66,7 +59,10 @@ if(SPDLOG_WCHAR_FILENAMES)
     )
 endif()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
-                    "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/include/spdlog/fmt/bundled"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -65,4 +65,5 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF v1.x
     PATCHES
         fmt-header.patch # https://github.com/gabime/spdlog/pull/2545
+        fmt-10-support.patch # Upstream patch: https://github.com/gabime/spdlog/commit/0ca574ae168820da0268b3ec7607ca7b33024d05
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/spdlog/usage
+++ b/ports/spdlog/usage
@@ -1,0 +1,8 @@
+The package spdlog provides CMake targets:
+
+    find_package(spdlog CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE spdlog::spdlog)
+
+    # Or use the header-only version
+    find_package(spdlog CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE spdlog::spdlog_header_only)

--- a/ports/spdlog/vcpkg.json
+++ b/ports/spdlog/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "spdlog",
   "version-semver": "1.11.0",
+  "port-version": 1,
   "description": "Very fast, header only, C++ logging library",
   "homepage": "https://github.com/gabime/spdlog",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7578,7 +7578,7 @@
     },
     "spdlog": {
       "baseline": "1.11.0",
-      "port-version": 0
+      "port-version": 1
     },
     "spectra": {
       "baseline": "1.0.1",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67656948712582d93d9096cc08871a3270908d38",
+      "version-semver": "1.11.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "296d78e54c14ce64474b66f60847026ddb1f576e",
       "version-semver": "1.11.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

This patch is necessary for #31378.

Additionally, a few portfile updates were made, most notably:
- Remove redundant checks for the `wchar` feature on non-Windows platforms since it is handled in vcpkg.json
- Add a usage file