### PR TITLE
[libunifex] Update to 2023-06-07 (v0.3.0)

### DIFF
--- a/ports/libunifex/portfile.cmake
+++ b/ports/libunifex/portfile.cmake
@@ -3,9 +3,9 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookexperimental/libunifex
-    REF 591ec09e7d51858ad05be979d4034574215f5971
-    SHA512 b07ebad2e6fa9a40c73fe2712e65cfe49591857bf784bd901acb7f35549746a36679c969df89321866530fd774bde176aa2d800f3da1462e818eecb8d0822842
-    HEAD_REF master
+    REF "v${VERSION}"
+    SHA512 91a02d50e45c0458e25bd51c50fb6e98a668298733a3e66e8eb5353b0a5ea78a3656fe83b873e0ea50b26c6a7de572a663160b458c0fb1272ffa8bfd7715d1cc
+    HEAD_REF main
     PATCHES
         fix-compile-error.patch
         fix-linux-timespec.patch

--- a/ports/libunifex/vcpkg.json
+++ b/ports/libunifex/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libunifex",
-  "version-date": "2023-01-25",
-  "port-version": 2,
+  "version": "0.3.0",
   "description": "Unified Executors",
   "homepage": "https://github.com/facebookexperimental/libunifex",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4709,8 +4709,8 @@
       "port-version": 1
     },
     "libunifex": {
-      "baseline": "2023-01-25",
-      "port-version": 2
+      "baseline": "0.3.0",
+      "port-version": 0
     },
     "libunistring": {
       "baseline": "1.1",

--- a/versions/l-/libunifex.json
+++ b/versions/l-/libunifex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c60e3416d322f4e80f25e565190f679c99967931",
+      "version": "0.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4cc9469cbd38b11cc3966599bcb60c29d4dc34bc",
       "version-date": "2023-01-25",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

