### PR TITLE
[live555] Update version to 2023.5.10

### DIFF
--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://live555.com/liveMedia/public/live.2023.03.30.tar.gz"
-    FILENAME "live.2023.03.30.tar.gz"
-    SHA512 84dcc9af7fcfd565342b913e8420e2cca9b45e9a8ff74c04ef8e32449f6bbf35eb594ba48ae06d93efe6ec4c3d7c6812ce5989d02676398cdbd63f2ec0042b68
+    URLS "http://live555.com/liveMedia/public/live.2023.05.10.tar.gz"
+    FILENAME "live.2023.05.10.tar.gz"
+    SHA512 2997305d5b338466ba765c2969f7fab59907e6e4cabf5fa6d12b1c2b450f9dd543dc59936717352e9a3fc98d6a9bdf316d3a67fc690eebbf62482c21f21634ea
 )
 
 vcpkg_extract_source_archive(

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "live555",
-  "version-date": "2023-03-30",
+  "version-date": "2023-05-10",
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4885,7 +4885,7 @@
       "port-version": 2
     },
     "live555": {
-      "baseline": "2023-03-30",
+      "baseline": "2023-05-10",
       "port-version": 0
     },
     "llfio": {

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4042dde466ab9adcd96e5271751a65a8b67270f7",
+      "version-date": "2023-05-10",
+      "port-version": 0
+    },
+    {
       "git-tree": "0a8b18570460ba3155d5c6cba9f5c05c95d876e2",
       "version-date": "2023-03-30",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/31480
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
 There is a policy of rolling release, and the previous version will not be retained. Update the version in time.
 Update `live555` version to `2023.05.10`.
<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
