### PR TITLE
[libosmscout] Refine feature name

### DIFF
--- a/ports/libosmscout/portfile.cmake
+++ b/ports/libosmscout/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS FEATURES
     directx OSMSCOUT_BUILD_MAP_DIRECTX
     gdi     OSMSCOUT_BUILD_MAP_GDI
     svg     OSMSCOUT_BUILD_MAP_SVG
-    qt      OSMSCOUT_BUILD_MAP_QT
+    qt5      OSMSCOUT_BUILD_MAP_QT
 )
 
 vcpkg_cmake_configure(

--- a/ports/libosmscout/vcpkg.json
+++ b/ports/libosmscout/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libosmscout",
   "version": "1.1.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "libosmscout offers applications simple, high-level interfaces for offline location and POI lokup, rendering and routing functionalities based on OpenStreetMap (OSM) data.",
   "homepage": "http://libosmscout.sourceforge.net/",
   "documentation": "http://libosmscout.sourceforge.net/documentation/",

--- a/ports/libosmscout/vcpkg.json
+++ b/ports/libosmscout/vcpkg.json
@@ -40,8 +40,8 @@
       "description": "GDI+ backend renderer",
       "supports": "windows"
     },
-    "qt": {
-      "description": "Enable build of Qt map drawing backend",
+    "qt5": {
+      "description": "Enable build of Qt5 map drawing backend",
       "dependencies": [
         "qt5-base",
         "qt5-svg"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4398,7 +4398,7 @@
     },
     "libosmscout": {
       "baseline": "1.1.1",
-      "port-version": 3
+      "port-version": 4
     },
     "libp7-baical": {
       "baseline": "replaced",

--- a/versions/l-/libosmscout.json
+++ b/versions/l-/libosmscout.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55b989b709d0c12649e6b2a522249bbf3d0788c7",
+      "version": "1.1.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "6a036a2f5b16cbc586266834abfe3c7a3f712c7e",
       "version": "1.1.1",
       "port-version": 3


### PR DESCRIPTION
`libosmscout` supports both qt5 and qt6 as backends, rename feature `qt` to `qt5` for clarity.

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
