### PR TITLE
[tinyexr] Update to 1.0.5

### DIFF
--- a/ports/tinyexr/fix-uwp.patch
+++ b/ports/tinyexr/fix-uwp.patch
@@ -1,0 +1,12 @@
+--- a/tinyexr.h
++++ b/tinyexr.h
+@@ -608,7 +608,9 @@ extern int LoadEXRFromMemory(float **out_rgba, int *width, int *height,
+ #define NOMINMAX
+ #endif
+ #include <windows.h>  // for UTF-8 and memory-mapping
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+ #define TINYEXR_USE_WIN32_MMAP (1)
++#endif
+ 
+ #elif defined(__linux__) || defined(__unix__)
+ #include <fcntl.h>     // for open()

--- a/ports/tinyexr/portfile.cmake
+++ b/ports/tinyexr/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO syoyo/tinyexr
-    REF v1.0.1
-    SHA512 ba3bc09e7c2a93016b260849eb365a05fe1113c55f824767a19a20e3a6ff2a09dd686aa15094dd6c4508e68915dc8eb4a0ccc9778de73d9b55354701e7820e76
+    REF "v${VERSION}"
+    SHA512 c15ac7d21cba70c3247ea49674191097325fcba7bfaeb8163298ded2e3b67f55b1b6486fd90a80f23f950661e96c063a28a70569f40a8938cd41249c34b4bbfe
     HEAD_REF master
     PATCHES
         fixtargets.patch

--- a/ports/tinyexr/portfile.cmake
+++ b/ports/tinyexr/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fixtargets.patch
+        fix-uwp.patch # https://github.com/syoyo/tinyexr/pull/195
 )
 
 vcpkg_cmake_configure(

--- a/ports/tinyexr/vcpkg.json
+++ b/ports/tinyexr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyexr",
-  "version": "1.0.1",
+  "version": "1.0.5",
   "description": "Library to load and save OpenEXR(.exr) images",
   "homepage": "https://github.com/syoyo/tinyexr",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8057,7 +8057,7 @@
       "port-version": 2
     },
     "tinyexr": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.5",
       "port-version": 0
     },
     "tinyfiledialogs": {

--- a/versions/t-/tinyexr.json
+++ b/versions/t-/tinyexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3185c74444a21c5f632ba561e96cd4ff2ffd529a",
+      "version": "1.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "d0381d495cb1b502e1b5ccaafb2409f75c0726a3",
       "version": "1.0.1",
       "port-version": 0

--- a/versions/t-/tinyexr.json
+++ b/versions/t-/tinyexr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3185c74444a21c5f632ba561e96cd4ff2ffd529a",
+      "git-tree": "14f0bcbec927dc73035b2642284f1329a113209f",
       "version": "1.0.5",
       "port-version": 0
     },


### PR DESCRIPTION
https://github.com/syoyo/tinyexr/releases/tag/v1.0.5

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.