### PR TITLE
[linux ci] install golang-go for boringssl

### DIFF
--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -88,6 +88,9 @@ APT_PACKAGES="$APT_PACKAGES libxtst-dev"
 ## required by bond
 APT_PACKAGES="$APT_PACKAGES haskell-stack"
 
+## required by boringssl
+APT_PACKAGES="$APT_PACKAGES golang-go"
+
 ## CUDA
 APT_PACKAGES="$APT_PACKAGES cuda-compiler-12-1 cuda-libraries-dev-12-1 cuda-driver-dev-12-1 \
   cuda-cudart-dev-12-1 libcublas-12-1 libcurand-dev-12-1 cuda-nvml-dev-12-1 libcudnn8-dev libnccl2 \


### PR DESCRIPTION
Currently fails with:
```
Building boringssl:x64-linux...
CMake Error at scripts/cmake/vcpkg_find_acquire_program.cmake:163 (message):
  Could not find go.  Please install it via your package manager:

      sudo apt-get install golang-go
Call Stack (most recent call first):
  ports/boringssl/portfile.cmake:13 (vcpkg_find_acquire_program)
  scripts/ports.cmake:147 (include)


error: building boringssl:x64-linux failed with: BUILD_FAILED

```