### PR TITLE
[blaze] Update to 3.8.2

### DIFF
--- a/ports/blaze/portfile.cmake
+++ b/ports/blaze/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_bitbucket(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO blaze-lib/blaze
-    REF v3.8.1
-    SHA512 6dfd3cb46d796b94cc44a30c4cd5ebfb366d2eb312d75a28787cacb4636df52e4e4e3dce3d9501bf2c07e7fd3621e8ce7f9ffa61a950a4146375b12d75d4872b
+    REF "v${VERSION}"
+    SHA512 9786628159991f547902ceb44a159f0ba84d08be16ccc45bfb9aad3cfbf16eaede4ea43d2d4981d420a8a387a07721b113754f6038a6db2d9c7ed2ea967b5361
     HEAD_REF master
 )
 
@@ -19,4 +19,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/blaze/cmake)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/blaze/vcpkg.json
+++ b/ports/blaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "blaze",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Blaze is an open-source, high-performance C++ math library for dense and sparse arithmetic.",
   "homepage": "https://bitbucket.org/blaze-lib/blaze",
   "license": "BSD-3-Clause",

--- a/versions/b-/blaze.json
+++ b/versions/b-/blaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f237bb789d83a4004b263f9544ed3d6668f160f",
+      "version": "3.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "6bea7e024ba776f0a7c5462056054529f79aa86d",
       "version": "3.8.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -589,7 +589,7 @@
       "port-version": 0
     },
     "blaze": {
-      "baseline": "3.8.1",
+      "baseline": "3.8.2",
       "port-version": 0
     },
     "blend2d": {


### PR DESCRIPTION
Fixes #31531, update `blaze` to 3.8.2.

No feature to be tested, the usage test passed(header files found): 
```
blaze provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(blaze CONFIG REQUIRED)
    target_link_libraries(main PRIVATE blaze::blaze)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
