### PR TITLE
[openvino]: new port

### DIFF
--- a/ports/openvino/001-disable-tools.patch
+++ b/ports/openvino/001-disable-tools.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3182d12693..db70cca198 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -134,7 +134,7 @@ if (ENABLE_TESTS OR ENABLE_TEMPLATE)
+ endif()
+ include(cmake/extra_modules.cmake)
+ add_subdirectory(docs)
+-add_subdirectory(tools)
++# add_subdirectory(tools)
+ add_subdirectory(scripts)
+ add_subdirectory(licensing)
+ 

--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -1,0 +1,135 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO openvinotoolkit/openvino
+    REF 50c85f01ab44b2470f08b0f8824cced109628fc6
+    SHA512 e14ac8d48f577188522d0b80f55d53a839f843a03bf0eccf7e370a7bfe977d19e65e4f4748274baf9b0a71751bbdcb7c1e2d4270e54b1ddd72f578176f48058d
+    PATCHES
+        001-disable-tools.patch
+    HEAD_REF master)
+
+function(ov_checkout_in_path PATH REPO REF SHA512)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH DEP_SOURCE_PATH
+        REPO ${REPO}
+        REF ${REF}
+        SHA512 ${SHA512}
+    )
+
+    file(COPY "${DEP_SOURCE_PATH}/" DESTINATION "${SOURCE_PATH}/${PATH}")
+endfunction()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cpu             ENABLE_INTEL_CPU
+        gpu             ENABLE_INTEL_GPU
+        auto            ENABLE_AUTO
+        hetero          ENABLE_HETERO
+        auto-batch      ENABLE_AUTO_BATCH
+        ir              ENABLE_OV_IR_FRONTEND
+        onnx            ENABLE_OV_ONNX_FRONTEND
+        paddle          ENABLE_OV_PADDLE_FRONTEND
+        pytorch         ENABLE_OV_PYTORCH_FRONTEND
+        tensorflow      ENABLE_OV_TF_FRONTEND
+        tensorflow-lite ENABLE_OV_TF_LITE_FRONTEND
+)
+
+if(ENABLE_INTEL_GPU)
+    # python is required for conversion of OpenCL source files into .cpp.
+    vcpkg_find_acquire_program(PYTHON3)
+
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        message(WARNING
+            "OneDNN for GPU is not available for static build, which is required for dGPU."
+            "Please, consider using VCPKG_LIBRARY_LINKAGE=\"dynamic\".")
+        list(APPEND FEATURE_OPTIONS "-DENABLE_ONEDNN_FOR_GPU=OFF")
+    else()
+        ov_checkout_in_path(
+            src/plugins/intel_gpu/thirdparty/onednn_gpu
+            oneapi-src/oneDNN
+            f27dedbfc093f51032a4580198bb80579440dc15
+            882eb42e31490df1b35b5e55bef1be8452b710b7a16f5ad648961510abd288e16dbd783e0163aab9dd161fd3a9bd836b0f4afc82b14043d80d1dad9c3400af1b
+        )
+    endif()
+
+    list(APPEND FEATURE_OPTIONS
+        "-DENABLE_SYSTEM_OPENCL=ON"
+        "-DPYTHON_EXECUTABLE=${PYTHON3}")
+endif()
+
+if(ENABLE_INTEL_CPU)
+    ov_checkout_in_path(
+        src/plugins/intel_cpu/thirdparty/onednn
+        openvinotoolkit/oneDNN
+        48bf41e04ba8cdccb1e7ad166fecfb329f5f84a1
+        8a5ef1ce07545bc28328d1cfd49a8ee8f2ff13c2e393623cb842982b83963881f3d096230805d2a187100c68a2ca30c99add5a975f3f623d9f4a51517c2d585f
+    )
+
+    if(VCPKG_TARGET_ARCHITECTURE MATCHES "arm")
+        # scons (python tool) is required for ARM Compute Library building
+        vcpkg_find_acquire_program(PYTHON3)
+
+        x_vcpkg_get_python_packages(
+            PYTHON_VERSION 3
+            PYTHON_EXECUTABLE ${PYTHON3}
+            PACKAGES scons
+            OUT_PYTHON_VAR OV_PYTHON_WITH_SCONS
+        )
+
+        ov_checkout_in_path(
+            src/plugins/intel_cpu/thirdparty/ComputeLibrary
+            ARM-software/ComputeLibrary
+            v23.02.1
+            ee9439e0804bacd365f079cedc548ffe2c12b0d4a86780e0783186884eb5a6d7aa7ceac11c504e242bedc55c3d026b826c90adaafbdbd3e5cfa2562a1c4ee04d
+        )
+    endif()
+endif()
+
+if(ENABLE_OV_TF_FRONTEND OR ENABLE_OV_ONNX_FRONTEND OR ENABLE_OV_PADDLE_FRONTEND)
+    list(APPEND FEATURE_OPTIONS "-DENABLE_SYSTEM_PROTOBUF=ON")
+endif()
+
+if(ENABLE_OV_TF_FRONTEND)
+    list(APPEND FEATURE_OPTIONS "-DENABLE_SYSTEM_SNAPPY=ON")
+endif()
+
+if(ENABLE_OV_TF_LITE_FRONTEND)
+    list(APPEND FEATURE_OPTIONS "-DENABLE_SYSTEM_FLATBUFFERS=ON")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        "-DENABLE_SYSTEM_TBB=ON"
+        "-DENABLE_SYSTEM_PUGIXML=ON"
+        "-DENABLE_TBBBIND_2_5=OFF"
+        "-DENABLE_CLANG_FORMAT=OFF"
+        "-DENABLE_NCC_STYLE=OFF"
+        "-DENABLE_CPPLINT=OFF"
+        "-DENABLE_SAMPLES=OFF"
+        "-DENABLE_COMPILE_TOOL=OFF"
+        "-DENABLE_TEMPLATE=OFF"
+        "-DENABLE_INTEL_GNA=OFF"
+        "-DENABLE_PYTHON=OFF"
+        "-DENABLE_GAPI_PREPROCESSING=OFF"
+        "-DCPACK_GENERATOR=VCPKG"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/licensing/third-party-programs.txt"
+        "${SOURCE_PATH}/licensing/tbb_third-party-programs.txt"
+        "${SOURCE_PATH}/licensing/onednn_third-party-programs.txt"
+        "${SOURCE_PATH}/licensing/runtime-third-party-programs.txt"
+    COMMENT
+        "OpenVINO License")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/openvino/usage
+++ b/ports/openvino/usage
@@ -1,0 +1,4 @@
+The package OpenVINO can be used in cmake scripts as:
+
+    find_package(OpenVINO REQUIRED)
+    target_link_libraries(main PRIVATE openvino::runtime)

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "openvino",
+  "version-date": "2023-06-11",
+  "maintainers": "OpenVINO Developers <openvino@intel.com>",
+  "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
+  "description": [
+    "Intel® Distribution of OpenVINO™ toolkit is an open-source toolkit for optimizing ",
+    "and deploying AI inference. It can be used to develop applications and solutions based ",
+    "on deep learning tasks, such as: emulation of human vision, automatic speech recognition, ",
+    "natural language processing, recommendation systems, etc. It provides high-performance ",
+    "and rich deployment options, from edge to cloud"
+  ],
+  "homepage": "https://github.com/openvinotoolkit/openvino",
+  "documentation": "https://docs.openvino.ai/latest/index.html",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "ade",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
+    "pugixml",
+    {
+      "name": "tbb",
+      "platform": "static | osx",
+      "version>=": "2021.9.0#2"
+    },
+    {
+      "name": "tbb",
+      "features": [
+        "hwloc"
+      ],
+      "platform": "!static & !osx",
+      "version>=": "2021.9.0#2"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-get-python-packages",
+      "host": true
+    },
+    {
+      "name": "xbyak",
+      "platform": "!(arm | uwp)",
+      "version>=": "6.69"
+    }
+  ],
+  "default-features": [
+    "auto",
+    "auto-batch",
+    "default-features",
+    "hetero",
+    "ir",
+    "onnx",
+    "paddle",
+    "pytorch",
+    "tensorflow",
+    "tensorflow-lite"
+  ],
+  "features": {
+    "auto": {
+      "description": "Enables Auto plugin for inference"
+    },
+    "auto-batch": {
+      "description": "Enables Auto Batch plugin for inference, useful for throughput mode"
+    },
+    "cpu": {
+      "description": "Enables CPU plugin for inference",
+      "supports": "!(windows & arm)"
+    },
+    "default-features": {
+      "description": "Enables all default features",
+      "dependencies": [
+        {
+          "name": "openvino",
+          "features": [
+            "cpu"
+          ],
+          "platform": "!(windows & arm)"
+        },
+        {
+          "name": "openvino",
+          "features": [
+            "gpu"
+          ],
+          "platform": "x64 & !(osx | uwp) & !static"
+        }
+      ]
+    },
+    "gpu": {
+      "description": "Enables GPU plugin for inference",
+      "supports": "x64 & !(osx | uwp) & !static",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "hetero": {
+      "description": "Enables Hetero plugin for inference"
+    },
+    "ir": {
+      "description": "Enables IR frontend for reading models in OpenVINO IR format"
+    },
+    "onnx": {
+      "description": "Enables ONNX frontend for reading models in ONNX format",
+      "dependencies": [
+        {
+          "name": "onnx",
+          "version>=": "1.13.1"
+        },
+        {
+          "name": "protobuf",
+          "version>=": "3.20.3"
+        },
+        {
+          "name": "protobuf",
+          "host": true,
+          "version>=": "3.20.3"
+        }
+      ]
+    },
+    "paddle": {
+      "description": "Enables PaddlePaddle frontend for reading models in PaddlePaddle format",
+      "dependencies": [
+        {
+          "name": "protobuf",
+          "version>=": "3.20.3"
+        },
+        {
+          "name": "protobuf",
+          "host": true,
+          "version>=": "3.20.3"
+        }
+      ]
+    },
+    "pytorch": {
+      "description": "Enables PyTorch frontend to convert models in PyTorch format"
+    },
+    "tensorflow": {
+      "description": "Enables TensorFlow frontend for reading models in TensorFlow format",
+      "dependencies": [
+        {
+          "name": "protobuf",
+          "version>=": "3.20.3"
+        },
+        {
+          "name": "protobuf",
+          "host": true,
+          "version>=": "3.20.3"
+        },
+        "snappy"
+      ]
+    },
+    "tensorflow-lite": {
+      "description": "Enables TensorFlow Lite frontend for reading models in TensorFlow Lite format",
+      "dependencies": [
+        {
+          "name": "flatbuffers",
+          "version>=": "2.0.6"
+        },
+        {
+          "name": "flatbuffers",
+          "host": true,
+          "version>=": "2.0.6"
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6032,6 +6032,10 @@
       "baseline": "10.0.0",
       "port-version": 2
     },
+    "openvino": {
+      "baseline": "2023-06-11",
+      "port-version": 0
+    },
     "openvpn3": {
       "baseline": "3.7.0",
       "port-version": 1

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "85c70516c12c1c3544e7a2996e6f83e35aa6a88f",
+      "version-date": "2023-06-11",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Version 2023.0.0-plus is provided (it's based on current OpenVINO 2023.0.0 release plus extra fixes to support dependencies from vcpkg). This is why we were suggested to use `version-date` as a current versioning scheme. Later, It's supposed that once new is out, we will use typical `version` consisting of gidits.

**Description:** OpenVINO is Intel solution for inference of deep learning models. This can be useful for a lot of customers who already uses vcpkg as their dependency manager.

**Note:** OpenVINO core team will maintain this port and provide all updates when new versions are out.
In case of any issues, we are also ready to fix all bugs / answer all questions.