### PR TITLE
[tesseract] fix unrecognized command line option -mfpu=neon on aarch64

### DIFF
--- a/ports/tesseract/fix-aarch64-mfpu-not-available.patch
+++ b/ports/tesseract/fix-aarch64-mfpu-not-available.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index db4c39d5..276c65f3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -257,7 +257,11 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm.*")
+   set(HAVE_AVX512F FALSE)
+   set(HAVE_FMA FALSE)
+   set(HAVE_SSE4_1 FALSE)
++
+   check_cxx_compiler_flag("-mfpu=neon" HAVE_NEON)
++  if(HAVE_NEON)
++    set(NEON_COMPILE_FLAGS "-mfpu=neon")
++  endif(HAVE_NEON)
+ 
+ else()
+ 
+@@ -271,7 +275,6 @@ else()
+ endif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|x86_64|AMD64|amd64|i386|i686")
+ 
+ if(HAVE_NEON)
+-  set(NEON_COMPILE_FLAGS "-mfpu=neon")
+   message(STATUS "LTO build is not supported on arm/RBPi.")
+   set(ENABLE_LTO FALSE)  # enable LTO cause fatal error on arm/RBPi
+ endif()
+ 

--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     PATCHES
         ${tesseract_patch}
         fix_static_link_icu.patch
+        fix-aarch64-mfpu-not-available.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/tesseract/vcpkg.json
+++ b/ports/tesseract/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tesseract",
   "version": "5.3.1",
+  "port-version": 1,
   "description": "An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.",
   "homepage": "https://github.com/tesseract-ocr/tesseract",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7994,7 +7994,7 @@
     },
     "tesseract": {
       "baseline": "5.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "tfhe": {
       "baseline": "1.0.1",

--- a/versions/t-/tesseract.json
+++ b/versions/t-/tesseract.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0b39327eee123cac1611afe9d88303822fedbdf",
+      "version": "5.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "aeb035e40f678090353d237cc6de1089fb58d89c",
       "version": "5.3.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #32264

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
