### PR TITLE
[sentry-native] Allow ARM builds outside of macOS

### DIFF
--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",
-  "supports": "osx | (!arm & !uwp)",
+  "supports": "osx | linux | (!arm & !uwp)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "29eccf6f70b601b7e5ba3b94e0cbc38fe707b2fa",
+      "git-tree": "fd5779f3ac082cce4ffa01f13b9ed0f9f4f74d73",
       "version": "0.6.4",
       "port-version": 0
     },


### PR DESCRIPTION
Remove the restriction of the only supported ARM platform being macOS. It builds and runs fine on ARM Linux.