### PR TITLE
[folly] fix openssl dependency

### DIFF
--- a/ports/folly/openssl.patch
+++ b/ports/folly/openssl.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b5e8758..bb488d6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,9 +24,6 @@ ELSEIF (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+   MESSAGE(STATUS "current platform: FreeBSD")
+ ELSEIF (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+   MESSAGE(STATUS "current platform: MacOS")
+-  set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl" )
+-  set(OPENSSL_LIBRARIES "/usr/local/opt/openssl/lib" )
+-  set(OPENSSL_INCLUDE_DIR "/usr/local/opt/openssl/include" )
+ ELSE ()
+   MESSAGE(STATUS "other platform: ${CMAKE_SYSTEM_NAME}")
+ ENDIF (CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         boost-1.70.patch
         fix-windows-minmax.patch
         fix-deps.patch
+        openssl.patch # from https://github.com/facebook/folly/pull/2016
 )
 
 file(REMOVE "${SOURCE_PATH}/CMake/FindFmt.cmake")

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "folly",
   "version-string": "2023.05.22.00",
+  "port-version": 1,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2574,7 +2574,7 @@
     },
     "folly": {
       "baseline": "2023.05.22.00",
-      "port-version": 0
+      "port-version": 1
     },
     "font-chef": {
       "baseline": "1.1.0",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5c2e858383fffea763ce85c2672d1d2aeead9e6",
+      "version-string": "2023.05.22.00",
+      "port-version": 1
+    },
+    {
       "git-tree": "4af22bbbe7fd8616fc5dfdeef6c2475f4fc3a4e5",
       "version-string": "2023.05.22.00",
       "port-version": 0


### PR DESCRIPTION
Otherwise downstream use of folly fails with 
```
CMake Error in CMakeLists.txt:
  Imported target "Folly::folly" includes non-existent path

    "/usr/local/opt/openssl/include"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.

```
Submitted upstream as https://github.com/facebook/folly/pull/2016