### PR TITLE
[spout2] upgrade to 2.007.010, fix spoutDX include path

### DIFF
--- a/ports/spout2/fix-dx-keyed.patch
+++ b/ports/spout2/fix-dx-keyed.patch
@@ -1,0 +1,18 @@
+Subject: [PATCH] fix dx keyed
+---
+Index: SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.cpp
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.cpp b/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.cpp
+--- a/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.cpp	(revision e16402c39ed2389692876d7bbd1c7d4a771a5b86)
++++ b/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.cpp	(revision f3ba250699b87c8004a3430d6b00f3f537af0c0d)
+@@ -193,6 +193,7 @@
+ 	m_bSwapRB = false;
+ 	m_bAdapt = false; // Receiver switch to the sender's graphics adapter
+ 	m_bMemoryShare = GetMemoryShareMode(); // 2.006 memoryshare mode
++    m_bKeyed = false;
+ 
+ 	ZeroMemory(&m_SenderInfo, sizeof(SharedTextureInfo));
+ 	ZeroMemory(&m_ShExecInfo, sizeof(m_ShExecInfo));

--- a/ports/spout2/fix-include-path.patch
+++ b/ports/spout2/fix-include-path.patch
@@ -1,0 +1,48 @@
+Subject: [PATCH] fixup for vcpkg
+---
+Index: SPOUTSDK/SpoutDirectX/SpoutDX/CMakeLists.txt
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/SPOUTSDK/SpoutDirectX/SpoutDX/CMakeLists.txt b/SPOUTSDK/SpoutDirectX/SpoutDX/CMakeLists.txt
+--- a/SPOUTSDK/SpoutDirectX/SpoutDX/CMakeLists.txt	(revision 62362774c96547d63b502d7efd5cfbf138eb7570)
++++ b/SPOUTSDK/SpoutDirectX/SpoutDX/CMakeLists.txt	(revision e16402c39ed2389692876d7bbd1c7d4a771a5b86)
+@@ -67,6 +67,10 @@
+     SPOUT_BUILD_DLL
+     SPOUTLIBRARY_EXPORTS
+ )
++
++
++target_include_directories(SpoutDX_static PRIVATE ../../)
++target_include_directories(SpoutDX PRIVATE ../../)
+ #/-------------------------------------- . -----------------------------------\#
+ 
+ 
+Index: SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.h
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.h b/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.h
+--- a/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.h	(revision 62362774c96547d63b502d7efd5cfbf138eb7570)
++++ b/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.h	(revision e16402c39ed2389692876d7bbd1c7d4a771a5b86)
+@@ -33,12 +33,12 @@
+ #define __spoutDX__
+ 
+ // Change the path as required
+-#include "..\..\SpoutGL\SpoutCommon.h" // for dll build
+-#include "..\..\SpoutGL\SpoutSenderNames.h" // for sender creation and update
+-#include "..\..\SpoutGL\SpoutDirectX.h" // for creating DX11 textures
+-#include "..\..\SpoutGL\SpoutFrameCount.h" // for mutex lock and new frame signal
+-#include "..\..\SpoutGL\SpoutCopy.h" // for pixel copy
+-#include "..\..\SpoutGL\SpoutUtils.h" // Registry utiities
++#include "SpoutGL\SpoutCommon.h" // for dll build
++#include "SpoutGL\SpoutSenderNames.h" // for sender creation and update
++#include "SpoutGL\SpoutDirectX.h" // for creating DX11 textures
++#include "SpoutGL\SpoutFrameCount.h" // for mutex lock and new frame signal
++#include "SpoutGL\SpoutCopy.h" // for pixel copy
++#include "SpoutGL\SpoutUtils.h" // Registry utiities
+ 
+ #include <direct.h> // for _getcwd
+ #include <TlHelp32.h> // for PROCESSENTRY32

