### PR TITLE
[bit7z] new port bit7z

### DIFF
--- a/ports/bit7z/0001-Fix-using-vcpkg-7z-package-and-install.patch
+++ b/ports/bit7z/0001-Fix-using-vcpkg-7z-package-and-install.patch
@@ -1,0 +1,113 @@
+From 3f1705653f2ad7fbc9f0e4563f6e4fa92585a889 Mon Sep 17 00:00:00 2001
+From: uuiid <957714080@qq.com>
+Date: Wed, 29 Mar 2023 09:14:44 +0800
+Subject: [PATCH] Fix using vcpkg 7z package and install
+
+---
+ CMakeLists.txt        | 39 +++++++++++++++++++++++++++++++++------
+ bit7z-config.cmake.in |  7 +++++++
+ tests/CMakeLists.txt  |  4 +---
+ 3 files changed, 41 insertions(+), 9 deletions(-)
+ create mode 100644 bit7z-config.cmake.in
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 41476ca..b980aaa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,7 +16,7 @@ if( POLICY CMP0076 )
+ endif()
+ 
+ set( EXTERNAL_LIBS_DIR ${PROJECT_SOURCE_DIR}/third_party )
+-set( 7ZIP_SOURCE_DIR ${EXTERNAL_LIBS_DIR}/7-zip )
++find_package(7zip CONFIG REQUIRED)
+ 
+ # public headers
+ set( PUBLIC_HEADERS
+@@ -172,18 +172,24 @@ message( STATUS "Language Standard: C++${CMAKE_CXX_STANDARD}" )
+ set( LIB_TARGET bit7z${ARCH_POSTFIX} )
+ add_library( ${LIB_TARGET} STATIC )
+ target_sources( ${LIB_TARGET}
+-                PUBLIC ${PUBLIC_HEADERS}
++                # PUBLIC ${PUBLIC_HEADERS}
+                 PRIVATE ${HEADERS} ${SOURCES} )
+ 
++target_sources(${LIB_TARGET}
++    PUBLIC
++    FILE_SET bit7z_headers TYPE HEADERS
++    BASE_DIRS ${CMAKE_CURRENT_LIST_DIR}/include
++    FILES ${PUBLIC_HEADERS}
++)
++
++target_link_libraries(${LIB_TARGET} PRIVATE 7zip::7zip)
+ # public includes
+ target_include_directories( ${LIB_TARGET} PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+                                                  "$<INSTALL_INTERFACE:include>" )
+ 
+ # private includes
+ target_include_directories( ${LIB_TARGET} PRIVATE "${PROJECT_SOURCE_DIR}/include/bit7z"
+-                                                  "${PROJECT_SOURCE_DIR}/src"
+-                                                  "${EXTERNAL_LIBS_DIR}"
+-                                                  "${7ZIP_SOURCE_DIR}/CPP/" )
++                                                  "${PROJECT_SOURCE_DIR}/src" )
+ 
+ # 7-zip compilation definitions
+ target_compile_definitions( ${LIB_TARGET} PRIVATE UNICODE _UNICODE )
+@@ -212,4 +218,25 @@ endif()
+ if( BIT7Z_BUILD_DOCS )
+     # docs
+     add_subdirectory( docs )
+-endif()
+\ No newline at end of file
++endif()
++    
++install(
++    TARGETS ${LIB_TARGET}
++    EXPORT ${PROJECT_NAME}_target
++    ARCHIVE DESTINATION lib
++    LIBRARY DESTINATION lib
++    RUNTIME DESTINATION bin
++    FILE_SET bit7z_headers
++)
++
++
++include(CMakePackageConfigHelpers)
++configure_package_config_file(${PROJECT_NAME}-config.cmake.in ${PROJECT_NAME}-config.cmake INSTALL_DESTINATION share/${PROJECT_NAME})
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake DESTINATION share/${PROJECT_NAME})
++
++install(
++    EXPORT ${PROJECT_NAME}_target
++    NAMESPACE ${PROJECT_NAME}::
++    FILE ${PROJECT_NAME}-targets.cmake
++    DESTINATION share/${PROJECT_NAME}
++)
+diff --git a/bit7z-config.cmake.in b/bit7z-config.cmake.in
+new file mode 100644
+index 0000000..f7037d8
+--- /dev/null
++++ b/bit7z-config.cmake.in
+@@ -0,0 +1,7 @@
++@PACKAGE_INIT@
++
++include(CMakeFindDependencyMacro)
++
++find_dependency(7zip CONFIG)
++
++include("${CMAKE_CURRENT_LIST_DIR}/bit7z-targets.cmake")
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index a0e139c..f6ff95d 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -28,9 +28,7 @@ set( CMAKE_CXX_STANDARD_LIBRARIES "" )
+ 
+ target_link_libraries( ${TESTS_TARGET} PRIVATE ${LIB_TARGET} )
+ target_include_directories( ${TESTS_TARGET} PRIVATE "${PROJECT_SOURCE_DIR}/include/bit7z"
+-                                                    "${PROJECT_SOURCE_DIR}/src"
+-                                                    "${EXTERNAL_LIBS_DIR}"
+-                                                    "${7ZIP_SOURCE_DIR}/CPP/" )
++                                                    "${PROJECT_SOURCE_DIR}/src" )
+ 
+ if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+     if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.6 )
+-- 
+2.39.2.windows.1
+

