### PR TITLE
[kealib] Block attempting to load gdal's package. 

### DIFF
--- a/ports/kealib/portfile.cmake
+++ b/ports/kealib/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DLIBKEA_WITH_GDAL=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_GDAL=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/kealib/vcpkg.json
+++ b/ports/kealib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kealib",
   "version": "1.4.14",
+  "port-version": 1,
   "description": "KEALib provides an implementation of the GDAL data model using HDF5.",
   "homepage": "https://github.com/ubarsc/kealib",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3566,7 +3566,7 @@
     },
     "kealib": {
       "baseline": "1.4.14",
-      "port-version": 0
+      "port-version": 1
     },
     "kenlm": {
       "baseline": "20230531",

--- a/versions/k-/kealib.json
+++ b/versions/k-/kealib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6136ef42467c0204cd6a082a272c16ab955caa3",
+      "version": "1.4.14",
+      "port-version": 1
+    },
+    {
       "git-tree": "11878c71d1418c0bdcc380e7ebf8e90f9e563260",
       "version": "1.4.14",
       "port-version": 0


### PR DESCRIPTION
Resolves https://github.com/microsoft/vcpkg/issues/32653

The problem is that regardless of `LIBKEA_WITH_GDAL` it runs `find_package(GDAL`. (Ignoring the answer) Inside GDAL's package, they do `find_dependency(HDF5 COMPONENTS C)` which overrides kealib's attempted `find_package(HDF5 COMPONENTS CXX HL REQUIRED)` with the wrong libraries.