### PR TITLE
[mp-units] add feature flag, use development version 2

### DIFF
--- a/ports/mp-units/portfile.cmake
+++ b/ports/mp-units/portfile.cmake
@@ -1,11 +1,21 @@
-vcpkg_from_github(
+if ("version-2" IN_LIST FEATURES)
+  vcpkg_from_github(
+      OUT_SOURCE_PATH SOURCE_PATH
+      REPO mpusz/units
+      HEAD_REF v2_framework
+      REF a6434e6b602b3ca05103848ccc94da04cf850ac9
+      SHA512 92f29b8b72cfc757be07a23d6aa5bfddbcc6ac34dbf60f494ace7772a2b83f692afeb72bef8324bbb06b131bd851b7bd5e5b42752ba0f84d7e481b1605190a98
+  )
+else ()
+  vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mpusz/units
     REF v0.7.0
     SHA512 72175f34f358d0741650ce9c8a7b28fced90cc45ddd3f1662ae1cb9ff7d31403ff742ee07ab4c96bd2d95af714d9111a888cf6acccb91e568e12d1ef663b2f64
     PATCHES
         config.patch
-)
+  )
+endif ()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/src"

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mp-units",
   "version-semver": "0.7.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "mp-units - A Units Library for C++",
   "homepage": "https://github.com/mpusz/units",
   "license": "MIT",
@@ -16,5 +16,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "version-2": {
+      "description": "Use development v2_framework branch"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5378,7 +5378,7 @@
     },
     "mp-units": {
       "baseline": "0.7.0",
-      "port-version": 1
+      "port-version": 2
     },
     "mp3lame": {
       "baseline": "3.100",

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7eb50feac7a72327706e7195f4e46b1151ed2ce",
+      "version-semver": "0.7.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b4bce95b7e67f66db9d613e7e3601c2b90cec665",
       "version-semver": "0.7.0",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
