### PR TITLE
[brpc] update to 1.5.0

### DIFF
--- a/ports/brpc/fix-build.patch
+++ b/ports/brpc/fix-build.patch
@@ -1,16 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 35365b27..53c5fffd 100644
+index 4ac815d6..dbb9b7ee 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -26,7 +26,7 @@ option(WITH_THRIFT "With thrift framed protocol supported" OFF)
- option(WITH_SNAPPY "With snappy" OFF)
- option(WITH_RDMA "With RDMA" OFF)
- option(BUILD_UNIT_TESTS "Whether to build unit tests" OFF)
--option(BUILD_BRPC_TOOLS "Whether to build brpc tools" ON)
-+option(BUILD_BRPC_TOOLS "Whether to build brpc tools" OFF)
- option(DOWNLOAD_GTEST "Download and build a fresh copy of googletest. Requires Internet access." ON)
- 
- # Enable MACOSX_RPATH. Run "cmake --help-policy CMP0042" for policy details.
 @@ -66,7 +66,8 @@ endif()
  
  if(WITH_THRIFT)
@@ -21,7 +12,7 @@ index 35365b27..53c5fffd 100644
  endif()
  
  set(WITH_RDMA_VAL "0")
-@@ -150,14 +151,14 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+@@ -150,11 +151,15 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
      endif()
  endif()
  
@@ -30,19 +21,16 @@ index 35365b27..53c5fffd 100644
 +get_target_property(PROTOBUF_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
 +set(PROTOBUF_LIBRARIES protobuf::libprotobuf)
  find_package(Threads REQUIRED)
++find_package(ZLIB REQUIRED)
  
--find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
--find_library(LEVELDB_LIB NAMES leveldb)
--if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
--    message(FATAL_ERROR "Fail to find leveldb")
--endif()
 +find_package(leveldb CONFIG REQUIRED)
-+set(LEVELDB_INCLUDE_PATH ${PROTOBUF_INCLUDE_DIR})
+ find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
+-find_library(LEVELDB_LIB NAMES leveldb)
 +set(LEVELDB_LIB leveldb::leveldb)
- 
- if(WITH_SNAPPY)
-     find_path(SNAPPY_INCLUDE_PATH NAMES snappy.h)
-@@ -169,8 +170,9 @@ if(WITH_SNAPPY)
+ if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
+     message(FATAL_ERROR "Fail to find leveldb")
+ endif()
+@@ -169,8 +174,9 @@ if(WITH_SNAPPY)
  endif()
  
  if(WITH_GLOG)
@@ -54,7 +42,7 @@ index 35365b27..53c5fffd 100644
      if((NOT GLOG_INCLUDE_PATH) OR (NOT GLOG_LIB))
          message(FATAL_ERROR "Fail to find glog")
      endif()
-@@ -197,7 +199,7 @@ if(WITH_RDMA)
+@@ -197,7 +203,7 @@ if(WITH_RDMA)
      endif()
  endif()
  
@@ -63,7 +51,7 @@ index 35365b27..53c5fffd 100644
  if(NOT PROTOC_LIB)
      message(FATAL_ERROR "Fail to find protoc lib")
  endif()
-@@ -208,7 +210,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+@@ -208,7 +214,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
          )
  endif()
  
@@ -72,7 +60,7 @@ index 35365b27..53c5fffd 100644
  
  include_directories(
          ${GFLAGS_INCLUDE_PATH}
-@@ -223,9 +225,9 @@ set(DYNAMIC_LIB
+@@ -223,11 +229,11 @@ set(DYNAMIC_LIB
      ${LEVELDB_LIB}
      ${PROTOC_LIB}
      ${CMAKE_THREAD_LIBS_INIT}
@@ -82,8 +70,11 @@ index 35365b27..53c5fffd 100644
 +    ${OPENSSL_SSL_LIBRARY}
 +    ${THRIFT_LIB}
      dl
-     z)
+-    z)
++    ZLIB::ZLIB)
  
+ if(WITH_MESALINK)
+     list(APPEND DYNAMIC_LIB ${MESALINK_LIB})
 diff --git a/cmake/FindGFLAGS.cmake b/cmake/FindGFLAGS.cmake
 index dfad5fd8..8423d55a 100644
 --- a/cmake/FindGFLAGS.cmake
