### PR TITLE
Add automatic close community-triplet issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,3 +29,10 @@ jobs:
           days-before-issue-stale: 60
           days-before-pr-stale: -1
           days-before-close: 14
+      - uses: actions/stale@v6
+        with:
+          stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 90 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
+          only-labels: 'category:community-triplet'
+          days-before-issue-stale: 90
+          days-before-pr-stale: -1
+          days-before-close: 14


### PR DESCRIPTION
Add community-triplet issues that have been inactive for 90 days to the auto-closing actions as well.