### PR TITLE
[gtk3] Turn hang into timeout

### DIFF
--- a/ports/gtk3/portfile.cmake
+++ b/ports/gtk3/portfile.cmake
@@ -82,7 +82,7 @@ endforeach()
 if(EXISTS "${SCRIPTS}/cmake/vcpkg_install_meson.cmake")
     file(READ "${SCRIPTS}/cmake/vcpkg_install_meson.cmake" install_meson)
     string(REPLACE [[COMMAND "${NINJA}"]] [[
-        TIMEOUT 3600
+        TIMEOUT 18000 # 5 h
         COMMAND "${NINJA}"]]
         install_meson "${install_meson}"
     )

--- a/ports/gtk3/portfile.cmake
+++ b/ports/gtk3/portfile.cmake
@@ -76,6 +76,19 @@ foreach(dir IN ITEMS "${TARGET_TRIPLET}-dbg" "${TARGET_TRIPLET}-rel")
         vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${dir}/build.ninja" "/${dir}/../src/" "/src/")
     endif()
 endforeach()
+
+# Temporary mitigation for build being stuck for unclear reasons,
+# https://github.com/microsoft/vcpkg/issues/29018
+if(EXISTS "${SCRIPTS}/cmake/vcpkg_install_meson.cmake")
+    file(READ "${SCRIPTS}/cmake/vcpkg_install_meson.cmake" install_meson)
+    string(REPLACE [[COMMAND "${NINJA}"]] [[
+        TIMEOUT 3600
+        COMMAND "${NINJA}"]]
+        install_meson "${install_meson}"
+    )
+    file(WRITE "${CURRENT_BUILDTREES_DIR}/gtk3_install_meson.cmake" "${install_meson}")
+    include("${CURRENT_BUILDTREES_DIR}/gtk3_install_meson.cmake")
+endif()
 vcpkg_install_meson(ADD_BIN_TO_PATH)
 
 vcpkg_copy_pdbs()

--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gtk3",
   "version": "3.24.38",
+  "port-version": 1,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3022,7 +3022,7 @@
     },
     "gtk3": {
       "baseline": "3.24.38",
-      "port-version": 0
+      "port-version": 1
     },
     "gtkmm": {
       "baseline": "4.10.0",

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d8590147ded2f8507937c985884ca4839c5e103f",
+      "git-tree": "13e53adc7d4f128b462577dd4bb11149b1f4152e",
       "version": "3.24.38",
       "port-version": 1
     },

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8590147ded2f8507937c985884ca4839c5e103f",
+      "version": "3.24.38",
+      "port-version": 1
+    },
+    {
       "git-tree": "63636acf7b77eead112fc9faa84680d1df97acd3",
       "version": "3.24.38",
       "port-version": 0


### PR DESCRIPTION
Mitigation for #29018.
From proper failures, we will be able to get CI logs for port gtk3.
CC @BillyONeal.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
