### PR TITLE
[ixwebsocket] update to 11.4.4

### DIFF
--- a/ports/ixwebsocket/fix-C2065-of-errorMsg.patch
+++ b/ports/ixwebsocket/fix-C2065-of-errorMsg.patch
@@ -1,0 +1,13 @@
+diff --git a/ixwebsocket/IXSocketMbedTLS.cpp b/ixwebsocket/IXSocketMbedTLS.cpp
+index f5c0cf6..0192dc7 100644
+--- a/ixwebsocket/IXSocketMbedTLS.cpp
++++ b/ixwebsocket/IXSocketMbedTLS.cpp
+@@ -49,7 +49,7 @@ namespace ix
+         mbedtls_pk_init(&_pkey);
+     }
+ 
+-    bool SocketMbedTLS::loadSystemCertificates(std::string& /* errorMsg */)
++    bool SocketMbedTLS::loadSystemCertificates(std::string& errorMsg)
+     {
+ #ifdef _WIN32
+         DWORD flags = CERT_STORE_READONLY_FLAG | CERT_STORE_OPEN_EXISTING_FLAG |

--- a/ports/ixwebsocket/portfile.cmake
+++ b/ports/ixwebsocket/portfile.cmake
@@ -3,8 +3,10 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO machinezone/IXWebSocket
-    REF v11.4.3
-    SHA512 6db4f05b3a73aa5f6efdb6d4692d9f9665b14c3a6e4837ff6b2719d9261aa660166fd4ddf99ca8e6804202d6f71c399fe1c223932493ea8db0a73752cb5b8e97
+    REF "v${VERSION}"
+    SHA512 698ad96f25f53bf48906201826008bad46c657f8043d3653988716ddd9fb5dfeb52cebc002b3af76b91d0561155607a5f38bbc2c808aa67f438432207da82a35
+    PATCHES
+        fix-C2065-of-errorMsg.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -33,4 +35,4 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/ixwebsocket/vcpkg.json
+++ b/ports/ixwebsocket/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ixwebsocket",
-  "version-semver": "11.4.3",
+  "version-semver": "11.4.4",
   "description": "Lightweight WebSocket Client and Server + HTTP Client and Server",
   "homepage": "https://github.com/machinezone/IXWebSocket",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3417,7 +3417,7 @@
       "port-version": 10
     },
     "ixwebsocket": {
-      "baseline": "11.4.3",
+      "baseline": "11.4.4",
       "port-version": 0
     },
     "jack2": {

--- a/versions/i-/ixwebsocket.json
+++ b/versions/i-/ixwebsocket.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8831fc46f1465a5630978a28255c9edab0fed860",
+      "version-semver": "11.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "c5abcb4348cb05507367eeaac8fb075c5cf8ed35",
       "version-semver": "11.4.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/31997

Add patch to fix below errors:
```
\ixwebsocket\IXSocketMbedTLS.cpp(61): error C2065: 'errorMsg': undeclared identifier
\ixwebsocket\IXSocketMbedTLS.cpp(62): error C2065: 'errorMsg': undeclared identifier
\ixwebsocket\IXSocketMbedTLS.cpp(88): error C2065: 'errorMsg': undeclared identifier
```
I also submitted a PR https://github.com/machinezone/IXWebSocket/pull/471 to the upstream to fix this issue.

Feature test passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static 
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
