### PR TITLE
[libmysql] remove duplicated symbols

### DIFF
--- a/ports/libmysql/fix_dup_symbols.patch
+++ b/ports/libmysql/fix_dup_symbols.patch
@@ -1,0 +1,20 @@
+diff --git a/client/CMakeLists.txt b/client/CMakeLists.txt
+index 058967b..bcd8841 100644
+--- a/client/CMakeLists.txt
++++ b/client/CMakeLists.txt
+@@ -43,7 +43,6 @@ MYSQL_ADD_EXECUTABLE(mysql
+   pattern_matcher.cc
+   readline.cc
+   client_query_attributes.cc
+-  multi_factor_passwordopt-vars.cc
+   ${CMAKE_CURRENT_SOURCE_DIR}/common/user_registration.cc
+   LINK_LIBRARIES mysqlclient client_base ${EDITLINE_LIBRARY}
+   )
+@@ -226,7 +226,6 @@ SET(MYSQLBINLOG_SOURCES
+   ${CMAKE_SOURCE_DIR}/sql/binlog_reader.cc
+   ${CMAKE_SOURCE_DIR}/sql/stream_cipher.cc
+   ${CMAKE_SOURCE_DIR}/sql/rpl_log_encryption.cc
+-  ${CMAKE_SOURCE_DIR}/libbinlogevents/src/trx_boundary_parser.cpp
+   )
+ 
+ SET(MYSQLBINLOG_LIBRARIES

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
         export-cmake-targets.patch
         Add-target-include-directories.patch
         homebrew.patch
+        fix_dup_symbols.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/include/boost_1_70_0")

--- a/ports/libmysql/vcpkg.json
+++ b/ports/libmysql/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmysql",
   "version": "8.0.32",
-  "port-version": 5,
+  "port-version": 6,
   "description": "A MySQL client library for C development",
   "homepage": "https://github.com/mysql/mysql-server",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4326,7 +4326,7 @@
     },
     "libmysql": {
       "baseline": "8.0.32",
-      "port-version": 5
+      "port-version": 6
     },
     "libnice": {
       "baseline": "0.1.21",

--- a/versions/l-/libmysql.json
+++ b/versions/l-/libmysql.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5696eb818512a5f9375068dc057c3e074de4bc3d",
+      "version": "8.0.32",
+      "port-version": 6
+    },
+    {
       "git-tree": "d32101a913ac66b95dff40eb0ce3e315438566ab",
       "version": "8.0.32",
       "port-version": 5


### PR DESCRIPTION
lld-link complains about duplicated symbols. One of the linked static libraries already has the c files compiled in.