### PR TITLE
[mp-units] update v0.8.0

### DIFF
--- a/ports/mp-units/config.patch
+++ b/ports/mp-units/config.patch
@@ -1,14 +1,17 @@
 diff --git a/src/mp-unitsConfig.cmake b/src/mp-unitsConfig.cmake
+index 668fd97d..0eebeded 100644
 --- a/src/mp-unitsConfig.cmake
 +++ b/src/mp-unitsConfig.cmake
-@@ -39,8 +39,8 @@ function(__check_libcxx_in_use variable)
- endfunction()
- 
+@@ -42,10 +42,10 @@ endfunction()
  include(CMakeFindDependencyMacro)
--find_dependency(fmt)
+ 
+ if(UNITS_USE_LIBFMT)
+-    find_dependency(fmt)
++    find_dependency(fmt CONFIG)
+ endif()
+ 
 -find_dependency(gsl-lite)
-+find_dependency(fmt CONFIG)
 +find_dependency(gsl-lite CONFIG)
  
  # add range-v3 dependency only for clang + libc++
- if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/ports/mp-units/portfile.cmake
+++ b/ports/mp-units/portfile.cmake
@@ -1,14 +1,21 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mpusz/units
-    REF v0.7.0
-    SHA512 72175f34f358d0741650ce9c8a7b28fced90cc45ddd3f1662ae1cb9ff7d31403ff742ee07ab4c96bd2d95af714d9111a888cf6acccb91e568e12d1ef663b2f64
+    REF "v${VERSION}"
+    SHA512 6369c886629955c6457911b98a702c29bacce58e9049e1da700055a3f8b1981cce4f545c1d09550ec1c57f8805f7fc1f0198118950a14b2a7b797dd437ed72df
     PATCHES
-        config.patch
+      config.patch
 )
+
+set(USE_LIBFMT OFF)
+if ("use-libfmt" IN_LIST FEATURES)
+    set(USE_LIBFMT ON)
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/src"
+    OPTIONS
+      -DUNITS_USE_LIBFMT=${USE_LIBFMT}
 )
 
 vcpkg_cmake_install()
@@ -16,7 +23,7 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 # Handle copyright/readme/package files
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
 file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug"

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -7,6 +7,7 @@
   "dependencies": [
     "fmt",
     "gsl-lite",
+    "range-v3",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -23,9 +23,10 @@
       "description": "Platform specific default features",
       "dependencies": [
         {
+          "name": "mp-units",
           "features": [
-            "fmt",
-            "range-v3"
+            "install-range-v3",
+            "use-libfmt"
           ],
           "platform": "osx"
         }

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -15,7 +15,23 @@
       "host": true
     }
   ],
+  "default-features": [
+    "default-features"
+  ],
   "features": {
+    "default-features": {
+      "description": "osx default dependencies",
+      "dependencies": [
+        {
+          "name": "mp-units",
+          "features": [
+            "fmt",
+            "range-v3"
+          ],
+          "platform": "osx"
+        }
+      ]
+    },
     "install-range-v3": {
       "description": "Provide range-v3 for compilers not supporting std::ranges",
       "dependencies": [

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -5,9 +5,7 @@
   "homepage": "https://github.com/mpusz/units",
   "license": "MIT",
   "dependencies": [
-    "fmt",
     "gsl-lite",
-    "range-v3",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -18,8 +16,17 @@
     }
   ],
   "features": {
+    "install-range-v3": {
+      "description": "Provide range-v3 for compilers not supporting std::ranges",
+      "dependencies": [
+        "range-v3"
+      ]
+    },
     "use-libfmt": {
-      "description": "Use libfmt instead of std::format"
+      "description": "Use libfmt instead of std::format",
+      "dependencies": [
+        "fmt"
+      ]
     }
   }
 }

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mp-units",
-  "version-semver": "0.7.0",
-  "port-version": 1,
+  "version": "0.8.0",
   "description": "mp-units - A Units Library for C++",
   "homepage": "https://github.com/mpusz/units",
   "license": "MIT",
@@ -16,5 +15,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "use-libfmt": {
+      "description": "Use libfmt instead of std::format"
+    }
+  }
 }

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -20,10 +20,9 @@
   ],
   "features": {
     "default-features": {
-      "description": "osx default dependencies",
+      "description": "Platform specific default features",
       "dependencies": [
         {
-          "name": "mp-units",
           "features": [
             "fmt",
             "range-v3"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5397,8 +5397,8 @@
       "port-version": 0
     },
     "mp-units": {
-      "baseline": "0.7.0",
-      "port-version": 1
+      "baseline": "0.8.0",
+      "port-version": 0
     },
     "mp3lame": {
       "baseline": "3.100",

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "021a312d63b606ed37abcbccbdfc826ed2cb1812",
+      "git-tree": "324181386d0dcda5a5f33049b7f32d485fa5f255",
       "version": "0.8.0",
       "port-version": 0
     },

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02718e2d964cf28e8344dea96539b68b02a50fe6",
+      "version": "0.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b4bce95b7e67f66db9d613e7e3601c2b90cec665",
       "version-semver": "0.7.0",
       "port-version": 1

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "02718e2d964cf28e8344dea96539b68b02a50fe6",
+      "git-tree": "e3a556c8c958ac3a863dbef9db34cf486844c5e5",
       "version": "0.8.0",
       "port-version": 0
     },

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e3a556c8c958ac3a863dbef9db34cf486844c5e5",
+      "git-tree": "021a312d63b606ed37abcbccbdfc826ed2cb1812",
       "version": "0.8.0",
       "port-version": 0
     },

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "324181386d0dcda5a5f33049b7f32d485fa5f255",
+      "git-tree": "f26957340de86e12abc971d4db95b5a2a2cd7d37",
       "version": "0.8.0",
       "port-version": 0
     },


### PR DESCRIPTION
closes mpusz/units#453
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.