### PR TITLE
[dirent] add license id and use vcpkg_install_copyright()

### DIFF
--- a/ports/dirent/portfile.cmake
+++ b/ports/dirent/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 file(INSTALL ${SOURCE_PATH}/include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/dirent RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 vcpkg_copy_pdbs()
 
 set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS enabled)

--- a/ports/dirent/vcpkg.json
+++ b/ports/dirent/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "dirent",
   "version": "1.23.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Dirent is a C/C++ programming interface that allows programmers to retrieve information about files and directories under Linux/UNIX. This project provides Linux compatible Dirent interface for Microsoft Windows.",
-  "homepage": "https://github.com/tronkko/dirent"
+  "homepage": "https://github.com/tronkko/dirent",
+  "license": "MIT"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2122,7 +2122,7 @@
     },
     "dirent": {
       "baseline": "1.23.2",
-      "port-version": 2
+      "port-version": 3
     },
     "discord-game-sdk": {
       "baseline": "3.2.1",

--- a/versions/d-/dirent.json
+++ b/versions/d-/dirent.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6df6238f6f97735c39e2e9b19d90f3895c4a636b",
+      "version": "1.23.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "9d27b241631b1f540dd16824cd8a2df735233733",
       "version": "1.23.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.