### PR TITLE
[xcb-proto] set license id and use vcpkg_install_copyright()

### DIFF
--- a/ports/xcb-proto/portfile.cmake
+++ b/ports/xcb-proto/portfile.cmake
@@ -45,5 +45,5 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()

--- a/ports/xcb-proto/vcpkg.json
+++ b/ports/xcb-proto/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "xcb-proto",
   "version": "1.14.1",
+  "port-version": 1,
   "description": "XML-XCB protocol descriptions used by libxcb for the X11 protocol & extensions",
   "homepage": "https://xcb.freedesktop.org/",
-  "license": null,
+  "license": "X11-distribute-modifications-variant",
   "dependencies": [
     "bzip2",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8778,7 +8778,7 @@
     },
     "xcb-proto": {
       "baseline": "1.14.1",
-      "port-version": 0
+      "port-version": 1
     },
     "xcb-render-util": {
       "baseline": "0.3.10",

--- a/versions/x-/xcb-proto.json
+++ b/versions/x-/xcb-proto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2eac40d0f3ae01205792344a254ac956e0adcd2",
+      "version": "1.14.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e5933d2463549d6d3b00a8aa1f0279f2a974ec1c",
       "version": "1.14.1",
       "port-version": 0


### PR DESCRIPTION
According to the repository the project is licensed under the [X11 License Distribution Modification Variant](https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/master/COPYING).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.