### PR TITLE
Update passing remove from fail lists 2023-07-10.

### DIFF
--- a/ports/chipmunk/vcpkg.json
+++ b/ports/chipmunk/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "chipmunk",
   "version": "7.0.3",
-  "port-version": 5,
+  "port-version": 6,
   "description": "A fast and lightweight 2D game physics library.",
   "homepage": "https://github.com/slembcke/Chipmunk2D",
+  "supports": "!(arm & !arm64 & android)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -177,7 +177,6 @@ chartdir:x86-windows=skip
 chartdir:x64-windows=skip
 chartdir:x64-windows-static-md=skip
 chartdir:x64-osx=skip
-chipmunk:arm-neon-android=fail
 
 # chromium-base has several problems and is upgraded to "skip" because it hits a lot of servers that can slow CI
 #  broken on Windows because it does not yet support VS2022
@@ -342,10 +341,13 @@ evpp:arm-neon-android=fail
 evpp:arm64-android=fail
 evpp:x64-android=fail
 faiss:arm64-windows=fail
+fastrtps:arm-neon-android=fail
 fastrtps:arm-uwp=fail
+fastrtps:arm64-android=fail
+fastrtps:x64-android=fail
 fastrtps:x64-uwp=fail
-fastrtps:x64-windows-static=fail
 fastrtps:x64-windows-static-md=fail
+fastrtps:x64-windows-static=fail
 fdk-aac:arm-neon-android=fail
 fdk-aac:arm64-android=fail
 fdk-aac:x64-android=fail
@@ -379,11 +381,8 @@ folly:arm64-android=fail
 folly:x64-android=fail
 fontconfig:x64-uwp=fail
 fontconfig:arm-uwp=fail
-foonathan-memory:arm64-android=fail
 foonathan-memory:arm64-windows=fail
 foonathan-memory:arm-uwp=fail
