### PR TITLE
[geogram] Fix imgui not downloading

### DIFF
--- a/ports/geogram/fix_imgui.patch
+++ b/ports/geogram/fix_imgui.patch
@@ -1,0 +1,81 @@
+diff --git a/src/lib/geogram_gfx/CMakeLists.txt b/src/lib/geogram_gfx/CMakeLists.txt
+index 195b1e2..75bc931 100644
+--- a/src/lib/geogram_gfx/CMakeLists.txt
++++ b/src/lib/geogram_gfx/CMakeLists.txt
+@@ -26,8 +26,8 @@ endif()
+ 
+ add_library(geogram_gfx ${SOURCES} $<TARGET_OBJECTS:geogram_gfx_third_party>)
+ 
+-target_include_directories(geogram_gfx PUBLIC ${PROJECT_SOURCE_DIR}/src/lib/geogram_gfx/third_party)
+-target_include_directories(geogram_gfx PRIVATE ${PROJECT_SOURCE_DIR}/src/lib/geogram_gfx/third_party/imgui)
++target_include_directories(geogram_gfx PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/geogram_gfx/third_party>)
++target_include_directories(geogram_gfx PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/geogram_gfx/third_party/imgui>)
+ 
+ if(ANDROID)
+   target_include_directories(geogram_gfx PRIVATE
+diff --git a/src/lib/geogram_gfx/third_party/CMakeLists.txt b/src/lib/geogram_gfx/third_party/CMakeLists.txt
+index ef97a11..b0ab769 100644
+--- a/src/lib/geogram_gfx/third_party/CMakeLists.txt
++++ b/src/lib/geogram_gfx/third_party/CMakeLists.txt
+@@ -55,6 +55,8 @@ set_target_properties(
+     geogram_gfx_third_party PROPERTIES
+     FOLDER "GEOGRAM"
+ )
++find_package(glfw3 CONFIG REQUIRED)
++target_link_libraries(geogram_gfx_third_party PRIVATE glfw)
+ 
+ if(ANDROID)
+   target_include_directories(geogram_gfx_third_party PRIVATE
+diff --git a/src/lib/geogram_gfx/third_party/ImGuiColorTextEdit/TextEditor.cpp b/src/lib/geogram_gfx/third_party/ImGuiColorTextEdit/TextEditor.cpp
+index a00355b..227c084 100644
+--- a/src/lib/geogram_gfx/third_party/ImGuiColorTextEdit/TextEditor.cpp
++++ b/src/lib/geogram_gfx/third_party/ImGuiColorTextEdit/TextEditor.cpp
+@@ -18,11 +18,7 @@
+ 
+ // [Bruno Levy] includes for GLFW, needed by pixelratio()
+ #ifndef __ANDROID__
+-#ifdef GEO_USE_SYSTEM_GLFW3
+ #include <GLFW/glfw3.h>
+-#else
+-#include <third_party/glfw/include/GLFW/glfw3.h>
+-#endif
+ #endif
+ 
+ // [Bruno Levy] 
+@@ -482,7 +478,6 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
+ 	//[Bruno Levy] added 'NoNav' flag
+ 	ImGui::BeginChild(aTitle, aSize, aBorder, ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoNav);
+ 
+-	ImGui::PushAllowKeyboardFocus(true);
+ 
+ 	auto shift = io.KeyShift;
+ 	auto ctrl = io.KeyCtrl;
+@@ -850,7 +845,6 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
+ 		mScrollToCursor = false;
+ 	}
+ 
+-	ImGui::PopAllowKeyboardFocus();
+ 	ImGui::EndChild();
+ 	ImGui::PopStyleVar();
+ // [Bruno Levy] Commented out because I'd rather use the default style.
+diff --git a/src/lib/geogram_gfx/third_party/imgui_lua_bindings/imgui_iterator.h b/src/lib/geogram_gfx/third_party/imgui_lua_bindings/imgui_iterator.h
+index 8f923fd..5e3c441 100644
+--- a/src/lib/geogram_gfx/third_party/imgui_lua_bindings/imgui_iterator.h
++++ b/src/lib/geogram_gfx/third_party/imgui_lua_bindings/imgui_iterator.h
+@@ -380,14 +380,14 @@ IMGUI_FUNCTION(PopTextWrapPos)
+ CALL_FUNCTION_NO_RET(PopTextWrapPos)
+ END_IMGUI_FUNC
+ //    IMGUI_API void          PushAllowKeyboardFocus(bool allow_keyboard_focus);              // allow focusing using TAB/Shift-TAB, enabled by default but you can disable it for certain widgets
+-IMGUI_FUNCTION(PushAllowKeyboardFocus)
++/*IMGUI_FUNCTION(PushAllowKeyboardFocus)
+ BOOL_ARG(allow_keyboard_focus)
+ CALL_FUNCTION_NO_RET(PushAllowKeyboardFocus, allow_keyboard_focus)
+ END_IMGUI_FUNC
+ //    IMGUI_API void          PopAllowKeyboardFocus();
+ IMGUI_FUNCTION(PopAllowKeyboardFocus)
+ CALL_FUNCTION_NO_RET(PopAllowKeyboardFocus)
+-END_IMGUI_FUNC
++END_IMGUI_FUNC*/
+ //    IMGUI_API void          PushButtonRepeat(bool repeat);                                  // in 'repeat' mode, Button*() functions return repeated true in a typematic manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting). Note that you can call IsItemActive() after any Button() to tell if the button is held in the current frame.
+ IMGUI_FUNCTION(PushButtonRepeat)
+ BOOL_ARG(repeat)

--- a/ports/geogram/portfile.cmake
+++ b/ports/geogram/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 ae3d95be1c5061ace92921b3fcfb0027d23c595b131b0d31f1788adbe0d8f92367bef71736d6c936504bd37eba5fcdae658369f03734e233bf3eab14bca6f9e5
     PATCHES
         fix-vcpkg-install.patch
+        fix_imgui.patch
 )
 
 #third_party: amgcl
