### PR TITLE
[vsg] Update to v1.0.6

### DIFF
--- a/ports/vsg/devendor-glslang.patch
+++ b/ports/vsg/devendor-glslang.patch
@@ -16,10 +16,10 @@ index 6e7ec437..db4d30f1 100644
  
          if (Git_FOUND)
 diff --git a/src/vsg/CMakeLists.txt b/src/vsg/CMakeLists.txt
-index 3d9625e4..8fe89f89 100644
+index 3d9625e4..96285e99 100644
 --- a/src/vsg/CMakeLists.txt
 +++ b/src/vsg/CMakeLists.txt
-@@ -227,7 +227,7 @@ set(SOURCES
+@@ -227,14 +227,24 @@ set(SOURCES
      utils/LoadPagedLOD.cpp
  )
  
@@ -28,10 +28,12 @@ index 3d9625e4..8fe89f89 100644
  
      # include glslang source code directly into the VulkanScenegraph library build.
      include(../glslang/build_vars.cmake)
-@@ -235,6 +235,14 @@ endif()
+ endif()
  
  # set up library dependencies
- set(LIBRARIES PUBLIC
+-set(LIBRARIES PUBLIC
++set(LIBRARIES
++	PRIVATE
 +        glslang::glslang
 +        glslang::OSDependent
 +        glslang::MachineIndependent
@@ -40,10 +42,11 @@ index 3d9625e4..8fe89f89 100644
 +        glslang::OGLCompiler
 +        glslang::SPVRemapper
 +        glslang::SPIRV
++	PUBLIC
          Vulkan::Vulkan
          Threads::Threads
  )
-@@ -365,9 +373,6 @@ target_include_directories(vsg
+@@ -365,9 +375,6 @@ target_include_directories(vsg
      PUBLIC
          $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/include>
          $<BUILD_INTERFACE:${VSG_BINARY_DIR}/include>

--- a/ports/vsg/devendor-glslang.patch
+++ b/ports/vsg/devendor-glslang.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 61da709f..472bc6af 100644
+index 6e7ec437..db4d30f1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -37,9 +37,11 @@ find_package(Vulkan ${Vulkan_MIN_VERSION} REQUIRED)
@@ -16,10 +16,10 @@ index 61da709f..472bc6af 100644
  
          if (Git_FOUND)
 diff --git a/src/vsg/CMakeLists.txt b/src/vsg/CMakeLists.txt
-index 4154312..7afcdd4 100644
+index 3d9625e4..8fe89f89 100644
 --- a/src/vsg/CMakeLists.txt
 +++ b/src/vsg/CMakeLists.txt
-@@ -226,7 +226,7 @@ set(SOURCES
+@@ -227,7 +227,7 @@ set(SOURCES
      utils/LoadPagedLOD.cpp
  )
  
@@ -28,7 +28,7 @@ index 4154312..7afcdd4 100644
  
      # include glslang source code directly into the VulkanScenegraph library build.
      include(../glslang/build_vars.cmake)
-@@ -234,6 +234,14 @@ endif()
+@@ -235,6 +235,14 @@ endif()
  
  # set up library dependencies
  set(LIBRARIES PUBLIC
@@ -43,7 +43,7 @@ index 4154312..7afcdd4 100644
          Vulkan::Vulkan
          Threads::Threads
  )
-@@ -364,9 +372,6 @@ target_include_directories(vsg
+@@ -365,9 +373,6 @@ target_include_directories(vsg
      PUBLIC
          $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/include>
          $<BUILD_INTERFACE:${VSG_BINARY_DIR}/include>

--- a/ports/vsg/devendor-glslang.patch
+++ b/ports/vsg/devendor-glslang.patch
@@ -69,3 +69,15 @@ index 71a7f09f..803f26a1 100644
  #    include <glslang/Public/ResourceLimits.h>
  #    include <glslang/Public/ShaderLang.h>
  #endif
+diff --git a/src/vsg/vsgConfig.cmake.in b/src/vsg/vsgConfig.cmake.in
+index 7ea0de02..4f7e77bd 100644
+--- a/src/vsg/vsgConfig.cmake.in
++++ b/src/vsg/vsgConfig.cmake.in
+@@ -2,6 +2,7 @@ include(CMakeFindDependencyMacro)
+ 
+ find_package(Vulkan @Vulkan_MIN_VERSION@ REQUIRED)
+ find_dependency(Threads)
++find_dependency(glslang)
+ 
+ @FIND_DEPENDENCY_WINDOWING@
+ include("${CMAKE_CURRENT_LIST_DIR}/vsgTargets.cmake")

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vsg-dev/VulkanSceneGraph
     REF "v${VERSION}"
-    SHA512 da5c9448da6bd2bd6edcb82ed1ac67aded9c3fd957fb7d3c78bb741d8993a5e90b134433237a63bf1a6eb23b30a1e6b4ea2115416f8d32464bd04925d8dbcd34
+    SHA512 b5f00190689473402157dfed34234359129a6b62f8eb0c118358af36639dcafce6c747c43d83b8602f3d06c011d3fcc98f27a95282be0a7601795ebe88921dbb
     HEAD_REF master
 	PATCHES devendor-glslang.patch
 )

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vsg",
-  "version": "1.0.5",
-  "port-version": 1,
+  "version": "1.0.6",
   "description": "A modern, cross platform, high performance scene graph library built upon Vulkan.",
   "homepage": "http://www.vulkanscenegraph.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8477,8 +8477,8 @@
       "port-version": 2
     },
     "vsg": {
-      "baseline": "1.0.5",
-      "port-version": 1
+      "baseline": "1.0.6",
+      "port-version": 0
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a28fafb639c82c5073955269eb3f931e41d3b17a",
+      "version": "1.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "c2ade86b1dee203ecaa4a401e76d80a205b6c71f",
       "version": "1.0.5",
       "port-version": 1

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f20a9579b1ddebc5321d5177f3604ed74965abd3",
+      "git-tree": "083510fe30c973a53fe65f4565d7c4159fdff36a",
       "version": "1.0.6",
       "port-version": 0
     },

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a28fafb639c82c5073955269eb3f931e41d3b17a",
+      "git-tree": "f20a9579b1ddebc5321d5177f3604ed74965abd3",
       "version": "1.0.6",
       "port-version": 0
     },


### PR DESCRIPTION
In addition to updating `vsg` to version 1.0.6, this also changes the order that the glslang and Vulkan targets are linked, which may prevent the error described in #31801.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
