### PR TITLE
[libadwaita] update to 1.3.2

### DIFF
--- a/ports/libadwaita/portfile.cmake
+++ b/ports/libadwaita/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.gnome.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libadwaita
-    REF a905117bd2150de9e85d65f8cdce8d8fb001b89e # 1.2.0
-    SHA512 7fc3c054e261d09acefde5571848f36cbe0956c2a9a8c7b4dda255e2a48b96496b3481b325b13e9a93232f2280acb74d63872f3452b64d510d749109c0b0b078
+    REF "${VERSION}"
+    SHA512 5cea6396bab3439fb3ddef95fe86bc84955ce1eb426fc5dd323329eeab8a51e10de5f4d9c45380f905ceea43e094362a577a67386a3ddcefff362af030c8c7e3
     HEAD_REF main
     PATCHES
 )
@@ -20,7 +20,7 @@ vcpkg_configure_meson(
         -Dexamples=false
         -Dvapi=false
     ADDITIONAL_BINARIES
-        glib-genmarshal='${GLIB_TOOLS_DIR}/glib-genmarshal${VCPKG_HOST_EXECUTABLE_SUFFIX}'
+        glib-genmarshal='${GLIB_TOOLS_DIR}/glib-genmarshal'
         glib-mkenums='${GLIB_TOOLS_DIR}/glib-mkenums'
         glib-compile-resources='${GLIB_TOOLS_DIR}/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'
         glib-compile-schemas='${GLIB_TOOLS_DIR}/glib-compile-schemas${VCPKG_HOST_EXECUTABLE_SUFFIX}'

--- a/ports/libadwaita/vcpkg.json
+++ b/ports/libadwaita/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libadwaita",
-  "version": "1.2.0",
+  "version": "1.3.2",
   "description": "Building blocks for modern GNOME applications",
   "homepage": "https://gnome.pages.gitlab.gnome.org/libadwaita",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3821,7 +3821,7 @@
       "port-version": 1
     },
     "libadwaita": {
-      "baseline": "1.2.0",
+      "baseline": "1.3.2",
       "port-version": 0
     },
     "libaiff": {

--- a/versions/l-/libadwaita.json
+++ b/versions/l-/libadwaita.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c273bec50ed1314ccfb55bd957905df22c9ed61",
+      "version": "1.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "259b1d8ef5c02605235b773df4382e86ef0df01a",
       "version": "1.2.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/31665

Remove the `${VCPKG_HOST_EXECUTABLE_SUFFIX}` from `${GLIB_TOOLS_DIR}/glib-genmarshal` with below reasons.
1. The generated `glib-genmarshal` file from glib does not have an extension.
2. Having an extension would cause the following error when install the latest `libadwaita`:
```
ninja: error: 'vcpkg/installed/x64-windows/tools/glib/glib-genmarshal.exe', needed by 'src/adw-marshalers.h', missing and no known rule to make it
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
