### PR TITLE
[fribidi] add license id and use vcpkg_install_copyright()

### DIFF
--- a/ports/fribidi/portfile.cmake
+++ b/ports/fribidi/portfile.cmake
@@ -53,4 +53,4 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/fribidi/vcpkg.json
+++ b/ports/fribidi/vcpkg.json
@@ -1,7 +1,9 @@
 {
   "name": "fribidi",
   "version": "1.0.12",
+  "port-version": 1,
   "description": "GNU FriBidi is an implementation of the Unicode Bidirectional Algorithm (bidi)",
+  "license": "LGPL-2.1-or-later",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2670,7 +2670,7 @@
     },
     "fribidi": {
       "baseline": "1.0.12",
-      "port-version": 0
+      "port-version": 1
     },
     "frozen": {
       "baseline": "1.1.1",

--- a/versions/f-/fribidi.json
+++ b/versions/f-/fribidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b611119763d80fa18b07cf2e3c99c02069b0ec55",
+      "version": "1.0.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "43f84b32dcc2e675fac20a42c0cf0c7f801c1fbc",
       "version": "1.0.12",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.