### PR TITLE
[fftw3] Fix Build error with feature avx2

### DIFF
--- a/ports/fftw3/fix-feature-avx2.patch
+++ b/ports/fftw3/fix-feature-avx2.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e3d0caa..5511c25 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -293,7 +293,11 @@ if (ENABLE_FLOAT)
+ endif ()
+ 
+ if (ENABLE_LONG_DOUBLE)
+-  set (FFTW_LDOUBLE TRUE)
++  if(ENABLE_AVX2)
++    set (FFTW_LDOUBLE FALSE)
++  else()
++    set (FFTW_LDOUBLE TRUE)
++  endif()
+   set (BENCHFFT_LDOUBLE TRUE)
+   set (PREC_SUFFIX l)
+ endif ()

--- a/ports/fftw3/portfile.cmake
+++ b/ports/fftw3/portfile.cmake
@@ -36,7 +36,7 @@ foreach(PRECISION ENABLE_FLOAT ENABLE_LONG_DOUBLE Z_DEFAULT_PRECISION)
     vcpkg_cmake_configure(
         SOURCE_PATH "${SOURCE_PATH}"
         OPTIONS 
-            -D${PRECISION}=ON
+            -D${PRECISION}=OFF
             ${FEATURE_OPTIONS}
             -DBUILD_TESTS=OFF
             -DCMAKE_REQUIRE_FIND_PACKAGE_OpenMP=ON

--- a/ports/fftw3/portfile.cmake
+++ b/ports/fftw3/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_extract_source_archive(
         aligned_malloc.patch
         bigobj.patch
         fix-openmp.patch
+        fix-feature-avx2.patch
 )
 
 vcpkg_check_features(
@@ -36,7 +37,7 @@ foreach(PRECISION ENABLE_FLOAT ENABLE_LONG_DOUBLE Z_DEFAULT_PRECISION)
     vcpkg_cmake_configure(
         SOURCE_PATH "${SOURCE_PATH}"
         OPTIONS 
-            -D${PRECISION}=OFF
+            -D${PRECISION}=ON
             ${FEATURE_OPTIONS}
             -DBUILD_TESTS=OFF
             -DCMAKE_REQUIRE_FIND_PACKAGE_OpenMP=ON
@@ -63,6 +64,6 @@ file(WRITE "${SOURCE_PATH}/include/fftw3.h" "${_contents}")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/fftw3/vcpkg.json
+++ b/ports/fftw3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fftw3",
   "version": "3.3.10",
-  "port-version": 7,
+  "port-version": 8,
   "description": "FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data (as well as of even/odd data, i.e. the discrete cosine/sine transforms or DCT/DST).",
   "homepage": "https://www.fftw.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2518,7 +2518,7 @@
     },
     "fftw3": {
       "baseline": "3.3.10",
-      "port-version": 7
+      "port-version": 8
     },
     "fftwpp": {
       "baseline": "2019-12-19",

--- a/versions/f-/fftw3.json
+++ b/versions/f-/fftw3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e44079cf9aa1836e88d3d2eafe6d4d48f00c322",
+      "version": "3.3.10",
+      "port-version": 8
+    },
+    {
       "git-tree": "5b1eac37609e9187b1ddf4666cc564ce6e07e891",
       "version": "3.3.10",
       "port-version": 7

--- a/versions/f-/fftw3.json
+++ b/versions/f-/fftw3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8e44079cf9aa1836e88d3d2eafe6d4d48f00c322",
+      "git-tree": "a335ac06e8cae591fc7ef61364e32b04a311cd0a",
       "version": "3.3.10",
       "port-version": 8
     },


### PR DESCRIPTION
Fixes #32808

From the error, 
````
#error "AVX2 only works in single or double precision"
````
`ENABLE_LONG_DOUBLE` is permanently turned ON in port file.cmake, which causes `FFTW_LDOUBLE` to be TRUE forever, according to the upstream code:
````
#if defined(FFTW_LDOUBLE) || defined(FFTW_QUAD)
# error "VSX only works in single or double precision"
#endif
````
It will definitely report an error, so my current solution is to change FFTW_LDOUBLE to FEALSE only for feature avx2 to solve this error.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

Tested feature `avx2,threads` successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static
- x64-linux

