### PR TITLE
[google-cloud-cpp] update to latest release (v2.14.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 b708945b5cdfe49e17208f7ff372064cce8844c0ed9e0a60f291a4a0b4d01b886997e8365e3802740d8914e58426d91cf3db1b37261c60d9661579212231c2ee
+    SHA512 c7fd2445339fbb9f66d6863693feff456fa14381e83f3e28456aed2e8102c8d776868afa1a5020874672306f68e911f199b5ce667c61708166925c63877e8c5d
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch
@@ -14,8 +14,10 @@ vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/grpc")
 
 set(GOOGLE_CLOUD_CPP_ENABLE "${FEATURES}")
 list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "core")
-# This feature does not exist, but allows us to simplify the vcpkg.json file.
+# This feature does not exist, but allows us to simplify the vcpkg.json
+# file.
 list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "grpc-common")
+list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "rest-common")
 list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "googleapis")
 # google-cloud-cpp uses dialogflow_cx and dialogflow_es. Underscores
 # are invalid in `vcpkg` features, we use dashes (`-`) as a separator

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -295,6 +295,18 @@
         }
       ]
     },
+    "commerce": {
+      "description": "Cloud Commerce C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "composer": {
       "description": "Cloud Composer C++ Client Library",
       "dependencies": [
@@ -534,6 +546,20 @@
             "grpc-common"
           ]
         }
+      ]
+    },
+    "experimental-opentelemetry": {
+      "description": "OpenTelemetry C++ GCP Exporter Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "rest-common",
+            "trace"
+          ]
+        },
+        "opentelemetry-cpp"
       ]
     },
     "experimental-storage-grpc": {
@@ -984,6 +1010,18 @@
         }
       ]
     },
+    "rest-common": {
+      "description": "Dependencies used by all REST-based libraries",
+      "dependencies": [
+        {
+          "name": "curl",
+          "features": [
+            "ssl"
+          ]
+        },
+        "nlohmann-json"
+      ]
+    },
     "retail": {
       "description": "Retail API C++ Client Library",
       "dependencies": [
@@ -1133,12 +1171,12 @@
       "dependencies": [
         "crc32c",
         {
-          "name": "curl",
+          "name": "google-cloud-cpp",
+          "default-features": false,
           "features": [
-            "ssl"
+            "rest-common"
           ]
-        },
-        "nlohmann-json"
+        }
       ]
     },
     "storageinsights": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2949,7 +2949,7 @@
       "port-version": 3
     },
     "google-cloud-cpp": {
-      "baseline": "2.13.0",
+      "baseline": "2.14.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "696c1d17cd2174ffde1c0d53779b76e8d98d924a",
+      "version": "2.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c067a236b62d38d1f56a658b086039bf22441c4a",
       "version": "2.13.0",
       "port-version": 0


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v2.14.0)

Tested locally (on x64-linux) with:

```
./vcpkg install 'google-cloud-cpp[*]'
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
