### PR TITLE
[pango] set correct license id and use vcpkg_install_copyright()

### DIFF
--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -52,4 +52,4 @@ vcpkg_copy_pdbs()
 
 vcpkg_copy_tools(TOOL_NAMES pango-view pango-list pango-segmentation AUTO_CLEAN)
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "pango",
   "version": "1.50.14",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
-  "license": "LGPL-2.0-only",
+  "license": "LGPL-2.0-or-later",
   "supports": "!xbox",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6178,7 +6178,7 @@
     },
     "pango": {
       "baseline": "1.50.14",
-      "port-version": 1
+      "port-version": 2
     },
     "pangolin": {
       "baseline": "0.8",

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4a19a3119134de662a854a19436609b484d60ce",
+      "version": "1.50.14",
+      "port-version": 2
+    },
+    {
       "git-tree": "ae2c0487d81de23e5f928edd4905c379be0bac54",
       "version": "1.50.14",
       "port-version": 1


### PR DESCRIPTION
According to the [projects source files](https://gitlab.gnome.org/GNOME/pango/-/tree/main/pango), it is licensed under LGPL-2.0-or-later:

```
This library is free software; you can redistribute it and/or
modify it under the terms of the GNU Library General Public
License as published by the Free Software Foundation; either
version 2 of the License, or (at your option) any later version.
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.