### PR TITLE
[angle] Fix gcc13 compilation error

### DIFF
--- a/ports/angle/002-fix-builder-error.patch
+++ b/ports/angle/002-fix-builder-error.patch
@@ -26,3 +26,15 @@ index f4bb137f2..86495013b 100644
  namespace angle
  {
  
+diff --git a/include/GLSLANG/ShaderVars.h b/include/GLSLANG/ShaderVars.h
+index 94cb93e..5593f66 100644
+--- a/include/GLSLANG/ShaderVars.h
++++ b/include/GLSLANG/ShaderVars.h
+@@ -14,6 +14,7 @@
+ #include <array>
+ #include <string>
+ #include <vector>
++#include <stdint.h>
+ 
+ namespace sh
+ {

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_5414",
-  "port-version": 4,
+  "port-version": 5,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8849e7cee8eb5754ec1aefba7644bb393863f94",
+      "version-string": "chromium_5414",
+      "port-version": 5
+    },
+    {
       "git-tree": "f5963e0a9c6de152e825e610333e626e8a9df144",
       "version-string": "chromium_5414",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -122,7 +122,7 @@
     },
     "angle": {
       "baseline": "chromium_5414",
-      "port-version": 4
+      "port-version": 5
     },
     "annoy": {
       "baseline": "1.17.2",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/32494
`/home/vliumonica/angle/buildtrees/angle/src/fb17168c17-081a7ef021.clean/include/GLSLANG/ShaderVars.h:127:70: error: ‘uint32_t’ has not been declared`
Add the header file corresponding to `uint32_t`.
Usage test pass with following triplets:

```
x64-linux
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.