### PR TITLE
[nanomsg] Always remove nanomsg_BINDIR check

### DIFF
--- a/ports/nanomsg/portfile.cmake
+++ b/ports/nanomsg/portfile.cmake
@@ -49,7 +49,8 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
         "defined(NN_STATIC_LIB)"
         "1 // defined(NN_STATIC_LIB)"
     )
-
+endif()
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string(
         ${CURRENT_PACKAGES_DIR}/share/${PORT}/nanomsg-config.cmake
         "set_and_check(nanomsg_BINDIR \${PACKAGE_PREFIX_DIR}/bin)"

--- a/ports/nanomsg/vcpkg.json
+++ b/ports/nanomsg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nanomsg",
   "version-semver": "1.2.0",
+  "port-version": 1,
   "description": [
     "A simple high-performance implementation of several \"scalability protocols\".",
     "These scalability protocols are light-weight messaging protocols which can be used to solve a number of very common messaging patterns, such as request/reply, publish/subscribe, surveyor/respondent, and so forth. These protocols can run over a variety of transports such as TCP, UNIX sockets, and even WebSocket."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5530,7 +5530,7 @@
     },
     "nanomsg": {
       "baseline": "1.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nanopb": {
       "baseline": "0.4.7",

--- a/versions/n-/nanomsg.json
+++ b/versions/n-/nanomsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "776c37386c83ec3b242fb17bf418f4a22e5cc300",
+      "version-semver": "1.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9c6dee5730547fccf7eae09ec55d2cea5fb593d1",
       "version-semver": "1.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This patch unconditionally removes the check for `nanomsg_BINDIR` in `nanomsg-config.cmake` since it will always fail regardless of the chosen linkage type