### PR TITLE
[smpeg2] Change the vcpkg cmake to not error on narrowing conversions.

### DIFF
--- a/ports/smpeg2/CMakeLists.txt
+++ b/ports/smpeg2/CMakeLists.txt
@@ -10,6 +10,8 @@ include_directories(${CMAKE_SOURCE_DIR})
 
 if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+else()
+    add_compile_options(-Wno-narrowing)
 endif()
 add_definitions(-DNOCONTROLS -DTHREADED_AUDIO)
 


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes an issue on non-msvc compilers where the CMake added by the vcpkg port is causing warnings as errors to occur.

Might be better to change this to `-Wno-error`, but I started with this. The vcpkg provided cmake seems to be targeting a _very_ old cmake version, so I wasn't sure what the best ways to detect what should be done here (or what to most appropriately do). I'm open to suggestions, just want to be able to build this on Ubuntu and such :)