### PR TITLE
[mruby] New port

### DIFF
--- a/ports/mruby/portfile.cmake
+++ b/ports/mruby/portfile.cmake
@@ -1,0 +1,15 @@
+set(VERSION 3.2.0)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mruby/mruby
+    REF 87260e7bb1a9edfb2ce9b41549c4142129061ca5
+    SHA512 dbc0602ac7265076dc9fa1f862585fe0a3669be32cef0f0b13f1fdc18e82e45d2b9eb205723a87581a8a96382fb0ca23ec19fe0494cba29f7a2eaa512e5b26cc
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/mruby/portfile.cmake
+++ b/ports/mruby/portfile.cmake
@@ -3,13 +3,15 @@ set(VERSION 3.2.0)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mruby/mruby
-    REF 87260e7bb1a9edfb2ce9b41549c4142129061ca5
-    SHA512 dbc0602ac7265076dc9fa1f862585fe0a3669be32cef0f0b13f1fdc18e82e45d2b9eb205723a87581a8a96382fb0ca23ec19fe0494cba29f7a2eaa512e5b26cc
+    REF ${VERSION}
+    SHA512 bb46fa0eda6507cabe775e3f9cceec6da64d5a96c20e704e7ada94f5b4906989553c363cfd85789c4adcb030a6cfd36b8a99d8247f32687c913bbe06edb9bbca
     HEAD_REF master
 )
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+vcpkg_execute_in_download_mode(
+    COMMAND rake
+    WORKING_DIRECTORY "${SOURCE_PATH}"
 )
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/mruby/vcpkg.json
+++ b/ports/mruby/vcpkg.json
@@ -3,15 +3,5 @@
   "version": "3.2.0",
   "description": "Lightweight Ruby",
   "homepage": "https://mruby.org/",
-  "license": "MIT",
-  "dependencies": [
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    }
-  ]
+  "license": "MIT"
 }

--- a/ports/mruby/vcpkg.json
+++ b/ports/mruby/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "mruby",
+  "version": "3.2.0",
+  "description": "Lightweight Ruby",
+  "homepage": "https://mruby.org/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5484,6 +5484,10 @@
       "baseline": "13.1.0",
       "port-version": 0
     },
+    "mruby": {
+      "baseline": "3.2.0",
+      "port-version": 0
+    },
     "ms-angle": {
       "baseline": "alias",
       "port-version": 1

--- a/versions/m-/mruby.json
+++ b/versions/m-/mruby.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3b18866e356b138ef918c190d5e490c3391ff174",
+      "git-tree": "c1b2dbdc8e7271232ac35eca4c6f208c323d5637",
       "version": "3.2.0",
       "port-version": 0
     }

--- a/versions/m-/mruby.json
+++ b/versions/m-/mruby.json
@@ -1,0 +1,9 @@
+{
+    "version": [
+        {
+            "git-tree": "3b18866e356b138ef918c190d5e490c3391ff174",
+            "version": "3.2.0",
+            "port-version": 0
+        }
+    ]
+}

--- a/versions/m-/mruby.json
+++ b/versions/m-/mruby.json
@@ -1,5 +1,5 @@
 {
-    "version": [
+    "versions": [
         {
             "git-tree": "3b18866e356b138ef918c190d5e490c3391ff174",
             "version": "3.2.0",

--- a/versions/m-/mruby.json
+++ b/versions/m-/mruby.json
@@ -1,9 +1,9 @@
 {
-    "versions": [
-        {
-            "git-tree": "3b18866e356b138ef918c190d5e490c3391ff174",
-            "version": "3.2.0",
-            "port-version": 0
-        }
-    ]
+  "versions": [
+    {
+      "git-tree": "3b18866e356b138ef918c190d5e490c3391ff174",
+      "version": "3.2.0",
+      "port-version": 0
+    }
+  ]
 }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

