### PR TITLE
[libffi] Fix mingw output name, cleanup

### DIFF
--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 project(libffi C ASM)
 
-set(CMAKE_SHARED_LIBRARY_PREFIX)
-set(CMAKE_STATIC_LIBRARY_PREFIX)
-
 if(NOT CMAKE_SYSTEM_PROCESSOR)
     set(CMAKE_SYSTEM_PROCESSOR "${CMAKE_HOST_SYSTEM_PROCESSOR}")
 endif()
@@ -219,6 +216,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 add_library(libffi ${FFI_SOURCES})
+
+if(CMAKE_STATIC_LIBRARY_PREFIX STREQUAL "lib")
+    set_target_properties(libffi PROPERTIES OUTPUT_NAME ffi)
+endif()
 
 install(TARGETS libffi
     EXPORT ${PROJECT_NAME}Targets

--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 project(libffi C ASM)
 
-if(NOT CMAKE_SYSTEM_PROCESSOR)
-    set(CMAKE_SYSTEM_PROCESSOR "${CMAKE_HOST_SYSTEM_PROCESSOR}")
-endif()
-
-# config variables for ffi.h.in
-set(VERSION 3.4.4)
-
 set(KNOWN_PROCESSORS x86 x86_64 amd64 arm arm64 i386 i686 armv7l armv7-a aarch64 mips64el riscv32 riscv64)
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" lower_system_processor)

--- a/ports/libffi/libffiConfig.cmake.in
+++ b/ports/libffi/libffiConfig.cmake.in
@@ -1,7 +1,5 @@
 @PACKAGE_INIT@
 
-include(CMakeFindDependencyMacro)
-
 if(NOT TARGET libffi)
   include("${CMAKE_CURRENT_LIST_DIR}/libffiTargets.cmake")
 endif()

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libffi/libffi
@@ -20,8 +18,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
 
-# Create pkgconfig file
 set(PACKAGE_VERSION ${VERSION})
 set(prefix "${CURRENT_INSTALLED_DIR}")
 set(exec_prefix "\${prefix}")
@@ -29,9 +28,7 @@ set(libdir "\${prefix}/lib")
 set(toolexeclibdir "\${libdir}")
 set(includedir "\${prefix}/include")
 configure_file("${SOURCE_PATH}/libffi.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libffi.pc" @ONLY)
-
-# debug
-if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+if (NOT VCPKG_BUILD_TYPE)
   set(prefix "${CURRENT_INSTALLED_DIR}/debug")
   set(exec_prefix "\${prefix}")
   set(libdir "\${prefix}/lib")
@@ -39,18 +36,10 @@ if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
   set(includedir "\${prefix}/../include")
     configure_file("${SOURCE_PATH}/libffi.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libffi.pc" @ONLY)
 endif()
-
-vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup()
-
-if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libffi.pc"
-            "-lffi" "-llibffi")
-    endif()
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libffi.pc"
-            "-lffi" "-llibffi")
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libffi.pc" " -lffi" " -llibffi")
+    if(NOT DEFINED VCPKG_BUILD_TYPE)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libffi.pc" " -lffi" " -llibffi")
     endif()
 endif()
 vcpkg_fixup_pkgconfig()

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DFFI_CONFIG_FILE=${CMAKE_CURRENT_LIST_DIR}/fficonfig.h"
+        "-DVERSION=${VERSION}"
     OPTIONS_DEBUG
         -DFFI_SKIP_HEADERS=ON
 )
@@ -44,14 +45,8 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 endif()
 vcpkg_fixup_pkgconfig()
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ffi.h"
-        "   *know* they are going to link with the static library.  */"
-        "   *know* they are going to link with the static library.  */
-
-#define FFI_BUILDING
-"
-    )
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ffi.h" "!defined FFI_BUILDING" "0")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libffi",
   "version": "3.4.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4046,7 +4046,7 @@
     },
     "libffi": {
       "baseline": "3.4.4",
-      "port-version": 1
+      "port-version": 2
     },
     "libfido2": {
       "baseline": "1.13.0",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df29b345dbd3f713c6bad15ca3d5f19ec961d79f",
+      "version": "3.4.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "2422375e9ac93e01de0b511e1181000c340da613",
       "version": "3.4.4",
       "port-version": 1


### PR DESCRIPTION
Fixes #32358.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

