### PR TITLE
[redis-plus-plus] Add TLS feature and update to 1.3.9

### DIFF
--- a/ports/redis-plus-plus/portfile.cmake
+++ b/ports/redis-plus-plus/portfile.cmake
@@ -1,13 +1,18 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sewenew/redis-plus-plus
-    REF 4368319fb668204f345da05b9dd79762506c67b6 # 1.3.8
-    SHA512 37774078fb98992c4b4be276c91a2b6a8b8810d62a5087184d1fa2c05db77de15058d5139747578f7a2f9219351c05de32740b63c153ea902493d4b5d05c2d68
+    REF "${VERSION}"
+    SHA512 a9afecc4059155137d524542e7ad699f78e5efc8b1136c1aac093e60fe70dddede3594afe6920f813ba011fb61740bec09b3564c8f8f42118e21fdd5f40f6161
     HEAD_REF master
     PATCHES
         fix-conversion.patch
         fix-dependency-libuv.patch
         fix-absolute-path.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "tls"   REDIS_PLUS_PLUS_USE_TLS
 )
 
 if("cxx17" IN_LIST FEATURES)
@@ -18,10 +23,10 @@ endif()
 
 set(EXTRA_OPT "")
 if ("async" IN_LIST FEATURES)
-    list(APPEND EXTRA_OPT -DREDIS_PLUS_PLUS_BUILD_ASYNC="libuv")
+    list(APPEND EXTRA_OPT "-DREDIS_PLUS_PLUS_BUILD_ASYNC=libuv")
 endif()
 if ("async-std" IN_LIST FEATURES)
-    list(APPEND EXTRA_OPT -DREDIS_PLUS_PLUS_ASYNC_FUTURE="std")
+    list(APPEND EXTRA_OPT "-DREDIS_PLUS_PLUS_ASYNC_FUTURE=std")
 endif()
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" REDIS_PLUS_PLUS_BUILD_STATIC)
@@ -31,7 +36,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
-        -DREDIS_PLUS_PLUS_USE_TLS=OFF
+        ${FEATURE_OPTIONS}
         -DREDIS_PLUS_PLUS_BUILD_STATIC=${REDIS_PLUS_PLUS_BUILD_STATIC}
         -DREDIS_PLUS_PLUS_BUILD_SHARED=${REDIS_PLUS_PLUS_BUILD_SHARED}
         -DREDIS_PLUS_PLUS_BUILD_TEST=OFF
@@ -43,10 +48,12 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
+vcpkg_cmake_config_fixup(PACKAGE_NAME redis++ CONFIG_PATH share/cmake/redis++)
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright )
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/redis-plus-plus/vcpkg.json
+++ b/ports/redis-plus-plus/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "redis-plus-plus",
-  "version-semver": "1.3.8",
-  "port-version": 1,
+  "version-semver": "1.3.9",
   "description": "This is a C++ client for Redis. It's based on hiredis, and written in C++ 11",
   "homepage": "https://github.com/sewenew/redis-plus-plus",
   "license": "Apache-2.0",
@@ -37,6 +36,18 @@
     },
     "cxx17": {
       "description": "Build redis-plus-plus with cxx 17 standard"
+    },
+    "tls":{
+      "description": "Build with TLS support",
+      "dependencies": [
+        {
+          "name": "hiredis",
+          "default-features": false,
+          "features": [
+            "ssl"
+          ]
+        }
+      ]
     }
   }
 }

--- a/ports/redis-plus-plus/vcpkg.json
+++ b/ports/redis-plus-plus/vcpkg.json
@@ -37,7 +37,7 @@
     "cxx17": {
       "description": "Build redis-plus-plus with cxx 17 standard"
     },
-    "tls":{
+    "tls": {
       "description": "Build with TLS support",
       "dependencies": [
         {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7093,8 +7093,8 @@
       "port-version": 0
     },
     "redis-plus-plus": {
-      "baseline": "1.3.8",
-      "port-version": 1
+      "baseline": "1.3.9",
+      "port-version": 0
     },
     "refl-cpp": {
       "baseline": "0.12.3",

--- a/versions/r-/redis-plus-plus.json
+++ b/versions/r-/redis-plus-plus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce8c8a22b5a791c7a3a96d72d5e2ce47881db17c",
+      "version-semver": "1.3.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "6be6c4d075dc736952132603d31f0ca568a0edde",
       "version-semver": "1.3.8",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/32027

Updates version to 1.3.9.
Fixes below error in feature `async` and `async-std` by moving the double quotes:
```
CMake Error at CMakeLists.txt:42 (message):
  invalid REDIS_PLUS_PLUS_BUILD_ASYNC
```
Fixes usage issue by adding vcpkg_cmake_config_fixup() function.

All features and usage test passed with following triplets:
```
x86-windows 
x64-windows 
x64-windows-static 
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
