### PR TITLE
[mujoco] use correct https:// schema for hompage url

### DIFF
--- a/ports/mujoco/vcpkg.json
+++ b/ports/mujoco/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mujoco",
   "version": "2.3.2",
+  "port-version": 1,
   "description": "Multi-Joint dynamics with Contact.",
   "homepage": "https://mujoco.org",
   "license": "Apache-2.0",

--- a/ports/mujoco/vcpkg.json
+++ b/ports/mujoco/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "mujoco",
   "version": "2.3.2",
   "description": "Multi-Joint dynamics with Contact.",
-  "homepage": "mujoco.org",
+  "homepage": "https://mujoco.org",
   "license": "Apache-2.0",
   "supports": "!(windows & static)",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5518,7 +5518,7 @@
     },
     "mujoco": {
       "baseline": "2.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "mujs": {
       "baseline": "1.3.2",

--- a/versions/m-/mujoco.json
+++ b/versions/m-/mujoco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c70b9104b75fe8947ddac6e9450207cadb59cb0b",
+      "version": "2.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "086053d3e52e0d7565733cf06db736f2e1617a63",
       "version": "2.3.2",
       "port-version": 0


### PR DESCRIPTION
Fixing a recommendation from repology 

> 2023-07-11 08:31:04   mujoco: ERROR: homepage: "mujoco.org" does not look like an URL (schema missing)

(ref: https://repology.org/log/928074)

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

