### PR TITLE
New port: libtracepoint-control

### DIFF
--- a/ports/libtracepoint-control/portfile.cmake
+++ b/ports/libtracepoint-control/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "microsoft/LinuxTracepoints"
+    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
+    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
+    HEAD_REF main)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/libtracepoint-control-cpp")
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME tracepoint-control
+    CONFIG_PATH lib/cmake/tracepoint-control)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libtracepoint-control/vcpkg.json
+++ b/ports/libtracepoint-control/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "libtracepoint-control",
+  "version": "1.1.0",
+  "description": "C++ classes for collecting Linux Tracepoints",
+  "homepage": "https://github.com/microsoft/LinuxTracepoints/",
+  "license": "MIT",
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "libtracepoint-decode",
+      "version>=": "1.1.0"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4660,6 +4660,10 @@
       "baseline": "1.1.0",
       "port-version": 0
     },
+    "libtracepoint-control": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "libtracepoint-decode": {
       "baseline": "1.1.0",
       "port-version": 0

--- a/versions/l-/libtracepoint-control.json
+++ b/versions/l-/libtracepoint-control.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "46fe85ffc8eb1f431685a49dace1cf330d54d6c9",
+      "version": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
libtracepoint-control supports controlling a Linux tracepoint event collection session. It integrates with existing ports libtracepoint and libtracepoint-decode.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
