### PR TITLE
[vulkan-memory-allocator] add cstdio import for gcc13

### DIFF
--- a/ports/vulkan-memory-allocator/gcc13.patch
+++ b/ports/vulkan-memory-allocator/gcc13.patch
@@ -1,0 +1,15 @@
+diff --git a/include/vk_mem_alloc.h b/include/vk_mem_alloc.h
+index 60f5720..31164bc 100644
+--- a/include/vk_mem_alloc.h
++++ b/include/vk_mem_alloc.h
+@@ -2578,6 +2578,10 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(
+     #include <bit> // For std::popcount
+ #endif
+ 
++#if VMA_STATS_STRING_ENABLED
++    #include <cstdio> // For snprintf
++#endif
++
+ /*******************************************************************************
+ CONFIGURATION SECTION
+ 

--- a/ports/vulkan-memory-allocator/portfile.cmake
+++ b/ports/vulkan-memory-allocator/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF a6bfc237255a6bac1513f7c1ebde6d8aed6b5191 #v3.0.1
     SHA512  14361ff201fd660c22b60de54c648ff20a2e2a7f65105f66853a9a4dbffbeca2ae42098dcb1528bb4e524639b92fa4ff27ebd3940c42ccfaf7c99c08bdd0d8ce
     HEAD_REF master
+    PATCHES
+        gcc13.patch # https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/commit/29d492b60c84ca784ea0943efc7d2e6e0f3bdaac
 )
 
 file(COPY "${SOURCE_PATH}/include/vk_mem_alloc.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")

--- a/ports/vulkan-memory-allocator/vcpkg.json
+++ b/ports/vulkan-memory-allocator/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vulkan-memory-allocator",
   "version": "3.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Easy to integrate Vulkan memory allocation library from GPUOpen",
   "homepage": "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8510,7 +8510,7 @@
     },
     "vulkan-memory-allocator": {
       "baseline": "3.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "vulkan-memory-allocator-hpp": {
       "baseline": "3.0.1",

--- a/versions/v-/vulkan-memory-allocator.json
+++ b/versions/v-/vulkan-memory-allocator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0295d831ef2217a424c4739767ecde90e5bc7554",
+      "version": "3.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "49c724c78cf76e8858c92ce7b1acdc52fd9bf62b",
       "version": "3.0.1",
       "port-version": 1


### PR DESCRIPTION
fixes #31875 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


