### PR TITLE
[xtd] Add new port

### DIFF
--- a/ports/xtd/portfile.cmake
+++ b/ports/xtd/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gammasoft71/xtd
+    REF 83f33454e496755076d13442ef9a2fe3323e7830
+    SHA512 bf3b9ee8c429339304e0f8e80e8bbd85dd33686b5f0c1f655933de8f42a4ff5f695ba43fe0feb97edbd2518a17415b799ca425d99c30e8cfb7c7f6a3316ecd31
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DXTD_BUILD_TOOL_GUIDGEN_COMMAND_LINE=OFF
+        -DXTD_BUILD_TOOL_GUIDGEN_GUI=OFF
+        -DXTD_BUILD_TOOL_KEYCODES=OFF
+        -DXTD_BUILD_TOOL_SLEEPFOR_COMMAND_LINE=OFF
+        -DXTD_BUILD_TOOL_SET_PATH=OFF
+        -DXTD_BUILD_TOOL_XTDC_COMMAND_LINE=OFF
+        -DXTD_BUILD_TOOL_XTDC_GUI=OFF
+        -DXTD_INSTALL_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "cmake")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/xtd/vcpkg.json
+++ b/ports/xtd/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "xtd",
+  "version-date": "2023-06-06",
+  "description": "Free open-source modern C++17 / C++20 framework to create console, GUI and unit test applications",
+  "homepage": "https://gammasoft71.github.io/xtd",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "wxwidgets"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8788,6 +8788,10 @@
       "baseline": "10.0.0",
       "port-version": 0
     },
+    "xtd": {
+      "baseline": "2023-06-06",
+      "port-version": 0
+    },
     "xtensor": {
       "baseline": "0.24.6",
       "port-version": 0

--- a/versions/x-/xtd.json
+++ b/versions/x-/xtd.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1786cfbf56b3bc2402b12b267b9b4e745a5c20cf",
+      "version-date": "2023-06-06",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.