### PR TITLE
[vcpkg baseline][qtinterfaceframework] Fix ci error

### DIFF
--- a/ports/qtinterfaceframework/requirements_minimal.txt
+++ b/ports/qtinterfaceframework/requirements_minimal.txt
@@ -7,7 +7,7 @@ Jinja2==2.11.3
 MarkupSafe==1.1
 path.py==11.0.1
 pathtools==0.1.2
-PyYAML==5.4
+PyYAML==6.0.1
 six==1.11.0
 watchdog==2.1.7
 pytest==5.3.5

--- a/ports/qtinterfaceframework/vcpkg.json
+++ b/ports/qtinterfaceframework/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtinterfaceframework",
   "version": "6.5.1",
+  "port-version": 1,
   "description": "Qt Interface Framework",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6838,7 +6838,7 @@
     },
     "qtinterfaceframework": {
       "baseline": "6.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "qtkeychain": {
       "baseline": "0.13.2",

--- a/versions/q-/qtinterfaceframework.json
+++ b/versions/q-/qtinterfaceframework.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4605314d419179ae92fc2e96a364e75b43a6615e",
+      "version": "6.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "f68eabb8f185b700ff927d6bbf92a9442d7997c9",
       "version": "6.5.1",
       "port-version": 0


### PR DESCRIPTION
Fix CI issue: 
````
REGRESSION: qtinterfaceframework:x64-windows failed with BUILD_FAILED. If expected, add qtinterfaceframework:x64-windows=fail to D:\a\_work\1\s\scripts\azure-pipelines/../ci.baseline.txt.

````
````
  error: subprocess-exited-with-error
  
  Getting requirements to build wheel did not run successfully.
  exit code: 1
......
......
File "C:\Users\cloudtest\AppData\Local\Temp\pip-build-env-owt2w25q\overlay\Lib\site-packages\setuptools\_distutils\cmd.py", line 107, in __getattr__
      raise AttributeError(attr)
  AttributeError: cython_sources
  [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

Getting requirements to build wheel did not run successfully.
exit code: 1

See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
````

The reason for this error is that the wheel build required for Python 3 failed, I upgraded PyYAML to the latest 6.0.1 version, because it has wheels available for Python 3.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.




<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
