### PR TITLE
[libigl] Fix libigl features

### DIFF
--- a/ports/libigl/install-extra-targets.patch
+++ b/ports/libigl/install-extra-targets.patch
@@ -12,7 +12,7 @@ index 8143963..784ac50 100644
              DESTINATION ${export_dest_dir}
              NAMESPACE igl${suffix}::
 diff --git a/cmake/igl/libigl-config.cmake.in b/cmake/igl/libigl-config.cmake.in
-index 629896d..4db4396 100644
+index 629896d..b161f9e 100644
 --- a/cmake/igl/libigl-config.cmake.in
 +++ b/cmake/igl/libigl-config.cmake.in
 @@ -4,5 +4,30 @@ include(CMakeFindDependencyMacro)
@@ -42,7 +42,7 @@ index 629896d..4db4396 100644
 +
 +include("${CMAKE_CURRENT_LIST_DIR}/LibiglConfigTargets_copyleft.cmake" OPTIONAL)
 +if(TARGET igl_copyless::igl_copyless_cgal)
-+  find_dependency(CGAL CONFIG REQUIRED COMPONENTS Core)
++  find_dependency(CGAL)
 +endif()
  
  check_required_components(Libigl)
@@ -152,16 +152,6 @@ index 8d8decc..293da91 100644
  )
 +
 +igl_install(igl_png ${INC_FILES} ${SRC_FILES})
