### PR TITLE
[portmidi] Add patch that fixes framework linking

### DIFF
--- a/ports/portmidi/framework_link.patch
+++ b/ports/portmidi/framework_link.patch
@@ -1,0 +1,49 @@
+From aa375d4fe0bf91ab1edd445baa7912a23a5e6a60 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Sch=C3=BCrmann?= <daschuer@mixxx.org>
+Date: Thu, 27 Jul 2023 08:30:44 +0200
+Subject: [PATCH] Don't use absolut paths to macOS frameworks
+
+This fixes https://github.com/PortMidi/portmidi/issues/56
+---
+ pm_common/CMakeLists.txt | 21 +++++++++++++--------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/pm_common/CMakeLists.txt b/pm_common/CMakeLists.txt
+index 062887b..e474244 100644
+--- a/pm_common/CMakeLists.txt
++++ b/pm_common/CMakeLists.txt
+@@ -81,21 +81,25 @@ endif()
+ # first include the appropriate system-dependent file:
+ if(UNIX AND APPLE)
+   set(Threads::Threads "" PARENT_SCOPE)
+-  find_library(COREAUDIO_LIBRARY CoreAudio REQUIRED)
+-  find_library(COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
+-  find_library(COREMIDI_LIBRARY CoreMIDI REQUIRED)
+-  find_library(CORESERVICES_LIBRARY CoreServices REQUIRED)
+   set(PM_LIB_PRIVATE_SRC 
+       ${PMDIR}/porttime/ptmacosx_mach.c
+       ${PMDIR}/pm_mac/pmmac.c
+       ${PMDIR}/pm_mac/pmmacosxcm.c
+       ${PMDIR}/pm_mac/finddefault.c
+       ${PMDIR}/pm_mac/readbinaryplist.c)
+-  set(PM_NEEDED_LIBS ${CMAKE_THREAD_LIBS_INIT} ${COREAUDIO_LIBRARY}
+-      ${COREFOUNDATION_LIBRARY} ${COREMIDI_LIBRARY} ${CORESERVICES_LIBRARY}
+-      PARENT_SCOPE)
+-  target_link_libraries(portmidi PRIVATE Threads::Threads ${COREAUDIO_LIBRARY}
+-      ${COREFOUNDATION_LIBRARY} ${COREMIDI_LIBRARY} ${CORESERVICES_LIBRARY})
++  set(PM_NEEDED_LIBS
++      ${CMAKE_THREAD_LIBS_INIT}
++      -Wl,-framework,CoreAudio
++      -Wl,-framework,CoreFoundation
++      -Wl,-framework,CoreMidi
++      -Wl,-framework,CoreServices)
++  target_link_libraries(portmidi
++    PRIVATE
++      Threads::Threads
++      -Wl,-framework,CoreAudio
++      -Wl,-framework,CoreFoundation
++      -Wl,-framework,CoreMidi
++      -Wl,-framework,CoreServices)
+   # set to CMake default; is this right?:
+   set_target_properties(portmidi PROPERTIES MACOSX_RPATH ON)
+ elseif(HAIKU)

--- a/ports/portmidi/portfile.cmake
+++ b/ports/portmidi/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         "search-for-threads-in-config.patch"
+        "framework_link.patch"
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL static)

--- a/ports/portmidi/vcpkg.json
+++ b/ports/portmidi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "portmidi",
   "version": "2.0.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "PortMidi is a cross platform (Windows, macOS, Linux, and BSDs which support alsalib) library for interfacing with operating systems' MIDI I/O APIs.",
   "homepage": "https://github.com/PortMidi/portmidi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6462,7 +6462,7 @@
     },
     "portmidi": {
       "baseline": "2.0.4",
-      "port-version": 1
+      "port-version": 2
     },
     "portsmf": {
       "baseline": "239",

--- a/versions/p-/portmidi.json
+++ b/versions/p-/portmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73cae77fb0424c85894d1165fd2cc162bd4cd98a",
+      "version": "2.0.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "b8607f833773d8d45e83a3390c2096d28226c1d2",
       "version": "2.0.4",
       "port-version": 1


### PR DESCRIPTION
This contributes to https://github.com/microsoft/vcpkg/issues/16259

I have also proposed the patch upstream: https://github.com/PortMidi/portmidi/pull/57

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
