### PR TITLE
[geotrans] Passes now on Android.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -431,10 +431,6 @@ gemmlowp:x64-android=fail
 gherkin-c:arm-neon-android=fail
 gherkin-c:arm64-android=fail
 gherkin-c:x64-android=fail
-geotrans:arm-neon-android=fail
-geotrans:arm64-android=fail
-geotrans:x64-android=fail
-
 # Conflicts with libevent
 gherkin-c:arm64-windows         = skip
 gherkin-c:arm-uwp               = skip


### PR DESCRIPTION
https://dev.azure.com/vcpkg/public/_build/results?buildId=91681&view=logs&j=185c373b-2f55-539e-a6cb-ef2677cc0d97&t=bd42ae40-c428-56e6-fb3d-bb973ea0084d

```
PASSING, REMOVE FROM FAIL LIST: geotrans:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt). 
PASSING, REMOVE FROM FAIL LIST: geotrans:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt). 
PASSING, REMOVE FROM FAIL LIST: geotrans:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt). 
```

Previously was changed from skip to fail in https://github.com/microsoft/vcpkg/commit/6b8459636c7ab9f2ccb638697b2ac990e1fd64b1
