### PR TITLE
[google-cloud-cpp] add opentelemetry feature

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -29,6 +29,11 @@ if ("dialogflow-es" IN_LIST FEATURES)
     list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "dialogflow-es")
     list(APPEND GOOGLE_CLOUD_CPP_ENABLE "dialogflow_es")
 endif ()
+# This feature is experimental.
+if ("opentelemetry" IN_LIST FEATURES)
+    list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "opentelemetry")
+    list(APPEND GOOGLE_CLOUD_CPP_ENABLE "experimental-opentelemetry")
+endif ()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -14,8 +14,10 @@ vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/grpc")
 
 set(GOOGLE_CLOUD_CPP_ENABLE "${FEATURES}")
 list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "core")
-# This feature does not exist, but allows us to simplify the vcpkg.json file.
+# These features do not exist, but they allow us to simplify the vcpkg.json
+# file.
 list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "grpc-common")
+list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "rest-common")
 list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "googleapis")
 # google-cloud-cpp uses dialogflow_cx and dialogflow_es. Underscores
 # are invalid in `vcpkg` features, we use dashes (`-`) as a separator
@@ -28,11 +30,6 @@ endif ()
 if ("dialogflow-es" IN_LIST FEATURES)
     list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "dialogflow-es")
     list(APPEND GOOGLE_CLOUD_CPP_ENABLE "dialogflow_es")
-endif ()
-# This feature is experimental.
-if ("opentelemetry" IN_LIST FEATURES)
-    list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "opentelemetry")
-    list(APPEND GOOGLE_CLOUD_CPP_ENABLE "experimental-opentelemetry")
 endif ()
 
 vcpkg_cmake_configure(

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.13.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -8,10 +8,7 @@
   "dependencies": [
     "abseil",
     "grpc",
-    {
-      "name": "opentelemetry-cpp",
-      "host": true
-    },
+    "opentelemetry-cpp",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -540,6 +537,19 @@
         }
       ]
     },
+    "experimental-opentelemetry": {
+      "description": "OpenTelemetry C++ GCP Exporter Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "rest-common",
+            "trace"
+          ]
+        }
+      ]
+    },
     "experimental-storage-grpc": {
       "description": "The GCS+gRPC plugin",
       "dependencies": [
@@ -832,25 +842,6 @@
         }
       ]
     },
-    "opentelemetry": {
-      "description": "OpenTelemetry C++ GCP Exporter Library",
-      "dependencies": [
-        {
-          "name": "curl",
-          "features": [
-            "ssl"
-          ]
-        },
-        {
-          "name": "google-cloud-cpp",
-          "default-features": false,
-          "features": [
-            "trace"
-          ]
-        },
-        "nlohmann-json"
-      ]
-    },
     "optimization": {
       "description": "Cloud Optimization API C++ Client Library",
       "dependencies": [
@@ -1007,6 +998,18 @@
         }
       ]
     },
+    "rest-common": {
+      "description": "Dependencies used by all REST-based libraries",
+      "dependencies": [
+        {
+          "name": "curl",
+          "features": [
+            "ssl"
+          ]
+        },
+        "nlohmann-json"
+      ]
+    },
     "retail": {
       "description": "Retail API C++ Client Library",
       "dependencies": [
@@ -1156,12 +1159,12 @@
       "dependencies": [
         "crc32c",
         {
-          "name": "curl",
+          "name": "google-cloud-cpp",
+          "default-features": false,
           "features": [
-            "ssl"
+            "rest-common"
           ]
-        },
-        "nlohmann-json"
+        }
       ]
     },
     "storageinsights": {

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -9,6 +9,10 @@
     "abseil",
     "grpc",
     {
+      "name": "opentelemetry-cpp",
+      "host": true
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
@@ -826,6 +830,25 @@
             "grpc-common"
           ]
         }
+      ]
+    },
+    "opentelemetry": {
+      "description": "OpenTelemetry C++ GCP Exporter Library",
+      "dependencies": [
+        {
+          "name": "curl",
+          "features": [
+            "ssl"
+          ]
+        },
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "trace"
+          ]
+        },
+        "nlohmann-json"
       ]
     },
     "optimization": {

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -9,7 +9,6 @@
   "dependencies": [
     "abseil",
     "grpc",
-    "opentelemetry-cpp",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -548,7 +547,8 @@
             "rest-common",
             "trace"
           ]
-        }
+        },
+        "opentelemetry-cpp"
       ]
     },
     "experimental-storage-grpc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2942,7 +2942,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.13.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce495cdd6fd083393a55827b5338ad244b131ec2",
+      "git-tree": "a14e88242b5cc905b0620d3c1a149c9277842542",
       "version": "2.13.0",
       "port-version": 0
     },

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "d9ee54a1cac40ce75bb8684d4e8bd146fe90f214",
+      "git-tree": "3f128bd1382b7b8f46b217656293516bea800c56",
       "version": "2.13.0",
       "port-version": 1
     },
     {
-      "git-tree": "a14e88242b5cc905b0620d3c1a149c9277842542",
+      "git-tree": "c067a236b62d38d1f56a658b086039bf22441c4a",
       "version": "2.13.0",
       "port-version": 0
     },

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c067a236b62d38d1f56a658b086039bf22441c4a",
+      "git-tree": "ce495cdd6fd083393a55827b5338ad244b131ec2",
       "version": "2.13.0",
       "port-version": 0
     },

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9ee54a1cac40ce75bb8684d4e8bd146fe90f214",
+      "version": "2.13.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a14e88242b5cc905b0620d3c1a149c9277842542",
       "version": "2.13.0",
       "port-version": 0


### PR DESCRIPTION
Tested locally (on x64-linux) with:

```sh
for feature in storage experimental-opentelemetry; do ./vcpkg remove google-cloud-cpp; ./vcpkg install "google-cloud-cpp[core,${feature}]" || break; done
```

and

```sh
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'
```

cc @coryan 