### PR TITLE
[angelscript] fix build dependency error

### DIFF
--- a/ports/angelscript/fix-dependency.patch
+++ b/ports/angelscript/fix-dependency.patch
@@ -1,0 +1,9 @@
+diff --git a/angelscript/projects/cmake/cmake/AngelscriptConfig.cmake b/angelscript/projects/cmake/cmake/AngelscriptConfig.cmake
+index 4d1ef0f..ec14fe9 100644
+--- a/angelscript/projects/cmake/cmake/AngelscriptConfig.cmake
++++ b/angelscript/projects/cmake/cmake/AngelscriptConfig.cmake
+@@ -1,2 +1,4 @@
+ include("${CMAKE_CURRENT_LIST_DIR}/AngelscriptTargets.cmake")
++include(CMakeFindDependencyMacro)
++find_dependency(Threads REQUIRED)
+ 

--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE}"
     PATCHES
         mark-threads-private.patch
+		fix-dependency.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE}"
     PATCHES
         mark-threads-private.patch
-		fix-dependency.patch
+        fix-dependency.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/angelscript/vcpkg.json
+++ b/ports/angelscript/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "angelscript",
   "version": "2.36.1",
+  "port-version": 1,
   "description": "The AngelCode Scripting Library, or AngelScript as it is also known, is an extremely flexible cross-platform scripting library designed to allow applications to extend their functionality through external scripts. It has been designed from the beginning to be an easy to use component, both for the application programmer and the script writer.",
   "homepage": "https://angelcode.com/angelscript",
   "license": "Zlib",

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b2201125685375e9427ff82e40e6db16c6bc7a94",
+      "version": "2.36.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e90e0fe54ab8038226b849471fba169157753c19",
       "version": "2.36.1",
       "port-version": 0

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b2201125685375e9427ff82e40e6db16c6bc7a94",
+      "git-tree": "5c1bc126371829227e923c11f029a539a234a483",
       "version": "2.36.1",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -118,7 +118,7 @@
     },
     "angelscript": {
       "baseline": "2.36.1",
-      "port-version": 0
+      "port-version": 1
     },
     "angle": {
       "baseline": "chromium_5414",


### PR DESCRIPTION
Fixes #31697 

Fix error:
````
CMake Error at vcpkg/installed/x64-linux/share/angelscript/AngelscriptTargets.cmake:60 (set_target_properties):
  The link interface of target "Angelscript::angelscript" contains:

    Threads::Threads

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
````

Tested usage successfully by `angelscript:x64-windows` and `angelscript:x64-linux`:
````
angelscript provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(Angelscript CONFIG REQUIRED)
    target_link_libraries(main PRIVATE Angelscript::angelscript)
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
