### PR TITLE
[trantor] fix: link to vcpkg c-ares target

### DIFF
--- a/ports/trantor/000-fix-deps.patch
+++ b/ports/trantor/000-fix-deps.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 83bd458..ad56a27 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -135,7 +135,7 @@ endif()
+ 
+ set(HAVE_C-ARES NO)
+ if (BUILD_C-ARES)
+-    find_package(c-ares)
++    find_package(c-ares CONFIG)
+     if(c-ares_FOUND)
+       message(STATUS "c-ares found!")
+       set(HAVE_C-ARES TRUE)
+@@ -143,7 +143,7 @@ if (BUILD_C-ARES)
+ endif ()
+ 
+ if(HAVE_C-ARES)
+-  target_link_libraries(${PROJECT_NAME} PRIVATE c-ares_lib)
++  target_link_libraries(${PROJECT_NAME} PRIVATE c-ares::cares)
+   set(TRANTOR_SOURCES
+       ${TRANTOR_SOURCES}
+       trantor/net/inner/AresResolver.cc)
+diff --git a/cmake/templates/TrantorConfig.cmake.in b/cmake/templates/TrantorConfig.cmake.in
+index e18652d..6dad38e 100644
+--- a/cmake/templates/TrantorConfig.cmake.in
++++ b/cmake/templates/TrantorConfig.cmake.in
+@@ -14,7 +14,7 @@ if(@OpenSSL_FOUND@)
+   find_dependency(OpenSSL)
+ endif()
+ if(@c-ares_FOUND@)
+-  find_dependency(c-ares)
++  find_dependency(c-ares CONFIG)
+ endif()
+ find_dependency(Threads)
+ # Compute paths

--- a/ports/trantor/portfile.cmake
+++ b/ports/trantor/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 dd65938bebb2e6714e5603db3bfc82cd1a63395c17dce014147a41fdc74548cb526e1457a7472aa51bb80ce629a9935b4db9eeadf735efaf30899ef73f776a58
     HEAD_REF master
     PATCHES
+        000-fix-deps.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/trantor/vcpkg.json
+++ b/ports/trantor/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "trantor",
   "version-semver": "1.5.11",
+  "port-version": 1,
   "description": "A non-blocking I/O cross-platform TCP network library, using C++14",
   "homepage": "https://github.com/an-tao/trantor",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8218,7 +8218,7 @@
     },
     "trantor": {
       "baseline": "1.5.11",
-      "port-version": 0
+      "port-version": 1
     },
     "tre": {
       "baseline": "0.8.0",

--- a/versions/t-/trantor.json
+++ b/versions/t-/trantor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ac910f7ba58f9ee8ceff1c8ac1d2dfa0200136f",
+      "version-semver": "1.5.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "bdeefc43943ee1bd39f5c46db28a89b01e446b8f",
       "version-semver": "1.5.11",
       "port-version": 0


### PR DESCRIPTION
it links to c-ares_lib target which is created by its own FindC-ares.cmake. this causes the cmake configs to behave normally but when it's used by third-party it would try to link against c-ares_lib which doesn't exist.

it only happens when building in manifest mode.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
