### PR TITLE
[concurrencpp] Fix build failure (#32035)

### DIFF
--- a/ports/concurrencpp/fix-include-path.patch
+++ b/ports/concurrencpp/fix-include-path.patch
@@ -10,3 +10,11 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
  
  install(
    TARGETS concurrencpp
+@@ -126,7 +126,6 @@ install(
+           COMPONENT concurrencpp_Development
+   INCLUDES
+   DESTINATION "${concurrencpp_include_directory}"
+-  COMPONENT concurrencpp_Development
+   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+           COMPONENT concurrencpp_Runtime
+           NAMELINK_COMPONENT concurrencpp_Development

--- a/ports/concurrencpp/vcpkg.json
+++ b/ports/concurrencpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "concurrencpp",
   "version": "0.1.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "concurrencpp is a tasking library for C++ allowing developers to write highly concurrent applications easily and safely by using tasks, executors and coroutines.",
   "homepage": "https://github.com/David-Haim/concurrencpp/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1698,7 +1698,7 @@
     },
     "concurrencpp": {
       "baseline": "0.1.6",
-      "port-version": 1
+      "port-version": 2
     },
     "concurrentqueue": {
       "baseline": "1.0.4",

--- a/versions/c-/concurrencpp.json
+++ b/versions/c-/concurrencpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80e475aa0cf6a50936090964cdd032108453eade",
+      "version": "0.1.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "692f9ce2162c5dd6ee54170400c4df33aaec6b5d",
       "version": "0.1.6",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #32035, remove COMPONENT after INCLUDES

- Implements workaround for [concurrencpp] v0.1.6 until https://github.com/David-Haim/concurrencpp/issues/135 is fixed and a new version is released upstream.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
