### PR TITLE
[csound] Add new port CSound

### DIFF
--- a/ports/csound/add-dirent-to-ftsamplebank.patch
+++ b/ports/csound/add-dirent-to-ftsamplebank.patch
@@ -1,0 +1,34 @@
+From d4d5905e92f1c1c074015a301bb4be3030b674df Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Thu, 31 Aug 2023 01:09:35 +0100
+Subject: [PATCH] add dirent to ftsamplebank
+
+---
+ Opcodes/CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/Opcodes/CMakeLists.txt b/Opcodes/CMakeLists.txt
+index 82327ed3d..6ea32794f 100644
+--- a/Opcodes/CMakeLists.txt
++++ b/Opcodes/CMakeLists.txt
+@@ -23,12 +23,17 @@ message(STATUS "## Building Plugin Opcodes ##")
+ make_plugin(doppler doppler.cpp)
+ make_plugin(fractalnoise tl/fractalnoise.cpp)
+ make_plugin(ftsamplebank ftsamplebank.cpp)
++find_path(DIRENT_INCLUDE_DIRS "dirent.h" REQUIRED)
++target_include_directories(ftsamplebank PRIVATE ${DIRENT_INCLUDE_DIRS})
++
+ make_plugin(lfsr lfsr.cpp)
+ make_plugin(bformdec2 bformdec2.cpp)
+ make_plugin(mixer mixer.cpp)
+ make_plugin(signalflowgraph signalflowgraph.cpp)
+ make_plugin(ampmidid ampmidid.cpp)
+ 
++
++
+ if(APPLE)
+    make_plugin(arrayops arrayops.cpp)
+    make_plugin(pvsops pvsops.cpp)
+-- 
+2.39.2
+

--- a/ports/csound/add-framework-option.patch
+++ b/ports/csound/add-framework-option.patch
@@ -1,0 +1,89 @@
+From 7552acc22040e441a5100b09253753d37e62e014 Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Tue, 29 Aug 2023 11:54:37 +0100
+Subject: [PATCH] add framework option
+
+---
+ CMakeLists.txt         | 18 ++++++++++++------
+ include/CMakeLists.txt |  2 +-
+ 2 files changed, 13 insertions(+), 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cc54076d9..bc1dd2a7f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -185,6 +185,7 @@ option(BUILD_TESTS "Build tests" ON)
+ option(USE_GIT_COMMIT "Show the git commit in version information" ON)
+ option(REQUIRE_PTHREADS "For non-Windows systems, set whether Csound will use threads or not" ON)
+ option(DEBUG_ERROR_ON_WARNING "Error on compiler warning" ON)
++option(APPLE_FRAMEWORK "Build framework on Apple" ON)
+ 
+ # Include this after the install path definitions so we can override them here.
+ # Also after function definitions so we can use them there
+@@ -369,14 +370,14 @@ endif()
+ 
+ # Set plugins install directory
+ if(USE_DOUBLE)
+-    if(APPLE)
++    if(APPLE AND APPLE_FRAMEWORK)
+         set(CSOUNDLIB "CsoundLib64")
+         set(PLUGIN_INSTALL_DIR "${CS_FRAMEWORK_DEST}/${CSOUNDLIB}.framework/Versions/${APIVERSION}/Resources/Opcodes64")
+     else()
+         set(CSOUNDLIB "csound64")
+     endif()
+ else()
+-    if(APPLE)
++    if(APPLE AND APPLE_FRAMEWORK)
+         set(CSOUNDLIB "CsoundLib")
+         set(PLUGIN_INSTALL_DIR "${CS_FRAMEWORK_DEST}/${CSOUNDLIB}.framework/Versions/${APIVERSION}/Resources/Opcodes")
+     else()
+@@ -392,8 +393,13 @@ if(APPLE)
+         get_filename_component(CS_FRAMEWORK_FULL_PATH ${PLUGIN_INSTALL_DIR} ABSOLUTE)
+     endif()
+ 
+-    add_definitions("-DCS_DEFAULT_PLUGINDIR=\"${CS_FRAMEWORK_FULL_PATH}\"")
+-    set(DEFAULT_OPCODEDIR ${CS_FRAMEWORK_FULL_PATH})
++    if (APPLE_FRAMEWORK)
++        add_definitions("-DCS_DEFAULT_PLUGINDIR=\"${CS_FRAMEWORK_FULL_PATH}\"")
++        set(DEFAULT_OPCODEDIR ${CS_FRAMEWORK_FULL_PATH})
++    else()
++        set(DEFAULT_OPCODEDIR "${PLUGIN_INSTALL_DIR}")
++        add_definitions("-DCS_DEFAULT_PLUGINDIR=\"${PLUGIN_INSTALL_DIR}\"")
++    endif()
+ 
+     # dir relative to $HOME
+     if(USE_DOUBLE)
+@@ -1124,7 +1130,7 @@ if(INIT_STATIC_MODULES)
+     set_target_properties(${CSOUNDLIB} PROPERTIES COMPILE_FLAGS "-DINIT_STATIC_MODULES")
+ endif()
+ 
+-if(APPLE)
++if(APPLE AND APPLE_FRAMEWORK)
+     set_target_properties(${CSOUNDLIB} PROPERTIES FRAMEWORK YES)
+     set_target_properties(${CSOUNDLIB} PROPERTIES FRAMEWORK_VERSION "${APIVERSION}")
+     set_target_properties(${CSOUNDLIB} PROPERTIES PUBLIC_HEADER
+@@ -1448,7 +1454,7 @@ install(FILES ${CMAKE_SOURCE_DIR}/cmake/Modules/FindCsound.cmake
+         DESTINATION "${CMAKE_INSTALL_PREFIX}/share/cmake/Csound")
+ 
+ # install samples
+-if(APPLE)
++if(APPLE AND APPLE_FRAMEWORK)
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/samples
+           DESTINATION  ${CS_FRAMEWORK_DEST}/${CSOUNDLIB}.framework/Versions/${APIVERSION})
+ else()
+diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
+index 32413a89e..d4b8200f9 100644
+--- a/include/CMakeLists.txt
++++ b/include/CMakeLists.txt
+@@ -19,7 +19,7 @@ list(APPEND csheaders
+     ../interfaces/csPerfThread.hpp)
+ 
+ 
+-if(NOT APPLE)
++if(NOT (APPLE AND APPLE_FRAMEWORK))
+     INSTALL(FILES ${csheaders} DESTINATION ${HEADER_INSTALL_DIR})
+     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/float-version.h
+      DESTINATION ${HEADER_INSTALL_DIR})
+-- 
+2.39.2
+

