### PR TITLE
[uvw] Bump to 3.2.0

### DIFF
--- a/ports/uvw/fix-find-libuv.patch
+++ b/ports/uvw/fix-find-libuv.patch
@@ -2,17 +2,15 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 8c4b664..92267d6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -193,6 +193,14 @@ if (BUILD_UVW_LIBS)
+@@ -193,6 +193,12 @@ if (BUILD_UVW_LIBS)
          SOVERSION ${UVW_VERSION_MAJOR}
      )
  endif()
 +
 +find_path(LIBUV_INCLUDE_DIR NAMES uv.h PATH_SUFFIXES uv REQUIRED)
 +find_library(LIBUV_LIBRARY NAMES uv uv_a REQUIRED)
-+if (LIBUV_LIBRARY)
-+    target_include_directories(uvw PUBLIC ${LIBUV_INCLUDE_DIR})
-+    target_link_libraries(uvw PRIVATE ${LIBUV_LIBRARY})
-+endif()
++target_include_directories(uvw PUBLIC ${LIBUV_INCLUDE_DIR})
++target_link_libraries(uvw PRIVATE ${LIBUV_LIBRARY})
 +
  install(
      EXPORT uvwConfig 

--- a/ports/uvw/fix-find-libuv.patch
+++ b/ports/uvw/fix-find-libuv.patch
@@ -8,7 +8,7 @@ index 8c4b664..92267d6 100644
  endif()
 +
 +find_path(LIBUV_INCLUDE_DIR NAMES uv.h PATH_SUFFIXES uv REQUIRED)
-+find_library(LIBUV_LIBRARY NAMES uv uv_a REQUIRED)
++find_library(LIBUV_LIBRARY NAMES uv uv_a libuv REQUIRED)
 +target_include_directories(uvw PUBLIC ${LIBUV_INCLUDE_DIR})
 +target_link_libraries(uvw PRIVATE ${LIBUV_LIBRARY})
 +

--- a/ports/uvw/fix-find-libuv.patch
+++ b/ports/uvw/fix-find-libuv.patch
@@ -2,15 +2,17 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 8c4b664..92267d6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -193,6 +193,12 @@ if (BUILD_UVW_LIBS)
+@@ -193,6 +193,14 @@ if (BUILD_UVW_LIBS)
          SOVERSION ${UVW_VERSION_MAJOR}
      )
  endif()
 +
-+find_path(LIBUV_INCLUDE_DIR NAMES uv.h PATH_SUFFIXES uv REQUIRED)
-+find_library(LIBUV_LIBRARY NAMES uv uv_a libuv REQUIRED)
-+target_include_directories(uvw PUBLIC ${LIBUV_INCLUDE_DIR})
-+target_link_libraries(uvw PRIVATE ${LIBUV_LIBRARY})
++find_package(libuv CONFIG REQUIRED)
++if (TARGET libuv::uv)
++    target_link_libraries(uvw PRIVATE libuv::uv)
++else()
++    target_link_libraries(uvw PRIVATE libuv::uv_a)
++endif()
 +
  install(
      EXPORT uvwConfig 

--- a/ports/uvw/fix-find-libuv.patch
+++ b/ports/uvw/fix-find-libuv.patch
@@ -9,9 +9,9 @@ index 289c006..180383f 100644
 +
 +find_package(libuv CONFIG REQUIRED)
 +if (TARGET libuv::uv)
-+    target_link_libraries(uvw PRIVATE libuv::uv)
++    target_link_libraries(uvw INTERFACE libuv::uv)
 +else()
-+    target_link_libraries(uvw PRIVATE libuv::uv_a)
++    target_link_libraries(uvw INTERFACE libuv::uv_a)
 +endif()
 +
  install(

--- a/ports/uvw/fix-find-libuv.patch
+++ b/ports/uvw/fix-find-libuv.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8c4b664..92267d6 100644
+index 289c006..180383f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -193,6 +193,14 @@ if (BUILD_UVW_LIBS)

--- a/ports/uvw/fix-find-libuv.patch
+++ b/ports/uvw/fix-find-libuv.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 289c006..180383f 100644
+index 8c4b664..92267d6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -193,6 +193,14 @@ if (BUILD_UVW_LIBS)
@@ -7,11 +7,11 @@ index 289c006..180383f 100644
      )
  endif()
 +
-+find_package(libuv CONFIG REQUIRED)
-+if (TARGET libuv::uv)
-+    target_link_libraries(uvw INTERFACE libuv::uv)
-+else()
-+    target_link_libraries(uvw INTERFACE libuv::uv_a)
++find_path(LIBUV_INCLUDE_DIR NAMES uv.h PATH_SUFFIXES uv REQUIRED)
++find_library(LIBUV_LIBRARY NAMES uv uv_a REQUIRED)
++if (LIBUV_LIBRARY)
++    target_include_directories(uvw PUBLIC ${LIBUV_INCLUDE_DIR})
++    target_link_libraries(uvw PRIVATE ${LIBUV_LIBRARY})
 +endif()
 +
  install(

--- a/ports/uvw/portfile.cmake
+++ b/ports/uvw/portfile.cmake
@@ -21,6 +21,13 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/uvw)
 
+file(READ "${CURRENT_PACKAGES_DIR}/share/uvw/uvwConfig.cmake" cmake_config)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/uvw/uvwConfig.cmake"
+"include(CMakeFindDependencyMacro)
+find_dependency(libuv)
+${cmake_config}
+")
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/uvw/portfile.cmake
+++ b/ports/uvw/portfile.cmake
@@ -1,15 +1,13 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO skypjack/uvw
-    REF "v${VERSION}_libuv_v1.44"
-    SHA512 6794d71f88888e58d53fbea18eecb8e43a01f9965012a4b0f3c29bd5dd1280aac8dfe735d3df7f401d309e182fa7ed4e2e0b4aff49beaa1973dcd61153bbb1af
+    REF "v${VERSION}_libuv_v1.46"
+    SHA512 a790f74a4d151319d3d692167b7d2229e6660dee34e7dc266815c3e5579dbe99e1da55e0466832ac8ec1881073317b744e384908de60bf62ef16420ee2fbc318
     PATCHES
         fix-find-libuv.patch
 )
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -22,7 +20,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/uvw)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-# Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/uvw/portfile.cmake
+++ b/ports/uvw/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO skypjack/uvw
@@ -7,12 +9,11 @@ vcpkg_from_github(
         fix-find-libuv.patch
 )
 
