### PR TITLE
[redis-plus-plus] Update to 1.3.10

### DIFF
--- a/ports/redis-plus-plus/portfile.cmake
+++ b/ports/redis-plus-plus/portfile.cmake
@@ -50,6 +50,13 @@ vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME redis++ CONFIG_PATH share/cmake/redis++)
 
+if("async" IN_LIST FEATURES)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/redis++/redis++-config.cmake"
+"include(CMakeFindDependencyMacro)"
+[[include(CMakeFindDependencyMacro)
+find_dependency(libuv CONFIG)]])
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/redis-plus-plus/portfile.cmake
+++ b/ports/redis-plus-plus/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sewenew/redis-plus-plus
     REF "${VERSION}"
-    SHA512 a9afecc4059155137d524542e7ad699f78e5efc8b1136c1aac093e60fe70dddede3594afe6920f813ba011fb61740bec09b3564c8f8f42118e21fdd5f40f6161
+    SHA512 43741da2222a9416cee16f522244ddf243b7a188f08704bb05e66f659213b05189fcef35b7b100b128d301e889765ad3f151889e9b5b9e6510479bec58b04ce0
     HEAD_REF master
     PATCHES
         fix-conversion.patch

--- a/ports/redis-plus-plus/vcpkg.json
+++ b/ports/redis-plus-plus/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "redis-plus-plus",
-  "version-semver": "1.3.9",
-  "port-version": 1,
+  "version-semver": "1.3.10",
   "description": "This is a C++ client for Redis. It's based on hiredis, and written in C++ 11",
   "homepage": "https://github.com/sewenew/redis-plus-plus",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7121,8 +7121,8 @@
       "port-version": 0
     },
     "redis-plus-plus": {
-      "baseline": "1.3.9",
-      "port-version": 1
+      "baseline": "1.3.10",
+      "port-version": 0
     },
     "refl-cpp": {
       "baseline": "0.12.3",

--- a/versions/r-/redis-plus-plus.json
+++ b/versions/r-/redis-plus-plus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "468a561c80f787996ddc9f9d94f610c6f7bef137",
+      "git-tree": "0304c085aa643a482f93ed391ba61bed356577f9",
       "version-semver": "1.3.10",
       "port-version": 0
     },

--- a/versions/r-/redis-plus-plus.json
+++ b/versions/r-/redis-plus-plus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "468a561c80f787996ddc9f9d94f610c6f7bef137",
+      "version-semver": "1.3.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "8c31ae593f450352915471514d517a772cd5099b",
       "version-semver": "1.3.9",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #32465, update `redis-plus-plus` to 1.3.10. 
All features passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```
Usage passed on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
