### PR TITLE
[coinutils] Add feature glpk

### DIFF
--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -11,12 +11,15 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SO
 set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
 
 #--enable-msvc
+if("glpk" IN_LIST FEATURES)
+    string(APPEND with-glpk "--with-glpk")
+endif()
 
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     OPTIONS
-        --with-glpk
+        ${with_glpk}
         --with-lapack
         --without-netlib
         --without-sample

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -11,15 +11,16 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SO
 set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
 
 #--enable-msvc
+set(options "")
 if("glpk" IN_LIST FEATURES)
-    string(APPEND with-glpk "--with-glpk")
+    string(APPEND options "--with-glpk")
 endif()
 
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     OPTIONS
-        ${with_glpk}
+        ${options}
         --with-lapack
         --without-netlib
         --without-sample

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -13,7 +13,9 @@ set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
 #--enable-msvc
 set(options "")
 if("glpk" IN_LIST FEATURES)
-    string(APPEND options "--with-glpk")
+    list(APPEND options "--with-glpk")
+else()
+    list(APPEND options "--without-glpk")
 endif()
 
 vcpkg_configure_make(

--- a/ports/coinutils/vcpkg.json
+++ b/ports/coinutils/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "coinutils",
   "version-date": "2023-02-02",
+  "port-version": 1,
   "description": "CoinUtils (Coin-or Utilities) is an open-source collection of classes and functions that are generally useful to more than one COIN-OR project",
   "homepage": "https://www.coin-or.org/",
   "license": "EPL-2.0",
@@ -8,8 +9,18 @@
   "dependencies": [
     "bzip2",
     "coin-or-buildtools",
-    "glpk",
     "lapack",
     "zlib"
-  ]
+  ],
+  "features": {
+    "glpk": {
+      "description": "ThirdParty wrapper for building Glpk",
+      "dependencies": [
+        {
+          "name": "glpk",
+          "default-features": false
+        }
+      ]
+    }
+  }
 }

--- a/ports/coinutils/vcpkg.json
+++ b/ports/coinutils/vcpkg.json
@@ -14,7 +14,7 @@
   ],
   "features": {
     "glpk": {
-      "description": "ThirdParty wrapper for building Glpk",
+      "description": "Build with Glpk",
       "dependencies": [
         {
           "name": "glpk",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1658,7 +1658,7 @@
     },
     "coinutils": {
       "baseline": "2023-02-02",
-      "port-version": 0
+      "port-version": 1
     },
     "collada-dom": {
       "baseline": "2.5.0",

--- a/versions/c-/coinutils.json
+++ b/versions/c-/coinutils.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c1ed0051bc0a9576b8471a3012199d5ec5ff731e",
+      "git-tree": "52e9ea70dfd58b6e27c535c31cc34dfac5e49748",
       "version-date": "2023-02-02",
       "port-version": 1
     },

--- a/versions/c-/coinutils.json
+++ b/versions/c-/coinutils.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "067e1534fb38e61e8ba6e31898465650a2e1e6e6",
+      "git-tree": "c1ed0051bc0a9576b8471a3012199d5ec5ff731e",
       "version-date": "2023-02-02",
       "port-version": 1
     },

--- a/versions/c-/coinutils.json
+++ b/versions/c-/coinutils.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "52e9ea70dfd58b6e27c535c31cc34dfac5e49748",
+      "git-tree": "5ab5035f6a4fc5601ecc3e644a107b1763426259",
       "version-date": "2023-02-02",
       "port-version": 1
     },

--- a/versions/c-/coinutils.json
+++ b/versions/c-/coinutils.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "067e1534fb38e61e8ba6e31898465650a2e1e6e6",
+      "version-date": "2023-02-02",
+      "port-version": 1
+    },
+    {
       "git-tree": "9f78d3e4a95d02a06ad5fe90773ca39a25cd93de",
       "version-date": "2023-02-02",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/31588
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: Change dependency `glpk` to feature, because `glpk` is optional upstream.
https://github.com/coin-or/CoinUtils/blob/master/.coin-or/config.yml#LL36C1-L39C23

The feature `glpk` are tested successfully in the following triplet:

- x86-windows
- x64-windows
- x64-windows-stataic

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file. 

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
