### PR TITLE
[breakpad] Fix installation regex

### DIFF
--- a/ports/breakpad/CMakeLists.txt
+++ b/ports/breakpad/CMakeLists.txt
@@ -192,7 +192,7 @@ if(INSTALL_HEADERS)
     if(WIN32)
         set(HEADER_EXCLUDE_REGEX "/apple|/ios|/linux|/mac|/solaris|/android|/dwarf|/tests|/testdata|/unittests")
     elseif(APPLE)
-        set(HEADER_EXCLUDE_REGEX "/apple|/ios|/linux|/windows|/solaris|/android|/dwarf|/tests|/testdata|/unittests|/sender|/testapp|/*proj|/gcov")
+        set(HEADER_EXCLUDE_REGEX "/apple|/ios|/linux|/windows|/solaris|/android|/dwarf|/tests|/testdata|/unittests|/sender|/testapp|\.xcodeproj|/gcov")
     else()
         set(HEADER_EXCLUDE_REGEX "/apple|/ios|/windows|/mac|/solaris|/android|/dwarf|/tests|/testdata|/unittests")
         install(

--- a/ports/breakpad/vcpkg.json
+++ b/ports/breakpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "breakpad",
   "version-date": "2022-07-12",
-  "port-version": 4,
+  "port-version": 5,
   "description": "a set of client and server components which implement a crash-reporting system.",
   "homepage": "https://github.com/google/breakpad",
   "license": "BSD-3-Clause",

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a451811c203f1ec086288b40dd4571d97bb7033e",
+      "version-date": "2022-07-12",
+      "port-version": 5
+    },
+    {
       "git-tree": "26e6e78bdd989c749aa0f61ad6357374480bc184",
       "version-date": "2022-07-12",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1258,7 +1258,7 @@
     },
     "breakpad": {
       "baseline": "2022-07-12",
-      "port-version": 4
+      "port-version": 5
     },
     "brigand": {
       "baseline": "1.3.0",


### PR DESCRIPTION
If you are in a cwd like `/Users/leanderSchulten/git_projekte/vcpkg` the installation failed because no header was installed. The problem was that `/*proj` matches for every installed path because the full path is checked by cmake and my cwd contains `/git_projekte`. The intended behavior was to filter out the `.xcodeproj` folders. 