### PR TITLE
Ability to bootstrap a pre-release version of vcpkg-tool

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,7 +10,7 @@ done
 vcpkgDisableMetrics="OFF"
 vcpkgUseSystem=false
 vcpkgUseMuslC="OFF"
-vcpkgUseHead="OFF"
+vcpkgToolHead="OFF"
 for var in "$@"
 do
     if [ "$var" = "-disableMetrics" -o "$var" = "--disableMetrics" ]; then
@@ -24,7 +24,7 @@ do
     elif [ "$var" = "-musl" ]; then
         vcpkgUseMuslC="ON"
     elif [ "$var" = "-vcpkgToolHead" ]; then
-        vcpkgUseHead="ON"
+        vcpkgToolHead="ON"
     elif [ "$var" = "-help" -o "$var" = "--help" ]; then
         echo "Usage: ./bootstrap-vcpkg.sh [options]"
         echo
@@ -132,7 +132,7 @@ fi
 # Choose the vcpkg binary to download
 vcpkgDownloadTool="ON"
 vcpkgToolReleaseTag="2023-06-15"
-if [ "$vcpkgUseHead" = "ON" ]; then
+if [ "$vcpkgToolHead" = "ON" ]; then
     vcpkgDownloadTool="OFF"
 elif [ "$UNAME" = "Darwin" ]; then
     echo "Downloading vcpkg-macos..."
@@ -230,7 +230,7 @@ else
     rm -rf "$baseBuildDir"
     mkdir -p "$buildDir"
 
-    if [ "$vcpkgUseHead" = "ON" ]; then
+    if [ "$vcpkgToolHead" = "ON" ]; then
         srcDir="$srcBaseDir/vcpkg-tool"
         git clone -b main --single-branch --depth=1 https://github.com/microsoft/vcpkg-tool.git "$srcDir"
     else


### PR DESCRIPTION
This PR adds switch to the Unix bootstrap shell script that instructs it to build the vcpkg binary from the HEAD of the default branch for vcpkg-tool.

This allows users to opt-in to bootstrap a vcpkg binary before it is included in a release. This is primarily useful for early adopter testing that may happen between cuts of official releases, but it presents the possibility of further extension so that users can test their change to branches of vcpkg-tool in an easier manner.
