### PR TITLE
Skip bde due to conflict with pcre and ryu.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -71,6 +71,7 @@ azure-identity-cpp:x64-android=fail
 backward-cpp:arm-neon-android=fail
 backward-cpp:arm64-android=fail
 backward-cpp:x64-android=fail
+bde:x64-linux=skip
 bento4:arm-neon-android=fail
 berkeleydb:arm-neon-android=fail
 berkeleydb:arm64-android=fail


### PR DESCRIPTION
Replaces https://github.com/microsoft/vcpkg/pull/32601/ ; will proceed with deindex only after some time for bde maintainers to fix this.
