### PR TITLE
[bzip2] Fix version in pc file

### DIFF
--- a/ports/bzip2/CMakeLists.txt
+++ b/ports/bzip2/CMakeLists.txt
@@ -17,7 +17,7 @@ set(BZ2_SOURCES
 add_library(bz2 ${BZ2_SOURCES})
 set_target_properties(bz2 PROPERTIES
     DEBUG_POSTFIX d
-    VERSION 1.0.6
+    VERSION "${BZ2_VERSION}"
     SOVERSION 1.0)
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(bz2 PRIVATE -DBZ_BUILD_DLL)

--- a/ports/bzip2/bzip2.pc.in
+++ b/ports/bzip2/bzip2.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 
 Name: bzip2
 Description: bzip2
-Version: 1.0.6
+Version: @VERSION@
 Requires: 
 Libs: -L${libdir} -l@bzname@
 Cflags: -I${includedir}

--- a/ports/bzip2/portfile.cmake
+++ b/ports/bzip2/portfile.cmake
@@ -1,27 +1,27 @@
-set(BZIP2_VERSION 1.0.8)
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://sourceware.org/pub/bzip2/bzip2-${BZIP2_VERSION}.tar.gz"
-    FILENAME "bzip2-${BZIP2_VERSION}.tar.gz"
+    URLS "https://sourceware.org/pub/bzip2/bzip2-${VERSION}.tar.gz"
+    FILENAME "bzip2-${VERSION}.tar.gz"
     SHA512 083f5e675d73f3233c7930ebe20425a533feedeaaa9d8cc86831312a6581cefbe6ed0d08d2fa89be81082f2a5abdabca8b3c080bf97218a1bd59dc118a30b9f3
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
     PATCHES fix-import-export-macros.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     INVERTED_FEATURES
-        tool    BZIP2_SKIP_TOOLS
+        tool BZIP2_SKIP_TOOLS
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        "-DBZ2_VERSION=${VERSION}"
     OPTIONS_DEBUG
         -DBZIP2_SKIP_HEADERS=ON
         -DBZIP2_SKIP_TOOLS=ON
@@ -39,18 +39,18 @@ endif()
 file(WRITE "${CURRENT_PACKAGES_DIR}/include/bzlib.h" "${BZLIB_H}")
 
 if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-  set(BZIP2_PREFIX "${CURRENT_INSTALLED_DIR}")
-  set(bzname bz2)
-  configure_file("${CMAKE_CURRENT_LIST_DIR}/bzip2.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/bzip2.pc" @ONLY)
+    set(BZIP2_PREFIX "${CURRENT_INSTALLED_DIR}")
+    set(bzname bz2)
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/bzip2.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/bzip2.pc" @ONLY)
 endif()
 
 if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-  set(BZIP2_PREFIX "${CURRENT_INSTALLED_DIR}/debug")
-  set(bzname bz2d)
-  configure_file("${CMAKE_CURRENT_LIST_DIR}/bzip2.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/bzip2.pc" @ONLY)
+    set(BZIP2_PREFIX "${CURRENT_INSTALLED_DIR}/debug")
+    set(bzname bz2d)
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/bzip2.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/bzip2.pc" @ONLY)
 endif()
 
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bzip2/vcpkg.json
+++ b/ports/bzip2/vcpkg.json
@@ -1,18 +1,14 @@
 {
   "name": "bzip2",
   "version-semver": "1.0.8",
-  "port-version": 4,
+  "port-version": 5,
   "description": "bzip2 is a freely available, patent free, high-quality data compressor. It typically compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical compressors), whilst being around twice as fast at compression and six times faster at decompression.",
   "homepage": "https://sourceware.org/bzip2/",
   "documentation": "https://sourceware.org/bzip2/docs.html",
-  "license": "bzip2-1.0.6",
+  "license": "bzip2-1.0.8",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ],

--- a/ports/bzip2/vcpkg.json
+++ b/ports/bzip2/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "bzip2 is a freely available, patent free, high-quality data compressor. It typically compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical compressors), whilst being around twice as fast at compression and six times faster at decompression.",
   "homepage": "https://sourceware.org/bzip2/",
   "documentation": "https://sourceware.org/bzip2/docs.html",
-  "license": "bzip2-1.0.8",
+  "license": "bzip2-1.0.6",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/b-/bzip2.json
+++ b/versions/b-/bzip2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92e9a8bbf1abbd89872b48ad82fcf75852de1006",
+      "version-semver": "1.0.8",
+      "port-version": 5
+    },
+    {
       "git-tree": "6165360d15e6de08dff3a5f079d51e69908cc55d",
       "version-semver": "1.0.8",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1338,7 +1338,7 @@
     },
     "bzip2": {
       "baseline": "1.0.8",
-      "port-version": 4
+      "port-version": 5
     },
     "c-ares": {
       "baseline": "1.19.0",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Updates the version in the pc file and in CMakeLists.txt to match the actual version of the port. By using the VERSION variable in all cases, we can avoid this issue in the future.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
