### PR TITLE
[libphonenumber] Update to 8.13.13

### DIFF
--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/libphonenumber
     REF "v${VERSION}"
-    SHA512 e685bb9501104527ceec9af7ac424a5f642f6960454fe5a6f10f5e6555bb6d52b68a0465c5475162e8a1ac20a0b1bfb68bd4587ffae64dc017a5c8a5efc5b09f
+    SHA512 03bd6a6c4499a7135dbfe30acfd0ede818008a1c9a40068c04c0d3cff5638ea10502e186b625534d9f06cbc69da81c470f7d7308cdd08b41428b1a2e0236f409
     HEAD_REF master
     PATCHES 
         fix-re2-identifiers.patch

--- a/ports/libphonenumber/vcpkg.json
+++ b/ports/libphonenumber/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libphonenumber",
-  "version": "8.13.11",
+  "version": "8.13.13",
   "description": "Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.",
   "license": "Apache-2.0",
   "supports": "!linux & !osx",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4393,7 +4393,7 @@
       "port-version": 1
     },
     "libphonenumber": {
-      "baseline": "8.13.11",
+      "baseline": "8.13.13",
       "port-version": 0
     },
     "libplist": {

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2289b15c4eee8082041820c9eb1bfc2cb3982cd9",
+      "version": "8.13.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "8f6bcac3d621a03907f69278cb2a1e303fa414f1",
       "version": "8.13.11",
       "port-version": 0


### PR DESCRIPTION
Fixes #31582, update libphonenumber to 8.13.13.

No feature needs to be tested, the usage test passed (header files found):
```
libphonenumber provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(libphonenumber CONFIG REQUIRED)
    target_link_libraries(main PRIVATE libphonenumber::phonenumber)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
