### PR TITLE
[fastgltf] fix link simdjson error

### DIFF
--- a/ports/fastgltf/portfile.cmake
+++ b/ports/fastgltf/portfile.cmake
@@ -16,4 +16,10 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
 vcpkg_copy_pdbs()
 
+file(READ "${CURRENT_PACKAGES_DIR}/share/fastgltf/fastgltfConfig.cmake" _contents)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/fastgltf/fastgltfConfig.cmake" "
+include(CMakeFindDependencyMacro)
+find_dependency(simdjson)
+${_contents}")
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/fastgltf/portfile.cmake
+++ b/ports/fastgltf/portfile.cmake
@@ -16,10 +16,10 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
 vcpkg_copy_pdbs()
 
-file(READ "${CURRENT_PACKAGES_DIR}/share/fastgltf/fastgltfConfig.cmake" _contents)
+file(READ "${CURRENT_PACKAGES_DIR}/share/fastgltf/fastgltfConfig.cmake" contents)
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/fastgltf/fastgltfConfig.cmake" "
 include(CMakeFindDependencyMacro)
 find_dependency(simdjson)
-${_contents}")
+${contents}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/fastgltf/vcpkg.json
+++ b/ports/fastgltf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fastgltf",
   "version": "0.5.0",
+  "port-version": 1,
   "description": "Blazing fast C++17 glTF 2.0 loader powered by SIMD",
   "homepage": "https://github.com/spnda/fastgltf",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2462,7 +2462,7 @@
     },
     "fastgltf": {
       "baseline": "0.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "fastio": {
       "baseline": "2022-11-14",

--- a/versions/f-/fastgltf.json
+++ b/versions/f-/fastgltf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "920668d172a344d61da359c3bd25a0c356043338",
+      "version": "0.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5fdd22bd96978abf4f7d8b8fef6406eb8d79ec3f",
       "version": "0.5.0",
       "port-version": 0

--- a/versions/f-/fastgltf.json
+++ b/versions/f-/fastgltf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "920668d172a344d61da359c3bd25a0c356043338",
+      "git-tree": "28cc725ac91ea72117083d152661ba131f8bca94",
       "version": "0.5.0",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/32874
Error:
```
CMake Error at vcpkg/installed/x64-linux/share/fastgltf/fastgltfConfig.cmake:60 (set_target_properties):
  The link interface of target "fastgltf::fastgltf" contains:

    simdjson::simdjson

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  vcpkg/scripts/buildsystems/vcpkg.cmake:855 (_find_package)
  CMakeLists.txt:5 (find_package)
```

No feature needs to test.
Usage tested pass on the following triplets:
```
x64-linux
x64-windows
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
