### PR TITLE
[google-cloud-cpp] update to latest release (v2.13.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 206d07eb65da472a9cc743ef6de0ddc7c0e13833cb990dc2415681be7c2a9d8ddfac6a25880ff3dbd2c73257d2ad8f7b8331cc1755e31d85bdb5386a12c91dbe
+    SHA512 b708945b5cdfe49e17208f7ff372064cce8844c0ed9e0a60f291a4a0b4d01b886997e8365e3802740d8914e58426d91cf3db1b37261c60d9661579212231c2ee
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -380,6 +380,18 @@
         }
       ]
     },
+    "datafusion": {
+      "description": "Cloud Data Fusion API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "datamigration": {
       "description": "Database Migration API C++ Client Library",
       "dependencies": [
@@ -732,6 +744,30 @@
         }
       ]
     },
+    "metastore": {
+      "description": "Dataproc Metastore API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "migrationcenter": {
+      "description": "Migration Center API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "monitoring": {
       "description": "Cloud Monitoring API C++ Client Library",
       "dependencies": [
@@ -758,6 +794,18 @@
     },
     "networkmanagement": {
       "description": "Network Management API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "networksecurity": {
+      "description": "Secure Web Proxy API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -866,6 +914,18 @@
     },
     "pubsub": {
       "description": "The Google Cloud Bigtable C++ client library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "rapidmigrationassessment": {
+      "description": "Rapid Migration Assessment C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2921,7 +2921,7 @@
       "port-version": 3
     },
     "google-cloud-cpp": {
-      "baseline": "2.12.0",
+      "baseline": "2.13.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c067a236b62d38d1f56a658b086039bf22441c4a",
+      "version": "2.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f7179212beeb134849f381dbe2c200580cc37c97",
       "version": "2.12.0",
       "port-version": 0


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v2.13.0)

Tested locally (on x64-linux) with:

```shell
for feature in datafusion metastore migrationcenter networksecurity rapidmigrationassessment; do ./vcpkg remove google-cloud-cpp; ./vcpkg install "google-cloud-cpp[core,${feature}]" || break; done
```

and

```shell
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
