### PR TITLE
[raygui] Update to 3.6

### DIFF
--- a/ports/raygui/portfile.cmake
+++ b/ports/raygui/portfile.cmake
@@ -5,10 +5,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO raysan5/raygui
     REF "${VERSION}"
-    SHA512 09643f3661879a9130122351d0f9310f1ecde5dd1242d15f7b9c61e80dc9acfc3e6b85682ae7079c8579fd39340da8c5dfdea62aabc6cc72a966dea675ddfd38
+    SHA512 c1d970d98fb721203934fcc3b50d8185271c43e426112bfd0d350899b76586e1cc82dacf4e676827725cff75bc35c7e7e51acbfb8db47f92ad67ee58c9560778
     HEAD_REF master
 )
 
 file(INSTALL "${SOURCE_PATH}/src/raygui.h"  DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/raygui.h" "#include \"raylib.h\"" "#define RAYGUI_STANDALONE")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/raygui/vcpkg.json
+++ b/ports/raygui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "raygui",
-  "version": "3.2",
+  "version": "3.6",
   "description": "A simple and easy-to-use immediate-mode gui library",
   "homepage": "https://github.com/raysan5/raylib",
   "license": "Zlib"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6993,7 +6993,7 @@
       "port-version": 4
     },
     "raygui": {
-      "baseline": "3.2",
+      "baseline": "3.6",
       "port-version": 0
     },
     "raylib": {

--- a/versions/r-/raygui.json
+++ b/versions/r-/raygui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef13f786419316766a2600a289e8de60beb3e7ee",
+      "version": "3.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "96eade6012fdd28a62fd21748edfd06d63674317",
       "version": "3.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #31715, update `raygui` to 3.6.

* Error C1083 occurred when testing usage, to avoid including `raygui.h` in `raygui.h`, so add this line `vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/raygui.h" "#include \"raylib.h\"" "#define RAYGUI_STANDALONE")` to fix it. See the upstream description: [raygui.h#L117-L120](https://github.com/raysan5/raygui/blob/3.6/src/raygui.h#L117-L120).

    ```
    E:\vcpkg01\installed\x64-windows\include\raygui.h(254,14): fatal error C1083: Cannot open include file: 'raylib.h': No such file or directory 
    ```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


No feature needs to be tested, the usage test passed (header files found):
```
raygui is header-only and can be used from CMake via:

    find_path(RAYGUI_INCLUDE_DIRS "raygui.h")
    target_include_directories(main PRIVATE ${RAYGUI_INCLUDE_DIRS})
```
