### PR TITLE
libtracepoint, libeventheader-tracepoint, libeventheader-decode

### DIFF
--- a/ports/libeventheader-decode/portfile.cmake
+++ b/ports/libeventheader-decode/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "microsoft/LinuxTracepoints"
+    REF f3a5b3e4c12a19924a4d6fc30a7681742fd7eb01
+    SHA512 f94a3cf1367ec4749f40217923f1158da40caaf5cd75529d1ca9a5e8b51c581f0aec286f715a88b6203f9979a2e32ad69efde1738a12fa71a0301b8ddbfcc6e4
+    HEAD_REF main)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/libeventheader-decode-cpp"
+    OPTIONS
+        -DBUILD_SAMPLES=OFF
+        -DBUILD_TOOLS=OFF)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME eventheader-decode
+    CONFIG_PATH lib/cmake/eventheader-decode)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libeventheader-decode/vcpkg.json
+++ b/ports/libeventheader-decode/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "libeventheader-decode",
+  "version": "1.0.0",
+  "description": "EventHeader tracepoint decoding classes for C++",
+  "homepage": "https://github.com/microsoft/LinuxTracepoints/",
+  "license": "MIT",
+  "supports": "linux | windows",
+  "dependencies": [
+    {
+      "name": "libeventheader-tracepoint",
+      "version>=": "1.0.0"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libeventheader-tracepoint/portfile.cmake
+++ b/ports/libeventheader-tracepoint/portfile.cmake
@@ -1,0 +1,37 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(VCPKG_BUILD_TYPE release) # Windows port only includes headers.
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "microsoft/LinuxTracepoints"
+    REF f3a5b3e4c12a19924a4d6fc30a7681742fd7eb01
+    SHA512 f94a3cf1367ec4749f40217923f1158da40caaf5cd75529d1ca9a5e8b51c581f0aec286f715a88b6203f9979a2e32ad69efde1738a12fa71a0301b8ddbfcc6e4
+    HEAD_REF main)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/libeventheader-tracepoint"
+    OPTIONS
+        -DBUILD_SAMPLES=OFF
+        -DBUILD_TOOLS=OFF)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_cmake_config_fixup(
+        PACKAGE_NAME eventheader-tracepoint
+        CONFIG_PATH lib/cmake/eventheader-tracepoint
+        DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endif()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME eventheader-headers
+    CONFIG_PATH lib/cmake/eventheader-headers)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libeventheader-tracepoint/vcpkg.json
+++ b/ports/libeventheader-tracepoint/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "libeventheader-tracepoint",
+  "version": "1.0.0",
+  "description": "EventHeader-encoded Linux tracepoints for C/C++",
+  "homepage": "https://github.com/microsoft/LinuxTracepoints/",
+  "license": "MIT",
+  "supports": "linux | windows",
+  "dependencies": [
+    {
+      "name": "libtracepoint",
+      "version>=": "1.0.0"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libtracepoint/portfile.cmake
+++ b/ports/libtracepoint/portfile.cmake
@@ -1,0 +1,37 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(VCPKG_BUILD_TYPE release) # Windows port only includes headers.
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "microsoft/LinuxTracepoints"
+    REF f3a5b3e4c12a19924a4d6fc30a7681742fd7eb01
+    SHA512 f94a3cf1367ec4749f40217923f1158da40caaf5cd75529d1ca9a5e8b51c581f0aec286f715a88b6203f9979a2e32ad69efde1738a12fa71a0301b8ddbfcc6e4
+    HEAD_REF main)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/libtracepoint"
+    OPTIONS
+        -DBUILD_SAMPLES=OFF
+        -DBUILD_TESTS=OFF)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_cmake_config_fixup(
+        PACKAGE_NAME tracepoint
+        CONFIG_PATH lib/cmake/tracepoint
+        DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endif()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME tracepoint-headers
+    CONFIG_PATH lib/cmake/tracepoint-headers)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libtracepoint/vcpkg.json
+++ b/ports/libtracepoint/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libtracepoint",
+  "version": "1.0.0",
+  "description": "Linux tracepoints interface for C/C++",
+  "homepage": "https://github.com/microsoft/LinuxTracepoints/",
+  "license": "MIT",
+  "supports": "linux | windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3988,6 +3988,14 @@
       "baseline": "2.1.12+20230128",
       "port-version": 0
     },
+    "libeventheader-decode": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
+    "libeventheader-tracepoint": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "libevhtp": {
       "baseline": "1.2.18",
       "port-version": 5
@@ -4618,6 +4626,10 @@
     },
     "libtorrent": {
       "baseline": "2.0.8",
+      "port-version": 0
+    },
+    "libtracepoint": {
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "libu2f-server": {

--- a/versions/l-/libeventheader-decode.json
+++ b/versions/l-/libeventheader-decode.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fd67531cc60d91c4d8b45da15cd7414b398b9cd7",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libeventheader-tracepoint.json
+++ b/versions/l-/libeventheader-tracepoint.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d8ba8b72bb5c6dde050b85f84e01efb6b36d535c",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libtracepoint.json
+++ b/versions/l-/libtracepoint.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f60f9a909a55a04c9bc87b6a3e10df5f0faec1a4",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.

3 tightly-related but relatively-simple ports, all from the same repo.

Bing search for "libtracepoint" and "libeventheader" show the appropriate github repo in the results. I am not aware of any other libtracepoint or libeventheader.