### PR TITLE
[fmt] Add C++20 module feature cppmodule

### DIFF
--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -9,12 +9,19 @@ vcpkg_from_github(
         fix-format-conflict.patch
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cppmodule FMT_MODULE
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DFMT_CMAKE_DIR=share/fmt
         -DFMT_TEST=OFF
         -DFMT_DOC=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -33,6 +40,8 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fmt/fmt-targets.cmake" "${CMAKE_CURRENT_BINARY_DIR}" "`dirname $0`/../../../..")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.rst")

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+	"cppmodule": {
+      "description": "Build a module instead of a traditional library"
+    }
+  }
 }

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fmt",
   "version": "10.0.0",
+  "port-version": 1,
   "description": "Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.",
   "homepage": "https://github.com/fmtlib/fmt",
   "license": "MIT",

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -15,7 +15,7 @@
     }
   ],
   "features": {
-	"cppmodule": {
+    "cppmodule": {
       "description": "Build a module instead of a traditional library"
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2590,7 +2590,7 @@
     },
     "fmt": {
       "baseline": "10.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "folly": {
       "baseline": "2023.07.03.00",

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8b508f47e8b19dc689c5b936538d6f41dbc47f7",
+      "version": "10.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "eedb31bb1318118ec6a2d1bec60ab12e484092fd",
       "version": "10.0.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #32572.

All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```
The usage test passed on `x64-windows` (header files found):
```
The package fmt provides CMake targets:

    find_package(fmt CONFIG REQUIRED)
    target_link_libraries(main PRIVATE fmt::fmt)

    # Or use the header-only version
    find_package(fmt CONFIG REQUIRED)
    target_link_libraries(main PRIVATE fmt::fmt-header-only)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