-diff --git a/cmake/igl/modules/predicates.cmake b/cmake/igl/modules/predicates.cmake
-index 8f52119..899f540 100644
---- a/cmake/igl/modules/predicates.cmake
-+++ b/cmake/igl/modules/predicates.cmake
-@@ -23,3 +23,5 @@ target_link_libraries(igl_predicates ${IGL_SCOPE}
- # 5. Unit tests
- file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/tests/include/igl/predicates/*.cpp")
- igl_add_test(igl_predicates ${SRC_FILES})
-+
-+igl_install(igl_predicates ${INC_FILES} ${SRC_FILES})
 diff --git a/cmake/igl/modules/xml.cmake b/cmake/igl/modules/xml.cmake
 index 31ab979..815ea62 100644
 --- a/cmake/igl/modules/xml.cmake

--- a/ports/libigl/install-extra-targets.patch
+++ b/ports/libigl/install-extra-targets.patch
@@ -12,23 +12,37 @@ index 8143963..784ac50 100644
              DESTINATION ${export_dest_dir}
              NAMESPACE igl${suffix}::
 diff --git a/cmake/igl/libigl-config.cmake.in b/cmake/igl/libigl-config.cmake.in
-index 629896d..1bd0492 100644
+index 629896d..4db4396 100644
 --- a/cmake/igl/libigl-config.cmake.in
 +++ b/cmake/igl/libigl-config.cmake.in
-@@ -4,5 +4,16 @@ include(CMakeFindDependencyMacro)
+@@ -4,5 +4,30 @@ include(CMakeFindDependencyMacro)
  find_dependency(Eigen3)
  find_dependency(Threads)
  include("${CMAKE_CURRENT_LIST_DIR}/LibiglConfigTargets.cmake")
-+include("${CMAKE_CURRENT_LIST_DIR}/LibiglConfigTargets_copyleft.cmake" OPTIONAL)
-+if(TARGET igl::igl_xml)
-+  find_dependency(tinyxml2)
++if(TARGET igl::igl_embree)
++  find_dependency(embree 3)
++endif()
++if(TARGET igl::igl_glfw)
++  find_dependency(glfw3)
++endif()
++if(TARGET igl::igl_imgui)
++  find_dependency(imgui)
++  find_dependency(imguizmo)
 +endif()
 +if(TARGET igl::igl_opengl)
 +  find_dependency(OpenGL)
 +  find_dependency(glad)
 +endif()
-+if(TARGET igl::igl_glfw)
-+  find_dependency(glfw3)
++if(TARGET igl::igl_png)
++  find_dependency(Stb)
++endif()
++if(TARGET igl::igl_xml)
++  find_dependency(tinyxml2)
++endif()
++
++include("${CMAKE_CURRENT_LIST_DIR}/LibiglConfigTargets_copyleft.cmake" OPTIONAL)
++if(TARGET igl_copyless::igl_copyless_cgal)
++  find_dependency(CGAL CONFIG REQUIRED COMPONENTS Core)
 +endif()
  
  check_required_components(Libigl)

--- a/ports/libigl/install-extra-targets.patch
+++ b/ports/libigl/install-extra-targets.patch
@@ -1,0 +1,93 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8143963..784ac50 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -157,7 +157,7 @@ if(LIBIGL_INSTALL)
+     set(version_config_file "${CMAKE_CURRENT_BINARY_DIR}/LibiglConfigVersion.cmake")
+     set(export_dest_dir "${CMAKE_INSTALL_LIBDIR}/cmake/igl")
+ 
+-    foreach(suffix IN ITEMS "") #"_restricted" "_copyleft")
++    foreach(suffix IN ITEMS "" "_copyleft") #  "_restricted"
+         install(EXPORT LibiglTargets${suffix}
+             DESTINATION ${export_dest_dir}
+             NAMESPACE igl${suffix}::
+diff --git a/cmake/igl/modules/copyleft/cgal.cmake b/cmake/igl/modules/copyleft/cgal.cmake
+index 7ee7d84..d434cf3 100644
+--- a/cmake/igl/modules/copyleft/cgal.cmake
++++ b/cmake/igl/modules/copyleft/cgal.cmake
+@@ -31,3 +31,5 @@ igl_add_test(igl_copyleft_cgal ${SRC_FILES})
+ if(TARGET test_igl_copyleft_cgal)
+     igl_copy_dll(test_igl_copyleft_cgal)
+ endif()
++
++igl_install(igl_copyleft_cgal ${INC_FILES} ${SRC_FILES})
+diff --git a/cmake/igl/modules/copyleft/core.cmake b/cmake/igl/modules/copyleft/core.cmake
+index 8d03a90..aff8241 100644
+--- a/cmake/igl/modules/copyleft/core.cmake
++++ b/cmake/igl/modules/copyleft/core.cmake
+@@ -17,3 +17,5 @@ igl_target_sources(igl_copyleft_core ${INC_FILES} ${SRC_FILES})
+ target_link_libraries(igl_copyleft_core ${IGL_SCOPE}
+     igl::core
+ )
++
++igl_install(igl_copyleft_core ${INC_FILES} ${SRC_FILES})
+diff --git a/cmake/igl/modules/embree.cmake b/cmake/igl/modules/embree.cmake
+index de85066..bcc9992 100644
+--- a/cmake/igl/modules/embree.cmake
++++ b/cmake/igl/modules/embree.cmake
+@@ -23,3 +23,5 @@ target_link_libraries(igl_embree ${IGL_SCOPE}
+ # 5. Unit tests
+ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/tests/include/igl/embree/*.cpp")
+ igl_add_test(igl_embree ${SRC_FILES})
++
++igl_install(igl_embree ${INC_FILES} ${SRC_FILES})
+diff --git a/cmake/igl/modules/glfw.cmake b/cmake/igl/modules/glfw.cmake
+index f42d22a..e9930d8 100644
+--- a/cmake/igl/modules/glfw.cmake
++++ b/cmake/igl/modules/glfw.cmake
+@@ -21,3 +21,5 @@ target_link_libraries(igl_glfw ${IGL_SCOPE}
+     igl::opengl
+     $<TARGET_NAME:glfw>
+ )
++
++igl_install(igl_glfw ${INC_FILES} ${SRC_FILES})
+diff --git a/cmake/igl/modules/imgui.cmake b/cmake/igl/modules/imgui.cmake
+index f331854..7ff9738 100644
+--- a/cmake/igl/modules/imgui.cmake
++++ b/cmake/igl/modules/imgui.cmake
+@@ -23,3 +23,5 @@ target_link_libraries(igl_imgui ${IGL_SCOPE}
+     imgui::imgui
+     imguizmo::imguizmo
+ )
++
++igl_install(igl_imgui ${INC_FILES} ${SRC_FILES})
+diff --git a/cmake/igl/modules/opengl.cmake b/cmake/igl/modules/opengl.cmake
+index dfadb38..185494b 100644
+--- a/cmake/igl/modules/opengl.cmake
++++ b/cmake/igl/modules/opengl.cmake
+@@ -22,3 +22,5 @@ target_link_libraries(igl_opengl ${IGL_SCOPE}
+     # Link against OpenGL::OpenGL if available, or fallback to OpenGL::GL
+     $<IF:$<TARGET_EXISTS:OpenGL::OpenGL>,OpenGL::OpenGL,OpenGL::GL>
+ )
++
++igl_install(igl_opengl ${INC_FILES} ${SRC_FILES})
+diff --git a/cmake/igl/modules/png.cmake b/cmake/igl/modules/png.cmake
+index 8d8decc..293da91 100644
+--- a/cmake/igl/modules/png.cmake
++++ b/cmake/igl/modules/png.cmake
+@@ -21,3 +21,5 @@ target_link_libraries(igl_png ${IGL_SCOPE}
+     igl::opengl
+     stb::stb
+ )
++
++igl_install(igl_png ${INC_FILES} ${SRC_FILES})
+diff --git a/cmake/igl/modules/xml.cmake b/cmake/igl/modules/xml.cmake
+index 31ab979..815ea62 100644
+--- a/cmake/igl/modules/xml.cmake
++++ b/cmake/igl/modules/xml.cmake
+@@ -19,3 +19,5 @@ target_link_libraries(igl_xml ${IGL_SCOPE}
+     igl::core
+     tinyxml2::tinyxml2
+ )
++
++igl_install(igl_xml ${INC_FILES} ${SRC_FILES})

--- a/ports/libigl/install-extra-targets.patch
+++ b/ports/libigl/install-extra-targets.patch
@@ -12,7 +12,7 @@ index 8143963..784ac50 100644
              DESTINATION ${export_dest_dir}
              NAMESPACE igl${suffix}::
 diff --git a/cmake/igl/libigl-config.cmake.in b/cmake/igl/libigl-config.cmake.in
-index 629896d..b161f9e 100644
+index 629896d..0b05692 100644
 --- a/cmake/igl/libigl-config.cmake.in
 +++ b/cmake/igl/libigl-config.cmake.in
 @@ -4,5 +4,30 @@ include(CMakeFindDependencyMacro)
@@ -41,7 +41,7 @@ index 629896d..b161f9e 100644
 +endif()
 +
 +include("${CMAKE_CURRENT_LIST_DIR}/LibiglConfigTargets_copyleft.cmake" OPTIONAL)
-+if(TARGET igl_copyless::igl_copyless_cgal)
++if(TARGET igl_copyleft::igl_copyleft_cgal)
 +  find_dependency(CGAL)
 +endif()
  

--- a/ports/libigl/install-extra-targets.patch
+++ b/ports/libigl/install-extra-targets.patch
@@ -11,16 +11,54 @@ index 8143963..784ac50 100644
          install(EXPORT LibiglTargets${suffix}
              DESTINATION ${export_dest_dir}
              NAMESPACE igl${suffix}::
+diff --git a/cmake/igl/libigl-config.cmake.in b/cmake/igl/libigl-config.cmake.in
+index 629896d..1bd0492 100644
+--- a/cmake/igl/libigl-config.cmake.in
++++ b/cmake/igl/libigl-config.cmake.in
+@@ -4,5 +4,16 @@ include(CMakeFindDependencyMacro)
+ find_dependency(Eigen3)
+ find_dependency(Threads)
+ include("${CMAKE_CURRENT_LIST_DIR}/LibiglConfigTargets.cmake")
++include("${CMAKE_CURRENT_LIST_DIR}/LibiglConfigTargets_copyleft.cmake" OPTIONAL)
++if(TARGET igl::igl_xml)
++  find_dependency(tinyxml2)
++endif()
++if(TARGET igl::igl_opengl)
++  find_dependency(OpenGL)
++  find_dependency(glad)
++endif()
++if(TARGET igl::igl_glfw)
++  find_dependency(glfw3)
++endif()
+ 
+ check_required_components(Libigl)
 diff --git a/cmake/igl/modules/copyleft/cgal.cmake b/cmake/igl/modules/copyleft/cgal.cmake
-index 7ee7d84..d434cf3 100644
+index 7ee7d84..d06c6ee 100644
 --- a/cmake/igl/modules/copyleft/cgal.cmake
 +++ b/cmake/igl/modules/copyleft/cgal.cmake
-@@ -31,3 +31,5 @@ igl_add_test(igl_copyleft_cgal ${SRC_FILES})
+@@ -9,7 +9,7 @@ target_include_directories(igl_copyleft_cgal ${IGL_SCOPE}
+ )
+ 
+ # 3. Target sources
+-file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/cgal/*.h")
++file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/cgal/*.h" "${libigl_SOURCE_DIR}/include/igl/copyleft/cgal/*.hpp")
+ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/copyleft/cgal/*.cpp")
+ igl_target_sources(igl_copyleft_cgal ${INC_FILES} ${SRC_FILES})
+ 
+@@ -22,6 +22,8 @@ target_link_libraries(igl_copyleft_cgal ${IGL_SCOPE}
+     CGAL::CGAL
+ )
+ 
++igl_install(igl_copyleft_cgal ${INC_FILES} ${SRC_FILES})
++
+ # 5. Unit tests
+ file(GLOB SRC_FILES
+     "${libigl_SOURCE_DIR}/tests/include/igl/copyleft/boolean/*.cpp"
+@@ -31,3 +33,4 @@ igl_add_test(igl_copyleft_cgal ${SRC_FILES})
  if(TARGET test_igl_copyleft_cgal)
      igl_copy_dll(test_igl_copyleft_cgal)
  endif()
 +
-+igl_install(igl_copyleft_cgal ${INC_FILES} ${SRC_FILES})
 diff --git a/cmake/igl/modules/copyleft/core.cmake b/cmake/igl/modules/copyleft/core.cmake
 index 8d03a90..aff8241 100644
 --- a/cmake/igl/modules/copyleft/core.cmake
@@ -32,15 +70,19 @@ index 8d03a90..aff8241 100644
 +
 +igl_install(igl_copyleft_core ${INC_FILES} ${SRC_FILES})
 diff --git a/cmake/igl/modules/embree.cmake b/cmake/igl/modules/embree.cmake
-index de85066..bcc9992 100644
+index de85066..052fc76 100644
 --- a/cmake/igl/modules/embree.cmake
 +++ b/cmake/igl/modules/embree.cmake
-@@ -23,3 +23,5 @@ target_link_libraries(igl_embree ${IGL_SCOPE}
+@@ -20,6 +20,9 @@ target_link_libraries(igl_embree ${IGL_SCOPE}
+     $<TARGET_NAME:embree>
+ )
+ 
++igl_install(igl_embree ${INC_FILES} ${SRC_FILES})
++
  # 5. Unit tests
  file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/tests/include/igl/embree/*.cpp")
  igl_add_test(igl_embree ${SRC_FILES})
 +
-+igl_install(igl_embree ${INC_FILES} ${SRC_FILES})
 diff --git a/cmake/igl/modules/glfw.cmake b/cmake/igl/modules/glfw.cmake
 index f42d22a..e9930d8 100644
 --- a/cmake/igl/modules/glfw.cmake

--- a/ports/libigl/install-extra-targets.patch
+++ b/ports/libigl/install-extra-targets.patch
@@ -83,6 +83,21 @@ index 8d03a90..aff8241 100644
  )
 +
 +igl_install(igl_copyleft_core ${INC_FILES} ${SRC_FILES})
+diff --git a/cmake/igl/modules/core.cmake b/cmake/igl/modules/core.cmake
+index 137d30b..597c26b 100644
+--- a/cmake/igl/modules/core.cmake
++++ b/cmake/igl/modules/core.cmake
+@@ -12,8 +12,8 @@ target_include_directories(igl_core ${IGL_SCOPE}
+ )
+ 
+ # 3. Target sources
+-file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/*.h")
+-file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/*.cpp")
++file(GLOB INC_FILES "${libigl_SOURCE_DIR}/include/igl/*.h" "${libigl_SOURCE_DIR}/include/igl/*.hpp")
++file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/*.cpp" "${libigl_SOURCE_DIR}/include/igl/*.c")
+ igl_target_sources(igl_core ${INC_FILES} ${SRC_FILES})
+ 
+ # 4. Install target & headers
 diff --git a/cmake/igl/modules/embree.cmake b/cmake/igl/modules/embree.cmake
 index de85066..052fc76 100644
 --- a/cmake/igl/modules/embree.cmake
@@ -137,6 +152,16 @@ index 8d8decc..293da91 100644
  )
 +
 +igl_install(igl_png ${INC_FILES} ${SRC_FILES})
+diff --git a/cmake/igl/modules/predicates.cmake b/cmake/igl/modules/predicates.cmake
+index 8f52119..899f540 100644
+--- a/cmake/igl/modules/predicates.cmake
++++ b/cmake/igl/modules/predicates.cmake
+@@ -23,3 +23,5 @@ target_link_libraries(igl_predicates ${IGL_SCOPE}
+ # 5. Unit tests
+ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/tests/include/igl/predicates/*.cpp")
+ igl_add_test(igl_predicates ${SRC_FILES})
++
++igl_install(igl_predicates ${INC_FILES} ${SRC_FILES})
 diff --git a/cmake/igl/modules/xml.cmake b/cmake/igl/modules/xml.cmake
 index 31ab979..815ea62 100644
 --- a/cmake/igl/modules/xml.cmake

--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -66,4 +66,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/igl)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.MPL2" "${SOURCE_PATH}/LICENSE.GPL")
+
+if(NOT LIBIGL_COPYLEFT_CGAL)
+    vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.MPL2")
+else()
+    vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.MPL2" "${SOURCE_PATH}/LICENSE.GPL" COMMENT "GPL for targets in \"igl_copyleft::\" namespace.")
+endif()

--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         dependencies.patch
         upstream_fixes.patch
+        install-extra-targets.patch
 )
 file(REMOVE
     "${SOURCE_PATH}/cmake/find/FindGMP.cmake"
@@ -65,4 +66,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/igl)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.GPL")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.MPL2" "${SOURCE_PATH}/LICENSE.GPL")

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 3,
   "description": "libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.",
   "homepage": "https://github.com/libigl/libigl",
-  "license": "GPL-3.0-only",
+  "license": "MPL-2.0 OR GPL-3.0-only",
   "dependencies": [
     "eigen3",
     {

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 4,
   "description": "libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.",
   "homepage": "https://github.com/libigl/libigl",
-  "license": "MPL-2.0 OR GPL-3.0-only",
+  "license": null,
   "dependencies": [
     "eigen3",
     {

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libigl",
   "version": "2.4.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.",
   "homepage": "https://github.com/libigl/libigl",
   "license": "MPL-2.0 OR GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4126,7 +4126,7 @@
     },
     "libigl": {
       "baseline": "2.4.0",
-      "port-version": 3
+      "port-version": 4
     },
     "libilbc": {
       "baseline": "3.0.4",

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f50493cfb3f9c2acefdc99bc840cb906897948b2",
+      "version": "2.4.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "4754633723fc5e93c13f54e405ce0b8662bb570b",
       "version": "2.4.0",
       "port-version": 3

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f50493cfb3f9c2acefdc99bc840cb906897948b2",
+      "git-tree": "260c09078445cfce5ce800b1d3cfa47877f6f783",
       "version": "2.4.0",
       "port-version": 4
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #30621 C
Fixes #31168
Probably related
#31162
#30332

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

* libigl does not install and export any targets beside igl_core by default, hence the patch
* The license is updated to reflect more closely upstream. The library is mostly under MPL2, only the copyless folder is under GPL which is bounded to specific "igl_copyleft_*" targets

For some reason the usage on Windows was `find_package(Libigl)` (note the uppercase L) while on codespace under Linux I got away with and without the capitalized package name, 

Simple example (tested on x64-windows) involving embree, opengl, glfw, imgui, xml:
[mwe_igl.zip](https://github.com/microsoft/vcpkg/files/11470223/mwe_igl.zip)
Also tested on x64-windows with a cgal example

