### PR TITLE
[sleef] Disable COMPILER_SUPPORTS_OPENMP on Linux

### DIFF
--- a/ports/sleef/portfile.cmake
+++ b/ports/sleef/portfile.cmake
@@ -6,6 +6,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+if(VCPKG_TARGET_IS_LINUX)
+    set(openmp_options -DCOMPILER_SUPPORTS_OPENMP=FALSE)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -15,13 +19,14 @@ vcpkg_cmake_configure(
         -DBUILD_GNUABI_LIBS=${VCPKG_TARGET_IS_LINUX}
         -DBUILD_TESTS=OFF
         -DBUILD_INLINE_HEADERS=OFF
+        ${openmp_options}
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
 
 # Install DLL and PDB files
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/sleef/vcpkg.json
+++ b/ports/sleef/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sleef",
   "version": "3.5.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "SIMD Library for Evaluating Elementary Functions, vectorized libm and DFT",
   "homepage": "https://sleef.org/",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7586,7 +7586,7 @@
     },
     "sleef": {
       "baseline": "3.5.1",
-      "port-version": 4
+      "port-version": 5
     },
     "sleepy-discord": {
       "baseline": "2022-02-05",

--- a/versions/s-/sleef.json
+++ b/versions/s-/sleef.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be92d22b599c37d9003d6e15f160dfd74b6f0648",
+      "version": "3.5.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "12afaa5146f51bf2912339befaafd1776e10442a",
       "version": "3.5.1",
       "port-version": 4


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #32360, disable option `COMPILER_SUPPORTS_OPENMP` on Linux, fix build error of `rubberband[cli,core]:x64-linux`:
```
/usr/bin/ld: /home/user/lily/0717/installed/x64-linux/debug/lib/libsleefdft.a(dftcommon.c.o): in function `initPlanMapLock':
/home/user/lily/0703/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/dft/dftcommon.c:183: undefined reference to `GOMP_critical_start'
/usr/bin/ld: /home/user/lily/0703/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/dft/dftcommon.c:187: undefined reference to `omp_init_lock'
/usr/bin/ld: /home/user/lily/0703/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/dft/dftcommon.c:183: undefined reference to `GOMP_critical_end'
/usr/bin/ld: /home/user/lily/0717/installed/x64-linux/debug/lib/libsleefdft.a(dftcommon.c.o): in function `PlanManager_loadMeasurementResultsP':
/home/user/lily/0703/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/dft/dftcommon.c:330: undefined reference to `omp_set_lock'
/usr/bin/ld: /home/user/lily/0703/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/dft/dftcommon.c:337: undefined reference to `omp_unset_lock'
/usr/bin/ld: /home/user/lily/0703/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/dft/dftcommon.c:354: undefined reference to `omp_unset_lock'
/usr/bin/ld: /home/user/lily/0717/installed/x64-linux/debug/lib/libsleefdft.a(dftcommon.c.o): in function `PlanManager_saveMeasurementResultsP':
/home/user/lily/0703/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/dft/dftcommon.c:365: undefined reference to `omp_set_lock'
/usr/bin/ld: /home/user/lily/0703/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/dft/dftcommon.c:371: undefined reference to `omp_unset_lock'
/usr/bin/ld: /home/user/lily/0703/buildtrees/sleef/src/3.5.1-7f3a2e645a.clean/src/dft/dftcommon.c:386: undefined reference to `omp_unset_lock'
```

I have submitted an issue on upstream: https://github.com/shibatch/sleef/issues/467.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
