### PR TITLE
[flann] Fix pop_t is not defined under non-gunc platform.

### DIFF
--- a/ports/flann/fix_undefined_pot_t.patch
+++ b/ports/flann/fix_undefined_pot_t.patch
@@ -1,20 +1,13 @@
 diff --git a/src/cpp/flann/algorithms/dist.h b/src/cpp/flann/algorithms/dist.h
-index 4e6eb73..fd78902 100644
+index 4e6eb73..bbcdda1 100644
 --- a/src/cpp/flann/algorithms/dist.h
 +++ b/src/cpp/flann/algorithms/dist.h
-@@ -477,6 +477,7 @@ struct HammingPopcnt
-     ResultType operator()(Iterator1 a, Iterator2 b, size_t size, ResultType /*worst_dist*/ = -1) const
-     {
-         ResultType result = 0;
-+        typedef unsigned long long pop_t;
- #if __GNUC__
- #if ANDROID && HAVE_NEON
-         static uint64_t features = android_getCpuFeatures();
-@@ -500,7 +501,6 @@ struct HammingPopcnt
-         else
+@@ -519,7 +519,7 @@ struct HammingPopcnt
+ #else
+         HammingLUT lut;
+         result = lut(reinterpret_cast<const unsigned char*> (a),
+-                     reinterpret_cast<const unsigned char*> (b), size * sizeof(pop_t));
++                     reinterpret_cast<const unsigned char*> (b), size);
  #endif
-         //for portability just use unsigned long -- and use the __builtin_popcountll (see docs for __builtin_popcountll)
--        typedef unsigned long long pop_t;
-         const size_t modulo = size % sizeof(pop_t);
-         const pop_t* a2 = reinterpret_cast<const pop_t*> (a);
-         const pop_t* b2 = reinterpret_cast<const pop_t*> (b);
+         return result;
+     }

--- a/ports/flann/fix_undefined_pot_t.patch
+++ b/ports/flann/fix_undefined_pot_t.patch
@@ -1,0 +1,20 @@
+diff --git a/src/cpp/flann/algorithms/dist.h b/src/cpp/flann/algorithms/dist.h
+index 4e6eb73..fd78902 100644
+--- a/src/cpp/flann/algorithms/dist.h
++++ b/src/cpp/flann/algorithms/dist.h
+@@ -477,6 +477,7 @@ struct HammingPopcnt
+     ResultType operator()(Iterator1 a, Iterator2 b, size_t size, ResultType /*worst_dist*/ = -1) const
+     {
+         ResultType result = 0;
++        typedef unsigned long long pop_t;
+ #if __GNUC__
+ #if ANDROID && HAVE_NEON
+         static uint64_t features = android_getCpuFeatures();
+@@ -500,7 +501,6 @@ struct HammingPopcnt
+         else
+ #endif
+         //for portability just use unsigned long -- and use the __builtin_popcountll (see docs for __builtin_popcountll)
+-        typedef unsigned long long pop_t;
+         const size_t modulo = size % sizeof(pop_t);
+         const pop_t* a2 = reinterpret_cast<const pop_t*> (a);
+         const pop_t* b2 = reinterpret_cast<const pop_t*> (b);

--- a/ports/flann/portfile.cmake
+++ b/ports/flann/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     PATCHES
         fix-build-error.patch
         fix-dependency-hdf5.patch
-        fix_undefined_pot_t.patch #https://github.com/flann-lib/flann/pull/405
+        fix_undefined_pot_t.patch # https://github.com/opencv/opencv/pull/13270/
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/flann/portfile.cmake
+++ b/ports/flann/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         fix-build-error.patch
         fix-dependency-hdf5.patch
+        fix_undefined_pot_t.patch #https://github.com/flann-lib/flann/pull/405
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -37,6 +38,6 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/flann RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/flann/vcpkg.json
+++ b/ports/flann/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "flann",
   "version-date": "2019-04-07",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Fast Library for Approximate Nearest Neighbors",
   "homepage": "https://github.com/mariusmuja/flann",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2518,7 +2518,7 @@
     },
     "flann": {
       "baseline": "2019-04-07",
-      "port-version": 6
+      "port-version": 7
     },
     "flash-runtime-extensions": {
       "baseline": "2.4",

--- a/versions/f-/flann.json
+++ b/versions/f-/flann.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61dbfbe71726825e951c5794fe00854dc83e35e7",
+      "version-date": "2019-04-07",
+      "port-version": 7
+    },
+    {
       "git-tree": "300415ad416640a5b4a4f0895a3250b306726181",
       "version-date": "2019-04-07",
       "port-version": 6

--- a/versions/f-/flann.json
+++ b/versions/f-/flann.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "61dbfbe71726825e951c5794fe00854dc83e35e7",
+      "git-tree": "5e7c5d75ccf67401b964ccace6529cb7fced451c",
       "version-date": "2019-04-07",
       "port-version": 7
     },

--- a/versions/f-/flann.json
+++ b/versions/f-/flann.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e7c5d75ccf67401b964ccace6529cb7fced451c",
+      "git-tree": "827bba7345ec924adeee28bacb5b0a79f705920d",
       "version-date": "2019-04-07",
       "port-version": 7
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/32448
Add fix_undefined_pop_t.patch.（https://github.com/opencv/opencv/pull/13270）
Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.