### PR TITLE
[mathgl] URL Encode

### DIFF
--- a/ports/mathgl/portfile.cmake
+++ b/ports/mathgl/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mathgl/mathgl
-    REF "mathgl 8.0"
+    REF "mathgl%208.0"
     FILENAME "mathgl-${VERSION}.tar.gz"
     SHA512 1ff3023f1bbd7bfd84202777a0166a8d4255a020a07f3650b9858929345bc8a2ceea4db155d2c93ba32b762d2304474276290a9edac99fda70fb4b5bc12982c2
     PATCHES

--- a/ports/mathgl/vcpkg.json
+++ b/ports/mathgl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mathgl",
   "version": "8.0.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "MathGL is a free library of fast C++ routines for the plotting of the data varied in one or more dimensions",
   "license": "GPL-3.0-only",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5158,7 +5158,7 @@
     },
     "mathgl": {
       "baseline": "8.0.1",
-      "port-version": 3
+      "port-version": 4
     },
     "matio": {
       "baseline": "1.5.23",

--- a/versions/m-/mathgl.json
+++ b/versions/m-/mathgl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "629d09b4394436b3821f1871eaa6caa27bf04be0",
+      "version": "8.0.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "2c1da85e695d3767410b3acf59567da2faf32ea2",
       "version": "8.0.1",
       "port-version": 3


### PR DESCRIPTION
Workaround on Ubuntu 22.04:

error: https://sourceforge.net/projects/mathgl/files/mathgl/mathgl 8.0/mathgl-8.0.1.tar.gz/download: curl failed to download with exit code 3
curl: (3) URL using bad/illegal format or missing URL
