### PR TITLE
[mfl] Disable warnings as errors.

### DIFF
--- a/ports/mfl/portfile.cmake
+++ b/ports/mfl/portfile.cmake
@@ -15,7 +15,11 @@ vcpkg_from_github(
         fix-clang-detection.patch
 )
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DWARNINGS_AS_ERRORS=FALSE
+)
+
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/mfl)

--- a/ports/mfl/vcpkg.json
+++ b/ports/mfl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mfl",
   "version": "0.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Computes the layout information for mathematical formulas provided in TeX-like syntax.",
   "homepage": "https://github.com/cpp-niel/mfl",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5282,7 +5282,7 @@
     },
     "mfl": {
       "baseline": "0.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "mfx-dispatch": {
       "baseline": "1.35.1",

--- a/versions/m-/mfl.json
+++ b/versions/m-/mfl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e78930d433356d545a61de55d6a23a6debb704b0",
+      "version": "0.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "a987e0da7b7b8bee335c9764cf2b8abcc6b68d2a",
       "version": "0.0.1",
       "port-version": 2


### PR DESCRIPTION
This fixes `mfl` with prerelease MSVC++.

See also:
* https://github.com/microsoft/STL/pull/3818
* https://github.com/fmtlib/fmt/issues/3540

