### PR TITLE
[sqlpp11] Fix link sqlite3 error

### DIFF
--- a/ports/sqlpp11/fix_link_sqlite3.patch
+++ b/ports/sqlpp11/fix_link_sqlite3.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 88a8ae0..a36cb19 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,7 +62,7 @@ if(DEPENDENCY_CHECK AND BUILD_POSTGRESQL_CONNECTOR)
+ endif()
+ 
+ if(DEPENDENCY_CHECK AND BUILD_SQLITE3_CONNECTOR)
+-  find_package(SQLite3 REQUIRED)
++  find_package(unofficial-sqlite3 CONFIG REQUIRED)
+ endif()
+ 
+ if(DEPENDENCY_CHECK AND BUILD_SQLCIPHER_CONNECTOR)
+@@ -89,7 +89,7 @@ target_compile_features(sqlpp11 INTERFACE cxx_std_11)
+ 
+ 
+ if(BUILD_SQLITE3_CONNECTOR)
+-  add_component(NAME sqlite3 DEPENDENCIES SQLite::SQLite3)
++  add_component(NAME sqlite3 DEPENDENCIES unofficial::sqlite3::sqlite3)
+ endif()
+ 
+ if(BUILD_SQLCIPHER_CONNECTOR)
+diff --git a/cmake/configs/Sqlpp11Config.cmake b/cmake/configs/Sqlpp11Config.cmake
+index c25da97..b15524e 100644
+--- a/cmake/configs/Sqlpp11Config.cmake
++++ b/cmake/configs/Sqlpp11Config.cmake
+@@ -30,6 +30,7 @@ list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+ include(CMakeFindDependencyMacro)
+ find_dependency(Threads)
+ find_dependency(date REQUIRED)
++find_dependency(unofficial-sqlite3 CONFIG)
+ 
+ # Work out the set of components to load
+ if(${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)

--- a/ports/sqlpp11/portfile.cmake
+++ b/ports/sqlpp11/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         ddl2cpp_path.patch
+        fix_link_sqlite3.patch
 )
 
 vcpkg_check_features(

--- a/ports/sqlpp11/vcpkg.json
+++ b/ports/sqlpp11/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlpp11",
   "version": "0.61",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A type safe embedded domain specific language for SQL queries and results in C++.",
   "homepage": "https://github.com/rbock/sqlpp11",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7798,7 +7798,7 @@
     },
     "sqlpp11": {
       "baseline": "0.61",
-      "port-version": 2
+      "port-version": 3
     },
     "sqlpp11-connector-mysql": {
       "baseline": "0.61",

--- a/versions/s-/sqlpp11.json
+++ b/versions/s-/sqlpp11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f84d46c5d6cac9efc370ba6d4a4d0788281481c5",
+      "version": "0.61",
+      "port-version": 3
+    },
+    {
       "git-tree": "1800c18be7c4fe76b515891d6f7d51525873f264",
       "version": "0.61",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/32671
```
The link interface of target "sqlpp11::sqlite3" contains:

SQLite::SQLite3

but the target was not found. Possible reasons include:

* There is a typo in the target name.
* A find_package call is missing for an IMPORTED target.
* An ALIAS target is missing.
```
Fix feature `sqlite3` can't link to `sqlite3` in `vcpkg` port, add `find_dependency(unofficial-sqlite3 CONFIG)` dependency lookup.

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.