### PR TITLE
[glib] update to 2.76.2

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -2,12 +2,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIB_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIB_ARCHIVE
     URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${VERSION}.tar.xz"
     FILENAME "glib-${VERSION}.tar.xz"
-    SHA512 7ab8740925fa4ed2d860a35544c475ae905df5fa7fc0cc64ffa8c543df6073794e44c8ff39e3e1de1d677016ef9d27e9bc709d2505d13090faa8d6c47cd64bd0
-)
-vcpkg_download_distfile(GLIB_MR_3386
-    URLS "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3386.diff"
-    FILENAME "glib-mr-3386.diff"
-    SHA512 cb67e8908a7cb6f945d019da1bf56f504b9c2131a832bcdfbdc61c973c89efd8e4380d5d67f83e229998da1e8579f3ff87b7695a3318eee9613d1ab1168bd0db
+    SHA512 5a99723d72ae987999bdf3eac4f3cabe2e014616038f2006e84060b97d6d290b7d44a20d700e9c0f4572a6defed56169f624bcd21b0337f32832b311aa2737e6
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH
@@ -15,7 +10,6 @@ vcpkg_extract_source_archive(SOURCE_PATH
     PATCHES
         use-libiconv-on-windows.patch
         libintl.patch
-        ${GLIB_MR_3386}
 )
 
 vcpkg_list(SET OPTIONS)

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glib",
-  "version": "2.76.1",
-  "port-version": 1,
+  "version": "2.76.2",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2829,8 +2829,8 @@
       "port-version": 2
     },
     "glib": {
-      "baseline": "2.76.1",
-      "port-version": 1
+      "baseline": "2.76.2",
+      "port-version": 0
     },
     "glibmm": {
       "baseline": "2.76.0",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "219fb684c85e933ff56764423c86055a7a23ee62",
+      "version": "2.76.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "82258d825872b8c0987fe62b759b7602edbed17b",
       "version": "2.76.1",
       "port-version": 1


### PR DESCRIPTION
Fixes #31490 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
