### PR TITLE
[libde265] Fix incorrect pc file

### DIFF
--- a/ports/libde265/fix-lib-version.patch
+++ b/ports/libde265/fix-lib-version.patch
@@ -1,13 +1,11 @@
-diff --git a/libde265.pc.in b/libde265.pc.in
-index e3f23ed..ca4ace9 100644
---- a/libde265.pc.in
-+++ b/libde265.pc.in
-@@ -6,7 +6,7 @@ includedir=@includedir@
- Name: libde265
- Description: H.265/HEVC video decoder.
- URL: https://github.com/strukturag/libde265
--Version: @VERSION@
-+Version: @PROJECT_VERSION@
- Requires: 
- Libs: -lde265 -L${libdir}
- Libs.private: @LIBS@ -lstdc++
+diff --git a/libde265/CMakeLists.txt b/libde265/CMakeLists.txt
+index 2856f90..ccbc8b6 100644
+--- a/libde265/CMakeLists.txt
++++ b/libde265/CMakeLists.txt
+@@ -147,5 +147,6 @@ else()
+     set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ endif()
+ 
++set(VERSION ${PROJECT_VERSION}) # so that the replacement in libde265.pc will work with both autotools and CMake
+ configure_file(../libde265.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/ports/libde265/fix-lib-version.patch
+++ b/ports/libde265/fix-lib-version.patch
@@ -1,0 +1,13 @@
+diff --git a/libde265.pc.in b/libde265.pc.in
+index e3f23ed..ca4ace9 100644
+--- a/libde265.pc.in
++++ b/libde265.pc.in
+@@ -6,7 +6,7 @@ includedir=@includedir@
+ Name: libde265
+ Description: H.265/HEVC video decoder.
+ URL: https://github.com/strukturag/libde265
+-Version: @VERSION@
++Version: @PROJECT_VERSION@
+ Requires: 
+ Libs: -lde265 -L${libdir}
+ Libs.private: @LIBS@ -lstdc++

--- a/ports/libde265/portfile.cmake
+++ b/ports/libde265/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-interface-include.patch
+        fix-lib-version.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -23,22 +24,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libde265)
 vcpkg_copy_tools(TOOL_NAMES dec265 AUTO_CLEAN)
-
-set(prefix "")
-set(exec_prefix [[${prefix}]])
-set(libdir [[${prefix}/lib]])
-set(includedir [[${prefix}/include]])
-set(LIBS "")
-configure_file("${SOURCE_PATH}/libde265.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libde265.pc" @ONLY)
-# The produced library name is `liblibde265.a` or `libde265.lib`
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libde265.pc" "-lde265" "-llibde265")
-# libde265's pc file assumes libstdc++, which isn't always true.
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libde265.pc" " -lstdc++" "")
-if(NOT VCPKG_BUILD_TYPE)
-    configure_file("${SOURCE_PATH}/libde265.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libde265.pc" @ONLY)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libde265.pc" "-lde265" "-llibde265")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libde265.pc" " -lstdc++" "")
-endif()
 vcpkg_fixup_pkgconfig()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libde265",
   "version": "1.0.11",
+  "port-version": 1,
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3930,7 +3930,7 @@
     },
     "libde265": {
       "baseline": "1.0.11",
-      "port-version": 0
+      "port-version": 1
     },
     "libdeflate": {
       "baseline": "1.17",

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "df132b92e9f40e4a5362c5ea7d83d1a489a847ff",
+      "git-tree": "35f74e1100615e9ff16d6b05529baf8e7de774aa",
       "version": "1.0.11",
       "port-version": 1
     },

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df132b92e9f40e4a5362c5ea7d83d1a489a847ff",
+      "version": "1.0.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "3c0c0eec97e9b7d9a46d6f1f5fb22c5b07aa5550",
       "version": "1.0.11",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/31434

In the latest update of `libde265`, the upstream changed the target name from `${PROJECT_NAME}` to `de265`, which resulted in the generated library name being `de265`. However, in line 34 of the [portfile.cmake](https://github.com/microsoft/vcpkg/blob/master/ports/libde265/portfile.cmake), `-lde265` was changed to `llibde265` which caused the following error:
```
LINK : fatal error LNK1181: cannot open input file 'libde265.lib'
```
Since upstream have the sentence to `configure_file` the `libde265.pc.in` file, remove unnecessary codes from `portfile.cmake`.
Add patch to fix version missing issue in pc file, see https://github.com/strukturag/libde265/commit/5452f688e4c76989276cf5829aaa0222b258e925

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
