### PR TITLE
Fix wrong label name

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 60 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
           any-of-labels: 'category:new-port'
-          close-issue-label: 'new-port-unresolved'
+          close-issue-label: 'info:new-port-unresolved'
           days-before-issue-stale: 60
           days-before-pr-stale: -1
           days-before-close: 14


### PR DESCRIPTION
The name of the label should be `info:new-port-unresolved` and not `new-port-unresolved`