### PR TITLE
[botan] Fix osx cross builds

### DIFF
--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -32,6 +32,7 @@ endif()
 
 vcpkg_list(SET configure_arguments
     "--distribution-info=vcpkg ${TARGET_TRIPLET}"
+    --disable-cc-tests
     --with-pkg-config
     --link-method=copy
     --with-debug-info

--- a/ports/botan/vcpkg.json
+++ b/ports/botan/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "botan",
   "version": "2.19.3",
+  "port-version": 1,
   "description": "A cryptography library written in C++11",
   "homepage": "https://botan.randombit.net",
   "license": "BSD-2-Clause",

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b9240ee18f12e8acaedf11613aa6bc1d7aad9d5",
+      "version": "2.19.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "1ad976f3e650d7188414a0c2c62ec7290bed64e8",
       "version": "2.19.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1238,7 +1238,7 @@
     },
     "botan": {
       "baseline": "2.19.3",
-      "port-version": 0
+      "port-version": 1
     },
     "box2d": {
       "baseline": "2.4.1",


### PR DESCRIPTION
Fixes #31399.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
