### PR TITLE
[bullet3] Add OpenMP feature for bullet3

### DIFF
--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         multithreading       BULLET2_MULTITHREADING
         double-precision     USE_DOUBLE_PRECISION
+        openmp               BULLET2_USE_OPEN_MP_MULTITHREADING
     INVERTED_FEATURES
         rtti                 USE_MSVC_DISABLE_RTTI
 )

--- a/ports/bullet3/vcpkg.json
+++ b/ports/bullet3/vcpkg.json
@@ -23,6 +23,9 @@
     },
     "rtti": {
       "description": "Enable RTTI on windows"
+    },
+    "openmp": {
+      "description": "Use openmp scheduler for bullet3"
     }
   }
 }


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.


