### PR TITLE
[python3] Enable cross-compiling for non-macOS *nix platforms

### DIFF
--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -227,15 +227,30 @@ else()
         "--without-readline"
         "--disable-test-modules"
     )
+
     if(VCPKG_TARGET_IS_OSX)
         list(APPEND OPTIONS "LIBS=-liconv -lintl")
-    endif()
 
-    vcpkg_configure_make(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS ${OPTIONS}
-        OPTIONS_DEBUG "--with-pydebug"
-    )
+        vcpkg_configure_make(
+            SOURCE_PATH "${SOURCE_PATH}"
+            PRERUN_SHELL "chmod a+x ./configure"
+            OPTIONS ${OPTIONS}
+            OPTIONS_DEBUG "--with-pydebug"
+        )
+    else()
+        if (VCPKG_CROSSCOMPILING)
+            list(APPEND OPTIONS "ac_cv_file__dev_ptmx=no")
+            list(APPEND OPTIONS "ac_cv_file__dev_ptc=no")
+        endif()
+
+        vcpkg_configure_make(
+            SOURCE_PATH "${SOURCE_PATH}"
+            PRERUN_SHELL "chmod a+x ./configure"
+            DETERMINE_BUILD_TRIPLET
+            OPTIONS ${OPTIONS}
+            OPTIONS_DEBUG "--with-pydebug"
+        )
+    endif()
     vcpkg_install_make(ADD_BIN_TO_PATH INSTALL_TARGET altinstall)
 
     file(COPY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.10.7",
-  "port-version": 6,
+  "port-version": 7,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1236,9 +1236,6 @@ ptex:x64-android=fail
 python2:arm-neon-android=fail
 python2:arm64-android=fail
 python2:x64-android=fail
-python3:arm-neon-android=fail
-python3:arm64-android=fail
-python3:x64-android=fail
 # Not yet ready for these platforms.
 qbittorrent:x64-osx=fail
 qbittorrent:x64-linux=fail

--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -296,9 +296,13 @@ function(vcpkg_configure_make)
             # This is used via --host as a prefix for all other bin tools as well. 
             # Setting the compiler directly via CC=arm-linux-gnueabihf-gcc does not work acording to: 
             # https://www.gnu.org/software/autoconf/manual/autoconf-2.65/html_node/Specifying-Target-Triplets.html
-            if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "([^\/]*)-gcc$" AND CMAKE_MATCH_1)
+            if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "([^\/]*)-gcc$" AND CMAKE_MATCH_1) # we don't need to specify the additional flags if we build natively.
                 set(arg_BUILD_TRIPLET "--host=${CMAKE_MATCH_1}") # (Host activates crosscompilation; The name given here is just the prefix of the host tools for the target)
             endif()
+        endif()
+        if(arg_BUILD_TRIPLET MATCHES "--host")
+            z_vcpkg_determine_autotools_host_cpu(BUILD_ARCH) # VCPKG_HOST => machine you are building on => --build=
+            string(APPEND arg_BUILD_TRIPLET " --build=${BUILD_ARCH}")
             debug_message("Using make triplet: ${arg_BUILD_TRIPLET}")
         endif()
     endif()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6462,7 +6462,7 @@
     },
     "python3": {
       "baseline": "3.10.7",
-      "port-version": 6
+      "port-version": 7
     },
     "qca": {
       "baseline": "2.3.5",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76d55f6f65e17c0bcca4532bdfff8318aea80892",
+      "version": "3.10.7",
+      "port-version": 7
+    },
+    {
       "git-tree": "d3a8a2c668d77aaf0fa1862c6b3eff5018519e19",
       "version": "3.10.7",
       "port-version": 6


### PR DESCRIPTION
Python does not support cross-compiling on macOS, so we can't enable this here (see  https://github.com/microsoft/vcpkg/pull/27830 & https://github.com/microsoft/vcpkg/pull/28468).

Hopefully this will fix https://github.com/microsoft/vcpkg/issues/30501.

When trying to cross-compile for Linux-x86, I ran into an issue where the configure script wasn't executable on the GitHub Actions runner after downloading Python sources. I'm not sure why that would be the case, since it is marked as executable in the downloaded sources, but adding the `PRERUN_SHELL` line fixed it 🤷🏼‍♂️ 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

/cc @autoantwort 