### PR TITLE
[librsvg] add license id and use vcpkg_install_copyright()

### DIFF
--- a/ports/librsvg/portfile.cmake
+++ b/ports/librsvg/portfile.cmake
@@ -30,4 +30,4 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-librsvg CONFIG_PATH share/unoff
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/librsvg/vcpkg.json
+++ b/ports/librsvg/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "librsvg",
   "version": "2.40.20",
-  "port-version": 6,
+  "port-version": 7,
   "description": "A small library to render Scalable Vector Graphics (SVG)",
   "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
+  "license": "LGPL-2.0-or-later",
   "dependencies": [
     "cairo",
     "gdk-pixbuf",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4510,7 +4510,7 @@
     },
     "librsvg": {
       "baseline": "2.40.20",
-      "port-version": 6
+      "port-version": 7
     },
     "librsync": {
       "baseline": "2.3.2",

--- a/versions/l-/librsvg.json
+++ b/versions/l-/librsvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7896420ce5b25f27747238c63c89bd09d551d817",
+      "version": "2.40.20",
+      "port-version": 7
+    },
+    {
       "git-tree": "3e077a8a58a07c8c3d869ff6b875cc2dd7325025",
       "version": "2.40.20",
       "port-version": 6


### PR DESCRIPTION
COPYING and COPYING.LIB have identical texts.

The source files state, that the LGPL is the:

GNU Library General Public License as published by the Free Software
Foundation; either version 2 of the License, or (at your option) any
later version.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.