### PR TITLE
Update Vulkan Headers to 1.3.250

### DIFF
--- a/ports/vulkan-headers/portfile.cmake
+++ b/ports/vulkan-headers/portfile.cmake
@@ -1,16 +1,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/Vulkan-Headers
-    REF d732b2de303ce505169011d438178191136bfb00
-    SHA512 425d393dec95902af46f182b3d8d5d279efefddc9cbce05c2b3e4f1706fa05ff74db0a3db2adc370bf6ac25c152c66d9a96feaac8a427acdc46b1d27e69c2608
-    HEAD_REF v1.3.243
+    REF bae9700cd9425541a0f6029957f005e5ad3ef660
+    SHA512 b1a51cb868563bf044c65cab8411547b8a08ea21998f01e5be53027217ddd18ff6907d78490c08e3f14865c53436ddf092811726ae3df23a29f8edd614bdb95b
+    HEAD_REF v1.3.250
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-)
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/vulkan-headers/usage
+++ b/ports/vulkan-headers/usage
@@ -1,0 +1,4 @@
+Vulkan-Headers provides official find_package support:
+
+    find_package(VulkanHeaders CONFIG)
+    target_link_libraries(main PRIVATE Vulkan::Headers)

--- a/ports/vulkan-headers/vcpkg.json
+++ b/ports/vulkan-headers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vulkan-headers",
-  "version": "1.3.243",
+  "version": "1.3.250",
   "port-version": 2,
   "description": "Vulkan header files and API registry",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Headers",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8489,7 +8489,7 @@
       "port-version": 6
     },
     "vulkan-headers": {
-      "baseline": "1.3.243",
+      "baseline": "1.3.250",
       "port-version": 2
     },
     "vulkan-hpp": {

--- a/versions/v-/vulkan-headers.json
+++ b/versions/v-/vulkan-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "58c480d0beaa5a34988bd99c452a6fcbfe08721a",
+      "version": "1.3.250",
+      "port-version": 2
+    },
+    {
       "git-tree": "535abf6f9fe02ff97da42e5594a4c1fd55190ec1",
       "version": "1.3.243",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.