### PR TITLE
[libcds] Add libcds support for arm64

### DIFF
--- a/ports/libcds/003-arm64-osx.patch
+++ b/ports/libcds/003-arm64-osx.patch
@@ -1,0 +1,24 @@
+diff --git a/build/cmake/TargetArch.cmake b/build/cmake/TargetArch.cmake
+index 026eace0..685820a3 100644
+--- a/build/cmake/TargetArch.cmake
++++ b/build/cmake/TargetArch.cmake
+@@ -80,6 +80,8 @@ function(target_architecture output_var)
+                 set(osx_arch_x86_64 TRUE)
+             elseif("${osx_arch}" STREQUAL "ppc64" AND ppc_support)
+                 set(osx_arch_ppc64 TRUE)
++            elseif("${osx_arch}" STREQUAL "arm64")
++                set(osx_arch_arm64 TRUE)
+             else()
+                 message(FATAL_ERROR "Invalid OS X arch name: ${osx_arch}")
+             endif()
+@@ -101,6 +103,10 @@ function(target_architecture output_var)
+         if(osx_arch_ppc64)
+             list(APPEND ARCH ppc64)
+         endif()
++
++        if(osx_arch_arm64)
++            list(APPEND ARCH arm64)
++        endif()
+     else()
+         file(WRITE "${CMAKE_BINARY_DIR}/arch.c" "${archdetect_c_code}")
+ 

--- a/ports/libcds/portfile.cmake
+++ b/ports/libcds/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         001-cmake-install.patch
         002-lib-suffix-option.patch
+        003-arm64-osx.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DISABLE_INSTALL_STATIC)

--- a/ports/libcds/vcpkg.json
+++ b/ports/libcds/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "a collection of concurrent containers that don't require external (manual) synchronization for shared access, and safe memory reclamation (SMR) algorithms like Hazard Pointer and user-space RCU that is used as an epoch-based SMR.",
   "homepage": "https://github.com/khizmax/libcds",
   "license": "BSL-1.0",
-  "supports": "!(arm & (osx | windows)) & !uwp",
+  "supports": "!uwp",
   "dependencies": [
     "boost-system",
     "boost-thread",


### PR DESCRIPTION
Adds support for macos arm64. I see logic for non-macos arm64 detection as well, so it should also work on windows.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
