### PR TITLE
[icu] fix rpath setting in osx dynamic debug build 

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -88,53 +88,58 @@ if(VCPKG_TARGET_IS_OSX AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     if("tools" IN_LIST FEATURES)
         set(LIBICUTU_RPATH "libicutu")
     endif()
-    # add ID_PREFIX to libicudata libicui18n libicuio libicutu libicuuc
-    foreach(LIB_NAME IN ITEMS libicudata libicui18n libicuio ${LIBICUTU_RPATH} libicuuc)
-        vcpkg_execute_build_process(
-            COMMAND "${INSTALL_NAME_TOOL}" -id "${ID_PREFIX}/${LIB_NAME}.${ICU_VERSION_MAJOR}.dylib"
-            "${LIB_NAME}.${VERSION}.dylib"
-            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
-            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
-        )
-    endforeach()
 
-    # add ID_PREFIX to libicui18n libicuio libicutu dependencies
-    foreach(LIB_NAME IN ITEMS libicui18n libicuio)
-        vcpkg_execute_build_process(
-            COMMAND "${INSTALL_NAME_TOOL}" -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
-                                                "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
-                                                "${LIB_NAME}.${VERSION}.dylib"
-            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
-            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
-        )
+    #31680: Fix @rpath in both debug and release build
+    foreach(CONFIG_TRIPLE IN ITEMS ${DEBUG_TRIPLET} ${RELEASE_TRIPLET})
+        # add ID_PREFIX to libicudata libicui18n libicuio libicutu libicuuc
+        foreach(LIB_NAME IN ITEMS libicudata libicui18n libicuio ${LIBICUTU_RPATH} libicuuc)
+            vcpkg_execute_build_process(
+                COMMAND "${INSTALL_NAME_TOOL}" -id "${ID_PREFIX}/${LIB_NAME}.${ICU_VERSION_MAJOR}.dylib"
+                "${LIB_NAME}.${VERSION}.dylib"
+                WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${CONFIG_TRIPLE}/lib"
+                LOGNAME "make-build-fix-rpath-${CONFIG_TRIPLE}"
+            )
+        endforeach()
+
+        # add ID_PREFIX to libicui18n libicuio libicutu dependencies
+        foreach(LIB_NAME IN ITEMS libicui18n libicuio)
+            vcpkg_execute_build_process(
+                COMMAND "${INSTALL_NAME_TOOL}" -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                    "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                    "${LIB_NAME}.${VERSION}.dylib"
+                WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${CONFIG_TRIPLE}/lib"
+                LOGNAME "make-build-fix-rpath-${CONFIG_TRIPLE}"
+            )
+            vcpkg_execute_build_process(
+                COMMAND "${INSTALL_NAME_TOOL}" -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                    "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                    "${LIB_NAME}.${VERSION}.dylib"
+                WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${CONFIG_TRIPLE}/lib"
+                LOGNAME "make-build-fix-rpath-${CONFIG_TRIPLE}"
+            )
+        endforeach()
+
+        # add ID_PREFIX to remaining libicuio libicutu dependencies
+        foreach(LIB_NAME libicuio libicutu)
+            vcpkg_execute_build_process(
+                COMMAND "${INSTALL_NAME_TOOL}" -change "libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                    "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                    "${LIB_NAME}.${VERSION}.dylib"
+                WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${CONFIG_TRIPLE}/lib"
+                LOGNAME "make-build-fix-rpath-${CONFIG_TRIPLE}"
+            )
+        endforeach()
+
+        # add ID_PREFIX to libicuuc dependencies
         vcpkg_execute_build_process(
             COMMAND "${INSTALL_NAME_TOOL}" -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
                                                 "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                                "${LIB_NAME}.${VERSION}.dylib"
-            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
-            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+                                                "libicuuc.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${CONFIG_TRIPLE}/lib"
+            LOGNAME "make-build-fix-rpath-${CONFIG_TRIPLE}"
         )
     endforeach()
 
-    # add ID_PREFIX to remaining libicuio libicutu dependencies
-    foreach(LIB_NAME libicuio libicutu)
-        vcpkg_execute_build_process(
-            COMMAND "${INSTALL_NAME_TOOL}" -change "libicui18n.${ICU_VERSION_MAJOR}.dylib"
-                                                "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
-                                                "${LIB_NAME}.${VERSION}.dylib"
-            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
-            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
-        )
-    endforeach()
-
-    # add ID_PREFIX to libicuuc dependencies
-    vcpkg_execute_build_process(
-        COMMAND "${INSTALL_NAME_TOOL}" -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                            "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                            "libicuuc.${VERSION}.dylib"
-        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
-        LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
-    )
 endif()
 
 vcpkg_install_make()

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "72.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3190,7 +3190,7 @@
     },
     "icu": {
       "baseline": "72.1",
-      "port-version": 4
+      "port-version": 5
     },
     "ideviceinstaller": {
       "baseline": "1.1.2.23",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c1735b83e7793135a9d1e3689f7d36475f6d5ff7",
+      "version": "72.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "1a0b575f86d37844108f940fd5f6a312a68d234c",
       "version": "72.1",
       "port-version": 4


### PR DESCRIPTION
Fixes #31680 and #31676:

- [x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ x] SHA512s are updated for each updated download
- [ x] The "supports" clause reflects platforms that may be fixed by this new version
- [ x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ x] Any patches that are no longer applied are deleted from the port's directory.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is added to each modified port's versions file.

