### PR TITLE
[tiff] Update to 4.5.1

### DIFF
--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -1,11 +1,9 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.com
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtiff/libtiff
     REF "v${VERSION}"
-    SHA512 5227cb7b496ac6829601d8d689233bd8f318c1d04e5ce3457cdd6eac9e4f8c80cd7211d90cd092c61ad38bc8a4949169a13eabd788c46c15bcee1f72519fa022
+    SHA512 859331284cd28df56c44644a355ecdd8eece19f0d5cd3e693e37c0fe37115091e46943ffbad784e84af1b39a6fd81cd196af2d4fefe86369258f89050dafaa84
     HEAD_REF master
     PATCHES
         FindCMath.patch
@@ -17,7 +15,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         jpeg    jpeg
         jpeg    CMAKE_REQUIRE_FIND_PACKAGE_JPEG
         lzma    lzma
-        lzma    CMAKE_REQUIRE_FIND_PACKAGE_LibLZMA
+        lzma    CMAKE_REQUIRE_FIND_PACKAGE_liblzma
         tools   tiff-tools
         webp    webp
         webp    CMAKE_REQUIRE_FIND_PACKAGE_WebP
@@ -31,6 +29,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON
         -Dtiff-docs=OFF
         -Dtiff-contrib=OFF
         -Dtiff-tests=OFF
@@ -50,7 +49,10 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+# CMake config wasn't packaged in the past and is not yet usable now,
+# cf. https://gitlab.com/libtiff/libtiff/-/merge_requests/496
+# vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/tiff")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake" "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
 
 set(_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libtiff-4.pc")
 if(EXISTS "${_file}")
@@ -61,7 +63,6 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
-    "${CURRENT_PACKAGES_DIR}/share"
 )
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)

--- a/ports/tiff/vcpkg.json
+++ b/ports/tiff/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tiff",
-  "version": "4.5.0",
-  "port-version": 3,
+  "version": "4.5.1",
   "description": "A library that supports the manipulation of TIFF image files",
   "homepage": "https://libtiff.gitlab.io/libtiff/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7989,8 +7989,8 @@
       "port-version": 0
     },
     "tiff": {
-      "baseline": "4.5.0",
-      "port-version": 3
+      "baseline": "4.5.1",
+      "port-version": 0
     },
     "tinkerforge": {
       "baseline": "2.1.25",

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5510d3f8317c71185268d5128e6a7c24b4d66863",
+      "version": "4.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "658dc44e4f5495f0820db6358d8edf74e6ac8d48",
       "version": "4.5.0",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
