### PR TITLE
[vcpkg-ci-llvm] Find cacheable feature sets

### DIFF
--- a/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
@@ -31,12 +31,20 @@
       "default-features": false,
       "features": [
         "bolt",
-        "flang",
         "openmp",
         "polly",
         "utils"
       ],
       "platform": "!static"
+    },
+    {
+      "$comment": "Platform restriction due to CI artifact upload quirks; flang",
+      "name": "llvm",
+      "default-features": false,
+      "features": [
+        "flang"
+      ],
+      "platform": "!static & !x86"
     }
   ]
 }

--- a/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
@@ -44,7 +44,7 @@
       "features": [
         "flang"
       ],
-      "platform": "!static & !x86"
+      "platform": "linux"
     }
   ]
 }

--- a/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
@@ -31,20 +31,12 @@
       "default-features": false,
       "features": [
         "bolt",
+        "flang",
         "openmp",
         "polly",
         "utils"
       ],
       "platform": "!static"
-    },
-    {
-      "$comment": "Platform restriction due to CI artifact upload quirks; flang",
-      "name": "llvm",
-      "default-features": false,
-      "features": [
-        "flang"
-      ],
-      "platform": "linux"
     }
   ]
 }

--- a/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
@@ -9,7 +9,6 @@
       "name": "llvm",
       "default-features": false,
       "features": [
-        "bolt",
         "clang",
         "default-targets",
         "disable-assertions",
@@ -23,28 +22,29 @@
         "enable-zlib",
         "lld",
         "lldb",
-        "openmp",
-        "polly"
+        "tools"
       ]
     },
     {
-      "$comment": "Platform restriction due to CI artifact upload quirks",
+      "$comment": "Platform restriction due to CI artifact upload quirks; features which need utils",
       "name": "llvm",
       "default-features": false,
       "features": [
-        "tools"
+        "bolt",
+        "openmp",
+        "polly",
+        "utils"
       ],
       "platform": "!static"
     },
     {
-      "$comment": "Platform restriction due to CI artifact upload quirks",
+      "$comment": "Platform restriction due to CI artifact upload quirks; flang",
       "name": "llvm",
       "default-features": false,
       "features": [
-        "flang",
-        "utils"
+        "flang"
       ],
-      "platform": "osx"
+      "platform": "linux"
     }
   ]
 }

--- a/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
@@ -11,6 +11,7 @@
       "features": [
         "bolt",
         "clang",
+        "default-targets",
         "disable-assertions",
         "disable-clang-static-analyzer",
         "enable-abi-breaking-checks",
@@ -23,22 +24,24 @@
         "lld",
         "lldb",
         "openmp",
-        "polly",
-        "target-aarch64",
-        "target-amdgpu",
-        "target-arm",
-        "target-webassembly",
-        "target-x86",
-        "tools"
+        "polly"
       ]
     },
     {
-      "$comment": "Only for osx artifact upload in CI succeeds when these features are enabled",
+      "$comment": "Platform restriction due to CI artifact upload quirks",
+      "name": "llvm",
+      "default-features": false,
+      "features": [
+        "tools"
+      ],
+      "platform": "!static"
+    },
+    {
+      "$comment": "Platform restriction due to CI artifact upload quirks",
       "name": "llvm",
       "default-features": false,
       "features": [
         "flang",
-        "target-all",
         "utils"
       ],
       "platform": "osx"


### PR DESCRIPTION
All PRs which touch `scripts/ci.baseline.txt` are affected by the CI's inability to cache `llvm` artifacts, also blocking resources for other PRs. E.g. (before this PR):
~~~
Building llvm[bolt,clang,core,default-options,default-targets,disable-assertions,disable-clang-static-analyzer,enable-abi-breaking-checks,enable-bindings,enable-eh,enable-rtti,enable-terminfo,enable-threads,enable-zlib,enable-zstd,flang,libclc,lld,lldb,mlir,openmp,polly,target-aarch64,target-all,target-amdgpu,target-arm,target-avr,target-bpf,target-hexagon,target-lanai,target-mips,target-msp430,target-nvptx,target-powerpc,target-riscv,target-sparc,target-spirv,target-systemz,target-ve,target-webassembly,target-x86,target-xcore,tools,utils]:x64-osx...
...
Stored binaries in 0 destinations in 13 min.
Elapsed time to handle llvm:x64-osx: 3.8 h
~~~

This PR is an attempt to trim the llvm artifact size so that caching can work normally. With this PR:

~~~
Building llvm[clang,core,default-options,default-targets,disable-assertions,disable-clang-static-analyzer,enable-abi-breaking-checks,enable-bindings,enable-eh,enable-rtti,enable-terminfo,enable-threads,enable-zlib,enable-zstd,libclc,lld,lldb,target-spirv,target-x86,tools]:x64-osx...
...
Stored binaries in 1 destinations in 7.6 min.
Elapsed time to handle llvm:x64-osx: 1.8 h
~~~

x64-linux: Even the default features from `llvm` don't give a cacheable artifact, so I moved `flang` to it. (However, this adds significant build time.)
All other triplets are cached (or not tested), https://dev.azure.com/vcpkg/public/_build/results?buildId=91452&view=results.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
