### PR TITLE
[mailio] Version 0.23

### DIFF
--- a/ports/mailio/portfile.cmake
+++ b/ports/mailio/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO karastojko/mailio
-    REF cc887a7808d9c55e07c8a7503c7ae2e2d7485120 # version_0-21-0
-    SHA512 7125bfe4274e1e126e335b2e4b5743ef54d5dc0b6fd83f0c10e7578b57924d3e398af6b3865fdee3de587e2e2d7c33d95dbe017b1966649e68cf52f2dd268ee5
+    REF 8a3b92361d244dbb1af722d1ad6dcaf321907936 # version_0-23-0
+    SHA512 81fc656ef5cb0cd79b792e795975292a84982b873289bd008f001b6225e0f6829e492551b1b844b5099c6f1b0dbabc222e1ecbb72f3f268803b5f76923c22d8f
     HEAD_REF master
 )
 
@@ -10,7 +10,6 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DMAILIO_BUILD_DOCUMENTATION=OFF
-        -DMAILIO_BUILD_EXAMPLES=OFF
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(

--- a/ports/mailio/vcpkg.json
+++ b/ports/mailio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mailio",
-  "version": "0.21.0",
+  "version": "0.23.0",
   "port-version": 2,
   "maintainers": "Tomislav Karastojković <contact@alepho.com>",
   "description": "mailio is a cross platform C++ library for MIME format and SMTP, POP3 and IMAP protocols. It is based on the standard C++ 17 and Boost library.",
@@ -12,6 +12,7 @@
     "boost-date-time",
     "boost-regex",
     "boost-system",
+    "boost-test",
     "openssl",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5122,7 +5122,7 @@
     },
     "mailio": {
       "baseline": "0.23.0",
-      "port-version": 2
+      "port-version": 0
     },
     "makeid": {
       "baseline": "1.0.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -484,6 +484,10 @@
       "baseline": "1.6",
       "port-version": 1
     },
+    "baresip-libre": {
+      "baseline": "3.2.0",
+      "port-version": 0
+    },
     "basisu": {
       "baseline": "1.11",
       "port-version": 7
@@ -4480,10 +4484,6 @@
       "baseline": "2.1.1",
       "port-version": 0
     },
-    "baresip-libre": {
-      "baseline": "3.2.0",
-      "port-version": 0
-    },
     "libredwg": {
       "baseline": "0.12.5.5178",
       "port-version": 1
@@ -5122,7 +5122,7 @@
     },
     "mailio": {
       "baseline": "0.23.0",
-      "port-version": 0
+      "port-version": 2
     },
     "makeid": {
       "baseline": "1.0.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5121,7 +5121,7 @@
       "port-version": 10
     },
     "mailio": {
-      "baseline": "0.21.0",
+      "baseline": "0.23.0",
       "port-version": 2
     },
     "makeid": {

--- a/versions/m-/mailio.json
+++ b/versions/m-/mailio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2297f8f97ca2172e1eac79c00dab9f287be05385",
+      "version": "0.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a9f20b309b2d9f68c5e10eb193ef19c3c51a3faa",
       "version": "0.21.0",
       "port-version": 2


### PR DESCRIPTION

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
