### PR TITLE
[cairomm] Disable test 

### DIFF
--- a/ports/cairomm/portfile.cmake
+++ b/ports/cairomm/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_configure_meson(
     OPTIONS
         -Dbuild-examples=false
         -Dmsvc14x-parallel-installable=false    # Use separate DLL and LIB filenames for Visual Studio 2017 and 2019
+        -Dbuild-tests=false
 )
 
 vcpkg_install_meson()

--- a/ports/cairomm/vcpkg.json
+++ b/ports/cairomm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairomm",
   "version": "1.16.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A C++ wrapper for the cairo graphics library",
   "homepage": "https://www.cairographics.org",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1354,7 +1354,7 @@
     },
     "cairomm": {
       "baseline": "1.16.2",
-      "port-version": 2
+      "port-version": 3
     },
     "calceph": {
       "baseline": "3.5.2",

--- a/versions/c-/cairomm.json
+++ b/versions/c-/cairomm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a7e6f9ecf73d0a2ec27e9a70a099746e643ec84",
+      "version": "1.16.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "9e3f77f8b4d02d2a5bd898b0ca96031da57aae12",
       "version": "1.16.2",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/31474

This issue occurred because `boost test` was locally installed:
```
Run-time dependency Boost (found: unit_test_framework) found: YES 1.67.0 (C:/local/boost_1_67_0)
```
which triggered the build of tests of cairomm. 
According to [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md#do-not-build-testsdocsexamples-by-default), I added `-Dbuild-tests=false` to explicitly disabled test be built.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
