### PR TITLE
[strtk] Add feature boost

### DIFF
--- a/ports/strtk/portfile.cmake
+++ b/ports/strtk/portfile.cmake
@@ -5,5 +5,11 @@ vcpkg_from_github(
     SHA512 c37c0df1dd3f7bc1dfcceea83ed9303cf9388ba400ee645f26a24bca50bf85209f7b8a2169f6b98b0267ece986a29a27605ff3eaef50a44629fb7e042d06f26a
 )
 
-file(COPY ${SOURCE_PATH}/strtk.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/strtk)
+file(COPY "${SOURCE_PATH}/strtk.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+if("boost" IN_LIST FEATURES)
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/strtk.hpp" "#ifndef strtk_no_tr1_or_boost" "#if 0")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${CMAKE_CURRENT_LIST_DIR}/copyright")

--- a/ports/strtk/vcpkg.json
+++ b/ports/strtk/vcpkg.json
@@ -1,10 +1,16 @@
 {
   "name": "strtk",
   "version-date": "2020-09-14",
-  "port-version": 2,
+  "port-version": 3,
   "description": "robust, optimized and portable string processing algorithms for the C++ language",
   "homepage": "https://github.com/ArashPartow/strtk",
-  "dependencies": [
-    "boost"
-  ]
+  "license": null,
+  "features": {
+    "boost": {
+      "description": "Request boost libraries",
+      "dependencies": [
+        "boost"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7886,7 +7886,7 @@
     },
     "strtk": {
       "baseline": "2020-09-14",
-      "port-version": 2
+      "port-version": 3
     },
     "stx": {
       "baseline": "0.0.3",

--- a/versions/s-/strtk.json
+++ b/versions/s-/strtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25bd007473e6ece64e317dc8b4ea97d29188a173",
+      "version-date": "2020-09-14",
+      "port-version": 3
+    },
+    {
       "git-tree": "42d71cbd4755eecc7183ac64b262ddd87450c431",
       "version-date": "2020-09-14",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #32622, change dependency `boost` to feature, it could use macro `strtk_no_tr1_or_boost` to control, the related upstream description: https://github.com/ArashPartow/strtk/blob/d2b446bf1f7854e8b08f5295ec6f6852cae066a2/readme.txt#L57-L61

```
(2) If the Boost libraries  (random, regex,  lexical_cast etc) are not
available  or  it  not  wished   they  be  used  then  the   following
preprocessor directive needs defining, either in code before strtk.hpp
is included or as a compiler switch:
   (*) strtk_no_tr1_or_boost
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
