### PR TITLE
[libgit2] Update to 1.6.4

### DIFF
--- a/ports/libgit2/fix-configcmake.patch
+++ b/ports/libgit2/fix-configcmake.patch
@@ -19,20 +19,19 @@ index 2a3a91b8c..cbb409350 100644
  	list(APPEND LIBGIT2_PC_REQUIRES "libpcre")
  elseif(REGEX_BACKEND STREQUAL "regcomp")
  	add_feature_info(regex ON "using system regcomp")
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index e7b54d036..6b549deef 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -298,10 +298,28 @@ if(MSVC_IDE)
- endif()
+diff --git a/src/libgit2/CMakeLists.txt b/src/libgit2/CMakeLists.txt
+index 876a703e8..8283f9585 100644
+--- a/src/libgit2/CMakeLists.txt
++++ b/src/libgit2/CMakeLists.txt
+@@ -110,10 +110,28 @@ FILE(WRITE "${PROJECT_BINARY_DIR}/include/${LIBGIT2_FILENAME}.h" ${LIBGIT2_INCLU
  
  # Install
--install(TARGETS git2
-+install(TARGETS git2 EXPORT unofficial-git2Targets
+ 
+-install(TARGETS libgit2package
++install(TARGETS libgit2package EXPORT unofficial-git2Targets
  	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
  	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
- 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
- )
+ 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +
 +install(EXPORT unofficial-git2Targets
 +    NAMESPACE unofficial::git2::
@@ -51,5 +50,6 @@ index e7b54d036..6b549deef 100644
 +configure_file("${CMAKE_CURRENT_BINARY_DIR}/unofficial-git2-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/unofficial-git2-config.cmake" @ONLY)
 +install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-git2-config.cmake DESTINATION share/unofficial-git2)
 +
- install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/git2 DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
- install(FILES ${PROJECT_SOURCE_DIR}/include/git2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/git2/
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBGIT2_FILENAME}")
+ install(FILES ${PROJECT_BINARY_DIR}/include/git2/experimental.h

--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libgit2/libgit2
-    REF v1.4.2
-    SHA512 144bec7f8e66d97b20335d87d1eb68d522f5e59064b0c557505c088d3c486d45704f023d701f51de572efa8e2eb111e3136eb5d23c035e29d16698206b5ec277
-    HEAD_REF maint/v1.4
+    REF v1.6.4
+    SHA512 fd73df91710f19b0d6c3765c37c7f529233196da91cf4d58028a8d3840244f11df44abafabd74a8ed1cbe4826d1afd6ff9f01316d183ace0924c65e7cf0eb8d5
+    HEAD_REF maint/v1.6
     PATCHES
         fix-configcmake.patch
 )
@@ -30,7 +30,7 @@ function(set_tls_backend VALUE)
 endfunction()
 
 if("openssl" IN_LIST FEATURES)
-    list(APPEND GIT_OPTIONS "-DGIT_OPENSSL=1")  
+    list(APPEND GIT_OPTIONS "-DGIT_OPENSSL=1")
 endif()
 
 foreach(GIT2_FEATURE ${FEATURES})
@@ -67,6 +67,7 @@ vcpkg_cmake_configure(
         -DUSE_HTTPS=${USE_HTTPS}
         -DREGEX_BACKEND=${REGEX_BACKEND}
         -DSTATIC_CRT=${STATIC_CRT}
+        -DBUILD_CLI=OFF
         ${GIT2_FEATURES}
         ${GIT_OPTIONS}
 )

--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libgit2",
-  "version-semver": "1.4.2",
-  "port-version": 3,
+  "version-semver": "1.6.4",
   "description": "Git linkable library",
   "homepage": "https://github.com/libgit2/libgit2",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4061,8 +4061,8 @@
       "port-version": 2
     },
     "libgit2": {
-      "baseline": "1.4.2",
-      "port-version": 3
+      "baseline": "1.6.4",
+      "port-version": 0
     },
     "libgme": {
       "baseline": "0.6.3",

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e400f294d284f6a7ff3a19b2454c919873405f08",
+      "version-semver": "1.6.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "7c2173f86743e6e3c6759d5c781f236c08adbec4",
       "version-semver": "1.4.2",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

