### PR TITLE
[hypergrep] New Port v0.1.1

### DIFF
--- a/ports/hypergrep/portfile.cmake
+++ b/ports/hypergrep/portfile.cmake
@@ -1,0 +1,70 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   CURRENT_INSTALLED_DIR     = ${VCPKG_ROOT_DIR}\installed\${TRIPLET}
+#   DOWNLOADS                 = ${VCPKG_ROOT_DIR}\downloads
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#   VCPKG_TOOLCHAIN           = ON OFF
+#   TRIPLET_SYSTEM_ARCH       = arm x86 x64
+#   BUILD_ARCH                = "Win32" "x64" "ARM"
+#   DEBUG_CONFIG              = "Debug Static" "Debug Dll"
+#   RELEASE_CONFIG            = "Release Static"" "Release DLL"
+#   VCPKG_TARGET_IS_WINDOWS
+#   VCPKG_TARGET_IS_UWP
+#   VCPKG_TARGET_IS_LINUX
+#   VCPKG_TARGET_IS_OSX
+#   VCPKG_TARGET_IS_FREEBSD
+#   VCPKG_TARGET_IS_ANDROID
+#   VCPKG_TARGET_IS_MINGW
+#   VCPKG_TARGET_EXECUTABLE_SUFFIX
+#   VCPKG_TARGET_STATIC_LIBRARY_SUFFIX
+#   VCPKG_TARGET_SHARED_LIBRARY_SUFFIX
+#
+# 	See additional helpful variables in /docs/maintainers/vcpkg_common_definitions.md
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO p-ranav/hypergrep
+    REF v0.1.1
+    SHA512 22565b6763299b80edd6d80573b4cc2983668b65605caebb41d81349d4c8d7e245c1113c14bb2cd2e7174c629f490afa2e91e3bb6e8ded0177d91b617c3b3f7f
+    HEAD_REF master
+)
+
+# # Check if one or more features are a part of a package installation.
+# # See /docs/maintainers/vcpkg_check_features.md for more details
+# vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+#   FEATURES # <- Keyword FEATURES is required because INVERTED_FEATURES are being used
+#     tbb   WITH_TBB
+#   INVERTED_FEATURES
+#     tbb   ROCKSDB_IGNORE_PACKAGE_TBB
+# )
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_cmake_install()
+
+# # Moves all .cmake files from /debug/share/@PORT@/ to /share/@PORT@/
+# # See /docs/maintainers/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.md for more details
+# When you uncomment "vcpkg_cmake_config_fixup()", you need to add the following to "dependencies" vcpkg.json:
+#{
+#    "name": "vcpkg-cmake-config",
+#    "host": true
+#}
+# vcpkg_cmake_config_fixup()
+
+# Uncomment the line below if necessary to install the license file for the port
+# as a file named `copyright` to the directory `${CURRENT_PACKAGES_DIR}/share/${PORT}`
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hypergrep/portfile.cmake
+++ b/ports/hypergrep/portfile.cmake
@@ -1,33 +1,3 @@
-# Common Ambient Variables:
-#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
-#   CURRENT_INSTALLED_DIR     = ${VCPKG_ROOT_DIR}\installed\${TRIPLET}
-#   DOWNLOADS                 = ${VCPKG_ROOT_DIR}\downloads
-#   PORT                      = current port name (zlib, etc)
-#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
-#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
-#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
-#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
-#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
-#   VCPKG_TOOLCHAIN           = ON OFF
-#   TRIPLET_SYSTEM_ARCH       = arm x86 x64
-#   BUILD_ARCH                = "Win32" "x64" "ARM"
-#   DEBUG_CONFIG              = "Debug Static" "Debug Dll"
-#   RELEASE_CONFIG            = "Release Static"" "Release DLL"
-#   VCPKG_TARGET_IS_WINDOWS
-#   VCPKG_TARGET_IS_UWP
-#   VCPKG_TARGET_IS_LINUX
-#   VCPKG_TARGET_IS_OSX
-#   VCPKG_TARGET_IS_FREEBSD
-#   VCPKG_TARGET_IS_ANDROID
-#   VCPKG_TARGET_IS_MINGW
-#   VCPKG_TARGET_EXECUTABLE_SUFFIX
-#   VCPKG_TARGET_STATIC_LIBRARY_SUFFIX
-#   VCPKG_TARGET_SHARED_LIBRARY_SUFFIX
-#
-# 	See additional helpful variables in /docs/maintainers/vcpkg_common_definitions.md
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO p-ranav/hypergrep
@@ -36,35 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-# # Check if one or more features are a part of a package installation.
-# # See /docs/maintainers/vcpkg_check_features.md for more details
-# vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-#   FEATURES # <- Keyword FEATURES is required because INVERTED_FEATURES are being used
-#     tbb   WITH_TBB
-#   INVERTED_FEATURES
-#     tbb   ROCKSDB_IGNORE_PACKAGE_TBB
-# )
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
 vcpkg_cmake_install()
-
-# # Moves all .cmake files from /debug/share/@PORT@/ to /share/@PORT@/
-# # See /docs/maintainers/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.md for more details
-# When you uncomment "vcpkg_cmake_config_fixup()", you need to add the following to "dependencies" vcpkg.json:
-#{
-#    "name": "vcpkg-cmake-config",
-#    "host": true
-#}
-# vcpkg_cmake_config_fixup()
-
-# Uncomment the line below if necessary to install the license file for the port
-# as a file named `copyright` to the directory `${CURRENT_PACKAGES_DIR}/share/${PORT}`
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hypergrep/vcpkg.json
+++ b/ports/hypergrep/vcpkg.json
@@ -1,14 +1,10 @@
 {
   "name": "hypergrep",
   "version": "0.1.0",
-  "homepage": "https://www.github.com/p-ranav/hypergrep",
   "description": "Recursively search directories for a regex pattern",
-  "supports": "linux",  
+  "homepage": "https://www.github.com/p-ranav/hypergrep",
+  "supports": "linux",
   "dependencies": [
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
     {
       "name": "argparse",
       "host": true
@@ -27,6 +23,10 @@
     },
     {
       "name": "libgit2",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
       "host": true
     }
   ]

--- a/ports/hypergrep/vcpkg.json
+++ b/ports/hypergrep/vcpkg.json
@@ -1,0 +1,33 @@
+{
+  "name": "hypergrep",
+  "version": "0.1.0",
+  "homepage": "https://www.github.com/p-ranav/hypergrep",
+  "description": "Recursively search directories for a regex pattern",
+  "supports": "linux",  
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "argparse",
+      "host": true
+    },
+    {
+      "name": "concurrentqueue",
+      "host": true
+    },
+    {
+      "name": "fmt",
+      "host": true
+    },
+    {
+      "name": "hyperscan",
+      "host": true
+    },
+    {
+      "name": "libgit2",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3172,6 +3172,10 @@
       "baseline": "2.9.0",
       "port-version": 0
     },
+    "hypergrep": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "hyperscan": {
       "baseline": "5.4.2",
       "port-version": 0

--- a/versions/h-/hypergrep.json
+++ b/versions/h-/hypergrep.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fe75f78e0e36c4932a1d73b218641e8581c82820",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.