### PR TITLE
[gcc] Add gcc port

### DIFF
--- a/ports/gcc/disable_autoconf_check.patch
+++ b/ports/gcc/disable_autoconf_check.patch
@@ -1,0 +1,14 @@
+diff --git a/config/override.m4 b/config/override.m4
+--- a/config/override.m4
++++ b/config/override.m4
+@@ -38,9 +38,9 @@
+ dnl in configure.ac before AC_INIT,
+ dnl without rewriting this file.
+ dnl Or for updating the whole tree at once with the definition above.
+ AC_DEFUN([_GCC_AUTOCONF_VERSION_CHECK],
+-[m4_if(m4_defn([_GCC_AUTOCONF_VERSION]),
++[m4_if(m4_defn([m4_PACKAGE_VERSION]),
+   m4_defn([m4_PACKAGE_VERSION]), [],
+   [m4_fatal([Please use exactly Autoconf ]_GCC_AUTOCONF_VERSION[ instead of ]m4_defn([m4_PACKAGE_VERSION])[.])])
+ ])
+ m4_define([AC_INIT], m4_defn([AC_INIT])[

--- a/ports/gcc/portfile.cmake
+++ b/ports/gcc/portfile.cmake
@@ -1,0 +1,30 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gcc-mirror/gcc
+    REF releases/gcc-${VERSION}
+    SHA512 5fcc2c33cd1a535e0ac07677cafe8054efbf28182eeae61cc2e6d91e73e663302671f32bdf6ab25c883fe95de1f70a362e6189af4fa1f48d7725f2c5b634b974
+    HEAD_REF master
+    PATCHES
+        disable_autoconf_check.patch
+)
+
+if (VCPKG_TARGET_IS_WINDOWS)
+    set(OPTIONS "CXXFLAGS=-Zc:__cplusplus")
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS
+        --enable-languages=c,c++
+        --disable-multilib
+        ${OPTIONS}
+)
+
+vcpkg_install_make()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/gcc/vcpkg.json
+++ b/ports/gcc/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "gcc",
+  "version": "13.1.0",
+  "description": "The GNU Compiler Collection.",
+  "homepage": "https://gcc.gnu.org/",
+  "license": "GPL-2.0",
+  "supports": "linux",
+  "dependencies": [
+    "gmp",
+    "mpc",
+    "mpfr",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2748,6 +2748,10 @@
       "baseline": "2022-01-20",
       "port-version": 4
     },
+    "gcc": {
+      "baseline": "13.1.0",
+      "port-version": 0
+    },
     "gcem": {
       "baseline": "1.16.0",
       "port-version": 0

--- a/versions/g-/gcc.json
+++ b/versions/g-/gcc.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a0f1ec1894b9cf1e5407127b512e3305951b1f08",
+      "version": "13.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) 
