### PR TITLE
[benchmark] Update to 1.8.2

### DIFF
--- a/ports/benchmark/portfile.cmake
+++ b/ports/benchmark/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/benchmark
-    REF v1.8.0
-    SHA512 ae8df163ca1319752a03497a259800dc33c71164e7def2feeadcf18d018c64eaf846ea2a562183e3d3cde0af58291de0b091ec6d9c025076f469c403b2ab0d51
+    REF v1.8.2
+    SHA512 532f2cee66cf527ef4452a060cfdedba6417e5d8f72225d6bf50adf6422d9a769b0f54f48982b438fa9ced975ac47bcc5e62c3c23ce871b5cfdbcf9cc0d2b829
     HEAD_REF main
 )
 

--- a/ports/benchmark/vcpkg.json
+++ b/ports/benchmark/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$comment": "https://github.com/google/benchmark/issues/661 describes the missing UWP support upstream",
   "name": "benchmark",
-  "version-semver": "1.8.0",
+  "version-semver": "1.8.2",
   "description": "A library to support the benchmarking of functions, similar to unit-tests.",
   "homepage": "https://github.com/google/benchmark",
   "license": "Apache-2.0",

--- a/versions/b-/benchmark.json
+++ b/versions/b-/benchmark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54f61ab31bcb486a12c859c33db17905f397cc0c",
+      "version-semver": "1.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "faeb0b56e68483860ab8cc468a6c594ac361167f",
       "version-semver": "1.8.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -521,7 +521,7 @@
       "port-version": 0
     },
     "benchmark": {
-      "baseline": "1.8.0",
+      "baseline": "1.8.2",
       "port-version": 0
     },
     "bento4": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
