### PR TITLE
[ccfits] Support for Release-only build

### DIFF
--- a/ports/ccfits/portfile.cmake
+++ b/ports/ccfits/portfile.cmake
@@ -28,7 +28,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
 endif()
 
 # Remove duplicate include files
-# file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Patch installed headers to look in the correct subdirectory
 file(GLOB HEADERS "${CURRENT_PACKAGES_DIR}/include/CCfits/*")

--- a/ports/ccfits/portfile.cmake
+++ b/ports/ccfits/portfile.cmake
@@ -20,13 +20,15 @@ vcpkg_cmake_install()
 
 if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
     file(RENAME "${CURRENT_PACKAGES_DIR}/lib/CCfits.dll" "${CURRENT_PACKAGES_DIR}/bin/CCfits.dll")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/CCfits.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/CCfits.dll")
+    if(NOT VCPKG_BUILD_TYPE)
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/CCfits.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/CCfits.dll")
+    endif()
 endif()
 
 # Remove duplicate include files
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+# file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Patch installed headers to look in the correct subdirectory
 file(GLOB HEADERS "${CURRENT_PACKAGES_DIR}/include/CCfits/*")
@@ -38,4 +40,4 @@ vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/CCfits/CCfits.h
     "#include \"longnam.h\"" "#include \"cfitsio/longnam.h\""
 )
 
-file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")

--- a/ports/ccfits/vcpkg.json
+++ b/ports/ccfits/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ccfits",
   "version": "2.5",
-  "port-version": 10,
+  "port-version": 11,
   "description": "CCfits is an object oriented interface to the cfitsio library. It is designed to make the capabilities of cfitsio available to programmers working in C++.",
   "homepage": "https://heasarc.gsfc.nasa.gov/fitsio/CCfits/",
   "license": "NASA-1.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1406,7 +1406,7 @@
     },
     "ccfits": {
       "baseline": "2.5",
-      "port-version": 10
+      "port-version": 11
     },
     "cctag": {
       "baseline": "1.0.2",

--- a/versions/c-/ccfits.json
+++ b/versions/c-/ccfits.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d42ea5328ac404ea3f6ce45a20af3836acab13c7",
+      "version": "2.5",
+      "port-version": 11
+    },
+    {
       "git-tree": "77b570d63ebf64b4110d2555ce945144cc695364",
       "version": "2.5",
       "port-version": 10

--- a/versions/c-/ccfits.json
+++ b/versions/c-/ccfits.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d42ea5328ac404ea3f6ce45a20af3836acab13c7",
+      "git-tree": "69b00d0813b3ec9b7b963f07cf570cca5a8e2fd5",
       "version": "2.5",
       "port-version": 11
     },


### PR DESCRIPTION
Fixes #29069, support for Release-only build.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
