### PR TITLE
Csound

### DIFF
--- a/ports/csound/error_address.patch
+++ b/ports/csound/error_address.patch
@@ -1,0 +1,16 @@
+diff --git a/util1/CMakeLists.txt b/util1/CMakeLists.txt
+index 639ed0a..30e1661 100644
+--- a/util1/CMakeLists.txt
++++ b/util1/CMakeLists.txt
+@@ -17,8 +17,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG OR MSVC)
+         csd_util/base64.c csd_util/makecsd.c)
+     make_utility(makecsd "${makecsd_SRCS}")
+ 
+-    set(scot_SRCS
+-        scot/scot_main.c scot/scot.c)
+-    make_utility(scot "${scot_SRCS}")
++    # set(scot_SRCS
++    #     scot/scot_main.c scot/scot.c)
++    # make_utility(scot "${scot_SRCS}")
+ endif()
+ 

--- a/ports/csound/format_truncation.patch
+++ b/ports/csound/format_truncation.patch
@@ -1,0 +1,32 @@
+diff --git a/InOut/rtjack.c b/InOut/rtjack.c
+index a0b1c97..b607de3 100644
+--- a/InOut/rtjack.c
++++ b/InOut/rtjack.c
+@@ -341,7 +341,8 @@ static void listPorts(CSOUND *csound, int isOutput){
+ 
+ static void rtJack_RegisterPorts(RtJackGlobals *p)
+ {
+-    char          portName[MAX_NAME_LEN + 4];
++    volatile int max_name_length_plus_4 = MAX_NAME_LEN + 4;
++    char          portName[max_name_length_plus_4];
+     unsigned long flags = 0UL;
+     int           i;
+     CSOUND *csound = p->csound;
+@@ -351,7 +352,7 @@ static void rtJack_RegisterPorts(RtJackGlobals *p)
+     if (p->inputEnabled) {
+       /* register input ports */
+       for (i = 0; i < p->nChannels_i; i++) {
+-        snprintf(portName, MAX_NAME_LEN + 4, "%s%d", p->inputPortName, i + 1);
++        snprintf(portName, max_name_length_plus_4, "%s%d", p->inputPortName, i + 1);
+         p->inPorts[i] = jack_port_register(p->client, &(portName[0]),
+                                            JACK_DEFAULT_AUDIO_TYPE,
+                                            flags | JackPortIsInput, 0UL);
+@@ -362,7 +363,7 @@ static void rtJack_RegisterPorts(RtJackGlobals *p)
+     if (p->outputEnabled) {
+       /* register output ports */
+       for (i = 0; i < p->nChannels; i++) {
+-        snprintf(portName, MAX_NAME_LEN + 4, "%s%d", p->outputPortName, i + 1);
++        snprintf(portName, max_name_length_plus_4, "%s%d", p->outputPortName, i + 1);
+         p->outPorts[i] = jack_port_register(p->client, &(portName[0]),
+                                             JACK_DEFAULT_AUDIO_TYPE,
+                                             flags | JackPortIsOutput, 0UL);

--- a/ports/csound/incompatible_pointer_types.patch
+++ b/ports/csound/incompatible_pointer_types.patch
@@ -1,0 +1,14 @@
+diff --git a/Top/threadsafe.c b/Top/threadsafe.c
+index 8cf7335..797f72e 100644
+--- a/Top/threadsafe.c
++++ b/Top/threadsafe.c
+@@ -70,7 +70,8 @@ typedef struct _message_queue {
+ 
+ /* atomicGetAndIncrementWithModulus */
+ static long atomicGet_Incr_Mod(volatile long* val, long mod) {
+-  volatile long oldVal, newVal;
++  volatile long oldVal;
++  long newVal;
+   do {
+     oldVal = *val;
+     newVal = (oldVal + 1) % mod;

--- a/ports/csound/misleading_indentation.patch
+++ b/ports/csound/misleading_indentation.patch
@@ -1,0 +1,16 @@
+diff --git a/Engine/musmon.c b/Engine/musmon.c
+index 58f10cc..0c90af9 100644
+--- a/Engine/musmon.c
++++ b/Engine/musmon.c
+@@ -63,9 +63,9 @@ void print_csound_version(CSOUND*);
+ 
+ #ifdef HAVE_PTHREAD_SPIN_LOCK
+ #define RT_SPIN_UNLOCK \
+-if(csound->oparms->realtime) \
++if(csound->oparms->realtime) { \
+   csoundSpinUnLock(&csound->alloc_spinlock); \
+-  trylock = CSOUND_SUCCESS; } }
++  trylock = CSOUND_SUCCESS; } } }
+ #else
+ #define RT_SPIN_UNLOCK csoundSpinUnLock(&csound->alloc_spinlock);
+ #endif

--- a/ports/csound/permission_denied.patch
+++ b/ports/csound/permission_denied.patch
@@ -1,0 +1,40 @@
+diff --git a/interfaces/CMakeLists.txt b/interfaces/CMakeLists.txt
+index aff6e8f..9f276c4 100644
+--- a/interfaces/CMakeLists.txt
++++ b/interfaces/CMakeLists.txt
+@@ -109,21 +109,21 @@ check_deps(BUILD_LUA_INTERFACE SWIG_FOUND BUILD_CXX_INTERFACE
+ LUA_LIBRARY LUA_H_PATH)
+ 
+ 
+-if(NOT APPLE)
+-      execute_process (
+-           COMMAND python3 -c
+-           "import site, sys; sys.stdout.write(site.getsitepackages()[0])"
+-           OUTPUT_VARIABLE PYTHON3_SITE_PACKAGES
+-         )
+-      SET(PYTHON3_MODULE_INSTALL_DIR ${PYTHON3_SITE_PACKAGES} CACHE
+-       PATH "Python3 module install dir")
++# if(NOT APPLE)
++#       execute_process (
++#            COMMAND python3 -c
++#            "import site, sys; sys.stdout.write(site.getsitepackages()[0])"
++#            OUTPUT_VARIABLE PYTHON3_SITE_PACKAGES
++#          )
++#       SET(PYTHON3_MODULE_INSTALL_DIR ${PYTHON3_SITE_PACKAGES} CACHE
++#        PATH "Python3 module install dir")
+        
+-      if (PYTHON3_MODULE_INSTALL_DIR)
+-         message(STATUS "PYTHON3 MODULE INSTALL DIR: ${PYTHON3_MODULE_INSTALL_DIR}" )
+-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/ctcsound.py
+-            DESTINATION ${PYTHON3_MODULE_INSTALL_DIR})
+-      endif()
+-endif(NOT APPLE)
++#       if (PYTHON3_MODULE_INSTALL_DIR)
++#          message(STATUS "PYTHON3 MODULE INSTALL DIR: ${PYTHON3_MODULE_INSTALL_DIR}" )
++#         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/ctcsound.py
++#             DESTINATION ${PYTHON3_MODULE_INSTALL_DIR})
++#       endif()
++# endif(NOT APPLE)
+ 
+ 
+ if(BUILD_JAVA_INTERFACE OR BUILD_LUA_INTERFACE)

--- a/ports/csound/portfile.cmake
+++ b/ports/csound/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO csound/csound
+    REF 6.18.1
+    SHA512 4ea4dccb36017c96482389a8d139f6f55c79c5ceb9cc34e6d2bfabcb930b4833d0301be4a4b21929db27b2d8ce30754b5c5867acd2ea5a849135e1b8d1506acf
+    PATCHES 
+        "use_after_free.patch"
+        "misleading_indentation.patch"
+        "incompatible_pointer_types.patch"
+        "format_truncation.patch"
+        "error_address.patch"
+        "permission_denied.patch"
+)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/csound" RENAME copyright)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/csound/use_after_free.patch
+++ b/ports/csound/use_after_free.patch
@@ -1,0 +1,25 @@
+diff --git a/Engine/memalloc.c b/Engine/memalloc.c
+index 541b6eb..999dedb 100644
+--- a/Engine/memalloc.c
++++ b/Engine/memalloc.c
+@@ -207,13 +207,13 @@ void *mrealloc(CSOUND *csound, void *oldp, size_t size)
+     /* allocate memory */
+     p = realloc((void*) pp, ALLOC_BYTES(size));
+     if (UNLIKELY(p == NULL)) {
+-#ifdef MEMDEBUG
+-      CSOUND_MEM_SPINLOCK
+-      /* alloc failed, restore original header */
+-      pp->magic = MEMALLOC_MAGIC;
+-      pp->ptr = oldp;
+-      CSOUND_MEM_SPINUNLOCK
+-#endif
++// #ifdef MEMDEBUG
++//       CSOUND_MEM_SPINLOCK
++//       /* alloc failed, restore original header */
++//       pp->magic = MEMALLOC_MAGIC;
++//       pp->ptr = oldp;
++//       CSOUND_MEM_SPINUNLOCK
++// #endif
+       memdie(csound, size);
+       return NULL;
+     }

--- a/ports/csound/vcpkg.json
+++ b/ports/csound/vcpkg.json
@@ -1,0 +1,42 @@
+{
+  "name": "csound",
+  "version-string": "6.18.1",
+  "description": "Csound is a sound and music computing system which was originally developed by Barry Vercoe in 1985 at MIT Media Lab.",
+  "license": " LGPL-2.1-only",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "libsndfile"
+    }
+  ],
+  "features": {
+    "real-time-portaudio": {
+      "description": "Enable PortAudio for real-time audio",
+      "dependencies": [
+        "portaudio"
+      ]
+    },
+    "real-time-jack": {
+      "description": "Enable Jack for real-time audio",
+      "dependencies": [
+        "jack2"
+      ]
+    },
+    "real-time-alsa": {
+      "description": "Enable ALSA for real-time audio",
+      "dependencies": [
+        "alsa"
+      ]
+    }
+  },
+  "default-features": [
+    "real-time-portaudio"
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
