### PR TITLE
[tracy] require dbus dependency

### DIFF
--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tracy",
   "version-semver": "0.9.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",
@@ -52,6 +52,10 @@
             "arm64",
             "x86"
           ]
+        },
+        {
+          "name": "dbus",
+          "platform": "!windows"
         },
         "freetype",
         "glfw3"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8214,7 +8214,7 @@
     },
     "tracy": {
       "baseline": "0.9.1",
-      "port-version": 1
+      "port-version": 2
     },
     "transwarp": {
       "baseline": "2.2.2",

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "10b47fa5363e3108af03ccd6729f17b7a05c4804",
+      "version-semver": "0.9.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "77e2063ccf000ddf44db90335335b0d87efe0bf4",
       "version-semver": "0.9.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
