### PR TITLE
[proj] Update to 9.2.1

### DIFF
--- a/ports/proj/fix-proj4-targets-cmake.patch
+++ b/ports/proj/fix-proj4-targets-cmake.patch
@@ -38,11 +38,11 @@ diff --git a/cmake/project-config.cmake.in b/cmake/project-config.cmake.in
 index 7d5579ae..0cf96252 100644
 --- a/cmake/project-config.cmake.in
 +++ b/cmake/project-config.cmake.in
-@@ -15,6 +15,7 @@ if(@PROJECT_VARIANT_NAME@ STREQUAL "PROJ4")
-
- cmake_policy(PUSH)
- cmake_policy(SET CMP0012 NEW)
+@@ -27,6 +27,7 @@ if(@PROJECT_VARIANT_NAME@ STREQUAL "PROJ4")
+ endif()
+ cmake_policy(POP)
+ 
 +find_dependency(unofficial-sqlite3 CONFIG)
- if("@ENABLE_TIFF@")
+ if(DEFINED PROJ_CONFIG_FIND_TIFF_DEP)
      find_dependency(TIFF)
  endif()

--- a/ports/proj/portfile.cmake
+++ b/ports/proj/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/PROJ
     REF "${VERSION}"
-    SHA512 a48980b94b6c68738dd5ab70a1de6aa42f325fd612155623195a14774caadcaceff08035c01696458d3dd706b2277d89ea093949a1855fafa9951c59821cb1cb
+    SHA512 ac6cf14c7a4bf0435b0b6c373b665762f46ea7609fdbffc512efc308441bf0ac7bf4dee2bcf3b60e98a604b2e3f1e7a67fdac9f455c1ad37ad3f705185a2b620
     HEAD_REF master
     PATCHES
         fix-win-output-name.patch

--- a/ports/proj/vcpkg.json
+++ b/ports/proj/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "proj",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "PROJ library for cartographic projections",
   "homepage": "https://proj.org/",
   "license": "MIT",
@@ -13,6 +13,7 @@
     {
       "name": "sqlite3",
       "host": true,
+      "default-features": false,
       "features": [
         "tool"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6409,7 +6409,7 @@
       "port-version": 2
     },
     "proj": {
-      "baseline": "9.2.0",
+      "baseline": "9.2.1",
       "port-version": 0
     },
     "proj4": {

--- a/versions/p-/proj.json
+++ b/versions/p-/proj.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7dc980fc3b1ca19e8ca6aa5b1ad625949229b2e",
+      "version": "9.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "24665244df24460f20293fc879787852554b16c7",
       "version": "9.2.0",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
