### PR TITLE
[libuuid] add license id and use vcpkg_install_copyright()

### DIFF
--- a/ports/libuuid/portfile.cmake
+++ b/ports/libuuid/portfile.cmake
@@ -35,8 +35,6 @@ endif()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/unofficial-libuuid PACKAGE_NAME unofficial-libuuid)
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL
-    "${SOURCE_PATH}/COPYING"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_copy_pdbs()

--- a/ports/libuuid/vcpkg.json
+++ b/ports/libuuid/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libuuid",
   "version": "1.0.3",
-  "port-version": 13,
+  "port-version": 14,
   "description": "Universally unique id library",
   "homepage": "https://sourceforge.net/projects/libuuid",
+  "license": "BSD-3-Clause",
   "supports": "!osx & !windows",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4734,7 +4734,7 @@
     },
     "libuuid": {
       "baseline": "1.0.3",
-      "port-version": 13
+      "port-version": 14
     },
     "libuv": {
       "baseline": "1.45.0",

--- a/versions/l-/libuuid.json
+++ b/versions/l-/libuuid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09be6774f518692bc418aa03623cc9dbc19e6516",
+      "version": "1.0.3",
+      "port-version": 14
+    },
+    {
       "git-tree": "356948d66a6dd59bd830d26c78d1df673de20ea1",
       "version": "1.0.3",
       "port-version": 13


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.