### PR TITLE
[skia] Fix include path

### DIFF
--- a/ports/skia/skiaConfig.cmake
+++ b/ports/skia/skiaConfig.cmake
@@ -3,17 +3,9 @@ message(AUTHOR_WARNING "find_package(skia) is deprecated.\n${usage}")
 include(CMakeFindDependencyMacro)
 find_dependency(unofficial-skia)
 if(NOT TARGET skia)
-    get_filename_component(z_vcpkg_skia_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
-    get_filename_component(z_vcpkg_skia_root "${z_vcpkg_skia_root}" PATH)
-    get_filename_component(z_vcpkg_skia_root "${z_vcpkg_skia_root}" PATH)
-    if(z_vcpkg_skia_root STREQUAL "/")
-        set(z_vcpkg_skia_root "")
-    endif()
     add_library(skia INTERFACE IMPORTED)
     set_target_properties(skia PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${z_vcpkg_skia_root}/include"
         INTERFACE_LINK_LIBRARIES unofficial::skia::skia
     )
     add_library(skia::skia ALIAS skia)
-    unset(z_vcpkg_skia_root)
 endif()

--- a/ports/skia/unofficial-skia-config.cmake
+++ b/ports/skia/unofficial-skia-config.cmake
@@ -28,7 +28,7 @@ if(NOT TARGET unofficial::skia::skia)
 
     add_library(unofficial::skia::skia UNKNOWN IMPORTED)
     set_target_properties(unofficial::skia::skia PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${z_vcpkg_skia_root}/include/skia"
+        INTERFACE_INCLUDE_DIRECTORIES "${z_vcpkg_skia_root}/include/skia;${z_vcpkg_skia_root}/include"
     )
 
     find_library(z_vcpkg_skia_lib_release NAMES skia skia.dll PATHS "${z_vcpkg_skia_root}/lib" NO_DEFAULT_PATH)

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "skia",
   "version": "0.36.0",
-  "port-version": 8,
+  "port-version": 9,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7590,7 +7590,7 @@
     },
     "skia": {
       "baseline": "0.36.0",
-      "port-version": 8
+      "port-version": 9
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb6200d5ed99a1be9fac0b42f552396a0a7b6819",
+      "version": "0.36.0",
+      "port-version": 9
+    },
+    {
       "git-tree": "59bcc7110298012cf8f0d6e68ec8d04a4cb01e8b",
       "version": "0.36.0",
       "port-version": 8


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix #32657 and #28591
It was a mistake in the first place, and now it's time to fix it.