### PR TITLE
[entt] Update to 3.12.0

### DIFF
--- a/ports/entt/portfile.cmake
+++ b/ports/entt/portfile.cmake
@@ -9,7 +9,7 @@ else()
         OUT_SOURCE_PATH SOURCE_PATH
         REPO skypjack/entt
         REF "v${VERSION}"
-        SHA512 dfbf95e70685e04f1917589fe2484e928cf8883615840b7b5b2906e21bec0830cefcb97133f8822f682bffae8f98d99d525407a00e8dc885f6aa5655af3bcc94
+        SHA512 51fe70e68cbb7d3a5a9ca6b5ff974d324e34248a13a1c828b6c5876461a173861ab26f1bfd0bac7287f8499d07b93bdb73622b579d11a65c916aad7b642dc6e0
         HEAD_REF master
     )
 endif()

--- a/ports/entt/vcpkg.json
+++ b/ports/entt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "entt",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "description": "Gaming meets modern C++ - a fast and reliable entity-component system and much more",
   "homepage": "https://github.com/skypjack/entt",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2329,7 +2329,7 @@
       "port-version": 5
     },
     "entt": {
-      "baseline": "3.11.1",
+      "baseline": "3.12.0",
       "port-version": 0
     },
     "epsilon": {

--- a/versions/e-/entt.json
+++ b/versions/e-/entt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "715488654a998a72da8fff6596cbeedf1962fa56",
+      "version": "3.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d9bf4ab0cc1354ea754f3038dee29ae00ded6331",
       "version": "3.11.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
