### PR TITLE
[openal-soft] Fix android config

### DIFF
--- a/ports/openal-soft/c12ada68951ea67a59bef7d4fcdf22334990c12a.patch
+++ b/ports/openal-soft/c12ada68951ea67a59bef7d4fcdf22334990c12a.patch
@@ -1,0 +1,54 @@
+From c12ada68951ea67a59bef7d4fcdf22334990c12a Mon Sep 17 00:00:00 2001
+From: Chris Robinson <chris.kcat@gmail.com>
+Date: Tue, 4 Jul 2023 11:30:18 -0700
+Subject: [PATCH] Don't use an import target for OpenSL
+
+---
+ CMakeLists.txt         |  3 ++-
+ cmake/FindOpenSL.cmake | 12 +++++-------
+ 2 files changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 34fd33122..af25a96c7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1183,7 +1183,8 @@ if(ALSOFT_BACKEND_OPENSL)
+         set(HAVE_OPENSL 1)
+         set(ALC_OBJS  ${ALC_OBJS} alc/backends/opensl.cpp alc/backends/opensl.h)
+         set(BACKENDS  "${BACKENDS} OpenSL,")
+-        set(EXTRA_LIBS "OpenSL::OpenSLES" ${EXTRA_LIBS})
++        set(EXTRA_LIBS ${OPENSL_LIBRARIES} ${EXTRA_LIBS})
++        set(INC_PATHS ${INC_PATHS} ${OPENSL_INCLUDE_DIRS})
+     endif()
+ endif()
+ if(ALSOFT_REQUIRE_OPENSL AND NOT HAVE_OPENSL)
+diff --git a/cmake/FindOpenSL.cmake b/cmake/FindOpenSL.cmake
+index 004287494..3df54d447 100644
+--- a/cmake/FindOpenSL.cmake
++++ b/cmake/FindOpenSL.cmake
+@@ -2,8 +2,9 @@
+ # Find the OpenSL libraries
+ #
+ #  This module defines the following variables and targets:
+-#     OPENSL_FOUND     - True if OPENSL was found
+-#     OpenSL::OpenSLES - The OpenSLES target
++#     OPENSL_FOUND        - True if OPENSL was found
++#     OPENSL_INCLUDE_DIRS - The OpenSL include paths
++#     OPENSL_LIBRARIES    - The OpenSL libraries to link
+ #
+ 
+ #=============================================================================
+@@ -53,11 +54,8 @@ find_package_handle_standard_args(OpenSL REQUIRED_VARS OPENSL_LIBRARY OPENSL_INC
+     OPENSL_ANDROID_INCLUDE_DIR)
+ 
+ if(OPENSL_FOUND)
+-    add_library(OpenSL::OpenSLES UNKNOWN IMPORTED)
+-    set_target_properties(OpenSL::OpenSLES PROPERTIES
+-        IMPORTED_LOCATION ${OPENSL_LIBRARY}
+-        INTERFACE_INCLUDE_DIRECTORIES ${OPENSL_INCLUDE_DIR}
+-        INTERFACE_INCLUDE_DIRECTORIES ${OPENSL_ANDROID_INCLUDE_DIR})
++    set(OPENSL_LIBRARIES ${OPENSL_LIBRARY})
++    set(OPENSL_INCLUDE_DIRS ${OPENSL_INCLUDE_DIR} ${OPENSL_ANDROID_INCLUDE_DIR})
+ endif()
+ 
+ mark_as_advanced(OPENSL_INCLUDE_DIR OPENSL_ANDROID_INCLUDE_DIR OPENSL_LIBRARY)

--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF ${VERSION}
     SHA512 7384e734ba6b0668adbb2b2629c950bdb61814584a745ced2327cc20b1b9ff9bc53a8e10ec3260ef2a2915048f4e3af8499d91f8515bb18a4e61c5eeef609d1a
     HEAD_REF master
+    PATCHES
+      c12ada68951ea67a59bef7d4fcdf22334990c12a.patch # Merged upstream, remove in next version
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openal-soft",
   "version": "1.23.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
   "homepage": "https://github.com/kcat/openal-soft",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5918,7 +5918,7 @@
     },
     "openal-soft": {
       "baseline": "1.23.0",
-      "port-version": 1
+      "port-version": 2
     },
     "openblas": {
       "baseline": "0.3.23",

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98c0f637759df2df98bf090cb115ad19cc2fdc06",
+      "version": "1.23.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "2179403cae57a853e75e3d30363750c39e370bc6",
       "version": "1.23.0",
       "port-version": 1


### PR DESCRIPTION
Fixes issue with linking command with an undefined OpenSL::OpenSLES in static mode and android.

Upstream issue: https://github.com/kcat/openal-soft/issues/871

The patch is already merged upstream and there is a prerelease out but I'm uncertain about the time table for release is.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

