### PR TITLE
[c89stringutils, rhasheq] Update

### DIFF
--- a/ports/c89stringutils/no_flags.patch
+++ b/ports/c89stringutils/no_flags.patch
@@ -1,20 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0ce714554..f9f28b890 100644
+index 9e3c005..75dee3f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -18,15 +18,7 @@ target_compile_features("${PROJECT_NAME}_compiler_flags" INTERFACE "c_std_${CMAK
- set(gcc_like "$<COMPILE_LANG_AND_ID:C,CXX,ARMClang,AppleClang,Clang,GNU,LCC>")
- set(msvc "$<COMPILE_LANG_AND_ID:C,CXX,MSVC>")
- # -g -fsanitize=address -fno-omit-frame-pointer
--target_compile_options(
--        "${PROJECT_NAME}_compiler_flags"
--        INTERFACE
--        "$<${gcc_like}:$<BUILD_INTERFACE:-Wall;-Wextra;-Wshadow;-Wformat=2;-Wunused;-pedantic>>"
--        "$<${msvc}:$<BUILD_INTERFACE:-W3;-WX;-Zi;-permissive->>"
--)
- if (CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
--    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
--    set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
- endif (CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
- 
- # configure a header file to pass the version number only
+@@ -24,12 +24,6 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
+     # the BUILD_INTERFACE genex
+     set(gcc_like "$<COMPILE_LANG_AND_ID:C,CXX,ARMClang,AppleClang,Clang,GNU,LCC>")
+     set(msvc "$<COMPILE_LANG_AND_ID:C,CXX,MSVC>")
+-    target_compile_options(
+-            "${PROJECT_NAME}_compiler_flags"
+-            INTERFACE
+-            "$<${gcc_like}:$<BUILD_INTERFACE:-Wshadow;-Wformat=2;-Wall;-pedantic>>"
+-            "$<${msvc}:$<BUILD_INTERFACE:-W3;-WX;-Zi;-permissive->>"
+-    )
+ endif (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
+ # Set the build directories
+ if (CMAKE_SYSTEM_NAME STREQUAL "Windows"

--- a/ports/c89stringutils/portfile.cmake
+++ b/ports/c89stringutils/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO            offscale/c89stringutils
-    REF             375c87aaf50a945b17a76727f3314eb217897caf
-    SHA512          395d942a133209daf510094814830e35daf2047c35b0ff15b17051d7095e4598fd830e0e7f763cac6929b867ff3b0c03c5350c4c3cfc68ed98b69c9c68c04be0
-    HEAD_REF        master
+    REPO offscale/c89stringutils
+    REF "${VERSION}"
+    SHA512 82edb341d5566c42eaffcd5c87d4fbd82a4e47b9c31a8533b08d28b9e1311ced281b59b3b6103e274355a82117095fcff1cb5f9c29eecc9563dc3cd962a37773
+    HEAD_REF master
     PATCHES
         no_flags.patch
 )
@@ -11,10 +11,13 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DBUILD_TESTS=OFF"
+        -DBUILD_TESTING=OFF
 )
 vcpkg_cmake_install()
-file(INSTALL "${SOURCE_PATH}/cmake/LICENSE.txt"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/c89stringutils"
-     RENAME copyright)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE" "${SOURCE_PATH}/LICENSE-MIT")

--- a/ports/c89stringutils/usage
+++ b/ports/c89stringutils/usage
@@ -1,0 +1,4 @@
+c89stringutils provides CMake targets:
+
+    find_package(c89stringutils CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE c89stringutils)

--- a/ports/c89stringutils/vcpkg.json
+++ b/ports/c89stringutils/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "c89stringutils",
-  "version": "0.0.1",
-  "port-version": 1,
+  "version": "0.0.2",
   "description": "string functions from newer standards / common non-standards for C89",
+  "homepage": "https://github.com/offscale/c89stringutils",
   "license": "Apache-2.0 OR MIT",
   "supports": "!uwp",
   "dependencies": [

--- a/ports/c89stringutils/vcpkg.json
+++ b/ports/c89stringutils/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "string functions from newer standards / common non-standards for C89",
   "homepage": "https://github.com/offscale/c89stringutils",
   "license": "Apache-2.0 OR MIT",
-  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/rhasheq/find-rhash.patch
+++ b/ports/rhasheq/find-rhash.patch
@@ -1,0 +1,26 @@
+diff --git a/rhasheq/CMakeLists.txt b/rhasheq/CMakeLists.txt
+index fb7357f..baaaaf8 100644
+--- a/rhasheq/CMakeLists.txt
++++ b/rhasheq/CMakeLists.txt
+@@ -23,8 +23,9 @@ else ()
+ endif (VCPKG_TOOLCHAIN)
+ 
+ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules;${CMAKE_MODULE_PATH}")
+-find_package(LibRHash)
++find_package(unofficial-rhash CONFIG REQUIRED)
+ 
++if(0)
+ if (NOT LibRHash_FOUND)
+     set(CMAKE_FIND_LIBRARY_PREFIXES ${CMAKE_FIND_LIBRARY_PREFIXES} lib)
+     set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} _imp.lib -d.lib -d_imp.lib)
+@@ -40,8 +41,9 @@ endif (NOT TARGET LibRHash)
+ if (NOT LibRHash_FOUND)
+     message(FATAL_ERROR "LibRHash not found")
+ endif (NOT LibRHash_FOUND)
++endif()
+ 
+-target_link_libraries("${LIBRARY_NAME}" INTERFACE "LibRHash::LibRHash")
++target_link_libraries("${LIBRARY_NAME}" INTERFACE unofficial::rhash::rhash)
+ 
+ include(GNUInstallDirs)
+ target_include_directories(

--- a/ports/rhasheq/find-rhash.patch
+++ b/ports/rhasheq/find-rhash.patch
@@ -1,3 +1,16 @@
+diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
+index c64c475..d57179e 100644
+--- a/cmake/Config.cmake.in
++++ b/cmake/Config.cmake.in
+@@ -1,4 +1,8 @@
+ 
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++
++find_dependency(unofficial-rhash)
++
+ include ( "${CMAKE_CURRENT_LIST_DIR}/rhasheqTargets.cmake" )
 diff --git a/rhasheq/CMakeLists.txt b/rhasheq/CMakeLists.txt
 index fb7357f..baaaaf8 100644
 --- a/rhasheq/CMakeLists.txt

--- a/ports/rhasheq/portfile.cmake
+++ b/ports/rhasheq/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF cf5442f6468871beb6088991501e6ba052fe4467
     SHA512 2be63bc32c7cea35eefbcc7186255e9cd8ba6ed4b03cb9ee2e62740fe17ad74a81ee7e4ada37f4a2dca99a82becf790d6aa86822cdbeba3972cf11d54095ca91
     HEAD_REF master
+    PATCHES
+        find-rhash.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/rhasheq/portfile.cmake
+++ b/ports/rhasheq/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
         find-rhash.patch
 )
 
+file(REMOVE "${SOURCE_PATH}/cmake/modules/FindLibRHash.cmake")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/rhasheq/portfile.cmake
+++ b/ports/rhasheq/portfile.cmake
@@ -1,18 +1,18 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO            offscale/rhasheq
-    REF             c42b672daf9bb1525cb94645244a09344c2a7363
-    SHA512          55947069a67e7de8561b92bad753481402dd353aa40b06719346fa1247d8d0a5073a8a3e38419e7d9028684c091eb23b11b254fea836383a24ce8dcfe0cffefc
-    HEAD_REF        master
+    REPO offscale/rhasheq
+    REF cf5442f6468871beb6088991501e6ba052fe4467
+    SHA512 2be63bc32c7cea35eefbcc7186255e9cd8ba6ed4b03cb9ee2e62740fe17ad74a81ee7e4ada37f4a2dca99a82becf790d6aa86822cdbeba3972cf11d54095ca91
+    HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DBUILD_TESTING=OFF"
+        -DBUILD_TESTING=OFF
 )
 vcpkg_cmake_install()
-file(INSTALL "${SOURCE_PATH}/COPYING"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/rhasheq"
-     RENAME copyright)
+vcpkg_cmake_config_fixup()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/rhasheq/vcpkg.json
+++ b/ports/rhasheq/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "rhasheq",
-  "version": "0.0.1",
+  "version-date": "2023-07-29",
   "description": "Simple header-only librhash wrapper for verifying hashes from a file to a given `const char *`.",
+  "homepage": "https://github.com/offscale/rhasheq",
   "license": "0BSD",
-  "supports": "!uwp",
   "dependencies": [
     "c89stringutils",
     "rhash",

--- a/ports/rhasheq/vcpkg.json
+++ b/ports/rhasheq/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rhasheq",
-  "version-date": "2023-07-29",
+  "version-date": "2023-06-17",
   "description": "Simple header-only librhash wrapper for verifying hashes from a file to a given `const char *`.",
   "homepage": "https://github.com/offscale/rhasheq",
   "license": "0BSD",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1353,8 +1353,8 @@
       "port-version": 0
     },
     "c89stringutils": {
-      "baseline": "0.0.1",
-      "port-version": 1
+      "baseline": "0.0.2",
+      "port-version": 0
     },
     "c9y": {
       "baseline": "0.8.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7193,7 +7193,7 @@
       "port-version": 1
     },
     "rhasheq": {
-      "baseline": "0.0.1",
+      "baseline": "2023-07-29",
       "port-version": 0
     },
     "riffcpp": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7193,7 +7193,7 @@
       "port-version": 1
     },
     "rhasheq": {
-      "baseline": "2023-07-29",
+      "baseline": "2023-06-17",
       "port-version": 0
     },
     "riffcpp": {

--- a/versions/c-/c89stringutils.json
+++ b/versions/c-/c89stringutils.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c50f8f8a4bfb937214a3327ea7099ef8c9ea8e4c",
+      "version": "0.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e4c282e10d69a020f581a2bd7b8d8ead1e29d9a2",
       "version": "0.0.1",
       "port-version": 1

--- a/versions/r-/rhasheq.json
+++ b/versions/r-/rhasheq.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "255cfa293a9a2a64778ccfb88a5e21f2f4c063a9",
+      "git-tree": "9b9d7eec44e958e70a4d732c7d815b13995c93d6",
       "version-date": "2023-06-17",
       "port-version": 0
     },

