### PR TITLE
[Exiv2] Add feature to enable BMFF support

### DIFF
--- a/ports/exiv2/portfile.cmake
+++ b/ports/exiv2/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         video   EXIV2_ENABLE_VIDEO
         png     EXIV2_ENABLE_PNG
         nls     EXIV2_ENABLE_NLS
+        bmff    EXIV2_ENABLE_BMFF
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" EXIV2_CRT_DYNAMIC)

--- a/ports/exiv2/vcpkg.json
+++ b/ports/exiv2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "exiv2",
   "version": "0.27.6",
+  "port-version": 1,
   "description": "Image metadata library and tools",
   "homepage": "https://exiv2.org",
   "license": "GPL-2.0-or-later",
@@ -20,6 +21,9 @@
     }
   ],
   "features": {
+    "bmff": {
+      "description": "Support for BMFF files (e.g., CR3, HEIF, HEIC, AVIF, and JPEG XL)"
+    },
     "nls": {
       "description": "Build native language support",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2362,7 +2362,7 @@
     },
     "exiv2": {
       "baseline": "0.27.6",
-      "port-version": 0
+      "port-version": 1
     },
     "expat": {
       "baseline": "2.5.0",

--- a/versions/e-/exiv2.json
+++ b/versions/e-/exiv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e3ce02246c1ef4cdc28caed2afa2fe2b394476f",
+      "version": "0.27.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "19442ed87a9f3827ddb22debf6b446e4cdca2d4f",
       "version": "0.27.6",
       "port-version": 0


### PR DESCRIPTION
Fixes #31777

Add feature `bmff` to enable BMFF support


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Tesetd feature `bmff` successfully in the follwoing triplet:

- x86-windows
- x64-windows
- x64-windows-static
- x64-linux


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
