### PR TITLE
[vcpkg baseline][concurrencpp] remove concurrencpp:x64-linux from ci.baseline

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -235,7 +235,6 @@ coin-or-ipopt:x64-linux=fail
 concurrencpp:arm-neon-android=fail
 concurrencpp:arm64-android=fail
 concurrencpp:x64-android=fail
-concurrencpp:x64-linux=fail
 concurrencpp:x64-osx=fail
 constexpr-contracts:arm-neon-android=fail
 constexpr-contracts:arm64-android=fail


### PR DESCRIPTION
Fixed [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=91981&view=results) issue:

`PASSING, REMOVE FROM FAIL LIST: concurrencpp:x64-linux (/agent/_work/1/s/scripts/azure-pipelines/../ci.baseline.txt).`
Above records were added into the ci.baseline.txt by PR https://github.com/microsoft/vcpkg/pull/19997,it has been fixed by https://github.com/microsoft/vcpkg/pull/30342, so removed the following records.
`concurrencpp:x64-linux=fail`
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~