--- a/versions/r-/rhasheq.json
+++ b/versions/r-/rhasheq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78ccf8c1b31e4c01731a8ff08dc68e6e3cd3f015",
+      "version-date": "2023-07-29",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f26547ad3e879dcf8083e3db488bdb1cda587f4",
       "version": "0.0.1",
       "port-version": 0

--- a/versions/r-/rhasheq.json
+++ b/versions/r-/rhasheq.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9b9d7eec44e958e70a4d732c7d815b13995c93d6",
+      "git-tree": "3c15162bd5553142806ade9ab97735f2ffc237df",
       "version-date": "2023-06-17",
       "port-version": 0
     },

--- a/versions/r-/rhasheq.json
+++ b/versions/r-/rhasheq.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "78ccf8c1b31e4c01731a8ff08dc68e6e3cd3f015",
-      "version-date": "2023-07-29",
+      "git-tree": "255cfa293a9a2a64778ccfb88a5e21f2f4c063a9",
+      "version-date": "2023-06-17",
       "port-version": 0
     },
     {

--- a/versions/r-/rhasheq.json
+++ b/versions/r-/rhasheq.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3c15162bd5553142806ade9ab97735f2ffc237df",
+      "git-tree": "ba4955f3d43cf99dfa0d770482ba6cf62d97ab4e",
       "version-date": "2023-06-17",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

- Update c89stringutils to 0.0.2
- Update rhasheq to latest commit (build failure with previous version; no new version was published)

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
