### PR TITLE
[cpptoml] `version-string` --> `version`

### DIFF
--- a/ports/cpptoml/portfile.cmake
+++ b/ports/cpptoml/portfile.cmake
@@ -1,10 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO skystrife/cpptoml
-
-	REF fededad7169e538ca47e11a9ee9251bc361a9a65
-	SHA512 2ec50f4585bca33bb343170470048a7d7e7902f1ffa5709cf84ddf9f53a899ff1cc9ffa49e059f6dad93d13823c4d2661bc8109e4356078cdbdfef1a2be6a622
-
+    REF fededad7169e538ca47e11a9ee9251bc361a9a65
+    SHA512 2ec50f4585bca33bb343170470048a7d7e7902f1ffa5709cf84ddf9f53a899ff1cc9ffa49e059f6dad93d13823c4d2661bc8109e4356078cdbdfef1a2be6a622
     HEAD_REF master
 )
 
@@ -12,6 +10,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCPPTOML_BUILD_EXAMPLES=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/cpptoml/vcpkg.json
+++ b/ports/cpptoml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpptoml",
-  "version-string": "v0.1.1",
-  "port-version": 2,
+  "version": "0.1.1",
+  "port-version": 3,
   "description": "A header-only library for parsing TOML configuration files.",
   "homepage": "https://github.com/skystrife/cpptoml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1841,8 +1841,8 @@
       "port-version": 0
     },
     "cpptoml": {
-      "baseline": "v0.1.1",
-      "port-version": 2
+      "baseline": "0.1.1",
+      "port-version": 3
     },
     "cppunit": {
       "baseline": "1.15.1",

--- a/versions/c-/cpptoml.json
+++ b/versions/c-/cpptoml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fde8b7854f0796406eada5609cb2cc54728d73db",
+      "version": "0.1.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "56b510542b03ac901331cc1d074c140ff7aaaad1",
       "version-string": "v0.1.1",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Switch from `version-string` to `version`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
