### PR TITLE
[modern-cpp-kafka] New port

### DIFF
--- a/ports/modern-cpp-kafka/CMakeLists.txt
+++ b/ports/modern-cpp-kafka/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+project(modern-cpp-kafka LANGUAGES CXX)
+
+include(GNUInstallDirs)
+
+find_package(RdKafka CONFIG REQUIRED)
+
+add_library(modern-cpp-kafka INTERFACE)
+target_include_directories(modern-cpp-kafka INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/modern-cpp-kafka>)
+target_link_libraries(modern-cpp-kafka INTERFACE RdKafka::rdkafka)
+
+install(TARGETS modern-cpp-kafka EXPORT unofficial-modern-cpp-kafka)
+
+install(
+    EXPORT unofficial-modern-cpp-kafka
+    FILE unofficial-modern-cpp-kafka-config.cmake
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/unofficial-modern-cpp-kafka"
+    NAMESPACE unofficial::modern-cpp-kafka::
+)
+
+install(
+    DIRECTORY "${CMAKE_SOURCE_DIR}/include/kafka"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/modern-cpp-kafka"
+)

--- a/ports/modern-cpp-kafka/CMakeLists.txt
+++ b/ports/modern-cpp-kafka/CMakeLists.txt
@@ -5,10 +5,12 @@ project(modern-cpp-kafka LANGUAGES CXX)
 include(GNUInstallDirs)
 
 find_package(RdKafka CONFIG REQUIRED)
+find_package(Boost REQUIRED)
+find_package(RapidJSON CONFIG REQUIRED)
 
 add_library(modern-cpp-kafka INTERFACE)
 target_include_directories(modern-cpp-kafka INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/modern-cpp-kafka>)
-target_link_libraries(modern-cpp-kafka INTERFACE RdKafka::rdkafka)
+target_link_libraries(modern-cpp-kafka INTERFACE RdKafka::rdkafka Boost::boost rapidjson)
 
 install(TARGETS modern-cpp-kafka EXPORT unofficial-modern-cpp-kafka)
 

--- a/ports/modern-cpp-kafka/CMakeLists.txt
+++ b/ports/modern-cpp-kafka/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(Boost REQUIRED)
 find_package(RapidJSON CONFIG REQUIRED)
 
 add_library(modern-cpp-kafka INTERFACE)
-target_include_directories(modern-cpp-kafka INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/modern-cpp-kafka>)
+target_include_directories(modern-cpp-kafka INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(modern-cpp-kafka INTERFACE RdKafka::rdkafka Boost::boost rapidjson)
 
 install(TARGETS modern-cpp-kafka EXPORT unofficial-modern-cpp-kafka)
@@ -23,5 +23,5 @@ install(
 
 install(
     DIRECTORY "${CMAKE_SOURCE_DIR}/include/kafka"
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/modern-cpp-kafka"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )

--- a/ports/modern-cpp-kafka/portfile.cmake
+++ b/ports/modern-cpp-kafka/portfile.cmake
@@ -21,6 +21,8 @@ file(READ "${CURRENT_PACKAGES_DIR}/share/unofficial-modern-cpp-kafka/unofficial-
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-modern-cpp-kafka/unofficial-modern-cpp-kafka-config.cmake"
 "include(CMakeFindDependencyMacro)
 find_dependency(RdKafka CONFIG)
+find_dependency(Boost)
+find_dependency(RapidJSON CONFIG)
 ${cmake_config}
 ")
 

--- a/ports/modern-cpp-kafka/portfile.cmake
+++ b/ports/modern-cpp-kafka/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO morganstanley/modern-cpp-kafka
+    REF "v${VERSION}"
+    SHA512 5071ba4aeb80d94fd078df054e3a36249e2e433bda2af4c26686cd5b0615d622cfd964c7193d075cc549a572cfa5b11bc4bbab9e00de7c80ea2bbf4a9d797201
+    HEAD_REF main
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(READ "${CURRENT_PACKAGES_DIR}/share/unofficial-modern-cpp-kafka/unofficial-modern-cpp-kafka-config.cmake" cmake_config)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-modern-cpp-kafka/unofficial-modern-cpp-kafka-config.cmake"
+"include(CMakeFindDependencyMacro)
+find_dependency(RdKafka CONFIG)
+${cmake_config}
+")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/modern-cpp-kafka/usage
+++ b/ports/modern-cpp-kafka/usage
@@ -1,0 +1,4 @@
+modern-cpp-kafka provides CMake targets:
+
+    find_package(unofficial-modern-cpp-kafka CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::modern-cpp-kafka::modern-cpp-kafka)

--- a/ports/modern-cpp-kafka/vcpkg.json
+++ b/ports/modern-cpp-kafka/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "modern-cpp-kafka",
+  "version-string": "2023.03.07",
+  "description": "A C++ API for Kafka clients (i.e. KafkaProducer, KafkaConsumer, AdminClient)",
+  "homepage": "https://github.com/morganstanley/modern-cpp-kafka",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "librdkafka",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/modern-cpp-kafka/vcpkg.json
+++ b/ports/modern-cpp-kafka/vcpkg.json
@@ -5,7 +5,9 @@
   "homepage": "https://github.com/morganstanley/modern-cpp-kafka",
   "license": "Apache-2.0",
   "dependencies": [
+    "boost-optional",
     "librdkafka",
+    "rapidjson",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5400,6 +5400,10 @@
       "baseline": "1.1.0",
       "port-version": 5
     },
+    "modern-cpp-kafka": {
+      "baseline": "2023.03.07",
+      "port-version": 0
+    },
     "modp-base64": {
       "baseline": "2020-09-26",
       "port-version": 2

--- a/versions/m-/modern-cpp-kafka.json
+++ b/versions/m-/modern-cpp-kafka.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "62e67194439499455176358e538c574f5847f627",
+      "git-tree": "59154cbd88929c38363c56e64f3755033ba7b923",
       "version-string": "2023.03.07",
       "port-version": 0
     }

--- a/versions/m-/modern-cpp-kafka.json
+++ b/versions/m-/modern-cpp-kafka.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "59154cbd88929c38363c56e64f3755033ba7b923",
+      "git-tree": "2da384edebac3371ee02b0a1d06606e93add35d5",
       "version-string": "2023.03.07",
       "port-version": 0
     }

--- a/versions/m-/modern-cpp-kafka.json
+++ b/versions/m-/modern-cpp-kafka.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "62e67194439499455176358e538c574f5847f627",
+      "version-string": "2023.03.07",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Close #32897