### PR TITLE
[python3] force disable hashlib, ssl and tkinter

### DIFF
--- a/ports/python3/0015-force-disable-hashlib-ssl-tkinter.patch
+++ b/ports/python3/0015-force-disable-hashlib-ssl-tkinter.patch
@@ -1,0 +1,23 @@
+From 017011941e5f17e9c98ee50b27209f97ab748f36 Mon Sep 17 00:00:00 2001
+From: Frank Yonamine <fsy0jpn@gmail.com>
+Date: Sat, 27 May 2023 08:54:06 +0200
+Subject: [PATCH 1/1] [python3] force disable hashlib ssl tkinter
+
+---
+ Modules/Setup | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Modules/Setup b/Modules/Setup
+index 7ad53f5..79ba4a4 100644
+--- a/Modules/Setup
++++ b/Modules/Setup
+@@ -379,3 +379,6 @@ xxsubtype xxsubtype.c
+ *disabled*
+ _curses
+ _curses_panel
++_hashlib
++_ssl
++_tkinter
+-- 
+2.39.2 (Apple Git-143)
+

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -30,6 +30,10 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND PATCHES 0011-gcc-ldflags-fix.patch)
 endif()
 
+if(VCPKG_TARGET_IS_OSX)
+    list(APPEND PATCHES 0015-force-disable-hashlib-ssl-tkinter.patch)
+endif()
+
 # Python 3.9 removed support for Windows 7. This patch re-adds support for Windows 7 and is therefore
 # required to build this port on Windows 7 itself due to Python using itself in its own build system.
 if("deprecated-win7-support" IN_LIST FEATURES)

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "293f815c30f6ff2b6f42020cf5b03f7e94cfea6a",
+      "version": "3.10.7",
+      "port-version": 7
+    },
+    {
       "git-tree": "d3a8a2c668d77aaf0fa1862c6b3eff5018519e19",
       "version": "3.10.7",
       "port-version": 6


### PR DESCRIPTION
Fixes #31668.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
