### PR TITLE
[vtk] patch GCC13 compilation errors

### DIFF
--- a/ports/vtk/missing-include-fixes.patch
+++ b/ports/vtk/missing-include-fixes.patch
@@ -1,0 +1,40 @@
+diff --git a/IO/Image/vtkSEPReader.cxx b/IO/Image/vtkSEPReader.cxx
+index 2b15bc249e..cec84d1712 100644
+--- a/IO/Image/vtkSEPReader.cxx
++++ b/IO/Image/vtkSEPReader.cxx
+@@ -34,7 +34,6 @@
+ #include <vtksys/SystemTools.hxx>
+ 
+ #include <algorithm>
+-#include <cstdint>
+ 
+ namespace details
+ {
+diff --git a/IO/Image/vtkSEPReader.h b/IO/Image/vtkSEPReader.h
+index 83d127a41e..bdb33a258b 100644
+--- a/IO/Image/vtkSEPReader.h
++++ b/IO/Image/vtkSEPReader.h
+@@ -25,8 +25,9 @@
+ #include "vtkImageAlgorithm.h"
+ #include "vtkNew.h" // for ivars
+ 
+-#include <array>  // for std::array
+-#include <string> // for std::string
++#include <array>   // for std::array
++#include <cstdint> // for std::uint8_t
++#include <string>  // for std::string
+ 
+ namespace details
+ {
+diff --git a/ThirdParty/libproj/vtklibproj/src/proj_json_streaming_writer.hpp b/ThirdParty/libproj/vtklibproj/src/proj_json_streaming_writer.hpp
+index 6267684218..cf19b83af4 100644
+--- a/ThirdParty/libproj/vtklibproj/src/proj_json_streaming_writer.hpp
++++ b/ThirdParty/libproj/vtklibproj/src/proj_json_streaming_writer.hpp
+@@ -31,6 +31,7 @@
+ 
+ /*! @cond Doxygen_Suppress */
+ 
++#include <cstdint>
+ #include <vector>
+ #include <string>
+ 

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -40,6 +40,7 @@ vcpkg_from_github(
         iotr.patch
         ${STRING_PATCH}
         9690.diff
+        missing-include-fixes.patch
 )
 
 # =============================================================================

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.2.0-pv5.11.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8426,7 +8426,7 @@
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",
-      "port-version": 6
+      "port-version": 7
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9ec376669498a8b43b3dc1779386dcc383d7cc1f",
+      "version-semver": "9.2.0-pv5.11.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "340d82faf130e467fb4ed6d5e8ce5bf93101513e",
       "version-semver": "9.2.0-pv5.11.0",
       "port-version": 6


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- ~~[ ] SHA512s are updated for each updated download~~
- ~~[ ] The "supports" clause reflects platforms that may be fixed by this new version~~
- ~~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
