### PR TITLE
[drogon] fix: patch drogon redis link

### DIFF
--- a/ports/drogon/portfile.cmake
+++ b/ports/drogon/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         vcpkg.patch
+        vcpkg_redis.patch
         drogon_config.patch
         fix_gcc13.patch #https://github.com/drogonframework/drogon/pull/1563
 )

--- a/ports/drogon/vcpkg.json
+++ b/ports/drogon/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "drogon",
   "version": "1.8.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A C++14/17 based HTTP web application framework running on Linux/macOS/Unix/Windows",
   "homepage": "https://github.com/an-tao/drogon",
   "documentation": "https://drogon.docsforge.com/master/overview/",

--- a/ports/drogon/vcpkg_redis.patch
+++ b/ports/drogon/vcpkg_redis.patch
@@ -1,0 +1,69 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4406362..62d7f50 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -461,33 +461,28 @@ if (BUILD_SQLITE)
+ endif (BUILD_SQLITE)
+ 
+ if (BUILD_REDIS)
+-    find_package(Hiredis)
+-    if (Hiredis_FOUND)
+-        add_definitions(-DUSE_REDIS)
+-        target_link_libraries(${PROJECT_NAME} PRIVATE Hiredis_lib)
+-        set(DROGON_SOURCES
+-            ${DROGON_SOURCES}
+-            nosql_lib/redis/src/RedisClientImpl.cc
+-            nosql_lib/redis/src/RedisClientLockFree.cc
+-            nosql_lib/redis/src/RedisClientManager.cc
+-            nosql_lib/redis/src/RedisConnection.cc
+-            nosql_lib/redis/src/RedisResult.cc
+-            nosql_lib/redis/src/RedisTransactionImpl.cc
+-            nosql_lib/redis/src/SubscribeContext.cc
+-            nosql_lib/redis/src/RedisSubscriberImpl.cc)
+-        set(private_headers
+-            ${private_headers}
+-            nosql_lib/redis/src/RedisClientImpl.h
+-            nosql_lib/redis/src/RedisClientLockFree.h
+-            nosql_lib/redis/src/RedisConnection.h
+-            nosql_lib/redis/src/RedisTransactionImpl.h
+-            nosql_lib/redis/src/SubscribeContext.h
+-            nosql_lib/redis/src/RedisSubscriberImpl.h)
+-
+-    endif (Hiredis_FOUND)
+-endif (BUILD_REDIS)
+-
+-if (NOT Hiredis_FOUND)
++    find_package(hiredis CONFIG REQUIRED)
++    add_definitions(-DUSE_REDIS)
++    target_link_libraries(${PROJECT_NAME} PRIVATE hiredis::hiredis)
++    set(DROGON_SOURCES
++        ${DROGON_SOURCES}
++        nosql_lib/redis/src/RedisClientImpl.cc
++        nosql_lib/redis/src/RedisClientLockFree.cc
++        nosql_lib/redis/src/RedisClientManager.cc
++        nosql_lib/redis/src/RedisConnection.cc
++        nosql_lib/redis/src/RedisResult.cc
++        nosql_lib/redis/src/RedisTransactionImpl.cc
++        nosql_lib/redis/src/SubscribeContext.cc
++        nosql_lib/redis/src/RedisSubscriberImpl.cc)
++    set(private_headers
++        ${private_headers}
++        nosql_lib/redis/src/RedisClientImpl.h
++        nosql_lib/redis/src/RedisClientLockFree.h
++        nosql_lib/redis/src/RedisConnection.h
++        nosql_lib/redis/src/RedisTransactionImpl.h
++        nosql_lib/redis/src/SubscribeContext.h
++        nosql_lib/redis/src/RedisSubscriberImpl.h)
++else()
+     set(DROGON_SOURCES
+         ${DROGON_SOURCES}
+         lib/src/RedisClientSkipped.cc
+@@ -496,7 +491,7 @@ if (NOT Hiredis_FOUND)
+     set(private_headers
+         ${private_headers}
+         lib/src/RedisClientManager.h)
+-endif (NOT Hiredis_FOUND)
++endif (BUILD_REIDS)
+ 
+ if (BUILD_TESTING)
+     add_subdirectory(nosql_lib/redis/tests)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2194,7 +2194,7 @@
     },
     "drogon": {
       "baseline": "1.8.4",
-      "port-version": 1
+      "port-version": 2
     },
     "dstorage": {
       "baseline": "1.2.0",

--- a/versions/d-/drogon.json
+++ b/versions/d-/drogon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddae8d79f08366e60ecaddf472fcf24a2c8c2ffd",
+      "version": "1.8.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "29376f140626e1d34d6ca573b5a00e6dd7006d2f",
       "version": "1.8.4",
       "port-version": 1


### PR DESCRIPTION
drogon's source root CMakeLists.txt is now patched to link to `hiredis::hiredis` provided by vcpkg hiredis port. previosly it was linking against `hiredis_lib` target.

when using vcpkg manifest mode it used to link drogon.dll target to hiredis.dll while on debug build, hiredisd.dll is only available. this patch resolves this problem.

Fixes #32584

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
