### PR TITLE
[charls] update to 2.4.2

### DIFF
--- a/ports/charls/portfile.cmake
+++ b/ports/charls/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO team-charls/charls
-    REF dd9e90d2d2be86194cc3bd164b5cce35abcf2024 #v2.4.1
-    SHA512 33690d1647e57dedb22ad5cb75e4b41de41d0c603e0ec8e4b27dc2fa2ce71a97ab07deaa1aa42154369efb609b3954f7db51317f1dafd83d6cf882f2bade59a9
+    REF "${VERSION}"
+    SHA512 4f1b587f008956ab6fb9d2473c37a7b1a842633113245be7f8bb29b8c64304a6d580a29fcfca97ba1ac75adedbaf89e29adc4ac9e4117e1af1aa5949dbd34df9
     HEAD_REF master
 )
 

--- a/ports/charls/portfile.cmake
+++ b/ports/charls/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/charls)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
 
 vcpkg_copy_pdbs()
 

--- a/ports/charls/vcpkg.json
+++ b/ports/charls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "charls",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "CharLS, a C++ JPEG-LS library implementation.",
   "homepage": "https://github.com/team-charls/charls",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1473,7 +1473,7 @@
       "port-version": 3
     },
     "charls": {
-      "baseline": "2.4.1",
+      "baseline": "2.4.2",
       "port-version": 0
     },
     "chartdir": {

--- a/versions/c-/charls.json
+++ b/versions/c-/charls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "531014b210201e4064a1b7f759f61bf8b2b28e05",
+      "version": "2.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "5459a82cfd650a18a79539aa30a03fa751a8cfcb",
       "version": "2.4.1",
       "port-version": 0

--- a/versions/c-/charls.json
+++ b/versions/c-/charls.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "531014b210201e4064a1b7f759f61bf8b2b28e05",
+      "git-tree": "f9909aaef0219e8727c8f7e22ab93cf3aabbc685",
       "version": "2.4.2",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #31478


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note: no feature need to test.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
