### PR TITLE
[angelscript] update to 2.36.1

### DIFF
--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://angelcode.com/angelscript/sdk/files/angelscript_2.36.0.zip"
-    FILENAME "angelscript_2.36.0.zip"
-    SHA512 afd2b9096d0b62bc3d182d684fe34ddc8e9520af7734eea1f1a5c7d3439a28a1be7502faf692080cb0c4591799b7fea09fc8c4ccf25b8ec63a3d306e678682ff
+    URLS "https://angelcode.com/angelscript/sdk/files/angelscript_2.36.1.zip"
+    FILENAME "angelscript_2.36.1.zip"
+    SHA512 d6d213ce72135c89e47e67521f654611ff67673f3decd9db3da4b7bf317a04a3f91c5c6ae36658ec3f2b20498facd069af02a91255a24ec79c96d8c90d6b554e
 )
 
 vcpkg_extract_source_archive(
@@ -26,4 +26,4 @@ if("addons" IN_LIST FEATURES)
     file(INSTALL "${SOURCE_PATH}/add_on/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/angelscript" FILES_MATCHING PATTERN "*.h" PATTERN "*.cpp")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/docs/manual/doc_license.html" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/docs/manual/doc_license.html")

--- a/ports/angelscript/vcpkg.json
+++ b/ports/angelscript/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "angelscript",
-  "version": "2.36.0",
-  "port-version": 1,
+  "version": "2.36.1",
   "description": "The AngelCode Scripting Library, or AngelScript as it is also known, is an extremely flexible cross-platform scripting library designed to allow applications to extend their functionality through external scripts. It has been designed from the beginning to be an easy to use component, both for the application programmer and the script writer.",
   "homepage": "https://angelcode.com/angelscript",
   "license": "Zlib",

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e90e0fe54ab8038226b849471fba169157753c19",
+      "version": "2.36.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "579a4c31ad7d7972339105a9c043a3658af5705d",
       "version": "2.36.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -113,8 +113,8 @@
       "port-version": 8
     },
     "angelscript": {
-      "baseline": "2.36.0",
-      "port-version": 1
+      "baseline": "2.36.1",
+      "port-version": 0
     },
     "angle": {
       "baseline": "chromium_5414",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/31524

Tested usage and all feature on the following triplets:

- x64-windows
- x64-windows-static
- x86-windows

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
