### PR TITLE
[arrayfire] Fix compilation missing macro variables

### DIFF
--- a/ports/arrayfire/build.patch
+++ b/ports/arrayfire/build.patch
@@ -218,3 +218,50 @@ index d618ff2..9f51739 100644
        )
  
      set_target_properties(opencl_sort_by_key_${SBK_TYPE}
+diff --git a/src/backend/opencl/CMakeLists.txt b/src/backend/opencl/CMakeLists.txt
+index b543433..9b5923b 100644
+--- a/src/backend/opencl/CMakeLists.txt
++++ b/src/backend/opencl/CMakeLists.txt
+@@ -432,12 +432,9 @@ if(AF_OPENCL_BLAS_LIBRARY STREQUAL "clBLAS")
+     PRIVATE
+       clBLAS::clBLAS)
+ elseif(AF_OPENCL_BLAS_LIBRARY STREQUAL "CLBlast")
+-  include(build_CLBlast)
++  find_package(CLBlast CONFIG REQUIRED)
+   target_compile_definitions(afopencl PRIVATE USE_CLBLAST)
+-  target_link_libraries(afopencl
+-    PRIVATE
+-      CLBlast)
+-    add_dependencies(afopencl CLBlast-ext)
++  target_link_libraries(afopencl PRIVATE clblast)
+ endif()
+
+
+diff --git a/src/backend/opencl/homography.cpp b/src/backend/opencl/homography.cpp
+index 3b598b0..2815923 100644
+--- a/src/backend/opencl/homography.cpp
++++ b/src/backend/opencl/homography.cpp
+@@ -39,7 +39,7 @@ int homography(Array<T> &bestH, const Array<float> &x_src,
+             ::std::min(iter, static_cast<unsigned>(
+                                  log(1.f - LMEDSConfidence) /
+                                  log(1.f - pow(1.f - LMEDSOutlierRatio, 4.f))));
+-        err = createValueArray<float>(af::dim4(nsamples, iter), FLT_MAX);
++        err = createValueArray<float>(af::dim4(nsamples, iter), std::numeric_limits<float>::max());
+     } else {
+         // Avoid passing "null" cl_mem object to kernels
+         err = createEmptyArray<float>(af::dim4(1));
+diff --git a/src/backend/opencl/kernel/homography.hpp b/src/backend/opencl/kernel/homography.hpp
+index b84e599..90d0c80 100644
+--- a/src/backend/opencl/kernel/homography.hpp
++++ b/src/backend/opencl/kernel/homography.hpp
+@@ -39,7 +39,9 @@ std::array<Kernel, 5> getHomographyKernels(const af_homography_type htype) {
+     };
+     options.emplace_back(getTypeBuildDefinition<T>());
+     options.emplace_back(DefineKeyValue(
+-        EPS, (std::is_same<T, double>::value ? DBL_EPSILON : FLT_EPSILON)));
++        EPS, (std::is_same<T, double>::value
++                                 ? std::numeric_limits<double>::epsilon()
++                                 : std::numeric_limits<float>::epsilon())));
+     if (htype == AF_HOMOGRAPHY_RANSAC) {
+         options.emplace_back(DefineKey(RANSAC));
+     }

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -43,7 +43,8 @@
       "description": "ArrayFire OpenCL backend",
       "dependencies": [
         "clfft",
-        "opencl"
+        "opencl",
+        "clblast"
       ]
     },
     "unified": {

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -42,9 +42,9 @@
     "opencl": {
       "description": "ArrayFire OpenCL backend",
       "dependencies": [
+        "clblast",
         "clfft",
-        "opencl",
-        "clblast"
+        "opencl"
       ]
     },
     "unified": {

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrayfire",
   "version-semver": "3.8.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "homepage": "https://github.com/arrayfire/arrayfire",
   "license": "BSD-3-Clause",

--- a/ports/clblast/fix_install_path.patch
+++ b/ports/clblast/fix_install_path.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2d28050..e2a060d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -347,7 +347,10 @@ endif()
+ # Installs the library
+ include(GNUInstallDirs)
+ 
+-install(TARGETS clblast EXPORT CLBlast DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(TARGETS clblast EXPORT CLBlast 
++        ARCHIVE DESTINATION lib
++        LIBRARY DESTINATION lib
++        RUNTIME DESTINATION bin)
+ install(FILES include/clblast_half.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ if(OPENCL)
+   install(FILES include/clblast.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/ports/clblast/portfile.cmake
+++ b/ports/clblast/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 1.5.2
     SHA512 6693704321bb7623a632ebfc71dcf07bbe4ba6c6f03a2ecf52bc10b401ae546bf82cdd3f6cc28aa9ea10f40dc7b2e86a6530f32cfbd522e24d4cf6a75c8c1100
     HEAD_REF master
+    PATCHES
+        fix_install_path.patch
 )
 
 vcpkg_cmake_configure(
@@ -13,16 +15,6 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/bin/clblast.dll")
-    
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
-        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/clblast.dll")
-    endif()
-endif()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/CLBLast)
 vcpkg_copy_pdbs()

--- a/ports/clblast/vcpkg.json
+++ b/ports/clblast/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "clblast",
   "version": "1.5.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A modern, lightweight, performant and tunable OpenCL BLAS library written in C++11.",
   "homepage": "https://github.com/CNugteren/CLBlast",
   "license": "Apache-2.0",

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2019e0cc5d45cd1ec58b8a55b6ecc5d0d7aead60",
+      "version-semver": "3.8.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "37adfc5544ac7301c3ff4a8e16d84804d45b566a",
       "version-semver": "3.8.0",
       "port-version": 4

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2019e0cc5d45cd1ec58b8a55b6ecc5d0d7aead60",
+      "git-tree": "4e9b4b24be953b97638224c3563759c7d8a86602",
       "version-semver": "3.8.0",
       "port-version": 5
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -218,7 +218,7 @@
     },
     "arrayfire": {
       "baseline": "3.8.0",
-      "port-version": 4
+      "port-version": 5
     },
     "arrow": {
       "baseline": "12.0.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1558,7 +1558,7 @@
     },
     "clblast": {
       "baseline": "1.5.2",
-      "port-version": 2
+      "port-version": 3
     },
     "clfft": {
       "baseline": "2.12.2",

--- a/versions/c-/clblast.json
+++ b/versions/c-/clblast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d3c066f06df46440c055d265aa2dee1c21a9971",
+      "version": "1.5.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "f3fc8c351cba8b45e06d835b27101617a5ba74b0",
       "version": "1.5.2",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/32145
1.Fix the installation path of `clblast`.
2.Fix compilation missing macro variables.([homography.hpp#L40](https://github.com/arrayfire/arrayfire/blob/787d92780d30a4b8ccccb4d7bfdc6bd312899d5f/src/backend/opencl/kernel/homography.hpp#L40),([homography.cpp#L46](https://github.com/arrayfire/arrayfire/blob/787d92780d30a4b8ccccb4d7bfdc6bd312899d5f/src/backend/opencl/homography.cpp#L46)))
3.Fix `opencl's` dependency method on `clblast`.
All features passed with following triplets:

```
x64-windows
x64-linux
```
Usage test pass with following triplets:

```
x64-windows
x64-linux
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.