### PR TITLE
[thor] Update to current master

### DIFF
--- a/ports/thor/fix-dependency-sfml.patch
+++ b/ports/thor/fix-dependency-sfml.patch
@@ -1,31 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 03536be..abcff44 100644
+index 352fea9..01c1695 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -115,11 +115,10 @@ set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/;${CMAKE_MODULE_PATH
+@@ -111,7 +111,7 @@ endif()
  if(NOT THOR_SHARED_LIBS)
  	set(SFML_STATIC_LIBRARIES TRUE)
  endif()
--find_package(SFML 2 COMPONENTS audio graphics window system)
-+find_package(SFML COMPONENTS system window graphics CONFIG REQUIRED)
-+set(SFML_LIBRARIES sfml-system sfml-network sfml-graphics sfml-window)
+-find_package(SFML 2.5 COMPONENTS audio graphics window system REQUIRED)
++find_package(SFML COMPONENTS audio graphics window system CONFIG REQUIRED)
  
--if(SFML_FOUND)
--	include_directories(${SFML_INCLUDE_DIR})
--else()
-+if(0)
- 	set(SFML_ROOT "" CACHE PATH "SFML top-level directory")
- 	message("\n-> SFML directory not found. Set SFML_ROOT to SFML's top-level path (containing \"include\" and \"lib\" directories).")
- 	message("-> Make sure the SFML libraries with the same configuration (Release/Debug, Static/Dynamic) exist.\n")
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 75e118e..0f90ac8 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -72,6 +72,7 @@ else()
- 	add_library(${THOR_LIB} STATIC ${THOR_SRC})
- 	set_target_properties(${THOR_LIB} PROPERTIES DEBUG_POSTFIX -s-d)
- 	set_target_properties(${THOR_LIB} PROPERTIES RELEASE_POSTFIX -s)
-+    thor_link_sfml(${THOR_LIB})
- endif()
- 
- 
+ if(NOT SFML_FOUND)
+ 	set(SFML_DIR "" CACHE PATH "SFML top-level directory")

--- a/ports/thor/portfile.cmake
+++ b/ports/thor/portfile.cmake
@@ -1,10 +1,11 @@
 vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO Bromeon/Thor
-  REF v2.0
-  SHA512 634fa5286405d9a8a837c082ace98bbb02e609521418935855b9e2fcad57003dbe35088bd771cf6a9292e55d3787f7e463d7a4cca0d0f007509de2520d9a8cf9
-  HEAD_REF master
-  PATCHES fix-dependency-sfml.patch
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Bromeon/Thor
+    REF 3e320cb52606f0b44fd9d2bb272b3cb6d01d7f20
+    SHA512 de5eeee0f3f7142ffa1fcb7694cf157a65e95af4ad22e3dc7eaa199b98c9fa2dc0dd0635d057c9ba8601a22a6b36ef7d4d420a09ade1c77360c3a6582534f12b
+    HEAD_REF master
+    PATCHES
+        fix-dependency-sfml.patch
 )
 file(REMOVE "${SOURCE_PATH}/cmake/Modules/FindSFML.cmake")
 
@@ -16,10 +17,12 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" THOR_STATIC_STD_LIBS)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" THOR_SHARED_LIBS)
 
 vcpkg_cmake_configure(
-  SOURCE_PATH "${SOURCE_PATH}"
-  OPTIONS
-    -DTHOR_SHARED_LIBS=${THOR_SHARED_LIBS}
-    -DTHOR_STATIC_STD_LIBS=${THOR_STATIC_STD_LIBS}
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DTHOR_SHARED_LIBS=${THOR_SHARED_LIBS}
+        -DTHOR_STATIC_STD_LIBS=${THOR_STATIC_STD_LIBS}
+    MAYBE_UNUSED_VARIABLES
+        THOR_STATIC_STD_LIBS # Only on Windows
 )
 
 vcpkg_cmake_install()
@@ -47,7 +50,12 @@ if(LICENSE)
   file(REMOVE ${LICENSE})
 endif()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/include/Aurora")
+file(REMOVE_RECURSE
+  "${CURRENT_PACKAGES_DIR}/debug/include"
+  "${CURRENT_PACKAGES_DIR}/include/Aurora"
+  "${CURRENT_PACKAGES_DIR}/cmake"
+  "${CURRENT_PACKAGES_DIR}/debug/cmake"
+)
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/thor/vcpkg.json
+++ b/ports/thor/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "thor",
-  "version": "2.0",
-  "port-version": 6,
+  "version-date": "2022-04-16",
   "description": "Extends the multimedia library SFML with higher-level features",
   "homepage": "https://bromeon.ch/libraries/thor/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7969,8 +7969,8 @@
       "port-version": 2
     },
     "thor": {
-      "baseline": "2.0",
-      "port-version": 6
+      "baseline": "2022-04-16",
+      "port-version": 0
     },
     "thorvg": {
       "baseline": "0.9.0",

--- a/versions/t-/thor.json
+++ b/versions/t-/thor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52c5298a73cdd120b4138b72dd84085cf18f53c1",
+      "version-date": "2022-04-16",
+      "port-version": 0
+    },
+    {
       "git-tree": "d337ec42ced0695748c94113eb08515810e3408f",
       "version": "2.0",
       "port-version": 6


### PR DESCRIPTION
This is necessary to build on Ubuntu 22.04 because it includes https://github.com/Bromeon/Thor/commit/d5e641d86b964c4c9294fdf515811f755ccfbd77

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
