### PR TITLE
[ada-url] Add new port

### DIFF
--- a/ports/ada-url/portfile.cmake
+++ b/ports/ada-url/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ada-url/ada
+    REF "v${VERSION}"
+    SHA512 a27fc3f8713e73baacbec4f36688bb60c71cdde0ad6142dfe314d09385757833e6166995a955856620183f6fe9bf04d7e4d62e3f3de11c6af86d2d988b719729
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DADA_BENCHMARKS=OFF
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ada CONFIG_PATH "lib/cmake/ada")
+
+vcpkg_copy_tools(TOOL_NAMES adaparse AUTO_CLEAN)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE" "${SOURCE_PATH}/LICENSE-MIT")

--- a/ports/ada-url/portfile.cmake
+++ b/ports/ada-url/portfile.cmake
@@ -2,8 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ada-url/ada
     REF "v${VERSION}"
-    SHA512 a27fc3f8713e73baacbec4f36688bb60c71cdde0ad6142dfe314d09385757833e6166995a955856620183f6fe9bf04d7e4d62e3f3de11c6af86d2d988b719729
+    SHA512 689dcdc3e89f2ae51e039f6d354efea3231d3ff025c58f572596d87cebd7d5f2bf5ca8c530df8514369a14831dfdb1c65bc1d93a0ece579031eb3f0dd47548c0
     HEAD_REF main
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools ADA_TOOLS
 )
 
 vcpkg_cmake_configure(
@@ -12,6 +18,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DADA_BENCHMARKS=OFF
         -DBUILD_TESTING=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -20,7 +27,9 @@ vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME ada CONFIG_PATH "lib/cmake/ada")
 
-vcpkg_copy_tools(TOOL_NAMES adaparse AUTO_CLEAN)
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES adaparse AUTO_CLEAN)
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/ada-url/vcpkg.json
+++ b/ports/ada-url/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "ada-url",
+  "version": "2.4.1",
+  "description": "WHATWG-compliant and fast URL parser written in modern C++",
+  "homepage": "https://ada-url.com/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/ada-url/vcpkg.json
+++ b/ports/ada-url/vcpkg.json
@@ -16,7 +16,8 @@
   ],
   "features": {
     "tools": {
-      "description": "Build CLI tools (adaparse)"
+      "description": "Build CLI tools (adaparse)",
+      "supports": "!uwp"
     }
   }
 }

--- a/ports/ada-url/vcpkg.json
+++ b/ports/ada-url/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ada-url",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "WHATWG-compliant and fast URL parser written in modern C++",
   "homepage": "https://ada-url.com/",
   "license": "MIT",
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build CLI tools (adaparse)"
+    }
+  }
 }

--- a/versions/a-/ada-url.json
+++ b/versions/a-/ada-url.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fb3ba1bf37356f538db56db9af440338cc8de761",
+      "git-tree": "184ab96a9e448d759aafb20f540502f43b5fc7f9",
       "version": "2.4.2",
       "port-version": 0
     }

--- a/versions/a-/ada-url.json
+++ b/versions/a-/ada-url.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "9c379cd4c6b72ab63c4fe29a4b69ef3cd2600d89",
-      "version": "2.4.1",
+      "git-tree": "fb3ba1bf37356f538db56db9af440338cc8de761",
+      "version": "2.4.2",
       "port-version": 0
     }
   ]

--- a/versions/a-/ada-url.json
+++ b/versions/a-/ada-url.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9c379cd4c6b72ab63c4fe29a4b69ef3cd2600d89",
+      "version": "2.4.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -37,7 +37,7 @@
       "port-version": 12
     },
     "ada-url": {
-      "baseline": "2.4.1",
+      "baseline": "2.4.2",
       "port-version": 0
     },
     "ade": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -36,6 +36,10 @@
       "baseline": "3.9.5",
       "port-version": 12
     },
+    "ada-url": {
+      "baseline": "2.4.1",
+      "port-version": 0
+    },
     "ade": {
       "baseline": "0.1.1f",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.