### PR TITLE
[bde] Updated to 3.117.0

### DIFF
--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -1,31 +1,31 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-set(CONFIGURE_COMMON_ARGS ${CONFIGURE_COMMON_ARGS} --library-type=static)
 
-set(BDE_VERSION 3.2.0.0)
-set(BDE_TOOLS_VERSION 1.x)
+set(BDE_VERSION 3.117.0.0)
+set(BDE_TOOLS_VERSION 3.117.0.0)
 
 # Paths used in build
 set(SOURCE_PATH_DEBUG ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bde-${BDE_VERSION})
 set(SOURCE_PATH_RELEASE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bde-${BDE_VERSION})
 
-# Acquire Python 2 and add it to PATH
-vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_EXE_PATH ${PYTHON2} DIRECTORY)
+# Acquire Python and add it to PATH
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
 
 # Acquire BDE Tools and add them to PATH
 vcpkg_from_github(
     OUT_SOURCE_PATH TOOLS_PATH
     REPO "bloomberg/bde-tools"
-    REF d4b1a7670829228f4ec81ecdccc598ce03ae8e80
-    SHA512 80af734c080adb225d5369157301ae0af18e02b1912351e34d23f5f2ba4e19f9ae2b5a367923f036330c9f9afd11a90cdf12680eb3e59b4297a312a1b713f17f
-    HEAD_REF master
+    REF 3.117.0.0
+    SHA512 3c39da8d1ea40459e36e11ada93cc2821ae1b16a831f93cccab463996394a400cc08bb1654642eae1aa5187f139d7fb80c4729e464051eee182133eb8a74158d
+    HEAD_REF 3.117.0.0
 )
+
 message(STATUS "Configure bde-tools-v${BDE_TOOLS_VERSION}")
 if(VCPKG_CMAKE_SYSTEM_NAME)
-    set(ENV{PATH} "$ENV{PATH}:${PYTHON2_EXE_PATH}")
+    set(ENV{PATH} "$ENV{PATH}:${PYTHON3_EXE_PATH}")
     set(ENV{PATH} "$ENV{PATH}:${TOOLS_PATH}/bin")
 else()
-    set(ENV{PATH} "$ENV{PATH};${PYTHON2_EXE_PATH}")
+    set(ENV{PATH} "$ENV{PATH};${PYTHON3_EXE_PATH}")
     set(ENV{PATH} "$ENV{PATH};${TOOLS_PATH}/bin")
 endif()
 
@@ -33,101 +33,47 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "bloomberg/bde"
-    REF 3720d132d0879f19b9084cca62ebc75f1f24e1a3
-    SHA512 234ebb71997f5b7d3951584235ead10f977689cef323ae1c198629a6b1995b1481d8a1515d827c46df10209bdc66e1f3cc7780dafee9ca0ff4172be47c460d78
-    HEAD_REF master
+    REF 3.117.0.0
+    SHA512 810b4a06a08739dcd990751dd543aa7dc58355f9d64a7c96ef0cf45c81501946434db42ad5bcf5d16110d5a463586b587ce09a446136e824298f39a8a871b490
+    HEAD_REF 3.117.0.0
 )
 
 # Clean up previous builds
 file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel
                     ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
 
-# Identify waf executable and calculate configure args
-if(VCPKG_CMAKE_SYSTEM_NAME)
-    set(WAF_COMMAND waf)
-else()
-    set(WAF_COMMAND waf.bat)
-endif()
-set(CONFIGURE_COMMON_ARGS ${CONFIGURE_COMMON_ARGS} --use-flat-include-dir)
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-    set(CONFIGURE_COMMON_ARGS ${CONFIGURE_COMMON_ARGS} --abi-bits=32)
-elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    set(CONFIGURE_COMMON_ARGS ${CONFIGURE_COMMON_ARGS} --abi-bits=64)
-else()
-    message(FATAL_ERROR "Unsupported target architecture: ${VCPKG_TARGET_ARCHITECTURE}")
-endif()
-if(VCPKG_TARGET_IS_WINDOWS)
-    set(CONFIGURE_COMMON_ARGS ${CONFIGURE_COMMON_ARGS} --msvc-runtime-type=static)
-else()
-    set(ENV{CFLAGS} "$ENV{CFLAGS} -Wno-error=implicit-function-declaration")
-endif()
-
-# Configure debug
-message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
-vcpkg_execute_required_process(
-    COMMAND ${WAF_COMMAND} configure ${CONFIGURE_COMMON_ARGS}
-            --prefix=${CURRENT_PACKAGES_DIR}/debug --out=${SOURCE_PATH_DEBUG}
-            --build-type=debug
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME configure-${TARGET_TRIPLET}--dbg
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    cxx17 BDE_USE_CXX17
 )
