### PR TITLE
[openmvg] builds on arm64 osx

### DIFF
--- a/ports/openmvg/build_fixes.patch
+++ b/ports/openmvg/build_fixes.patch
@@ -639,3 +639,18 @@ index 8a69c2344..1ed9a21fe 100644
          FIND_LIBRARY(OSICLP_LIBRARY NAMES OsiClp)
  
          # locate Clp libraries
+
+diff --git a/src/openMVG/matching/metric_simd.hpp b/src/openMVG/matching/metric_simd.hpp
+index 7e09f6ed..916c84e0 100644
+--- a/src/openMVG/matching/metric_simd.hpp
++++ b/src/openMVG/matching/metric_simd.hpp
+@@ -17,7 +17,9 @@
+ #include <numeric>
+
+ #include <cstdint>
++#if defined(__amd64__) || defined(__i386__)
+ #include <immintrin.h>
++#endif
+
+ namespace openMVG {
+ namespace matching {

--- a/ports/openmvg/vcpkg.json
+++ b/ports/openmvg/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "openmvg",
   "version": "2.0",
-  "port-version": 8,
+  "port-version": 9,
   "description": "open Multiple View Geometry library. Basis for 3D computer vision and Structure from Motion.",
   "license": "MPL-2.0-no-copyleft-exception",
-  "supports": "(x86 | x64) & !xbox",
+  "supports": "(x86 | x64 | arm64) & !xbox",
   "dependencies": [
     "cereal",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6046,7 +6046,7 @@
     },
     "openmvg": {
       "baseline": "2.0",
-      "port-version": 8
+      "port-version": 9
     },
     "openmvs": {
       "baseline": "2.1.0",

--- a/versions/o-/openmvg.json
+++ b/versions/o-/openmvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ddaa3bedcc57eb498c9e180bb8546a2726a1ddc",
+      "version": "2.0",
+      "port-version": 9
+    },
+    {
       "git-tree": "3712d684593f777107e58a37bf601083a6351738",
       "version": "2.0",
       "port-version": 8


### PR DESCRIPTION
Fixes #30630

It applies patch for the upstream issue. [The issue has already been fixed on upstream,](https://github.com/openMVG/openMVG/pull/1979) but its release has been stopped for 2 years. I think it's reasonable to have patch here until the next upstream release.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
