### PR TITLE
[gdcm] Update to 3.0.22

### DIFF
--- a/ports/gdcm/fix-dependence-getopt.patch
+++ b/ports/gdcm/fix-dependence-getopt.patch
@@ -19,11 +19,11 @@ index 4cdc999..c6ede41 100644
  # you could be running mingw32 on linux in which case you do NOT want the gdcmuuid lib
  APPEND_COPYRIGHT(${CMAKE_CURRENT_SOURCE_DIR}/gdcmuuid/COPYING)
 diff --git a/Utilities/VTK/Applications/CMakeLists.txt b/Utilities/VTK/Applications/CMakeLists.txt
-index c7f1ad9..20883a2 100644
+index a7f7e7e..ab89a73 100644
 --- a/Utilities/VTK/Applications/CMakeLists.txt
 +++ b/Utilities/VTK/Applications/CMakeLists.txt
-@@ -45,7 +45,13 @@ foreach(app ${GDCM_VTK_APPS})
-     target_link_libraries(${app} ${VTK_LIBRARIES} vtkIOXML)
+@@ -60,7 +60,12 @@ foreach(app ${GDCM_VTK_APPS})
+     endif()
    endif()
    if(WIN32 AND NOT CYGWIN)
 -    target_link_libraries(${app} gdcmgetopt)
@@ -33,7 +33,6 @@ index c7f1ad9..20883a2 100644
 +    else()
 +        target_link_libraries(${app} gdcmgetopt)
 +    endif()
-+else()
    endif()
    if(NOT GDCM_INSTALL_NO_RUNTIME)
      install(TARGETS ${app}

--- a/ports/gdcm/portfile.cmake
+++ b/ports/gdcm/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO malaterre/GDCM
-    REF 1f94bafc929db3648612848836f7899f101d6641 # v3.0.12
-    SHA512 cec050c61d9880880b8b72234f8b0824a1f1fa8f9b2419fec85a0f27fe3bca4f9f80aa735b35775ac098f5827fde454aba700ebea17f5f8657894d26f5140f4a
+    REF "v${VERSION}"
+    SHA512 f4fd81db731b60eebd7d67b8a7f2aa67f44d788f4c0a3f2cef9490fd4f0f1ae9caea1a9a8727619edab6aeda815ae6ace5266b1428b9bea81b7c984deb78bbac
     HEAD_REF master
     PATCHES
         use-openjpeg-config.patch
@@ -37,6 +37,8 @@ vcpkg_cmake_configure(
         -DGDCM_USE_SYSTEM_OPENJPEG=ON
         -DGDCM_BUILD_TESTING=OFF
         -DUSE_VCPKG_GETOPT=${USE_VCPKG_GETOPT}
+    MAYBE_UNUSED_VARIABLES
+        USE_VCPKG_GETOPT
 )
 
 vcpkg_cmake_install()

--- a/ports/gdcm/vcpkg.json
+++ b/ports/gdcm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdcm",
-  "version": "3.0.12",
-  "port-version": 1,
+  "version": "3.0.22",
   "description": "Grassroots DICOM library",
   "homepage": "https://github.com/malaterre/GDCM",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2713,8 +2713,8 @@
       "port-version": 0
     },
     "gdcm": {
-      "baseline": "3.0.12",
-      "port-version": 1
+      "baseline": "3.0.22",
+      "port-version": 0
     },
     "gdcm2": {
       "baseline": "deprecated",

--- a/versions/g-/gdcm.json
+++ b/versions/g-/gdcm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4083ad5a17c338266c7e0b74adf6126c55112b0d",
+      "version": "3.0.22",
+      "port-version": 0
+    },
+    {
       "git-tree": "cb3870f85a108727ba53c35d59633f9d6fdb4c4e",
       "version": "3.0.12",
       "port-version": 1


### PR DESCRIPTION
Fixes #31469, update `gdcm` to 3.0.22.

No feature to be tested, the usage test passed (header files found): 
```
gdcm provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(GDCM CONFIG REQUIRED)
    # note: 7 additional targets are not displayed.
    target_link_libraries(main PRIVATE gdcmIOD gdcmDICT gdcmDSED gdcmMEXD)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
