### PR TITLE
[seacas] Add upstream patch for fmt 10

### DIFF
--- a/ports/seacas/fix-fmt-10.patch
+++ b/ports/seacas/fix-fmt-10.patch
@@ -1,0 +1,28 @@
+From 5a576de57ee1664d845c83f552f2100cc9303a26 Mon Sep 17 00:00:00 2001
+From: Greg Sjaardema <gsjaardema@gmail.com>
+Date: Wed, 10 May 2023 15:28:53 -0600
+Subject: [PATCH] IOSS: Fix enum printing to work with fmt-10
+
+---
+ .../seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C     | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
+index b6827aa177..59507085fc 100644
+--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
++++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
+@@ -1,4 +1,4 @@
+-// Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
++// Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
+ // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+ // NTESS, the U.S. Government retains certain rights in this software.
+ //
+@@ -802,7 +802,7 @@ namespace Iotm {
+           std::ostringstream errmsg;
+           fmt::print(errmsg,
+                      "Error: Failed to find entity of type {} with name {} for Assembly {}.\n",
+-                     type, members[j], assem->name());
++                     Ioss::Utils::entity_type_to_string(type), members[j], assem->name());
+           IOSS_ERROR(errmsg);
+         }
+       }

--- a/ports/seacas/portfile.cmake
+++ b/ports/seacas/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
             deps-and-shared.patch
             fix-mpi.patch
             fix-headers.patch
+            fix-fmt-10.patch
 )
 
 if(HDF5_WITH_PARALLEL AND NOT "mpi" IN_LIST FEATURES)

--- a/ports/seacas/vcpkg.json
+++ b/ports/seacas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "seacas",
   "version-date": "2022-11-22",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The Sandia Engineering Analysis Code Access System (SEACAS) is a suite of preprocessing, postprocessing, translation, and utility applications supporting finite element analysis software using the Exodus database file format.",
   "homepage": "https://github.com/sandialabs/seacas",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7286,7 +7286,7 @@
     },
     "seacas": {
       "baseline": "2022-11-22",
-      "port-version": 3
+      "port-version": 4
     },
     "seal": {
       "baseline": "4.1.1",

--- a/versions/s-/seacas.json
+++ b/versions/s-/seacas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "709e85621b7fe043156154d04e5d9c174e47fab9",
+      "version-date": "2022-11-22",
+      "port-version": 4
+    },
+    {
       "git-tree": "f49bca0bdf21c4b79c80ecefe3d3aa9a75ba49e7",
       "version-date": "2022-11-22",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

This patch is necessary for #31378.