### PR TITLE
[catch2] Fix wrong lib Catch2WithMain dir

### DIFF
--- a/ports/catch2/fix-install-path.patch
+++ b/ports/catch2/fix-install-path.patch
@@ -1,7 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6d381d8..94122e6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -164,7 +164,7 @@
+@@ -164,7 +164,7 @@ if (NOT_SUBPROJECT)
  
      ## Provide some pkg-config integration
      set(PKGCONFIG_INSTALL_DIR
@@ -10,36 +11,3 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
          CACHE PATH "Path where catch2.pc is installed"
      )
      configure_file(
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -401,16 +401,28 @@
-     install(
-       TARGETS
-         Catch2
--        Catch2WithMain
-       EXPORT
-         Catch2Targets
-       LIBRARY DESTINATION
-         ${CMAKE_INSTALL_LIBDIR}
-       ARCHIVE DESTINATION
-         ${CMAKE_INSTALL_LIBDIR}
-       RUNTIME DESTINATION
-         ${CMAKE_INSTALL_BINDIR}
-     )
-+
-+     install(
-+      TARGETS
-+        Catch2WithMain
-+      EXPORT
-+        Catch2Targets
-+      LIBRARY DESTINATION
-+        ${CMAKE_INSTALL_LIBDIR}/manual-link
-+      ARCHIVE DESTINATION
-+        ${CMAKE_INSTALL_LIBDIR}/manual-link
-+      RUNTIME DESTINATION
-+        ${CMAKE_INSTALL_BINDIR}
-+    )
- 
- 
-     install(

--- a/ports/catch2/fix-install-path.patch
+++ b/ports/catch2/fix-install-path.patch
@@ -11,3 +11,35 @@ index 6d381d8..94122e6 100644
          CACHE PATH "Path where catch2.pc is installed"
      )
      configure_file(
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index fd05dbd..a31060d 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -404,7 +404,6 @@ if (NOT_SUBPROJECT)
+     install(
+       TARGETS
+         Catch2
+-        Catch2WithMain
+       EXPORT
+         Catch2Targets
+       LIBRARY DESTINATION
+@@ -415,6 +414,19 @@ if (NOT_SUBPROJECT)
+         ${CMAKE_INSTALL_BINDIR}
+     )
+ 
++     install(
++      TARGETS
++        Catch2WithMain
++      EXPORT
++        Catch2Targets
++      LIBRARY DESTINATION
++        ${CMAKE_INSTALL_PREFIX}/lib/manual-link
++      ARCHIVE DESTINATION
++        ${CMAKE_INSTALL_PREFIX}/lib/manual-link
++      RUNTIME DESTINATION
++        ${CMAKE_INSTALL_PREFIX}/bin
++    )
++
+ 
+     install(
+       EXPORT

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     SHA512 3d0c5666509a19be54ea0c48a3c8e1c4a951a2d991a7c9f7fe6d326661464538f1ab9dc573b1b2647f49fb6bef45bbd866142a4ce0fba38545ad182b8d55f61f
     HEAD_REF devel
     PATCHES
-     #   fix-install-path.patch
+        fix-install-path.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -1,7 +1,6 @@
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
-vcpkg_minimum_required(VERSION 2022-11-10)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     SHA512 3d0c5666509a19be54ea0c48a3c8e1c4a951a2d991a7c9f7fe6d326661464538f1ab9dc573b1b2647f49fb6bef45bbd866142a4ce0fba38545ad182b8d55f61f
     HEAD_REF devel
     PATCHES
-        fix-install-path.patch
+     #   fix-install-path.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "catch2",
   "version-semver": "3.3.2",
+  "port-version": 1,
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1398,7 +1398,7 @@
     },
     "catch2": {
       "baseline": "3.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "cccapstone": {
       "baseline": "9b4128ee1153e78288a1b5433e2c06a0d47a4c4e",

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc20b6b9a6d12ade2893dd58a1d7173e9e11d763",
+      "version-semver": "3.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "e776d4cb313c846f6de82c05fa2ab9b7748edb6b",
       "version-semver": "3.3.2",
       "port-version": 0

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f1d21107fed707b36dc1d2f943471abc7c2d9ace",
+      "git-tree": "16ea5b904eb916dd2b2a624867a6cd03098b1472",
       "version-semver": "3.3.2",
       "port-version": 1
     },

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dc20b6b9a6d12ade2893dd58a1d7173e9e11d763",
+      "git-tree": "f1d21107fed707b36dc1d2f943471abc7c2d9ace",
       "version-semver": "3.3.2",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/31774
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: The function of [`manual-link`](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md#place-conflicting-libs-in-a-manual-link-directory)  is to solve the conflict problem of the library, and the `Catch2WithMain `does not conflict with other libraries, so it does not need to be put into the `manual-link`.
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