-set(VCPKG_BUILD_TYPE release) # header-only port
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_UVW_LIBS=${BUILD_STATIC}
+        -DBUILD_UVW_LIBS=ON
+        -DBUILD_UVW_SHARED_LIB=OFF
         -DFETCH_LIBUV=OFF
         -DFIND_LIBUV=OFF
 )
@@ -20,7 +21,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/uvw)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/uvw/usage
+++ b/ports/uvw/usage
@@ -1,0 +1,4 @@
+uvw provides CMake targets:
+
+    find_package(uvw CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE uvw::uvw)

--- a/ports/uvw/vcpkg.json
+++ b/ports/uvw/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "uvw",
-  "version": "3.0.0",
-  "port-version": 1,
+  "version": "3.2.0",
   "description": "A compilable static library, event based, tiny and easy to use libuv wrapper in modern C++.",
   "homepage": "https://github.com/skypjack/uvw",
   "license": "MIT",

--- a/ports/uvw/vcpkg.json
+++ b/ports/uvw/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "uvw",
   "version": "3.2.0",
-  "description": "A compilable static library, event based, tiny and easy to use libuv wrapper in modern C++.",
+  "description": "Header-only, event based, tiny and easy to use libuv wrapper in modern C++.",
   "homepage": "https://github.com/skypjack/uvw",
   "license": "MIT",
   "dependencies": [

--- a/ports/uvw/vcpkg.json
+++ b/ports/uvw/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "uvw",
   "version": "3.2.0",
-  "description": "Header-only, event based, tiny and easy to use libuv wrapper in modern C++.",
+  "description": "A compilable static library, event based, tiny and easy to use libuv wrapper in modern C++.",
   "homepage": "https://github.com/skypjack/uvw",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8381,8 +8381,8 @@
       "port-version": 0
     },
     "uvw": {
-      "baseline": "3.0.0",
-      "port-version": 1
+      "baseline": "3.2.0",
+      "port-version": 0
     },
     "uwebsockets": {
       "baseline": "20.44.0",

--- a/versions/u-/uvw.json
+++ b/versions/u-/uvw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b7b28b67f74e118559f39f8eb9b6f8644ef4a326",
+      "version": "3.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "67bc0402d4aa7c5cbb9f934c0e7c68fec4acdcfc",
       "version": "3.0.0",
       "port-version": 1

--- a/versions/u-/uvw.json
+++ b/versions/u-/uvw.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a95449384111bc358ec3a529c2f757042a4fc281",
+      "git-tree": "ad30aec2afd6d0829376e651c41cf342b474669c",
       "version": "3.2.0",
       "port-version": 0
     },

--- a/versions/u-/uvw.json
+++ b/versions/u-/uvw.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad30aec2afd6d0829376e651c41cf342b474669c",
+      "git-tree": "a5bb9a42074a40e1079d700b92de770247305bbc",
       "version": "3.2.0",
       "port-version": 0
     },

--- a/versions/u-/uvw.json
+++ b/versions/u-/uvw.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0c7ec9759fae0a10c70c780b831e0981bbfb68d8",
+      "git-tree": "82ef2ed3a8ae1df65e8e922c5d7917d3271f457d",
       "version": "3.2.0",
       "port-version": 0
     },

--- a/versions/u-/uvw.json
+++ b/versions/u-/uvw.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a5bb9a42074a40e1079d700b92de770247305bbc",
+      "git-tree": "79598be55e79a6b2fb882a30898971d0189bfa05",
       "version": "3.2.0",
       "port-version": 0
     },

--- a/versions/u-/uvw.json
+++ b/versions/u-/uvw.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b7b28b67f74e118559f39f8eb9b6f8644ef4a326",
+      "git-tree": "a95449384111bc358ec3a529c2f757042a4fc281",
       "version": "3.2.0",
       "port-version": 0
     },

--- a/versions/u-/uvw.json
+++ b/versions/u-/uvw.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "79598be55e79a6b2fb882a30898971d0189bfa05",
+      "git-tree": "0c7ec9759fae0a10c70c780b831e0981bbfb68d8",
       "version": "3.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This pr depends on #32525