### PR TITLE
[vcpkg baseline][binlog] disable performance tests

### DIFF
--- a/ports/binlog/portfile.cmake
+++ b/ports/binlog/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_cmake_configure(
         -DBINLOG_BUILD_EXAMPLES=OFF
         -DBINLOG_BUILD_UNIT_TESTS=OFF
         -DBINLOG_BUILD_INTEGRATION_TESTS=OFF
+        -Dbenchmark_FOUND=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/binlog/portfile.cmake
+++ b/ports/binlog/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
         -DBINLOG_BUILD_EXAMPLES=OFF
         -DBINLOG_BUILD_UNIT_TESTS=OFF
         -DBINLOG_BUILD_INTEGRATION_TESTS=OFF
-        -Dbenchmark_FOUND=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_benchmark=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/binlog/vcpkg.json
+++ b/ports/binlog/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "binlog",
   "version-date": "2021-04-16",
+  "port-version": 1,
   "description": "Binlog is a high performance C++ log library to produce structured binary logs.",
   "homepage": "http://opensource.morganstanley.com/binlog/",
   "license": "Apache-2.0",

--- a/versions/b-/binlog.json
+++ b/versions/b-/binlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1767a61a4ceda1e384e4eb5563f244a0e8b65e1",
+      "version-date": "2021-04-16",
+      "port-version": 1
+    },
+    {
       "git-tree": "eb0ae943fc2b0c1c19ad62308d1f321439967fd4",
       "version-date": "2021-04-16",
       "port-version": 0

--- a/versions/b-/binlog.json
+++ b/versions/b-/binlog.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d1767a61a4ceda1e384e4eb5563f244a0e8b65e1",
+      "git-tree": "53449cd8c7572c72137ace92720d632b671f2d17",
       "version-date": "2021-04-16",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -546,7 +546,7 @@
     },
     "binlog": {
       "baseline": "2021-04-16",
-      "port-version": 0
+      "port-version": 1
     },
     "binn": {
       "baseline": "3.0",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes vcpkg pipeline issue binlog:x64-linux installation failed with following error:
https://dev.azure.com/vcpkg/public/_build/results?buildId=89371&view=results
```
/mnt/vcpkg-ci/buildtrees/binlog/src/67e0b185a6-9b5f7f266f.clean/test/perf/PerftestQueue.cpp: In function ‘void {anonymous}::doNotOptimizeBuffer(const char*, std::size_t)’:
/mnt/vcpkg-ci/buildtrees/binlog/src/67e0b185a6-9b5f7f266f.clean/test/perf/PerftestQueue.cpp:18:36: error: ‘typename std::enable_if<(std::is_trivially_copyable<_Tp>::value && (sizeof (Tp) <= sizeof (Tp*)))>::type benchmark::DoNotOptimize(const Tp&) [with Tp = char; typename std::enable_if<(std::is_trivially_copyable<_Tp>::value && (sizeof (Tp) <= sizeof (Tp*)))>::type = void]’ is deprecated: The const-ref version of this method can permit undesired compiler optimizations in benchmarks [-Werror=deprecated-declarations]
   18 |     benchmark::DoNotOptimize(buf[i]);
      |
 ```
 
 For vcpkg, we don't need `binlog` to build performance tests. Even though we found `benchmark`. https://github.com/morganstanley/binlog/blob/3fef8846f5ef98e64211e7982c2ead67e0b185a6/CMakeLists.txt#L387
 ```
find_package(benchmark COMPONENTS benchmark)

 if (benchmark_FOUND)

  message(STATUS "Build performance tests")

  function(add_benchmark name)
    add_executable(${name} test/perf/${name}.cpp)
    target_link_libraries(${name} headers)
    target_link_libraries(${name} benchmark::benchmark)
  endfunction()

  add_benchmark(PerftestQueue)
  add_benchmark(PerftestSessionWriter)

else ()
  message(STATUS "Google Benchmark library not found, will not build performance tests")
endif ()
```
 
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
