### PR TITLE
Updated Recast Navigation to v1.6.0

### DIFF
--- a/ports/recast/portfile.cmake
+++ b/ports/recast/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO recastnavigation/recastnavigation
-    REF 1.5.1
+    REF 1.6.0
     SHA512 09900d8893e0c633a79e6188d15e68d1047040a0f2bceb2542f486dded64e69b918eaae159def81416a014fae26a46502783a2a712462bee4be2a3edf7bef47f
     HEAD_REF master
 )

--- a/ports/recast/vcpkg.json
+++ b/ports/recast/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "recast",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "port-version": 6,
   "description": "Navigation-mesh Toolset for Games",
   "homepage": "https://github.com/recastnavigation/recastnavigation",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.