### PR TITLE
[scotch] add new port

### DIFF
--- a/ports/scotch/fix-build.patch
+++ b/ports/scotch/fix-build.patch
@@ -1,0 +1,311 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 83144b41b..1cfe80d42 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,9 +41,9 @@
+ ##                                                        ##
+ ############################################################
+ 
+-project(SCOTCH)
+ cmake_minimum_required(VERSION 3.10)
+-enable_language(C Fortran)
++project(SCOTCH)
++enable_language(C)
+ 
+ # Add module directory
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 22a81ffbe..7746b22af 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -95,14 +95,23 @@ endif()
+ 
+ # Thread support in Scotch
+ if(THREADS)
+-  find_package(Threads)
+-  if(Threads_FOUND)
++set(USE_PTHREAD OFF)
++if(NOT WIN32)
++  find_package(Threads REQUIRED)
++  if(CMAKE_USE_PTHREADS_INIT)
+     add_definitions(-DCOMMON_PTHREAD -DSCOTCH_PTHREAD)
++    set(USE_PTHREAD ON)
+   endif()
+   include(CheckPthreadAffinity)
+   if(PTHREAD_AFFINITY_LINUX_OK)
+     add_definitions(-DCOMMON_PTHREAD_AFFINITY_LINUX)
+   endif()
++else()
++  find_package(PThreads4W REQUIRED)
++  add_definitions(-DCOMMON_PTHREAD -DSCOTCH_PTHREAD)
++  link_libraries(PThreads4W::PThreads4W)
++  set(USE_PTHREAD ON)
++endif()
+ endif()
+ 
+ # decompression libs
+@@ -174,8 +183,9 @@ if(BUILD_LIBSCOTCHMETIS)
+ endif(BUILD_LIBSCOTCHMETIS)
+ 
+ # Testing
+-add_subdirectory(check)
+-
++if(BUILD_TESTING)
++  add_subdirectory(check)
++endif()
+ ####################
+ #  Export targets  #
+ ####################
+diff --git a/src/libscotch/CMakeLists.txt b/src/libscotch/CMakeLists.txt
+index e3b0cb939..5ab322eca 100644
+--- a/src/libscotch/CMakeLists.txt
++++ b/src/libscotch/CMakeLists.txt
+@@ -503,12 +503,30 @@ set(SCOTCH_C_SOURCES
+   wgraph_part_zr.h
+   wgraph_store.c)
+ 
++add_library(scotcherr library_error.c)
++target_include_directories(scotcherr PUBLIC
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++  $<BUILD_INTERFACE:${GENERATED_INCLUDE_DIR}>
++  $<INSTALL_INTERFACE:include>)
++
++add_dependencies(scotcherr scotch_h)
++
++add_library(scotcherrexit library_error_exit.c)
++target_include_directories(scotcherrexit PUBLIC
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++  $<BUILD_INTERFACE:${GENERATED_INCLUDE_DIR}>
++  $<INSTALL_INTERFACE:include>)
++
++add_dependencies(scotcherrexit scotch_h)
++
+ add_library(scotch
+   ${SCOTCH_C_SOURCES})
+ set_target_properties(scotch PROPERTIES VERSION
+   ${SCOTCH_VERSION}.${SCOTCH_RELEASE}.${SCOTCH_PATCHLEVEL})
+ add_dependencies(scotch parser_yy_c parser_ll_c)
+-target_link_libraries(scotch PUBLIC m)
++if(NOT WIN32)
++    target_link_libraries(scotch PUBLIC m)
++endif()
+ target_include_directories(scotch PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+@@ -539,10 +557,14 @@ if(LIBLZMA_FOUND)
+ endif()
+ 
+ # Add thread library
+-if(Threads_FOUND)
+-  target_compile_definitions(scotch PUBLIC COMMON_PTHREAD SCOTCH_PTHREAD)
+-  target_link_libraries(scotch PUBLIC Threads::Threads)
+-endif(Threads_FOUND)
++if(USE_PTHREAD)
++    target_compile_definitions(scotch PUBLIC COMMON_PTHREAD SCOTCH_PTHREAD)
++    if(NOT WIN32)
++      target_link_libraries(scotch PUBLIC Threads::Threads)
++    else()
++      target_link_libraries(scotch PUBLIC PThreads4W::PThreads4W)
++    endif()
++endif(USE_PTHREAD)
+ 
+ # Include files
+ add_dependencies(scotch scotch_h scotchf_h)
+@@ -555,21 +577,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
+   target_compile_definitions(scotch PRIVATE SCOTCH_DEBUG_LIBRARY1)
+ endif()
+ 
+-add_library(scotcherr library_error.c)
+-target_include_directories(scotcherr PUBLIC
+-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-  $<BUILD_INTERFACE:${GENERATED_INCLUDE_DIR}>
+-  $<INSTALL_INTERFACE:include>)
+-
+-add_dependencies(scotcherr scotch_h)
+-
+-add_library(scotcherrexit library_error_exit.c)
+-target_include_directories(scotcherrexit PUBLIC
+-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-  $<BUILD_INTERFACE:${GENERATED_INCLUDE_DIR}>
+-  $<INSTALL_INTERFACE:include>)
+-
+-add_dependencies(scotcherrexit scotch_h)
++target_link_libraries(scotch PRIVATE scotcherr)
+ 
+ #################
+ #  libPTScotch  #
+@@ -769,10 +777,14 @@ if(BUILD_PTSCOTCH)
+     set_target_properties(ptscotch PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+   endif(APPLE)
+ 
+-  if(Threads_FOUND)
+-    target_compile_definitions(ptscotch PUBLIC SCOTCH_PTHREAD COMMON_PTHREAD)
+-    target_link_libraries(ptscotch PUBLIC Threads::Threads)
+-  endif(Threads_FOUND)
++  if(USE_PTHREAD)
++      target_compile_definitions(ptscotch PUBLIC COMMON_PTHREAD SCOTCH_PTHREAD)
++      if(NOT WIN32)
++        target_link_libraries(ptscotch PUBLIC Threads::Threads)
++      else()
++        target_link_libraries(ptscotch PUBLIC PThreads4W::PThreads4W)
++      endif()
++  endif(USE_PTHREAD)
+ 
+   add_library(ptscotcherr library_error.c)
+   target_include_directories(ptscotcherr PUBLIC
+diff --git a/src/libscotch/common_file_compress.c b/src/libscotch/common_file_compress.c
+index e1ccff54d..4dc7673a6 100644
+--- a/src/libscotch/common_file_compress.c
++++ b/src/libscotch/common_file_compress.c
+@@ -378,8 +378,11 @@ FileCompress * const        compptr)
+   encodat.avail_out = FILECOMPRESSDATASIZE;
+   do {
+     if ((encodat.avail_in == 0) && (enacval == LZMA_RUN)) {
++#ifdef _MSC_VER
++      int                 bytenbr; //According to MSDN _read only returns int
++#else
+       ssize_t             bytenbr;
+-
++#endif
+       bytenbr = read (compptr->infdnum, compptr->bufftab, FILECOMPRESSDATASIZE); /* Read from pipe */
+       if (bytenbr < 0) {
+         errorPrint ("fileCompressLzma: cannot read");
+diff --git a/src/libscotch/common_file_decompress.c b/src/libscotch/common_file_decompress.c
+index 648b6f053..02bd9412c 100644
+--- a/src/libscotch/common_file_decompress.c
++++ b/src/libscotch/common_file_decompress.c
+@@ -373,7 +373,11 @@ FileCompress * const        compptr)
+   decodat.avail_out = FILECOMPRESSDATASIZE;
+   do {
+     if ((decodat.avail_in == 0) && (deacval == LZMA_RUN)) {
++#ifdef _MSC_VER
++      size_t              bytenbr; //According to MSDN fread returns size_t
++#else
+       ssize_t             bytenbr;
++#endif
+ 
+       bytenbr = fread (compptr->bufftab, 1, FILECOMPRESSDATASIZE, compptr->oustptr); /* Read from pipe */
+       if (ferror (compptr->oustptr)) {
+diff --git a/src/libscotch/common_thread.h b/src/libscotch/common_thread.h
+index 235d92044..6d35aeb1a 100644
+--- a/src/libscotch/common_thread.h
++++ b/src/libscotch/common_thread.h
+@@ -81,6 +81,8 @@ typedef struct ThreadContext_ {
+   union {                                         /*+ Context save area for main thread   +*/
+ #ifdef COMMON_PTHREAD_AFFINITY_LINUX
+     cpu_set_t                   cpusdat;          /*+ Original thread mask of main thread +*/
++#else
++    void*                       dummy;
+ #endif /* COMMON_PTHREAD_AFFINITY_LINUX */
+   }                             savedat;
+ #endif /* COMMON_PTHREAD */
+diff --git a/src/libscotch/context.c b/src/libscotch/context.c
+index 6becac0af..a88da0099 100644
+--- a/src/libscotch/context.c
++++ b/src/libscotch/context.c
+@@ -70,7 +70,11 @@ static struct ContextValuesData_ {
+ #else /* ((defined SCOTCH_DETERMINISTIC) || (defined COMMON_RANDOM_FIXED_SEED)) */
+                               0
+ #endif /* ((defined SCOTCH_DETERMINISTIC) || (defined COMMON_RANDOM_FIXED_SEED)) */
+-  }, { } };
++  }
++#ifndef _MSC_VER
++  , { }
++#endif
++  };
+ 
+ /***********************************/
+ /*                                 */
+@@ -89,6 +93,6 @@ contextOptionsInit (
+ Context * const             contptr)
+ {
+   return (contextValuesInit (contptr, &contextvaluesdat, sizeof (contextvaluesdat),
+-                             CONTEXTOPTIONNUMNBR, (void *) &contextvaluesdat.vinttab - (void *) &contextvaluesdat,
+-                             CONTEXTOPTIONDBLNBR, (void *) &contextvaluesdat.vdbltab - (void *) &contextvaluesdat));
++                             CONTEXTOPTIONNUMNBR, (char *) &contextvaluesdat.vinttab - (char *) &contextvaluesdat,
++                             CONTEXTOPTIONDBLNBR, (char *) &contextvaluesdat.vdbltab - (char *) &contextvaluesdat));
+ }
+diff --git a/src/libscotch/parser_ll.l b/src/libscotch/parser_ll.l
+index 6a795aad6..582f5e201 100644
+--- a/src/libscotch/parser_ll.l
++++ b/src/libscotch/parser_ll.l
+@@ -85,6 +85,10 @@
+ %option noyywrap
+ %option reentrant
+ 
++/* To support build on Windows */
++%option nounistd
++
++
+ IDENT                       [A-Za-z][0-9A-Za-z]*
+ INTEGER                     [0-9]+
+ FLOAT                       [0-9]+(\.[0-9]+)?([Ee][-+]?[0-9]+)?
+diff --git a/src/libscotch/parser_yy.y b/src/libscotch/parser_yy.y
+index b287da4ca..bbc10b3ef 100644
+--- a/src/libscotch/parser_yy.y
++++ b/src/libscotch/parser_yy.y
+@@ -81,6 +81,9 @@ typedef void * YY_BUFFER_STATE;                   /* The same; Flex and Bison de
+ **  The defines and includes (bis).
+ */
+ 
++#ifdef _MSC_VER
++#define YY_NO_UNISTD_H
++#endif
+ #include "parser.h"
+ #include "parser_yy.h"
+ #include "parser_ly.h"
+diff --git a/src/scotch/CMakeLists.txt b/src/scotch/CMakeLists.txt
+index 3974f4fce..b9149b931 100644
+--- a/src/scotch/CMakeLists.txt
++++ b/src/scotch/CMakeLists.txt
+@@ -67,10 +67,15 @@ function(add_scotch_exe)
+   add_dependencies(${file_we} scotch_h)
+   target_include_directories(${file_we} PRIVATE ${GENERATED_INCLUDE_DIR})
+   target_compile_definitions(${file_we} PUBLIC "SCOTCH_CODENAME=\"${SCOTCH_CODENAME}\"")
+-  if(Threads_FOUND)
+-    target_compile_definitions(${file_we} PUBLIC SCOTCH_PTHREAD COMMON_PTHREAD)
+-    target_link_libraries(${file_we} PUBLIC Threads::Threads)
+-  endif(Threads_FOUND)
++  
++  if(USE_PTHREAD)
++      target_compile_definitions(${file_we} PUBLIC COMMON_PTHREAD SCOTCH_PTHREAD)
++      if(NOT WIN32)
++        target_link_libraries(${file_we} PUBLIC Threads::Threads)
++      else()
++        target_link_libraries(${file_we} PUBLIC PThreads4W::PThreads4W)
++      endif()
++  endif(USE_PTHREAD)
+   target_link_libraries(${file_we} PUBLIC scotch scotcherrexit)
+ endfunction(add_scotch_exe)
+ 
+@@ -110,8 +115,9 @@ endforeach()
+ 
+ # Targets which need special source lists
+ add_scotch_exe(gout gout_c.c gout_o.c)
+-target_link_libraries(gout PRIVATE m)
+-
++if(NOT WIN32)
++    target_link_libraries(gout PRIVATE m)
++endif()
+ # gpart is a special target (same source as gmap)
+ add_scotch_exe(gpart gmap.c gmap.h)
+ target_compile_definitions(gpart PRIVATE SCOTCH_COMPILE_PART)
+@@ -142,10 +148,14 @@ if(BUILD_PTSCOTCH)
+       ${GENERATED_INCLUDE_DIR}/ptscotch.h)
+     add_dependencies(${file_we} ptscotch_h)
+     target_compile_definitions(${file_we} PUBLIC "SCOTCH_CODENAME=\"${SCOTCH_CODENAME}\"")
+-    if(Threads_FOUND)
+-      target_compile_definitions(${file_we} PUBLIC SCOTCH_PTHREAD COMMON_PTHREAD)
+-      target_link_libraries(${file_we} PUBLIC Threads::Threads)
+-    endif(Threads_FOUND)
++    if(USE_PTHREAD)
++      target_compile_definitions(${file_we} PUBLIC COMMON_PTHREAD SCOTCH_PTHREAD)
++      if(NOT WIN32)
++        target_link_libraries(${file_we} PUBLIC Threads::Threads)
++      else()
++        target_link_libraries(${file_we} PUBLIC PThreads4W::PThreads4W)
++      endif()
++    endif(USE_PTHREAD)
+     target_include_directories(${file_we} PRIVATE ${GENERATED_INCLUDE_DIR})
+     target_link_libraries(${file_we} PUBLIC scotch ptscotch ptscotcherrexit)
+   endfunction(add_ptscotch_exe)

--- a/ports/scotch/portfile.cmake
+++ b/ports/scotch/portfile.cmake
@@ -48,4 +48,7 @@ vcpkg_copy_tools(TOOL_NAMES
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/CeCILL-C_V1-en.txt")
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/scotch/SCOTCHConfig.cmake" "find_dependency(Threads)" "if(NOT WIN32)\nfind_dependency(Threads)\nelse()\nfind_dependency(PThreads4W)\nendif()")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/man"
+                    "${CURRENT_PACKAGES_DIR}/man"
+                    )

--- a/ports/scotch/portfile.cmake
+++ b/ports/scotch/portfile.cmake
@@ -1,0 +1,50 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.inria.fr/
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO scotch/scotch
+    REF b43864123e820e3ca541bfecd3738aed385a4c47
+    SHA512 66d84624ff608a8557789b9f48e83694151f824c4be57ce294863390b4d2f6702bed381f9dbb1527456414385e0a7793752750d7d2731f551d2f34e2aaa4f6b4
+    HEAD_REF master
+    PATCHES fix-build.patch
+)
+
+vcpkg_find_acquire_program(FLEX)
+cmake_path(GET FLEX PARENT_PATH FLEX_DIR)
+vcpkg_add_to_path("${FLEX_DIR}")
+
+vcpkg_find_acquire_program(BISON)
+cmake_path(GET BISON PARENT_PATH BISON_DIR)
+vcpkg_add_to_path("${BISON_DIR}")
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    #Uses gcc intrinsics otherwise
+    string(APPEND VCPKG_C_FLAGS     " -DGRAPHMATCHNOTHREAD")
+    string(APPEND VCPKG_CXX_FLAGS   " -DGRAPHMATCHNOTHREAD")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_PTSCOTCH=OFF # Requires MPI
+        -DBUILD_LIBESMUMPS=OFF
+        -DBUILD_LIBSCOTCHMETIS=OFF
+        -DTHREADS=ON
+        -DMPI_THREAD_MULTIPLE=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/scotch")
+vcpkg_copy_tools(TOOL_NAMES
+    acpl amk_ccc amk_fft2 amk_grf amk_hy
+    amk_m2 amk_p2 atst gbase gcv gmap gmk_hy
+    gmk_m2 gmk_m3 gmk_msh gmk_ub2 gmtst
+    gord gotst gscat gtst mcv mmk_m2 mmk_m3
+    mord mtst
+    AUTO_CLEAN
+    )
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/CeCILL-C_V1-en.txt")
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/scotch/SCOTCHConfig.cmake" "find_dependency(Threads)" "if(NOT WIN32)\nfind_dependency(Threads)\nelse()\nfind_dependency(PThreads4W)\nendif()")

--- a/ports/scotch/portfile.cmake
+++ b/ports/scotch/portfile.cmake
@@ -48,3 +48,4 @@ vcpkg_copy_tools(TOOL_NAMES
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/CeCILL-C_V1-en.txt")
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/scotch/SCOTCHConfig.cmake" "find_dependency(Threads)" "if(NOT WIN32)\nfind_dependency(Threads)\nelse()\nfind_dependency(PThreads4W)\nendif()")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/scotch/vcpkg.json
+++ b/ports/scotch/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "scotch",
+  "version": "7.0.3",
+  "description": "Scotch: a software package for graph and mesh/hypergraph partitioning, graph clustering, and sparse matrix ordering",
+  "homepage": "https://gitlab.inria.fr/scotch/scotch",
+  "license": null,
+  "dependencies": [
+    "zlib",
+    "liblzma",
+    "bzip2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/scotch/vcpkg.json
+++ b/ports/scotch/vcpkg.json
@@ -5,9 +5,8 @@
   "homepage": "https://gitlab.inria.fr/scotch/scotch",
   "license": null,
   "dependencies": [
-    "zlib",
-    "liblzma",
     "bzip2",
+    "liblzma",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -15,6 +14,7 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "zlib"
   ]
 }

--- a/ports/scotch/vcpkg.json
+++ b/ports/scotch/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Scotch: a software package for graph and mesh/hypergraph partitioning, graph clustering, and sparse matrix ordering",
   "homepage": "https://gitlab.inria.fr/scotch/scotch",
   "license": null,
+  "supports": "!arm & !uwp & !android & !osx",
   "dependencies": [
     "bzip2",
     "liblzma",

--- a/ports/scotch/vcpkg.json
+++ b/ports/scotch/vcpkg.json
@@ -7,6 +7,7 @@
   "dependencies": [
     "bzip2",
     "liblzma",
+    "pthread",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7380,6 +7380,10 @@
       "baseline": "1.1.0",
       "port-version": 0
     },
+    "scotch": {
+      "baseline": "7.0.3",
+      "port-version": 0
+    },
     "scottt-debugbreak": {
       "baseline": "1.0",
       "port-version": 0

--- a/versions/s-/scotch.json
+++ b/versions/s-/scotch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "afc37ba0cc3db4238e624e6e6984c8fcbb30d521",
+      "git-tree": "6038e864e74954b29c48485287ba15b015cc3901",
       "version": "7.0.3",
       "port-version": 0
     }

--- a/versions/s-/scotch.json
+++ b/versions/s-/scotch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "29ef8663edc9f82645c7237214b3198835eaee05",
+      "git-tree": "10494fcbf6bfcfb71c28b1c69a62eece44980895",
       "version": "7.0.3",
       "port-version": 0
     }

--- a/versions/s-/scotch.json
+++ b/versions/s-/scotch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2dc4c454416a02039c42e8e61875a60a7cdd6846",
+      "git-tree": "afc37ba0cc3db4238e624e6e6984c8fcbb30d521",
       "version": "7.0.3",
       "port-version": 0
     }

--- a/versions/s-/scotch.json
+++ b/versions/s-/scotch.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "29ef8663edc9f82645c7237214b3198835eaee05",
+      "version": "7.0.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/scotch.json
+++ b/versions/s-/scotch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "10494fcbf6bfcfb71c28b1c69a62eece44980895",
+      "git-tree": "2dc4c454416a02039c42e8e61875a60a7cdd6846",
       "version": "7.0.3",
       "port-version": 0
     }


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
