### PR TITLE
[manif] Add new port

### DIFF
--- a/ports/manif/portfile.cmake
+++ b/ports/manif/portfile.cmake
@@ -1,3 +1,4 @@
+#header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO artivis/manif

--- a/ports/manif/portfile.cmake
+++ b/ports/manif/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO artivis/manif
+    REF bb3f6758ae467b7f24def71861798d131f157032
+    SHA512 aaead27e1a177a1ded644bac270702c7d6232ac5345148be41d3ebca7e181d194e106d74f175182af51a72a4f26d5632749306d86676b5cb8862ddc34ea16a05
+    HEAD_REF devel
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/manif/cmake)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/manif/vcpkg.json
+++ b/ports/manif/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "manif",
+  "version-date": "2023-07-17",
+  "description": "A small C++11 header-only library for Lie theory.",
+  "homepage": "https://github.com/artivis/manif",
+  "documentation": "https://artivis.github.io/manif/",
+  "license": "MIT",
+  "dependencies": [
+    "eigen3",
+    "tl-optional",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5148,6 +5148,10 @@
       "baseline": "1.0.2",
       "port-version": 0
     },
+    "manif": {
+      "baseline": "2023-07-17",
+      "port-version": 0
+    },
     "mapbox-geojson-cpp": {
       "baseline": "0.5.1",
       "port-version": 1

--- a/versions/m-/manif.json
+++ b/versions/m-/manif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8884dd6c5ed73c04f5286979c8b80fee18db25e9",
+      "git-tree": "85cbc740d2b88302059e858e4f0fe74cf59c5a08",
       "version-date": "2023-07-17",
       "port-version": 0
     }

--- a/versions/m-/manif.json
+++ b/versions/m-/manif.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8884dd6c5ed73c04f5286979c8b80fee18db25e9",
+      "version-date": "2023-07-17",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
