### PR TITLE
[cudnn] Fix cudnn on arm64 architecture

### DIFF
--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -4,11 +4,11 @@ vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT OUT_CUDA_VERSION CUDA_VE
 
 # Try to find CUDNN if it exists; only download if it doesn't exist
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include /usr/include/x86_64-linux-gnu/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
   PATH_SUFFIXES cuda/include include)
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/ /usr/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64)
 message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")

--- a/ports/cudnn/vcpkg.json
+++ b/ports/cudnn/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cudnn",
   "version": "7.6.5",
-  "port-version": 9,
+  "port-version": 10,
   "description": "NVIDIA's cuDNN deep neural network acceleration library.",
   "homepage": "https://developer.nvidia.com/cudnn",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1942,7 +1942,7 @@
     },
     "cudnn": {
       "baseline": "7.6.5",
-      "port-version": 9
+      "port-version": 10
     },
     "cunit": {
       "baseline": "2.1.3",

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "406576a41668942aa5f0be5ee12ea54239be2d84",
+      "version": "7.6.5",
+      "port-version": 10
+    },
+    {
       "git-tree": "77f6c8d8f5669619fde9b2bc596a406d0fee2839",
       "version": "7.6.5",
       "port-version": 9


### PR DESCRIPTION
To resolve the issue of not finding the cuDNN library on the arm64 architecture.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.