### PR TITLE
[date] set correct license and use vcpkg_install_copyright()

### DIFF
--- a/ports/date/portfile.cmake
+++ b/ports/date/portfile.cmake
@@ -8,7 +8,7 @@ endif()
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO HowardHinnant/date
-  REF v3.0.1
+  REF "v${VERSION}"
   SHA512 6bdc7cba821d66e17a559250cc0ce0095808e9db81cec9e16eaa4c31abdfa705299c67b72016d9b06b302bc306d063e83a374eb00728071b83a5ad650d59034f
   HEAD_REF master
   PATCHES

--- a/ports/date/portfile.cmake
+++ b/ports/date/portfile.cmake
@@ -41,4 +41,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/date/vcpkg.json
+++ b/ports/date/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "date",
   "version": "3.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A date and time library based on the C++17 <chrono> header",
   "homepage": "https://github.com/HowardHinnant/date",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2018,7 +2018,7 @@
     },
     "date": {
       "baseline": "3.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "dav1d": {
       "baseline": "1.2.1",

--- a/versions/d-/date.json
+++ b/versions/d-/date.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a802a3934ea96971b4a7676781a400b664f53600",
+      "git-tree": "b3ca1bdc08676cd1bb802421bd94a18872305737",
       "version": "3.0.1",
       "port-version": 3
     },

--- a/versions/d-/date.json
+++ b/versions/d-/date.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a802a3934ea96971b4a7676781a400b664f53600",
+      "version": "3.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "14d5c6822908ad2fd1d700cca2067ae4b8ef4404",
       "version": "3.0.1",
       "port-version": 2


### PR DESCRIPTION
Fixes #32543
Set correct license and use vcpkg_install_copyright().

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
