### PR TITLE
[angle] Avoid link to frameworks with absolute path on macOS

### DIFF
--- a/ports/angle/cmake-buildsystem/PlatformMac.cmake
+++ b/ports/angle/cmake-buildsystem/PlatformMac.cmake
@@ -1,8 +1,3 @@
-find_library(COREGRAPHICS_LIBRARY CoreGraphics)
-find_library(FOUNDATION_LIBRARY Foundation)
-find_library(IOKIT_LIBRARY IOKit)
-find_library(IOSURFACE_LIBRARY IOSurface)
-find_library(QUARTZ_LIBRARY Quartz)
 find_package(ZLIB REQUIRED)
 
 list(APPEND ANGLE_SOURCES
@@ -12,16 +7,15 @@ list(APPEND ANGLE_SOURCES
 )
 
 list(APPEND ANGLEGLESv2_LIBRARIES
-    ${COREGRAPHICS_LIBRARY}
-    ${FOUNDATION_LIBRARY}
-    ${IOKIT_LIBRARY}
-    ${IOSURFACE_LIBRARY}
-    ${QUARTZ_LIBRARY}
+    "-framework CoreGraphics"
+    "-framework Foundation"
+    "-framework IOKit"
+    "-framework IOSurface"
+    "-framework Quartz"
 )
 
 # Metal backend
 if(USE_METAL)
-    find_library(METAL_LIBRARY Metal)
     list(APPEND ANGLE_SOURCES
         ${_metal_backend_sources}
 
@@ -35,7 +29,7 @@ if(USE_METAL)
     )
 
     list(APPEND ANGLEGLESv2_LIBRARIES
-        ${METAL_LIBRARY}
+        "-framework Metal"
     )
 endif()
 

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_5414",
-  "port-version": 6,
+  "port-version": 7,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b5502570ef18abdcf0535470f3ea6589db70607b",
+      "version-string": "chromium_5414",
+      "port-version": 7
+    },
+    {
       "git-tree": "28f33feb91072e2df5daa5b7e10846db4a6f3a50",
       "version-string": "chromium_5414",
       "port-version": 6

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -126,7 +126,7 @@
     },
     "angle": {
       "baseline": "chromium_5414",
-      "port-version": 6
+      "port-version": 7
     },
     "annoy": {
       "baseline": "1.17.2",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Close #32782
See also #16259