### PR TITLE
[onednn] Update to 3.1.1

### DIFF
--- a/ports/onednn/portfile.cmake
+++ b/ports/onednn/portfile.cmake
@@ -1,13 +1,40 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/oneDNN
-    REF 3fef24ec08eb89a2c4be4425162c0651af7f1de3
-    SHA512 3b012fcc92cf39b3205784f5f11607a8af9420d5affccb54079b275c7214dd93daa2ca1e29032de06483126eb103a85d2665da5291995b0f1e5e9978d4290462
+    REF v3.1.1
+    SHA512 0dae0ccff1e459ce24356694732bf4ee3c459469de70984863e1aed3bc965471793a110dedbb11f2baa762749cea7652a150d2f9a442c299d9ffa00febd87fec
     HEAD_REF master
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     set(DNNL_OPTIONS "-DDNNL_LIBRARY_TYPE=STATIC")
+endif()
+
+# Can't have both sycl and any other feature
+list(LENGTH FEATURES _features_length)
+if ("sycl" IN_LIST FEATURES AND ${_features_length} GREATER 2)
+    message(FATAL_ERROR "sycl must be the only feature for GPU + CPU runtimes")
+endif()
+
+# Can't have both openmp and tbb
+if ("openmp" IN_LIST FEATURES AND "tbb" IN_LIST FEATURES)
+    message(FATAL_ERROR "Cannot enable openmp and tbb features simultaneously")
+endif()
+
+if ("sycl" IN_LIST FEATURES)
+    list(APPEND DNNL_OPTIONS "-DDNNL_CPU_RUNTIME=SYCL" "-DDNNL_GPU_RUNTIME=SYCL")
+endif()
+
+if ("openmp" IN_LIST FEATURES)
+    list(APPEND DNNL_OPTIONS "-DDNNL_CPU_RUNTIME=OMP")
+endif()
+
+if ("tbb" IN_LIST FEATURES)
+    list(APPEND DNNL_OPTIONS "-DDNNL_CPU_RUNTIME=TBB")
+endif()
+
+if ("opencl" IN_LIST FEATURES)
+    list(APPEND DNNL_OPTIONS "-DDNNL_GPU_RUNTIME=OCL")
 endif()
 
 vcpkg_cmake_configure(
@@ -21,6 +48,6 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME dnnl CONFIG_PATH lib/cmake/dnnl)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc/dnnl/reference/html")
 
-# Copyright and license
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/onednn/portfile.cmake
+++ b/ports/onednn/portfile.cmake
@@ -10,33 +10,6 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     set(DNNL_OPTIONS "-DDNNL_LIBRARY_TYPE=STATIC")
 endif()
 
-# Can't have both sycl and any other feature
-list(LENGTH FEATURES _features_length)
-if ("sycl" IN_LIST FEATURES AND ${_features_length} GREATER 2)
-    message(FATAL_ERROR "sycl must be the only feature for GPU + CPU runtimes")
-endif()
-
-# Can't have both openmp and tbb
-if ("openmp" IN_LIST FEATURES AND "tbb" IN_LIST FEATURES)
-    message(FATAL_ERROR "Cannot enable openmp and tbb features simultaneously")
-endif()
-
-if ("sycl" IN_LIST FEATURES)
-    list(APPEND DNNL_OPTIONS "-DDNNL_CPU_RUNTIME=SYCL" "-DDNNL_GPU_RUNTIME=SYCL")
-endif()
-
-if ("openmp" IN_LIST FEATURES)
-    list(APPEND DNNL_OPTIONS "-DDNNL_CPU_RUNTIME=OMP")
-endif()
-
-if ("tbb" IN_LIST FEATURES)
-    list(APPEND DNNL_OPTIONS "-DDNNL_CPU_RUNTIME=TBB")
-endif()
-
-if ("opencl" IN_LIST FEATURES)
-    list(APPEND DNNL_OPTIONS "-DDNNL_GPU_RUNTIME=OCL")
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${DNNL_OPTIONS}

--- a/ports/onednn/vcpkg.json
+++ b/ports/onednn/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "onednn",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "description": "oneAPI Deep Neural Network Library (oneDNN)",
   "homepage": "https://github.com/oneapi-src/oneDNN",
   "license": "Apache-2.0",
@@ -14,5 +14,25 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "opencl": {
+      "description": "Build the CPU runtime with OpenCL",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "openmp": {
+      "description": "Build the CPU runtime with OpenMP"
+    },
+    "sycl": {
+      "description": "Build the CPU and GPU runtimes with SYCL. Compiler must support SYCL."
+    },
+    "tbb": {
+      "description": "Build the CPU runtime with Intel Thread Building Blocks",
+      "dependencies": [
+        "tbb"
+      ]
+    }
+  }
 }

--- a/ports/onednn/vcpkg.json
+++ b/ports/onednn/vcpkg.json
@@ -14,25 +14,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "opencl": {
-      "description": "Build the CPU runtime with OpenCL",
-      "dependencies": [
-        "opencl"
-      ]
-    },
-    "openmp": {
-      "description": "Build the CPU runtime with OpenMP"
-    },
-    "sycl": {
-      "description": "Build the CPU and GPU runtimes with SYCL. Compiler must support SYCL."
-    },
-    "tbb": {
-      "description": "Build the CPU runtime with Intel Thread Building Blocks",
-      "dependencies": [
-        "tbb"
-      ]
-    }
-  }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5857,7 +5857,7 @@
       "port-version": 5
     },
     "onednn": {
-      "baseline": "3.0.0",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "oniguruma": {

--- a/versions/o-/onednn.json
+++ b/versions/o-/onednn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7339d1ff44ffb5f4b06952eeb63bbd768a1dce5a",
+      "version": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d9dad8bf4f6fa7eae90870c5c3aac1ec4346f40",
       "version": "3.0.0",
       "port-version": 0

--- a/versions/o-/onednn.json
+++ b/versions/o-/onednn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7339d1ff44ffb5f4b06952eeb63bbd768a1dce5a",
+      "git-tree": "151a4ce15e279a44a305bc438e5beed45c7054b9",
       "version": "3.1.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.