### PR TITLE
[hazelcast-cpp-client] Update to new released version 5.3.0 

### DIFF
--- a/ports/hazelcast-cpp-client/portfile.cmake
+++ b/ports/hazelcast-cpp-client/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hazelcast/hazelcast-cpp-client
     REF "v${VERSION}"
-    SHA512 1e4203b546f3737e7fd2ea7a7ed04fa5b0663e7c319ed796140407d4e56d70e40eb5a9497d9f9eb7be182b038efe36f6ba1a42f10d24d3732cf54886c40db8eb 
+    SHA512 9f6668fe88b1e10e1c91fea26acb12efab464f652d9008e43b06d92413a7bc4b66cd0ef00c0643ddf12c8d29b099cd767209a096e609fa214233dcc3288d194e
     HEAD_REF master
 )
 

--- a/ports/hazelcast-cpp-client/vcpkg.json
+++ b/ports/hazelcast-cpp-client/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hazelcast-cpp-client",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "C++ client library for Hazelcast in-memory database.",
   "homepage": "https://github.com/hazelcast/hazelcast-cpp-client",
   "documentation": "http://hazelcast.github.io/hazelcast-cpp-client/index.html",
@@ -31,7 +31,7 @@
       "description": "Build examples for Hazelcast C++ client"
     },
     "openssl": {
-      "description": "Build hazelcast C++ client with SSL support",
+      "description": "Build Hazelcast C++ client with SSL support",
       "dependencies": [
         "openssl"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3101,7 +3101,7 @@
       "port-version": 3
     },
     "hazelcast-cpp-client": {
-      "baseline": "5.2.0",
+      "baseline": "5.3.0",
       "port-version": 0
     },
     "hdf5": {

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4940909398dd70e7610c314749ca143bb0c23918",
+      "version": "5.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "eda58413d2940bc24bef92485ff1fce31e2e583c",
       "version": "5.2.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ x] SHA512s are updated for each updated download
- [ x] The "supports" clause reflects platforms that may be fixed by this new version
- [ x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ x] Any patches that are no longer applied are deleted from the port's directory.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
