### PR TITLE
[geogram] Enable MacOs+Arm64 build

### DIFF
--- a/ports/geogram/vcpkg.json
+++ b/ports/geogram/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "geogram",
   "version": "1.8.3",
+  "port-version": 1,
   "description": "Geogram is a programming library of geometric algorithms.",
   "homepage": "https://github.com/BrunoLevy/geogram",
   "license": "BSD-3-Clause",
-  "supports": "!uwp & !(osx & arm64)",
+  "supports": "!uwp",
   "dependencies": [
     "blas",
     "lapack",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2770,7 +2770,7 @@
     },
     "geogram": {
       "baseline": "1.8.3",
-      "port-version": 0
+      "port-version": 1
     },
     "geographiclib": {
       "baseline": "2.2",

--- a/versions/g-/geogram.json
+++ b/versions/g-/geogram.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee6286e71522b6c0bd498066597094e57ff505b4",
+      "version": "1.8.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "86346ad187bf9f8b54be1e50b3bb52dd4c69171d",
       "version": "1.8.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #32365
Geogram build is currently disabled on macos arm64 from supports `!uwp & !(osx & arm64)`,
the user tested this port can build geogram from the code source on mac with arm (m2) processor, so I remove restriction `!(osx & arm64) `.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
