### PR TITLE
[libxlsxwriter] fix cmake zlib ver required

### DIFF
--- a/ports/libxlsxwriter/fix-zlib-ver-required.patch
+++ b/ports/libxlsxwriter/fix-zlib-ver-required.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 776c88a..ccc057d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,7 +219,7 @@ enable_language(CXX)
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ 
+ # ZLIB
+-find_package(ZLIB REQUIRED "1.0")
++find_package(ZLIB "1.0" REQUIRED)
+ list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS})
+ message("zlib version: " ${ZLIB_VERSION})
+ 

--- a/ports/libxlsxwriter/portfile.cmake
+++ b/ports/libxlsxwriter/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         dependencies.diff
+        fix-zlib-ver-required.patch
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/third_party/minizip")
 

--- a/ports/libxlsxwriter/vcpkg.json
+++ b/ports/libxlsxwriter/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libxlsxwriter",
   "version": "1.1.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Libxlsxwriter is a C library that can be used to write text, numbers, formulas and hyperlinks to multiple worksheets in an Excel 2007+ XLSX file.",
   "homepage": "https://github.com/jmcnamara/libxlsxwriter",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4814,7 +4814,7 @@
     },
     "libxlsxwriter": {
       "baseline": "1.1.5",
-      "port-version": 1
+      "port-version": 2
     },
     "libxml2": {
       "baseline": "2.10.3",

--- a/versions/l-/libxlsxwriter.json
+++ b/versions/l-/libxlsxwriter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a877e6dd9e9652cedcb94daa467c8fd7580bf5fb",
+      "version": "1.1.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "2769eadc216de088f724efd09edce1c73f9e8b4b",
       "version": "1.1.5",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/31994
Add patch to fix zlib ver required, this fix comes from upstream and should be removed during the next version update. see https://github.com/jmcnamara/libxlsxwriter/commit/f477741dd3782101eefb35f9c6f9ed93ee3f642d.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
