### PR TITLE
[angle] Fix static build

### DIFF
--- a/ports/angle/cmake-buildsystem/CMakeLists.txt
+++ b/ports/angle/cmake-buildsystem/CMakeLists.txt
@@ -58,6 +58,16 @@ if(ANGLE_USE_D3D11_COMPOSITOR_NATIVE_WINDOW)
     endif()
     set(angle_enable_d3d11_compositor_native_window TRUE)
 endif()
+if(NOT BUILD_SHARED_LIBS)
+    add_definitions(
+        -DANGLE_EXPORT=
+        -DANGLE_STATIC=1
+        -DANGLE_UTIL_EXPORT=
+        -DEGLAPI=
+        -DGL_APICALL=
+        -DGL_API=
+    )
+endif()
 
 find_package(ZLIB REQUIRED)
 
@@ -416,20 +426,52 @@ install(TARGETS ${_installableTargets} EXPORT ANGLEExport
 install(EXPORT ANGLEExport FILE unofficial-angle-targets.cmake NAMESPACE unofficial::angle:: DESTINATION share/unofficial-angle)
 install(FILES unofficial-angle-config.cmake DESTINATION share/unofficial-angle)
 
-if(NOT DISABLE_INSTALL_HEADERS)
-    install(
-        DIRECTORY "${ANGLE_FRAMEWORK_HEADERS_DIR}"
-        DESTINATION include
-        FILES_MATCHING
-        PATTERN "*.h"
-        PATTERN "*.inc"
-        PATTERN "CL" EXCLUDE
-        PATTERN "GLSLANG" EXCLUDE
-        PATTERN "egl.h" EXCLUDE
-        PATTERN "eglext.h" EXCLUDE
-        PATTERN "eglplatform.h" EXCLUDE
-        PATTERN "KHR" EXCLUDE
-        PATTERN "WGL" EXCLUDE
-        PATTERN "export.h" EXCLUDE
-    )
+install(
+    DIRECTORY "${ANGLE_FRAMEWORK_HEADERS_DIR}/"
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.inc"
+    PATTERN "CL" EXCLUDE
+    PATTERN "GLSLANG" EXCLUDE
+    PATTERN "EGL/egl.h" EXCLUDE
+    PATTERN "EGL/eglext.h" EXCLUDE
+    PATTERN "EGL/eglplatform.h" EXCLUDE
+    PATTERN "KHR" EXCLUDE
+    PATTERN "WGL" EXCLUDE
+    PATTERN "export.h" EXCLUDE
+    PATTERN "GLES/egl.h" EXCLUDE
+    PATTERN "GLES/gl.h" EXCLUDE
+    PATTERN "GLES/glext.h" EXCLUDE
+    PATTERN "GLES/glplatform.h" EXCLUDE
+    PATTERN "GLES2/gl2.h" EXCLUDE
+    PATTERN "GLES2/gl2ext.h" EXCLUDE
+    PATTERN "GLES2/gl2platform.h" EXCLUDE
+    PATTERN "GLES3/gl3.h" EXCLUDE
+    PATTERN "GLES3/gl31.h" EXCLUDE
+    PATTERN "GLES3/gl32.h" EXCLUDE
+    PATTERN "GLES3/gl3platform.h" EXCLUDE
+)
+install(
+    DIRECTORY "${ANGLE_FRAMEWORK_HEADERS_DIR}/"
+    DESTINATION include/angle
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.inc"
+    PATTERN "CL" EXCLUDE
+    PATTERN "GLSLANG" EXCLUDE
+    PATTERN "EGL/egl.h" EXCLUDE
+    PATTERN "EGL/eglext.h" EXCLUDE
+    PATTERN "EGL/eglplatform.h" EXCLUDE
+    PATTERN "KHR" EXCLUDE
+    PATTERN "WGL" EXCLUDE
+    PATTERN "export.h" EXCLUDE
+)
+
+if(NOT BUILD_SHARED_LIBS)
+    foreach(angle_target EGL GLESv2 ANGLE)
+        if(TARGET ${angle_target})
+            target_compile_definitions(${angle_target} INTERFACE $<INSTALL_INTERFACE:KHRONOS_STATIC>)
+        endif()
+    endforeach()
 endif()

--- a/ports/angle/portfile.cmake
+++ b/ports/angle/portfile.cmake
@@ -168,31 +168,19 @@ vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
-# File conflict with opengl-registry! Make sure headers are similar on Update!
-# angle defines some additional entrypoints.
-# opengl-registry probably needs an upstream update to account for those
-# Due to that all angle headers get moved to include/angle.
-# If you want to use those instead of the onces provided by opengl-registry make sure
-# VCPKG_INSTALLED_DIR/include/angle is before VCPKG_INSTALLED_DIR/include
-file(GLOB_RECURSE angle_includes "${CURRENT_PACKAGES_DIR}/include")
-file(COPY ${angle_includes} DESTINATION "${CURRENT_PACKAGES_DIR}/include/angle")
-
-set(_double_files
-    "include/GLES/egl.h"
-    "include/GLES/gl.h"
-    "include/GLES/glext.h"
-    "include/GLES/glplatform.h"
-    "include/GLES2/gl2.h"
-    "include/GLES2/gl2ext.h"
-    "include/GLES2/gl2platform.h"
-    "include/GLES3/gl3.h"
-    "include/GLES3/gl31.h"
-    "include/GLES3/gl32.h"
-    "include/GLES3/gl3platform.h")
-foreach(_file ${_double_files})
-    if(EXISTS "${CURRENT_PACKAGES_DIR}/${_file}")
-        file(REMOVE "${CURRENT_PACKAGES_DIR}/${_file}")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+# Remove empty directories inside include directory
+file(GLOB directory_children RELATIVE "${CURRENT_PACKAGES_DIR}/include" "${CURRENT_PACKAGES_DIR}/include/*")
+foreach(directory_child ${directory_children})
+    if(IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/include/${directory_child}")
+        file(GLOB_RECURSE subdirectory_children "${CURRENT_PACKAGES_DIR}/include/${directory_child}/*")
+        if("${subdirectory_children}" STREQUAL "")
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/${directory_child}")
+        endif()
     endif()
 endforeach()
+unset(subdirectory_children)
+unset(directory_child)
+unset(directory_children)
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_5414",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5671959f9f2a59ecd232c72df54682bb10a14be",
+      "version-string": "chromium_5414",
+      "port-version": 3
+    },
+    {
       "git-tree": "784aa16c1dacc9aedb49de3bd1393bb6ef6b853d",
       "version-string": "chromium_5414",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -122,7 +122,7 @@
     },
     "angle": {
       "baseline": "chromium_5414",
-      "port-version": 2
+      "port-version": 3
     },
     "annoy": {
       "baseline": "1.17.2",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix #31164
This PR based on #31254 by @tdcosta100.
The author chose to close the original PR for various reasons. Anyway, thanks @@tdcosta100 so much!
This PR incorporates some of the changes suggested by reviewer, and I've tested it on both macOS and Windows.