### PR TITLE
[glib] Fix build race between gio subdirs and gversionmacros.h

### DIFF
--- a/ports/glib/fix-build-race-on-gio.patch
+++ b/ports/glib/fix-build-race-on-gio.patch
@@ -1,0 +1,24 @@
+diff --git a/gio/kqueue/meson.build b/gio/kqueue/meson.build
+index 7447e56..f3e573f 100644
+--- a/gio/kqueue/meson.build
++++ b/gio/kqueue/meson.build
+@@ -10,6 +10,7 @@ kqueue_lib = static_library('kqueue',
+   include_directories : [configinc, glibinc],
+   dependencies : [
+     gioenumtypes_dep,
++    libglib_dep,
+     gmodule_inc_dep,
+   ],
+   gnu_symbol_visibility : 'hidden',
+diff --git a/gio/win32/meson.build b/gio/win32/meson.build
+index 08be6b0..6699f10 100644
+--- a/gio/win32/meson.build
++++ b/gio/win32/meson.build
+@@ -13,6 +13,7 @@ giowin32_lib = static_library('giowin32',
+   dependencies : [
+     libintl,
+     gioenumtypes_dep,
++    libglib_dep,
+     gmodule_inc_dep,
+   ],
+   gnu_symbol_visibility : 'hidden',

--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     PATCHES
         use-libiconv-on-windows.patch
         libintl.patch
+        fix-build-race-on-gio.patch # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3512
 )
 
 vcpkg_list(SET OPTIONS)

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glib",
   "version": "2.76.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2890,7 +2890,7 @@
     },
     "glib": {
       "baseline": "2.76.3",
-      "port-version": 1
+      "port-version": 2
     },
     "glibmm": {
       "baseline": "2.76.0",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4aa04cd3294219ddd4b43c2f02b95c100683156",
+      "version": "2.76.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "1d1c3788ae7982f573db3e59116dd1ca885b88a4",
       "version": "2.76.3",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #28722, syncing up the fix of build race between `gio` subdirs and `gversionmacros.h` from upstream: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3512.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
