### PR TITLE
[freetype-gl] Add feature glad

### DIFF
--- a/ports/freetype-gl/portfile.cmake
+++ b/ports/freetype-gl/portfile.cmake
@@ -14,6 +14,12 @@ vcpkg_from_github(
         0005-add-version.patch
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "glad" freetype-gl_WITH_GLAD
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -21,6 +27,7 @@ vcpkg_cmake_configure(
         -Dfreetype-gl_BUILD_DEMOS=OFF
         -Dfreetype-gl_BUILD_TESTS=OFF
         -Dfreetype-gl_BUILD_MAKEFONT=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -33,5 +40,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_fixup_pkgconfig()
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/freetype-gl" RENAME copyright)
-
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/freetype-gl/portfile.cmake
+++ b/ports/freetype-gl/portfile.cmake
@@ -39,5 +39,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_fixup_pkgconfig()
-# Handle copyright
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/freetype-gl/vcpkg.json
+++ b/ports/freetype-gl/vcpkg.json
@@ -6,8 +6,8 @@
   "homepage": "https://github.com/rougier/freetype-gl",
   "dependencies": [
     "freetype",
-    "glew",
     "glad",
+    "glew",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/freetype-gl/vcpkg.json
+++ b/ports/freetype-gl/vcpkg.json
@@ -6,7 +6,6 @@
   "homepage": "https://github.com/rougier/freetype-gl",
   "dependencies": [
     "freetype",
-    "glad",
     "glew",
     {
       "name": "vcpkg-cmake",
@@ -19,7 +18,10 @@
   ],
   "features": {
     "glad": {
-      "description": "Use the GLAD gl loader"
+      "description": "Use the GLAD gl loader",
+      "dependencies": [
+        "glad"
+      ]
     }
   }
 }

--- a/ports/freetype-gl/vcpkg.json
+++ b/ports/freetype-gl/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "freetype-gl",
   "version-date": "2022-01-17",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenGL text using one vertex buffer, one texture and FreeType",
   "homepage": "https://github.com/rougier/freetype-gl",
   "dependencies": [
     "freetype",
     "glew",
+    "glad",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -15,5 +16,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "glad": {
+      "description": "Use the GLAD gl loader"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2622,7 +2622,7 @@
     },
     "freetype-gl": {
       "baseline": "2022-01-17",
-      "port-version": 1
+      "port-version": 2
     },
     "freexl": {
       "baseline": "1.0.6",

--- a/versions/f-/freetype-gl.json
+++ b/versions/f-/freetype-gl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "462609b81118058c79e2ebfa043e4bfdd7f70a49",
+      "version-date": "2022-01-17",
+      "port-version": 2
+    },
+    {
       "git-tree": "c966935c663878c91381818cae1b87590be48191",
       "version-date": "2022-01-17",
       "port-version": 1

--- a/versions/f-/freetype-gl.json
+++ b/versions/f-/freetype-gl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "462609b81118058c79e2ebfa043e4bfdd7f70a49",
+      "git-tree": "a356f56c15dd0a66094c00cc35670791c545027e",
       "version-date": "2022-01-17",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes #31424 


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


feature `glad `tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
