### PR TITLE
[curl] Update to 8.2.1

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO curl/curl
     REF "${curl_version}"
-    SHA512 8dfca7f322b2a8f26ab866fd67f0a6a73ce9fa032b20f031e46df66ad04c79b6df4a2731945e6aa719460f3b4daef09f45ea671b2349140f915935c22040ba00
+    SHA512 7b0aef4f1cb93d446017a337e752d43254db92e02561875d1eb88eb3020a3efaf5d3f7fdfb1ff12dfd561d526789b284a10bef35af81bd6d9cfb2c3dc325815b
     HEAD_REF master
     PATCHES
         0002_fix_uwp.patch

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "curl",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1973,7 +1973,7 @@
       "port-version": 8
     },
     "curl": {
-      "baseline": "8.2.0",
+      "baseline": "8.2.1",
       "port-version": 0
     },
     "curlpp": {

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e4df4c9590fb15d2d73014c66dbbc151b624b9b",
+      "version": "8.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c82d0a822ec7d4044a58c18f2e198df681822cf6",
       "version": "8.2.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #32856, update `curl` to 8.2.1.
All features passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```
Usage passed on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
