### PR TITLE
[libguarded] Bump to 1.4.1

### DIFF
--- a/ports/libguarded/fix-install.patch
+++ b/ports/libguarded/fix-install.patch
@@ -1,0 +1,41 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 20eaf53..b81f056 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,20 +32,7 @@ include(CheckIncludeFiles)
+ include(CheckTypeSize)
+ 
+ # location for install or package
+-if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+-   include(GNUInstallDirs)
+-   set(CMAKE_INSTALL_RPATH "@executable_path")
+-
+-elseif (CMAKE_SYSTEM_NAME MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD|DragonFly)")
+-   include(GNUInstallDirs)
+-   set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+-
+-elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+-   set(CMAKE_INSTALL_BINDIR bin)
+-   set(CMAKE_INSTALL_LIBDIR lib)
+-   set(CMAKE_INSTALL_INCLUDEDIR include)
+-
+-endif()
++include(GNUInstallDirs)
+ 
+ set(PACKAGE           "cs_libguarded")
+ set(PACKAGE_NAME      "CsLibGuarded")
+@@ -98,13 +85,7 @@ else()
+ endif()
+ 
+ # destination for cmake export files
+-if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+-   set(PKG_PREFIX "cmake/CsLibGuarded")
+-
+-else()
+-   set(PKG_PREFIX "${CMAKE_INSTALL_LIBDIR}/cmake/CsLibGuarded")
+-
+-endif()
++set(PKG_PREFIX "${CMAKE_INSTALL_LIBDIR}/cmake/CsLibGuarded")
+ 
+ # catch2 set up
+ if(BUILD_TESTS)

--- a/ports/libguarded/portfile.cmake
+++ b/ports/libguarded/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 9c1e82f42f228345f3b024bed5d08be643c00f8a
     SHA512 ab690489151f5f8451c63c8a78a89a586950f88d19b6df685d979db9442f36b68db402ae5a6749e75b17ac3e1c06447d2d4803d43f9d373031cc05d9b25770e9
     HEAD_REF master
+    PATCHES
+        fix-install.patch
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port

--- a/ports/libguarded/portfile.cmake
+++ b/ports/libguarded/portfile.cmake
@@ -1,11 +1,23 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO copperspice/cs_libguarded
-    REF 1f159aa866a50f5d2952de41d8a99821b8ec37df
-    SHA512 91380262e65ec7b8990c500c60b8d141960be24b69e01a4661c2e8fbfdb8e315c9a4509c2c65a74bc60a8fe690d6dbc8f2b39757d13da5068c95283a19d4c6c4
+    REF 9c1e82f42f228345f3b024bed5d08be643c00f8a
+    SHA512 ab690489151f5f8451c63c8a78a89a586950f88d19b6df685d979db9442f36b68db402ae5a6749e75b17ac3e1c06447d2d4803d43f9d373031cc05d9b25770e9
     HEAD_REF master
 )
 
-File(COPY ${SOURCE_PATH}/src/libguarded DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+set(VCPKG_BUILD_TYPE release) # header-only port
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME CsLibGuarded CONFIG_PATH lib/cmake/CsLibGuarded)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libguarded/usage
+++ b/ports/libguarded/usage
@@ -1,0 +1,4 @@
+CsLibGuarded provides CMake targets:
+
+    find_package(CsLibGuarded CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CsLibGuarded::CsLibGuarded)

--- a/ports/libguarded/vcpkg.json
+++ b/ports/libguarded/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "libguarded",
-  "version-date": "2019-08-27",
-  "port-version": 3,
+  "version": "1.4.1",
   "description": "The libGuarded library is a standalone header-only library for multithreaded programming.",
-  "homepage": "https://github.com/copperspice/libguarded"
+  "homepage": "https://github.com/copperspice/libguarded",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/libguarded/vcpkg.json
+++ b/ports/libguarded/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libguarded",
   "version": "1.4.1",
-  "description": "The libGuarded library is a standalone header-only library for multithreaded programming.",
+  "description": "Header-only library for multithreaded programming.",
   "homepage": "https://github.com/copperspice/libguarded",
   "license": "BSD-2-Clause",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4141,8 +4141,8 @@
       "port-version": 5
     },
     "libguarded": {
-      "baseline": "2019-08-27",
-      "port-version": 3
+      "baseline": "1.4.1",
+      "port-version": 0
     },
     "libgwenhywfar": {
       "baseline": "5.6.0",

--- a/versions/l-/libguarded.json
+++ b/versions/l-/libguarded.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ed900882ffd0bc91478f8c6c3adc851a0617784",
+      "version": "1.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "139aa9fff34e4003d7dab0be9699501c91a6d8ad",
       "version-date": "2019-08-27",
       "port-version": 3

--- a/versions/l-/libguarded.json
+++ b/versions/l-/libguarded.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3ed900882ffd0bc91478f8c6c3adc851a0617784",
+      "git-tree": "626fd11ff4faf2724d17861ab93b4fa9bb002591",
       "version": "1.4.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Close #32672