### PR TITLE
[ftxui] Add version 4.1.1

### DIFF
--- a/ports/ftxui/portfile.cmake
+++ b/ports/ftxui/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ArthurSonzogni/FTXUI
     REF "v${VERSION}"
-    SHA512 989afc109e31fa083f5d953d199dc7f4515daaee7014ec1616b48bc66ff49643bc32e5cdd273016a1d44f6921f6031d1e7e41fc2375cfee44fc719223baaaa7b
+    SHA512 14de98770e8a23707455f9197e9ef3b41effc1b5b8a594a7270b1378034720f58b5a81b99653d8b1f04e003565ae4778a1e5a3d756c8cbf297e2d09e327f608e
     HEAD_REF master
 )
 
@@ -20,6 +20,11 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/ftxui.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ftxui.pc")
+file(RENAME "${CURRENT_PACKAGES_DIR}/lib/ftxui.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ftxui.pc")
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/ftxui/vcpkg.json
+++ b/ports/ftxui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ftxui",
-  "version-semver": "4.0.0",
+  "version-semver": "4.1.1",
   "description": "C++ Functional Terminal User Interface",
   "homepage": "https://github.com/ArthurSonzogni/FTXUI",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2661,7 +2661,7 @@
       "port-version": 1
     },
     "ftxui": {
-      "baseline": "4.0.0",
+      "baseline": "4.1.1",
       "port-version": 0
     },
     "function2": {

--- a/versions/f-/ftxui.json
+++ b/versions/f-/ftxui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e69be1052699ec7fee92c1aaf9b4c1e66f9d47ef",
+      "version-semver": "4.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "acaddb4b8448c853dac8d132d591fd8062692ae8",
       "version-semver": "4.0.0",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
