### PR TITLE
[c9y] update to version 0.8.0

### DIFF
--- a/ports/c9y/portfile.cmake
+++ b/ports/c9y/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rioki/c9y
-    REF v0.7.0
-    SHA512 1c68351a42cea3a5cc52e00d3828acb16d6a96dfc4b9bf53fa4f8090b691a6f5734e2bb219af5cc54bc997517434417a4567d133c5a589f247abe9de73ba1cac
+    REF v0.8.0
+    SHA512 f3161bde45fd534029ef4609b1b49d4edbeb636c9305e01e7e9cfa6a62cde0978632d46597510bea0ff96cae09b819905c0d8c5d2fd85cf641d7b47ea2a732b1
     )
 
 vcpkg_cmake_configure(

--- a/ports/c9y/vcpkg.json
+++ b/ports/c9y/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c9y",
-  "version-semver": "0.7.0",
+  "version-semver": "0.8.0",
   "description": "Concurency",
   "homepage": "https://github.com/rioki/c9y",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1333,7 +1333,7 @@
       "port-version": 1
     },
     "c9y": {
-      "baseline": "0.7.0",
+      "baseline": "0.8.0",
       "port-version": 0
     },
     "cachelib": {

--- a/versions/c-/c9y.json
+++ b/versions/c-/c9y.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f7e3a1f7a70d40127c90193447fe5595f86c9fb",
+      "version-semver": "0.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c9ab8ee7af65218c39d096c8d8d369bb413a49a5",
       "version-semver": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.