### PR TITLE
UWP toolchain switch to disable use of deprecated C++/CX extensions

### DIFF
--- a/scripts/toolchains/uwp.cmake
+++ b/scripts/toolchains/uwp.cmake
@@ -27,6 +27,10 @@ endif()
 get_property( _CMAKE_IN_TRY_COMPILE GLOBAL PROPERTY IN_TRY_COMPILE )
 if(NOT _CMAKE_IN_TRY_COMPILE)
 
+    if(NOT (DEFINED VCPKG_MSVC_CXX_WINRT_EXTENSIONS))
+        set(VCPKG_MSVC_CXX_WINRT_EXTENSIONS ON)
+    endif()
+
     if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
         set(VCPKG_CRT_LINK_FLAG_PREFIX "/MD")
     elseif(VCPKG_CRT_LINKAGE STREQUAL "static")
@@ -48,12 +52,15 @@ if(NOT _CMAKE_IN_TRY_COMPILE)
 
     set(_vcpkg_cpp_flags "/DWIN32 /D_WINDOWS /D_UNICODE /DUNICODE /DWINAPI_FAMILY=WINAPI_FAMILY_APP /D__WRL_NO_DEFAULT_LIB__" ) # VS adds /D "_WINDLL" for DLLs;
     set(_vcpkg_common_flags "/nologo /Z7 ${MP_BUILD_FLAG} /GS /Gd /Gm- /W3 /WX- /Zc:wchar_t /Zc:inline /Zc:forScope /fp:precise /Oy- /EHsc")
+
     #/ZW:nostdlib -> ZW is added by CMake # VS also normally adds /sdl but not cmake MSBUILD
     set(_vcpkg_winmd_flag "")
-    file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}" _vcpkg_vctools)
-    set(ENV{_CL_} "/FU\"${_vcpkg_vctools}/lib/x86/store/references/platform.winmd\" $ENV{_CL_}")
-    # CMake has problems to correctly pass this in the compiler test so probably need special care in get_cmake_vars
-    #set(_vcpkg_winmd_flag "/FU\\\\\"${_vcpkg_vctools}/lib/x86/store/references/platform.winmd\\\\\"") # VS normally passes /ZW for Apps
+    if(VCPKG_MSVC_CXX_WINRT_EXTENSIONS)
+        file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}" _vcpkg_vctools)
+        set(ENV{_CL_} "/FU\"${_vcpkg_vctools}/lib/x86/store/references/platform.winmd\" $ENV{_CL_}")
+        # CMake has problems to correctly pass this in the compiler test so probably need special care in get_cmake_vars
+        #set(_vcpkg_winmd_flag "/FU\\\\\"${_vcpkg_vctools}/lib/x86/store/references/platform.winmd\\\\\"") # VS normally passes /ZW for Apps
+    endif()
 
     set(CMAKE_CXX_FLAGS "${_vcpkg_cpp_flags} ${_vcpkg_common_flags} ${_vcpkg_winmd_flag} ${CHARSET_FLAG} ${VCPKG_CXX_FLAGS}" CACHE STRING "")
     set(CMAKE_C_FLAGS "${_vcpkg_cpp_flags} ${_vcpkg_common_flags} ${_vcpkg_winmd_flag} ${CHARSET_FLAG} ${VCPKG_C_FLAGS}" CACHE STRING "")
@@ -72,10 +79,13 @@ if(NOT _CMAKE_IN_TRY_COMPILE)
 
     string(APPEND CMAKE_STATIC_LINKER_FLAGS_RELEASE_INIT " /nologo ") # VS adds /LTCG
 
-    if(CMAKE_GENERATOR MATCHES "Ninja")
-        set(additional_exe_flags "/WINMD") # VS Generator chokes on this in the compiler detection
+    if(VCPKG_MSVC_CXX_WINRT_EXTENSIONS)
+        set(additional_dll_flags "/WINMD:NO")
+        if(CMAKE_GENERATOR MATCHES "Ninja")
+            set(additional_exe_flags "/WINMD") # VS Generator chokes on this in the compiler detection
+        endif()
     endif()
-    string(APPEND CMAKE_SHARED_LINKER_FLAGS " /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD:NO /APPCONTAINER /SUBSYSTEM:CONSOLE /MANIFESTUAC:NO ${VCPKG_LINKER_FLAGS}")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG ${additional_dll_flags} /APPCONTAINER /SUBSYSTEM:CONSOLE /MANIFESTUAC:NO ${VCPKG_LINKER_FLAGS}")
     # VS adds /DEBUG:FULL /TLBID:1.    WindowsApp.lib is in CMAKE_C|CXX_STANDARD_LIBRARIES
     string(APPEND CMAKE_EXE_LINKER_FLAGS " /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG ${additional_exe_flags} /APPCONTAINER /MANIFESTUAC:NO ${VCPKG_LINKER_FLAGS}")
 


### PR DESCRIPTION
The C++/CX language extensions (i.e. ``/ZW``, ``/FU``, /``WINMD``, and friends) are a Microsoft-only feature and are deprecated in favor of the more modern C++/WinRT projections. This PR adds a way to disable the use of C++/CX for custom triplets that want to avoid using it, as well as for a future scenario where you'll want to default to having them off.
