### PR TITLE
[vcpkg baseline][fastrtps] Use more precise version comparison

### DIFF
--- a/ports/fastrtps/fix-xtime.patch
+++ b/ports/fastrtps/fix-xtime.patch
@@ -11,7 +11,7 @@ index 7ca47ae..632c38b 100644
 +# MSVC, it will be deleted after release.
 +###############################################################################
 +if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.36.32528.95")
++    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.37.32705.0")
 +        file(READ "${PROJECT_SOURCE_DIR}/include/fastrtps/utils/TimedMutex.hpp" _contents)
 +        string(REPLACE "xtime*" "_timespec64*" _contents "${_contents}")
 +        file(WRITE "${PROJECT_SOURCE_DIR}/include/fastrtps/utils/TimedMutex.hpp" "${_contents}")

--- a/ports/fastrtps/vcpkg.json
+++ b/ports/fastrtps/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fastrtps",
   "version": "2.7.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Eprosima Fast RTPS is a C++ implementation of the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2454,7 +2454,7 @@
     },
     "fastrtps": {
       "baseline": "2.7.0",
-      "port-version": 1
+      "port-version": 2
     },
     "fawdlstty-libfv": {
       "baseline": "0.0.8",

--- a/versions/f-/fastrtps.json
+++ b/versions/f-/fastrtps.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "443f550810af037dae538dc5555d7e069f2896ec",
+      "version": "2.7.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b2d64bc038a30ea7ad49dc5cb923c0e13618281c",
       "version": "2.7.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixed [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=91248&view=results) issue:
```
fastrtps:x86-windows
fastrtps:x64-windows
include\fastrtps/utils/TimedMutex.hpp(93): error C2664: 'int _Mtx_timedlock(_Mtx_t,const xtime *)': cannot convert argument 2 from '_timespec64 *' to 'const xtime *'
```
This issue is due to the compiler version of VS2022 17.6.3 being greater than the version condition we have set, resulting in the execution of new behaviors introduced by the patch. However, these new behaviors were actually intended for VS2022 17.7 preview 2 (internal modifications have already been released in this version).

To fix this issue, I am using the compiler version from VS2022 17.7 preview 2 as the condition for judgment.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
