### PR TITLE
[tracy] compatible with non wayland systems

### DIFF
--- a/ports/tracy/005-fix-imgui-path-legacy.patch
+++ b/ports/tracy/005-fix-imgui-path-legacy.patch
@@ -1,0 +1,13 @@
+diff --git a/profiler/build/unix/legacy.mk b/profiler/build/unix/legacy.mk
+index 24765f1a..dc2923c8 100644
+--- a/profiler/build/unix/legacy.mk
++++ b/profiler/build/unix/legacy.mk
+@@ -1,7 +1,7 @@
+ CFLAGS +=
+ CXXFLAGS := $(CFLAGS) -std=c++17
+ DEFINES += -DIMGUI_ENABLE_FREETYPE
+-INCLUDES := $(shell pkg-config --cflags glfw3 freetype2 capstone) -I../../../imgui
++INCLUDES := -I../../../imgui $(shell pkg-config --cflags glfw3 freetype2 capstone)
+ LIBS := $(shell pkg-config --libs glfw3 freetype2 capstone) -lpthread -ldl
+ 
+ PROJECT := Tracy

--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         002-fix-capstone-5.patch
         003-fix-imgui-path.patch
         004-fix-missing-threads-dep.patch # https://github.com/wolfpld/tracy/pull/562
+        005-fix-imgui-path-legacy.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -84,6 +85,7 @@ function(tracy_tool_install_make tracy_TOOL tracy_TOOL_NAME)
                 BASE_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}${short_buildtype}"
                 OUTPUT_VARIABLE relative_path_makefile_dir)
 
+            set(ENV{LEGACY} 1)
             vcpkg_backup_env_variables(VARS PKG_CONFIG_PATH)
             vcpkg_host_path_list(PREPEND ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}${path_suffix}/lib/pkgconfig")
 

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tracy",
   "version-semver": "0.9.1",
+  "port-version": 1,
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8094,7 +8094,7 @@
     },
     "tracy": {
       "baseline": "0.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "transwarp": {
       "baseline": "2.2.2",

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77e2063ccf000ddf44db90335335b0d87efe0bf4",
+      "version-semver": "0.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "1dbe1080d7c00eb3aa76f87c8c62511d9d9671a7",
       "version-semver": "0.9.1",
       "port-version": 0


### PR DESCRIPTION
Tracy 0.9.1 makes Wayland the default backend for the gui tool but a lot of systems don't support it yet, switching back to glfw3 keeps it backward compatible