### PR TITLE
[curl] update to 8.2.0

### DIFF
--- a/ports/curl/dependencies.patch
+++ b/ports/curl/dependencies.patch
@@ -1,11 +1,11 @@
 diff --git a/CMake/curl-config.cmake.in b/CMake/curl-config.cmake.in
-index dbe4ed2..267108e 100644
+index dbe4ed2..edf87fa 100644
 --- a/CMake/curl-config.cmake.in
 +++ b/CMake/curl-config.cmake.in
-@@ -30,6 +30,15 @@ endif()
- if(@USE_ZLIB@)
+@@ -31,5 +31,15 @@ if(@USE_ZLIB@)
    find_dependency(ZLIB @ZLIB_VERSION_MAJOR@)
  endif()
+ 
 +if("@USE_ARES@")
 +  find_dependency(c-ares CONFIG)
 +endif()
@@ -15,14 +15,14 @@ index dbe4ed2..267108e 100644
 +if("@HAVE_BROTLI@")
 +    find_dependency(unofficial-brotli CONFIG)
 +endif()
- 
++
  include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
  check_required_components("@PROJECT_NAME@")
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 42c9ae4..8c42d91 100644
+index ad3a63d..917cdbf 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -149,7 +149,8 @@ set(CURL_LIBS "")
+@@ -151,7 +151,8 @@ set(CURL_LIBS "")
  
  if(ENABLE_ARES)
    set(USE_ARES 1)
@@ -32,18 +32,18 @@ index 42c9ae4..8c42d91 100644
    list(APPEND CURL_LIBS ${CARES_LIBRARY})
  endif()
  
-@@ -522,7 +523,9 @@ endif()
+@@ -524,7 +525,9 @@ endif()
  option(CURL_BROTLI "Set to ON to enable building curl with brotli support." OFF)
  set(HAVE_BROTLI OFF)
  if(CURL_BROTLI)
--  find_package(Brotli QUIET)
+-  find_package(Brotli REQUIRED)
 +  find_package(BROTLI NAMES unofficial-brotli REQUIRED)
 +  set(BROTLI_INCLUDE_DIRS "")
 +  set(BROTLI_LIBRARIES "unofficial::brotli::brotlidec")
    if(BROTLI_FOUND)
      set(HAVE_BROTLI ON)
      set(CURL_LIBS "${BROTLI_LIBRARIES};${CURL_LIBS}")  # For 'ld' linker. Emulate `list(PREPEND ...)` to stay compatible with <v3.15 CMake.
-@@ -796,7 +800,13 @@ mark_as_advanced(CURL_USE_LIBSSH2)
+@@ -796,7 +799,13 @@ mark_as_advanced(CURL_USE_LIBSSH2)
  set(USE_LIBSSH2 OFF)
  
  if(CURL_USE_LIBSSH2)

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO curl/curl
     REF "${curl_version}"
-    SHA512 d3c0bd113c772249c7e4e83cc26c6e2a1ff5644486c96318de6ab035300c52aca10756af665d91c5ce71f9d4afa4afbf7fbb756e9e4c800869b50c8a653bd519
+    SHA512 8dfca7f322b2a8f26ab866fd67f0a6a73ce9fa032b20f031e46df66ad04c79b6df4a2731945e6aa719460f3b4daef09f45ea671b2349140f915935c22040ba00
     HEAD_REF master
     PATCHES
         0002_fix_uwp.patch

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "curl",
-  "version": "8.1.2",
-  "port-version": 2,
+  "version": "8.2.0",
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1961,8 +1961,8 @@
       "port-version": 8
     },
     "curl": {
-      "baseline": "8.1.2",
-      "port-version": 2
+      "baseline": "8.2.0",
+      "port-version": 0
     },
     "curlpp": {
       "baseline": "2018-06-15",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c82d0a822ec7d4044a58c18f2e198df681822cf6",
+      "version": "8.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c2681b59ec41e4ec760fe10a60385202ee4763bb",
       "version": "8.1.2",
       "port-version": 2


### PR DESCRIPTION
Fixes #32640
Update port curl to the latest version 8.2.0.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->


Feature `brotli,c-ares,http2,idn,idn2,mbedtls,non-http,schannel,sspi,tool,websockets,winidn,winldap,winssl,wolfssl` tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static
