### PR TITLE
[aws-c-common] Remove the unused openssl dependency.

### DIFF
--- a/ports/aws-c-common/vcpkg.json
+++ b/ports/aws-c-common/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-c-common",
   "version": "0.8.9",
+  "port-version": 1,
   "description": "AWS common library for C",
   "homepage": "https://github.com/awslabs/aws-c-common",
   "license": "Apache-2.0",
   "supports": "!(windows & arm) & !uwp",
   "dependencies": [
-    "openssl",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/a-/aws-c-common.json
+++ b/versions/a-/aws-c-common.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54a4a42c299e7b32a1199ad382c4b537a18df034",
+      "version": "0.8.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "d2ef01e925f6168e81c00ab304be70d312ea2ba9",
       "version": "0.8.9",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -346,7 +346,7 @@
     },
     "aws-c-common": {
       "baseline": "0.8.9",
-      "port-version": 0
+      "port-version": 1
     },
     "aws-c-compression": {
       "baseline": "0.2.16",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.