### PR TITLE
[Jsonifier] Updating to v0.9.4

### DIFF
--- a/ports/jsonifier/portfile.cmake
+++ b/ports/jsonifier/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO realtimechris/jsonifier
     REF "v${VERSION}"
-    SHA512 7373bd8d8554f9b76eb80d1c6b906d917ede80d55f5c363c6c26c67b4e659d9e657fb15d2da7d1eaf41fc24ee84fd54b16d8a0bd9bd76aacf899990eee425845
+    SHA512 6b7af20a5cfedd98200e537b284d513f8ee964d76c28d8f01cdc40e324f051b3fa48c2d68ddc92c8dd2ed494b807b4dfdaca25430fc4f6bf68b9e9a8fc9a8644
     HEAD_REF main
 )
 

--- a/ports/jsonifier/vcpkg.json
+++ b/ports/jsonifier/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonifier",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A few classes for parsing and serializing json - very rapidly.",
   "homepage": "https://github.com/realtimechris/jsonifier",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3517,7 +3517,7 @@
       "port-version": 0
     },
     "jsonifier": {
-      "baseline": "0.9.3",
+      "baseline": "0.9.4",
       "port-version": 0
     },
     "jsonnet": {

--- a/versions/j-/jsonifier.json
+++ b/versions/j-/jsonifier.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81bce1af7b2990ff2664572b50e320b112044b78",
+      "version": "0.9.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "29c1237004abf2ca9bb395ab8f2d211f7ba563f3",
       "version": "0.9.3",
       "port-version": 0


### PR DESCRIPTION
The changes:
-Updated the DetectArchitecture.cmake script.
-Implemented new relational operator.
-Implemented fallback friendly derailleur functions.
-Modified the Vector and String implementations to simplify them, and fix a read access violation.
-Fixed an indexing issue with a Vector internal to the Simd-system.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] Only one version is added to each modified port's versions file.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
