### PR TITLE
New port: libtracepoint-decode

### DIFF
--- a/ports/libtracepoint-decode/portfile.cmake
+++ b/ports/libtracepoint-decode/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "microsoft/LinuxTracepoints"
+    REF abf1f6d3e32546aeaab75ed3cea45b54b94fbd50
+    SHA512 ac67bbd8184a29c8058a7b2cde51db9a14f97326396ba894f56a36d4219bebbc580f64a3ed5f182df4a0111ad97294a6b780bd44181d37e0fda1be16a6e23dea
+    HEAD_REF main)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/libtracepoint-decode-cpp")
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME tracepoint-decode
+    CONFIG_PATH lib/cmake/tracepoint-decode)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libtracepoint-decode/vcpkg.json
+++ b/ports/libtracepoint-decode/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libtracepoint-decode",
+  "version": "1.0.0",
+  "description": "Tracepoint decoding classes for C++",
+  "homepage": "https://github.com/microsoft/LinuxTracepoints/",
+  "license": "MIT",
+  "supports": "linux | windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4640,6 +4640,10 @@
       "baseline": "1.0.0",
       "port-version": 0
     },
+    "libtracepoint-decode": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "libu2f-server": {
       "baseline": "1.1.0",
       "port-version": 5

--- a/versions/l-/libtracepoint-decode.json
+++ b/versions/l-/libtracepoint-decode.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6bd99da97aa18ca05fd3a67eb77f6df1ea210d2e",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
