### PR TITLE
[libb2] Fix using absolute install name in arm64-osx-dynamic triple

### DIFF
--- a/ports/libb2/vcpkg.json
+++ b/ports/libb2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libb2",
   "version": "0.98.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp",
   "homepage": "https://github.com/BLAKE2/libb2",
   "supports": "!windows"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3854,7 +3854,7 @@
     },
     "libb2": {
       "baseline": "0.98.1",
-      "port-version": 6
+      "port-version": 7
     },
     "libbacktrace": {
       "baseline": "2021-03-14",

--- a/versions/l-/libb2.json
+++ b/versions/l-/libb2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44f6dc3f78e49afde1d14b56295ebbadf8f0d01e",
+      "version": "0.98.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "7c113e12089453e4e2cf2bbf67ad1f0b80a133a8",
       "version": "0.98.1",
       "port-version": 6


### PR DESCRIPTION
 Fix #31719:

- [ x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ x] SHA512s are updated for each updated download
- [ x] The "supports" clause reflects platforms that may be fixed by this new version
- [ x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x ] Any patches that are no longer applied are deleted from the port's directory.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is added to each modified port's versions file.