### PR TITLE
[vcpkg baseline][dcmtk] Remove the leading spaces of pc file

### DIFF
--- a/ports/dcmtk/fix-pc-format.patch
+++ b/ports/dcmtk/fix-pc-format.patch
@@ -1,0 +1,32 @@
+diff --git a/CMake/dcmtk.pc.in b/CMake/dcmtk.pc.in
+index 13c79c0..46fc98a 100644
+--- a/CMake/dcmtk.pc.in
++++ b/CMake/dcmtk.pc.in
+@@ -1,14 +1,14 @@
+- prefix="@CMAKE_INSTALL_PREFIX@"
+- exec_prefix="${prefix}"
+- libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
+- includedir="${prefix}/include/"
++prefix="@CMAKE_INSTALL_PREFIX@"
++exec_prefix="${prefix}"
++libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
++includedir="${prefix}/include/"
+ 
+- Name: DCMTK
+- Description: DICOM Toolkit (DCMTK)
+- URL: https://dcmtk.org
+- Version: @DCMTK_MAJOR_VERSION@.@DCMTK_MINOR_VERSION@.@DCMTK_BUILD_VERSION@
+- Requires: @PKGCONF_REQ_PUB@
+- Requires.private: @PKGCONF_REQ_PRIV@
+- Cflags: -I"${includedir}"
+- Libs: -L"${libdir}" @PKGCONF_LIBS@
+- Libs.private: -L"${libdir}" @PKGCONF_LIBS_PRIV@
++Name: DCMTK
++Description: DICOM Toolkit (DCMTK)
++URL: https://dcmtk.org
++Version: @DCMTK_MAJOR_VERSION@.@DCMTK_MINOR_VERSION@.@DCMTK_BUILD_VERSION@
++Requires: @PKGCONF_REQ_PUB@
++Requires.private: @PKGCONF_REQ_PRIV@
++Cflags: -I"${includedir}"
++Libs: -L"${libdir}" @PKGCONF_LIBS@
++Libs.private: -L"${libdir}" @PKGCONF_LIBS_PRIV@

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         dcmtk.patch
         windows-patch.patch
+        fix-pc-format.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -132,7 +133,7 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dcmtk/config/osconfig.h" "
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dcmtk/config/osconfig.h" "#define DEFAULT_CONFIGURATION_DIR \"${CURRENT_PACKAGES_DIR}/etc/dcmtk/\"" "")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dcmtk/config/osconfig.h" "#define DEFAULT_SUPPORT_DATA_DIR \"${CURRENT_PACKAGES_DIR}/share/dcmtk/\"" "")
 
-vcpkg_fixup_pkgconfig(SKIP_CHECK)
+vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")
 

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -132,8 +132,8 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dcmtk/config/osconfig.h" "
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dcmtk/config/osconfig.h" "#define DEFAULT_CONFIGURATION_DIR \"${CURRENT_PACKAGES_DIR}/etc/dcmtk/\"" "")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dcmtk/config/osconfig.h" "#define DEFAULT_SUPPORT_DATA_DIR \"${CURRENT_PACKAGES_DIR}/share/dcmtk/\"" "")
 
-vcpkg_fixup_pkgconfig()
+vcpkg_fixup_pkgconfig(SKIP_CHECK)
 
-file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/dcmtk/vcpkg.json
+++ b/ports/dcmtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dcmtk",
   "version": "3.6.7",
-  "port-version": 4,
+  "port-version": 5,
   "description": "This DICOM ToolKit (DCMTK) package consists of source code, documentation and installation instructions for a set of software libraries and applications implementing part of the DICOM/MEDICOM Standard.",
   "homepage": "https://github.com/DCMTK/dcmtk",
   "license": "BSD-3-Clause OR BSD-2-Clause OR libtiff OR MIT OR Zlib OR Libpng",

--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
@@ -129,7 +129,7 @@ function(z_vcpkg_fixup_pkgconfig_check_files arg_file arg_config)
     cmake_path(GET arg_file STEM LAST_ONLY package_name)
     debug_message("Checking package (${arg_config}): ${package_name}")
     execute_process(
-        COMMAND "${PKGCONFIG}" --print-errors --errors-to-stdout --version --simulate --exists "${package_name}"
+        COMMAND "${PKGCONFIG}" --print-errors --exists "${package_name}"
         WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
         RESULT_VARIABLE error_var
         OUTPUT_VARIABLE output

--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
@@ -129,7 +129,7 @@ function(z_vcpkg_fixup_pkgconfig_check_files arg_file arg_config)
     cmake_path(GET arg_file STEM LAST_ONLY package_name)
     debug_message("Checking package (${arg_config}): ${package_name}")
     execute_process(
-        COMMAND "${PKGCONFIG}" --print-errors --exists "${package_name}"
+        COMMAND "${PKGCONFIG}" --print-errors --errors-to-stdout --version --simulate --exists "${package_name}"
         WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
         RESULT_VARIABLE error_var
         OUTPUT_VARIABLE output

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2050,7 +2050,7 @@
     },
     "dcmtk": {
       "baseline": "3.6.7",
-      "port-version": 4
+      "port-version": 5
     },
     "debug-assert": {
       "baseline": "1.3.3",

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fed38b8126fdf2042d120d14825ff1afd20e88de",
+      "version": "3.6.7",
+      "port-version": 5
+    },
+    {
       "git-tree": "99287653b98406054ee56cb8447c38aff0528444",
       "version": "3.6.7",
       "port-version": 4

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fed38b8126fdf2042d120d14825ff1afd20e88de",
+      "git-tree": "a66dd62879ace07389aae2f77cc909744f9d7458",
       "version": "3.6.7",
       "port-version": 5
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixed [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=90705&view=results) issue:
```
dcmtk:x86-windows
dcmtk:x64-windows
dcmtk:x64-windows-static
dcmtk:x64-windows-static-md
```
```
CMake Error at scripts/cmake/vcpkg_fixup_pkgconfig.cmake:141 (message):
  D:/downloads/tools/msys2/6f3fa1a12ef85a6f/mingw32/bin/pkg-config.exe
  --exists dcmtk failed with error code: 1
      ENV{PKG_CONFIG_PATH}: "D:/packages/dcmtk_x64-windows-static/lib/pkgconfig;D:/packages/dcmtk_x64-windows-static/share/pkgconfig;D:/installed/x64-windows-static/lib/pkgconfig;D:/installed/x64-windows-static/share/pkgconfig"
      output: Package dcmtk was not found in the pkg-config search path.
  Perhaps you should add the directory containing `dcmtk.pc' to the PKG_CONFIG_PATH environment variable
  Package 'dcmtk', required by 'virtual:world', not found
```
This issue occurred after the merge of PR https://github.com/microsoft/vcpkg/pull/31924. When I tried using the older version of `pkg-config`, the problem disappeared. I checked the relevant files of `dcmtk`, and there have been no recent changes to them.

Remove the leading spaces of pc file could fix this issue.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
