### PR TITLE
[usd] Fix hash after repository redirect

### DIFF
--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -14,9 +14,9 @@ string(REGEX REPLACE "^([0-9]+)[.]([0-9])\$" "\\1.0\\2" USD_VERSION "${VERSION}"
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO PixarAnimationStudios/USD
+    REPO PixarAnimationStudios/OpenUSD
     REF "v${USD_VERSION}"
-    SHA512 fd3e7a90f837a5d016d94be34747b2c1daed3f01f252e4b1aa5cb195f32acaecca9373b8f5c7be9c235148f04b0afa47da9462b357ef1dd1e11cf20a7225ae66
+    SHA512 6669191c3497e244c958949b62a749958ab01e8e1edc7b3476d59c31395e147acf6f4ba7aae069c5ceab7fe2eb321e81e4e5f66beb72814be36e0fec98d3d034
     HEAD_REF master
     PATCHES
         fix_build-location.patch

--- a/ports/usd/vcpkg.json
+++ b/ports/usd/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "usd",
   "version": "23.5",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.",
   "homepage": "https://github.com/PixarAnimationStudios/USD",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8326,7 +8326,7 @@
     },
     "usd": {
       "baseline": "23.5",
-      "port-version": 2
+      "port-version": 3
     },
     "usockets": {
       "baseline": "0.8.6",

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a589441a5a488b6ad5d797ae17dab850b8b03620",
+      "version": "23.5",
+      "port-version": 3
+    },
+    {
       "git-tree": "b5cb814be5a5aec9d600aeb98cd2126f407ca062",
       "version": "23.5",
       "port-version": 2


### PR DESCRIPTION
Pixar recently changed the repository `USD` to `OpenUSD`.  
This resulted in a change in archive sha512 value breaking all the previous VCPKG versions.  
I updated the repository name and the sha512 value.

See https://github.com/PixarAnimationStudios/OpenUSD/issues/2511

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- ~[ ] The "supports" clause reflects platforms that may be fixed by this new version~
- ~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- ~[ ] Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

