### PR TITLE
[starlink-ast] no absolute paths

### DIFF
--- a/ports/starlink-ast/portfile.cmake
+++ b/ports/starlink-ast/portfile.cmake
@@ -75,6 +75,14 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/${PORT}/ast"
 )
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    string(REPLACE "/" "\\\\" with_double_slash "${DOWNLOADS}")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ast.h" "${with_double_slash}\\\\tools\\\\msys2\\\\" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ast.h" "${DOWNLOADS}/tools/msys2/" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/star/ast.h" "${with_double_slash}\\\\tools\\\\msys2\\\\" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/star/ast.h" "${DOWNLOADS}/tools/msys2/" "")
+endif()
+
 vcpkg_install_copyright(
     FILE_LIST
         "${SOURCE_PATH}/COPYING.LESSER"

--- a/ports/starlink-ast/vcpkg.json
+++ b/ports/starlink-ast/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "starlink-ast",
   "version": "9.2.10",
+  "port-version": 1,
   "description": "The AST library provides a comprehensive range of facilities for attaching world coordinate systems to astronomical data, for retrieving and interpreting that information and for generating graphical output based on it",
   "homepage": "https://starlink.eao.hawaii.edu/starlink/AST",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7766,7 +7766,7 @@
     },
     "starlink-ast": {
       "baseline": "9.2.10",
-      "port-version": 0
+      "port-version": 1
     },
     "staticjson": {
       "baseline": "1.0.0",

--- a/versions/s-/starlink-ast.json
+++ b/versions/s-/starlink-ast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1284e22b9538559a080690d659131a1ef8ff2b70",
+      "version": "9.2.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "f79db80b697effc13bf43a3d370701e0e7a244c4",
       "version": "9.2.10",
       "port-version": 0


### PR DESCRIPTION
Otherwise you get 
```
-- Performing post-build validation
warning: There should be no absolute paths, such as the following, in an installed package:
    C:\Users\admin\git_projects\vcpkg2\packages\starlink-ast_x64-windows
    C:\Users\admin\git_projects\vcpkg2\vcpkg_installed
    C:\Users\admin\git_projects\vcpkg2\buildtrees\starlink-ast
    C:\Users\admin\git_projects\vcpkg2\downloads
Absolute paths were found in the following files:
    C:\Users\admin\git_projects\vcpkg2\packages\starlink-ast_x64-windows\include\ast.h
    C:\Users\admin\git_projects\vcpkg2\packages\starlink-ast_x64-windows\include\star\ast.h
```
with the new tool release on windows 