### PR TITLE
[bullet3] Add featrue extras

### DIFF
--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         multithreading       BULLET2_MULTITHREADING
         double-precision     USE_DOUBLE_PRECISION
+		extras               BUILD_EXTRAS
     INVERTED_FEATURES
         rtti                 USE_MSVC_DISABLE_RTTI
 )
@@ -27,7 +28,6 @@ vcpkg_cmake_configure(
         -DBUILD_BULLET2_DEMOS=OFF
         -DBUILD_OPENGL3_DEMOS=OFF
         -DBUILD_BULLET3=OFF
-        -DBUILD_EXTRAS=ON
         -DBUILD_BULLET_ROBOTICS_GUI_EXTRA=OFF
         -DBUILD_BULLET_ROBOTICS_EXTRA=OFF
         -DBUILD_GIMPACTUTILS_EXTRA=OFF        

--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -1,5 +1,4 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         multithreading       BULLET2_MULTITHREADING
         double-precision     USE_DOUBLE_PRECISION
-		extras               BUILD_EXTRAS
+        extras               BUILD_EXTRAS
     INVERTED_FEATURES
         rtti                 USE_MSVC_DISABLE_RTTI
 )

--- a/ports/bullet3/vcpkg.json
+++ b/ports/bullet3/vcpkg.json
@@ -19,14 +19,14 @@
     "double-precision": {
       "description": "Use float64 doubles for bullet3"
     },
+    "extras": {
+      "description": "Build the extras"
+    },
     "multithreading": {
       "description": "Multithreading functionality for bullet3"
     },
     "rtti": {
       "description": "Enable RTTI on windows"
-    },
-	"extras": {
-      "description": "Build the extras"
     }
   }
 }

--- a/ports/bullet3/vcpkg.json
+++ b/ports/bullet3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "bullet3",
   "version": "3.25",
+  "port-version": 1,
   "description": "Bullet Physics is a professional collision detection, rigid body, and soft body dynamics library",
   "homepage": "https://github.com/bulletphysics/bullet3",
   "license": "Zlib",
@@ -23,6 +24,9 @@
     },
     "rtti": {
       "description": "Enable RTTI on windows"
+    },
+	"extras": {
+      "description": "Build the extras"
     }
   }
 }

--- a/versions/b-/bullet3.json
+++ b/versions/b-/bullet3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "749b894e0161c23e525bf7aafbb43718d8fa26fa",
+      "git-tree": "97fa5e4897653fbef0b1084d71cf832c39726d60",
       "version": "3.25",
       "port-version": 1
     },

--- a/versions/b-/bullet3.json
+++ b/versions/b-/bullet3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "749b894e0161c23e525bf7aafbb43718d8fa26fa",
+      "version": "3.25",
+      "port-version": 1
+    },
+    {
       "git-tree": "2ddb8da6a7bd04aff093231935f5ead2a8ee7c79",
       "version": "3.25",
       "port-version": 0

--- a/versions/b-/bullet3.json
+++ b/versions/b-/bullet3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "97fa5e4897653fbef0b1084d71cf832c39726d60",
+      "git-tree": "9ecadb6b6e0651347e89555207f28c4ee5b1b51c",
       "version": "3.25",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1318,7 +1318,7 @@
     },
     "bullet3": {
       "baseline": "3.25",
-      "port-version": 0
+      "port-version": 1
     },
     "bustache": {
       "baseline": "1.1.0",


### PR DESCRIPTION
Fixes #10808, add featrue `extras` for `bullet3`.

All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
x64-linux
```
The usage test passed on `x64-windows`  and `x64-linux`(header files found):
```
Bullet3 provides CMake targets:

    find_package(Bullet CONFIG REQUIRED)
    target_link_libraries(main PRIVATE ${BULLET_LIBRARIES})
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
