### PR TITLE
[DiscordCoreAPI] Updating to v1.70

### DIFF
--- a/ports/discordcoreapi/portfile.cmake
+++ b/ports/discordcoreapi/portfile.cmake
@@ -6,8 +6,8 @@ vcpkg_from_github(
 	OUT_SOURCE_PATH SOURCE_PATH
 	REPO RealTimeChris/DiscordCoreAPI
 	REF "v${VERSION}"
-    	SHA512 e10bcf274b2487d117990a511b87d9ef15e390f23c5788ba34043167211a7182bbbb9c81ed0eb4f3a3435fa692401f3f7c4a6a15a2c7cbdcd2230d122d2ced13
-    	HEAD_REF main
+	SHA512 31a8fcab3b4cdded97881db486186f4fa741ba389edeb7a20fdf97da3bfe78428cef8daa2e5884e270e8da848fac1649e7ef2a590e7f63f699a61b4766794a74
+	HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/discordcoreapi/vcpkg.json
+++ b/ports/discordcoreapi/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "discordcoreapi",
-  "version": "1.60",
+  "version": "1.70",
   "description": "A Discord bot library written in C++ using custom asynchronous coroutines.",
   "homepage": "https://discordcoreapi.com",
-  "license": "LGPL-2.1-or-later",
+  "license": "MIT",
   "supports": "(windows & x64 & !xbox) | (linux & x64)",
   "dependencies": [
     "jsonifier",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2137,7 +2137,7 @@
       "port-version": 3
     },
     "discordcoreapi": {
-      "baseline": "1.60",
+      "baseline": "1.70",
       "port-version": 0
     },
     "discount": {

--- a/versions/d-/discordcoreapi.json
+++ b/versions/d-/discordcoreapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45cd301b69d6352ea1c59fa22d45539d42582142",
+      "version": "1.70",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ed32e38f0959575a32ad92111e6e2b157184cfd",
       "version": "1.60",
       "port-version": 0


### PR DESCRIPTION
The following changes:
-Refactored the "x"-Data data structures as well as created CacheData structures for the ones that are cached.
-Updated the CMakeLists.txt files.
-Fixed behavior of certain functions while caching is disabled.
-Improved the behavior of the ObjectCache's functions.
-Removed superfluous operators.
-Improved error reporting.
-Improved thread simplicity/reduced thread wastage by reusing threads instead of constructing new ones in the ThreadPool and Song[API](https://docs.github.com/) classes.
-Improved the KeyAccessor and Fnv1a Hash classes.
-Removed superfluous typedefs.
-Fixed an accidentally replaced system_clock call.
-Updated to fix various compiler warnings.
-Fixed a BaseSocketAgent indexing issue.
-Added an additional option to choose whether or not to cache GuildMembers, separately from Users.
-Removed noexcept from many of the functions.
-Improved interfaces for "Discord image urls".
-Moved a bunch of utilities out into their own headers, to be inlined.
-Switched to using the CoRoutine threadpool for launching VoiceConnection threads, instead of launching a new std::jthread for each one.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
