### PR TITLE
[z3] Update to 4.12.2

### DIFF
--- a/ports/z3/fix-cstdint-include.patch
+++ b/ports/z3/fix-cstdint-include.patch
@@ -1,0 +1,12 @@
+diff --git a/src/util/tptr.h b/src/util/tptr.h
+index 6213b2efa..2a35af535 100644
+--- a/src/util/tptr.h
++++ b/src/util/tptr.h
+@@ -20,6 +20,7 @@ Revision History:
+ #pragma once
+
+ #include "util/machine.h"
++#include <cstdint>
+
+ #define TAG_SHIFT        PTR_ALIGNMENT
+ #define ALIGNMENT_VALUE  (1 << PTR_ALIGNMENT)

--- a/ports/z3/portfile.cmake
+++ b/ports/z3/portfile.cmake
@@ -5,11 +5,12 @@ vcpkg_add_to_path("${PYTHON3_DIR}")
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO Z3Prover/z3
-  REF z3-4.11.0
-  SHA512 a3fd7e013948de6683b16aca03641bb845d02187152bebdee8c62c2a3f80a7710a1d3b9aef9c1490c2340571bb225f457928ac57a2ed28c0084ced34bcf3e905
+  REF z3-4.12.2
+  SHA512 375477cbbc9837b44e752c89916409d07bf6a73830b52878aab4f376f08b37dd5ab485da225744d394ab15f2a7e1014edc3be5eb9962934c440a8d55259317e2
   HEAD_REF master
   PATCHES
       fix-install-path.patch
+      fix-cstdint-include.patch
       remove-flag-overrides.patch
 )
 

--- a/ports/z3/remove-flag-overrides.patch
+++ b/ports/z3/remove-flag-overrides.patch
@@ -5,8 +5,8 @@ index 477410ba8..fcca03917 100644
 @@ -1,7 +1,6 @@
  # Enforce some CMake policies
  cmake_minimum_required(VERSION 3.4)
- 
+
 -set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_compiler_flags_overrides.cmake")
- project(Z3 VERSION 4.11.0.0 LANGUAGES CXX)
- 
+ project(Z3 VERSION 4.12.2.0 LANGUAGES CXX)
+
  ################################################################################

--- a/ports/z3/vcpkg.json
+++ b/ports/z3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "z3",
-  "version": "4.11.0",
+  "version": "4.12.2",
   "description": "Z3 is a theorem prover from Microsoft Research",
   "homepage": "https://github.com/Z3Prover/z3",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8913,7 +8913,7 @@
       "port-version": 0
     },
     "z3": {
-      "baseline": "4.11.0",
+      "baseline": "4.12.2",
       "port-version": 0
     },
     "z4kn4fein-semver": {

--- a/versions/z-/z3.json
+++ b/versions/z-/z3.json
@@ -1,6 +1,12 @@
 {
   "versions": [
     {
+      "git-tree": "dcef04d626f19434eaf9d2a3afb43d927bbd372e",
+      "version": "4.12.2",
+      "port-version": 0
+    },
+
+    {
       "git-tree": "4c57981e593026824fe9bedff234a82c13765e29",
       "version": "4.11.0",
       "port-version": 0


### PR DESCRIPTION
Updates the z3 port to 4.12.2 to fix building on macOS.
Also includes a patch for cstdint so it builds with gcc 13 (see https://github.com/Z3Prover/z3/pull/6723)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.