### PR TITLE
[tbb]: added support for hybrid processors via hwloc

### DIFF
--- a/ports/tbb/portfile.cmake
+++ b/ports/tbb/portfile.cmake
@@ -9,9 +9,15 @@ vcpkg_from_github(
     HEAD_REF onetbb_2021
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        hwloc TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DTBB_TEST=OFF
         -DTBB_STRICT=OFF
 )

--- a/ports/tbb/vcpkg.json
+++ b/ports/tbb/vcpkg.json
@@ -1,6 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tbb",
   "version": "2021.9.0",
+  "port-version": 1,
   "description": "Intel's Threading Building Blocks.",
   "homepage": "https://github.com/oneapi-src/oneTBB",
   "license": "Apache-2.0",
@@ -14,5 +16,14 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "hwloc": {
+      "description": "Builds TBB with TBBBind support for Hibrid CPUs or NUMA architectures.",
+      "supports": "!static & !osx",
+      "dependencies": [
+        "hwloc"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7882,7 +7882,7 @@
     },
     "tbb": {
       "baseline": "2021.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tcb-span": {
       "baseline": "2021-12-15",

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "97a86c92ba0419c50673782f0b3a7f1568aaaef7",
+      "version": "2021.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3a44303f590164f98542c516a049e1328a178bc2",
       "version": "2021.9.0",
       "port-version": 0


### PR DESCRIPTION
With this patch we are adding support of hybrid processors (new tbbbind library is being built), so TBB can distinguish performance and efficient cores on both ARM and x64 processors.

Note: this applicable only for shared libraries built, because tbbbind library is built as plugin for TBB.