### PR TITLE
[liburing] Set libdevdir

### DIFF
--- a/ports/liburing/portfile.cmake
+++ b/ports/liburing/portfile.cmake
@@ -13,6 +13,8 @@ vcpkg_from_github(
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     COPY_SOURCE
+    OPTIONS
+        [[--libdevdir=\${prefix}/lib]] # must match libdir
 )
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()

--- a/ports/liburing/vcpkg.json
+++ b/ports/liburing/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "liburing",
   "version": "2.3",
+  "port-version": 1,
   "description": "Linux-native io_uring I/O access library",
   "homepage": "https://github.com/axboe/liburing",
   "license": "MIT OR LGPL-2.1 OR GPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4694,7 +4694,7 @@
     },
     "liburing": {
       "baseline": "2.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libusb": {
       "baseline": "1.0.26.11791",

--- a/versions/l-/liburing.json
+++ b/versions/l-/liburing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c51f4ef4488799a1c1389216ea8f7cec8be14b62",
+      "version": "2.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "0c8b60f54ff0c4e9a0ae2a1a2cbcf72e2cfeaf04",
       "version": "2.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #32102

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
