### PR TITLE
[lua] update to 5.4.6

### DIFF
--- a/ports/lua/fix-ios-system.patch
+++ b/ports/lua/fix-ios-system.patch
@@ -1,23 +1,23 @@
 diff --git a/src/loslib.c b/src/loslib.c
-index e65e188..3595601 100644
+index ad5a927..7812011 100644
 --- a/src/loslib.c
 +++ b/src/loslib.c
-@@ -3,7 +3,9 @@
- ** Standard Operating System library
+@@ -4,6 +4,10 @@
  ** See Copyright Notice in lua.h
  */
--
+ 
 +#if defined(__APPLE__)
 +#include <TargetConditionals.h>
 +#endif
++
  #define loslib_c
  #define LUA_LIB
  
-@@ -143,7 +145,12 @@ static int os_execute (lua_State *L) {
+@@ -143,7 +147,12 @@ static int os_execute (lua_State *L) {
    const char *cmd = luaL_optstring(L, 1, NULL);
    int stat;
    errno = 0;
--  stat = system(cmd);
+-  stat = l_system(cmd);
 +#if defined(__APPLE__) && !TARGET_OS_OSX
 +   // system() is __IOS_PROHIBITED, __WATCHOS_PROHIBITED, and __TVOS_PROHIBITED.
 +   stat = 127; // error: shell execution failed

--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.lua.org/ftp/lua-5.4.4.tar.gz"
-    FILENAME "lua-5.4.4.tar.gz"
-    SHA512 af0c35d5ba00fecbb2dd617bd7b825edf7418a16a73076e04f2a0df58cdbf098dc3ff4402e974afd789eb5d86d2e12ec6df9c84b99b23656ea694a85f83bcd21
+    URLS "https://www.lua.org/ftp/lua-${VERSION}.tar.gz"
+    FILENAME "lua-${VERSION}.tar.gz"
+    SHA512 d90c6903355ee1309cb0d92a8a024522ff049091a117ea21efb585b5de35776191cd67d17a65b18c2f9d374795b7c944f047576f0e3fe818d094b26f0e4845c5
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/lua/vcpkg.json
+++ b/ports/lua/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "lua",
-  "version": "5.4.4",
-  "port-version": 7,
+  "version": "5.4.6",
   "description": "A powerful, fast, lightweight, embeddable scripting language",
   "homepage": "https://www.lua.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5033,8 +5033,8 @@
       "port-version": 0
     },
     "lua": {
-      "baseline": "5.4.4",
-      "port-version": 7
+      "baseline": "5.4.6",
+      "port-version": 0
     },
     "lua-compat53": {
       "baseline": "0.10",

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a25521a101ee330fd29139a6d4f377be3d814326",
+      "version": "5.4.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "804a148ba3bbecf8f998d38c682eaee628725fbb",
       "version": "5.4.4",
       "port-version": 7


### PR DESCRIPTION
Fixes #31442


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static

Tested usage successfully by `lua:x64-windows`