### PR TITLE
[abseil] update to 20230125.3 version

### DIFF
--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO abseil/abseil-cpp
-    REF 20230125.0
-    SHA512 b3d334215c78b31a2eb10bd9d4a978cd48367866d6daa2065c6c727282bafe19ef7ff5bd7cd4ed5c319d3b04e0711222e08ddbe7621ef1e079fed93a7307112f
+    REF 20230125.3
+    SHA512 50509acfc4128fd31435631f71ac8cd0350acd9e290f78502723149016e7f07c9d84182ba99e0938b1873fecda09393d3fd7af8dabfb0d89cdcdd8a69a917e70
     HEAD_REF master
     PATCHES
         fix-dll-support.patch

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "abseil",
-  "version": "20230125.0",
-  "port-version": 1,
+  "version": "20230125.3",
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a337fa251c0ac4489d9c0ea1e2f1c9a7d019eb5",
+      "version": "20230125.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a88e9003e0d38c2cfbcc676931a0204d749e6629",
       "version": "20230125.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,8 +17,8 @@
       "port-version": 0
     },
     "abseil": {
-      "baseline": "20230125.0",
-      "port-version": 1
+      "baseline": "20230125.3",
+      "port-version": 0
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
Protobuf >= 23.0 will require Abseil 20230125.3 or higher.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
