### PR TITLE
[highway] Bump to 1.0.4

### DIFF
--- a/ports/highway/portfile.cmake
+++ b/ports/highway/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/highway
     REF "${VERSION}"
-    SHA512 fc419c862e1686b6278081e8e10da41dc2bdfbd386a29b59e21a57375a47d3eeb5c7297e3078c78007b212121d936640b192a26a16c941e73cf599f24e081021
+    SHA512 75aaa0a3f97c6b044acb146ac4db20c1d813c4215b9c1620e72352d00c136939db7059f599122d6600e385bffa8b24d7fd9c1fe09772f4941e5300767a8c68dd
     HEAD_REF master
 )
 
@@ -20,6 +20,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/hwy)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/hwy/highway_export.h" "defined(HWY_SHARED_DEFINE)" "1")

--- a/ports/highway/vcpkg.json
+++ b/ports/highway/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "highway",
-  "version-semver": "1.0.3",
+  "version": "1.0.4",
   "description": "Performance-portable, length-agnostic SIMD with runtime dispatch",
   "homepage": "https://github.com/google/highway",
   "license": "Apache-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3157,7 +3157,7 @@
       "port-version": 0
     },
     "highway": {
-      "baseline": "1.0.3",
+      "baseline": "1.0.4",
       "port-version": 0
     },
     "hikogui": {

--- a/versions/h-/highway.json
+++ b/versions/h-/highway.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d516ee6b19d52dce62aae1d9ced2b7d9b18cb5cf",
+      "version": "1.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "c5445e6987068f7752475cf5f26c3402d3d8ef82",
       "version-semver": "1.0.3",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Close #32402