### PR TITLE
[vsg] Fix build error when the Vulkan component glslangValidator is already installed

### DIFF
--- a/ports/vsg/devendor-glslang.patch
+++ b/ports/vsg/devendor-glslang.patch
@@ -16,7 +16,7 @@ index 61da709f..472bc6af 100644
  
          if (Git_FOUND)
 diff --git a/src/vsg/CMakeLists.txt b/src/vsg/CMakeLists.txt
-index 4154312f..49d63b97 100644
+index 4154312..7afcdd4 100644
 --- a/src/vsg/CMakeLists.txt
 +++ b/src/vsg/CMakeLists.txt
 @@ -226,7 +226,7 @@ set(SOURCES
@@ -28,10 +28,10 @@ index 4154312f..49d63b97 100644
  
      # include glslang source code directly into the VulkanScenegraph library build.
      include(../glslang/build_vars.cmake)
-@@ -236,6 +236,14 @@ endif()
+@@ -234,6 +234,14 @@ endif()
+ 
+ # set up library dependencies
  set(LIBRARIES PUBLIC
-         Vulkan::Vulkan
-         Threads::Threads
 +        glslang::glslang
 +        glslang::OSDependent
 +        glslang::MachineIndependent
@@ -40,9 +40,9 @@ index 4154312f..49d63b97 100644
 +        glslang::OGLCompiler
 +        glslang::SPVRemapper
 +        glslang::SPIRV
+         Vulkan::Vulkan
+         Threads::Threads
  )
- 
- # Check for std::atomic
 @@ -364,9 +372,6 @@ target_include_directories(vsg
      PUBLIC
          $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/include>

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vsg",
   "version": "1.0.5",
+  "port-version": 1,
   "description": "A modern, cross platform, high performance scene graph library built upon Vulkan.",
   "homepage": "http://www.vulkanscenegraph.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8470,7 +8470,7 @@
     },
     "vsg": {
       "baseline": "1.0.5",
-      "port-version": 0
+      "port-version": 1
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c2ade86b1dee203ecaa4a401e76d80a205b6c71f",
+      "version": "1.0.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "0542d7bb873d65fa6ecbf2c3a02d7a2c7221d34a",
       "version": "1.0.5",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #31801 
When `Vulkan` component `glslangValidator` is already installed, `vsg` will install failed with the following error:
```
C:\Dev\vcpkg\buildtrees\vsg\src\v1.0.5-2524ec1552.clean\src\vsg\utils\ShaderCompiler.cpp(172): error C2065: 'EShLangTask': undeclared identifier
C:\Dev\vcpkg\buildtrees\vsg\src\v1.0.5-2524ec1552.clean\src\vsg\utils\ShaderCompiler.cpp(176): error C2065: 'EShLangMesh': undeclared identifier
C:\Dev\vcpkg\buildtrees\vsg\src\v1.0.5-2524ec1552.clean\src\vsg\utils\ShaderCompiler.cpp(282): error C2039: 'emitNonSemanticShaderDebugInfo': is not a member of 'glslang::SpvOptions'
C:\VulkanSDK\1.3.204.1\Include\glslang\SPIRV\SpvTools.h(55): note: see declaration of 'glslang::SpvOptions'
C:\Dev\vcpkg\buildtrees\vsg\src\v1.0.5-2524ec1552.clean\src\vsg\utils\ShaderCompiler.cpp(283): error C2039: 'emitNonSemanticShaderDebugSource': is not a member of 'glslang::SpvOptions'
C:\VulkanSDK\1.3.204.1\Include\glslang\SPIRV\SpvTools.h(55): note: see declaration of 'glslang::SpvOptions'
```
Because `vsg` is calling the `glslang` headers provided by Vulkan, it did not use the `glslang` headers which provided by `glslang` in vcpkg.

The upstream use internal `gslang`, the related codes are as below:
```
if (${VSG_SUPPORTS_ShaderCompiler})

    # include glslang source code directly into the VulkanScenegraph library build.
    include(../glslang/build_vars.cmake)
endif()

# set up library dependencies
set(LIBRARIES PUBLIC
        Vulkan::Vulkan
        Threads::Threads
)
......
target_include_directories(vsg
    PUBLIC
        $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/include>
        $<BUILD_INTERFACE:${VSG_BINARY_DIR}/include>
    PRIVATE
        $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/src/glslang>
        $<BUILD_INTERFACE:${GLSLANG_GENERATED_INCLUDEDIR}>
)
```
Since we want use `glslang` provided by vcpkg instead of internal `glslang`, we need to follow the order of upstream linked libraries, linking `glslang` first and then linking `Vulkan`.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
