### PR TITLE
[mbedtls]: update to 2.28.3

### DIFF
--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -3,8 +3,9 @@ set(VCPKG_LIBRARY_LINKAGE static)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ARMmbed/mbedtls
-    REF v2.28.1
-    SHA512 b71d052acfb83daff11e0182f32b0ad0af7c59d2b74bd19f270531a3da9ed3ce1d3adcaf756e161bf05a10fe1b6b7753e360e9dbb5b7b123f09201b1202ef689
+    REF "v${VERSION}"
+    SHA512
+ e2de0260341c7e2be7f1dcc2bde48b2287272528de3a9e7d7b4c8468b74a6530d4e84b2a4e959dff46169c34d70c908ec58b33f67db151129d5a3c0c6b34b297
     HEAD_REF mbedtls-2.28
     PATCHES
         enable-pthread.patch

--- a/ports/mbedtls/vcpkg.json
+++ b/ports/mbedtls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mbedtls",
-  "version": "2.28.1",
+  "version": "2.28.3",
   "description": "An open source, portable, easy to use, readable and flexible SSL library",
   "homepage": "https://github.com/ARMmbed/mbedtls",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5173,7 +5173,7 @@
       "port-version": 1
     },
     "mbedtls": {
-      "baseline": "2.28.1",
+      "baseline": "2.28.3",
       "port-version": 0
     },
     "mchehab-zbar": {

--- a/versions/m-/mbedtls.json
+++ b/versions/m-/mbedtls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7189b576ef0eeec7d4eefc915b7410e5dd9cc91",
+      "version": "2.28.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f6fd876a24f60e3034438c6793627be091ab6426",
       "version": "2.28.1",
       "port-version": 0


### PR DESCRIPTION


- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
