### PR TITLE
[gtk] update to 4.10.3

### DIFF
--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.gnome.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/gtk
-    REF  74677018183b7b815c54b236841447132c0141e3 #v4.10.1
-    SHA512 7611c09c1b259c1e079b84abae603920b27403c0900b3265a07e540166bd468603ee2eb77e68e820921d979c345e69c62447fcead6fe38bb21d32bde8ece1e26
+    REF  06b3ced8e7fc936caed43379b120d75be09713ca #v4.10.3
+    SHA512 3fe7da84993bab8afbd0725b06e10546fbbb550a1e2b356431c152b5392fc1e94e400430f1b6a2c39bdddf8fecbe34fb65794bd1bf41c9bdca4e40e12136ac91
     HEAD_REF master # branch name
     PATCHES
         0001-build.patch

--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtk",
-  "version": "4.10.1",
+  "version": "4.10.3",
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2993,7 +2993,7 @@
       "port-version": 0
     },
     "gtk": {
-      "baseline": "4.10.1",
+      "baseline": "4.10.3",
       "port-version": 0
     },
     "gtk3": {

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f6542974036eeeb96bcfa2f343a58dc9a07c54b3",
+      "version": "4.10.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "416961a907f2f0412d4d59517a904d06b4985ffb",
       "version": "4.10.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #31614

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.