-message(STATUS "Configuring ${TARGET_TRIPLET}-dbg done")
 
-# Build debug
-message(STATUS "Building ${TARGET_TRIPLET}-dbg")
-vcpkg_execute_required_process(
-    COMMAND ${WAF_COMMAND} build
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME build-${TARGET_TRIPLET}--dbg
-)
-message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
-
-# Install debug
-message(STATUS "Installing ${TARGET_TRIPLET}-dbg")
-vcpkg_execute_required_process(
-    COMMAND ${WAF_COMMAND} install
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME install-${TARGET_TRIPLET}--dbg
-)
-# Include files should not be duplicated
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-# pkg-config files should point to correct include directory
-file(GLOB PC_FILES "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
-foreach(PC_FILE_NAME ${PC_FILES})
-    file(READ "${PC_FILE_NAME}" _contents)
-    string(REPLACE "includedir=\${prefix}/include" "includedir=\${prefix}/../include" _contents "${_contents}")
-    file(WRITE "${PC_FILE_NAME}" "${_contents}")
-endforeach()
-message(STATUS "Installing ${TARGET_TRIPLET}-dbg done")
+if (BDE_USE_CXX17)
+    set(BDE_OPTIONS "-DBDE_BUILD_TARGET_CPP17=ON" "-DCMAKE_CXX_STANDARD=17" "-DCMAKE_CXX_STANDARD_REQUIRED=ON" "-DCMAKE_CXX_EXTENSIONS=OFF")
+endif ()
 
 # Configure release
-message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
-vcpkg_execute_required_process(
-    COMMAND ${WAF_COMMAND} configure ${CONFIGURE_COMMON_ARGS}
-            --prefix=${CURRENT_PACKAGES_DIR} --out=${SOURCE_PATH_RELEASE}
-            --build-type=release
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME configure-${TARGET_TRIPLET}--rel
+if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    list(APPEND BDE_OPTIONS "-DBDE_BUILD_TARGET_OPT=1")
+else()
+    list(APPEND BDE_OPTIONS "-DBDE_BUILD_TARGET_DBG=1")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
+    OPTIONS 
+    ${BDE_OPTIONS}
+    -DBBS_BUILD_SYSTEM=1
+    -DBdeBuildSystem_DIR:PATH=${TOOLS_PATH}/BdeBuildSystem
 )
-message(STATUS "Configuring ${TARGET_TRIPLET}-rel done")
 
 # Build release
-message(STATUS "Building ${TARGET_TRIPLET}-rel")
-vcpkg_execute_required_process(
-    COMMAND ${WAF_COMMAND} build
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME build-${TARGET_TRIPLET}--rel
-)
-message(STATUS "Building ${TARGET_TRIPLET}-rel done")
+vcpkg_cmake_build()
 
 # Install release
-message(STATUS "Installing ${TARGET_TRIPLET}-rel")
-vcpkg_execute_required_process(
-    COMMAND ${WAF_COMMAND} install
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME install-${TARGET_TRIPLET}--rel
-)
-message(STATUS "Installing ${TARGET_TRIPLET}-rel done")
+vcpkg_cmake_install()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "bde",
   "version": "3.117.0.0",
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
-  "supports": "!windows & !arm",
+  "supports": "!windows & !arm & !android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "bde",
   "version": "3.117.0.0",
-  "port-version": 7,
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
   "supports": "!windows & !arm",
   "dependencies": [

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,7 +1,22 @@
 {
   "name": "bde",
-  "version": "3.2.0.0",
-  "port-version": 5,
+  "version": "3.117.0.0",
+  "port-version": 7,
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
-  "supports": "!windows & !arm"
+  "supports": "!windows & !arm",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cxx17": {
+      "description": "Enable compiler C++17."
+    }
+  }
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -71,9 +71,6 @@ azure-identity-cpp:x64-android=fail
 backward-cpp:arm-neon-android=fail
 backward-cpp:arm64-android=fail
 backward-cpp:x64-android=fail
-bde:x64-android=fail
-# broken when `python` is python3, https://github.com/microsoft/vcpkg/issues/18937
-bde:x64-linux=fail
 bento4:arm-neon-android=fail
 berkeleydb:arm-neon-android=fail
 berkeleydb:arm64-android=fail

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,34 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "7ce72f2854f44eee806e6e5f3e97d29897549787",
-      "version": "3.2.0.0",
-      "port-version": 5
-    },
-    {
-      "git-tree": "60082ad73e5c9fb9828041183b026fc15e453218",
-      "version-string": "3.2.0.0",
-      "port-version": 4
-    },
-    {
-      "git-tree": "b940e98efec0d1f48f2edfe2027d2bce251ec7a8",
-      "version-string": "3.2.0.0",
-      "port-version": 3
-    },
-    {
-      "git-tree": "b1182a3ba7b24edd58e7471796c1f157c9ff402c",
-      "version-string": "3.2.0.0",
-      "port-version": 2
-    },
-    {
-      "git-tree": "d25bfe5e576d146569520871134a5c6fecb16a96",
-      "version-string": "3.2.0.0-1",
-      "port-version": 0
-    },
-    {
-      "git-tree": "0ee2aa4b9efbf8de1fc277f0064e6022fbfac778",
-      "version-string": "3.2.0.0",
-      "port-version": 0
+      "version": "3.117.0.0",
+      "port-version": 7,
+      "git-tree": "a0f1c365cbd5416461e4ce0d5fcae7b30177a9c0"
     }
   ]
 }

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "2f927afdb589cbdf4e2886eb046feef153f3dfeb",
+      "git-tree": "d1d4edb4c8f1d945cc02063d71f336f4a4ccd568",
       "version": "3.117.0.0",
