### PR TITLE
[wmipp] Update to 1.2.0

### DIFF
--- a/ports/wmipp/portfile.cmake
+++ b/ports/wmipp/portfile.cmake
@@ -2,7 +2,6 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sonodima/wmipp
     REF "v${VERSION}"
-
     SHA512 3cfa7bacc1e03077503fa04e636106ce5bfc66a3fce25e52033433c2328a62229fdf7baad4a0116459fb0c299839ea02507fe8da43c853b9dd8bcfcb3d2301d3
     HEAD_REF main
 )

--- a/ports/wmipp/portfile.cmake
+++ b/ports/wmipp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO sonodima/wmipp
     REF "v${VERSION}"
 
-    SHA512 e52ad6edadcb5b56c941d18e10968f10ea4fbbb0773132c2eb929e83cbf4aa22b72a161f55b358541e27786ff7f967786eb156b7ff519f8d3449d8b5ef2aa727 
+    SHA512 3cfa7bacc1e03077503fa04e636106ce5bfc66a3fce25e52033433c2328a62229fdf7baad4a0116459fb0c299839ea02507fe8da43c853b9dd8bcfcb3d2301d3
     HEAD_REF main
 )
 

--- a/ports/wmipp/vcpkg.json
+++ b/ports/wmipp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wmipp",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Streamlined Windows Management Instrumentation (WMI) integration for seamless C++ development",
   "homepage": "https://github.com/sonodima/wmipp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8581,7 +8581,7 @@
       "port-version": 2
     },
     "wmipp": {
-      "baseline": "1.0.0",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "woff2": {

--- a/versions/w-/wmipp.json
+++ b/versions/w-/wmipp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "411e8d9146821a52cbc32af5f674fb58ce86f475",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "70a7cc2553e70e4a9e6f50110b0e8b6eedb8c0f9",
       "version": "1.0.0",
       "port-version": 0

--- a/versions/w-/wmipp.json
+++ b/versions/w-/wmipp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "411e8d9146821a52cbc32af5f674fb58ce86f475",
+      "git-tree": "62fe399df24f53348677d6ee7af427a6d0018aaf",
       "version": "1.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
