### PR TITLE
[hidapi] Update to 0.14.0

### DIFF
--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/hidapi
-    REF hidapi-0.14.0
+    REF hidapi-${VERSION}
     SHA512 66a045144f90b41438898b82f0398e80223323ebfe6e4f197d2713696bb3ae60f36aea5a37a9999b34b12294783fd7e4c28c6e785462559cbe21276009da1eac
     HEAD_REF master
 )

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -26,9 +26,7 @@ vcpkg_copy_pdbs()
 
 
 if ("pp-data-dump" IN_LIST FEATURES)
-    file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/bin/pp_data_dump.exe" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/pp_data_dump.exe")
-    file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/pp_data_dump.exe")
+    vcpkg_copy_tools(TOOL_NAMES pp_data_dump AUTO_CLEAN)
 endif()
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hidapi/libhidapi.cmake" "\"/hidapi\"" "\"\${_IMPORT_PREFIX}/include\"")

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -16,22 +16,17 @@ vcpkg_cmake_configure(
     OPTIONS -DHIDAPI_BUILD_HIDTEST=OFF
     ${FEATURE_OPTIONS}
 )
-
 vcpkg_cmake_install()
-
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
-
 
 if ("pp-data-dump" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES pp_data_dump AUTO_CLEAN)
 endif()
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hidapi/libhidapi.cmake" "\"/hidapi\"" "\"\${_IMPORT_PREFIX}/include\"")
-
-
 
 file(INSTALL "${SOURCE_PATH}/LICENSE-bsd.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -1,22 +1,39 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/hidapi
-    REF hidapi-0.13.1
-    SHA512 07b224b9b5146caf693e6d67514fed236436ed68f38a3ada98ebf8352dfaa4e175f576902affb4b79da1bb8c9b47a1ee0831a93c7d3d210e93faee24632f7d53
+    REF hidapi-0.14.0
+    SHA512 66a045144f90b41438898b82f0398e80223323ebfe6e4f197d2713696bb3ae60f36aea5a37a9999b34b12294783fd7e4c28c6e785462559cbe21276009da1eac
     HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+FEATURES
+    "pp-data-dump"           HIDAPI_BUILD_PP_DATA_DUMP
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS -DHIDAPI_BUILD_HIDTEST=OFF
+    ${FEATURE_OPTIONS}
 )
+
 vcpkg_cmake_install()
+
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
+
+if ("pp-data-dump" IN_LIST FEATURES)
+    file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/bin/pp_data_dump.exe" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/pp_data_dump.exe")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/pp_data_dump.exe")
+endif()
+
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hidapi/libhidapi.cmake" "\"/hidapi\"" "\"\${_IMPORT_PREFIX}/include\"")
+
+
 
 file(INSTALL "${SOURCE_PATH}/LICENSE-bsd.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/hidapi/vcpkg.json
+++ b/ports/hidapi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hidapi",
-  "version-semver": "0.13.1",
+  "version-semver": "0.14.0",
   "description": "A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac and Windows.",
   "homepage": "https://github.com/libusb/hidapi",
   "license": "BSD-3-Clause-Clear",
@@ -18,5 +18,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "pp-data-dump": {
+      "description": "Build pp_data_dump.exe tool, to store WIN32 HidD Preparsed Data as file",
+      "supports": "windows"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3117,7 +3117,7 @@
       "port-version": 0
     },
     "hidapi": {
-      "baseline": "0.13.1",
+      "baseline": "0.14.0",
       "port-version": 0
     },
     "highfive": {

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "268d40e34c59f1473b3b6e45a1f92cab2142bb7d",
+      "version-semver": "0.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7deb8cf068244c5583ce565bf1d302b369ed622b",
       "version-semver": "0.13.1",
       "port-version": 0

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "268d40e34c59f1473b3b6e45a1f92cab2142bb7d",
+      "git-tree": "f734f9ff0b8c468d466a7983a5e93b4497162d75",
       "version-semver": "0.14.0",
       "port-version": 0
     },

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f734f9ff0b8c468d466a7983a5e93b4497162d75",
+      "git-tree": "ef7fae56bd9bec8a3b50d4ab3f87ba7537ea330b",
       "version-semver": "0.14.0",
       "port-version": 0
     },


### PR DESCRIPTION
Changes:
- Updated hidapi to 0.14.0
- Added new feature pp-data-dump, to make the build of the new pp_data_dump.exe developer tool optional


Checklist:
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
