### PR TITLE
[platform-folders] Fix incorrect install location for .cmake file

### DIFF
--- a/ports/platform-folders/portfile.cmake
+++ b/ports/platform-folders/portfile.cmake
@@ -26,7 +26,7 @@ endif()
 if (VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP OR VCPKG_TARGET_IS_MinGW)
     vcpkg_cmake_config_fixup(PACKAGE_NAME platform_folders CONFIG_PATH cmake)
 else()
-    vcpkg_cmake_config_fixup(PACKAGE_NAME platform_folders CONFIG_PATH lib/cmake)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME platform_folders CONFIG_PATH lib/cmake/platform_folders)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/platform-folders/vcpkg.json
+++ b/ports/platform-folders/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "platform-folders",
   "version": "4.2.0",
+  "port-version": 1,
   "description": "A C++ library to look for special directories like \"My Documents\" and \"%APPDATA%\"",
   "homepage": "https://github.com/sago007/PlatformFolders",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6254,7 +6254,7 @@
     },
     "platform-folders": {
       "baseline": "4.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "plf-colony": {
       "baseline": "6.33",

--- a/versions/p-/platform-folders.json
+++ b/versions/p-/platform-folders.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf5e8d5b3192a857b2e85276a2ff8c6f76e28d82",
+      "version": "4.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8448d41ddd7f2f2302c9a6a80dde44bb8494b096",
       "version": "4.2.0",
       "port-version": 0


### PR DESCRIPTION
Fixes `find_package(platform_folders)` not working anymore in recent versions (not sure when it stopped working though).
 
[x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.