### PR TITLE
[tree-similarity] Fix wrong port name in usage file

### DIFF
--- a/ports/tree-similarity/usage
+++ b/ports/tree-similarity/usage
@@ -1,4 +1,4 @@
-The package idyntree provides CMake targets:
+tree-similiarity provides CMake targets:
 
-	find_path(TREE_SIMILARITY_INCLUDE_DIRS "tree-similiarity")
-	target_include_directories(main PRIVATE ${TREE_SIMILARITY_INCLUDE_DIRS})
+    find_path(TREE_SIMILARITY_INCLUDE_DIRS "tree-similiarity")
+    target_include_directories(main PRIVATE ${TREE_SIMILARITY_INCLUDE_DIRS})

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8189,7 +8189,7 @@
       "port-version": 5
     },
     "tree-similarity": {
-      "baseline": "0.1.1#2",
+      "baseline": "0.1.1",
       "port-version": 1
     },
     "tree-sitter": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8190,7 +8190,7 @@
     },
     "tree-similarity": {
       "baseline": "0.1.1",
-      "port-version": 1
+      "port-version": 0
     },
     "tree-sitter": {
       "baseline": "0.20.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8190,7 +8190,7 @@
     },
     "tree-similarity": {
       "baseline": "0.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "tree-sitter": {
       "baseline": "0.20.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8189,8 +8189,8 @@
       "port-version": 5
     },
     "tree-similarity": {
-      "baseline": "0.1.1",
-      "port-version": 0
+      "baseline": "0.1.1#2",
+      "port-version": 1
     },
     "tree-sitter": {
       "baseline": "0.20.6",

--- a/versions/t-/tree-similarity.json
+++ b/versions/t-/tree-similarity.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "d7f5637a5f1a5c0ba5d50a5734a69c6d190ac75d",
+      "git-tree": "70687dc8d04de8f3a23c3bf8570644b4069205f3",
       "version-semver": "0.1.1",
-      "port-version": 1
+      "port-version": 0
     }
   ]
 }

--- a/versions/t-/tree-similarity.json
+++ b/versions/t-/tree-similarity.json
@@ -3,7 +3,7 @@
     {
       "git-tree": "70687dc8d04de8f3a23c3bf8570644b4069205f3",
       "version-semver": "0.1.1",
-      "port-version": 0
+      "port-version": 1
     }
   ]
 }

--- a/versions/t-/tree-similarity.json
+++ b/versions/t-/tree-similarity.json
@@ -1,9 +1,14 @@
 {
   "versions": [
     {
-      "git-tree": "70687dc8d04de8f3a23c3bf8570644b4069205f3",
+      "git-tree": "d7f5637a5f1a5c0ba5d50a5734a69c6d190ac75d",
       "version-semver": "0.1.1",
       "port-version": 0
+    },
+	{
+      "git-tree": "70687dc8d04de8f3a23c3bf8570644b4069205f3",
+      "version-semver": "0.1.1",
+      "port-version": 1
     }
   ]
 }

--- a/versions/t-/tree-similarity.json
+++ b/versions/t-/tree-similarity.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d7f5637a5f1a5c0ba5d50a5734a69c6d190ac75d",
+      "git-tree": "70687dc8d04de8f3a23c3bf8570644b4069205f3",
       "version-semver": "0.1.1",
       "port-version": 0
     }

--- a/versions/t-/tree-similarity.json
+++ b/versions/t-/tree-similarity.json
@@ -7,7 +7,7 @@
     },
 	{
       "git-tree": "70687dc8d04de8f3a23c3bf8570644b4069205f3",
-      "version-semver": "0.1.1",
+      "version-semver": "0.1.1#2",
       "port-version": 1
     }
   ]

--- a/versions/t-/tree-similarity.json
+++ b/versions/t-/tree-similarity.json
@@ -3,11 +3,6 @@
     {
       "git-tree": "d7f5637a5f1a5c0ba5d50a5734a69c6d190ac75d",
       "version-semver": "0.1.1",
-      "port-version": 0
-    },
-	{
-      "git-tree": "70687dc8d04de8f3a23c3bf8570644b4069205f3",
-      "version-semver": "0.1.1#2",
       "port-version": 1
     }
   ]


### PR DESCRIPTION
Small typo in the usage file. I had copied the file from another port and forgot to update the name.

No changes in the port's version

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
