### PR TITLE
[quickfix]: fix exception specification

### DIFF
--- a/ports/quickfix/00001-fix-build.patch
+++ b/ports/quickfix/00001-fix-build.patch
@@ -75,7 +75,7 @@ index 0aa2cd3e..2829e110 100644
  #endif
  
 +#ifdef __cpp_noexcept_function_type
-+#define QUICKFIX_THROW(...) noexcept(false)
++#define QUICKFIX_THROW(...) noexcept
 +#else
 +#define QUICKFIX_THROW(...) throw(__VA_ARGS__)
 +#endif

--- a/ports/quickfix/vcpkg.json
+++ b/ports/quickfix/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "quickfix",
   "version": "1.15.1",
-  "port-version": 8,
+  "port-version": 9,
   "description": "QuickFIX is a free and open source implementation of the FIX protocol.",
   "homepage": "https://github.com/quickfix/quickfix",
   "supports": "!uwp & !(osx & arm64)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6922,7 +6922,7 @@
     },
     "quickfix": {
       "baseline": "1.15.1",
-      "port-version": 8
+      "port-version": 9
     },
     "quill": {
       "baseline": "2.9.1",

--- a/versions/q-/quickfix.json
+++ b/versions/q-/quickfix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08f8b2eb6b5493a1faae9707021fe1d287ed6fa5",
+      "version": "1.15.1",
+      "port-version": 9
+    },
+    {
       "git-tree": "a8cdc0c05fb161bb28059f93d8dc05ea60d4c118",
       "version": "1.15.1",
       "port-version": 8


### PR DESCRIPTION
Fixes #31380 

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [X] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. ~
- [X] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

