### PR TITLE
[glslang] Add support for rtti in glslang port

### DIFF
--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         tools ENABLE_GLSLANG_BINARIES
+        rtti ENABLE_RTTI
 )
 
 if (ENABLE_GLSLANG_BINARIES)

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glslang",
   "version": "12.2.0",
+  "port-version": 1,
   "description": "Khronos-reference front end for GLSL/ESSL, partial front end for HLSL, and a SPIR-V generator.",
   "homepage": "https://github.com/KhronosGroup/glslang",
   "license": "Apache-2.0 AND BSD-3-Clause AND MIT AND GPL-3.0-or-later",
@@ -15,6 +16,9 @@
     }
   ],
   "features": {
+    "rtti": {
+      "description": "Build with dynamic typeinfo"
+    },
     "tools": {
       "description": "Build the glslangValidator and spirv-remap binaries",
       "supports": "!ios"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2902,7 +2902,7 @@
     },
     "glslang": {
       "baseline": "12.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "glui": {
       "baseline": "2019-11-30",

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "796a20fde44858a311783328a0555813894631bb",
+      "version": "12.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "aaa917d7743ac6e466f2d4ecf20b5745cd44fe98",
       "version": "12.2.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

This adds support for using the `ENABLE_RTTI` option in the `glslang` port. 