### PR TITLE
[pango] Silence false positive in pango when using GCC 13

### DIFF
--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -12,10 +12,7 @@ vcpkg_from_gitlab(
 # Mimics patch for Gentoo https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=f688df5100ef2b88c975ecd40fd343c62e2ab276
 # Silence false positive with GCC 13 and -O3 at least
 # https://gitlab.gnome.org/GNOME/pango/-/issues/740	
-execute_process(
-    COMMAND bash "-c" "sed -i -e '/\-Werror=array-bounds/d' ${SOURCE_PATH}/meson.build" 
-    OUTPUT_VARIABLE FOO
-)
+vcpkg_replace_string("${SOURCE_PATH}/meson.build" "-Werror=array-bounds" "")
 
 if("introspection" IN_LIST FEATURES)
     if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -8,6 +8,15 @@ vcpkg_from_gitlab(
     HEAD_REF master
 ) 
 
+# Fix for https://github.com/microsoft/vcpkg/issues/31573
+# Mimics patch for Gentoo https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=f688df5100ef2b88c975ecd40fd343c62e2ab276
+# Silence false positive with GCC 13 and -O3 at least
+# https://gitlab.gnome.org/GNOME/pango/-/issues/740	
+execute_process(
+    COMMAND bash "-c" "sed -i -e '/\-Werror=array-bounds/d' ${SOURCE_PATH}/meson.build" 
+    OUTPUT_VARIABLE FOO
+)
+
 if("introspection" IN_LIST FEATURES)
     if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
         message(FATAL_ERROR "Feature introspection currently only supports dynamic build.")

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pango",
   "version": "1.50.14",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6182,7 +6182,7 @@
     },
     "pango": {
       "baseline": "1.50.14",
-      "port-version": 2
+      "port-version": 3
     },
     "pangolin": {
       "baseline": "0.8",

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60e6fbb827dc23e62117a56ceef52fd92ae2e331",
+      "version": "1.50.14",
+      "port-version": 3
+    },
+    {
       "git-tree": "d4a19a3119134de662a854a19436609b484d60ce",
       "version": "1.50.14",
       "port-version": 2

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "60e6fbb827dc23e62117a56ceef52fd92ae2e331",
+      "git-tree": "4c3bbb58011a3e259be06531c08854dfd7bbabee",
       "version": "1.50.14",
       "port-version": 3
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/31573

Upstream bug: https://gitlab.gnome.org/GNOME/pango/-/issues/740

I'm not sure if this would be a proper fix, as it would only work when having `sed` installed, but it worked for me.
I'm not too familiar with CMake so I would appreciate any tips to make this a more proper fix while the upstream bug is not fixed.

This fix worked for me on Fedora 38 (GCC 13), which was making me unable to build a vcpkg project that depends on OpenCV Linux -> GTK -> pango

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