-      "port-version": 7
+      "port-version": 0
     },
     {
       "git-tree": "7ce72f2854f44eee806e6e5f3e97d29897549787",

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -4,6 +4,36 @@
       "git-tree": "2f927afdb589cbdf4e2886eb046feef153f3dfeb",
       "version": "3.117.0.0",
       "port-version": 7
+    },
+    {
+      "git-tree": "7ce72f2854f44eee806e6e5f3e97d29897549787",
+      "version": "3.2.0.0",
+      "port-version": 5
+    },
+    {
+      "git-tree": "60082ad73e5c9fb9828041183b026fc15e453218",
+      "version-string": "3.2.0.0",
+      "port-version": 4
+    },
+    {
+      "git-tree": "b940e98efec0d1f48f2edfe2027d2bce251ec7a8",
+      "version-string": "3.2.0.0",
+      "port-version": 3
+    },
+    {
+      "git-tree": "b1182a3ba7b24edd58e7471796c1f157c9ff402c",
+      "version-string": "3.2.0.0",
+      "port-version": 2
+    },
+    {
+      "git-tree": "d25bfe5e576d146569520871134a5c6fecb16a96",
+      "version-string": "3.2.0.0-1",
+      "port-version": 0
+    },
+    {
+      "git-tree": "0ee2aa4b9efbf8de1fc277f0064e6022fbfac778",
+      "version-string": "3.2.0.0",
+      "port-version": 0
     }
   ]
 }

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
+      "git-tree": "2f927afdb589cbdf4e2886eb046feef153f3dfeb",
       "version": "3.117.0.0",
-      "port-version": 7,
-      "git-tree": "a0f1c365cbd5416461e4ce0d5fcae7b30177a9c0"
+      "port-version": 7
     }
   ]
 }

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d1d4edb4c8f1d945cc02063d71f336f4a4ccd568",
+      "git-tree": "4e2c03aa72390fcf5365824064f5276c855a3787",
       "version": "3.117.0.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -493,8 +493,8 @@
       "port-version": 0
     },
     "bde": {
-      "baseline": "3.2.0.0",
-      "port-version": 5
+      "baseline": "3.117.0.0",
+      "port-version": 7
     },
     "bdwgc": {
       "baseline": "8.2.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -494,7 +494,7 @@
     },
     "bde": {
       "baseline": "3.117.0.0",
-      "port-version": 7
+      "port-version": 0
     },
     "bdwgc": {
       "baseline": "8.2.2",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/18937

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.