### PR TITLE
[magic-enum] Update to v0.9.2

### DIFF
--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/magic_enum
-    REF v0.9.1
-    SHA512 d76acfec5c8bdd1c22d1e278bc28965c8a15ec119b9671bf1bc49c143171f3ec9924e7f7b2e5ca689674f862f81600f7e92ace04f95f9cd96eeeed519fdf55d5
+    REF v0.9.2
+    SHA512 5c88ebcb30282bea5c2b38d17a6ee6a9014e5d282f2c08e92f398f30d9846cbd5a09599270afe82e927069bad9c50d691fa53a82da059f77dc1c01b179e65689
     HEAD_REF master
 )
 

--- a/ports/magic-enum/vcpkg.json
+++ b/ports/magic-enum/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-enum",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.",
   "homepage": "https://github.com/Neargye/magic_enum",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5073,7 +5073,7 @@
       "port-version": 0
     },
     "magic-enum": {
-      "baseline": "0.9.1",
+      "baseline": "0.9.2",
       "port-version": 0
     },
     "magic-get": {

--- a/versions/m-/magic-enum.json
+++ b/versions/m-/magic-enum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52780f8b8e0c2f55c3841e133c813f2bc739abcc",
+      "version": "0.9.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d423a24705ddc48956d0c7683f3f8e418ae44b0d",
       "version": "0.9.1",
       "port-version": 0


### PR DESCRIPTION
Describe the pull request

What does your PR fix?
Update magic-enum to v0.9.2

Changelog:
https://github.com/Neargye/magic_enum/releases/tag/v0.9.2

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.