--- a/ports/csound/add-python-option.patch
+++ b/ports/csound/add-python-option.patch
@@ -1,0 +1,42 @@
+From ee58eb8e5c2ee72fb7c71574753cd34f9261c69b Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Tue, 29 Aug 2023 11:21:24 +0100
+Subject: [PATCH] add python option
+
+---
+ interfaces/CMakeLists.txt | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/interfaces/CMakeLists.txt b/interfaces/CMakeLists.txt
+index aff6e8fec..cf4d123aa 100644
+--- a/interfaces/CMakeLists.txt
++++ b/interfaces/CMakeLists.txt
+@@ -6,6 +6,7 @@ option(BUILD_CXX_INTERFACE "Build the C++ interface library" ON)
+ option(BUILD_JAVA_INTERFACE "Build the Java interface (needs BUILD_CXX_INTERFACE)" ON)
+ option(BUILD_LUA_INTERFACE "Build the Lua interface (needs
+ BUILD_CXX_INTERFACE)" ON)
++option(BUILD_PYTHON_INTERFACE "Build the Python interface" ON)
+ 
+ if(BUILD_CXX_INTERFACE)
+     message(STATUS "Building C++ interface library.")
+@@ -109,7 +110,7 @@ check_deps(BUILD_LUA_INTERFACE SWIG_FOUND BUILD_CXX_INTERFACE
+ LUA_LIBRARY LUA_H_PATH)
+ 
+ 
+-if(NOT APPLE)
++if(BUILD_PYTHON_INTERFACE AND NOT APPLE)
+       execute_process (
+            COMMAND python3 -c
+            "import site, sys; sys.stdout.write(site.getsitepackages()[0])"
+@@ -123,7 +124,7 @@ if(NOT APPLE)
+         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/ctcsound.py
+             DESTINATION ${PYTHON3_MODULE_INSTALL_DIR})
+       endif()
+-endif(NOT APPLE)
++endif()
+ 
+ 
+ if(BUILD_JAVA_INTERFACE OR BUILD_LUA_INTERFACE)
+-- 
+2.39.2
+

