### PR TITLE
[ntf-core] new port

### DIFF
--- a/ports/ntf-core/portfile.cmake
+++ b/ports/ntf-core/portfile.cmake
@@ -1,0 +1,92 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bloomberg/ntf-core
+    REF "${VERSION}"
+    SHA512 57662d2dd105b2781e580623c26cd7bde84fce8374bbd70c18595a5f6934869b7a570f0d3c2e17e115f6c7eb1067541f8d19523639815b285324061f807d3179
+    HEAD_REF main
+)
+
+function (ntf_configure var val)
+    set(ENV{NTF_CONFIGURE_${var}} ${val})
+endfunction()
+
+ntf_configure(WITH_MOCKS 0)
+ntf_configure(WITH_APPLICATIONS 0)
+ntf_configure(WITH_TESTS 0)
+ntf_configure(WITH_USAGE_EXAMPLES 0)
+ntf_configure(FROM_PACKAGING 1)
+ntf_configure(WITH_BSL 1)
+ntf_configure(WITH_BAL 1)
+ntf_configure(WITH_BDL 1)
+ntf_configure(WITH_NTS 1)
+ntf_configure(WITH_NTC 1)
+ntf_configure(WITH_ADDRESS_FAMILY_IPV4 1)
+ntf_configure(WITH_ADDRESS_FAMILY_IPV6 1)
+ntf_configure(WITH_ADDRESS_FAMILY_LOCAL 1)
+ntf_configure(WITH_TRANSPORT_PROTOCOL_TCP 1)
+ntf_configure(WITH_TRANSPORT_PROTOCOL_UDP 1)
+ntf_configure(WITH_TRANSPORT_PROTOCOL_LOCAL 1)
+ntf_configure(WITH_SELECT 1)
+ntf_configure(WITH_POLL 1)
+ntf_configure(WITH_DYNAMIC_LOAD_BALANCING 1)
+ntf_configure(WITH_THREAD_SCALING 1)
+ntf_configure(WITH_BRANCH_PREDICTION 1)
+ntf_configure(WITH_WITH_METRICS 1)
+
+if(${VCPKG_TARGET_IS_LINUX})
+    ntf_configure(WITH_EPOLL 1)
+elseif(${VCPKG_TARGET_IS_OSX})
+    ntf_configure(WITH_KQUEUE 1)
+elseif(${VCPKG_TARGET_IS_WINDOWS})
+    ntf_configure(WITH_IOCP 1)
+endif()
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_build()
+
+vcpkg_cmake_install()
+
+function(replace_in_file file_path to_match to_replace)
+    file(READ  "${file_path}" file_contents)
+    string(REPLACE "${to_match}" "${to_replace}" file_contents "${file_contents}")
+    file(WRITE "${file_path}" "${file_contents}")
+endfunction()
+
+function(fix_pkgconfig_ufid lib_dir ufid pc_name)
+    replace_in_file("${CURRENT_PACKAGES_DIR}/${lib_dir}/pkgconfig/${pc_name}.pc" "/${ufid}" "")
+    if ("${ufid}" MATCHES opt)
+        set(build_mode "release")
+    else()
+        set(build_mode "debug")
+    endif()
+
+    replace_in_file("${CURRENT_PACKAGES_DIR}/${lib_dir}/cmake/${pc_name}Targets-${build_mode}.cmake" "/${ufid}" "")
+endfunction()
+
+function(fix_install_dir lib_dir ufid)
+    message(STATUS "Fixing ufid layout for ${CURRENT_PACKAGES_DIR}/${lib_dir}/${ufid}")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/${lib_dir}/${ufid}" "${CURRENT_PACKAGES_DIR}/tmp")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/${lib_dir}")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/tmp" "${CURRENT_PACKAGES_DIR}/${lib_dir}")
+
+    fix_pkgconfig_ufid("${lib_dir}" "${ufid}" "nts")
+    fix_pkgconfig_ufid("${lib_dir}" "${ufid}" "ntc")
+endfunction()
+
+fix_install_dir("lib" "opt_exc_mt")
+fix_install_dir("debug/lib" "dbg_exc_mt")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_fixup_pkgconfig()
+
+# Usage
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+

--- a/ports/ntf-core/usage
+++ b/ports/ntf-core/usage
@@ -1,0 +1,5 @@
+The package ntf-core provides the CMake targets:
+
+    find_package(ntc REQUIRED)
+    find_package(nts REQUIRED)
+    target_link_libraries(main PRIVATE ntc nts)

--- a/ports/ntf-core/vcpkg.json
+++ b/ports/ntf-core/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "ntf-core",
+  "version": "2.1.0",
+  "description": "The Network Transport Framework: Core Libraries",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "bde",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5764,6 +5764,10 @@
       "baseline": "2019-08-10",
       "port-version": 3
     },
+    "ntf-core": {
+      "baseline": "2.1.0",
+      "port-version": 0
+    },
     "nu-book-zxing-cpp": {
       "baseline": "2.1.0",
       "port-version": 0

--- a/versions/n-/ntf-core.json
+++ b/versions/n-/ntf-core.json
@@ -1,0 +1,9 @@
+{
+    "versions": [
+        {
+            "version": "2.1.0",
+            "port-version": 0,
+            "git-tree": "4db35d4dcd1b7435380c73492f8f05aa12ab0fb4"   
+        }
+    ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
