### PR TITLE
[minizip-ng] Restore non-conflicting filepaths

### DIFF
--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -29,7 +29,7 @@ vcpkg_cmake_configure(
     OPTIONS 
         ${FEATURE_OPTIONS}
         -DMZ_FETCH_LIBS=OFF
-        -DMZ_PROJECT_SUFFIX:STRING=-ng
+        -DMZ_LIB_SUFFIX=-ng
 )
 
 vcpkg_cmake_install()
@@ -41,4 +41,4 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "minizip-ng",
   "version": "4.0.0",
+  "port-version": 1,
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5286,7 +5286,7 @@
     },
     "minizip-ng": {
       "baseline": "4.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "mio": {
       "baseline": "2023-03-03",

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e55bf50acfd71d5f37f98bee270ff687f65219f",
+      "version": "4.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f9a2226720f5e72647d6b0399f9c0bd5baf8f9b9",
       "version": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
Amends #31575. The new version needs a different option to use the `-ng` suffix in filepaths. The suffix is required to not conflict with port minizip.
Cf. https://github.com/zlib-ng/minizip-ng/commit/10d06fa43cd552d0fccf5fcc7df793e46c57a657
Needed for #31603, cf. https://dev.azure.com/vcpkg/public/_build/results?buildId=89798.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
