### PR TITLE
[liblsquic] Fix found boringssl on debug or release

### DIFF
--- a/ports/liblsquic/fix-found-boringssl.patch
+++ b/ports/liblsquic/fix-found-boringssl.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5d4086a..e085a83 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -120,10 +120,12 @@ IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
+     SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -Od")
+     #SET (MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -DFIU_ENABLE=1")
+     #SET(LIBS ${LIBS} fiu)
++    SET(LIB_NAME ssld cryptod)
+ ELSE()
+     SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -Ox")
+     # Comment out the following line to compile out debug messages:
+     #SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -DLSQUIC_LOWEST_LOG_LEVEL=LSQ_LOG_INFO")
++    SET(LIB_NAME ssl crypto)
+ ENDIF()
+ 
+ ENDIF() #MSVC
+@@ -191,7 +193,7 @@ IF (NOT DEFINED BORINGSSL_LIB AND DEFINED BORINGSSL_DIR)
+ ELSE()
+ 
+ 
+-    FOREACH(LIB_NAME ssl crypto)
++    FOREACH(LIB ${LIB_NAME})
+         # If BORINGSSL_LIB is defined, try find each lib. Otherwise, user should define BORINGSSL_LIB_ssl,
+         # BORINGSSL_LIB_crypto and so on explicitly. For example, including boringssl and lsquic both via
+         # add_subdirectory:
+@@ -201,20 +203,20 @@ ELSE()
+         #   add_subdirectory(third_party/lsquic)
+         IF (DEFINED BORINGSSL_LIB)
+             IF (CMAKE_SYSTEM_NAME STREQUAL Windows)
+-                FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
+-                    NAMES ${LIB_NAME}
++                FIND_LIBRARY(BORINGSSL_LIB_${LIB}
++                    NAMES ${LIB}
+                     PATHS ${BORINGSSL_LIB}
+                     PATH_SUFFIXES Debug Release MinSizeRel RelWithDebInfo
+                     NO_DEFAULT_PATH)
+             ELSE()
+-                FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
+-                    NAMES lib${LIB_NAME}${LIB_SUFFIX}
++                FIND_LIBRARY(BORINGSSL_LIB_${LIB}
++                    NAMES lib${LI}${LIB_SUFFIX}
+                     PATHS ${BORINGSSL_LIB}
+-                    PATH_SUFFIXES ${LIB_NAME}
++                    PATH_SUFFIXES ${LIB}
+                     NO_DEFAULT_PATH)
+             ENDIF()
+         ENDIF()
+-        IF(BORINGSSL_LIB_${LIB_NAME})
++        IF(BORINGSSL_LIB_${LIB})
+             MESSAGE(STATUS "Found ${LIB_NAME} library: ${BORINGSSL_LIB_${LIB_NAME}}")
+         ELSE()
+             MESSAGE(FATAL_ERROR "BORINGSSL_LIB_${LIB_NAME} library not found")

--- a/ports/liblsquic/portfile.cmake
+++ b/ports/liblsquic/portfile.cmake
@@ -9,7 +9,10 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REF v3.1.1
     SHA512 b4675be355703fea12f4b7d24812b93e739b2dbef04e3d8108b6fbe45dd16c129c9e04e58cdcfdf2a4448ee2edea68565dbd2445a76515bbdc8d9980f4210bee
     HEAD_REF master
-    PATCHES disable-asan.patch)
+    PATCHES 
+        disable-asan.patch
+        fix-found-boringssl.patch
+)
 
 # Submodules
 vcpkg_from_github(OUT_SOURCE_PATH LSQPACK_SOURCE_PATH

--- a/ports/liblsquic/vcpkg.json
+++ b/ports/liblsquic/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "liblsquic",
   "version": "3.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An implementation of the QUIC and HTTP/3 protocols.",
   "homepage": "https://github.com/litespeedtech/lsquic",
   "license": "MIT AND BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4206,7 +4206,7 @@
     },
     "liblsquic": {
       "baseline": "3.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "liblzma": {
       "baseline": "5.4.1",

--- a/versions/l-/liblsquic.json
+++ b/versions/l-/liblsquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9117a86afaed60857454ba0b5a5e684fc947ba56",
+      "version": "3.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "2a2383de53efd9458419db7bd82db49b342023da",
       "version": "3.1.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/31546 
Related PR https://github.com/microsoft/vcpkg/pull/31387
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: Fix found `boringssl` on debug or release. 
`Debug`:
```
ssld.lib  cryptod.lib
```
`Release`:
```
ssl.lib  crypto.lib
```
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
