### PR TITLE
[librsvg] Remove -lm from the .pc file in Windows

### DIFF
--- a/ports/librsvg/portfile.cmake
+++ b/ports/librsvg/portfile.cmake
@@ -30,6 +30,11 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-librsvg CONFIG_PATH share/unoff
 
 vcpkg_fixup_pkgconfig()
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/librsvg.pc" " -lm" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/librsvg.pc" " -lm" "")
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/librsvg/portfile.cmake
+++ b/ports/librsvg/portfile.cmake
@@ -31,8 +31,10 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-librsvg CONFIG_PATH share/unoff
 vcpkg_fixup_pkgconfig()
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/librsvg.pc" " -lm" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/librsvg.pc" " -lm" "")
+    file(GLOB_RECURSE pc_files "${CURRENT_PACKAGES_DIR}/*.pc")
+    foreach(pc_file ${pc_files})
+        vcpkg_replace_string("${pc_file}" " -lm" "")
+    endforeach()
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/librsvg/vcpkg.json
+++ b/ports/librsvg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "librsvg",
   "version": "2.40.20",
-  "port-version": 8,
+  "port-version": 9,
   "description": "A small library to render Scalable Vector Graphics (SVG)",
   "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4530,7 +4530,7 @@
     },
     "librsvg": {
       "baseline": "2.40.20",
-      "port-version": 8
+      "port-version": 9
     },
     "librsync": {
       "baseline": "2.3.2",

--- a/versions/l-/librsvg.json
+++ b/versions/l-/librsvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7d62f5b9521ee69dfca9dc4133f6503c9cb5236",
+      "version": "2.40.20",
+      "port-version": 9
+    },
+    {
       "git-tree": "d72d62fa58fa959323e0bda46bcf26991e460289",
       "version": "2.40.20",
       "port-version": 8

--- a/versions/l-/librsvg.json
+++ b/versions/l-/librsvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7d62f5b9521ee69dfca9dc4133f6503c9cb5236",
+      "git-tree": "c75d4ca281d1bba78571abdb035e025ded217c00",
       "version": "2.40.20",
       "port-version": 9
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
According to the contents of https://github.com/microsoft/vcpkg/pull/32319#issuecomment-1658736753:
```
librsvg contains now -lm in Libs: "-L${libdir}" -lrsvg-2 -lm on Windows, which must not happen in any pc file on Windows. Maybe -lm should be removed via vcpkg_fixup_pkgconfig() which will fix it for every pc file.
```
`vcpkg_fixup_pkgconfig()` does not have such a feature, so I remove `-lm` in the portfile.cmake file.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
