### PR TITLE
[apache-datasketches] New port

### DIFF
--- a/ports/apache-datasketches/portfile.cmake
+++ b/ports/apache-datasketches/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO apache/datasketches-cpp
+    REF "${VERSION}"
+    SHA512 81047ec2ac4559afc46d68b2332256b3950fc7092404606a872d9204c7e0ac13b7b0e0d6a34de01483bcb03c813ab75ce4866cc0c6783ebf4adddaa6535d322a
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME DataSketches CONFIG_PATH lib/DataSketches/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/apache-datasketches/usage
+++ b/ports/apache-datasketches/usage
@@ -1,0 +1,4 @@
+apache-datasketches provides CMake targets:
+
+    find_package(DataSketches CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE datasketches)

--- a/ports/apache-datasketches/vcpkg.json
+++ b/ports/apache-datasketches/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "apache-datasketches",
+  "version": "4.1.0",
+  "description": "Apache DataSketches Core C++ Library Component.",
+  "homepage": "https://datasketches.apache.org/",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/apache-datasketches.json
+++ b/versions/a-/apache-datasketches.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7b8ef82b48832de95bf297231d0019f5cb2b4e82",
+      "version": "4.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -148,6 +148,10 @@
       "baseline": "3.5.0",
       "port-version": 1
     },
+    "apache-datasketches": {
+      "baseline": "4.1.0",
+      "port-version": 0
+    },
     "approval-tests-cpp": {
       "baseline": "10.12.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Close #32060

---

Usage test passed with following code on x64-osx-release

```cpp
#include <iostream>
#include "DataSketches/count_zeros.hpp"

int main() {
    uint32_t a = 45323454;
    std::cout << "leading_zeros  : " << (int)datasketches::count_leading_zeros_in_u32(a) << std::endl;
    std::cout << "trailing_zeros : " << (int)datasketches::count_trailing_zeros_in_u32(a) << std::endl;
    return 0;
}
```

```cmake
cmake_minimum_required(VERSION 3.15)
project(test_csv_parser)

set(CMAKE_CXX_STANDARD 17)

find_package(DataSketches CONFIG REQUIRED)
add_executable(test_data_sketches main.cpp)
target_link_libraries(test_data_sketches PRIVATE datasketches)

```

---

Should the name of this port be `datasketches-cpp` or `datasketches` ?

---

@BillyONeal suggest use `apache-datasketches`. https://github.com/microsoft/vcpkg/pull/32786#discussion_r1277706229