### PR TITLE
[luajit] Set strip options

### DIFF
--- a/ports/luajit/portfile.cmake
+++ b/ports/luajit/portfile.cmake
@@ -52,14 +52,18 @@ else()
     endif()
 
     vcpkg_list(SET make_options "EXECUTABLE_SUFFIX=${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+    set(strip_options "") # cf. src/Makefile
     if(VCPKG_TARGET_IS_OSX)
         vcpkg_list(APPEND make_options "TARGET_SYS=Darwin")
+        set(strip_options " -x")
     elseif(VCPKG_TARGET_IS_IOS)
         vcpkg_list(APPEND make_options "TARGET_SYS=iOS")
+        set(strip_options " -x")
     elseif(VCPKG_TARGET_IS_LINUX)
         vcpkg_list(APPEND make_options "TARGET_SYS=Linux")
     elseif(VCPKG_TARGET_IS_WINDOWS)
         vcpkg_list(APPEND make_options "TARGET_SYS=Windows")
+        set(strip_options " --strip-unneeded")
     endif()
 
     set(dasm_archs "")
@@ -84,7 +88,7 @@ else()
         OPTIONS
             ${make_options}
             "TARGET_AR=${VCPKG_DETECTED_CMAKE_AR} rcus"
-            "TARGET_STRIP=${VCPKG_DETECTED_CMAKE_STRIP}"
+            "TARGET_STRIP=${VCPKG_DETECTED_CMAKE_STRIP}${strip_options}"
     )
 endif()
 

--- a/ports/luajit/vcpkg.json
+++ b/ports/luajit/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "luajit",
   "version-date": "2023-01-04",
-  "port-version": 1,
+  "port-version": 2,
   "description": "LuaJIT is a Just-In-Time (JIT) compiler for the Lua programming language.",
   "homepage": "https://github.com/LuaJIT/LuaJIT",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5050,7 +5050,7 @@
     },
     "luajit": {
       "baseline": "2023-01-04",
-      "port-version": 1
+      "port-version": 2
     },
     "luasec": {
       "baseline": "1.3.1",

--- a/versions/l-/luajit.json
+++ b/versions/l-/luajit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b724aa5af80b253739609f1173da343d55251cd",
+      "version-date": "2023-01-04",
+      "port-version": 2
+    },
+    {
       "git-tree": "5a564decc9569af8e940353cab9623b6f93f3a4b",
       "version-date": "2023-01-04",
       "port-version": 1


### PR DESCRIPTION
Fixes #32243.

When we set `TARGET_STRIP` on the command line, `make` won't append any other flags from `+=` statements in the `Makefile`. We might patch in `override`, but we can just set the flags directly.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
