### PR TITLE
[vcpkg baseline][openvino] Disable find pybind11

### DIFF
--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -114,6 +114,7 @@ vcpkg_cmake_configure(
         "-DENABLE_PYTHON=OFF"
         "-DENABLE_GAPI_PREPROCESSING=OFF"
         "-DCPACK_GENERATOR=VCPKG"
+        "-DCMAKE_DISABLE_FIND_PACKAGE_pybind11=ON"
 )
 
 vcpkg_cmake_install()

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
   "version-date": "2023-06-11",
-  "port-version": 1,
+  "port-version": 2,
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6082,7 +6082,7 @@
     },
     "openvino": {
       "baseline": "2023-06-11",
-      "port-version": 1
+      "port-version": 2
     },
     "openvpn3": {
       "baseline": "3.7.0",

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42a42b174342b956f51bfd641761787fc3ced98a",
+      "version-date": "2023-06-11",
+      "port-version": 2
+    },
+    {
       "git-tree": "b845ea9bb49b0f44f2423d210e950003b67bfac4",
       "version-date": "2023-06-11",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixed [CI pipeline](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8049712&view=results) issue:
```
CMake Error at D:/installed/x64-windows/share/pybind11/FindPythonLibsNew.cmake:242 (message):
  Python libraries not found
Call Stack (most recent call first):
  D:/a/_work/1/s/scripts/buildsystems/vcpkg.cmake:855 (_find_package)
  D:/installed/x64-windows/share/pybind11/pybind11Tools.cmake:50 (find_package)
  D:/installed/x64-windows/share/pybind11/pybind11Common.cmake:180 (include)
  D:/installed/x64-windows/share/pybind11/pybind11Config.cmake:248 (include)
  D:/a/_work/1/s/scripts/buildsystems/vcpkg.cmake:855 (_find_package)
  cmake/developer_package/cross_compile/find_commands.cmake:147 (find_package)
  src/bindings/python/CMakeLists.txt:60 (find_host_package)
  src/bindings/python/CMakeLists.txt:71 (_ov_find_python_libs_new)
  src/bindings/python/CMakeLists.txt:131 (ov_check_python_build_conditions)
```
`openvino` will installed failed after installing `pybind11`, `pybind11` is not dependency of `openvino`, so disable find it.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
