### PR TITLE
[portaudio] Add patch that fixes framework linking

### DIFF
--- a/ports/portaudio/framework_link.patch
+++ b/ports/portaudio/framework_link.patch
@@ -1,0 +1,34 @@
+From 8fe2958d3202b409f7d54f53b41fca7b225c3f0e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Sch=C3=BCrmann?= <daschuer@mixxx.org>
+Date: Thu, 27 Jul 2023 15:06:24 +0200
+Subject: [PATCH] Don't use apsolute path when linking to macOS frameworks
+
+---
+ CMakeLists.txt | 18 +++++++-----------
+ 1 file changed, 7 insertions(+), 11 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 87d0bb832..75aa89e7b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -261,13 +261,13 @@ ELSE()
+       SET(PA_PRIVATE_INCLUDES ${PA_PRIVATE_INCLUDES} ${PA_COREAUDIO_INCLUDES})
+       SET(PA_SOURCES ${PA_SOURCES} ${PA_COREAUDIO_SOURCES})
+ 
+-      FIND_LIBRARY(COREAUDIO_LIBRARY CoreAudio REQUIRED)
+-      FIND_LIBRARY(AUDIOTOOLBOX_LIBRARY AudioToolbox REQUIRED)
+-      FIND_LIBRARY(AUDIOUNIT_LIBRARY AudioUnit REQUIRED)
+-      FIND_LIBRARY(COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
+-      FIND_LIBRARY(CORESERVICES_LIBRARY CoreServices REQUIRED)
+-      MARK_AS_ADVANCED(COREAUDIO_LIBRARY AUDIOTOOLBOX_LIBRARY AUDIOUNIT_LIBRARY COREFOUNDATION_LIBRARY CORESERVICES_LIBRARY)
+-      SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${COREAUDIO_LIBRARY} ${AUDIOTOOLBOX_LIBRARY} ${AUDIOUNIT_LIBRARY} ${COREFOUNDATION_LIBRARY} ${CORESERVICES_LIBRARY})
++      SET(PA_LIBRARY_DEPENDENCIES 
++        ${PA_LIBRARY_DEPENDENCIES} 
++        -Wl,-framework,CoreAudio
++        -Wl,-framework,AudioToolbox
++        -Wl,-framework,AudioUnit
++        -Wl,-framework,CoreFoundation
++        -Wl,-framework,CoreServices)
+       SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_USE_COREAUDIO)
+       SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices")
+     ENDIF()

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 0f56e5f5b004f51915f29771b8fc1fe886f1fef5d65ab5ea1db43f43c49917476b9eec14b36aa54d3e9fb4d8bdf61e68c79624d00b7e548d4c493395a758233a
     PATCHES
         fix-library-can-not-be-found.patch
+        framework_link.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PA_BUILD_SHARED)

--- a/ports/portaudio/vcpkg.json
+++ b/ports/portaudio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "portaudio",
   "version": "19.7",
-  "port-version": 4,
+  "port-version": 5,
   "description": "PortAudio Portable Cross-platform Audio I/O API PortAudio is a free, cross-platform, open-source, audio I/O library.  It lets you write simple audio programs in 'C' or C++ that will compile and run on many platforms including Windows, Macintosh OS X, and Unix (OSS/ALSA). It is intended to promote the exchange of audio software between developers on different platforms. Many applications use PortAudio for Audio I/O.",
   "homepage": "http://www.portaudio.com",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6462,7 +6462,7 @@
     },
     "portaudio": {
       "baseline": "19.7",
-      "port-version": 4
+      "port-version": 5
     },
     "portmidi": {
       "baseline": "2.0.4",

--- a/versions/p-/portaudio.json
+++ b/versions/p-/portaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34d770f3357878c7b7668acf63e7a3095f1b5afc",
+      "version": "19.7",
+      "port-version": 5
+    },
+    {
       "git-tree": "25fb6802e88b978f349df2e6af0ecfadb85e9e9b",
       "version": "19.7",
       "port-version": 4


### PR DESCRIPTION
This contributes to https://github.com/microsoft/vcpkg/issues/16259

I have also proposed the patch upstream: https://github.com/PortAudio/portaudio/pull/829

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
