### PR TITLE
[glm] Bump to 2023-06-08 & fix usage

### DIFF
--- a/ports/glm/portfile.cmake
+++ b/ports/glm/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO g-truc/glm
-    REF 5c46b9c07008ae65cb81ab79cd677ecc1934b903 #v0.9.9.8+20230608
+    REF 5c46b9c07008ae65cb81ab79cd677ecc1934b903 # commit on 2023-06-08
     SHA512 17315dd05059accf3d4084d35dd037d4001f88a1d91da9a6fd5cedecab652c8bef8efa89cd45e21cd227f964a03408401edc2384c22e50caa449abf71b23fd6a
     HEAD_REF master
 )

--- a/ports/glm/portfile.cmake
+++ b/ports/glm/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO g-truc/glm
-    REF bf71a834948186f4097caa076cd2663c69a10e1e #v0.9.9.8
-    SHA512 226266c02af616a96fb19ee32cf3f98347daa43a4fde5d618d36b38709dce1280de126c542524d40725ecf70359edcc5b60660554c65ce246514501fb4c9c87c
+    REF 5c46b9c07008ae65cb81ab79cd677ecc1934b903 #v0.9.9.8+20230608
+    SHA512 17315dd05059accf3d4084d35dd037d4001f88a1d91da9a6fd5cedecab652c8bef8efa89cd45e21cd227f964a03408401edc2384c22e50caa449abf71b23fd6a
     HEAD_REF master
 )
 
@@ -19,5 +19,5 @@ vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-# Put the license file where vcpkg expects it
-file(INSTALL "${SOURCE_PATH}/copying.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/copying.txt")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/glm/usage
+++ b/ports/glm/usage
@@ -1,0 +1,4 @@
+glm provides CMake targets:
+
+    find_package(glm CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE glm::glm)

--- a/ports/glm/vcpkg.json
+++ b/ports/glm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glm",
-  "version": "0.9.9.8",
-  "port-version": 2,
+  "version": "0.9.9.8+20230608",
   "description": "OpenGL Mathematics (GLM)",
   "homepage": "https://glm.g-truc.net",
   "license": "MIT",

--- a/ports/glm/vcpkg.json
+++ b/ports/glm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glm",
-  "version": "0.9.9.8+20230608",
+  "version-date": "2023-06-08",
   "description": "OpenGL Mathematics (GLM)",
   "homepage": "https://glm.g-truc.net",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2885,8 +2885,8 @@
       "port-version": 1
     },
     "glm": {
-      "baseline": "0.9.9.8",
-      "port-version": 2
+      "baseline": "2023-06-08",
+      "port-version": 0
     },
     "globjects": {
       "baseline": "1.1.0",

--- a/versions/g-/glm.json
+++ b/versions/g-/glm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6687c48e237aab1c30cf4c589d08f698f73cf178",
+      "version-date": "2023-06-08",
+      "port-version": 0
+    },
+    {
       "git-tree": "b940020b1f2958fcc468c615becec6ca5ad3bff5",
       "version": "0.9.9.8",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

1. Bump to 0.9.9.8+20230608. Since latest release (0.9.9.8) of glm is about 3 years ago, there have been many important fixes and improvements during this time. 
2. Fix usage