### PR TITLE
[socket-io-client] Update to latest commit

### DIFF
--- a/ports/socket-io-client/portfile.cmake
+++ b/ports/socket-io-client/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO socketio/socket.io-client-cpp
-    REF dbb4547d3160368feaaf55c3338ad085a8f968b8
-    SHA512 cbb2a4742d16ba9ee72ca49a56605690ed620c978f51012e0d655a86b110a557b196ffc55af8b0440c1d7cd76d9dffe6f85abd0af300095608434eb9394dc68b
+    REF b10474e3eaa6b27e75dbc1382ac9af74fdf3fa85
+    SHA512 d0529c1fb293bd0a468d224f14e176fc80226dd665d2a947253beabc8fbe1b0b0a939778bce45a2d8f68d10583920329cf404f41d6fd5ccf2d176cec733e8996
     HEAD_REF master
 )
 

--- a/ports/socket-io-client/vcpkg.json
+++ b/ports/socket-io-client/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-io-client",
-  "version-date": "2022-08-19",
+  "version-date": "2023-02-14",
   "description": "C++11 implementation of Socket.IO client",
   "homepage": "https://github.com/socketio/socket.io-client-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7601,7 +7601,7 @@
       "port-version": 0
     },
     "socket-io-client": {
-      "baseline": "2022-08-19",
+      "baseline": "2023-02-14",
       "port-version": 0
     },
     "sockpp": {

--- a/versions/s-/socket-io-client.json
+++ b/versions/s-/socket-io-client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2aa8fb06982abcd0918726ba79bf81edc9000a4b",
+      "version-date": "2023-02-14",
+      "port-version": 0
+    },
+    {
       "git-tree": "f4f6bebb98623c2bf8602d7538ae4c1d7de6c0ad",
       "version-date": "2022-08-19",
       "port-version": 0


### PR DESCRIPTION
Fixes #32224

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.