--- a/ports/bit7z/0001-Fix-using-vcpkg-7z-package-and-install.patch
+++ b/ports/bit7z/0001-Fix-using-vcpkg-7z-package-and-install.patch
@@ -1,6 +1,6 @@
-From 3f1705653f2ad7fbc9f0e4563f6e4fa92585a889 Mon Sep 17 00:00:00 2001
+From f0f324b2c075e44c60104539b65254337856fe0a Mon Sep 17 00:00:00 2001
 From: uuiid <957714080@qq.com>
-Date: Wed, 29 Mar 2023 09:14:44 +0800
+Date: Mon, 5 Jun 2023 13:08:47 +0800
 Subject: [PATCH] Fix using vcpkg 7z package and install
 
 ---
@@ -11,7 +11,7 @@ Subject: [PATCH] Fix using vcpkg 7z package and install
  create mode 100644 bit7z-config.cmake.in
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 41476ca..b980aaa 100644
+index 41476ca..efb7968 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -16,7 +16,7 @@ if( POLICY CMP0076 )
@@ -71,12 +71,12 @@ index 41476ca..b980aaa 100644
 +
 +
 +include(CMakePackageConfigHelpers)
-+configure_package_config_file(${PROJECT_NAME}-config.cmake.in ${PROJECT_NAME}-config.cmake INSTALL_DESTINATION share/${PROJECT_NAME})
-+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake DESTINATION share/${PROJECT_NAME})
++configure_package_config_file(${PROJECT_NAME}-config.cmake.in unofficial-${PROJECT_NAME}-config.cmake INSTALL_DESTINATION share/${PROJECT_NAME})
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake DESTINATION share/${PROJECT_NAME})
 +
 +install(
 +    EXPORT ${PROJECT_NAME}_target
-+    NAMESPACE ${PROJECT_NAME}::
++    NAMESPACE unofficial::${PROJECT_NAME}::
 +    FILE ${PROJECT_NAME}-targets.cmake
 +    DESTINATION share/${PROJECT_NAME}
 +)
@@ -109,5 +109,5 @@ index a0e139c..f6ff95d 100644
  if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
      if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.6 )
 -- 
-2.39.2.windows.1
+2.40.1.windows.1
 

