### PR TITLE
[gdal] Don't depend on default features of proj

### DIFF
--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.7.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,
@@ -13,8 +13,17 @@
       "name": "pkgconf",
       "host": true
     },
-    "proj",
-    "tiff",
+    {
+      "name": "proj",
+      "default-features": false,
+      "features": [
+        "tiff"
+      ]
+    },
+    {
+      "name": "tiff",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/libgeotiff/vcpkg.json
+++ b/ports/libgeotiff/vcpkg.json
@@ -1,12 +1,18 @@
 {
   "name": "libgeotiff",
   "version": "1.7.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Libgeotiff is an open source library on top of libtiff for reading and writing GeoTIFF information tags.",
   "homepage": "https://github.com/OSGeo/libgeotiff",
   "license": "MIT",
   "dependencies": [
-    "proj",
+    {
+      "name": "proj",
+      "default-features": false,
+      "features": [
+        "tiff"
+      ]
+    },
     {
       "name": "tiff",
       "default-features": false

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2722,7 +2722,7 @@
     },
     "gdal": {
       "baseline": "3.7.0",
-      "port-version": 1
+      "port-version": 2
     },
     "gdcm": {
       "baseline": "3.0.22",
@@ -4058,7 +4058,7 @@
     },
     "libgeotiff": {
       "baseline": "1.7.1",
-      "port-version": 2
+      "port-version": 3
     },
     "libgit2": {
       "baseline": "1.4.2",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f287b8dfcfba6e4f2d8ee8cdba0e63f0ae326fd7",
+      "version-semver": "3.7.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "119c87c321a3a925253f5503cfac1e6960d5923e",
       "version-semver": "3.7.0",
       "port-version": 1

--- a/versions/l-/libgeotiff.json
+++ b/versions/l-/libgeotiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f42371900964fce2757e37ad8d36ca2b7bd0dfd8",
+      "version": "1.7.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "2397fd7d09c89af1810821e9b4c47ec71e2748c5",
       "version": "1.7.1",
       "port-version": 2


### PR DESCRIPTION
The goal is to build gdal without curl.
@dg0yt I'm not sure if we should depend on just `core` or `core,tiff`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.