--- a/ports/csound/add-vcpkg-dependencies-option.patch
+++ b/ports/csound/add-vcpkg-dependencies-option.patch
@@ -1,0 +1,244 @@
+From ca5bccc2d35086e63752bbc37ac86c1cde025fb6 Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Thu, 31 Aug 2023 01:07:22 +0100
+Subject: [PATCH] add vcpkg dependencies option
+
+---
+ CMakeLists.txt            | 50 ++++++++++++++++++++++++++++-----------
+ InOut/CMakeLists.txt      | 44 +++++++++++++++++++++++-----------
+ interfaces/CMakeLists.txt |  7 +++++-
+ util/CMakeLists.txt       |  7 +++++-
+ 4 files changed, 78 insertions(+), 30 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0eb997c02..af1f0591c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -198,6 +198,7 @@ option(USE_GIT_COMMIT "Show the git commit in version information" ON)
+ option(REQUIRE_PTHREADS "For non-Windows systems, set whether Csound will use threads or not" ON)
+ option(DEBUG_ERROR_ON_WARNING "Error on compiler warning" ON)
+ option(APPLE_FRAMEWORK "Build framework on Apple" ON)
++option(USE_VCPKG_DEPENDENCIES "Use dependencies from vcpkg" OFF)
+ 
+ # Include this after the install path definitions so we can override them here.
+ # Also after function definitions so we can use them there
+@@ -485,7 +486,7 @@ SET(BUILD_SHARED_LIBS ON)
+ 
+ ## HEADER/LIBRARY/OTHER CHECKS ##
+ # First, required stuff
+-if(MSVC)
++if(MSVC OR USE_VCPKG_DEPENDENCIES)
+     find_package(SndFile CONFIG REQUIRED)
+ else()
+     find_library(LIBSNDFILE_LIBRARY NAMES sndfile libsndfile-1 libsndfile)
+@@ -498,11 +499,13 @@ endif()
+ if(EMSCRIPTEN)
+   include_directories(emscripten/deps/libsndfile-1.0.25/src/)
+ endif()
+-find_path(SNDFILE_H_PATH sndfile.h)
+-if(SNDFILE_H_PATH)
+-    include_directories(${SNDFILE_H_PATH})
+-else()
+-    message(FATAL_ERROR "Could not find sndfile.h")
++if (NOT USE_VCPKG_DEPENDENCIES)
++    find_path(SNDFILE_H_PATH sndfile.h)
++    if(SNDFILE_H_PATH)
++        include_directories(${SNDFILE_H_PATH})
++    else()
++        message(FATAL_ERROR "Could not find sndfile.h")
++    endif()
+ endif()
+ 
+ SET(CMAKE_REQUIRED_LIBRARIES ${LIBSNDFILE_LIBRARY})
+@@ -702,7 +705,9 @@ if(REQUIRE_PTHREADS AND (PTHREAD_LIBRARY OR HAIKU))
+   endif()
+ endif()
+ 
+-include_directories(${LIBSNDFILE_INCLUDE_DIRECTORY})
++if (NOT USE_VCPKG_DEPENDENCIES)
++    include_directories(${LIBSNDFILE_INCLUDE_DIRECTORY})
++endif()
+ # get the git hash and pass it to csound
+ SET(git_hash_values "none")
+ if(USE_GIT_COMMIT)
+@@ -1207,8 +1212,11 @@ else()
+     FRAMEWORK DESTINATION "${CS_FRAMEWORK_DEST}")
+ endif()
+ 
+-
+-set(libcsound_LIBS ${LIBSNDFILE_LIBRARY})
++if (USE_VCPKG_DEPENDENCIES)
++    set(libcsound_LIBS "")
++else()
++    set(libcsound_LIBS ${LIBSNDFILE_LIBRARY})
++endif()
+ 
+ if(REQUIRE_PTHREADS AND PTHREAD_LIBRARY)
+   list(APPEND libcsound_LIBS ${PTHREAD_LIBRARY})
+@@ -1220,7 +1228,9 @@ endif()
+ 
+ if(WIN32)
+     list(APPEND libcsound_LIBS "${CSOUND_WINDOWS_LIBRARIES}")
+-    list(APPEND libcsound_LIBS "${LIBSNDFILE_SUPPORT_LIBS}")
++    if (NOT USE_VCPKG_DEPENDENCIES)
++        list(APPEND libcsound_LIBS "${LIBSNDFILE_SUPPORT_LIBS}")
++    endif()
+ endif()
+ 
+ if(USE_CURL AND CURL_FOUND)
+@@ -1366,9 +1376,15 @@ endif()
+ 
+ target_compile_options(${CSOUNDLIB} PRIVATE ${libcsound_CFLAGS})
+ if(MSVC)
+-    target_link_libraries(${CSOUNDLIB} PRIVATE SndFile::sndfile ws2_32)
++    target_link_libraries(${CSOUNDLIB} PUBLIC SndFile::sndfile)
++    target_link_libraries(${CSOUNDLIB} PRIVATE ws2_32)
+ else()
+-    target_link_libraries(${CSOUNDLIB} PRIVATE ${libcsound_LIBS})
++    if (USE_VCPKG_DEPENDENCIES)
++        target_link_libraries(${CSOUNDLIB} PUBLIC SndFile::sndfile)
++        target_link_libraries(${CSOUNDLIB} PRIVATE ${libcsound_LIBS})
++    else()
++        target_link_libraries(${CSOUNDLIB} PRIVATE ${libcsound_LIBS})
++    endif()
+ endif()
+ 
+ set_target_properties(${CSOUNDLIB} PROPERTIES
+@@ -1387,9 +1403,15 @@ if(BUILD_STATIC_LIBRARY)
+     endif()
+ 
+     if(MSVC)
+-        target_link_libraries(${CSOUNDLIB_STATIC} PRIVATE SndFile::sndfile ${CSOUND_WINDOWS_LIBRARIES})
++        target_link_libraries(${CSOUNDLIB_STATIC} PUBLIC SndFile::sndfile)
++        target_link_libraries(${CSOUNDLIB_STATIC} PRIVATE ${CSOUND_WINDOWS_LIBRARIES})
+     else()
+-        target_link_libraries(${CSOUNDLIB_STATIC} ${libcsound_LIBS})
++        if (USE_VCPKG_DEPENDENCIES)
++            target_link_libraries(${CSOUNDLIB_STATIC} PUBLIC SndFile::sndfile)
++            target_link_libraries(${CSOUNDLIB_STATIC} PRIVATE ${libcsound_LIBS})
++        else()
++            target_link_libraries(${CSOUNDLIB_STATIC} ${libcsound_LIBS})
++        endif()
+     endif()
+ 
+     set_target_properties(${CSOUNDLIB_STATIC} PROPERTIES
+diff --git a/InOut/CMakeLists.txt b/InOut/CMakeLists.txt
+index 8a3fe7737..0a1986476 100644
+--- a/InOut/CMakeLists.txt
++++ b/InOut/CMakeLists.txt
+@@ -23,11 +23,11 @@ if(USE_ALSA AND LINUX)
+ endif()
+ if(USE_PORTAUDIO)
+     # FIXME the msvc branch should use the VCPKG config file for portaudio but it's currently broken
+-    # if(MSVC)
+-        # find_package(PORTAUDIO CONFIG REQUIRED)
+-    # else()
++    if(USE_VCPKG_DEPENDENCIES)
++        find_package(portaudio CONFIG)
++    else()
+         find_package(PORTAUDIO)
+-    # endif()
++    endif()
+     
+     # find_path(PORTAUDIO_INCLUDE_PATH portaudio.h)
+     # find_library(PORTAUDIO_LIBRARY NAMES portaudio portaudio_x64)
+@@ -46,7 +46,12 @@ if(USE_PORTAUDIO)
+     # endif()
+ endif()
+ if(USE_PORTMIDI)
+-    find_package(PORTMIDI)
++    if(USE_VCPKG_DEPENDENCIES)
++        find_package(Threads)
++        find_package(PortMidi CONFIG)  
++    else()
++        find_package(PORTMIDI)
++    endif()
+ endif()
+ if(USE_JACK)
+     find_library(JACK_LIBRARY jack)
+@@ -127,11 +132,18 @@ if(USE_PULSEAUDIO)
+     make_plugin(rtpulse rtpulse.c ${PULSEAUDIO_LIBRARY} ${PULSESIMPLE_LIBRARY})
+ endif()
+ 
+-if(PORTAUDIO_FOUND)
++if(PORTAUDIO_FOUND OR (TARGET portaudio_static) OR (TARGET portaudio))
+     message(STATUS "Building rtpa module.")
+     make_plugin(rtpa rtpa.c)
+ 
+-    if(MSVC)
++    if (USE_VCPKG_DEPENDENCIES)
++        # make sure we link the right target
++        if (TARGET portaudio_static)
++            target_link_libraries(rtpa PRIVATE portaudio_static)
++        else()
++            target_link_libraries(rtpa PRIVATE portaudio)
++        endif()
++    elseif(MSVC)
+         # FIXME should be able to use VCPKG export but not working currently
+         # target_link_libraries(rtpa PRIVATE portaudio portaudio_static)
+         target_link_libraries(rtpa PRIVATE ${PORTAUDIO_LIBRARIES})
+@@ -144,14 +156,18 @@ else()
+   message(STATUS "Portaudio v19 Found: ${PORTAUDIO_V19}.")
+ endif()
+ 
+-if(USE_PORTMIDI AND PORTMIDI_FOUND)
++if(USE_PORTMIDI AND (PORTMIDI_FOUND OR PortMidi_FOUND))
+     make_plugin(pmidi pmidi.c)
+-    target_include_directories(pmidi PRIVATE ${PORTMIDI_INCLUDE_DIRS})
+-    target_link_libraries(pmidi ${PORTMIDI_LIBRARIES})
+-    if(WIN32)
+-      target_link_libraries(pmidi ${CSOUND_WINDOWS_LIBRARIES})
+-    elseif(LINUX AND ALSA_LIBRARY)
+-      target_link_libraries(pmidi ${ALSA_LIBRARY})
++    if (USE_VCPKG_DEPENDENCIES)
++        target_link_libraries(pmidi PRIVATE PortMidi::portmidi)
++    else()
++        target_include_directories(pmidi PRIVATE ${PORTMIDI_INCLUDE_DIRS})
++        target_link_libraries(pmidi ${PORTMIDI_LIBRARIES})
++        if(WIN32)
++            target_link_libraries(pmidi ${CSOUND_WINDOWS_LIBRARIES})
++        elseif(LINUX AND ALSA_LIBRARY)
++            target_link_libraries(pmidi ${ALSA_LIBRARY})
++        endif()
+     endif()
+ endif()
+ 
+diff --git a/interfaces/CMakeLists.txt b/interfaces/CMakeLists.txt
+index 19ad3d1df..9c6c1b41e 100644
+--- a/interfaces/CMakeLists.txt
++++ b/interfaces/CMakeLists.txt
+@@ -38,7 +38,12 @@ if(BUILD_CXX_INTERFACE)
+     set(libcsnd6_CFLAGS "")
+     list(APPEND libcsnd6_LIBS ${CSOUNDLIB})
+ 
+-    target_link_libraries(libcsnd6 ${libcsnd6_LIBS})
++    if (USE_VCPKG_DEPENDENCIES)
++        target_link_libraries(libcsnd6 PUBLIC ${CSOUNDLIB} SndFile::sndfile)
++    else()
++        target_link_libraries(libcsnd6 ${libcsnd6_LIBS})
++    endif()
++
+     # users of this lib will need this dir included
+     target_include_directories(libcsnd6 INTERFACE
+         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+diff --git a/util/CMakeLists.txt b/util/CMakeLists.txt
+index ad34fdb1b..2d9df21e6 100644
+--- a/util/CMakeLists.txt
++++ b/util/CMakeLists.txt
+@@ -12,7 +12,12 @@ if(MSVC)
+     set(LIBSNDFILE_LIBRARY SndFile::sndfile)
+ endif()
+ 
+-make_plugin(stdutil "${stdutil_SRCS}" ${MATH_LIBRARY} ${LIBSNDFILE_LIBRARY} ${LIBSNDFILE_SUPPORT_LIBS})
++if (USE_VCPKG_DEPENDENCIES)
++    make_plugin(stdutil "${stdutil_SRCS}")
++    target_link_libraries(stdutil PRIVATE ${MATH_LIBRARY} SndFile::sndfile)
++else()
++    make_plugin(stdutil "${stdutil_SRCS}" ${MATH_LIBRARY} ${LIBSNDFILE_LIBRARY} ${LIBSNDFILE_SUPPORT_LIBS})
++endif()
+ 
+ if(BUILD_UTILITIES)
+     make_utility(atsa        atsa_main.c)
+-- 
+2.39.2
+

--- a/ports/csound/change-windows-plugin-folder.patch
+++ b/ports/csound/change-windows-plugin-folder.patch
@@ -1,0 +1,38 @@
+From 84743903977ac54bdb0598369c96f685d2183fb6 Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Tue, 29 Aug 2023 11:35:41 +0100
+Subject: [PATCH] change windows plugin folder
+
+---
+ CMakeLists.txt | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a3ae97d2d..cc54076d9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -245,12 +245,19 @@ elseif(NOT DEFINED LIBRARY_INSTALL_DIR)
+ endif()
+ message(STATUS "LIBRARY INSTALL DIR: ${LIBRARY_INSTALL_DIR}")
+ 
++# on windows, plugins are dll executables
++if (WIN32)
++    set(PLUGINS_BASE_FOLDER "${EXECUTABLE_INSTALL_DIR}")
++else()
++    set(PLUGINS_BASE_FOLDER "${LIBRARY_INSTALL_DIR}")
++endif()
++
+ if(USE_DOUBLE)
+     message(STATUS "Building with 64-bit floats")
+-    set(PLUGIN_INSTALL_DIR "${LIBRARY_INSTALL_DIR}/csound/plugins64-${APIVERSION}")
++    set(PLUGIN_INSTALL_DIR "${PLUGINS_BASE_FOLDER}/csound/plugins64-${APIVERSION}")
+ else()
+     message(STATUS "Building with 32-bit floats")
+-    set(PLUGIN_INSTALL_DIR "${LIBRARY_INSTALL_DIR}/csound/plugins-${APIVERSION}")
++    set(PLUGIN_INSTALL_DIR "${PLUGINS_BASE_FOLDER}/csound/plugins-${APIVERSION}")
+ endif()
+ 
+ if(WIN32 AND NOT MSVC)
+-- 
+2.39.2
+

--- a/ports/csound/cmake-exports.patch
+++ b/ports/csound/cmake-exports.patch
@@ -1,0 +1,113 @@
+From d16d44071bd6fa54fbb48f56c8d9db1745b3d6f6 Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Tue, 29 Aug 2023 11:59:06 +0100
+Subject: [PATCH] cmake exports
+
+---
+ CMakeLists.txt            | 13 +++++++++++--
+ interfaces/CMakeLists.txt |  4 ++++
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bc1dd2a7f..de5d25c4d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -108,6 +108,7 @@ function(make_executable name srcs libs)
+             OUTPUT_NAME ${ARGV3})
+     endif()
+     install(TARGETS ${name}
++    EXPORT CSoundExports
+ 	RUNTIME DESTINATION "${EXECUTABLE_INSTALL_DIR}" )
+ endfunction(make_executable)
+ 
+@@ -1168,6 +1169,7 @@ function(make_plugin libname srcs)
+         ARCHIVE_OUTPUT_DIRECTORY ${BUILD_PLUGINS_DIR})
+ 
+     install(TARGETS ${libname}
++        EXPORT CSoundExports
+         LIBRARY DESTINATION "${PLUGIN_INSTALL_DIR}"
+         ARCHIVE DESTINATION "${PLUGIN_INSTALL_DIR}" )
+ 
+@@ -1176,11 +1178,13 @@ endfunction(make_plugin)
+ # Add the install target
+ if(WIN32)
+   install(TARGETS ${CSOUNDLIB}
++    EXPORT CSoundExports
+     RUNTIME DESTINATION "${EXECUTABLE_INSTALL_DIR}"
+     ARCHIVE DESTINATION "${LIBRARY_INSTALL_DIR}"
+     FRAMEWORK DESTINATION "${CS_FRAMEWORK_DEST}")
+ else()
+   install(TARGETS ${CSOUNDLIB}
++    EXPORT CSoundExports
+     LIBRARY DESTINATION "${LIBRARY_INSTALL_DIR}"
+     ARCHIVE DESTINATION "${LIBRARY_INSTALL_DIR}"
+     FRAMEWORK DESTINATION "${CS_FRAMEWORK_DEST}")
+@@ -1378,6 +1382,7 @@ if(BUILD_STATIC_LIBRARY)
+ 
+     # Add the install target
+     install(TARGETS ${CSOUNDLIB_STATIC}
++        EXPORT CSoundExports
+         LIBRARY DESTINATION "${LIBRARY_INSTALL_DIR}"
+         ARCHIVE DESTINATION "${LIBRARY_INSTALL_DIR}")
+ endif()
+@@ -1385,6 +1390,7 @@ endif()
+ # VL -- this seems to be a duplicate instruction
+ # and it's breaking the build. See lines 1088-95
+ #install(TARGETS ${CSOUNDLIB}
++#    EXPORT CSoundExports
+ #    LIBRARY DESTINATION "${LIBRARY_INSTALL_DIR}"
+ #   ARCHIVE DESTINATION "${LIBRARY_INSTALL_DIR}")
+ 
+@@ -1450,8 +1456,11 @@ if(DOXYGEN_FOUND)
+ endif(DOXYGEN_FOUND)
+ 
+ # install CMake module
+-install(FILES ${CMAKE_SOURCE_DIR}/cmake/Modules/FindCsound.cmake
+-        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/cmake/Csound")
++install(EXPORT CSoundExports
++    FILE "CSoundConfig.cmake"
++    NAMESPACE "CSound::"
++    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/csound"
++)
+ 
+ # install samples
+ if(APPLE AND APPLE_FRAMEWORK)
+diff --git a/interfaces/CMakeLists.txt b/interfaces/CMakeLists.txt
+index cf4d123aa..d6fb1dd8a 100644
+--- a/interfaces/CMakeLists.txt
++++ b/interfaces/CMakeLists.txt
+@@ -60,6 +60,7 @@ if(BUILD_CXX_INTERFACE)
+ 
+ 
+     install(TARGETS libcsnd6
++        EXPORT CSoundExports
+         LIBRARY DESTINATION "${LIBRARY_INSTALL_DIR}"
+         ARCHIVE DESTINATION "${LIBRARY_INSTALL_DIR}")
+ 
+@@ -80,6 +81,7 @@ if(BUILD_STATIC_LIBRARY)
+ 
+     # Add the install target
+     install(TARGETS libcsnd6-static
++        EXPORT CSoundExports
+         LIBRARY DESTINATION "${LIBRARY_INSTALL_DIR}"
+         ARCHIVE DESTINATION "${LIBRARY_INSTALL_DIR}")
+ endif()
+@@ -209,6 +211,7 @@ if(BUILD_JAVA_INTERFACE OR BUILD_LUA_INTERFACE)
+          endif()
+ 
+         install(TARGETS _jcsound6
++            EXPORT CSoundExports
+             LIBRARY DESTINATION "${JAVA_MODULE_INSTALL_DIR}"
+             ARCHIVE DESTINATION "${JAVA_MODULE_INSTALL_DIR}")
+         install(FILES ${BUILD_LIB_DIR}/csnd6.jar
+@@ -255,6 +258,7 @@ if(BUILD_JAVA_INTERFACE OR BUILD_LUA_INTERFACE)
+         endif()
+ 
+         install(TARGETS luaCsnd6
++            EXPORT CSoundExports
+             LIBRARY DESTINATION "${LUA_MODULE_INSTALL_DIR}"
+             ARCHIVE DESTINATION "${LUA_MODULE_INSTALL_DIR}")
+ 
+-- 
+2.39.2
+

--- a/ports/csound/error-on-warning-option.patch
+++ b/ports/csound/error-on-warning-option.patch
@@ -1,0 +1,39 @@
+From 07803dc12bdbda04b05213a09502e1146c44ad4e Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Tue, 29 Aug 2023 11:31:54 +0100
+Subject: [PATCH] error on warning option
+
+---
+ CMakeLists.txt | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c333e83aa..a3ae97d2d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -184,6 +184,7 @@ option(BUILD_INSTALLER "Build installer" OFF)
+ option(BUILD_TESTS "Build tests" ON)
+ option(USE_GIT_COMMIT "Show the git commit in version information" ON)
+ option(REQUIRE_PTHREADS "For non-Windows systems, set whether Csound will use threads or not" ON)
++option(DEBUG_ERROR_ON_WARNING "Error on compiler warning" ON)
+ 
+ # Include this after the install path definitions so we can override them here.
+ # Also after function definitions so we can use them there
+@@ -212,8 +213,12 @@ if(NOT MSVC AND NOT WASM)
+     set(CMAKE_CXX_FLAGS_RELEASE "-O3 ")
+     set(CMAKE_C_FLAGS_RELEASE "-O3 ")
+     if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wall -Werror -Wno-missing-field-initializers")
+-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -Wno-missing-field-initializers")
++        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wall -Wno-missing-field-initializers")
++        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-missing-field-initializers")
++        if (DEBUG_ERROR_ON_WARNING)
++            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
++            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
++        endif()
+     endif()
+ endif()
+ 
+-- 
+2.39.2
+

--- a/ports/csound/fix-include-directory.patch
+++ b/ports/csound/fix-include-directory.patch
@@ -1,0 +1,28 @@
+From 48873e9d7a48b8252aa60fb65babc383fce1746b Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Tue, 29 Aug 2023 12:16:33 +0100
+Subject: [PATCH] fix include directory
+
+---
+ interfaces/CMakeLists.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/interfaces/CMakeLists.txt b/interfaces/CMakeLists.txt
+index d6fb1dd8a..19ad3d1df 100644
+--- a/interfaces/CMakeLists.txt
++++ b/interfaces/CMakeLists.txt
+@@ -40,7 +40,10 @@ if(BUILD_CXX_INTERFACE)
+ 
+     target_link_libraries(libcsnd6 ${libcsnd6_LIBS})
+     # users of this lib will need this dir included
+-    target_include_directories(libcsnd6 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
++    target_include_directories(libcsnd6 INTERFACE
++        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
++        "$<INSTALL_INTERFACE:include>"
++    )
+     set_target_properties(libcsnd6 PROPERTIES
+         SOVERSION ${APIVERSION}
+         OUTPUT_NAME csnd6
+-- 
+2.39.2
+

--- a/ports/csound/install-rpath.patch
+++ b/ports/csound/install-rpath.patch
@@ -1,0 +1,54 @@
+From 42ded1980a2eccac98d322ad6352a49c2c964622 Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Tue, 29 Aug 2023 12:09:56 +0100
+Subject: [PATCH] install rpath
+
+---
+ CMakeLists.txt | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de5d25c4d..0eb997c02 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,6 +4,10 @@ cmake_minimum_required(VERSION 3.5)
+ set(CMAKE_MACOSX_RPATH 1)
+ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+ 
++if (UNIX)
++    set(CMAKE_INSTALL_RPATH "$ORIGIN")
++endif()
++
+ 
+ option(USE_VCPKG "Use VCPKG to download and manage dependencies" OFF)
+ 
+@@ -102,6 +106,13 @@ function(make_executable name srcs libs)
+     target_link_libraries (${name} ${libs})
+     set_target_properties(${name} PROPERTIES
+         RUNTIME_OUTPUT_DIRECTORY ${BUILD_BIN_DIR})
++    
++    if(UNIX)
++        # out of bin
++        set_target_properties(${name} PROPERTIES
++            INSTALL_RPATH "$ORIGIN/../lib"
++        )
++    endif()
+ 
+     if(${ARGC} EQUAL 4)
+         set_target_properties(${name} PROPERTIES
+@@ -1157,6 +1168,12 @@ function(make_plugin libname srcs)
+         add_library(${libname} MODULE ${srcs})
+     endif()
+ 
++    if (UNIX)
++        set_target_properties(${libname} PROPERTIES
++            INSTALL_RPATH "$ORIGIN/../../../lib"
++        )
++    endif()
++
+     set(i 2)
+     while( ${i} LESS ${ARGC} )
+         target_link_libraries(${libname} ${ARGV${i}})
+-- 
+2.39.2
+

--- a/ports/csound/link-plugins-to-csound.patch
+++ b/ports/csound/link-plugins-to-csound.patch
@@ -1,0 +1,132 @@
+From e1bd6ec564601e52643c1f38064a03cd3c50e82b Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Thu, 31 Aug 2023 01:11:03 +0100
+Subject: [PATCH] link plugins to csound
+
+---
+ CMakeLists.txt         |  8 +++++++-
+ InOut/CMakeLists.txt   | 22 +++++++++++-----------
+ Opcodes/CMakeLists.txt | 12 ++++++------
+ 3 files changed, 24 insertions(+), 18 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index af1f0591c..833159191 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1181,10 +1181,16 @@ function(make_plugin libname srcs)
+ 
+     set(i 2)
+     while( ${i} LESS ${ARGC} )
+-        target_link_libraries(${libname} ${ARGV${i}})
++        target_link_libraries(${libname} PRIVATE ${ARGV${i}})
+         math(EXPR i "${i}+1")
+     endwhile()
+ 
++    if (BUILD_STATIC_LIBRARY)
++        target_link_libraries(${libname} PRIVATE ${CSOUNDLIB_STATIC})
++    else()
++        target_link_libraries(${libname} PRIVATE ${CSOUNDLIB})
++    endif()
++
+     set_target_properties(${libname} PROPERTIES
+         RUNTIME_OUTPUT_DIRECTORY ${BUILD_PLUGINS_DIR}
+         LIBRARY_OUTPUT_DIRECTORY ${BUILD_PLUGINS_DIR}
+diff --git a/InOut/CMakeLists.txt b/InOut/CMakeLists.txt
+index 0a1986476..b10e5afca 100644
+--- a/InOut/CMakeLists.txt
++++ b/InOut/CMakeLists.txt
+@@ -99,10 +99,10 @@ if(APPLE)
+ #   check_deps(USE_AUDIOUNIT APPLE COREAUDIO_INCLUDE_PATH COREAUDIO_LIBRARY AUDIOUNIT_INCLUDE_PATH AUDIOUNIT_LIBRARY COREFOUNDATION_LIBRARY)
+         make_plugin(cmidi cmidi.c)
+         target_include_directories(cmidi PRIVATE ${COREMIDI_INCLUDE_PATH})
+-        target_link_libraries(cmidi ${COREMIDI_LIBRARY} ${COREFOUNDATION_LIBRARY})
++        target_link_libraries(cmidi PRIVATE ${COREMIDI_LIBRARY} ${COREFOUNDATION_LIBRARY})
+         make_plugin(rtauhal rtauhal.c)
+         target_include_directories(rtauhal PRIVATE ${AUDIOUNIT_INCLUDE_PATH})
+-        target_link_libraries(rtauhal ${AUDIOUNIT_LIBRARY} ${COREFOUNDATION_LIBRARY} ${COREAUDIO_LIBRARY})
++        target_link_libraries(rtauhal PRIVATE ${AUDIOUNIT_LIBRARY} ${COREFOUNDATION_LIBRARY} ${COREAUDIO_LIBRARY})
+ endif()
+ 
+ check_deps(USE_ALSA ALSA_HEADER ALSA_LIBRARY PTHREAD_LIBRARY)
+@@ -116,9 +116,9 @@ if(WIN32)
+     message(STATUS "Building Windows MME plugin(rtwinmm).")
+     if(MSVC)
+       make_plugin(rtwinmm rtwinmm.c)
+-      target_link_libraries(rtwinmm winmm.lib)
+-      target_link_libraries(rtwinmm gdi32)
+-      target_link_libraries(rtwinmm kernel32)
++      target_link_libraries(rtwinmm PRIVATE winmm.lib)
++      target_link_libraries(rtwinmm PRIVATE gdi32)
++      target_link_libraries(rtwinmm PRIVATE kernel32)
+     else()
+       set(rtwinmm_LIBS
+           winmm gdi32 kernel32) # should probably do checks for these libs
+@@ -149,7 +149,7 @@ if(PORTAUDIO_FOUND OR (TARGET portaudio_static) OR (TARGET portaudio))
+         target_link_libraries(rtpa PRIVATE ${PORTAUDIO_LIBRARIES})
+     else()
+         target_include_directories(rtpa PRIVATE ${PORTAUDIO_INCLUDE_DIRS})
+-        target_link_libraries(rtpa ${PORTAUDIO_LIBRARIES})
++        target_link_libraries(rtpa PRIVATE ${PORTAUDIO_LIBRARIES})
+     endif()
+ else()
+   message(STATUS "Not building Portaudio Driver...")
+@@ -162,11 +162,11 @@ if(USE_PORTMIDI AND (PORTMIDI_FOUND OR PortMidi_FOUND))
+         target_link_libraries(pmidi PRIVATE PortMidi::portmidi)
+     else()
+         target_include_directories(pmidi PRIVATE ${PORTMIDI_INCLUDE_DIRS})
+-        target_link_libraries(pmidi ${PORTMIDI_LIBRARIES})
++        target_link_libraries(pmidi PRIVATE ${PORTMIDI_LIBRARIES})
+         if(WIN32)
+-            target_link_libraries(pmidi ${CSOUND_WINDOWS_LIBRARIES})
++            target_link_libraries(pmidi PRIVATE ${CSOUND_WINDOWS_LIBRARIES})
+         elseif(LINUX AND ALSA_LIBRARY)
+-            target_link_libraries(pmidi ${ALSA_LIBRARY})
++            target_link_libraries(pmidi PRIVATE ${ALSA_LIBRARY})
+         endif()
+     endif()
+ endif()
+@@ -205,8 +205,8 @@ if(HAIKU)
+ 	find_library(HAIKU_MIDI_LIBRARY midi2)
+ 	set(haiku_SRCS rthaiku.cpp HaikuAudio.cpp HaikuMidi.cpp)
+ 	make_plugin(rthaiku "${haiku_SRCS}")
+-    target_link_libraries(rthaiku ${HAIKU_MEDIA_LIBRARY})
+-    target_link_libraries(rthaiku ${HAIKU_MIDI_LIBRARY})
++    target_link_libraries(rthaiku PRIVATE ${HAIKU_MEDIA_LIBRARY})
++    target_link_libraries(rthaiku PRIVATE ${HAIKU_MIDI_LIBRARY})
+ endif()
+ 
+ 
+diff --git a/Opcodes/CMakeLists.txt b/Opcodes/CMakeLists.txt
+index 6ea32794f..e6fba5717 100644
+--- a/Opcodes/CMakeLists.txt
++++ b/Opcodes/CMakeLists.txt
+@@ -120,20 +120,20 @@ find_package(LIBLO)
+ if(BUILD_OSC_OPCODES AND LIBLO_FOUND)
+     make_plugin(osc OSC.c)
+     if(WIN32)
+-      target_link_libraries(osc ${LIBLO_LIBRARIES})
++      target_link_libraries(osc PRIVATE ${LIBLO_LIBRARIES})
+ 	  # FIXME how to build a static version of this?
+       if(BUILD_STATIC_LIBRARY AND NOT MSVC)
+         add_library(pthread_static STATIC IMPORTED)
+         set_target_properties(pthread_static PROPERTIES IMPORTED_LOCATION ${PTHREAD_LIBRARY})
+-        target_link_libraries(osc pthread_static)
++        target_link_libraries(osc PRIVATE pthread_static)
+       elseif(NOT MSVC)
+-        target_link_libraries(osc ${PTHREAD_LIBRARY})
++        target_link_libraries(osc PRIVATE ${PTHREAD_LIBRARY})
+       endif()
+-      target_link_libraries(osc wsock32 ws2_32 iphlpapi)
++      target_link_libraries(osc PRIVATE wsock32 ws2_32 iphlpapi)
+     elseif(HAIKU)
+-      target_link_libraries(osc ${LIBLO_LIBRARIES})
++      target_link_libraries(osc PRIVATE ${LIBLO_LIBRARIES})
+     else()
+-      target_link_libraries(osc ${LIBLO_LIBRARIES} pthread)
++      target_link_libraries(osc PRIVATE ${LIBLO_LIBRARIES} pthread)
+     endif()
+ endif()
+ 
+-- 
+2.39.2
+

--- a/ports/csound/portfile.cmake
+++ b/ports/csound/portfile.cmake
@@ -1,0 +1,89 @@
+vcpkg_find_acquire_program(BISON)
+get_filename_component(BISON_PATH ${BISON} DIRECTORY)
+vcpkg_add_to_path(${BISON_PATH})
+
+vcpkg_find_acquire_program(FLEX)
+get_filename_component(FLEX_PATH ${FLEX} DIRECTORY)
+vcpkg_add_to_path(${FLEX_PATH})
+
+set(EXTRA_OPTIONS "")
+if (VCPKG_CRT_LINKAGE="static")
+    list(APPEND EXTRA_OPTIONS "-DBUILD_STATIC_LIBRARY=ON")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO csound/csound
+    REF "${VERSION}"
+    SHA512 4ea4dccb36017c96482389a8d139f6f55c79c5ceb9cc34e6d2bfabcb930b4833d0301be4a4b21929db27b2d8ce30754b5c5867acd2ea5a849135e1b8d1506acf
+    PATCHES
+        "add-python-option.patch"
+        "remove-alloca.patch"
+        "error-on-warning-option.patch"
+        "change-windows-plugin-folder.patch"
+        "add-framework-option.patch"
+        "cmake-exports.patch"
+        "install-rpath.patch"
+        "fix-include-directory.patch"
+        "add-vcpkg-dependencies-option.patch"
+        "add-dirent-to-ftsamplebank.patch"
+        "link-plugins-to-csound.patch"
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    "portaudio" USE_PORTAUDIO
+    "portmidi" USE_PORTMIDI
+)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        # bump to match libsndfile?
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0"
+        -DAPPLE_FRAMEWORK=OFF
+        -DBUILD_CSBEATS=OFF # doesn't work
+        -DBUILD_DSSI_OPCODES=OFF # TODO: feature?
+        -DBUILD_JAVA_INTERFACE=OFF # TODO: feature?
+        -DBUILD_LUA_INTERFACE=OFF # TODO: feature?
+        -DBUILD_PYTHON_INTERFACE=OFF # TODO: feature?
+        -DBUILD_OSC_OPCODES=OFF # TODO: feature?
+        -DBUILD_UTILITIES=OFF # TODO: feature?
+        -DDEBUG_ERROR_ON_WARNING=OFF
+        -DUSE_ALSA=OFF # TODO: feature
+        -DUSE_GETTEXT=OFF # TODO: feature?
+        -DUSE_CURL=OFF # TODO: feature?
+        -DUSE_JACK=OFF # TODO: feature?
+        -DUSE_PULSEAUDIO=OFF # TODO: feature?
+        -DUSE_VCPKG_DEPENDENCIES=ON
+        ${EXTRA_OPTIONS}
+        ${FEATURE_OPTIONS}
+)
+vcpkg_cmake_install()
+
+if (NOT (VCPKG_TARGET_IS_OSX))
+    vcpkg_copy_tools(TOOL_NAMES
+        cs
+        csb64enc
+        csdebugger
+        csound
+        extract
+        makecsd
+        scot
+        scsort
+        sdif2ad
+        AUTO_CLEAN
+    )
+endif()
+
+vcpkg_cmake_config_fixup()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+

--- a/ports/csound/remove-alloca.patch
+++ b/ports/csound/remove-alloca.patch
@@ -1,0 +1,44 @@
+From b2e32cd876bef9491480a4d7b71cc9fc34759ca1 Mon Sep 17 00:00:00 2001
+From: Brandon Taylor <brandon.taylor221@gmail.com>
+Date: Tue, 29 Aug 2023 11:25:44 +0100
+Subject: [PATCH] remove alloca
+
+---
+ Engine/envvar.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/Engine/envvar.c b/Engine/envvar.c
+index ac35b1427..5c421dd9f 100644
+--- a/Engine/envvar.c
++++ b/Engine/envvar.c
+@@ -1031,12 +1031,13 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int type,
+ #if defined(WIN32)
+       /* To handle Widows errors in file name characters. */
+       size_t sz = 2 * MultiByteToWideChar(CP_UTF8, 0, name, -1, NULL, 0);
+-      wchar_t *wfname = alloca(sz);
++      // alloca not available on all platforms
++      wchar_t *wfname = malloc(sz);
+       wchar_t *wmode = 0;
+ 
+       MultiByteToWideChar(CP_UTF8, 0, name, -1, wfname, sz);
+       sz = 2 * MultiByteToWideChar(CP_UTF8, 0, param, -1, NULL, 0);
+-      wmode = alloca(sz);
++      wmode = malloc(sz);
+       MultiByteToWideChar(CP_UTF8, 0, param, -1, wmode, sz);
+       if (type == CSFILE_STD) {
+         tmp_f = _wfopen(wfname, wmode);
+@@ -1047,6 +1048,11 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int type,
+         }
+         fullName = (char*) name;
+       }
++      free(wfname);
++      free(wmode);
++      // so we can resume with an else still
++      if (type == CSFILE_STD) {
++      }
+ #else
+       if (type == CSFILE_STD) {
+         fullName = (char*) name;
+-- 
+2.39.2
+

--- a/ports/csound/usage
+++ b/ports/csound/usage
@@ -1,0 +1,34 @@
+To use in cmake:
+
+    find_package(CSound CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CSound::csound64 CSound::libcsnd6)
+    install(IMPORTED_RUNTIME_ARTIFACTS 
+        CSound::ampmidid
+        CSound::arrayops
+        CSound::bformdec2
+        CSound::control # available on linux and osx
+        CSound::deprecated
+        CSound::doppler
+        CSound::fractalnoise
+        CSound::ftsamplebank
+        CSound::ipmidi
+        CSound::joystick # available on linux
+        CSound::lfsr 
+        CSound::mixer
+        CSound::padsynth
+        CSound::pmidi
+        CSound::pvsops
+        CSound::rtauhal # available on osx
+        CSound::rtpa
+        CSound::rtwinmm # available on windows
+        CSound::scansyn
+        CSound::signalflowgraph
+        CSound::stdutil
+        CSound::trigenvsegs
+        CSound::urandom # available on linux and osx
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/csound/plugins64-6.0"
+    )
+
+To use the plugins, set this environmental variable before running a binary, perhaps in a shell script.
+
+    OPCODE6DIR64="${CMAKE_INSTALL_PREFIX}/csound/plugins64-6.0"

--- a/ports/csound/vcpkg.json
+++ b/ports/csound/vcpkg.json
@@ -1,0 +1,46 @@
+{
+  "name": "csound",
+  "version": "6.18.1",
+  "description": "Csound is a sound and music computing system which was originally developed by Barry Vercoe in 1985 at MIT Media Lab.",
+  "homepage": "https://csound.com/",
+  "license": "LGPL-2.1-only",
+  "dependencies": [
+    {
+      "name": "dirent",
+      "platform": "windows"
+    },
+    {
+      "name": "libsndfile",
+      "features": [
+        "external-libs",
+        "mpeg"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "portaudio",
+    "portmidi"
+  ],
+  "features": {
+    "portaudio": {
+      "description": "Enable PortAudio real-time audio",
+      "dependencies": [
+        "portaudio"
+      ]
+    },
+    "portmidi": {
+      "description": "Enable PortMidi midi",
+      "dependencies": [
+        "portmidi"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1932,6 +1932,10 @@
       "baseline": "4.3.0",
       "port-version": 1
     },
+    "csound": {
+      "baseline": "6.18.1",
+      "port-version": 0
+    },
     "cspice": {
       "baseline": "67",
       "port-version": 3

--- a/versions/c-/csound.json
+++ b/versions/c-/csound.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e2d10db38888b283481533298c0f68b138996210",
+      "version": "6.18.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes ##32030

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

