### PR TITLE
[flatbuffers] Update to 23.5.9

### DIFF
--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/flatbuffers
     REF "v${VERSION}"
-    SHA512 4066c94f2473c7ea16917d29a613e16f840a329089c88e0bdbdb999aef3442ba00abfd2aa92266fa9c067e399dc88e6f0ccac40dc151378857e665638e78bbf0
+    SHA512 6eb5417984782208e0fcc33285d02bb13cda526d4029e0dd58e27c4f813eb39f26105ab0ed0880f7c02614985b96a241aad5086dd4f2d131c534a44a2884d08e
     HEAD_REF master
     PATCHES
         fix-uwp-build.patch
@@ -36,7 +36,7 @@ if(flatc_path)
     vcpkg_copy_tools(TOOL_NAMES flatc AUTO_CLEAN)
 else()
     file(APPEND "${CURRENT_PACKAGES_DIR}/share/flatbuffers/flatbuffers-config.cmake"
-"include(\"\${CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/share/flatbuffers/FlatcTargets.cmake\")\n")
+"\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/share/flatbuffers/FlatcTargets.cmake\")\n")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbuffers",
-  "version": "23.3.3",
+  "version": "23.5.9",
   "description": [
     "Memory Efficient Serialization Library",
     "FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2521,7 +2521,7 @@
       "port-version": 0
     },
     "flatbuffers": {
-      "baseline": "23.3.3",
+      "baseline": "23.5.9",
       "port-version": 0
     },
     "flecs": {

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "787f5c089a87c5896ef5f0f8b200de1d1081158c",
+      "version": "23.5.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "007f5be0ca9f1fb0e4cd747153edafe584f3e090",
       "version": "23.3.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
