### PR TITLE
[concurrentqueue] Update to 1.0.4

### DIFF
--- a/ports/concurrentqueue/portfile.cmake
+++ b/ports/concurrentqueue/portfile.cmake
@@ -1,9 +1,11 @@
 # header-only library
+vcpkg_minimum_required(VERSION 2022-11-10)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cameron314/concurrentqueue
-    REF 3747268264d0fa113e981658a99ceeae4dad05b7#  v1.0.3
-    SHA512 798d61e8e5b87cd1870df20410db18e2fcbc5e4e1d849308663cc0403a0d50d29b72428fc0a39231ae8bcb460c946559bde0f2d22584c335fe849cbcbe607ec2
+    REF v${VERSION}
+    SHA512 a27306d1a7ad725daf5155a8e33a93efd29839708b2147ba703d036c4a92e04cbd8a505d804d2596ccb4dd797e88aca030b1cb34a4eaf09c45abb0ab55e604ea
     HEAD_REF master
 )
 
@@ -26,4 +28,6 @@ configure_file(
 
 file(GLOB HEADER_FILES "${SOURCE_PATH}/*.h")
 file(INSTALL ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+

--- a/ports/concurrentqueue/portfile.cmake
+++ b/ports/concurrentqueue/portfile.cmake
@@ -1,5 +1,4 @@
 # header-only library
-vcpkg_minimum_required(VERSION 2022-11-10)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -30,4 +29,3 @@ file(GLOB HEADER_FILES "${SOURCE_PATH}/*.h")
 file(INSTALL ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
-

--- a/ports/concurrentqueue/vcpkg.json
+++ b/ports/concurrentqueue/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "concurrentqueue",
-  "version": "1.0.3",
-  "port-version": 1,
+  "version": "1.0.4",
   "description": "A fast multi-producer, multi-consumer lock-free concurrent queue for C++11",
   "homepage": "https://github.com/cameron314/concurrentqueue",
+  "license": "BSD-2-Clause OR BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1697,8 +1697,8 @@
       "port-version": 1
     },
     "concurrentqueue": {
-      "baseline": "1.0.3",
-      "port-version": 1
+      "baseline": "1.0.4",
+      "port-version": 0
     },
     "configcat": {
       "baseline": "2.0.1",

--- a/versions/c-/concurrentqueue.json
+++ b/versions/c-/concurrentqueue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6ff4905722c1571b04fa0dd2439aafe15076ec6",
+      "version": "1.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "2a8223a8b75af74f94551fb342fd576e893c1ba7",
       "version": "1.0.3",
       "port-version": 1

--- a/versions/c-/concurrentqueue.json
+++ b/versions/c-/concurrentqueue.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e6ff4905722c1571b04fa0dd2439aafe15076ec6",
+      "git-tree": "d9e893a30c08cf74ea4155c9110c47d605e1e534",
       "version": "1.0.4",
       "port-version": 0
     },


### PR DESCRIPTION
Update concurrentqueue port from 1.0.3 to 1.0.4 : https://github.com/cameron314/concurrentqueue/releases/tag/v1.0.4

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

