### PR TITLE
[liburing] Update to 2.3

### DIFF
--- a/ports/liburing/portfile.cmake
+++ b/ports/liburing/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO axboe/liburing
-    REF dda4848a9911120a903bef6284fb88286f4464c9 #liburing-2.2
-    SHA512 c2e4969ffb895996bf7465ce86143d4d3401a052624ec19580d34e8adbb2b57801e03541493f61e19a3137984714db645b135b1bc3b41987bccfd926bb486c09 
+    REF "liburing-${VERSION}"
+    SHA512 0eda230e527e696189aa04c63f8c444bbfc2e5d2f6b1f2ac9454accdd0aa435979017b803d869c25c29a8575237bec25a8414940a09b6e1e971d84f7e8797506 
     HEAD_REF master
     PATCHES
         fix-configure.patch     # ignore unsupported options, handle ENABLE_SHARED
@@ -17,8 +17,7 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CURRENT_PORT_DIR}/usage"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 

--- a/ports/liburing/vcpkg.json
+++ b/ports/liburing/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "liburing",
-  "version": "2.2",
-  "port-version": 2,
+  "version": "2.3",
   "description": "Linux-native io_uring I/O access library",
   "homepage": "https://github.com/axboe/liburing",
-  "license": null,
+  "license": "MIT OR LGPL-2.1 OR GPL-2.0",
   "supports": "linux"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4669,8 +4669,8 @@
       "port-version": 2
     },
     "liburing": {
-      "baseline": "2.2",
-      "port-version": 2
+      "baseline": "2.3",
+      "port-version": 0
     },
     "libusb": {
       "baseline": "1.0.26.11791",

--- a/versions/l-/liburing.json
+++ b/versions/l-/liburing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c8b60f54ff0c4e9a0ae2a1a2cbcf72e2cfeaf04",
+      "version": "2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "92a2fd81331f9b6ad3119a166ed18159499fa403",
       "version": "2.2",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #31664 
Usage test pass on `x64-linux`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
