### PR TITLE
allow blank issues 

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: I have a question
     url: https://github.com/microsoft/vcpkg/discussions


### PR DESCRIPTION
From https://github.com/microsoft/vcpkg/issues/31753: 
> The template doesn't create / fill this form
The line:
[https://github.com/microsoft/vcpkg/issues/new?title=[libpq]+Build+error&body=Copy+issue+body+from+%2Fhome%2Fcees%2Fdevelopment%2Fdataverwerking%2Fcpp%2FTrDataLib%2Fbuild%2Fshared-debug%2Fvcpkg_installed%2Fvcpkg%2Fissue_body.md](https://github.com/microsoft/vcpkg/issues/new?title=%5Blibpq%5D+Build+error&body=Copy+issue+body+from+%2Fhome%2Fcees%2Fdevelopment%2Fdataverwerking%2Fcpp%2FTrDataLib%2Fbuild%2Fshared-debug%2Fvcpkg_installed%2Fvcpkg%2Fissue_body.md)
>
> is redirected to:
https://github.com/microsoft/vcpkg/issues/new/choose

We have to allow the creation of blank issues to correctly create the issue via the url. 