### PR TITLE
[Proj] remove toolset restriction

### DIFF
--- a/ports/proj/portfile.cmake
+++ b/ports/proj/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix-win-output-name.patch
         fix-proj4-targets-cmake.patch
         remove-doc.patch
+        remove_toolset_restriction.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/proj/remove_toolset_restriction.patch
+++ b/ports/proj/remove_toolset_restriction.patch
@@ -1,0 +1,19 @@
+diff --git a/cmake/project-config-version.cmake.in b/cmake/project-config-version.cmake.in
+index d9807b2c5..7ffe39364 100644
+--- a/cmake/project-config-version.cmake.in
++++ b/cmake/project-config-version.cmake.in
+@@ -35,14 +35,6 @@ elseif (NOT (APPLE OR (NOT DEFINED CMAKE_SIZEOF_VOID_P) OR
+   # since a multi-architecture library is built for that platform).
+   set (REASON "sizeof(*void) = @CMAKE_SIZEOF_VOID_P@")
+   set (PACKAGE_VERSION_UNSUITABLE TRUE)
+-elseif (MSVC AND NOT (
+-    # toolset version must be at least as great as @PROJECT_NAME@'s
+-    MSVC_TOOLSET_VERSION GREATER_EQUAL @MSVC_TOOLSET_VERSION@
+-    # and major versions must match
+-    AND MSVC_TOOLSET_MAJOR EQUAL @MSVC_TOOLSET_MAJOR@ ))
+-  # Reject if there's a mismatch in MSVC compiler versions
+-  set (REASON "MSVC_TOOLSET_VERSION = @MSVC_TOOLSET_VERSION@")
+-  set (PACKAGE_VERSION_UNSUITABLE TRUE)
+ elseif (NOT CMAKE_CROSSCOMPILING_STR STREQUAL "@CMAKE_CROSSCOMPILING_STR@")
+   # Reject if there's a mismatch in ${CMAKE_CROSSCOMPILING}
+   set (REASON "cross-compiling = @CMAKE_CROSSCOMPILING@")

--- a/ports/proj/vcpkg.json
+++ b/ports/proj/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "proj",
   "version": "9.2.1",
+  "port-version": 1,
   "description": "PROJ library for cartographic projections",
   "homepage": "https://proj.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6494,7 +6494,7 @@
     },
     "proj": {
       "baseline": "9.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "proj4": {
       "baseline": "8.9.9",

--- a/versions/p-/proj.json
+++ b/versions/p-/proj.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b3f5ec4ce13a932cb9f05f074e48b386fd5e4130",
+      "version": "9.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e7dc980fc3b1ca19e8ca6aa5b1ad625949229b2e",
       "version": "9.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

closes #32771