### PR TITLE
[qt5-tools] Fix build fail with mingw

### DIFF
--- a/ports/qt5-declarative/vcpkg.json
+++ b/ports/qt5-declarative/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-declarative",
   "version": "5.15.10",
+  "port-version": 1,
   "description": "Qt5 Declarative (Quick 2) Module. Includes QtQuick, QtQuickParticles, QtQuickWidgets, QtQml, and QtPacketProtocol.",
   "license": null,
   "dependencies": [
@@ -17,7 +18,7 @@
   "features": {
     "d3d12": {
       "description": "Provides a Direct3D 12 backend for the scenegraph.",
-      "supports": "windows"
+      "supports": "windows & !mingw"
     },
     "platform-default-features": {
       "description": "Enable platform-dependent default features",
@@ -27,7 +28,7 @@
           "features": [
             "d3d12"
           ],
-          "platform": "windows"
+          "platform": "windows & !mingw"
         }
       ]
     }

--- a/ports/qt5-tools/fix-pkgconfig-qt5uiplugin-not-found.patch
+++ b/ports/qt5-tools/fix-pkgconfig-qt5uiplugin-not-found.patch
@@ -1,0 +1,14 @@
+diff --git a/src/designer/src/lib/lib.pro b/src/designer/src/lib/lib.pro
+index de0dc73..eef68be 100644
+--- a/src/designer/src/lib/lib.pro
++++ b/src/designer/src/lib/lib.pro
+@@ -1,7 +1,8 @@
+ TARGET = QtDesigner
+ MODULE = designer
+ 
+-QT = core-private gui-private widgets-private xml uiplugin
++QT = core-private gui-private widgets-private xml
++QT_PRIVATE += uiplugin
+ 
+ DEFINES += \
+     QDESIGNER_SDK_LIBRARY \

--- a/ports/qt5-tools/portfile.cmake
+++ b/ports/qt5-tools/portfile.cmake
@@ -1,6 +1,9 @@
 include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
 
-qt_submodule_installation()
+qt_submodule_installation(
+    PATCHES
+        "fix-pkgconfig-qt5uiplugin-not-found.patch"
+)
 
 if(EXISTS "${CURRENT_INSTALLED_DIR}/plugins/platforms/qminimal${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")
     file(INSTALL "${CURRENT_INSTALLED_DIR}/plugins/platforms/qminimal${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/plugins/platforms")

--- a/ports/qt5-tools/vcpkg.json
+++ b/ports/qt5-tools/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-tools",
   "version": "5.15.10",
+  "port-version": 1,
   "description": "Qt5 Tools Module; Includes deployment tools and helpers, Qt Designer, Assistant, and other applications",
   "license": null,
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6734,7 +6734,7 @@
     },
     "qt5-tools": {
       "baseline": "5.15.10",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-translations": {
       "baseline": "5.15.10",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6646,7 +6646,7 @@
     },
     "qt5-declarative": {
       "baseline": "5.15.10",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-doc": {
       "baseline": "5.15.10",

--- a/versions/q-/qt5-declarative.json
+++ b/versions/q-/qt5-declarative.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c7cc59aec9e75dc548a741b01b94b13438904e99",
+      "version": "5.15.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "141dbdc4e7d234f55b336444a9e0a7f5add2e32b",
       "version": "5.15.10",
       "port-version": 0

--- a/versions/q-/qt5-tools.json
+++ b/versions/q-/qt5-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3e934f75a0e506d6c3329e0fa0b2a56d6f71324",
+      "version": "5.15.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "994691ced838ba1d2eab1f5531e9ebfc4bd046f1",
       "version": "5.15.10",
       "port-version": 0


### PR DESCRIPTION
Fixes #32689.

Fixes package Qt5UiPlugin was not found in the pkg-config search path.

```log
-- Using source at C:/Src/vcpkg/buildtrees/qt5-tools/src/5.15.10-453af505a4
-- Getting CMake variables for x64-mingw-dynamic
-- Using cached mingw-w64-i686-pkgconf-1~1.8.0-2-any.pkg.tar.zst.
-- Using cached msys2-msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst.
-- Using msys root at D:/Data/vcpkg-downloads/tools/msys2/6f3fa1a12ef85a6f
-- Configuring x64-mingw-dynamic-rel
-- Configuring x64-mingw-dynamic-rel done
-- Configuring x64-mingw-dynamic-dbg
-- Configuring x64-mingw-dynamic-dbg done
-- Package build-x64-mingw-dynamic-dbg
-- Package build-x64-mingw-dynamic-rel
-- Package install-x64-mingw-dynamic-dbg
-- Package install-x64-mingw-dynamic-rel
-- Fixing pkgconfig file: C:/Src/vcpkg/packages/qt5-tools_x64-mingw-dynamic/lib/pkgconfig/Qt5Designer.pc
-- Fixing pkgconfig file: C:/Src/vcpkg/packages/qt5-tools_x64-mingw-dynamic/lib/pkgconfig/Qt5Help.pc
-- Fixing pkgconfig file: C:/Src/vcpkg/packages/qt5-tools_x64-mingw-dynamic/lib/pkgconfig/Qt5UiTools.pc
CMake Error at scripts/cmake/vcpkg_fixup_pkgconfig.cmake:141 (message):

  D:/Data/vcpkg-downloads/tools/msys2/6f3fa1a12ef85a6f/mingw32/bin/pkg-config.exe
  --exists Qt5Designer failed with error code: 1

      ENV{PKG_CONFIG_PATH}: "C:/Src/vcpkg/packages/qt5-tools_x64-mingw-dynamic/lib/pkgconfig;C:/Src/vcpkg/packages/qt5-tools_x64-mingw-dynamic/share/pkgconfig;C:/Src/vcpkg/installed/x64-mingw-dynamic/lib/pkgconfig;C:/Src/vcpkg/installed/x64-mingw-dynamic/share/pkgconfig"
      output: Package Qt5UiPlugin was not found in the pkg-config search path.

  Perhaps you should add the directory containing `Qt5UiPlugin.pc'

  to the PKG_CONFIG_PATH environment variable

  Package 'Qt5UiPlugin', required by 'Qt5Designer', not found
Call Stack (most recent call first):
  scripts/cmake/vcpkg_fixup_pkgconfig.cmake:206 (z_vcpkg_fixup_pkgconfig_check_files)
  installed/x64-mingw-dynamic/share/qt5/qt_build_submodule.cmake:21 (vcpkg_fixup_pkgconfig)
  installed/x64-mingw-dynamic/share/qt5/qt_submodule_installation.cmake:9 (qt_build_submodule)
  ports/qt5-tools/portfile.cmake:3 (qt_submodule_installation)
  scripts/ports.cmake:147 (include)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

