### PR TITLE
[libcroco] add license id and use vcpkg_install_copyright()

### DIFF
--- a/ports/libcroco/portfile.cmake
+++ b/ports/libcroco/portfile.cmake
@@ -28,6 +28,6 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-libcroco)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_copy_pdbs()

--- a/ports/libcroco/vcpkg.json
+++ b/ports/libcroco/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libcroco",
   "version": "0.6.13",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A standalone css2 parsing and manipulation library",
+  "license": "LGPL-2.0-only",
   "dependencies": [
     "glib",
     "libxml2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3954,7 +3954,7 @@
     },
     "libcroco": {
       "baseline": "0.6.13",
-      "port-version": 4
+      "port-version": 5
     },
     "libcsv": {
       "baseline": "3.0.3",

--- a/versions/l-/libcroco.json
+++ b/versions/l-/libcroco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6962c2f97aca37a74b56870cc7ff032605cfba2",
+      "version": "0.6.13",
+      "port-version": 5
+    },
+    {
       "git-tree": "04dc173766f01e3ddad3bcd53c62ed56741ab3a8",
       "version": "0.6.13",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.