### PR TITLE
[curl] Add zstd feature.

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -34,6 +34,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         winidn      USE_WIN32_IDN
         winldap     USE_WIN32_LDAP
         websockets  ENABLE_WEBSOCKETS
+        zstd        CURL_ZSTD
     INVERTED_FEATURES
         non-http    HTTP_ONLY
         winldap     CURL_DISABLE_LDAP # Only WinLDAP support ATM

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curl",
   "version": "8.1.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": null,
@@ -199,6 +199,12 @@
       "description": "SSL support (wolfSSL)",
       "dependencies": [
         "wolfssl"
+      ]
+    },
+    "zstd": {
+      "description": "ZStandard support (zstd)",
+      "dependencies": [
+        "zstd"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1958,7 +1958,7 @@
     },
     "curl": {
       "baseline": "8.1.2",
-      "port-version": 1
+      "port-version": 2
     },
     "curlpp": {
       "baseline": "2018-06-15",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c2681b59ec41e4ec760fe10a60385202ee4763bb",
+      "version": "8.1.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "7d8ee40552d5b1c103d52b2b28d9577cb45e2593",
       "version": "8.1.2",
       "port-version": 1


### PR DESCRIPTION
Contributes to #32109.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.