### PR TITLE
[rubberband] Update to 3.2.1 and use recommended sleef dependecy where supported

### DIFF
--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -14,7 +14,7 @@ else()
 endif()
 
 # Select fastest available FFT library according https://github.com/breakfastquay/rubberband/blob/default/COMPILING.md#fft-libraries-supported
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64"))
     set(FFT_LIB "fftw")
 elseif(VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
     set(FFT_LIB "fftw")

--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -13,10 +13,19 @@ else()
     set(CLI_FEATURE disabled)
 endif()
 
+# Select fastest available FFT library according https://github.com/breakfastquay/rubberband/blob/default/COMPILING.md#fft-libraries-supported
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    set(FFT_LIB "fftw")
+elseif(VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(FFT_LIB "fftw")
+else()
+    set(FFT_LIB "sleef")
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -Dfft=fftw                 # 'auto', 'builtin', 'kissfft', 'fftw', sleef', 'vdsp', 'ipp' 'FFT library to use. The default (auto) will use vDSP if available, the builtin implementation otherwise.')
+        -Dfft=${FFT_LIB}           # 'auto', 'builtin', 'kissfft', 'fftw', sleef', 'vdsp', 'ipp' 'FFT library to use. The default (auto) will use vDSP if available, the builtin implementation otherwise.')
         -Dresampler=libsamplerate  # 'auto', 'builtin', 'libsamplerate', 'speex', 'libspeexdsp', 'ipp' 'Resampler library to use. The default (auto) simply uses the builtin implementation.'
         -Dipp_path=                # 'Path to Intel IPP libraries, if selected for any of the other options.'
         -Dextra_include_dirs=      # 'Additional local header directories to search for dependencies.'

--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO breakfastquay/rubberband
     REF "v${VERSION}"
-    SHA512 953d705e4a69ed40732644b8039dae02ddf596216e484ce8625fdde796e0de35fe6ac6c4f180eabc457c98b63c3fba212afa74b731eac570bea1902b667f506f
+    SHA512 811a8dbf05fbee3e4631b49fee9fd0e23ea750ac24a9a16f20e6a7ea07e683783a9edf980c43e732b64c229db29ade3575938c4e6f9db8c4255b220eb30d9dcc
     HEAD_REF default
 )
 

--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -14,7 +14,7 @@ else()
 endif()
 
 # Select fastest available FFT library according https://github.com/breakfastquay/rubberband/blob/default/COMPILING.md#fft-libraries-supported
-if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64"))
+if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64"))
     set(FFT_LIB "fftw")
 elseif(VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
     set(FFT_LIB "fftw")

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -8,12 +8,12 @@
   "dependencies": [
     {
       "name": "fftw3",
-      "platform": "(arm & windows) | (arm64 & osx)"
+      "platform": "(arm & windows) | (x86 & windows) | (arm64 & osx)"
     },
     "libsamplerate",
     {
       "name": "sleef",
-      "platform": "!(arm & windows) & !(arm64 & osx)"
+      "platform": "!(arm & windows) & !(x86 & windows) & !(arm64 & osx)"
     },
     {
       "name": "vcpkg-tool-meson",

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -6,7 +6,14 @@
   "license": "GPL-2.0-or-later",
   "supports": "!uwp & !(windows & static)",
   "dependencies": [
-    "fftw3",
+    {
+      "name": "fftw3",
+      "platform": "(arm & windows) | (arm64 & osx)"
+    },
+    {
+      "name": "sleef",
+      "platform": "!(arm & windows) & !(arm64 & osx)"
+    },
     "libsamplerate",
     {
       "name": "vcpkg-tool-meson",

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rubberband",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A high quality software library for audio time-stretching and pitch-shifting.",
   "homepage": "https://www.breakfastquay.com/rubberband/",
   "license": "GPL-2.0-or-later",
@@ -10,11 +10,11 @@
       "name": "fftw3",
       "platform": "(arm & windows) | (arm64 & osx)"
     },
+    "libsamplerate",
     {
       "name": "sleef",
       "platform": "!(arm & windows) & !(arm64 & osx)"
     },
-    "libsamplerate",
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7205,7 +7205,7 @@
       "port-version": 0
     },
     "rubberband": {
-      "baseline": "3.2.0",
+      "baseline": "3.2.1",
       "port-version": 0
     },
     "rxcpp": {

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c3d34f987eb5ef044fb3d11b6dba23ac4d4c6e41",
+      "git-tree": "66dc21d5c29b7406cf1408081b8d99d6df217d4b",
       "version": "3.2.1",
       "port-version": 0
     },

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f4356c5e6b66df92628bf5069489f41b56d578f",
+      "version": "3.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2cdedb774d373326dd7b2f2d138280653f97c89b",
       "version": "3.2.0",
       "port-version": 0

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f4356c5e6b66df92628bf5069489f41b56d578f",
+      "git-tree": "c3d34f987eb5ef044fb3d11b6dba23ac4d4c6e41",
       "version": "3.2.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This PR:
- Updates rubberband to the latest 3.2.1 release
- Uses sleef instead of fftw on platforms where it's supported. Because it's the fastest available FFT library according https://github.com/breakfastquay/rubberband/blob/default/COMPILING.md#fft-libraries-supported