### PR TITLE
[physx] Added physx usage file instructions for CPU-only with custom triplet

### DIFF
--- a/ports/physx/usage
+++ b/ports/physx/usage
@@ -1,4 +1,5 @@
 [Sample port usage]
+
 physx provides CMake targets:
 
     cmake_minimum_required(VERSION 3.15)
@@ -28,3 +29,12 @@ physx provides CMake targets:
     else()
         message(WARNING "GPU acceleration library target not defined - GPU acceleration will NOT be available!")
     endif()
+
+To install and build a CPU-only version of the PhysX engine (one which does not use CUDA), you can create a custom triplet file (e.g. vcpkg/triplets/community/x64-linux-nocuda.cmake) which inherits your desired triplet and ensures a CPU version is installed and built:
+
+    # Inherit all flags but add a PX_GENERATE_GPU_PROJECTS as FALSE
+    # to compile a CPU-only version of the PhysX engine
+    include(${CMAKE_CURRENT_LIST_DIR}/../x64-linux.cmake)
+    set(PX_GENERATE_GPU_PROJECTS FALSE)
+
+If you build a CPU-only version, remember to drop the unofficial::omniverse-physx-sdk::gpu-library target from the targets above.

--- a/versions/p-/physx.json
+++ b/versions/p-/physx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9663323fd4b0d5ff6623bad944b8f60ea2455821",
+      "git-tree": "9a8ebbba870ed5dcff3b1b4f42c364c6d3dfdef8",
       "version": "5.2.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Added some lines to the usage file to be able to compile the PhysX 5 engine in CPU-only mode (some users requested a way to do this).