### PR TITLE
[openblas] Add OpenMP feature and clarify thread description

### DIFF
--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -27,6 +27,7 @@ vcpkg_add_to_path("${SED_EXE_PATH}")
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         threads         USE_THREAD
+        openmp          USE_OPENMP
         simplethread    USE_SIMPLE_THREADED_LEVEL3
         "dynamic-arch"  DYNAMIC_ARCH
 )
@@ -42,7 +43,7 @@ endif()
 set(OPENBLAS_EXTRA_OPTIONS)
 # for UWP version, must build non uwp first for helper
 # binaries.
-if(VCPKG_TARGET_IS_UWP)    
+if(VCPKG_TARGET_IS_UWP)
     list(APPEND OPENBLAS_EXTRA_OPTIONS -DCMAKE_SYSTEM_PROCESSOR=AMD64
                 "-DBLASHELPER_BINARY_DIR=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}")
 elseif(NOT (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW))

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openblas",
   "version": "0.3.23",
+  "port-version": 1,
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/xianyi/OpenBLAS",
   "license": "BSD-3-Clause",
@@ -28,6 +29,9 @@
       "description": "Support for multiple targets in a single library",
       "supports": "!windows | mingw"
     },
+    "openmp": {
+      "description": "Use OpenMP threading backend"
+    },
     "simplethread": {
       "description": "Use simple thread",
       "dependencies": [
@@ -40,7 +44,7 @@
       ]
     },
     "threads": {
-      "description": "Use a threading backend",
+      "description": "Use POSIX-like threading backend",
       "dependencies": [
         {
           "name": "pthread",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5866,7 +5866,7 @@
     },
     "openblas": {
       "baseline": "0.3.23",
-      "port-version": 0
+      "port-version": 1
     },
     "opencascade": {
       "baseline": "7.6.2",

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0b92c2483bcf538d3d4d89f75886a1e535b3869e",
+      "version": "0.3.23",
+      "port-version": 1
+    },
+    {
       "git-tree": "716c00140c032ec22773130b006af542e011f00e",
       "version": "0.3.23",
       "port-version": 0


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md) - I think so? OpenMP isn't additive per se, but I'm pretty sure adding both OpenMP and any of the other threading features just has the OpenMP code override.
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.