### PR TITLE
[magnum] Fix compile feature-wavaudioimporter error

### DIFF
--- a/ports/magnum/004-fix-FindOpenAL.patch
+++ b/ports/magnum/004-fix-FindOpenAL.patch
@@ -11,22 +11,15 @@ index 64371a4..375ca58 100644
  if(BUILD_PLUGINS_STATIC)
      set(MAGNUM_ANYAUDIOIMPORTER_BUILD_STATIC 1)
 diff --git a/src/MagnumPlugins/WavAudioImporter/CMakeLists.txt b/src/MagnumPlugins/WavAudioImporter/CMakeLists.txt
-index f4172d4..3c0eefc 100644
+index f4172d4..bdfd9da 100644
 --- a/src/MagnumPlugins/WavAudioImporter/CMakeLists.txt
 +++ b/src/MagnumPlugins/WavAudioImporter/CMakeLists.txt
-@@ -24,6 +24,7 @@
+@@ -24,6 +24,8 @@
  #
 
  find_package(Corrade REQUIRED PluginManager)
-+find_package(OpenAL REQUIRED)
++include(CMakeFindDependencyMacro)
++find_dependency(OpenAL)
 
  if(BUILD_PLUGINS_STATIC)
      set(MAGNUM_WAVAUDIOIMPORTER_BUILD_STATIC 1)
-@@ -37,6 +38,7 @@ add_library(WavAudioImporterObjects OBJECT
-     WavHeader.cpp
-     WavHeader.h)
- target_include_directories(WavAudioImporterObjects PUBLIC
-+    $<TARGET_PROPERTY:OpenAL::OpenAL,INTERFACE_INCLUDE_DIRECTORIES>
-     $<TARGET_PROPERTY:Magnum,INTERFACE_INCLUDE_DIRECTORIES>
-     $<TARGET_PROPERTY:MagnumAudio,INTERFACE_INCLUDE_DIRECTORIES>)
- if(NOT BUILD_PLUGINS_STATIC)

--- a/ports/magnum/004-fix-FindOpenAL.patch
+++ b/ports/magnum/004-fix-FindOpenAL.patch
@@ -10,3 +10,23 @@ index 64371a4..375ca58 100644
  
  if(BUILD_PLUGINS_STATIC)
      set(MAGNUM_ANYAUDIOIMPORTER_BUILD_STATIC 1)
+diff --git a/src/MagnumPlugins/WavAudioImporter/CMakeLists.txt b/src/MagnumPlugins/WavAudioImporter/CMakeLists.txt
+index f4172d4..3c0eefc 100644
+--- a/src/MagnumPlugins/WavAudioImporter/CMakeLists.txt
++++ b/src/MagnumPlugins/WavAudioImporter/CMakeLists.txt
+@@ -24,6 +24,7 @@
+ #
+
+ find_package(Corrade REQUIRED PluginManager)
++find_package(OpenAL REQUIRED)
+
+ if(BUILD_PLUGINS_STATIC)
+     set(MAGNUM_WAVAUDIOIMPORTER_BUILD_STATIC 1)
+@@ -37,6 +38,7 @@ add_library(WavAudioImporterObjects OBJECT
+     WavHeader.cpp
+     WavHeader.h)
+ target_include_directories(WavAudioImporterObjects PUBLIC
++    $<TARGET_PROPERTY:OpenAL::OpenAL,INTERFACE_INCLUDE_DIRECTORIES>
+     $<TARGET_PROPERTY:Magnum,INTERFACE_INCLUDE_DIRECTORIES>
+     $<TARGET_PROPERTY:MagnumAudio,INTERFACE_INCLUDE_DIRECTORIES>)
+ if(NOT BUILD_PLUGINS_STATIC)

--- a/ports/magnum/vcpkg.json
+++ b/ports/magnum/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "magnum",
   "version-string": "2020.06",
-  "port-version": 12,
+  "port-version": 13,
   "description": "C++11/C++14 graphics middleware for games and data visualization",
   "homepage": "https://magnum.graphics/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5110,7 +5110,7 @@
     },
     "magnum": {
       "baseline": "2020.06",
-      "port-version": 12
+      "port-version": 13
     },
     "magnum-extras": {
       "baseline": "2020.06",

--- a/versions/m-/magnum.json
+++ b/versions/m-/magnum.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce2a54ad576987c8f88d7f95d6092068f26f6741",
+      "git-tree": "d0adac5f186692119e9a2b9826ac5ed7357ed8a1",
       "version-string": "2020.06",
       "port-version": 13
     },

--- a/versions/m-/magnum.json
+++ b/versions/m-/magnum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce2a54ad576987c8f88d7f95d6092068f26f6741",
+      "version-string": "2020.06",
+      "port-version": 13
+    },
+    {
       "git-tree": "8ea35ff59474f3e0eaf9c13c2d5b4bae6519d651",
       "version-string": "2020.06",
       "port-version": 12


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/31014
```
CMake Error at src/MagnumPlugins/WavAudioImporter/CMakeLists.txt:39 (target_include_directories):
  Error evaluating generator expression:

    $<TARGET_PROPERTY:OpenAL::OpenAL,INTERFACE_INCLUDE_DIRECTORIES>

  Target "OpenAL::OpenAL" not found.

```
Add `find_package(OpenAL REQUIRED)` to `cmakelists.txt` and add `OpenAL::OpenAL` to the link header file.

Compile test pass with following triplets:
```
x64-windows
x64-linux
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.