### PR TITLE
[vcpkg baseline][binlog] Remove binlog:arm64-android in ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -81,7 +81,6 @@ berkeleydb:arm-neon-android=fail
 berkeleydb:arm64-android=fail
 berkeleydb:x64-android=fail
 binlog:arm-neon-android=fail
-binlog:arm64-android=fail
 bitserializer:arm64-osx=fail
 blitz:x64-android=fail
 blitz:x64-uwp=fail


### PR DESCRIPTION
Fixed [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=89534&view=results) issue:
````
PASSING, REMOVE FROM FAIL LIST: binlog:arm64-android
````
`binlog:arm64-android` was added into the `ci.baseline.txt` by PR https://github.com/microsoft/vcpkg/pull/29406, it was fixed in PR https://github.com/microsoft/vcpkg/pull/31410, so remove the records from `ci.baseline.txt`.