### PR TITLE
[gdal] Fix build and symbol visibilty

### DIFF
--- a/ports/gdal/gdal-pr-8005.diff
+++ b/ports/gdal/gdal-pr-8005.diff
@@ -1,0 +1,61 @@
+diff --git a/ogr/ogrsf_frmts/shape/gdal_shapelib_symbol_rename.h b/ogr/ogrsf_frmts/shape/gdal_shapelib_symbol_rename.h
+index 61eb15ee951..79795835713 100644
+--- a/ogr/ogrsf_frmts/shape/gdal_shapelib_symbol_rename.h
++++ b/ogr/ogrsf_frmts/shape/gdal_shapelib_symbol_rename.h
+@@ -1,3 +1,4 @@
++/* This is a generated file by dump_symbols.h. *DO NOT EDIT MANUALLY !* */
+ #define compare_ints gdal_compare_ints
+ #define DBFAddField gdal_DBFAddField
+ #define DBFAddNativeFieldType gdal_DBFAddNativeFieldType
+@@ -13,6 +14,7 @@
+ #define DBFGetFieldCount gdal_DBFGetFieldCount
+ #define DBFGetFieldIndex gdal_DBFGetFieldIndex
+ #define DBFGetFieldInfo gdal_DBFGetFieldInfo
++#define DBFGetLenWithoutExtension gdal_DBFGetLenWithoutExtension
+ #define DBFGetNativeFieldType gdal_DBFGetNativeFieldType
+ #define DBFGetNullCharacter gdal_DBFGetNullCharacter
+ #define DBFGetRecordCount gdal_DBFGetRecordCount
+@@ -43,6 +45,7 @@
+ #define DBFWriteStringAttribute gdal_DBFWriteStringAttribute
+ #define DBFWriteTuple gdal_DBFWriteTuple
+ #define frame_dummy gdal_frame_dummy
++#define SASetupDefaultHooks gdal_SASetupDefaultHooks
+ #define SBNAddShapeId gdal_SBNAddShapeId
+ #define SBNCloseDiskTree gdal_SBNCloseDiskTree
+ #define SBNOpenDiskTree gdal_SBNOpenDiskTree
+@@ -66,6 +69,8 @@
+ #define SHPDestroyTree gdal_SHPDestroyTree
+ #define SHPDestroyTreeNode gdal_SHPDestroyTreeNode
+ #define SHPGetInfo gdal_SHPGetInfo
++#define SHPGetLenWithoutExtension gdal_SHPGetLenWithoutExtension
++#define SHPGetPartVertexCount gdal_SHPGetPartVertexCount
+ #define SHPGetSubNodeOffset gdal_SHPGetSubNodeOffset
+ #define SHPOpenDiskTree gdal_SHPOpenDiskTree
+ #define SHPOpen gdal_SHPOpen
+@@ -75,6 +80,7 @@
+ #define SHPReadObject gdal_SHPReadObject
+ #define SHPReallocObjectBufIfNecessary gdal_SHPReallocObjectBufIfNecessary
+ #define SHPRestoreSHX gdal_SHPRestoreSHX
++#define SHPRewindIsInnerRing gdal_SHPRewindIsInnerRing
+ #define SHPRewindObject gdal_SHPRewindObject
+ #define SHPSearchDiskTreeEx gdal_SHPSearchDiskTreeEx
+ #define SHPSearchDiskTree gdal_SHPSearchDiskTree
+@@ -97,6 +103,4 @@
+ #define SHPWriteTree gdal_SHPWriteTree
+ #define SHPWriteTreeLL gdal_SHPWriteTreeLL
+ #define SHPWriteTreeNode gdal_SHPWriteTreeNode
+-#define str_to_upper gdal_str_to_upper
+ #define SwapWord gdal_SwapWord
+-/* This is a generated file by dump_symbols.h. *DO NOT EDIT MANUALLY !* */
+diff --git a/ogr/ogrsf_frmts/shape/shp_vsi.h b/ogr/ogrsf_frmts/shape/shp_vsi.h
+index 9ee8056804e..9cbe653bead 100644
+--- a/ogr/ogrsf_frmts/shape/shp_vsi.h
++++ b/ogr/ogrsf_frmts/shape/shp_vsi.h
+@@ -31,6 +31,7 @@
+ #ifndef SHP_VSI_H_INCLUDED
+ #define SHP_VSI_H_INCLUDED
+ 
++#include "gdal_shapelib_symbol_rename.h"
+ #include "cpl_vsi.h"
+ #include "shapefil.h"
+ 

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -91,7 +91,7 @@ vcpkg_cmake_configure(
         -DGDAL_CHECK_PACKAGE_QHULL_NAMES=Qhull
         "-DGDAL_CHECK_PACKAGE_QHULL_TARGETS=${qhull_target}"
         "-DQHULL_LIBRARY=${qhull_target}"
-        -DCMAKE_PROJECT_INCLUDE="${CMAKE_CURRENT_LIST_DIR}/cmake-project-include.cmake"
+        "-DCMAKE_PROJECT_INCLUDE=${CMAKE_CURRENT_LIST_DIR}/cmake-project-include.cmake"
     OPTIONS_DEBUG
         -DBUILD_APPS=OFF
     MAYBE_UNUSED_VARIABLES

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         find-link-libraries.patch
         fix-gdal-target-interfaces.patch
         libkml.patch
+        gdal-pr-8005.diff # Remove in 3.7.1
 )
 # `vcpkg clean` stumbles over one subdir
 file(REMOVE_RECURSE "${SOURCE_PATH}/autotest")

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.7.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2738,7 +2738,7 @@
     },
     "gdal": {
       "baseline": "3.7.0",
-      "port-version": 3
+      "port-version": 4
     },
     "gdcm": {
       "baseline": "3.0.22",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e2de2263a527e2135c8532fcc9967e63378a552",
+      "version-semver": "3.7.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "35cbea48f44c5d0836cd0b6f171396eae2745177",
       "version-semver": "3.7.0",
       "port-version": 3


### PR DESCRIPTION
Fixes #32242.  
Fixes #32070.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