--- a/ports/spout2/portfile.cmake
+++ b/ports/spout2/portfile.cmake
@@ -3,9 +3,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO leadedge/Spout2
-    REF 9db0efadba16e1d884164d348f556922cfc80c50 #v2.007.009
-    SHA512 d45613590fb53155c90839cf6eb7fe646ef4ec463b6cd1624aff54870818f0bc4faccded78a6b2c089fa4e8756cf15c7e17def2ef32ac6c34144e562b58c5d8b
+    REF 62362774c96547d63b502d7efd5cfbf138eb7570 #v2.007.010
+    SHA512 89d0dcec719c068e27c2f55605e4b45b32fe3a5e097c821b0aa45f4ee9284e63830bd741ac7bb1bff917190d9a51daa36b452580fc673c05767b7bfcbc9a494f
     HEAD_REF master
+    PATCHES
+        fix-include-path.patch
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL "static")

--- a/ports/spout2/portfile.cmake
+++ b/ports/spout2/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-include-path.patch
+        fix-dx-keyed.patch
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL "static")

--- a/ports/spout2/usage
+++ b/ports/spout2/usage
@@ -1,11 +1,8 @@
 spout2 provides CMake targets:
 
-    # Dynamic Linkage
+    # SpoutGL
     find_package(Spout2 CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Spout2::Spout)
-
-    # Static Linkage
-    find_package(Spout2 CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Spout2::Spout_static)
 
     # SpoutLibrary
@@ -13,8 +10,4 @@ spout2 provides CMake targets:
 
     # SpoutDX
     target_link_libraries(main PRIVATE Spout2::SpoutDX)
-
-    Note: SpoutDX (`dx` feature) is not essential to use DirectX in Spout... It is a sub-set of the
-          Spout SDK for applications using DirectX rather than OpenGL. It doesn't mean enabling
-          DirectX ability for Spout. See https://github.com/leadedge/Spout2/tree/master/SPOUTSDK
-          It is more likely: 'Use only DirectX to implement Spout, and remove all codes that need OpenGL'.
+    target_link_libraries(main PRIVATE Spout2::SpoutDX_static)

--- a/ports/spout2/vcpkg.json
+++ b/ports/spout2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "spout2",
-  "version-string": "2.007.009",
+  "version-string": "2.007.010",
   "description": "Spout is a video frame sharing system for Microsoft Windows, which allows applications to share OpenGL textures in a similar way to Syphon for the Mac.",
   "homepage": "https://github.com/leadedge/Spout2",
   "supports": "windows & !uwp & !arm64",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -484,6 +484,10 @@
       "baseline": "1.6",
       "port-version": 1
     },
+    "baresip-libre": {
+      "baseline": "3.2.0",
+      "port-version": 0
+    },
     "basisu": {
       "baseline": "1.11",
       "port-version": 7
@@ -4480,10 +4484,6 @@
       "baseline": "2.1.1",
       "port-version": 0
     },
-    "baresip-libre": {
-      "baseline": "3.2.0",
-      "port-version": 0
-    },
     "libredwg": {
       "baseline": "0.12.5.5178",
       "port-version": 1
@@ -7733,7 +7733,7 @@
       "port-version": 0
     },
     "spout2": {
-      "baseline": "2.007.009",
+      "baseline": "2.007.010",
       "port-version": 0
     },
     "sprout": {

--- a/versions/s-/spout2.json
+++ b/versions/s-/spout2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c7bcd69652c5bc7b915ecb58f344dfbeaf91e5d8",
+      "git-tree": "e3e3dddea59b3f446dab21b4e4e9ca3c397197f6",
       "version-string": "2.007.010",
       "port-version": 0
     },

--- a/versions/s-/spout2.json
+++ b/versions/s-/spout2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c7bcd69652c5bc7b915ecb58f344dfbeaf91e5d8",
+      "version-string": "2.007.010",
+      "port-version": 0
+    },
+    {
       "git-tree": "6f13bac00168667a3628277bf6301fa4a25c954c",
       "version-string": "2.007.009",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
 
