### PR TITLE
[cppgraphqlgen] Update to v4.5.3

### DIFF
--- a/ports/cppgraphqlgen/portfile.cmake
+++ b/ports/cppgraphqlgen/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/cppgraphqlgen
-    REF v4.5.3
+    REF "v${VERSION}"
     SHA512 0a41306862bc9f370fb369bd0cdc015fd15b95179ac2de60d8d412a26d385044177d1ca6e730e96e2ff0b0ffabcfe0246fdd3d926348641a145cd2894eb9cb7f
     HEAD_REF main
 )

--- a/ports/cppgraphqlgen/portfile.cmake
+++ b/ports/cppgraphqlgen/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/cppgraphqlgen
-    REF v4.5.1
-    SHA512 a4539d09eabecc7dc0c6715796db4915c8ac602fc1650b8a212b2a09168be15eb0992646fd5b577b7c7c06d8f77e808dae2481027ceb053c96e5b5eabd560103
+    REF v4.5.3
+    SHA512 0a41306862bc9f370fb369bd0cdc015fd15b95179ac2de60d8d412a26d385044177d1ca6e730e96e2ff0b0ffabcfe0246fdd3d926348641a145cd2894eb9cb7f
     HEAD_REF main
 )
 

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppgraphqlgen",
-  "version": "4.5.1",
+  "version": "4.5.3",
   "description": "C++ GraphQL schema service generator",
   "homepage": "https://github.com/microsoft/cppgraphqlgen",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1785,7 +1785,7 @@
       "port-version": 2
     },
     "cppgraphqlgen": {
-      "baseline": "4.5.1",
+      "baseline": "4.5.3",
       "port-version": 0
     },
     "cppitertools": {

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "878bf8a46bd570c12961d8e50e0d94aa22698c1b",
+      "git-tree": "8d87ba9b4921a48271c8c6abbe7e9c3f96651b4f",
       "version": "4.5.3",
       "port-version": 0
     },

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "878bf8a46bd570c12961d8e50e0d94aa22698c1b",
+      "version": "4.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "28aa180fcf127016dd1d8ceca4fd964228af191a",
       "version": "4.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.