### PR TITLE
[mathgl] Fix GSL linakge

### DIFF
--- a/ports/mathgl/fix_link_gsl.patch
+++ b/ports/mathgl/fix_link_gsl.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1c931e2..4987f2d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -485,25 +485,13 @@ endif(enable-openmp)
+ 
+ if(enable-gsl)
+ 	set(MGL_HAVE_GSL 1)
+-	find_library(GSL_LIB gsl)
+-	find_library(GSL_CBLAS_LIB gslcblas)
+-	find_path(GSL_INCLUDE_DIR gsl/gsl_fft_complex.h)
+-	if(NOT GSL_LIB OR NOT GSL_CBLAS_LIB OR NOT GSL_INCLUDE_DIR)
+-		message(SEND_ERROR "${GSL_LIB}")
+-		message(SEND_ERROR "${GSL_CBLAS_LIB}")
+-		message(SEND_ERROR "${GSL_INCLUDE_DIR}")
+-		message(SEND_ERROR "Couldn't find GSL libraries.")
+-	else(NOT GSL_LIB OR NOT GSL_CBLAS_LIB OR NOT GSL_INCLUDE_DIR)
+-		set(CMAKE_REQUIRED_INCLUDES ${GSL_INCLUDE_DIR})
+-		set(CMAKE_REQUIRED_LIBRARIES ${GSL_LIB} ${GSL_CBLAS_LIB})
+-		CHECK_CXX_SOURCE_COMPILES("#include <gsl/gsl_multifit_nlin.h>
+-		int main(){gsl_multifit_fdfsolver *s=0;gsl_matrix *J = 0;
+-		gsl_multifit_fdfsolver_jac(s, J);}" MGL_HAVE_GSL2)
+-		unset(CMAKE_REQUIRED_INCLUDES)
+-		unset(CMAKE_REQUIRED_LIBRARIES)
+-	endif(NOT GSL_LIB OR NOT GSL_CBLAS_LIB OR NOT GSL_INCLUDE_DIR)
+-	set(MGL_DEP_LIBS ${GSL_LIB} ${GSL_CBLAS_LIB} ${MGL_DEP_LIBS})
+-	include_directories(${GSL_INCLUDE_DIR})
++    find_package(GSL REQUIRED)
++    set(MGL_DEP_LIBS GSL::gsl GSL::gslcblas ${MGL_DEP_LIBS})
++    set(CMAKE_REQUIRED_LIBRARIES GSL::gsl GSL::gslcblas)
++    CHECK_CXX_SOURCE_COMPILES("#include <gsl/gsl_multifit_nlin.h>
++    int main(){gsl_multifit_fdfsolver *s=0;gsl_matrix *J = 0;
++    gsl_multifit_fdfsolver_jac(s, J);}" MGL_HAVE_GSL2)
++    unset(CMAKE_REQUIRED_LIBRARIES)
+ else(enable-gsl)
+ 	set(MGL_HAVE_GSL 0)
+ endif(enable-gsl)

--- a/ports/mathgl/portfile.cmake
+++ b/ports/mathgl/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_sourceforge(
         fix-mgllab.patch
         include_functional.patch
         fix-include-property.patch
+        fix_link_gsl.patch
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/addons/getopt")
 

--- a/ports/mathgl/vcpkg.json
+++ b/ports/mathgl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mathgl",
   "version": "8.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "MathGL is a free library of fast C++ routines for the plotting of the data varied in one or more dimensions",
   "license": "GPL-3.0-only",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5150,7 +5150,7 @@
     },
     "mathgl": {
       "baseline": "8.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "matio": {
       "baseline": "1.5.23",

--- a/versions/m-/mathgl.json
+++ b/versions/m-/mathgl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c1da85e695d3767410b3acf59567da2faf32ea2",
+      "version": "8.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "34ffe72f88b0fa47c8bf8ad235ed3cf109560f65",
       "version": "8.0.1",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30029
The link method of repairing GSL is `find_package()`, linking the `gsl` inside `vcpkg`.
All features passed with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```
Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
