### PR TITLE
[libtracepoint, libeventheader] - v1.1.0

### DIFF
--- a/ports/libeventheader-decode/portfile.cmake
+++ b/ports/libeventheader-decode/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
-    REF f3a5b3e4c12a19924a4d6fc30a7681742fd7eb01
-    SHA512 f94a3cf1367ec4749f40217923f1158da40caaf5cd75529d1ca9a5e8b51c581f0aec286f715a88b6203f9979a2e32ad69efde1738a12fa71a0301b8ddbfcc6e4
+    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
+    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libeventheader-decode/vcpkg.json
+++ b/ports/libeventheader-decode/vcpkg.json
@@ -1,14 +1,18 @@
 {
   "name": "libeventheader-decode",
-  "version": "1.0.0",
-  "description": "EventHeader tracepoint decoding classes for C++",
+  "version": "1.1.0",
+  "description": "C++ classes for decoding EventHeader-encoded Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
   "supports": "linux | windows",
   "dependencies": [
     {
       "name": "libeventheader-tracepoint",
-      "version>=": "1.0.0"
+      "version>=": "1.1.0"
+    },
+    {
+      "name": "libtracepoint-decode",
+      "version>=": "1.1.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libeventheader-tracepoint/portfile.cmake
+++ b/ports/libeventheader-tracepoint/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
-    REF f3a5b3e4c12a19924a4d6fc30a7681742fd7eb01
-    SHA512 f94a3cf1367ec4749f40217923f1158da40caaf5cd75529d1ca9a5e8b51c581f0aec286f715a88b6203f9979a2e32ad69efde1738a12fa71a0301b8ddbfcc6e4
+    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
+    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libeventheader-tracepoint/vcpkg.json
+++ b/ports/libeventheader-tracepoint/vcpkg.json
@@ -1,14 +1,14 @@
 {
   "name": "libeventheader-tracepoint",
-  "version": "1.0.0",
-  "description": "EventHeader-encoded Linux tracepoints for C/C++",
+  "version": "1.1.0",
+  "description": "C/C++ interface for generating EventHeader-encoded Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
   "supports": "linux | windows",
   "dependencies": [
     {
       "name": "libtracepoint",
-      "version>=": "1.0.0"
+      "version>=": "1.1.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libtracepoint-decode/portfile.cmake
+++ b/ports/libtracepoint-decode/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
-    REF abf1f6d3e32546aeaab75ed3cea45b54b94fbd50
-    SHA512 ac67bbd8184a29c8058a7b2cde51db9a14f97326396ba894f56a36d4219bebbc580f64a3ed5f182df4a0111ad97294a6b780bd44181d37e0fda1be16a6e23dea
+    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
+    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint-decode/vcpkg.json
+++ b/ports/libtracepoint-decode/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtracepoint-decode",
-  "version": "1.0.0",
-  "description": "Tracepoint decoding classes for C++",
+  "version": "1.1.0",
+  "description": "C++ classes for decoding Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
   "supports": "linux | windows",

--- a/ports/libtracepoint/portfile.cmake
+++ b/ports/libtracepoint/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
-    REF f3a5b3e4c12a19924a4d6fc30a7681742fd7eb01
-    SHA512 f94a3cf1367ec4749f40217923f1158da40caaf5cd75529d1ca9a5e8b51c581f0aec286f715a88b6203f9979a2e32ad69efde1738a12fa71a0301b8ddbfcc6e4
+    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
+    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint/vcpkg.json
+++ b/ports/libtracepoint/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtracepoint",
-  "version": "1.0.0",
-  "description": "Linux tracepoints interface for C/C++",
+  "version": "1.1.0",
+  "description": "C/C++ interface for generating Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
   "supports": "linux | windows",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4017,11 +4017,11 @@
       "port-version": 0
     },
     "libeventheader-decode": {
-      "baseline": "1.0.0",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "libeventheader-tracepoint": {
-      "baseline": "1.0.0",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "libevhtp": {
@@ -4657,11 +4657,11 @@
       "port-version": 0
     },
     "libtracepoint": {
-      "baseline": "1.0.0",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "libtracepoint-decode": {
-      "baseline": "1.0.0",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "libu2f-server": {

--- a/versions/l-/libeventheader-decode.json
+++ b/versions/l-/libeventheader-decode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e830f1815ed8de8c73a7e90841533854b54261c",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fd67531cc60d91c4d8b45da15cd7414b398b9cd7",
       "version": "1.0.0",
       "port-version": 0

--- a/versions/l-/libeventheader-tracepoint.json
+++ b/versions/l-/libeventheader-tracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba5030dde966e742b068efb77cab8f820f0ab7ea",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d8ba8b72bb5c6dde050b85f84e01efb6b36d535c",
       "version": "1.0.0",
       "port-version": 0

--- a/versions/l-/libtracepoint-decode.json
+++ b/versions/l-/libtracepoint-decode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3559772cf7c926b54b92bdc0e72ecaa9e06534d6",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6bd99da97aa18ca05fd3a67eb77f6df1ea210d2e",
       "version": "1.0.0",
       "port-version": 0

--- a/versions/l-/libtracepoint.json
+++ b/versions/l-/libtracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0106479d49132d017d8c89f4189bce8cb4251479",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f60f9a909a55a04c9bc87b6a3e10df5f0faec1a4",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
Update `libtracepoint-*` and `libeventheader-*` to v1.1.0.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
