### PR TITLE
[crashpad] fix linux build

### DIFF
--- a/ports/crashpad/crashpadConfig.cmake.in
+++ b/ports/crashpad/crashpadConfig.cmake.in
@@ -9,7 +9,7 @@ endif()
 add_library(crashpad INTERFACE)
 add_library(crashpad::crashpad ALIAS crashpad)
 
-set(CRASHPAD_LIBRARIES client util base common)
+set(CRASHPAD_LIBRARIES client common crashpad_util base)
 
 if(WIN32)
 	target_compile_definitions(crashpad INTERFACE NOMINMAX)

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -9,6 +9,18 @@ vcpkg_from_git(
 vcpkg_find_acquire_program(PYTHON3)
 vcpkg_replace_string("${SOURCE_PATH}/.gn" "script_executable = \"python3\"" "script_executable = \"${PYTHON3}\"")
 
+# Rename 'util' lib to avoid collision with system libutil
+vcpkg_replace_string("${SOURCE_PATH}/util/BUILD.gn" "crashpad_static_library(\"util\")" "crashpad_static_library(\"crashpad_util\")")
+vcpkg_replace_string("${SOURCE_PATH}/util/BUILD.gn" ":util" ":crashpad_util")
+vcpkg_replace_string("${SOURCE_PATH}/snapshot/BUILD.gn" ":util" ":crashpad_util")
+vcpkg_replace_string("${SOURCE_PATH}/client/BUILD.gn" "/util\"" "/util:crashpad_util\"")
+vcpkg_replace_string("${SOURCE_PATH}/handler/BUILD.gn" "/util\"" "/util:crashpad_util\"")
+vcpkg_replace_string("${SOURCE_PATH}/minidump/BUILD.gn" "/util\"" "/util:crashpad_util\"")
+vcpkg_replace_string("${SOURCE_PATH}/snapshot/BUILD.gn" "/util\"" "/util:crashpad_util\"")
+vcpkg_replace_string("${SOURCE_PATH}/tools/BUILD.gn" "/util\"" "/util:crashpad_util\"")
+vcpkg_replace_string("${SOURCE_PATH}/test/BUILD.gn" "/util\"" "/util:crashpad_util\"")
+vcpkg_replace_string("${SOURCE_PATH}/test/ios/BUILD.gn" "/util\"" "/util:crashpad_util\"")
+
 function(checkout_in_path PATH URL REF)
     if(EXISTS "${PATH}")
         return()
@@ -108,7 +120,7 @@ vcpkg_gn_configure(
 
 vcpkg_gn_install(
     SOURCE_PATH "${SOURCE_PATH}"
-    TARGETS client client:common util third_party/mini_chromium/mini_chromium/base handler:crashpad_handler
+    TARGETS client client:common util:crashpad_util third_party/mini_chromium/mini_chromium/base handler:crashpad_handler
 )
 
 message(STATUS "Installing headers...")

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2022-09-05",
-  "port-version": 4,
+  "port-version": 5,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."
@@ -10,6 +10,10 @@
   "license": "Apache-2.0",
   "supports": "linux | osx | (windows & !uwp)",
   "dependencies": [
+    {
+      "name": "curl",
+      "platform": "linux"
+    },
     {
       "name": "vcpkg-cmake-get-vars",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1862,7 +1862,7 @@
     },
     "crashpad": {
       "baseline": "2022-09-05",
-      "port-version": 4
+      "port-version": 5
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5c0ba1bca4ebc21f7ccc486492d8b56cf93478fb",
+      "version-date": "2022-09-05",
+      "port-version": 5
+    },
+    {
       "git-tree": "63c757af964d6d69f6abdeb0a3849889ad3531a9",
       "version-date": "2022-09-05",
       "port-version": 4


### PR DESCRIPTION
Crashpad creates a library named `libutil.so`, but this causes issues if it installs before python3, which causes py's configure script to use the incorrect and unrelated libutil.so when trying to check 'openpty' support. I've added a couple script replacements for the gn scripts which renames util -> crashpad_util. I also ran into a gcc linker error which looks to be fixed with a simple reordering ( linux build support still requires clang for crashpad lib build )

I'm not sure exactly what would be wanted or best solution here, so ive only renamed the one problematic library the port creates

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
