### PR TITLE
[libidn2] Fix invalid macros in code

### DIFF
--- a/ports/libidn2/fix_invalid_macro.patch
+++ b/ports/libidn2/fix_invalid_macro.patch
@@ -1,0 +1,89 @@
+diff --git a/gl/stdint.in.h b/gl/stdint.in.h
+index eaa7874..8828d78 100644
+--- a/gl/stdint.in.h
++++ b/gl/stdint.in.h
+@@ -85,12 +85,21 @@
+ 
+ /* Override WINT_MIN and WINT_MAX if gnulib's <wchar.h> or <wctype.h> overrides
+    wint_t.  */
++#ifdef __linux__
+ #if @GNULIBHEADERS_OVERRIDE_WINT_T@
+ # undef WINT_MIN
+ # undef WINT_MAX
+ # define WINT_MIN 0x0U
+ # define WINT_MAX 0xffffffffU
+ #endif
++#else
++#if 0
++# undef WINT_MIN
++# undef WINT_MAX
++# define WINT_MIN 0x0U
++# define WINT_MAX 0xffffffffU
++#endif
++#endif
+ 
+ #if ! @HAVE_C99_STDINT_H@
+ 
+diff --git a/unistring/stdint.in.h b/unistring/stdint.in.h
+index eaa7874..8828d78 100644
+--- a/unistring/stdint.in.h
++++ b/unistring/stdint.in.h
+@@ -85,12 +85,21 @@
+ 
+ /* Override WINT_MIN and WINT_MAX if gnulib's <wchar.h> or <wctype.h> overrides
+    wint_t.  */
++#ifdef __linux__
+ #if @GNULIBHEADERS_OVERRIDE_WINT_T@
+ # undef WINT_MIN
+ # undef WINT_MAX
+ # define WINT_MIN 0x0U
+ # define WINT_MAX 0xffffffffU
+ #endif
++#else
++#if 0
++# undef WINT_MIN
++# undef WINT_MAX
++# define WINT_MIN 0x0U
++# define WINT_MAX 0xffffffffU
++#endif
++#endif
+ 
+ #if ! @HAVE_C99_STDINT_H@
+ 
+diff --git a/unistring/wchar.in.h b/unistring/wchar.in.h
+index 3558adf..7a0411a 100644
+--- a/unistring/wchar.in.h
++++ b/unistring/wchar.in.h
+@@ -140,6 +140,7 @@
+ /* mingw and MSVC define wint_t as 'unsigned short' in <crtdefs.h> or
+    <stddef.h>.  This is too small: ISO C 99 section 7.24.1.(2) says that
+    wint_t must be "unchanged by default argument promotions".  Override it.  */
++#ifdef __linux__
+ # if @GNULIBHEADERS_OVERRIDE_WINT_T@
+ #  if !GNULIB_defined_wint_t
+ #   if @HAVE_CRTDEFS_H@
+@@ -156,6 +157,24 @@ typedef unsigned int rpl_wint_t;
+ # ifndef WEOF
+ #  define WEOF ((wint_t) -1)
+ # endif
++#else
++# if 0
++#  if !GNULIB_defined_wint_t
++#   if @HAVE_CRTDEFS_H@
++#    include <crtdefs.h>
++#   else
++#    include <stddef.h>
++#   endif
++typedef unsigned int rpl_wint_t;
++#   undef wint_t
++#   define wint_t rpl_wint_t
++#   define GNULIB_defined_wint_t 1
++#  endif
++# endif
++# ifndef WEOF
++#  define WEOF ((wint_t) -1)
++# endif
++#endif
+ #endif
+ 
+ 

--- a/ports/libidn2/portfile.cmake
+++ b/ports/libidn2/portfile.cmake
@@ -23,6 +23,8 @@ vcpkg_extract_source_archive(SOURCE_PATH
         disable-subdirs.patch
         fix-msvc.patch
         fix-uwp.patch
+        fix_invalid_macro.patch
+        
 )
 
 vcpkg_list(SET options)

--- a/ports/libidn2/vcpkg.json
+++ b/ports/libidn2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libidn2",
   "version": "2.3.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.",
   "homepage": "https://www.gnu.org/software/libidn/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4134,7 +4134,7 @@
     },
     "libidn2": {
       "baseline": "2.3.4",
-      "port-version": 2
+      "port-version": 3
     },
     "libigl": {
       "baseline": "2.4.0",

--- a/versions/l-/libidn2.json
+++ b/versions/l-/libidn2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0dbd42a1ac306bfaab01af859699f436c47c1157",
+      "version": "2.3.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "4784d5f7f99d7ea1ebe6f1ef01943e402e7bfddf",
       "version": "2.3.4",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/31011
```
./stdint.h:89:5: error: expected value in expression
#if 
    ^
1 error generated.
In file included from rawmemchr.c:26:
```
Fix macro `GNULIBHEADERS_OVERRIDE_WINT_T` not working on `Windows `and `osx`.
Because there is no `GNULIBHEADERS_OVERRIDE_WINT_T `macro in `Windows `and `osx`, the code compilation and replacement fails. Add platform judgment in the code. When the platform is `Windows `or `osx`, replace the value of the macro `GNULIBHEADERS_OVERRIDE_WINT_T `with 0.

Compilation tests pass in the following triplet:
```
x64-osx
x86-windows
x64-windows
x64-linux
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
