### PR TITLE
[libxslt] set license id and use vcpkg_install_copyright()

### DIFF
--- a/ports/libxslt/portfile.cmake
+++ b/ports/libxslt/portfile.cmake
@@ -80,4 +80,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libxslt")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/Copyright" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/Copyright")

--- a/ports/libxslt/vcpkg.json
+++ b/ports/libxslt/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "libxslt",
   "version": "1.1.37",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Libxslt is a XSLT library implemented in C for XSLT 1.0 and most of EXSLT",
   "homepage": "https://github.com/GNOME/libxslt",
-  "license": null,
+  "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
     "libxml2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4890,7 +4890,7 @@
     },
     "libxslt": {
       "baseline": "1.1.37",
-      "port-version": 2
+      "port-version": 3
     },
     "libxt": {
       "baseline": "1.2.1",

--- a/versions/l-/libxslt.json
+++ b/versions/l-/libxslt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50fa718dd8efcd5bd8097b3198937b230fdcc90c",
+      "version": "1.1.37",
+      "port-version": 3
+    },
+    {
       "git-tree": "b5013956f82220811954d9ed3b68e122c11e88a0",
       "version": "1.1.37",
       "port-version": 2


### PR DESCRIPTION
The project was licensed under [MIT](https://gitlab.gnome.org/GNOME/libxslt/-/commit/ada89dddea264bb41fd5c0c293ce989eb90ef4da) with the release of 1.0.11.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.