### PR TITLE
[rubberband] Update to 3.3.0

### DIFF
--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO breakfastquay/rubberband
     REF "v${VERSION}"
-    SHA512 811a8dbf05fbee3e4631b49fee9fd0e23ea750ac24a9a16f20e6a7ea07e683783a9edf980c43e732b64c229db29ade3575938c4e6f9db8c4255b220eb30d9dcc
+    SHA512 6d7ce80f47a5870920748d6e2ff9425f9d90e3fd2d62d7b937158ad2134829bc1d1e34ec4fd6327de5d6f1924b4bb793dc4c9d10574102e11338383c4522ba84
     HEAD_REF default
 )
 
@@ -57,8 +57,4 @@ if("cli" IN_LIST FEATURES)
   vcpkg_copy_tools(TOOL_NAMES ${RUBBERBAND_PROGRAM_NAMES} AUTO_CLEAN)
 endif()
 
-file(
-  INSTALL "${SOURCE_PATH}/COPYING"
-  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-  RENAME copyright
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rubberband",
-  "version": "3.2.1",
-  "port-version": 1,
+  "version": "3.3.0",
   "description": "A high quality software library for audio time-stretching and pitch-shifting.",
   "homepage": "https://www.breakfastquay.com/rubberband/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7289,8 +7289,8 @@
       "port-version": 0
     },
     "rubberband": {
-      "baseline": "3.2.1",
-      "port-version": 1
+      "baseline": "3.3.0",
+      "port-version": 0
     },
     "rxcpp": {
       "baseline": "4.1.1",

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3a5ed426944950b92d114499028a3c4c5ed3219",
+      "version": "3.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e89e7b8691ae1ce66b0e82d00ec50061b23b593a",
       "version": "3.2.1",
       "port-version": 1


### PR DESCRIPTION
Fixes #32809, update `rubberband` to 3.3.0.

* All features are tested successfully in the following triplet:
    ```
    x86-windows
    x64-windows
    x64-windows-static
    ```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
