### PR TITLE
[usockets] WolfSSL feature

### DIFF
--- a/ports/usockets/CMakeLists.txt
+++ b/ports/usockets/CMakeLists.txt
@@ -12,6 +12,15 @@ else()
     set(NOT_USE_OPENSSL "-DLIBUS_NO_SSL")
 endif()
 
+if (CMAKE_USE_WOLFSSL)
+    find_package(wolfssl REQUIRED)
+    set(USE_WOLFSSL "-DUSE_WOLFSSL -DLIBUS_USE_WOLFSSL")
+
+    list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
+else()
+    set(NOT_USE_WOLFSSL "-DLIBUS_NO_SSL")
+endif()
+
 find_package(libuv CONFIG REQUIRED)
 if (TARGET uv)
     set(LIBUV_LIBRARY uv)
@@ -33,6 +42,13 @@ if (CMAKE_USE_OPENSSL)
     list(APPEND USOCKETS_EXT_LIBS OpenSSL::SSL OpenSSL::Crypto)
 endif()
 
+if (CMAKE_USE_WOLFSSL)
+    find_package(wolfssl REQUIRED)
+    #file(GLOB SSL_SOURCES src/crypto/*.c*)
+    #list(APPEND SOURCES ${SSL_SOURCES})
+    list(APPEND USOCKETS_EXT_LIBS wolfssl)
+endif()
+
 if (CMAKE_USE_EVENT)
     file(GLOB SSL_SOURCES src/eventing/*.c)
     list(APPEND SOURCES ${SSL_SOURCES})
@@ -50,7 +66,7 @@ if (${LIBUS_USE_LIBUV})
   target_compile_definitions(uSockets PRIVATE -DLIBUS_USE_LIBUV)
 endif()
 
-target_compile_definitions(uSockets PRIVATE ${NOT_USE_OPENSSL} ${USE_OPENSSL})
+target_compile_definitions(uSockets PRIVATE ${NOT_USE_OPENSSL} ${USE_OPENSSL} ${USE_WOLFSSL} ${NOT_USE_WOLFSSL})
 target_include_directories(uSockets PUBLIC ${OPENSSL_INCLUDE_DIR} ${USOCKETS_EXT_INCLUDE_DIR} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/src")
 target_link_libraries(uSockets PUBLIC ${OPENSSL_LIBRARIES} ${LIBUV_LIBRARY} ${USOCKETS_EXT_LIBS})
 

--- a/ports/usockets/CMakeLists.txt
+++ b/ports/usockets/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 if (CMAKE_USE_WOLFSSL)
     find_package(wolfssl REQUIRED)
+    find_package(Threads REQUIRED)
     set(USE_WOLFSSL "-DUSE_WOLFSSL -DLIBUS_USE_WOLFSSL")
 
     list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})

--- a/ports/usockets/portfile.cmake
+++ b/ports/usockets/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         ssl CMAKE_USE_OPENSSL
         event CMAKE_USE_EVENT
         network CMAKE_USE_NETWORK
+        wolfssl CMAKE_USE_WOLFSSL
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/usockets/vcpkg.json
+++ b/ports/usockets/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Miniscule cross-platform eventing, networking & crypto for async applications",
   "homepage": "https://github.com/uNetworking/uSockets",
   "license": "Apache-2.0",
+  "port-version": 1,
   "dependencies": [
     "libuv",
     {

--- a/ports/usockets/vcpkg.json
+++ b/ports/usockets/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "usockets",
   "version": "0.8.6",
+  "port-version": 1,
   "description": "Miniscule cross-platform eventing, networking & crypto for async applications",
   "homepage": "https://github.com/uNetworking/uSockets",
   "license": "Apache-2.0",
-  "port-version": 1,
   "dependencies": [
     "libuv",
     {

--- a/ports/usockets/vcpkg.json
+++ b/ports/usockets/vcpkg.json
@@ -26,6 +26,12 @@
       "dependencies": [
         "openssl"
       ]
+    },
+    "wolfssl": {
+      "description": "Build usockets with wolfssl support",
+      "dependencies": [
+        "wolfssl"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8314,7 +8314,7 @@
     },
     "usockets": {
       "baseline": "0.8.6",
-      "port-version": 0
+      "port-version": 1
     },
     "usrsctp": {
       "baseline": "0.9.5.0",

--- a/versions/u-/usockets.json
+++ b/versions/u-/usockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb54c223d7d11360e37cc1da62c1d398a20b0871",
+      "version": "0.8.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "648715b141f4bb501ebc83d09da547ee0b3fe467",
       "version": "0.8.6",
       "port-version": 0

--- a/versions/u-/usockets.json
+++ b/versions/u-/usockets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eb54c223d7d11360e37cc1da62c1d398a20b0871",
+      "git-tree": "bbfb3ab5fe6fc9c96028f24a129c8ebab2883553",
       "version": "0.8.6",
       "port-version": 1
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

This PR adds WolfSSL support as a feature for uSockets.

