### PR TITLE
[qtbase] no absolute paths

### DIFF
--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -471,18 +471,17 @@ if(VCPKG_CROSSCOMPILING)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/Qt6/Qt6Dependencies.cmake" "${CURRENT_HOST_INSTALLED_DIR}" "\${CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}")
 endif()
 
-# The following pattern exists in qt-cmake scripts, but is still relocatable, so disable the absolute paths check.
-# warning: There should be no absolute paths, such as the following, in an installed package:
-# Absolute paths were found in the following files:
-#     packages/qtbase_x64-linux/tools/Qt6/bin/qt-cmake-private
-#     packages/qtbase_x64-linux/tools/Qt6/bin/debug/qt-cmake-private
-#     packages/qtbase_x64-linux/tools/Qt6/bin/debug/qt-cmake
-#     packages/qtbase_x64-linux/tools/Qt6/bin/qt-cmake
-# 
-# # Try to use original cmake, otherwise to make it relocatable, use any cmake found in PATH.
-# original_cmake_path="/home/bion/vcpkg/downloads/tools/cmake-3.25.1-linux/cmake-3.25.1-linux-x86_64/bin/cmake"
-# cmake_path=$original_cmake_path
-# if ! test -f "$cmake_path"; then
-#     cmake_path="cmake"
-# fi
-set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)
+function(remove_original_cmake_path file)
+    file(READ "${file}" _contents)
+    string(REGEX REPLACE "original_cmake_path=[^\n]*" "original_cmake_path=''" _contents "${_contents}")
+    file(WRITE "${file}" "${_contents}")
+endfunction()
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    foreach(file "qt-cmake" "qt-cmake-private")
+        remove_original_cmake_path("${CURRENT_PACKAGES_DIR}/tools/Qt6/bin/${file}")
+        if(NOT VCPKG_BUILD_TYPE)
+            remove_original_cmake_path("${CURRENT_PACKAGES_DIR}/tools/Qt6/bin/debug/${file}")
+        endif()
+    endforeach()
+endif()

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.5.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6738,7 +6738,7 @@
     },
     "qtbase": {
       "baseline": "6.5.1",
-      "port-version": 1
+      "port-version": 2
     },
     "qtcharts": {
       "baseline": "6.5.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "384ddcfe175f58d6f498c91f6b8e790bb6ad70ac",
+      "version": "6.5.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "f5e0f416352dc6207bf48ac656e3747140232a31",
       "version": "6.5.1",
       "port-version": 1


### PR DESCRIPTION
Otherwise the build fails with:
```
-- Performing post-build validation
warning: There should be no absolute paths, such as the following, in an installed package:
    /Users/leanderSchulten/git_projekte/vcpkg/packages/qtbase_arm64-osx
    /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed
    /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/qtbase
    /Users/leanderSchulten/git_projekte/vcpkg/downloads
Absolute paths were found in the following files:
    /Users/leanderSchulten/git_projekte/vcpkg/packages/qtbase_arm64-osx/tools/Qt6/bin/qt-cmake-private
    /Users/leanderSchulten/git_projekte/vcpkg/packages/qtbase_arm64-osx/tools/Qt6/bin/debug/qt-cmake-private
    /Users/leanderSchulten/git_projekte/vcpkg/packages/qtbase_arm64-osx/tools/Qt6/bin/debug/qt-cmake
    /Users/leanderSchulten/git_projekte/vcpkg/packages/qtbase_arm64-osx/tools/Qt6/bin/qt-cmake
```
And the file content looks like:
```cmake
#!/bin/sh

# The directory of this script is the expanded absolute path of the "$qt_prefix/bin" directory.
script_dir_path=`dirname $0`
script_dir_path=`(cd "$script_dir_path"; /bin/pwd)`

# Try to use original cmake, otherwise to make it relocatable, use any cmake found in PATH.
original_cmake_path="/Users/leanderSchulten/git_projekte/vcpkg/downloads/tools/cmake-3.25.1-osx/cmake-3.25.1-macos-universal/CMake.app/Contents/bin/cmake"
cmake_path=$original_cmake_path
if ! test -f "$cmake_path"; then
    cmake_path="cmake"
fi

toolchain_path="$script_dir_path/../../../share/Qt6/qt.toolchain.cmake"

# Find the qt toolchain relative to the absolute bin dir path where the script is located.
exec "$cmake_path" -DCMAKE_TOOLCHAIN_FILE="$toolchain_path" -G"Ninja" "$@"

```