### PR TITLE
[mdspan] Bump to 0.6.0

### DIFF
--- a/ports/mdspan/portfile.cmake
+++ b/ports/mdspan/portfile.cmake
@@ -1,10 +1,12 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kokkos/mdspan
-    REF mdspan-0.5.0
-    SHA512 f14b021006f945434435c5575a734bcf308598b5c21fd62a54248ad6c5b1ffe29ba4bcf57935751f5c8dd3dd9b56bd799a502c4818f06f8594a32f0202b1b52e
+    REF "mdspan-${VERSION}"
+    SHA512 d0e247b5ed5765f3ddd04634462c428b19beceb81b0b7d8221443b3f6ab122e232e85c15d56c208b244be2f6667d7e1db571848b61190b64ec110f7d31c3e0c9
     HEAD_REF stable
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
@@ -12,6 +14,6 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/mdspan)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mdspan/vcpkg.json
+++ b/ports/mdspan/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mdspan",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A non-owning multi-dimensional array reference type.",
   "homepage": "https://github.com/kokkos/mdspan",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5265,7 +5265,7 @@
       "port-version": 0
     },
     "mdspan": {
-      "baseline": "0.5.0",
+      "baseline": "0.6.0",
       "port-version": 0
     },
     "mecab": {

--- a/versions/m-/mdspan.json
+++ b/versions/m-/mdspan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0a8dad5240bcaa137ad2b68ff3097a8d5e37109",
+      "version": "0.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4532b6ddb077c99218420a09a482a978903e162b",
       "version": "0.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Close #32871