### PR TITLE
[bdwgc] Update to v8.2.4

### DIFF
--- a/ports/bdwgc/portfile.cmake
+++ b/ports/bdwgc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ivmai/bdwgc
-    REF v8.2.2
-    SHA512 da6a2de30f096610ea1c0de1ff7a3ab434debaa39199bc1426daff620901fc76e5747e43171d742b17f4afa3c77ef447cba4fda69d76a711e108f3f03af917ca
+    REF v8.2.4
+    SHA512 323d65a867f95cfbf5ecb0ff57e8dede0282cffd0d75153526e50282fe019b2e9b3a0cf16d551654832bd4f01ce8f8461590bfc5f4ea9b5eed80384321d369d7
     HEAD_REF master
 )
 

--- a/ports/bdwgc/vcpkg.json
+++ b/ports/bdwgc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bdwgc",
-  "version": "8.2.2",
+  "version": "8.2.4",
   "description": "The Boehm-Demers-Weiser conservative C/C++ Garbage Collector (libgc, bdwgc, boehm-gc)",
   "homepage": "https://www.hboehm.info/gc/",
   "license": "MIT",

--- a/versions/b-/bdwgc.json
+++ b/versions/b-/bdwgc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12a48f09e61ae946a6858c69e2c40688bdff3980",
+      "version": "8.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "f99370553e85e9f6a10878253cdee86883b0ff30",
       "version": "8.2.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -497,7 +497,7 @@
       "port-version": 5
     },
     "bdwgc": {
-      "baseline": "8.2.2",
+      "baseline": "8.2.4",
       "port-version": 0
     },
     "beast": {


### PR DESCRIPTION
* Change REF from v8.2.2 to v8.2.4

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
