### PR TITLE
[skia] fix issue where vk_mem_alloc.h cannot find vulkan.h

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -180,6 +180,7 @@ endif()
 if("vulkan" IN_LIST FEATURES)
     string(APPEND OPTIONS " skia_use_vulkan=true")
     file(COPY "${CURRENT_INSTALLED_DIR}/include/vk_mem_alloc.h" DESTINATION "${SOURCE_PATH}/third_party/vulkanmemoryallocator")
+    file(COPY "${CURRENT_INSTALLED_DIR}/include/vulkan/vulkan.h" DESTINATION "${SOURCE_PATH}/third_party/vulkanmemoryallocator/vulkan")
 endif()
 
 if("direct3d" IN_LIST FEATURES)

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -137,6 +137,7 @@
       "description": "Vulkan support for skia",
       "dependencies": [
         "vulkan",
+		"vulkan-headers",
         "vulkan-memory-allocator"
       ]
     }

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "skia",
   "version": "0.36.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -137,7 +137,7 @@
       "description": "Vulkan support for skia",
       "dependencies": [
         "vulkan",
-		"vulkan-headers",
+        "vulkan-headers",
         "vulkan-memory-allocator"
       ]
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7578,7 +7578,7 @@
     },
     "skia": {
       "baseline": "0.36.0",
-      "port-version": 8
+      "port-version": 7
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7578,7 +7578,7 @@
     },
     "skia": {
       "baseline": "0.36.0",
-      "port-version": 7
+      "port-version": 8
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5c1cbb6b0377856f3185af7381850d67a8262024",
+      "version": "0.36.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "508710af38e0b50675532741bf899ec4c3f20c3b",
       "version": "0.36.0",
       "port-version": 7

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -2,11 +2,6 @@
   "versions": [
     {
       "git-tree": "508710af38e0b50675532741bf899ec4c3f20c3b",
-      "version":"0.36.0",
-      "port-version": 8
-    },
-    {
-      "git-tree": "508710af38e0b50675532741bf899ec4c3f20c3b",
       "version": "0.36.0",
       "port-version": 7
     },

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5c1cbb6b0377856f3185af7381850d67a8262024",
+      "git-tree": "6730213bf8ab0cd1e3245f46cb5cd5b59d9952e8",
       "version": "0.36.0",
       "port-version": 8
     },

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "git-tree": "508710af38e0b50675532741bf899ec4c3f20c3b",
+      "version":"0.36.0",
+      "port-version": 8
+    },
+    {
+      "git-tree": "508710af38e0b50675532741bf899ec4c3f20c3b",
       "version": "0.36.0",
       "port-version": 7
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/32706
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
- [x] Only one version is added to each modified port's versions file.
