### PR TITLE
[unordered-dense] New port

### DIFF
--- a/ports/unordered-dense/portfile.cmake
+++ b/ports/unordered-dense/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_minimum_required(VERSION 2023-04-07)
+
+vcpkg_from_github(
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO martinus/unordered_dense
+	REF v${VERSION}
+	SHA512 105eb88deeb89c9424973d2b5425a6e176f3f66a45f11cf6ed520cce177918cd5345e840d10561f6f790b6cc11b7b6e1357bd2fc4d199254a360de88ce553fe0
+	HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+	SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+	PACKAGE_NAME unordered_dense
+	CONFIG_PATH lib/cmake/unordered_dense
+)
+
+file(REMOVE_RECURSE
+	"${CURRENT_PACKAGES_DIR}/debug"
+	"${CURRENT_PACKAGES_DIR}/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/unordered-dense/vcpkg.json
+++ b/ports/unordered-dense/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "unordered-dense",
+  "version": "4.0.1",
+  "description": "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion",
+  "homepage": "https://github.com/martinus/unordered_dense",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/unordered-dense/vcpkg.json
+++ b/ports/unordered-dense/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "4.0.1",
   "description": "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion",
   "homepage": "https://github.com/martinus/unordered_dense",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8244,6 +8244,10 @@
       "baseline": "2.3.11",
       "port-version": 2
     },
+    "unordered-dense": {
+      "baseline": "4.0.1",
+      "port-version": 0
+    },
     "unqlite": {
       "baseline": "1.1.9",
       "port-version": 2

--- a/versions/u-/unordered-dense.json
+++ b/versions/u-/unordered-dense.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f77b493cfc5f64a6cd644f8dde5cfa7af3c727cb",
+      "version": "4.0.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/u-/unordered-dense.json
+++ b/versions/u-/unordered-dense.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f77b493cfc5f64a6cd644f8dde5cfa7af3c727cb",
+      "git-tree": "404e82b0f085a6d68323630f530c04e86b5eeb2b",
       "version": "4.0.1",
       "port-version": 0
     }


### PR DESCRIPTION
Add the unordered-dense port : https://github.com/martinus/unordered_dense

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