@@ -100,7 +91,7 @@ index dfad5fd8..8423d55a 100644
    set(GFLAGS_FOUND TRUE)
  endif(GFLAGS_INCLUDE_PATH AND GFLAGS_LIBRARY)
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index fbcc7cc5..c2d0d7bb 100644
+index fbcc7cc5..95037a0d 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -31,16 +31,24 @@ add_dependencies(SOURCES_LIB PROTO_LIB)
@@ -113,8 +104,9 @@ index fbcc7cc5..c2d0d7bb 100644
                                 $<TARGET_OBJECTS:PROTO_LIB>)
  
 -if(BRPC_WITH_THRIFT)
+-   target_link_libraries(brpc-static thrift)
 +if(WITH_THRIFT)
-    target_link_libraries(brpc-static thrift)
++   target_link_libraries(brpc-static ${THRIFT_LIB})
  endif()
  
 +target_link_libraries(brpc-static PUBLIC ${DYNAMIC_LIB})
@@ -129,7 +121,7 @@ index fbcc7cc5..c2d0d7bb 100644
  # for protoc-gen-mcpack
  set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/output/bin)
      
-@@ -49,35 +57,57 @@ set(protoc_gen_mcpack_SOURCES
+@@ -49,35 +57,62 @@ set(protoc_gen_mcpack_SOURCES
   )
      
  add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
@@ -145,22 +137,27 @@ index fbcc7cc5..c2d0d7bb 100644
          target_link_libraries(brpc-shared ${GLOG_LIB})
      endif()
 -    if(BRPC_WITH_THRIFT)
+-        target_link_libraries(brpc-shared thrift)
 +    if(WITH_THRIFT)
-         target_link_libraries(brpc-shared thrift)
++        target_link_libraries(brpc-shared ${THRIFT_LIB})
      endif()
      SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
- 
+-
++    if(0)
      target_link_libraries(protoc-gen-mcpack brpc-shared ${DYNAMIC_LIB} pthread)
- 
+-
 -    install(TARGETS brpc-shared
++    endif()
 +    install(TARGETS brpc-shared EXPORT unofficial-brpcTargets
              RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
              ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
              )
  else()
--    target_link_libraries(protoc-gen-mcpack brpc-static ${DYNAMIC_LIB} pthread)
++if(0)
+     target_link_libraries(protoc-gen-mcpack brpc-static ${DYNAMIC_LIB} pthread)
  endif()
++endif()
  
  
  
@@ -172,10 +169,12 @@ index fbcc7cc5..c2d0d7bb 100644
          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
          )
 +endif()
++
 +file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-brpc-config.cmake"
 +[[include(CMakeFindDependencyMacro)
 +find_dependency(OpenSSL)
 +find_dependency(Threads)
++find_dependency(ZLIB)
 +find_dependency(gflags CONFIG)
 +find_dependency(protobuf CONFIG)
 +find_dependency(leveldb CONFIG)

--- a/ports/brpc/portfile.cmake
+++ b/ports/brpc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/incubator-brpc
     REF "${VERSION}"
-    SHA512 7e75a4f03eddbd6ce841566bad415e34706a6d5db1abaffec3b512461a45ddbaee2b365589f505b64a11f9466e2a38e9eb83570fe1532caeae20dc1d059d29be
+    SHA512 0d3693ceff19952623511381d2df3ab3d17e725c0679154ce36f0cf52d1d4b46ad04699c4bacd0a906bcef33d19921fb5e1193a78218b6010b4c35d07ad62563
     HEAD_REF master
     PATCHES
         fix-build.patch
@@ -13,8 +13,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
+        -DBUILD_BRPC_TOOLS=OFF
         -DWITH_THRIFT=ON
-        -DWITH_MESALINK=OFF
         -DWITH_GLOG=ON
         -DDOWNLOAD_GTEST=OFF
 )

--- a/ports/brpc/vcpkg.json
+++ b/ports/brpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "brpc",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Industrial-grade RPC framework used throughout Baidu, with 1,000,000+ instances and thousands kinds of services, called \"baidu-rpc\" inside Baidu.",
   "homepage": "https://github.com/apache/incubator-brpc",
   "license": "Apache-2.0",

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c3039a58b23207cc87a0a938dbd943ef521b235",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a75ac2b64eae33d6ba6fc7494f6ea02d7156a23c",
       "version": "1.4.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1277,7 +1277,7 @@
       "port-version": 5
     },
     "brpc": {
-      "baseline": "1.4.0",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "brunocodutra-metal": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.