### PR TITLE
[x264] update to r3107

### DIFF
--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mirror/x264
-    REF baee400fa9ced6f5481a728138fed6e867b0ff7f # 0.164.3095 in pc file, to be updated below
-    SHA512 3c7147457cbe0fea20cf3ed8cf7bbdca9ac15060cf86f81b9b5b54b018f922964e91b3c38962c81fedef92bc5b14489e04d0966d03d2b7a85b4dabab6ad816a2
+    REF eaa68fad9e5d201d42fde51665f2d137ae96baf0 # 0.164.3107 in pc file, to be updated below
+    SHA512 9181b222e7f8bbde4331141ff399e1ef20d3e2e7a8f939b373fbe08df6f3caa99b992afb0e559cc19f78c96f0105b88b2eb4e4b935484e25b2c15da7903d179b
     HEAD_REF stable
     PATCHES
         uwp-cflags.patch

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "x264",
-  "version": "0.164.3095",
-  "port-version": 5,
+  "version": "0.164.3107",
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://www.videolan.org/developers/x264.html",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8717,8 +8717,8 @@
       "port-version": 2
     },
     "x264": {
-      "baseline": "0.164.3095",
-      "port-version": 5
+      "baseline": "0.164.3107",
+      "port-version": 0
     },
     "x265": {
       "baseline": "3.4",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fdfc4bb17ed8a4942a78dafd2ca5174d0695774",
+      "version": "0.164.3107",
+      "port-version": 0
+    },
+    {
       "git-tree": "36ff38fabd741ddef6ccf4c207ef99058383c0bb",
       "version": "0.164.3095",
       "port-version": 5


### PR DESCRIPTION
Fixes #31530

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static