### PR TITLE
[opencascade] Fix the paths in target files for static build

### DIFF
--- a/ports/opencascade/portfile.cmake
+++ b/ports/opencascade/portfile.cmake
@@ -77,7 +77,7 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Debug")
+if (NOT VCPKG_BUILD_TYPE)
     # fix paths in target files
     list(APPEND TARGET_FILES 
         "${CURRENT_PACKAGES_DIR}/share/opencascade/OpenCASCADEApplicationFrameworkTargets-debug.cmake"
@@ -91,8 +91,8 @@ if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Debug")
 
     foreach(TARGET_FILE IN LISTS TARGET_FILES)
         file(READ "${TARGET_FILE}" filedata)
-        string(REGEX REPLACE "libd" "lib" filedata "${filedata}")
-        string(REGEX REPLACE "bind" "bin" filedata "${filedata}")
+        string(REGEX REPLACE "/libd" "/lib" filedata "${filedata}")
+        string(REGEX REPLACE "/bind" "/bin" filedata "${filedata}")
         file(WRITE "${TARGET_FILE}" "${filedata}")
     endforeach()
 

--- a/ports/opencascade/portfile.cmake
+++ b/ports/opencascade/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
         fix-depend-freetype.patch
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(BUILD_TYPE "Shared")
 else()
     set(BUILD_TYPE "Static")
@@ -77,11 +77,7 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    # debug creates libd and bind directories that need moving
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bind" "${CURRENT_PACKAGES_DIR}/debug/bin")
-    
+if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Debug")
     # fix paths in target files
     list(APPEND TARGET_FILES 
         "${CURRENT_PACKAGES_DIR}/share/opencascade/OpenCASCADEApplicationFrameworkTargets-debug.cmake"
@@ -92,13 +88,20 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
         "${CURRENT_PACKAGES_DIR}/share/opencascade/OpenCASCADEModelingDataTargets-debug.cmake"
         "${CURRENT_PACKAGES_DIR}/share/opencascade/OpenCASCADEVisualizationTargets-debug.cmake"
     )
-    
+
     foreach(TARGET_FILE IN LISTS TARGET_FILES)
         file(READ "${TARGET_FILE}" filedata)
         string(REGEX REPLACE "libd" "lib" filedata "${filedata}")
         string(REGEX REPLACE "bind" "bin" filedata "${filedata}")
         file(WRITE "${TARGET_FILE}" "${filedata}")
     endforeach()
+
+endif()
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    # debug creates libd and bind directories that need moving
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bind" "${CURRENT_PACKAGES_DIR}/debug/bin")
 
     # the bin directory ends up with bat files that are noise, let's clean that up
     file(GLOB BATS "${CURRENT_PACKAGES_DIR}/bin/*.bat")
@@ -108,4 +111,4 @@ else()
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/OCCT_LGPL_EXCEPTION.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/OCCT_LGPL_EXCEPTION.txt")

--- a/ports/opencascade/vcpkg.json
+++ b/ports/opencascade/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencascade",
   "version": "7.6.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Open CASCADE Technology (OCCT) is an open-source software development platform for 3D CAD, CAM, CAE.",
   "homepage": "https://github.com/Open-Cascade-SAS/OCCT",
   "license": "LGPL-2.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5830,7 +5830,7 @@
     },
     "opencascade": {
       "baseline": "7.6.2",
-      "port-version": 2
+      "port-version": 3
     },
     "opencc": {
       "baseline": "1.1.6",

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "31711e2a163e591fd6d800f2810468c80361ee1f",
+      "version": "7.6.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "58939d51b0f33a014e48f1d7100ab8888d068c2d",
       "version": "7.6.2",
       "port-version": 2

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "31711e2a163e591fd6d800f2810468c80361ee1f",
+      "git-tree": "3bf7c68565ee022f685f20eb18bb2e38cfdffb17",
       "version": "7.6.2",
       "port-version": 3
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #31022, this change from PR: https://github.com/microsoft/vcpkg/pull/31024, but author Gellert5225 has no response for a long time.
Usage test passed on `x64-windows` and `x64-windows-static`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
