### PR TITLE
[starlink-ast] Switch tarball, misc fixes

### DIFF
--- a/ports/starlink-ast/cminpack.diff
+++ b/ports/starlink-ast/cminpack.diff
@@ -1,3 +1,36 @@
+diff --git a/Makefile.in b/Makefile.in
+index a935107..51c5e07 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1572,13 +1572,13 @@ libast_la_SOURCES = \
+ libast_la_LDFLAGS = -version-info @version_info@
+ @EXTERNAL_CMINPACK_FALSE@@EXTERNAL_PAL_FALSE@libast_la_LIBADD = libast_pal.la libast_cminpack.la
+ @EXTERNAL_CMINPACK_FALSE@@EXTERNAL_PAL_TRUE@libast_la_LIBADD = -lpal libast_cminpack.la
+-@EXTERNAL_CMINPACK_TRUE@@EXTERNAL_PAL_FALSE@libast_la_LIBADD = libast_pal.la -lcminpack
++@EXTERNAL_CMINPACK_TRUE@@EXTERNAL_PAL_FALSE@libast_la_LIBADD = libast_pal.la $(LIBCMINPACK)
+ 
+ # Ensure libast links against libraries containing functions used within
+ # libast. If AST is configured --with-external-pal, then the internal
+ # libast_pal library will be empty, and we link to an external PAL
+ # library instead. Do the same for cminpack
+-@EXTERNAL_CMINPACK_TRUE@@EXTERNAL_PAL_TRUE@libast_la_LIBADD = -lpal -lcminpack
++@EXTERNAL_CMINPACK_TRUE@@EXTERNAL_PAL_TRUE@libast_la_LIBADD = -lpal $(LIBCMINPACK)
+ 
+ # AST_PAR is really part of GRP_F_INCLUDE_FILES, but it must not be
+ # distributed, so list it separately.
+diff --git a/configure b/configure
+index d9db3ee..f3d3fc0 100755
+--- a/configure
++++ b/configure
+@@ -15763,7 +15763,7 @@ fi
+ EXTERNAL_CMINPACK=$external_cminpack
+ 
+ if test "$external_cminpack" = "1"; then
+-   LIBCMINPACK="-lcminpack"
++   LIBCMINPACK="-lcminpack$CMINPACK_DEBUG_SUFFIX"
+ 
+ 
+ $as_echo "#define EXTERNAL_CMINPACK 1" >>confdefs.h
 diff --git a/src/polymap.c b/src/polymap.c
 index 0b436cc..1aee268 100644
 --- a/src/polymap.c

--- a/ports/starlink-ast/portfile.cmake
+++ b/ports/starlink-ast/portfile.cmake
@@ -1,35 +1,26 @@
-# There is no 9.2.10 tarball with generated `configure`.
-# Reconfiguration needs a custom starlink autoconf.
-# Cf. https://github.com/Starlink/ast/issues/21
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_download_distfile(ARCHIVE
-    # regular: "https://github.com/Starlink/ast/releases/download/v${VERSION}/ast-${VERSION}.tar.gz"
-    URLS "https://github.com/Starlink/ast/files/8843897/ast-9.2.9.tar.gz" # not a release asset or tarball
+    URLS "https://github.com/Starlink/ast/releases/download/v${VERSION}/ast-${VERSION}.tar.gz"
     FILENAME "starlink-ast-${VERSION}.tar.gz"
-    SHA512 af19cdf41e20d9e92850d90ea760bd21bc9a53ca5bb181a6e27322a610fd13cd6cef30aaf8de6193a2c3fe3c66428b3bd46492a6b22ac22f18cd9be712aa357b
+    SHA512 b559535496b88b33845bd3732bb6ee80572dc0d8d963173e0199d44be09add244244d9aab90642de84c65714bca6c73b5bdc3b3290a55f171e6f3ce7643250f5
 )
-vcpkg_download_distfile(UPDATE_DIFF
-    URLS "https://github.com/Starlink/ast/compare/v9.2.9...v${VERSION}.diff"
-    FILENAME "starlink-ast-v9.2.9...v${VERSION}.diff"
-    SHA512 fd1255eaefcfdb57273ba241fc604e3ab5eabd2212c17f10daac8fd23436f6d50272bfa35bac292097441ff5334e3d28d12ea6d7d90838f6058e05fc7067c966
-)
-file(READ "${UPDATE_DIFF}" diff)
-set(files_to_ignore "(configure\\.ac|Makefile|\\.gitignore|component\\.xml)")
-string(REGEX REPLACE "diff --git a/${files_to_ignore}[^\n]*\n([-+@ i][^\n]*\n)*" "" diff "${diff}")
-file(WRITE "${CURRENT_BUILDTREES_DIR}/update-${VERSION}.diff" "${diff}")
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         cminpack.diff
-        "${CURRENT_BUILDTREES_DIR}/update-${VERSION}.diff"
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/cminpack")
-vcpkg_replace_string("${SOURCE_PATH}/configure" "9.2.9" "9.2.10")
 
 set(CONFIGURE_OPTIONS
     --without-fortran
     --with-external-cminpack
+    "--with-starlink=${CURRENT_INSTALLED_DIR}"
+    FC=false
 )
 
 if ("yaml" IN_LIST FEATURES)
@@ -51,8 +42,13 @@ vcpkg_configure_make(
     ADDITIONAL_MSYS_PACKAGES perl
     OPTIONS
         ${CONFIGURE_OPTIONS}
+    OPTIONS_DEBUG
+        CMINPACK_DEBUG_SUFFIX=_d
 )
-vcpkg_install_make()
+vcpkg_install_make(
+    OPTIONS
+        STAR_LDFLAGS= # Do not override build type's lib dirs
+)
 
 # Avoid vcpkg artifact issues with symlinks
 foreach(ast_lib IN ITEMS "${CURRENT_PACKAGES_DIR}/lib/libast" "${CURRENT_PACKAGES_DIR}/debug/lib/libast")

--- a/ports/starlink-ast/portfile.cmake
+++ b/ports/starlink-ast/portfile.cmake
@@ -71,6 +71,13 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/${PORT}/ast"
 )
 
+# Remove cl preprocessing comments
+foreach(file IN ITEMS "include/ast.h" "include/star/ast.h")
+    file(READ "${CURRENT_PACKAGES_DIR}/${file}" cpp_output)
+    string(REGEX REPLACE "#line [^ ]+ \"[^\"]*\"" "" cpp_output "${cpp_output}")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/${file}" "${cpp_output}")
+endforeach()
+
 vcpkg_install_copyright(
     FILE_LIST
         "${SOURCE_PATH}/COPYING.LESSER"

--- a/ports/starlink-ast/vcpkg.json
+++ b/ports/starlink-ast/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "starlink-ast",
   "version": "9.2.10",
+  "port-version": 1,
   "description": "The AST library provides a comprehensive range of facilities for attaching world coordinate systems to astronomical data, for retrieving and interpreting that information and for generating graphical output based on it",
   "homepage": "https://starlink.eao.hawaii.edu/starlink/AST",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7758,7 +7758,7 @@
     },
     "starlink-ast": {
       "baseline": "9.2.10",
-      "port-version": 0
+      "port-version": 1
     },
     "staticjson": {
       "baseline": "1.0.0",

--- a/versions/s-/starlink-ast.json
+++ b/versions/s-/starlink-ast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13d3dcf5fe4db3f9c3ec43869b4a4e343c35ff65",
+      "version": "9.2.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "f79db80b697effc13bf43a3d370701e0e7a244c4",
       "version": "9.2.10",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
