### PR TITLE
[folly]: fix build with gcc 13.

### DIFF
--- a/ports/folly/fix-build-with-gcc-13.patch
+++ b/ports/folly/fix-build-with-gcc-13.patch
@@ -1,0 +1,27 @@
+From e3cba5dd4f59c695d9cbf6bd02249af7103cc300 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Sun, 22 Jan 2023 05:06:16 +0000
+Subject: [PATCH] Fix build with GCC 13 (add missing includes)
+
+GCC 13 (as usual for new compiler releases) shuffles around some
+internal includes and so <stdexcept> etc is no longer transitively included.
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ folly/system/AtFork.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/folly/system/AtFork.cpp b/folly/system/AtFork.cpp
+index e888e52858a..a5570330dc3 100644
+--- a/folly/system/AtFork.cpp
++++ b/folly/system/AtFork.cpp
+@@ -14,6 +14,9 @@
+  * limitations under the License.
+  */
+ 
++#include <stdexcept>
++#include <system_error>
++
+ #include <folly/system/AtFork.h>
+ 
+ #include <folly/ScopeGuard.h>

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         boost-1.70.patch
         fix-windows-minmax.patch
         fix-deps.patch
+	fix-build-with-gcc-13.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/CMake/FindFmt.cmake")

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "folly",
   "version-string": "2022.10.31.00",
-  "port-version": 6,
+  "port-version": 7,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2558,7 +2558,7 @@
     },
     "folly": {
       "baseline": "2022.10.31.00",
-      "port-version": 6
+      "port-version": 7
     },
     "font-chef": {
       "baseline": "1.1.0",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "003ae8b1bc9dc0a460b5c6f6cacda76fa5931cf8",
+      "version-string": "2022.10.31.00",
+      "port-version": 7
+    },
+    {
       "git-tree": "204d88dbc53dc5ff37c58459c1af0c6f19f446db",
       "version-string": "2022.10.31.00",
       "port-version": 6


### PR DESCRIPTION
Fixes #31585.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
