### PR TITLE
[vulkan-memory-allocator-hpp] Update to 3.0.1-1

### DIFF
--- a/ports/vulkan-memory-allocator-hpp/portfile.cmake
+++ b/ports/vulkan-memory-allocator-hpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO YaaZ/VulkanMemoryAllocator-Hpp
-    REF v3.0.1
-    SHA512 0631319ec892161acb85903ddeecf0b18ff6772fdb44b46c756f6c148d150ea0850f7a35f105a04e9b23baf6ea5aa9bb373e04c7be598f1caa23c22cacf4ee00
+    REF v3.0.1-1
+    SHA512 71709a889ea4527c2ee273521fe62b61bb87cda3e3c3ae2964cc18bd70ac69629aeed00b1e92d4470ba6cb08394813880018401847a6d4ed5c15e4ee1fb60ff1
     HEAD_REF master
 )
 

--- a/ports/vulkan-memory-allocator-hpp/portfile.cmake
+++ b/ports/vulkan-memory-allocator-hpp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO YaaZ/VulkanMemoryAllocator-Hpp
-    REF v3.0.1-1
+    REF "v${VERSION}"
     SHA512 71709a889ea4527c2ee273521fe62b61bb87cda3e3c3ae2964cc18bd70ac69629aeed00b1e92d4470ba6cb08394813880018401847a6d4ed5c15e4ee1fb60ff1
     HEAD_REF master
 )

--- a/ports/vulkan-memory-allocator-hpp/portfile.cmake
+++ b/ports/vulkan-memory-allocator-hpp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO YaaZ/VulkanMemoryAllocator-Hpp
-    REF "v${VERSION}"
+    REF "v3.0.1-1"
     SHA512 71709a889ea4527c2ee273521fe62b61bb87cda3e3c3ae2964cc18bd70ac69629aeed00b1e92d4470ba6cb08394813880018401847a6d4ed5c15e4ee1fb60ff1
     HEAD_REF master
 )

--- a/ports/vulkan-memory-allocator-hpp/vcpkg.json
+++ b/ports/vulkan-memory-allocator-hpp/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "name": "vulkan-memory-allocator-hpp",
-  "version": "3.0.1",
-  "port-version": 1,
+  "version": "3.0.1-1",
   "description": "C++ bindings for VulkanMemoryAllocator",
   "homepage": "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp",
   "license": "CC0-1.0",
   "supports": "!uwp & !xbox",
   "dependencies": [
-    "vulkan"
+    "vulkan",
+    "vulkan-memory-allocator"
   ]
 }

--- a/ports/vulkan-memory-allocator-hpp/vcpkg.json
+++ b/ports/vulkan-memory-allocator-hpp/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "vulkan-memory-allocator-hpp",
   "version": "3.0.1-1",
-  "port-version": 1,
-  "description": "C++ bindings for VulkanMemoryAllocator",
+  "description": "C++ bindings for VulkanMemoryAllocator (Development branch)",
   "homepage": "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp",
   "license": "CC0-1.0",
   "supports": "!uwp & !xbox",

--- a/ports/vulkan-memory-allocator-hpp/vcpkg.json
+++ b/ports/vulkan-memory-allocator-hpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vulkan-memory-allocator-hpp",
   "version": "3.0.1-1",
+  "port-version": 1,
   "description": "C++ bindings for VulkanMemoryAllocator",
   "homepage": "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp",
   "license": "CC0-1.0",

--- a/ports/vulkan-memory-allocator-hpp/vcpkg.json
+++ b/ports/vulkan-memory-allocator-hpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vulkan-memory-allocator-hpp",
   "version": "3.0.1-1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ bindings for VulkanMemoryAllocator",
   "homepage": "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp",
   "license": "CC0-1.0",

--- a/ports/vulkan-memory-allocator-hpp/vcpkg.json
+++ b/ports/vulkan-memory-allocator-hpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vulkan-memory-allocator-hpp",
   "version": "3.0.1-1",
-  "port-version": 2,
+  "port-version": 1,
   "description": "C++ bindings for VulkanMemoryAllocator",
   "homepage": "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp",
   "license": "CC0-1.0",

--- a/ports/vulkan-memory-allocator-hpp/vcpkg.json
+++ b/ports/vulkan-memory-allocator-hpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vulkan-memory-allocator-hpp",
-  "version": "3.0.1-1",
+  "version": "3.0.1.1",
   "description": "C++ bindings for VulkanMemoryAllocator (Development branch)",
   "homepage": "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp",
   "license": "CC0-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8501,7 +8501,7 @@
       "port-version": 1
     },
     "vulkan-memory-allocator-hpp": {
-      "baseline": "3.0.1-1",
+      "baseline": "3.0.1.1",
       "port-version": 0
     },
     "vvenc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8501,7 +8501,7 @@
       "port-version": 1
     },
     "vulkan-memory-allocator-hpp": {
-      "baseline": "3.0.1-1",
+      "baseline": "3.0.1",
       "port-version": 1
     },
     "vvenc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8502,7 +8502,7 @@
     },
     "vulkan-memory-allocator-hpp": {
       "baseline": "3.0.1-1",
-      "port-version": 0
+      "port-version": 1
     },
     "vvenc": {
       "baseline": "1.7.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8501,8 +8501,8 @@
       "port-version": 1
     },
     "vulkan-memory-allocator-hpp": {
-      "baseline": "3.0.1",
-      "port-version": 1
+      "baseline": "3.0.1-1",
+      "port-version": 0
     },
     "vvenc": {
       "baseline": "1.7.0",

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e02f9ea4ffed5cc76773b89194af0d9990885b05",
+      "version": "3.0.1-1",
+      "port-version": 0
+    },
+    {
       "git-tree": "572ac6bfc63ddd4a37633aa76f54ff4c8325cb85",
       "version": "3.0.1",
       "port-version": 1

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80b89a75071c614dde352d2fb674b018828fe809",
+      "version": "3.0.1-1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e02f9ea4ffed5cc76773b89194af0d9990885b05",
       "version": "3.0.1-1",
       "port-version": 0

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "01dbec586cf53fae6d736cb03ca5647eb300cc69",
-      "version": "3.0.1-1",
+      "git-tree": "917058b3096f3375a29ff9960e4cae4a988655ea",
+      "version": "3.0.1.1",
       "port-version": 0
     },
     {

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "01dbec586cf53fae6d736cb03ca5647eb300cc69",
+      "version": "3.0.1-1",
+      "port-version": 0
+    },
+    {
       "git-tree": "572ac6bfc63ddd4a37633aa76f54ff4c8325cb85",
       "version": "3.0.1",
       "port-version": 1

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,16 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "80b89a75071c614dde352d2fb674b018828fe809",
-      "version": "3.0.1-1",
-      "port-version": 1
-    },
-    {
-      "git-tree": "e02f9ea4ffed5cc76773b89194af0d9990885b05",
-      "version": "3.0.1-1",
-      "port-version": 0
-    },
-    {
       "git-tree": "572ac6bfc63ddd4a37633aa76f54ff4c8325cb85",
       "version": "3.0.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
