### PR TITLE
[tiff] set correct license id in license field

### DIFF
--- a/ports/tiff/vcpkg.json
+++ b/ports/tiff/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "tiff",
   "version": "4.5.1",
+  "port-version": 2,
   "description": "A library that supports the manipulation of TIFF image files",
   "homepage": "https://libtiff.gitlab.io/libtiff/",
-  "license": null,
+  "license": "libtiff",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8038,7 +8038,7 @@
     },
     "tiff": {
       "baseline": "4.5.1",
-      "port-version": 0
+      "port-version": 2
     },
     "tinkerforge": {
       "baseline": "2.1.25",

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68f4ecc87b5ddce6c328c0f600a4c8b81d967d4c",
+      "version": "4.5.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "5510d3f8317c71185268d5128e6a7c24b4d66863",
       "version": "4.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.