### PR TITLE
[lightningscanner] Update to 1.0.1

### DIFF
--- a/ports/lightningscanner/portfile.cmake
+++ b/ports/lightningscanner/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO localcc/LightningScanner
     REF v${VERSION}
-    SHA512 7bd41e049ccdf1dbe39b2ab3c58344822300165482d7c5392fe1cd2b15a40baec9ff080963f7db60f2826ece983a06b921d8a28ba57edf751c2cc7644f0a1150
+    SHA512 fa2aefb6a6097544f578a96592b7b2ff58d5bccac7b10a0ab45fbe87e1204b3cbde5c16c64974e7434ea385727fb150b39080bf809f9698d944f75a6c110fe3c
 )
 
 vcpkg_cmake_configure(

--- a/ports/lightningscanner/vcpkg.json
+++ b/ports/lightningscanner/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lightningscanner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A lightning-fast memory signature/pattern scanner, capable of scanning gigabytes of data per second.",
   "homepage": "https://localcc.github.io/LightningScanner/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4901,7 +4901,7 @@
       "port-version": 0
     },
     "lightningscanner": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "lilv": {

--- a/versions/l-/lightningscanner.json
+++ b/versions/l-/lightningscanner.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9096d7c2c2c14b7e438e48f6aecd194c2356172",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "25cfcf5944e73bfe349e264a37f98ea36558da18",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version **(no changes)**
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. **(no changes)**
- [x] Any patches that are no longer applied are deleted from the port's directory. **(no changes)**
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
