### PR TITLE
[openimageio] Update to 2.4.11.1

### DIFF
--- a/ports/openimageio/fix-msvc-build.patch
+++ b/ports/openimageio/fix-msvc-build.patch
@@ -1,0 +1,13 @@
+diff --git a/src/python/py_oiio.cpp b/src/python/py_oiio.cpp
+index 6031d2c23..e71105da5 100644
+--- a/src/python/py_oiio.cpp
++++ b/src/python/py_oiio.cpp
+@@ -153,7 +153,7 @@ oiio_bufinfo::oiio_bufinfo(const py::buffer_info& pybuf, int nchans, int width,
+             format = TypeUnknown;  // No idea what's going on -- error
+             error  = Strutil::fmt::format(
+                 "Python array shape is [{:,}] but expecting h={}, w={}, ch={}",
+-                cspan<ssize_t>(pybuf.shape), height, width, nchans);
++                cspan<py::ssize_t>(pybuf.shape), height, width, nchans);
+         }
+     } else if (pixeldims == 1) {
+         // Reading a 1D scanline span

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenImageIO/oiio
     REF "v${VERSION}"
-    SHA512 e7dd7aba8dc0baa9bc50f362c21119bf4008edbd03a0c9f31bb03e01b5b0cc18c39f8a368885a4d756f6b475965138409c7e91eeae90b0ebc18d253ff314f025
+    SHA512 e8b232bb3c1bb66cc6c4f023dcf6e29633a1aee64c49a2860c2157c0885960c40114ee3988d4f132e6e55670b8b1e01b5b4cd4462651ae047a89d22de527581c 
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         imath-version-guard.patch
         fix-openimageio_include_dir.patch
         fix-openexr-target-missing.patch
+        fix-msvc-build.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/ext")

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openimageio",
-  "version": "2.4.9.0",
-  "port-version": 1,
+  "version": "2.4.11.1",
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5913,8 +5913,8 @@
       "port-version": 4
     },
     "openimageio": {
-      "baseline": "2.4.9.0",
-      "port-version": 1
+      "baseline": "2.4.11.1",
+      "port-version": 0
     },
     "openjpeg": {
       "baseline": "2.5.0",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c06030b088b87143ff7a85c23af606bbd967496",
+      "version": "2.4.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "34493d776df3b1fee4ba5e01c882d1237a135362",
       "version": "2.4.9.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
