### PR TITLE
[collada-dom] Fix calling zip.h in minizip

### DIFF
--- a/ports/collada-dom/use-vcpkg-minizip.patch
+++ b/ports/collada-dom/use-vcpkg-minizip.patch
@@ -12,16 +12,33 @@ index f6c2bb6..3351ab0 100644
  if(minizip_FOUND)
    set(MINIZIP_INCLUDE_DIR ${minizip_INCLUDE_DIRS})
  else()
+diff --git a/dom/include/dae/daeZAEUncompressHandler.h b/dom/include/dae/daeZAEUncompressHandler.h
+index e9b0e9e..3d120da 100644
+--- a/dom/include/dae/daeZAEUncompressHandler.h
++++ b/dom/include/dae/daeZAEUncompressHandler.h
+@@ -9,7 +9,7 @@
+ #ifndef __DAE_ZAE_UNCOMPRESS_HANDLER_H__
+ #define __DAE_ZAE_UNCOMPRESS_HANDLER_H__
+
+-#include <unzip.h>
++#include <../minizip/unzip.h>
+ #include <libxml/xmlreader.h>
+ #include <dae/daeURI.h>
+
 diff --git a/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp b/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp
-index 4536275..77651f9 100644
+index 4536275..2666959 100644
 --- a/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp
 +++ b/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp
-@@ -32,7 +32,7 @@
+@@ -32,9 +32,9 @@
  #include <iomanip>
  using namespace std;
- 
+
 -#include <zip.h> // for saving compressed files
-+#include <minizip/zip.h> // for saving compressed files
++#include <../minizip/zip.h> // for saving compressed files
  #ifdef _WIN32
- #include <iowin32.h>
+-#include <iowin32.h>
++#include <../minizip/iowin32.h>
  #else
+ #include <unistd.h>
+ #endif
+ 

--- a/ports/collada-dom/use-vcpkg-minizip.patch
+++ b/ports/collada-dom/use-vcpkg-minizip.patch
@@ -41,4 +41,3 @@ index 4536275..2666959 100644
  #else
  #include <unistd.h>
  #endif
- 

--- a/ports/collada-dom/use-vcpkg-minizip.patch
+++ b/ports/collada-dom/use-vcpkg-minizip.patch
@@ -12,3 +12,16 @@ index f6c2bb6..3351ab0 100644
  if(minizip_FOUND)
    set(MINIZIP_INCLUDE_DIR ${minizip_INCLUDE_DIRS})
  else()
+diff --git a/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp b/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp
+index 4536275..77651f9 100644
+--- a/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp
++++ b/dom/src/modules/LIBXMLPlugin/daeLIBXMLPlugin.cpp
+@@ -32,7 +32,7 @@
+ #include <iomanip>
+ using namespace std;
+ 
+-#include <zip.h> // for saving compressed files
++#include <minizip/zip.h> // for saving compressed files
+ #ifdef _WIN32
+ #include <iowin32.h>
+ #else

--- a/ports/collada-dom/vcpkg.json
+++ b/ports/collada-dom/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "collada-dom",
   "version": "2.5.0",
-  "port-version": 9,
+  "port-version": 10,
   "description": "The COLLADA Document Object Model (DOM) is an application programming interface (API) that provides a C++ object representation of a COLLADA XML instance document.",
   "homepage": "https://github.com/rdiankov/collada-dom",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1666,7 +1666,7 @@
     },
     "collada-dom": {
       "baseline": "2.5.0",
-      "port-version": 9
+      "port-version": 10
     },
     "colmap": {
       "baseline": "2023-03-12",

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f17787430ea1503b479beb9734174f2fc57ba4b",
+      "version": "2.5.0",
+      "port-version": 10
+    },
+    {
       "git-tree": "d9c3011f64673cff7d61bac99def8048f4027f32",
       "version": "2.5.0",
       "port-version": 9

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "646d6e3f068d54b52da0030741089be24f4cc80d",
+      "git-tree": "9efe9cf28c36df64035b505810bf68f445be62a1",
       "version": "2.5.0",
       "port-version": 10
     },

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1f17787430ea1503b479beb9734174f2fc57ba4b",
+      "git-tree": "646d6e3f068d54b52da0030741089be24f4cc80d",
       "version": "2.5.0",
       "port-version": 10
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/31887
Fix calling `zip.h` in `minizip`.
Compile test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.