### PR TITLE
[nowide] Update to 11.3.0

### DIFF
--- a/ports/nowide/portfile.cmake
+++ b/ports/nowide/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/boostorg/nowide/releases/download/v11.2.0/nowide_standalone_v11.2.0.tar.gz"
-    FILENAME "nowide_standalone_v11.2.0.tar.gz"
-    SHA512 c3748921b85648aa0e89970f2ab24588cbc72d05edd7ddf4f61a607d9ecbddd45e9e6799d2ed83386c43045b9487693e027494a81b11a6a7bdfaa939d1251938
+    URLS "https://github.com/boostorg/nowide/releases/download/v${VERSION}/nowide_standalone_v${VERSION}.tar.gz"
+    FILENAME "nowide_standalone_v${VERSION}.tar.gz"
+    SHA512 68e4d4b11db7265bf91e90b16e35ef2ea3a8ad80031b122067393a4cb89e20e26bacff81c7abddfc7a84d22c0d545875d7ba40b0288c665fb82028f08f957524
 )
 
 vcpkg_extract_source_archive(
@@ -20,4 +20,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/nowide)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/nowide/vcpkg.json
+++ b/ports/nowide/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nowide",
-  "version": "11.2.0",
-  "port-version": 1,
+  "version": "11.3.0",
   "description": "Boost nowide module (standalone)",
   "homepage": "https://github.com/boostorg/nowide",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5721,8 +5721,8 @@
       "port-version": 4
     },
     "nowide": {
-      "baseline": "11.2.0",
-      "port-version": 1
+      "baseline": "11.3.0",
+      "port-version": 0
     },
     "nrf-ble-driver": {
       "baseline": "4.1.4",

--- a/versions/n-/nowide.json
+++ b/versions/n-/nowide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d782a748c6b9013ca434f77a3c2b1838fce734d",
+      "version": "11.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d91d4dcfdca6cb36e7c2235e9a14ccc131ed165e",
       "version": "11.2.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #32295. Update `nowide` to 11.3.0.

No feature needs to be tested, the usage test passed (header files found): 
```
nowide provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(nowide CONFIG REQUIRED)
    target_link_libraries(main PRIVATE nowide::nowide)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