@@ -31,12 +32,22 @@ vcpkg_from_github(
     SHA512 b236279d3f0e6e1062703555415236183da31a9e40c49d478954586725f8dc6c0582aef0db7b605cb7967c3bd4a96d2fe8e6601cc56b8a1d53129a25efa7d1f2
 )
 
+#third_party: imgui
+vcpkg_from_github(
+    OUT_SOURCE_PATH IMGUI_SOURCE_PATH
+    REPO ocornut/imgui
+    REF ad44f5831acec714f2af437475406e2f002982a1
+    SHA512 55b96439fa5590e300f3ed5e60003d1c8424ccbd332d07477a9228e607f8ed288fce9cb465a37f88c4f904fbaf766d91ced6a744f756ab694d17a83117758e0a
+)
+
 file(REMOVE_RECURSE "${SOURCE_PATH}/src/lib/geogram/third_party/amgcl"
     "${SOURCE_PATH}/src/lib/geogram/third_party/libMeshb"
-	"${SOURCE_PATH}/src/lib/geogram/third_party/rply")
+	"${SOURCE_PATH}/src/lib/geogram/third_party/rply"
+    "${SOURCE_PATH}/src/lib/geogram_gfx/third_party/imgui")
 file(RENAME "${AMGCL_SOURCE_PATH}" "${SOURCE_PATH}/src/lib/geogram/third_party/amgcl")
 file(RENAME "${LIBMESHB_SOURCE_PATH}" "${SOURCE_PATH}/src/lib/geogram/third_party/libMeshb")
 file(RENAME "${RPLY_SOURCE_PATH}" "${SOURCE_PATH}/src/lib/geogram/third_party/rply")
+file(RENAME "${IMGUI_SOURCE_PATH}" "${SOURCE_PATH}/src/lib/geogram_gfx/third_party/imgui")
 
 file(COPY "${CURRENT_PORT_DIR}/Config.cmake.in" DESTINATION "${SOURCE_PATH}/cmake")
 

--- a/ports/geogram/vcpkg.json
+++ b/ports/geogram/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "geogram",
   "version": "1.8.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Geogram is a programming library of geometric algorithms.",
   "homepage": "https://github.com/BrunoLevy/geogram",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2778,7 +2778,7 @@
     },
     "geogram": {
       "baseline": "1.8.3",
-      "port-version": 1
+      "port-version": 2
     },
     "geographiclib": {
       "baseline": "2.2",

--- a/versions/g-/geogram.json
+++ b/versions/g-/geogram.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed722cce1b89765ca4f8014d1e2d886cb2f4d9d4",
+      "version": "1.8.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "ee6286e71522b6c0bd498066597094e57ff505b4",
       "version": "1.8.3",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/32421
Fixed `imgui` not downloading when compiling `geogram`.
Fix the issue that the header file cannot be found when compiling `geogram_gfx`.
Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.