### PR TITLE
[dbow3] Remove dynamic exception specs

### DIFF
--- a/ports/dbow3/portfile.cmake
+++ b/ports/dbow3/portfile.cmake
@@ -1,16 +1,24 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+# https://github.com/rmsalinas/DBow3/pull/50 , already accepted but not merged as of 2023-06-13
+vcpkg_download_distfile(REMOVE_DYNAMIC_EXCEPTION_SPECS
+    URLS https://patch-diff.githubusercontent.com/raw/rmsalinas/DBow3/pull/50.patch?full_index=1
+    SHA512 e39b9615aa8cfd4cf26b4ec977df823533b187d18ade5447c96fdcea53c9a58b1648e0a9fe78e3833360ba91c27ad56b6d65f944bd6c46f76969a652ba64cb5a
+    FILENAME 9f9d19930c3ec597bd1ebc2a9c2a84b9fd49674e.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rmsalinas/DBow3
-    REF master
-    SHA512 16e6789b77e8b42428d156ae5efa667861fa8ef2e85b54e3dd1d28e6f8dc7d119e973234c77cac82e775080fb9c859640d04159659a7d63941325e13e40b2814
+    REF c5ae539abddcef43ef64fa130555e2d521098369
+    SHA512 a1b35d2a524a23c367180574f7ddbcad73161c7fda6c3e7973273ab86092d9c6d89df28925a8e53691cd894f2d6588832604a0dbdba478557695806907bf36eb
     PATCHES
+      "${REMOVE_DYNAMIC_EXCEPTION_SPECS}"
       fix_cmake.patch
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DUSE_OPENCV_CONTRIB=ON
         -DBUILD_EXAMPLES=OFF

--- a/ports/dbow3/vcpkg.json
+++ b/ports/dbow3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dbow3",
   "version": "1.0.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "DBoW3 is an improved version of the DBow2 library, an open source C++ library for indexing and converting images into a bag-of-word representation.",
   "homepage": "https://github.com/rmsalinas/DBow3",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2038,7 +2038,7 @@
     },
     "dbow3": {
       "baseline": "1.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "dbus": {
       "baseline": "1.15.2",

--- a/versions/d-/dbow3.json
+++ b/versions/d-/dbow3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93b9dd598ac996f1dba459030964ba8fb79ae9dd",
+      "version": "1.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "0942151a7555bcac51e84d94474111ca96ff5974",
       "version": "1.0.0",
       "port-version": 2


### PR DESCRIPTION
Also changed "master" to the commit SHA on which master currently is so that doesn't break next time they merge something.