--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO rikyoz/bit7z
+        REF v${VERSION}
+        SHA512 daa1d5f051a2e07cbed07b81b1dcfa0cadc78a8cb12188e775d6d5f7a9344c40d0f02105c52c4079be58d9bcd6e4dd9c8a6fc01346a7d28824ab6a32e404db4e
+        HEAD_REF master
+        PATCHES
+        0001-Fix-using-vcpkg-7z-package-and-install.patch
+)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+        FEATURES
+        auto-format            BIT7Z_AUTO_FORMAT
+        regex-matching         BIT7Z_REGEX_MATCHING
+        use-std-byte           BIT7Z_USE_STD_BYTE
+        use-native-string      BIT7Z_USE_NATIVE_STRING
+        generate-pic           BIT7Z_GENERATE_PIC
+        link-libcpp            BIT7Z_LINK_LIBCPP
+        auto-prefix-long-paths BIT7Z_AUTO_PREFIX_LONG_PATHS
+        )
+
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/bit7z/vcpkg.json
+++ b/ports/bit7z/vcpkg.json
@@ -1,0 +1,51 @@
+{
+  "name": "bit7z",
+  "version": "4.0.0-rc",
+  "port-version": 1,
+  "description": "A C++ static library offering a clean and simple interface to the 7-zip shared libraries",
+  "homepage": "https://github.com/rikyoz/bit7z",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "7zip",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "auto-format",
+    "regex-matching",
+    "use-std-byte"
+  ],
+  "features": {
+    "auto-format": {
+      "description": "Enable auto format detection"
+    },
+    "regex-matching": {
+      "description": "Enable regex matching of archived files"
+    },
+    "use-std-byte": {
+      "description": "Enable using type safe byte type (like std::byte) for buffers"
+    },
+    "use-native-string": {
+      "description": "Enable using the OS native string type (e.g., std::wstring on Windows, std::string elsewhere)"
+    },
+    "generate-pic": {
+      "description": "Enable generating Position Independent Code"
+    },
+    "link-libcpp": {
+      "description": "Enable linking to libc++",
+      "supports": "!windows"
+    },
+    "auto-prefix-long-paths": {
+      "description": "Enable automatically prepend paths with Windows long path prefix",
+      "supports": "windows"
+    }
+  }
+}

--- a/ports/bit7z/vcpkg.json
+++ b/ports/bit7z/vcpkg.json
@@ -1,21 +1,20 @@
 {
   "name": "bit7z",
   "version": "4.0.0-rc",
-  "port-version": 1,
   "description": "A C++ static library offering a clean and simple interface to the 7-zip shared libraries",
   "homepage": "https://github.com/rikyoz/bit7z",
   "license": "MPL-2.0",
   "dependencies": [
+    {
+      "name": "7zip",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
-      "host": true
-    },
-    {
-      "name": "7zip",
       "host": true
     }
   ],
@@ -28,14 +27,9 @@
     "auto-format": {
       "description": "Enable auto format detection"
     },
-    "regex-matching": {
-      "description": "Enable regex matching of archived files"
-    },
-    "use-std-byte": {
-      "description": "Enable using type safe byte type (like std::byte) for buffers"
-    },
-    "use-native-string": {
-      "description": "Enable using the OS native string type (e.g., std::wstring on Windows, std::string elsewhere)"
+    "auto-prefix-long-paths": {
+      "description": "Enable automatically prepend paths with Windows long path prefix",
+      "supports": "windows"
     },
     "generate-pic": {
       "description": "Enable generating Position Independent Code"
@@ -44,8 +38,14 @@
       "description": "Enable linking to libc++",
       "supports": "!windows"
     },
-    "auto-prefix-long-paths": {
-      "description": "Enable automatically prepend paths with Windows long path prefix",
+    "regex-matching": {
+      "description": "Enable regex matching of archived files"
+    },
+    "use-native-string": {
+      "description": "Enable using the OS native string type (e.g., std::wstring on Windows, std::string elsewhere)"
+    },
+    "use-std-byte": {
+      "description": "Enable using type safe byte type (like std::byte) for buffers",
       "supports": "windows"
     }
   }

--- a/ports/bit7z/vcpkg.json
+++ b/ports/bit7z/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 1,
   "description": "A C++ static library offering a clean and simple interface to the 7-zip shared libraries",
   "homepage": "https://github.com/rikyoz/bit7z",
+  "license": "MPL-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "87419543caab4137a092aa4152837fc778b9a650",
+      "version": "4.0.0-rc",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -556,6 +556,10 @@
       "baseline": "3.0",
       "port-version": 3
     },
+    "bit7z": {
+      "baseline": "4.0.0-rc",
+      "port-version": 0
+    },
     "bitmagic": {
       "baseline": "7.12.3",
       "port-version": 0


### PR DESCRIPTION
https://github.com/rikyoz/bit7z

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

run `./vcpkg x-add-version --all ` crashes.

```
error: bit7z is not properly formatted
Run `vcpkg format-manifest ports/bit7z/vcpkg.json` to format the file
Don't forget to commit the result!

internal error: D:\a\_work\1\s\src\vcpkg\commands.add-version.cpp(437): vcpkg has crashed; no additional details are available.
Please open an issue at https://github.com/microsoft/vcpkg/issues/new?template=other-type-of-bug-report.md&labels=category:vcpkg-bug with detailed steps to reproduce the problem.
```


