### PR TITLE
[nameof] Bump to 0.10.3

### DIFF
--- a/ports/nameof/portfile.cmake
+++ b/ports/nameof/portfile.cmake
@@ -1,12 +1,12 @@
-# header-only library
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/nameof
-    REF v0.10.2
-    SHA512 1ec508378d12eb4a65da1bee8011302f65e78bbcab82aae716afc673665af5283a5aae5f1d0de85c7d6f59bb7268e02fc01b171f50de26bb86dc27c3b46097fa
+    REF "v${VERSION}"
+    SHA512 2b0bad2a3309202bcd6e361c2f2d4a61b474359a6c2df0a8b9e1a6c9e077bbf0c0d18dc5b603ecb4f82cc1f74656aae51e52ece0f7049ac3f75b593f14542b93
     HEAD_REF master
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -20,7 +20,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-# Handle copyright
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/nameof/usage
+++ b/ports/nameof/usage
@@ -1,0 +1,4 @@
+nameof provides CMake targets:
+
+    find_package(nameof CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE nameof::nameof)

--- a/ports/nameof/vcpkg.json
+++ b/ports/nameof/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nameof",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Nameof operator for modern C++, simply obtain the name of a variable, type, function, macro, and enum.",
   "homepage": "https://github.com/Neargye/nameof",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5549,7 +5549,7 @@
       "port-version": 1
     },
     "nameof": {
-      "baseline": "0.10.2",
+      "baseline": "0.10.3",
       "port-version": 0
     },
     "nana": {

--- a/versions/n-/nameof.json
+++ b/versions/n-/nameof.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f82961138b18791ffba3efef021f008c467988fb",
+      "version": "0.10.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6e74d9d06b8f8982ecfbad4b07e5215c8ea054b",
       "version": "0.10.2",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

1. Bump to 0.10.3
2. Modernization