### PR TITLE
[symengine] Update version to 0.10.1

### DIFF
--- a/ports/symengine/portfile.cmake
+++ b/ports/symengine/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO symengine/symengine
-    REF 7b1880824c2cce98787ae29a317682ba6c294484 #v0.9.0
-    SHA512 745b2616b88032ff047a28e46b703bc1912d109524f8aa411a5b7a650a6d89d3f16dc92812381e95b13bc5cf61218d2ff3db9d3809443264340eae180968cbcf
+    REF "v${VERSION}"
+    SHA512 e73f62a87d20b676cac66ce82ac93308b688ed2ac18ebdb6884bae1ae66868e1033e33908e797f86a1906f91b975e8607a02e8932db8550a677f6b41373b7934
     HEAD_REF master
 )
 
@@ -13,6 +13,7 @@ vcpkg_check_features(
         flint WITH_FLINT 
         mpfr WITH_MPFR
         tcmalloc WITH_TCMALLOC
+        llvm WITH_LLVM
 )
 
 if(integer-class-boostmp IN_LIST FEATURES)

--- a/ports/symengine/vcpkg.json
+++ b/ports/symengine/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "symengine",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "description": "SymEngine is a fast symbolic manipulation library",
   "homepage": "https://github.com/symengine/symengine",
   "license": "BSD-3-Clause",
@@ -43,6 +43,15 @@
       "dependencies": [
         "flint",
         "gmp"
+      ]
+    },
+    "llvm": {
+      "description": "Build with LLVM",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false
+        }
       ]
     },
     "mpfr": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7841,7 +7841,7 @@
       "port-version": 0
     },
     "symengine": {
-      "baseline": "0.9.0",
+      "baseline": "0.10.1",
       "port-version": 0
     },
     "systemc": {

--- a/versions/s-/symengine.json
+++ b/versions/s-/symengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63418f8cd771072202c4155627e90e280ddecf3c",
+      "version": "0.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "dd28d6549b4c7db81ef2ee9e91a4e41b0c739191",
       "version": "0.9.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/31580
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: update `symengine` version to `0.10.1`.
The feature `llvm` was tested successfully in the following triplet:

- x86-windows
- x64-windows
- x64-windows-stataic

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
