### PR TITLE
[pcre2] Update to 10.42

### DIFF
--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PCRE2Project/pcre2
-    REF pcre2-10.40
-    SHA512 098c21d60ecb3bb8449173f50c9ab8e6018fafd5d55548be08b15df37f8e08bcd4f851d75758c4d22505db30a3444bb65783d83cd876c63fdf0de2850815ef93
+    REF "pcre2-${VERSION}"
+    SHA512 3d0ee66e23809d3da2fe2bf4ed6e20b0fb96c293a91668935f6319e8d02e480eeef33da01e08a7436a18a1a85a116d83186b953520f394c866aad3cea73c7f5c
     HEAD_REF master
     PATCHES
         pcre2-10.35_fix-uwp.patch

--- a/ports/pcre2/vcpkg.json
+++ b/ports/pcre2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pcre2",
-  "version": "10.40",
-  "port-version": 2,
+  "version": "10.42",
   "description": "Regular Expression pattern matching using the same syntax and semantics as Perl 5.",
   "homepage": "https://github.com/PCRE2Project/pcre2",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6185,8 +6185,8 @@
       "port-version": 5
     },
     "pcre2": {
-      "baseline": "10.40",
-      "port-version": 2
+      "baseline": "10.42",
+      "port-version": 0
     },
     "pdal": {
       "baseline": "2.5.3",

--- a/versions/p-/pcre2.json
+++ b/versions/p-/pcre2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "148d5898b3c1925fd8e82663589917255172d5c9",
+      "version": "10.42",
+      "port-version": 0
+    },
+    {
       "git-tree": "533fc8ada3da33f695eb499fe8190a5e9b24a5c8",
       "version": "10.40",
       "port-version": 2


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
