### PR TITLE
[folly] Update folly to v2023.05.22.00

### DIFF
--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/folly
     REF "v${VERSION}"
-    SHA512 311cc6dfebfdfb49bfdd54e66c5dffabb16090610a3b0f05286aadb0e9d6b8b5b27f4bf3400cf74ba35b88f97d6ed7a79a6f32c093c78b8667684d4cbd8baedb
+    SHA512 69e2808e734f232eef2c3d1a6e4b1142b821e321f71ea7b1669b410e20200daa869aeabb177c7bddb3e7328b1c1b88fdc3a512f9991f9b0ebb006b898b23faf6
     HEAD_REF main
     PATCHES
         reorder-glog-gflags.patch

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/folly
     REF "v${VERSION}"
-    SHA512 69e2808e734f232eef2c3d1a6e4b1142b821e321f71ea7b1669b410e20200daa869aeabb177c7bddb3e7328b1c1b88fdc3a512f9991f9b0ebb006b898b23faf6
+    SHA512 8be640c0b87c85929aa0af2e147ef9556e24f777d80dc7d06019b7edc9b5738635ad3db9dea94f99f1a9eb7eb48e91d78a42d08bcb19b98a279fb805da41bf82
     HEAD_REF main
     PATCHES
         reorder-glog-gflags.patch

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "folly",
   "version-string": "2023.05.22.00",
-  "port-version": 0,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "folly",
-  "version-string": "2023.05.15.00",
+  "version-string": "2023.05.22.00",
+  "port-version": 0,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2569,7 +2569,7 @@
       "port-version": 0
     },
     "folly": {
-      "baseline": "2023.05.15.00",
+      "baseline": "2023.05.22.00",
       "port-version": 0
     },
     "font-chef": {

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3b61ea12796899ad5ca4e4f7bf97b24d1937882b",
+      "git-tree": "de1857916564fbf1f8aec432fe847f87175a35bc",
       "version-string": "2023.05.22.00",
       "port-version": 0
     },

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "de1857916564fbf1f8aec432fe847f87175a35bc",
+      "git-tree": "5ae6dac3d41eeaee3c4b313956de894a9cd66cae",
       "version-string": "2023.05.22.00",
       "port-version": 0
     },

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5ae6dac3d41eeaee3c4b313956de894a9cd66cae",
+      "git-tree": "4af22bbbe7fd8616fc5dfdeef6c2475f4fc3a4e5",
       "version-string": "2023.05.22.00",
       "port-version": 0
     },

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b61ea12796899ad5ca4e4f7bf97b24d1937882b",
+      "version-string": "2023.05.22.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "691eb72c1ad244629c0993986a9f33240afa4710",
       "version-string": "2023.05.15.00",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.