### PR TITLE
[yara] Update yara from 4.3.0 to 4.3.2

### DIFF
--- a/ports/yara/portfile.cmake
+++ b/ports/yara/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO VirusTotal/yara
   REF "v${VERSION}"
-  SHA512 fe239ae2f29fac7b4dbdc0ec84eba057dd4d93c6ae3a53d6bc2a333cc15ed45b1ff5cb896faf02813be667ce191ccbe1d64549552ea4f0834804ad0ec4b29092
+  SHA512 dc77ec46a30ca2fff33b639166fc554c9c6d9e955642774e23da3ea7dbb25fe154cfd4ef83c9808920193028b9099258a63b3f1b9a66864a1f3905f0a8e8053f
   HEAD_REF master
   PATCHES
     # Module elf request new library tlshc(https://github.com/avast/tlshc), the related upstream PR: https://github.com/VirusTotal/yara/pull/1624.

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yara",
-  "version": "4.3.0",
+  "version": "4.3.2",
   "port-version": 1,
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "yara",
   "version": "4.3.2",
-  "port-version": 1,
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8837,7 +8837,7 @@
       "port-version": 1
     },
     "yara": {
-      "baseline": "4.3.0",
+      "baseline": "4.3.2",
       "port-version": 1
     },
     "yas": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8838,7 +8838,7 @@
     },
     "yara": {
       "baseline": "4.3.2",
-      "port-version": 1
+      "port-version": 0
     },
     "yas": {
       "baseline": "7.1.0",

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "d65f6f24a06081fff06e29a601240dcb7f4511b5",
+      "git-tree": "993e6ee9f366ecd84f0636ae4f7de293293a9068",
       "version": "4.3.2",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "4deddff9f05a4c7f2fc13b77da1717b50d25072a",

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d65f6f24a06081fff06e29a601240dcb7f4511b5",
+      "version": "4.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "4deddff9f05a4c7f2fc13b77da1717b50d25072a",
       "version": "4.3.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.