### PR TITLE
[portable-file-dialogs] Add new port

### DIFF
--- a/ports/portable-file-dialogs/portfile.cmake
+++ b/ports/portable-file-dialogs/portfile.cmake
@@ -1,0 +1,11 @@
+# Header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO samhocevar/portable-file-dialogs
+    REF "${VERSION}"
+    SHA512 8f3f59534024357b1d4b9054f20f482bfb159c1666be1695220c1be8f028be6adac0d9d82aad7230922a5eea5971c051a8699e60bc99207813776f35ce6937b6
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/portable-file-dialogs.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/portable-file-dialogs/vcpkg.json
+++ b/ports/portable-file-dialogs/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "portable-file-dialogs",
+  "version": "0.1.0",
+  "description": "Portable GUI dialogs library",
+  "homepage": "https://github.com/samhocevar/portable-file-dialogs",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6336,6 +6336,10 @@
       "baseline": "0.9",
       "port-version": 5
     },
+    "portable-file-dialogs": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "portable-snippets": {
       "baseline": "2019-09-20",
       "port-version": 3

--- a/versions/p-/portable-file-dialogs.json
+++ b/versions/p-/portable-file-dialogs.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c205f3002701aeb61986151fb84016f820f04103",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
