### PR TITLE
[unicorn-lib] Fix missing headers

### DIFF
--- a/ports/unicorn-lib/fix-missing-headers.patch
+++ b/ports/unicorn-lib/fix-missing-headers.patch
@@ -1,0 +1,12 @@
+diff --git a/unicorn/utility.hpp b/unicorn/utility.hpp
+index e6a57b7..a2afa58 100644
+--- a/unicorn/utility.hpp
++++ b/unicorn/utility.hpp
+@@ -54,6 +54,7 @@
+ #include <istream>
+ #include <iterator>
+ #include <limits>
++#include <memory>
+ #include <mutex>
+ #include <new>
+ #include <optional>

--- a/ports/unicorn-lib/portfile.cmake
+++ b/ports/unicorn-lib/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF 44e975ffc8dcd8dedbe01a8cbe7812e351f3f74f # 2021-10-28
     SHA512 b22264420174c950ca8025e861366118d79a53edce9297d84af9511e255af5971c3719f0b464f4a4886848edea7c2ba4ae32ce9abab135628d64adbde5fa7b0d
     HEAD_REF master
+    PATCHES
+        fix-missing-headers.patch # https://github.com/CaptainCrowbar/unicorn-lib/pull/10
 )
 
 file(COPY "${CURRENT_PORT_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/unicorn-lib/vcpkg.json
+++ b/ports/unicorn-lib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "unicorn-lib",
   "version-date": "2022-01-24",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Unicode library for C++ by Ross Smith",
   "homepage": "https://github.com/CaptainCrowbar/unicorn-lib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8238,7 +8238,7 @@
     },
     "unicorn-lib": {
       "baseline": "2022-01-24",
-      "port-version": 1
+      "port-version": 2
     },
     "units": {
       "baseline": "2.3.3",

--- a/versions/u-/unicorn-lib.json
+++ b/versions/u-/unicorn-lib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a392f38ad3deeac937482462e7253e332e4a672",
+      "version-date": "2022-01-24",
+      "port-version": 2
+    },
+    {
       "git-tree": "20329e00e75f4f13bb1b77f3e19c23182861c6cd",
       "version-date": "2022-01-24",
       "port-version": 1


### PR DESCRIPTION
Necessary to compile on Ubuntu 22.04, submitted upstream as https://github.com/CaptainCrowbar/unicorn-lib/pull/10
