### PR TITLE
[flecs] Add usage file

### DIFF
--- a/ports/flecs/portfile.cmake
+++ b/ports/flecs/portfile.cmake
@@ -31,6 +31,7 @@ endif()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/flecs/portfile.cmake
+++ b/ports/flecs/portfile.cmake
@@ -30,6 +30,7 @@ endif()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/flecs/portfile.cmake
+++ b/ports/flecs/portfile.cmake
@@ -30,7 +30,6 @@ endif()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/flecs/usage
+++ b/ports/flecs/usage
@@ -1,0 +1,4 @@
+The package flecs provides CMake targets:
+
+    find_package(flecs CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:flecs::flecs>,flecs::flecs,flecs::flecs_static>)

--- a/ports/flecs/vcpkg-cmake-wrapper.cmake
+++ b/ports/flecs/vcpkg-cmake-wrapper.cmake
@@ -1,9 +1,0 @@
-_find_package(${ARGS})
-
-if(TARGET flecs::flecs AND NOT TARGET flecs::flecs_static)
-    add_library(flecs::flecs_static INTERFACE IMPORTED)
-    set_target_properties(flecs::flecs_static PROPERTIES INTERFACE_LINK_LIBRARIES flecs::flecs)
-elseif(TARGET flecs::flecs_static AND NOT TARGET flecs::flecs)
-    add_library(flecs::flecs INTERFACE IMPORTED)
-    set_target_properties(flecs::flecs PROPERTIES INTERFACE_LINK_LIBRARIES flecs::flecs_static)
-endif()

--- a/ports/flecs/vcpkg-cmake-wrapper.cmake
+++ b/ports/flecs/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,9 @@
+_find_package(${ARGS})
+
+if(TARGET flecs::flecs AND NOT TARGET flecs::flecs_static)
+    add_library(flecs::flecs_static INTERFACE IMPORTED)
+    set_target_properties(flecs::flecs_static PROPERTIES INTERFACE_LINK_LIBRARIES flecs::flecs)
+elseif(TARGET flecs::flecs_static AND NOT TARGET flecs::flecs)
+    add_library(flecs::flecs INTERFACE IMPORTED)
+    set_target_properties(flecs::flecs PROPERTIES INTERFACE_LINK_LIBRARIES flecs::flecs_static)
+endif()

--- a/ports/flecs/vcpkg.json
+++ b/ports/flecs/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "flecs",
   "version": "3.2.2",
+  "port-version": 1,
   "description": "A fast entity component system (ECS) for C & C++",
   "homepage": "https://github.com/SanderMertens/flecs",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2518,7 +2518,7 @@
     },
     "flecs": {
       "baseline": "3.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "flint": {
       "baseline": "2.8.0",

--- a/versions/f-/flecs.json
+++ b/versions/f-/flecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a59e268b884b19cbc93cb11f25d838af9c09f17",
+      "version": "3.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "912f444db03f6f652a404608a75df8fed734a701",
       "version": "3.2.2",
       "port-version": 0

--- a/versions/f-/flecs.json
+++ b/versions/f-/flecs.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2a59e268b884b19cbc93cb11f25d838af9c09f17",
+      "git-tree": "85940600d857ee3ef4a8dc3feded5e9bf35fc3cf",
       "version": "3.2.2",
       "port-version": 1
     },

--- a/versions/f-/flecs.json
+++ b/versions/f-/flecs.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "85940600d857ee3ef4a8dc3feded5e9bf35fc3cf",
+      "git-tree": "2a59e268b884b19cbc93cb11f25d838af9c09f17",
       "version": "3.2.2",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #31488.

The current usage is only for vcpkg, outside of vcpkg either a target is missing or the user will be linking two libraries that provide the same symbols but link differently: 
```
flecs provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(flecs CONFIG REQUIRED)
    target_link_libraries(main PRIVATE flecs::flecs flecs::flecs_static)
```
Add a explicit usage file which can work without the wrapper, it test passes `x64-windows` and `x64-windows-static` (header files found): 
```
The package flecs provides CMake targets:

    find_package(flecs CONFIG REQUIRED)
    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:flecs::flecs>,flecs::flecs,flecs::flecs_static>)
```


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