-foonathan-memory:x64-android=fail
-foonathan-memory:arm-neon-android=fail
 foonathan-memory:x64-uwp=fail
 freeglut:arm-neon-android=fail
 freeglut:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1502,7 +1502,7 @@
     },
     "chipmunk": {
       "baseline": "7.0.3",
-      "port-version": 5
+      "port-version": 6
     },
     "chmlib": {
       "baseline": "0.40",

--- a/versions/c-/chipmunk.json
+++ b/versions/c-/chipmunk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "daaeebb368f5c367d7005bb828913f8e158648c1",
+      "version": "7.0.3",
+      "port-version": 6
+    },
+    {
       "git-tree": "949b207c326b9ded582e3360db0375bfbde8e136",
       "version": "7.0.3",
       "port-version": 5


### PR DESCRIPTION
```
PASSING, REMOVE FROM FAIL LIST: chipmunk:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).  
PASSING, REMOVE FROM FAIL LIST: chipmunk:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).  
```

```
REGRESSION: fastrtps:arm-neon-android failed with BUILD_FAILED. If expected, add fastrtps:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.REGRESSION: fastrtps:arm64-android failed with BUILD_FAILED. If expected, add fastrtps:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt. REGRESSION: fastrtps:x64-android failed with BUILD_FAILED. If expected, add fastrtps:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
```
Previously blocked by:
```
PASSING, REMOVE FROM FAIL LIST: foonathan-memory:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt). PASSING, REMOVE FROM FAIL LIST: foonathan-memory:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt). PASSING, REMOVE FROM FAIL LIST: foonathan-memory:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
```

```
REGRESSION: cmake-user:x86-windows cascaded, but it is required to pass. (C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt).
REGRESSION: hdf5:x86-windows failed with BUILD_FAILED. If expected, add hdf5:x86-windows=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt.
REGRESSION: vcpkg-ci-mathgl:x86-windows cascaded, but it is required to pass. (C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt).
REGRESSION: vcpkg-ci-opencv:x86-windows cascaded, but it is required to pass. (C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt).
REGRESSION: vcpkg-ci-openimageio:x86-windows cascaded, but it is required to pass. (C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt).
REGRESSION: vcpkg-ci-paraview:x86-windows cascaded, but it is required to pass. (C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt).

CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:112 (message):
    Command failed: "C:/Program Files/PowerShell/7/pwsh.exe" -noprofile -executionpolicy Bypass -nologo -file C:/a/1/s/scripts/buildsystems/msbuild/applocal.ps1 -targetBinary D:/packages/hdf5_x86-windows/tools/hdf5/h5clear-shared.exe -installedDir D:/packages/hdf5_x86-windows/bin -verbose
    Working Directory: C:/a/1/s
    Error code: Access violation
    See logs for more information:
      D:\buildtrees\hdf5\copy-tool-dependencies-2-out.log
      D:\buildtrees\hdf5\copy-tool-dependencies-2-err.log
```

Previous CI run passed, so I'm going to hope we got a bad machine or something and move on for now.

```
REGRESSION: openvino:x64-linux failed with BUILD_FAILED. If expected, add openvino:x64-linux=fail to /agent/_work/1/s/scripts/azure-pipelines/../ci.baseline.txt. REGRESSION: openvino:x64-osx failed with BUILD_FAILED. If expected, add openvino:x64-osx=fail to /Users/vagrant/Data/work/2/s/scripts/azure-pipelines/../ci.baseline.txt. REGRESSION: openvino:x64-windows failed with BUILD_FAILED. If expected, add openvino:x64-windows=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt. REGRESSION: openvino:x64-windows-static failed with BUILD_FAILED. If expected, add openvino:x64-windows-static=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt. REGRESSION: openvino:x64-windows-static-md failed with BUILD_FAILED. If expected, add openvino:x64-windows-static-md=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt.
```
See discussion in https://github.com/microsoft/vcpkg/pull/32418 / https://github.com/openvinotoolkit/openvino/issues/18465 -- openvino conflicts with oneDNN because the vcpkg copy is not the same as their forked copy.

```
REGRESSION: physx:x64-linux failed with FILE_CONFLICTS. If expected, add physx:x64-linux=fail to /agent/_work/1/s/scripts/azure-pipelines/../ci.baseline.txt. REGRESSION: physx:x64-windows failed with FILE_CONFLICTS. If expected, add physx:x64-windows=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt. REGRESSION: physx:x64-windows-static failed with FILE_CONFLICTS. If expected, add physx:x64-windows-static=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt. REGRESSION: physx:x64-windows-static-md failed with FILE_CONFLICTS. If expected, add physx:x64-windows-static-md=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt.
```
See discussion in https://github.com/microsoft/vcpkg/pull/32432 -- omniverse-physx-sdk was added 5 days ago and conflicts.

```
REGRESSION: libev:arm-neon-android failed with FILE_CONFLICTS. If expected, add libev:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: libev:x64-android failed with FILE_CONFLICTS. If expected, add libev:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: libev:x64-linux failed with FILE_CONFLICTS. If expected, add libev:x64-linux=fail to /agent/_work/1/s/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: libev:x64-osx failed with FILE_CONFLICTS. If expected, add libev:x64-osx=fail to /Users/vagrant/Data/work/2/s/scripts/azure-pipelines/../ci.baseline.txt.
```

Fixed by https://github.com/microsoft/vcpkg/pull/32471

```
REGRESSION: ryu:x64-linux failed with FILE_CONFLICTS. If expected, add ryu:x64-linux=fail to /agent/_work/1/s/scripts/azure-pipelines/../ci.baseline.txt. error: The following files are already installed in /mnt/vcpkg-ci/installed/x64-linux and are in conflict with ryu:x64-linux Installed by bde:x64-linux
debug/lib/libryu.a
    include/ryu/ryu.h
    lib/libryu.a
```

Broken by https://github.com/microsoft/vcpkg/pull/31961, I don't have a fix yet.