### PR TITLE
[cairo] update license info and add all licenses to copyright file

### DIFF
--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -87,4 +87,4 @@ endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 # Handle copyright
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/COPYING-LGPL-2.1" "${SOURCE_PATH}/COPYING-MPL-1.1")

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairo",
   "version": "1.17.8",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1-only OR MPL-1.1",

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairo",
   "version": "1.17.8",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1 OR MPL-1.1",

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 2,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
-  "license": "MPL-1.1",
+  "license": "LGPL-2.1 OR MPL-1.1",
   "supports": "!xbox",
   "dependencies": [
     "dirent",

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairo",
   "version": "1.17.8",
-  "port-version": 4,
+  "port-version": 3,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1-only OR MPL-1.1",

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 3,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
-  "license": "LGPL-2.1 OR MPL-1.1",
+  "license": "LGPL-2.1-only OR MPL-1.1",
   "supports": "!xbox",
   "dependencies": [
     "dirent",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1362,7 +1362,7 @@
     },
     "cairo": {
       "baseline": "1.17.8",
-      "port-version": 4
+      "port-version": 3
     },
     "cairomm": {
       "baseline": "1.16.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1362,7 +1362,7 @@
     },
     "cairo": {
       "baseline": "1.17.8",
-      "port-version": 3
+      "port-version": 4
     },
     "cairomm": {
       "baseline": "1.16.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1362,7 +1362,7 @@
     },
     "cairo": {
       "baseline": "1.17.8",
-      "port-version": 2
+      "port-version": 3
     },
     "cairomm": {
       "baseline": "1.16.2",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8fda1b05b3f6a99f08c23f8ad94ed43d4a69875",
+      "version": "1.17.8",
+      "port-version": 4
+    },
+    {
       "git-tree": "b67d957e42cf244e0ebcee8771d690f6d3890f99",
       "version": "1.17.8",
       "port-version": 3

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b67d957e42cf244e0ebcee8771d690f6d3890f99",
+      "git-tree": "e8fda1b05b3f6a99f08c23f8ad94ed43d4a69875",
       "version": "1.17.8",
       "port-version": 3
     },

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b67d957e42cf244e0ebcee8771d690f6d3890f99",
+      "version": "1.17.8",
+      "port-version": 3
+    },
+    {
       "git-tree": "e94aef48f94b5cdac2387269b5f2ad421a684873",
       "version": "1.17.8",
       "port-version": 2

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "e8fda1b05b3f6a99f08c23f8ad94ed43d4a69875",
-      "version": "1.17.8",
-      "port-version": 4
-    },
-    {
       "git-tree": "b67d957e42cf244e0ebcee8771d690f6d3890f99",
       "version": "1.17.8",
       "port-version": 3


### PR DESCRIPTION
Cairo is licensed either under LGPL-2.1 OR MPL-1.1.

https://gitlab.freedesktop.org/cairo/cairo/-/blob/master/COPYING


- [x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~
