### PR TITLE
[live555] update to 2023-06-20

### DIFF
--- a/ports/live555/CMakeLists.txt
+++ b/ports/live555/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 
 file(GLOB BASIC_USAGE_ENVIRONMENT_SRCS BasicUsageEnvironment/*.c BasicUsageEnvironment/*.cpp)
 add_library(BasicUsageEnvironment ${BASIC_USAGE_ENVIRONMENT_SRCS})
-target_compile_features(BasicUsageEnvironment PUBLIC cxx_auto_type)
 
 file(GLOB GROUPSOCK_SRCS groupsock/*.c groupsock/*.cpp)
 add_library(groupsock ${GROUPSOCK_SRCS})

--- a/ports/live555/CMakeLists.txt
+++ b/ports/live555/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(live555 C CXX)
 
+set(CMAKE_CXX_STANDARD 20)
 include_directories(
     BasicUsageEnvironment/include
     groupsock/include
@@ -18,6 +19,7 @@ endif()
 
 file(GLOB BASIC_USAGE_ENVIRONMENT_SRCS BasicUsageEnvironment/*.c BasicUsageEnvironment/*.cpp)
 add_library(BasicUsageEnvironment ${BASIC_USAGE_ENVIRONMENT_SRCS})
+target_compile_features(BasicUsageEnvironment PUBLIC cxx_auto_type)
 
 file(GLOB GROUPSOCK_SRCS groupsock/*.c groupsock/*.cpp)
 add_library(groupsock ${GROUPSOCK_SRCS})

--- a/ports/live555/fix_operator_overload.patch
+++ b/ports/live555/fix_operator_overload.patch
@@ -1,17 +1,13 @@
 diff --git a/liveMedia/MPEGVideoStreamFramer.cpp b/liveMedia/MPEGVideoStreamFramer.cpp
-index 59c4656..7667a33 100644
+index 59c4656..a705e68 100644
 --- a/liveMedia/MPEGVideoStreamFramer.cpp
 +++ b/liveMedia/MPEGVideoStreamFramer.cpp
-@@ -129,7 +129,11 @@ void MPEGVideoStreamFramer
+@@ -129,7 +129,7 @@ void MPEGVideoStreamFramer
      fPictureTimeBase = fFrameRate == 0.0 ? 0.0 : tc.pictures/fFrameRate;
      fTcSecsBase = (((tc.days*24)+tc.hours)*60+tc.minutes)*60+tc.seconds;
      fHaveSeenFirstTimeCode = True;
 -  } else if (fCurGOPTimeCode == fPrevGOPTimeCode) {
-+  } else if (fCurGOPTimeCode.days == fPrevGOPTimeCode.days
-+             && fCurGOPTimeCode.hours == fPrevGOPTimeCode.hours
-+             && fCurGOPTimeCode.minutes == fPrevGOPTimeCode.minutes
-+             && fCurGOPTimeCode.seconds == fPrevGOPTimeCode.seconds
-+             && fCurGOPTimeCode.pictures == fPrevGOPTimeCode.pictures) {
++  } else if (fCurGOPTimeCode.TimeCode::operator==(fPrevGOPTimeCode)) {
      // The time code has not changed since last time.  Adjust for this:
      fPicturesAdjustment += picturesSinceLastGOP;
    } else {

--- a/ports/live555/fix_operator_overload.patch
+++ b/ports/live555/fix_operator_overload.patch
@@ -1,0 +1,17 @@
+diff --git a/liveMedia/MPEGVideoStreamFramer.cpp b/liveMedia/MPEGVideoStreamFramer.cpp
+index 59c4656..7667a33 100644
+--- a/liveMedia/MPEGVideoStreamFramer.cpp
++++ b/liveMedia/MPEGVideoStreamFramer.cpp
+@@ -129,7 +129,11 @@ void MPEGVideoStreamFramer
+     fPictureTimeBase = fFrameRate == 0.0 ? 0.0 : tc.pictures/fFrameRate;
+     fTcSecsBase = (((tc.days*24)+tc.hours)*60+tc.minutes)*60+tc.seconds;
+     fHaveSeenFirstTimeCode = True;
+-  } else if (fCurGOPTimeCode == fPrevGOPTimeCode) {
++  } else if (fCurGOPTimeCode.days == fPrevGOPTimeCode.days
++             && fCurGOPTimeCode.hours == fPrevGOPTimeCode.hours
++             && fCurGOPTimeCode.minutes == fPrevGOPTimeCode.minutes
++             && fCurGOPTimeCode.seconds == fPrevGOPTimeCode.seconds
++             && fCurGOPTimeCode.pictures == fPrevGOPTimeCode.pictures) {
+     // The time code has not changed since last time.  Adjust for this:
+     fPicturesAdjustment += picturesSinceLastGOP;
+   } else {

--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://live555.com/liveMedia/public/live.2023.06.10.tar.gz"
-    FILENAME "live.2023.06.10.tar.gz"
-    SHA512 634f90db6339ebef6c6bc28f382034150e04e1bcc26d651da8823de7ed8a62bd648737fdf8be0c2734ba17a2516033af48e85b256170eaf30a2c484ede2d2004
+    URLS "http://live555.com/liveMedia/public/live.2023.06.20.tar.gz"
+    FILENAME "live.2023.06.20.tar.gz"
+    SHA512 dad8cb279aa020a50ffe0e049e37ba872df52da930a75f44abbd8b07db10ba4174b1b96c0a2f4f678972d167c1bab8c5fc2bdc5ef1916c43618f12134293f672
 )
 
 vcpkg_extract_source_archive(
@@ -11,6 +11,7 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE}"
     PATCHES
         fix-RTSPClient.patch
+        fix_operator_overload.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "live555",
-  "version-date": "2023-06-10",
-  "port-version": 1,
+  "version-date": "2023-06-20",
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4953,8 +4953,8 @@
       "port-version": 2
     },
     "live555": {
-      "baseline": "2023-06-10",
-      "port-version": 1
+      "baseline": "2023-06-20",
+      "port-version": 0
     },
     "llfio": {
       "baseline": "2023-03-13",

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "919fedffde22cdd7450ebe296f2e4e5e697ed3a7",
+      "version-date": "2023-06-20",
+      "port-version": 0
+    },
+    {
       "git-tree": "e7944bec69900cba45393bcacfb4d903a3569300",
       "version-date": "2023-06-10",
       "port-version": 1

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2dc6257cb99f2a9872b07281cae337f65d742908",
+      "git-tree": "3145196c0ec759988b77ab9ef787f426b0efc02d",
       "version-date": "2023-06-20",
       "port-version": 0
     },

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "919fedffde22cdd7450ebe296f2e4e5e697ed3a7",
+      "git-tree": "2dc6257cb99f2a9872b07281cae337f65d742908",
       "version-date": "2023-06-20",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/32387
1.Update version to 2023-06-20.
2.Fix operator overloading bug.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.