### PR TITLE
[qt5] Apply CVE fixes

### DIFF
--- a/ports/qt5-base/patches/CVE-2023-32762-qtbase-5.15.diff
+++ b/ports/qt5-base/patches/CVE-2023-32762-qtbase-5.15.diff
@@ -1,0 +1,13 @@
+--- a/src/network/access/qhsts.cpp
++++ b/src/network/access/qhsts.cpp
+@@ -364,8 +364,8 @@ quoted-pair    = "\" CHAR
+ bool QHstsHeaderParser::parse(const QList<QPair<QByteArray, QByteArray>> &headers)
+ {
+     for (const auto &h : headers) {
+-        // We use '==' since header name was already 'trimmed' for us:
+-        if (h.first == "Strict-Transport-Security") {
++        // We compare directly because header name was already 'trimmed' for us:
++        if (h.first.compare("Strict-Transport-Security", Qt::CaseInsensitive) == 0) {
+             header = h.second;
+             // RFC6797, 8.1:
+             //

--- a/ports/qt5-base/patches/CVE-2023-32763-qtbase-5.15.diff
+++ b/ports/qt5-base/patches/CVE-2023-32763-qtbase-5.15.diff
@@ -1,0 +1,45 @@
+--- a/src/gui/painting/qfixed_p.h
++++ b/src/gui/painting/qfixed_p.h
+@@ -54,6 +54,7 @@
+ #include <QtGui/private/qtguiglobal_p.h>
+ #include "QtCore/qdebug.h"
+ #include "QtCore/qpoint.h"
++#include <QtCore/private/qnumeric_p.h>
+ #include "QtCore/qsize.h"
+ 
+ QT_BEGIN_NAMESPACE
+@@ -182,6 +183,14 @@ Q_DECL_CONSTEXPR inline bool operator<(int i, const QFixed &f) { return i * 64 <
+ Q_DECL_CONSTEXPR inline bool operator>(const QFixed &f, int i) { return f.value() > i * 64; }
+ Q_DECL_CONSTEXPR inline bool operator>(int i, const QFixed &f) { return i * 64 > f.value(); }
+ 
++inline bool qAddOverflow(QFixed v1, QFixed v2, QFixed *r)
++{
++    int val;
++    bool result = add_overflow(v1.value(), v2.value(), &val);
++    r->setValue(val);
++    return result;
++}
++
+ #ifndef QT_NO_DEBUG_STREAM
+ inline QDebug &operator<<(QDebug &dbg, const QFixed &f)
+ { return dbg << f.toReal(); }
+--- a/src/gui/text/qtextlayout.cpp
++++ b/src/gui/text/qtextlayout.cpp
+@@ -2163,11 +2163,14 @@ found:
+         eng->maxWidth = qMax(eng->maxWidth, line.textWidth);
+     } else {
+         eng->minWidth = qMax(eng->minWidth, lbh.minw);
+-        eng->maxWidth += line.textWidth;
++        if (qAddOverflow(eng->maxWidth, line.textWidth, &eng->maxWidth))
++            eng->maxWidth = QFIXED_MAX;
+     }
+ 
+-    if (line.textWidth > 0 && item < eng->layoutData->items.size())
+-        eng->maxWidth += lbh.spaceData.textWidth;
++    if (line.textWidth > 0 && item < eng->layoutData->items.size()) {
++        if (qAddOverflow(eng->maxWidth, lbh.spaceData.textWidth, &eng->maxWidth))
++            eng->maxWidth = QFIXED_MAX;
++    }
+ 
+     line.textWidth += trailingSpace;
+     if (lbh.spaceData.length) {

--- a/ports/qt5-base/patches/qtbug_96392.patch
+++ b/ports/qt5-base/patches/qtbug_96392.patch
@@ -1,0 +1,27 @@
+--- a/src/gui/configure.json
++++ b/src/gui/configure.json
+@@ -842,7 +842,8 @@                     "// Check if EGL is compatible with X. Some EGL implementations, typically on",
+                     "// embedded devices, are not intended to be used together with X. EGL support",
+                     "// has to be disabled in plugins like xcb in this case since the native display,",
+                     "// window and pixmap types will be different than what an X-based platform",
+-                    "// plugin would expect."
++                    "// plugin would expect.",
++                    "#define USE_X11"
+                 ],
+                 "include": [ "EGL/egl.h", "X11/Xlib.h" ],
+                 "main": [
+--- a/src/platformsupport/eglconvenience/qt_egl_p.h
++++ b/src/platformsupport/eglconvenience/qt_egl_p.h
+@@ -61,7 +61,11 @@ # endif
+ # if !defined(Q_OS_INTEGRITY)
+ #  define WIN_INTERFACE_CUSTOM   // NV
+ # endif // Q_OS_INTEGRITY
+-#endif  // QT_EGL_NO_X11
++#else // QT_EGL_NO_X11
++// If one has an eglplatform.h with https://github.com/KhronosGroup/EGL-Registry/pull/130
++// that needs USE_X11 to be defined.
++# define USE_X11
++#endif
+ 
+ #ifdef QT_EGL_WAYLAND
+ # define WAYLAND // NV

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -46,12 +46,17 @@ endif()
 
 qt_download_submodule(  OUT_SOURCE_PATH SOURCE_PATH
                         PATCHES
+                            # CVE fixes from https://download.qt.io/official_releases/qt/5.15/
+                            patches/CVE-2023-32762-qtbase-5.15.diff
+                            patches/CVE-2023-32763-qtbase-5.15.diff
+
                             patches/winmain_pro.patch          #Moves qtmain to manual-link
                             patches/windows_prf.patch          #fixes the qtmain dependency due to the above move
                             patches/qt_app.patch               #Moves the target location of qt5 host apps to always install into the host dir.
                             patches/gui_configure.patch        #Patches the gui configure.json to break freetype/fontconfig autodetection because it does not include its dependencies.
                             patches/xlib.patch                 #Patches Xlib check to actually use Pkgconfig instead of makeSpec only
                             patches/egl.patch                  #Fix egl detection logic.
+                            patches/qtbug_96392.patch          #Backport fix for QTBUG-96392
                             patches/mysql_plugin_include.patch #Fix include path of mysql plugin
                             patches/mysql-configure.patch      #Fix mysql project
                             patches/cocoa.patch                #Fix missing include on macOS Monterrey, https://code.qt.io/cgit/qt/qtbase.git/commit/src/plugins/platforms/cocoa?id=dece6f5840463ae2ddf927d65eb1b3680e34a547

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.9",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qt5-svg/CVE-2023-32573-qtsvg-5.15.diff
+++ b/ports/qt5-svg/CVE-2023-32573-qtsvg-5.15.diff
@@ -1,0 +1,32 @@
+--- a/src/svg/qsvgfont_p.h
++++ b/src/svg/qsvgfont_p.h
+@@ -74,6 +74,7 @@ public:
+ class Q_SVG_PRIVATE_EXPORT QSvgFont : public QSvgRefCounted
+ {
+ public:
++    static constexpr qreal DEFAULT_UNITS_PER_EM = 1000;
+     QSvgFont(qreal horizAdvX);
+ 
+     void setFamilyName(const QString &name);
+@@ -86,9 +87,7 @@ public:
+     void draw(QPainter *p, const QPointF &point, const QString &str, qreal pixelSize, Qt::Alignment alignment) const;
+ public:
+     QString m_familyName;
+-    qreal m_unitsPerEm;
+-    qreal m_ascent;
+-    qreal m_descent;
++    qreal m_unitsPerEm = DEFAULT_UNITS_PER_EM;
+     qreal m_horizAdvX;
+     QHash<QChar, QSvgGlyph> m_glyphs;
+ };
+--- a/src/svg/qsvghandler.cpp
++++ b/src/svg/qsvghandler.cpp
+@@ -2668,7 +2668,7 @@ static bool parseFontFaceNode(QSvgStyleProperty *parent,
+ 
+     qreal unitsPerEm = toDouble(unitsPerEmStr);
+     if (!unitsPerEm)
+-        unitsPerEm = 1000;
++        unitsPerEm = QSvgFont::DEFAULT_UNITS_PER_EM;
+ 
+     if (!name.isEmpty())
+         font->setFamilyName(name);

--- a/ports/qt5-svg/portfile.cmake
+++ b/ports/qt5-svg/portfile.cmake
@@ -1,2 +1,6 @@
 include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
-qt_submodule_installation(PATCHES "static_svg_link_fix.patch")
+qt_submodule_installation(
+    PATCHES
+        "CVE-2023-32573-qtsvg-5.15.diff" # CVE fix from https://download.qt.io/official_releases/qt/5.15/
+        "static_svg_link_fix.patch"
+)

--- a/ports/qt5-svg/vcpkg.json
+++ b/ports/qt5-svg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-svg",
   "version": "5.15.9",
+  "port-version": 1,
   "description": "Qt5 SVG Module - provides classes for displaying the contents of SVG files",
   "license": null,
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6534,7 +6534,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.9",
-      "port-version": 2
+      "port-version": 3
     },
     "qt5-canvas3d": {
       "baseline": "0",
@@ -6638,7 +6638,7 @@
     },
     "qt5-svg": {
       "baseline": "5.15.9",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-tools": {
       "baseline": "5.15.9",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9107483664812c119937623d402bea6395c24cd3",
+      "version": "5.15.9",
+      "port-version": 3
+    },
+    {
       "git-tree": "1137d1509e996fa4bde14ec310c6955b50408c8a",
       "version": "5.15.9",
       "port-version": 2

--- a/versions/q-/qt5-svg.json
+++ b/versions/q-/qt5-svg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a16175a9771d1e7556bcfb785956f0ce5afc26fb",
+      "version": "5.15.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "2182d0b3d29d1e3c4cf58c5a93e896f304d86805",
       "version": "5.15.9",
       "port-version": 0


### PR DESCRIPTION
Fixes #31587

I've also smuggled a fix for https://bugreports.qt.io/browse/QTBUG-96392, hope you don't mind.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.