### PR TITLE
Update discord-game-sdk to 3.2.1

### DIFF
--- a/ports/discord-game-sdk/include-cstdint.patch
+++ b/ports/discord-game-sdk/include-cstdint.patch
@@ -1,6 +1,6 @@
 From 91fab7c4b8f7da3182f07f5392ebe9388f979157 Mon Sep 17 00:00:00 2001
-From: Maki <mxmcube@gmail.com>
-Date: Wed, 3 Jun 2020 01:40:58 +0100
+From: l3nn0x <dragon83.super@gmail.com>
+Date: Wed, 17 Mai 2023 11:40:58 +0100
 Subject: [PATCH] Include cstdint
 
 ---
@@ -11,15 +11,14 @@ diff --git a/cpp/types.h b/cpp/types.h
 index 8c7cc2b..122dc71 100644
 --- a/cpp/types.h
 +++ b/cpp/types.h
-@@ -3,6 +3,8 @@
- #include "ffi.h"
- #include "event.h"
- 
-+#include <cstdint>
+@@ -6,6 +6,8 @@
+ #include <Windows.h>
+ #include <dxgi.h>
+ #endif
 +
- namespace discord {
++#include <cstdint>
  
- enum class Result {
+ namespace discord {
 -- 
-2.26.2
+3.2.1
 

--- a/ports/discord-game-sdk/include-cstdint.patch
+++ b/ports/discord-game-sdk/include-cstdint.patch
@@ -19,6 +19,4 @@ index 8c7cc2b..122dc71 100644
 +#include <cstdint>
  
  namespace discord {
--- 
-3.2.1
 

--- a/ports/discord-game-sdk/portfile.cmake
+++ b/ports/discord-game-sdk/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS https://dl-game-sdk.discordapp.net/2.5.6/discord_game_sdk.zip
+    URLS https://dl-game-sdk.discordapp.net/3.2.1/discord_game_sdk.zip
     FILENAME discord_game_sdk.zip
-    SHA512 4c8f72c7bdf92bc969fb86b96ea0d835e01b9bab1a2cc27ae00bdac1b9733a1303ceadfe138c24a7609b76d61d49999a335dd596cf3f335d894702e2aa23406f
+    SHA512 4851cb70f428eb391959018aa7206e11232348189f7e47f9b8e15535f02a8b114ef825198b0d772979b77ca47061ee7fa764ca90a1dc39370eb9802e8bf04541
 )
 
 vcpkg_extract_source_archive(
@@ -20,6 +20,8 @@ if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     set(ARCH_FOLDER "x86")
 elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     set(ARCH_FOLDER "x86_64")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(ARCH_FOLDER "aarch64")
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/discord-game-sdk/vcpkg.json
+++ b/ports/discord-game-sdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "discord-game-sdk",
   "version": "3.2.1",
-  "port-version": 6,
+  "port-version": 0,
   "description": "The Discord GameSDK is an easy drop-in SDK to help you manage all the hard things that come with making a game.",
   "homepage": "https://discord.com/developers/docs/game-sdk/sdk-starter-guide",
   "supports": "((x64 & (windows | osx | linux)) | (x86 & windows) | (arm64 & osx)) & !uwp & !static",

--- a/ports/discord-game-sdk/vcpkg.json
+++ b/ports/discord-game-sdk/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "discord-game-sdk",
-  "version": "2.5.6",
-  "port-version": 5,
+  "version": "3.2.1",
+  "port-version": 6,
   "description": "The Discord GameSDK is an easy drop-in SDK to help you manage all the hard things that come with making a game.",
   "homepage": "https://discord.com/developers/docs/game-sdk/sdk-starter-guide",
-  "supports": "((x64 & (windows | osx | linux)) | (x86 & windows)) & !uwp & !static",
+  "supports": "((x64 & (windows | osx | linux)) | (x86 & windows) | (arm64 & osx)) & !uwp & !static",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/discord-game-sdk/vcpkg.json
+++ b/ports/discord-game-sdk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "discord-game-sdk",
   "version": "3.2.1",
-  "port-version": 0,
   "description": "The Discord GameSDK is an easy drop-in SDK to help you manage all the hard things that come with making a game.",
   "homepage": "https://discord.com/developers/docs/game-sdk/sdk-starter-guide",
   "supports": "((x64 & (windows | osx | linux)) | (x86 & windows) | (arm64 & osx)) & !uwp & !static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2101,8 +2101,8 @@
       "port-version": 2
     },
     "discord-game-sdk": {
-      "baseline": "2.5.6",
-      "port-version": 5
+      "baseline": "3.2.1",
+      "port-version": 6
     },
     "discord-rpc": {
       "baseline": "3.4.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2102,7 +2102,7 @@
     },
     "discord-game-sdk": {
       "baseline": "3.2.1",
-      "port-version": 6
+      "port-version": 0
     },
     "discord-rpc": {
       "baseline": "3.4.0",

--- a/versions/d-/discord-game-sdk.json
+++ b/versions/d-/discord-game-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "458277132af79efa62ac977a0718998e443ad50b",
+      "version": "3.2.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "87af266946b8e9b9f6ed5b439b3af5e185b84766",
       "version": "2.5.6",
       "port-version": 5

--- a/versions/d-/discord-game-sdk.json
+++ b/versions/d-/discord-game-sdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7574e24f7b8a85025c34810e83b74628de55d0d1",
+      "git-tree": "b81659584b418c89a25dc9c6e68cb8d7d75fee5f",
       "version": "3.2.1",
       "port-version": 0
     },

--- a/versions/d-/discord-game-sdk.json
+++ b/versions/d-/discord-game-sdk.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "458277132af79efa62ac977a0718998e443ad50b",
-      "version": "3.2.1",
-      "port-version": 6
-    },
-    {
       "git-tree": "87af266946b8e9b9f6ed5b439b3af5e185b84766",
       "version": "2.5.6",
       "port-version": 5

--- a/versions/d-/discord-game-sdk.json
+++ b/versions/d-/discord-game-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7574e24f7b8a85025c34810e83b74628de55d0d1",
+      "version": "3.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "458277132af79efa62ac977a0718998e443ad50b",
       "version": "3.2.1",
       "port-version": 6


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
