### PR TITLE
[crossguid] Fix compilation on gcc v13

### DIFF
--- a/ports/crossguid/missing-include-cstdint.patch
+++ b/ports/crossguid/missing-include-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/include/crossguid/guid.hpp b/include/crossguid/guid.hpp
+index 61e0f17..70966f2 100644
+--- a/include/crossguid/guid.hpp
++++ b/include/crossguid/guid.hpp
+@@ -29,6 +29,7 @@ THE SOFTWARE.
+ #include <jni.h>
+ #endif
+ 
++#include <cstdint>
+ #include <functional>
+ #include <iostream>
+ #include <array>

--- a/ports/crossguid/portfile.cmake
+++ b/ports/crossguid/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         warnings.patch
+        missing-include-cstdint.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/crossguid/vcpkg.json
+++ b/ports/crossguid/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crossguid",
   "version-date": "2021-10-22",
-  "port-version": 2,
+  "port-version": 3,
   "description": "CrossGuid is a minimal, cross platform, C++ GUID library.",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1882,7 +1882,7 @@
     },
     "crossguid": {
       "baseline": "2021-10-22",
-      "port-version": 2
+      "port-version": 3
     },
     "crow": {
       "baseline": "1.0-5",

--- a/versions/c-/crossguid.json
+++ b/versions/c-/crossguid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39a8ec44dcb709796a0ecdc4c170f67ad5ad1175",
+      "version-date": "2021-10-22",
+      "port-version": 3
+    },
+    {
       "git-tree": "93714099ddf83b2f3437a080c8acc08ff74cbe37",
       "version-date": "2021-10-22",
       "port-version": 2


### PR DESCRIPTION
Crossguid no longer compiles with gcc v13 (tested on Linux), due to a missing include (cstdint). There is an upstream pull request to fix the issue which has been open for some time but not yet merged.

Let's patch the sources in vcpkg until upstream fixes it.

Fixes #31834.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
