### PR TITLE
[wmipp] Add new port

### DIFF
--- a/ports/wmipp/portfile.cmake
+++ b/ports/wmipp/portfile.cmake
@@ -1,0 +1,10 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO sonodima/wmipp
+    REF v1.0.0
+    HEAD_REF main
+)
+
+file(COPY "${SOURCE_PATH}/include/wmipp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/wmipp")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/wmipp/portfile.cmake
+++ b/ports/wmipp/portfile.cmake
@@ -1,7 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sonodima/wmipp
-    REF v1.0.0
+    REF "v${VERSION}"
+
     SHA512 e52ad6edadcb5b56c941d18e10968f10ea4fbbb0773132c2eb929e83cbf4aa22b72a161f55b358541e27786ff7f967786eb156b7ff519f8d3449d8b5ef2aa727 
     HEAD_REF main
 )

--- a/ports/wmipp/portfile.cmake
+++ b/ports/wmipp/portfile.cmake
@@ -2,9 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sonodima/wmipp
     REF v1.0.0
+    SHA512 e52ad6edadcb5b56c941d18e10968f10ea4fbbb0773132c2eb929e83cbf4aa22b72a161f55b358541e27786ff7f967786eb156b7ff519f8d3449d8b5ef2aa727 
     HEAD_REF main
 )
 
-file(COPY "${SOURCE_PATH}/include/wmipp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/wmipp")
+file(COPY "${SOURCE_PATH}/include/wmipp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/wmipp/vcpkg.json
+++ b/ports/wmipp/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "wmipp",
+  "version": "1.0.0",
+  "description": "Streamlined Windows Management Instrumentation (WMI) integration for seamless C++ development",
+  "supports": "windows & !uwp",
+  "homepage": "https://github.com/sonodima/wmipp",
+  "license": "MIT"
+}

--- a/ports/wmipp/vcpkg.json
+++ b/ports/wmipp/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "wmipp",
   "version": "1.0.0",
   "description": "Streamlined Windows Management Instrumentation (WMI) integration for seamless C++ development",
-  "supports": "windows & !uwp",
   "homepage": "https://github.com/sonodima/wmipp",
-  "license": "MIT"
+  "license": "MIT",
+  "supports": "windows & !uwp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8568,6 +8568,10 @@
       "baseline": "1.2.0",
       "port-version": 2
     },
+    "wmipp": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "woff2": {
       "baseline": "1.0.2",
       "port-version": 3

--- a/versions/w-/wmipp.json
+++ b/versions/w-/wmipp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f1335763e1a23d5fbe3b70ab835cbaf351a20c9",
+      "git-tree": "70a7cc2553e70e4a9e6f50110b0e8b6eedb8c0f9",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/w-/wmipp.json
+++ b/versions/w-/wmipp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e2b1d6e817eb6bc09142404325a616f036b3f9ca",
+      "git-tree": "7f1335763e1a23d5fbe3b70ab835cbaf351a20c9",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/w-/wmipp.json
+++ b/versions/w-/wmipp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e2b1d6e817eb6bc09142404325a616f036b3f9ca",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.