### PR TITLE
[sfml] Fix exported dependencies

### DIFF
--- a/ports/sfml/fix-dependencies.patch
+++ b/ports/sfml/fix-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/SFMLConfig.cmake.in b/cmake/SFMLConfig.cmake.in
-index ce81953..bd2d330 100644
+index ce81953..c8dd971 100644
 --- a/cmake/SFMLConfig.cmake.in
 +++ b/cmake/SFMLConfig.cmake.in
 @@ -1,3 +1,8 @@
@@ -12,10 +12,22 @@ index ce81953..bd2d330 100644
  # ------------------------------------
  #
 diff --git a/cmake/SFMLConfigDependencies.cmake.in b/cmake/SFMLConfigDependencies.cmake.in
-index 1028110..927d1a4 100644
+index 1028110..76fc650 100644
 --- a/cmake/SFMLConfigDependencies.cmake.in
 +++ b/cmake/SFMLConfigDependencies.cmake.in
-@@ -56,6 +56,9 @@ if(SFML_STATIC_LIBRARIES)
+@@ -31,9 +31,11 @@ if(SFML_STATIC_LIBRARIES)
+         endif()
+ 
+         # No lookup in environment variables (PATH on Windows), as they may contain wrong library versions
++        if(NOT ${THIS_FRIENDLY_NAME}_LIB)
+         find_library(${THIS_FRIENDLY_NAME}_LIB NAMES ${THIS_SEARCH_NAMES}
+                      PATHS ${FIND_SFML_PATHS} PATH_SUFFIXES lib NO_SYSTEM_ENVIRONMENT_PATH)
+         mark_as_advanced(${THIS_FRIENDLY_NAME}_LIB)
++        endif()
+         if(${THIS_FRIENDLY_NAME}_LIB)
+             set_property(TARGET ${THIS_TARGET} APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${${THIS_FRIENDLY_NAME}_LIB}")
+         else()
+@@ -56,6 +58,9 @@ if(SFML_STATIC_LIBRARIES)
          if (FIND_SFML_OS_WINDOWS)
              set_property(TARGET OpenGL APPEND PROPERTY INTERFACE_LINK_LIBRARIES "OpenGL32")
          elseif(NOT FIND_SFML_OS_IOS)
@@ -25,7 +37,7 @@ index 1028110..927d1a4 100644
              sfml_bind_dependency(TARGET OpenGL FRIENDLY_NAME "OpenGL" SEARCH_NAMES "OpenGL" "GL")
          endif()
      endif()
-@@ -63,6 +66,8 @@ if(SFML_STATIC_LIBRARIES)
+@@ -63,6 +68,8 @@ if(SFML_STATIC_LIBRARIES)
      # sfml-graphics
      list(FIND SFML_FIND_COMPONENTS "graphics" FIND_SFML_GRAPHICS_COMPONENT_INDEX)
      if(FIND_SFML_GRAPHICS_COMPONENT_INDEX GREATER -1)
@@ -35,7 +47,7 @@ index 1028110..927d1a4 100644
      endif()
  
 diff --git a/src/SFML/Graphics/CMakeLists.txt b/src/SFML/Graphics/CMakeLists.txt
-index 883c758..402efbe 100644
+index 883c758..b59e659 100644
 --- a/src/SFML/Graphics/CMakeLists.txt
 +++ b/src/SFML/Graphics/CMakeLists.txt
 @@ -97,7 +97,8 @@ sfml_add_library(sfml-graphics
@@ -48,7 +60,7 @@ index 883c758..402efbe 100644
  
  # let CMake know about our additional graphics libraries paths
  if(SFML_OS_WINDOWS)
-@@ -134,7 +134,8 @@ if(SFML_OS_ANDROID)
+@@ -134,7 +135,8 @@ if(SFML_OS_ANDROID)
      target_link_libraries(sfml-graphics PRIVATE z EGL GLESv1_CM)
  endif()
  
@@ -59,7 +71,7 @@ index 883c758..402efbe 100644
  
  # add preprocessor symbols
 diff --git a/src/SFML/Window/CMakeLists.txt b/src/SFML/Window/CMakeLists.txt
-index 98ea439..0f1fb53 100644
+index 98ea439..acb8d61 100644
 --- a/src/SFML/Window/CMakeLists.txt
 +++ b/src/SFML/Window/CMakeLists.txt
 @@ -254,7 +254,9 @@ if(SFML_OPENGL_ES)

--- a/ports/sfml/vcpkg.json
+++ b/ports/sfml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sfml",
   "version": "2.5.1",
-  "port-version": 15,
+  "port-version": 16,
   "description": "Simple and fast multimedia library",
   "homepage": "https://github.com/sfml/sfml",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7422,7 +7422,7 @@
     },
     "sfml": {
       "baseline": "2.5.1",
-      "port-version": 15
+      "port-version": 16
     },
     "sfsexp": {
       "baseline": "1.3.1",

--- a/versions/s-/sfml.json
+++ b/versions/s-/sfml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9e87b4e23cdcec8d249517f14a69d8e453d3418",
+      "version": "2.5.1",
+      "port-version": 16
+    },
+    {
       "git-tree": "477c029a9588d5f24c19fd0b6dbc82813fdc2150",
       "version": "2.5.1",
       "port-version": 15


### PR DESCRIPTION
Fixes #31962.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
