### PR TITLE
[llvm] Add atlmfc as a dependence in windows platform

### DIFF
--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llvm/llvm-project
-    REF llvmorg-${VERSION}
+    REF "llvmorg-${VERSION}"
     SHA512 99beff9ee6f8c26f16ea53f03ba6209a119099cbe361701b0d5f4df9d5cc5f2f0da7c994c899a4cec876da8428564dc7a8e798226a9ba8b5c18a3ef8b181d39e
     HEAD_REF main
     PATCHES

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -9,7 +9,7 @@
   "dependencies": [
     {
       "name": "atlmfc",
-      "platform": "windows"
+      "platform": "windows & !mingw"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "llvm",
   "version": "15.0.7",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",
   "supports": "!uwp & !(arm & windows)",
   "dependencies": [
+    {
+      "name": "atlmfc",
+      "platform": "windows"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4914,7 +4914,7 @@
     },
     "llvm": {
       "baseline": "15.0.7",
-      "port-version": 2
+      "port-version": 3
     },
     "lmdb": {
       "baseline": "0.9.29",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4d97d177d8110ba721cbb8330f0fee215901a9f9",
+      "git-tree": "1ba26e4d72f4d6112c483a09d9a2dd0aa42067f3",
       "version": "15.0.7",
       "port-version": 3
     },

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d97d177d8110ba721cbb8330f0fee215901a9f9",
+      "version": "15.0.7",
+      "port-version": 3
+    },
+    {
       "git-tree": "9c069ac90689417940c7a8e5a972afac79042619",
       "version": "15.0.7",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Related with https://github.com/microsoft/vcpkg/issues/31597.

Because `atls.lib` is a necessary requirement for building LLVM with MSVC, I added atlmfc a dependency for LLVM.
This way, if `atlmfc` is not installed locally, users will be aware in advance(port `atlmfc` install failed), rather than encountering errors during the build process.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
