### PR TITLE
[cgal] update to 5.6

### DIFF
--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         x86_windows.patch
+        # Upstream patch: https://github.com/CGAL/cgal/pull/7635
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -4,9 +4,11 @@ vcpkg_buildpath_length_warning(37)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CGAL/cgal
-    REF v5.5.3
-    SHA512 9353f42b892a7a331a1c12888c25523340d2f3643c520b58b5bfba5c9d8ce492727060ea56fef47cf5947d4e3e50a2b101fe28cf11680f28f238914f27022207
+    REF v5.6
+    SHA512 87817169f49c30d8dc4fa5e61ce9b28be5b1f0a9fcd3ebe0cb08b044631a2455de76c53d3cffaa1984f033f5fe21c9b55f54628fc431b7d3a34b3b3e18ad206d
     HEAD_REF master
+    PATCHES
+        x86_windows.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/cgal/vcpkg.json
+++ b/ports/cgal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cgal",
-  "version": "5.5.3",
+  "version": "5.6",
   "description": "The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.",
   "homepage": "https://github.com/CGAL/cgal",
   "license": "GPL-3.0-or-later AND LGPL-3.0-or-later AND BSL-1.0",

--- a/ports/cgal/x86_windows.patch
+++ b/ports/cgal/x86_windows.patch
@@ -1,0 +1,16 @@
+diff --git a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
+index 7329be33116..718d37f25b0 100644
+--- a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
++++ b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
+@@ -119,6 +119,11 @@ function(CGAL_setup_CGAL_dependencies target)
+     target_link_options(${target} INTERFACE -fsanitize=address)
+   endif()
+   # Now setup compilation flags
++  if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
++    message(STATUS "Boost MP is turned off for all Windows 32 bits architectures!")
++    target_compile_options(${target} INTERFACE "-DCGAL_DO_NOT_USE_BOOST_MP")
++  endif()
++
+   if(MSVC)
+     target_compile_options(${target} INTERFACE
+       "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS")

--- a/ports/cgal/x86_windows.patch
+++ b/ports/cgal/x86_windows.patch
@@ -1,16 +1,24 @@
-diff --git a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
-index 7329be33116..718d37f25b0 100644
---- a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
-+++ b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
-@@ -119,6 +119,11 @@ function(CGAL_setup_CGAL_dependencies target)
-     target_link_options(${target} INTERFACE -fsanitize=address)
-   endif()
-   # Now setup compilation flags
-+  if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
-+    message(STATUS "Boost MP is turned off for all Windows 32 bits architectures!")
-+    target_compile_options(${target} INTERFACE "-DCGAL_DO_NOT_USE_BOOST_MP")
-+  endif()
-+
-   if(MSVC)
-     target_compile_options(${target} INTERFACE
-       "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS")
+diff --git a/Number_types/include/CGAL/boost_mp.h b/Number_types/include/CGAL/boost_mp.h
+index 3dcaadcad21..b98980acbc5 100644
+--- a/Number_types/include/CGAL/boost_mp.h
++++ b/Number_types/include/CGAL/boost_mp.h
+@@ -20,8 +20,18 @@
+ // easy solution.
+ // MSVC had trouble with versions <= 1.69:
+ // https://github.com/boostorg/multiprecision/issues/98
++//
++// Disable also on Windows 32 bits
++// because CGAL/cpp_float.h assumes _BitScanForward64 is available
++// See https://learn.microsoft.com/en-us/cpp/intrinsics/bitscanforward-bitscanforward64
++//
++// Disable also with PowerPC processors, with Boost<1.80 because of that bug:
++// https://github.com/boostorg/multiprecision/pull/421
++//
+ #if !defined CGAL_DO_NOT_USE_BOOST_MP && \
+-    (!defined _MSC_VER || BOOST_VERSION >= 107000)
++    (!defined _MSC_VER || BOOST_VERSION >= 107000) && \
++    (!defined _WIN32 || defined _WIN64) && \
++    (BOOST_VERSION >= 108000 || (!defined _ARCH_PPC && !defined _ARCH_PPC64))
+ #define CGAL_USE_BOOST_MP 1
+ 
+ #include <CGAL/Quotient.h>

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1469,7 +1469,7 @@
       "port-version": 3
     },
     "cgal": {
-      "baseline": "5.5.3",
+      "baseline": "5.6",
       "port-version": 0
     },
     "cgicc": {

--- a/versions/c-/cgal.json
+++ b/versions/c-/cgal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfb31c38e7b3e2737867e90a1b583f7ac72741c9",
+      "version": "5.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "2361640f4f9d33c828b66c32b900beda59a63036",
       "version": "5.5.3",
       "port-version": 0

--- a/versions/c-/cgal.json
+++ b/versions/c-/cgal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dfb31c38e7b3e2737867e90a1b583f7ac72741c9",
+      "git-tree": "313da2aa8d1221c449a211a4d04a0d5976ae8930",
       "version": "5.6",
       "port-version": 0
     },


### PR DESCRIPTION
This pull-request updates the `cgal` port to [CGAL version 5.6](https://www.cgal.org/2023/07/28/cgal56/).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
