### PR TITLE
[c4core] Fix gcc4.8 build

### DIFF
--- a/ports/c4core/fix-gcc.patch
+++ b/ports/c4core/fix-gcc.patch
@@ -1,0 +1,13 @@
+diff --git a/c4Project.cmake b/c4Project.cmake
+index a9bd99a..939fed5 100644
+--- a/c4Project.cmake
++++ b/c4Project.cmake
+@@ -2154,7 +2154,7 @@ function(c4_add_target target)
+            (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 4.8) AND
+            (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0))
+             c4_dbg("${target}: adding compat include path")
+-            target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${_c4_project_dir}/compat>)
++            target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${_c4_project_dir}/compat> $<INSTALL_INTERFACE:include>)
+         endif()
+ 
+     # gather dlls so that they can be automatically copied to the target directory

--- a/ports/c4core/portfile.cmake
+++ b/ports/c4core/portfile.cmake
@@ -9,20 +9,21 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-set(CM_COMMIT_HASH fe41e86552046c3df9ba73a40bf3d755df028c1e)
+set(CM_COMMIT_HASH a1f9d73608025c595653e9d52236228efd23ea04)
 
 # Get cmake scripts for c4core
 vcpkg_download_distfile(
     CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${CM_COMMIT_HASH}.zip"
     FILENAME "cmake-${CM_COMMIT_HASH}.zip"
-    SHA512 7292f9856d9c41581f2731e73fdf08880e0f4353b757da38a13ec89b62c5c8cb52b9efc1a9ff77336efa0b6809727c17649e607d8ecacc965a9b2a7a49925237
+    SHA512 6b0dec93804288801ea8535665e04dc63d886f0ace1ebc7ff1660ed07b514ccf931a5cfa1be46c0c25ba390458f125b4f2546a158adeb5a782fcba39d1419440
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH_CMAKE
     ARCHIVE ${CMAKE_ARCHIVE}
     WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src/deps"
+    PATCHES fix-gcc.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/cmake")

--- a/ports/c4core/vcpkg.json
+++ b/ports/c4core/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "c4core",
   "version": "0.1.11",
+  "port-version": 1,
   "description": "Library of low-level C++ utilities",
   "homepage": "https://github.com/biojppm/c4core",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1334,7 +1334,7 @@
     },
     "c4core": {
       "baseline": "0.1.11",
-      "port-version": 0
+      "port-version": 1
     },
     "c89stringutils": {
       "baseline": "0.0.1",

--- a/versions/c-/c4core.json
+++ b/versions/c-/c4core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e451fea4699534d47152059b3853019d0fb6e7e3",
+      "version": "0.1.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "7bb0739490fde445f13be62a3630b08924fdc94f",
       "version": "0.1.11",
       "port-version": 0


### PR DESCRIPTION
Fixes #29876.

* Update [c4core/cmake](https://github.com/biojppm/cmake) to the latest commit.

* When building `c4core` with `gcc4.8`, the following error occurs, add `fix-gcc.patch` to fix it.
```
/vcpkg/installed/x64-linux/include/c4/compiler.hpp:105:41: fatal error: c4/gcc-4.8.hpp: No such file or directory
 #               include "c4/gcc-4.8.hpp"
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
