### PR TITLE
[csprng] Initial port

### DIFF
--- a/ports/csprng/portfile.cmake
+++ b/ports/csprng/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Duthomhas/CSPRNG
+    REF 98e75e23c469839ea62337ed11a165224ea1275e
+    SHA512 d637af9a758c88762c9d1a942d6cfe98f4d95cacef80ea64650b9408f0da6fcb61295ea3f717e24de37af33add795686c8a39654001b50548f2fb0ef2779d816
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/csprng)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE_1_0.txt")

--- a/ports/csprng/usage
+++ b/ports/csprng/usage
@@ -1,0 +1,4 @@
+The package zlib is compatible with built-in CMake targets:
+
+    find_package(csprng REQUIRED)
+    target_link_libraries(main PRIVATE csprng::csprng)

--- a/ports/csprng/vcpkg.json
+++ b/ports/csprng/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "csprng",
+  "version": "1.0.0",
+  "description": "OS-native Cryptographically-Secure Pseudo-Random Number Generator wrapper",
+  "homepage": "https://github.com/jherico/CSPRNG",
+  "license": "BSL-1.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1892,6 +1892,10 @@
       "baseline": "67",
       "port-version": 3
     },
+    "csprng": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "ctbignum": {
       "baseline": "2019-08-02",
       "port-version": 3

--- a/versions/c-/csprng.json
+++ b/versions/c-/csprng.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5a28f8765e83d508dbca38182feba63044005c44",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
  - I'm not super clear on when the use of `unofficial::` is mandated.  I modified the original repo based on modern CMake packaging practices and the original repo has been untouched for 6 years.
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
  - The name is somewhat generic.  I'm open to alternatives for the VCPKG portname.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.

I'm working on bringing cesium-native into vcpkg, and this is one of its upstream dependencies which isn't currently present.
