### PR TITLE
[vcpkg baseline][podofo] Fix absolute paths for .pc

### DIFF
--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -38,6 +38,9 @@ vcpkg_cmake_configure(
         CMAKE_DISABLE_FIND_PACKAGE_Boost
         CMAKE_DISABLE_FIND_PACKAGE_CppUnit
         CMAKE_DISABLE_FIND_PACKAGE_LIBCRYPTO
+        CMAKE_DISABLE_FIND_PACKAGE_FONTCONFIG
+        CMAKE_DISABLE_FIND_PACKAGE_LIBIDN
+        PODOFO_NO_FONTMANAGER
 )
 
 vcpkg_cmake_install()
@@ -53,6 +56,8 @@ find_dependency(OpenSSL)
 )
 
 vcpkg_cmake_config_fixup()
+
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/podofo/vcpkg.json
+++ b/ports/podofo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "podofo",
   "version": "0.10.0",
+  "port-version": 1,
   "description": "PoDoFo is a library to work with the PDF file format",
   "homepage": "https://sourceforge.net/projects/podofo/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6326,7 +6326,7 @@
     },
     "podofo": {
       "baseline": "0.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "poissonrecon": {
       "baseline": "2021-09-26",

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b96fb351fd118d45aa7294f9896fe186b7462507",
+      "version": "0.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "179964b988c6b05e259e8e631b2a3db4539589a1",
       "version": "0.10.0",
       "port-version": 0


### PR DESCRIPTION
Fixed issues with the vcpkg pipeline caused by #31584:
```
warning: There should be no absolute paths, such as the following, in an installed package:
    D:\packages\podofo_x86-windows
    D:\installed
    D:\buildtrees\podofo
Absolute paths were found in the following files:
    D:\packages\podofo_x86-windows\debug\lib\pkgconfig\libpodofo.pc
    D:\packages\podofo_x86-windows\lib\pkgconfig\libpodofo.pc
error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: C:\a\1\s\ports\podofo\portfile.cmake
error: building podofo:x86-windows failed with: POST_BUILD_CHECKS_FAILED
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
