### PR TITLE
[Docs] Fix the broken link in README_xx.md

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -57,6 +57,11 @@ donde el equipo de vcpkg y la comunidad pueden verlo, y potencialmente hacer un 
 Después de tener Vcpkg instalado y funcionando,
 puede que desee añadir [completado con tab](#Completado-TabAutoCompletado) en su terminal.
 
+Finalmente, si está interesado en el futuro de Vcpkg,
+puede ver la guía de [archivos de manifiesto][getting-started:manifest-spec]!
+esta es una característica experimental y es probable que tenga errores,
+así que se recomienda revisar y [crear incidencias][contributing:submit-issue]!
+
 ### Inicio Rápido: Windows
 
 Prerrequisitos:

--- a/README_es.md
+++ b/README_es.md
@@ -20,7 +20,7 @@ una vez instalado Vcpkg puede ejecutar `vcpkg help`, o
 * este programa en: [vcpkg-tool GitHub](https://github.com/microsoft/vcpkg-tool)
 * [Slack](https://cppalliance.org/slack/), en el canal #vcpkg
 * Discord: [\#include \<C++\>](https://www.includecpp.org), en el canal #🌏vcpkg
-* Docs: [Documentación](docs/README.md)
+* Docs: [Documentación](https://learn.microsoft.com/vcpkg)
 
 ## Tabla de contenido
 
@@ -55,12 +55,7 @@ puede [abrir una incidencia en el repositorio de GitHub][contributing:submit-iss
 donde el equipo de vcpkg y la comunidad pueden verlo, y potencialmente hacer un port a vcpkg.
 
 Después de tener Vcpkg instalado y funcionando,
-puede que desee añadir [completado con tab](#Completado-TabAuto-Completado) en su terminal.
-
-Finalmente, si está interesado en el futuro de Vcpkg,
-puede ver la guía de [archivos de manifiesto][getting-started:manifest-spec]!
-esta es una característica experimental y es probable que tenga errores,
-así que se recomienda revisar y [crear incidencias][contributing:submit-issue]!
+puede que desee añadir [completado con tab](#Completado-TabAutoCompletado) en su terminal.
 
 ### Inicio Rápido: Windows
 
@@ -118,9 +113,6 @@ puede utilizar el archivo de herramientas incluido:
 Con CMake, todavía necesitara `find_package` y las configuraciones adicionales de la biblioteca.
 Revise la [Sección de Cmake](#usando-vcpkg-con-cmake) para más información,
 incluyendo el uso de CMake con un IDE.
-
-Para cualquier otra herramienta, incluyendo Visual Studio Code,
-reviste la [guía de integración][getting-started:integration].
 
 ### Inicio rápido: Unix
 
@@ -318,14 +310,13 @@ puede usar un simple `vcpkg install --feature-flags=manifests`
 
 Para más información, revise la especificación de [manifiesto][getting-started:manifest-spec]
 
-[getting-started:using-a-package]: docs/examples/installing-and-using-packages.md
-[getting-started:integration]: docs/users/buildsystems/integration.md
+[getting-started:using-a-package]: https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages
 [getting-started:git]: https://git-scm.com/downloads
 [getting-started:cmake-tools]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools
 [getting-started:linux-gcc]: #Instalando-Herramientas-de-desarrollo-en-Linux
 [getting-started:macos-dev-tools]: #Instalando-Herramientas-de-desarrollo-en-macOS
 [getting-started:visual-studio]: https://visualstudio.microsoft.com/
-[getting-started:manifest-spec]: docs/specifications/manifests.md
+[getting-started:manifest-spec]: https://learn.microsoft.com/en-us/vcpkg/users/manifests
 
 ## Completado-Tab/Autocompletado
 
@@ -347,10 +338,10 @@ según la terminal que use, luego reinicie la consola.
 
 ## Ejemplos
 
-ver la [documentación](docs/README.md) para tutoriales específicos, incluyendo
-[instalando y usando un paquete](docs/examples/installing-and-using-packages.md),
-[agregando un nuevo paquete desde un archivo comprimido](docs/examples/packaging-zipfiles.md),
-[agregando un nuevo paquete desde un repositorio en GitHub](docs/examples/packaging-github-repos.md).
+ver la [documentación](https://learn.microsoft.com/vcpkg) para tutoriales específicos, incluyendo
+[instalando y usando un paquete](https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages),
+[agregando un nuevo paquete desde un archivo comprimido](https://learn.microsoft.com/vcpkg/examples/packaging-zipfiles),
+[agregando un nuevo paquete desde un repositorio en GitHub](https://learn.microsoft.com/vcpkg/examples/packaging-github-repos).
 
 Nuestra documentación también esta disponible en nuestro sitio web [vcpkg.io](https://vcpkg.io/).
 Si necesita ayuda puede [crear un incidente](https://github.com/vcpkg/vcpkg.github.io/issues).
@@ -390,7 +381,7 @@ La mayoría de los `ports` en vcpkg construyen las bibliotecas usando su sistema
 por los autores originales de las bibliotecas, y descargan el código fuente asi como las herramientas de compilación
 de sus ubicaciones de distribucion oficiales. Para aquellos que usan un firewall, el acceso dependerá de cuales `ports`
 están siendo instalados. Si tiene que instalarlos en un entorno aislado, puede instalarlos previamente en un entorno
-no aislado, generando un [caché del paquete](docs/users/assetcaching.md) compartido con el entorno aislado.
+no aislado, generando un [caché del paquete](https://learn.microsoft.com/vcpkg/users/assetcaching) compartido con el entorno aislado.
 
 ## Telemetría
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -14,7 +14,7 @@ Pour une description des commandes disponibles, quand vous avez installé vcpkg,
 * GitHub: [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg)
 * Slack: [https://cppalliance.org/slack/](https://cppalliance.org/slack/), the #vcpkg channel
 * Discord: [\#include \<C++\>](https://www.includecpp.org), le canal #🌏vcpkg
-* Docs: [Documentation](docs/README.md)
+* Docs: [Documentation](https://learn.microsoft.com/vcpkg)
 
 [![Build Status](https://dev.azure.com/vcpkg/public/_apis/build/status/microsoft.vcpkg.ci?branchName=master)](https://dev.azure.com/vcpkg/public/_build/latest?definitionId=29&branchName=master)
 
@@ -244,8 +244,8 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems
 
 Cela permettra toujours aux gens de ne pas utiliser vcpkg, en passant directement le CMAKE_TOOLCHAIN_FILE, mais cela rendra l'étape de configuration-construction légèrement plus facile.
 
-[getting-started:utiliser-un-paquet]: docs/examples/installing-and-using-packages.md
-[getting-started:integration]: docs/users/buildsystems/integration.md
+[getting-started:utiliser-un-paquet]: https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages
+[getting-started:integration]: https://learn.microsoft.com/en-us/vcpkg/users/buildsystems/msbuild-integration
 [getting-started:git]: https://git-scm.com/downloads
 [getting-started:cmake-tools]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools
 [getting-started:linux-gcc]: #installing-linux-developer-tools
@@ -253,7 +253,7 @@ Cela permettra toujours aux gens de ne pas utiliser vcpkg, en passant directemen
 [getting-started:macos-brew]: #installing-gcc-on-macos
 [getting-started:macos-gcc]: #installing-gcc-on-macos
 [getting-started:visual-studio]: https://visualstudio.microsoft.com/
-[getting-started:manifest-spec]: docs/specifications/manifests.md
+[getting-started:manifest-spec]: https://learn.microsoft.com/en-us/vcpkg/users/manifests
 
 # Tab-complétion/Auto-complétion
 
@@ -274,9 +274,9 @@ selon le shell que vous utilisez, puis redémarrez la console.
 
 # Exemples
 
-Lisez la [documentation](doc/README.md) pour des instructions plus spécifiques ainsi que [l'installation et l'utilisation des paquets](docs/examples/installing-and-using-packages.md),
-[ajouter un nouveau paquet depuis un fichier zip](docs/examples/packaging-zipfiles.md),
-et [ajouter un nouveau paquet depuis un dépôt GitHub](docs/examples/packaging-github-repos.md).
+Lisez la [documentation](https://learn.microsoft.com/vcpkg) pour des instructions plus spécifiques ainsi que [l'installation et l'utilisation des paquets](https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages),
+[ajouter un nouveau paquet depuis un fichier zip](https://learn.microsoft.com/vcpkg/examples/packaging-zipfiles),
+et [ajouter un nouveau paquet depuis un dépôt GitHub](https://learn.microsoft.com/vcpkg/examples/packaging-github-repos).
 
 La documentation est aussi disponible en ligne sur ReadTheDocs : <https://vcpkg.readthedocs.io/> !
 

--- a/README_ko_KR.md
+++ b/README_ko_KR.md
@@ -17,7 +17,7 @@ Vcpkg를 설치하였다면, `vcpkg help` 명령어로 사용 가능한 명령�
 * GitHub: port는 [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg)에, 관련 프로그램은 [https://github.com/microsoft/vcpkg-tool](https://github.com/microsoft/vcpkg-tool)에 있습니다.
 * Slack: [https://cppalliance.org/slack/](https://cppalliance.org/slack/), #vcpkg 채널
 * Discord: [\#include \<C++\>](https://www.includecpp.org), #🌏vcpkg 채널
-* 도움말: [Documentation](docs/README.md)
+* 도움말: [Documentation](https://learn.microsoft.com/vcpkg)
 
 # 목차
 
@@ -261,8 +261,8 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems
 또한, 여전히 `CMAKE_TOOLCHAIN_FILE`을 직접 전달하면
 vcpkg를 사용하지 않을 수 있습니다.
 
-[getting-started:using-a-package]: docs/examples/installing-and-using-packages.md
-[getting-started:integration]: docs/users/buildsystems/integration.md
+[getting-started:using-a-package]: https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages
+[getting-started:integration]: https://learn.microsoft.com/en-us/vcpkg/users/buildsystems/msbuild-integration
 [getting-started:git]: https://git-scm.com/downloads
 [getting-started:cmake-tools]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools
 [getting-started:linux-gcc]: #installing-linux-developer-tools
@@ -270,7 +270,7 @@ vcpkg를 사용하지 않을 수 있습니다.
 [getting-started:macos-brew]: #installing-gcc-on-macos
 [getting-started:macos-gcc]: #installing-gcc-on-macos
 [getting-started:visual-studio]: https://visualstudio.microsoft.com/
-[getting-started:manifest-spec]: docs/specifications/manifests.md
+[getting-started:manifest-spec]: https://learn.microsoft.com/en-us/vcpkg/users/manifests
 
 # 탭 완성/자동 완성
 
@@ -289,10 +289,10 @@ $ ./vcpkg integrate bash # or zsh
 
 # 예시
 
-[패키지 설치 및 사용](docs/examples/installing-and-using-packages.md),
-[zip 파일에서 새 패키지 추가](docs/examples/packaging-zipfiles.md),
-[GitHub 저장소에서 새 패키지 추가](docs/examples/packaging-github-repos.md)에
-대한 구체적인 예시는 [문서](docs/README.md)를 참고하세요.
+[패키지 설치 및 사용](https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages),
+[zip 파일에서 새 패키지 추가](https://learn.microsoft.com/vcpkg/examples/packaging-zipfiles),
+[GitHub 저장소에서 새 패키지 추가]([docs/examples/packaging-github-repos.md](https://learn.microsoft.com/vcpkg/examples/packaging-github-repos))에
+대한 구체적인 예시는 [문서](https://learn.microsoft.com/vcpkg)를 참고하세요.
 
 문서는 이제 웹사이트 https://vcpkg.io/ 에서도 온라인으로 확인 가능합니다. 모든 피드백에 진심으로 감사드립니다!
 https://github.com/vcpkg/vcpkg.github.io/issues 에서 이슈를 제출할 수 있습니다.

--- a/README_ko_KR.md
+++ b/README_ko_KR.md
@@ -291,7 +291,7 @@ $ ./vcpkg integrate bash # or zsh
 
 [패키지 설치 및 사용](https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages),
 [zip 파일에서 새 패키지 추가](https://learn.microsoft.com/vcpkg/examples/packaging-zipfiles),
-[GitHub 저장소에서 새 패키지 추가]([docs/examples/packaging-github-repos.md](https://learn.microsoft.com/vcpkg/examples/packaging-github-repos))에
+[GitHub 저장소에서 새 패키지 추가](https://learn.microsoft.com/vcpkg/examples/packaging-github-repos)에
 대한 구체적인 예시는 [문서](https://learn.microsoft.com/vcpkg)를 참고하세요.
 
 문서는 이제 웹사이트 https://vcpkg.io/ 에서도 온라인으로 확인 가능합니다. 모든 피드백에 진심으로 감사드립니다!
@@ -331,7 +331,7 @@ Vcpk가 제공하는 대부분의 port는 각각의 라이브러리를 빌드할
 소스 코드와 빌드 도구를 각각의 공식 배포처로부터 다운로드합니다.
 방화벽 뒤에서 사용하는 경우, 어떤 port를 설치하느냐에 따라 필요한 접근 권한이 달라질 수 있습니다.
 만약 "air gapped" 환경에서 설치해야만 한다면, "air gapped"가 아닌 환경에서 
-[asset 캐시](docs/users/assetcaching.md)를 다운로드하고, 
+[asset 캐시](https://learn.microsoft.com/vcpkg/users/assetcaching)를 다운로드하고, 
 이후에 "air gapped" 환경에서 공유하는 것을 고려해 보십시오.
 
 # 데이터 수집

--- a/README_pt.md
+++ b/README_pt.md
@@ -320,7 +320,7 @@ pelos desenvolvedores originais dessas bibliotecas e baixar o código-fonte e cr
 locais de distribuição oficiais. Para uso atrás de um firewall, o acesso específico necessário dependerá
 em quais portas estão sendo instaladas. Se você precisar instalar em um ambiente "air gap", considere
 instalando uma vez em um ambiente sem "air gap", preenchendo um
-[cache de ativos](docs/users/assetcaching.md) compartilhado com o ambiente "air gapped".
+[cache de ativos](https://learn.microsoft.com/vcpkg/users/assetcaching) compartilhado com o ambiente "air gapped".
 
 # Telemetria
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -18,7 +18,7 @@ você pode executar `vcpkg help`, ou `vcpkg help [command]` para obter ajuda esp
 * GitHub: pacote completo em [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg), programa em [https://github.com/microsoft/vcpkg-tool](https://github.com/microsoft/vcpkg-tool)
 * Slack: [https://cppalliance.org/slack/](https://cppalliance.org/slack/), the #vcpkg channel
 * Discord: [\#include \<C++\>](https://www.includecpp.org), the #🌏vcpkg channel
-* Documentos: [Documentation](docs/README.md)
+* Documentos: [Documentation](https://learn.microsoft.com/vcpkg)
 
 # Índice
 
@@ -255,8 +255,8 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems
 
 Isso ainda permitirá que as pessoas não usem o vcpkg, passando o `CMAKE_TOOLCHAIN_FILE` diretamente, mas tornará a etapa de configuração-construção um pouco mais fácil.
 
-[getting-started:using-a-package]: docs/examples/installing-and-using-packages.md
-[getting-started:integration]: docs/users/buildsystems/integration.md
+[getting-started:using-a-package]: https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages
+[getting-started:integration]: https://learn.microsoft.com/en-us/vcpkg/users/buildsystems/msbuild-integration
 [getting-started:git]: https://git-scm.com/downloads
 [getting-started:cmake-tools]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools
 [getting-started:linux-gcc]: #installing-linux-developer-tools
@@ -264,7 +264,7 @@ Isso ainda permitirá que as pessoas não usem o vcpkg, passando o `CMAKE_TOOLCH
 [getting-started:macos-brew]: #installing-gcc-on-macos
 [getting-started:macos-gcc]: #installing-gcc-on-macos
 [getting-started:visual-studio]: https://visualstudio.microsoft.com/
-[getting-started:manifest-spec]: docs/specifications/manifests.md
+[getting-started:manifest-spec]: https://learn.microsoft.com/en-us/vcpkg/users/manifests
 
 # Tab-Completion/Auto-Completion
 
@@ -284,10 +284,10 @@ dependendo do shell que você usa, reinicie o console.
 
 # Exemplos
 
-Consulte a [documentação](docs/README.md) para orientações específicas,
-incluindo [instalando e usando um pacote](docs/examples/installing-and-using-packages.md),
-[adicionando um novo pacote de um arquivo zip](docs/examples/packaging-zipfiles.md),
-e [adicionando um novo pacote de um repositório GitHub](docs/examples/packaging-github-repos.md).
+Consulte a [documentação](https://learn.microsoft.com/vcpkg) para orientações específicas,
+incluindo [instalando e usando um pacote](https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages),
+[adicionando um novo pacote de um arquivo zip](https://learn.microsoft.com/vcpkg/examples/packaging-zipfiles),
+e [adicionando um novo pacote de um repositório GitHub](https://learn.microsoft.com/vcpkg/examples/packaging-github-repos).
 
 Nossos documentos agora também estão disponíveis online em nosso site <https://vcpkg.io/>. Nós realmente apreciamos todo e qualquer feedback! Você pode enviar um problema em <https://github.com/vcpkg/vcpkg.github.io/issues>.
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -300,7 +300,7 @@ vcpkg会将库的协议文件放置在 `installed/<triplet>/share/<port>/copyrig
 
 大多数vcpkg中的库采用其官方发布的构建工具来构建它们，并从其官方渠道下载源码及构建工具。
 若您的环境包含防火墙或反病毒程序，为了避免构建失败，请考虑在禁用防火墙与反病毒程序的环境中构建它们一次，
-再将它们生成的二进制缓存共享给原始环境中使用。
+再将它们生成的[二进制缓存](https://learn.microsoft.com/vcpkg/users/assetcaching)共享给原始环境中使用。
 
 # 数据收集
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -9,7 +9,7 @@ Vcpkg 可帮助您在 Windows、 Linux 和 MacOS 上管理 C 和 C++ 库。
 
 如需获取有关可用命令的简短描述，请在编译 vcpkg 后执行 `vcpkg help` 或执行 `vcpkg help [command]` 来获取具体的帮助信息。
 
-* GitHub: [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg)
+* GitHub: 端口位于 [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg)，程序位于 [https://github.com/microsoft/vcpkg-tool](https://github.com/microsoft/vcpkg-tool)
 * Slack: [https://cppalliance.org/slack/](https://cppalliance.org/slack/)， #vcpkg 频道
 * Discord: [\#include \<C++\>](https://www.includecpp.org)， #🌏vcpkg 频道
 * 文档: [Documentation](https://learn.microsoft.com/vcpkg)
@@ -28,7 +28,7 @@ Vcpkg 可帮助您在 Windows、 Linux 和 MacOS 上管理 C 和 C++ 库。
     - [Visual Studio CMake 工程中使用 vcpkg](#visual-studio-cmake-工程中使用-vcpkg)
     - [CLion 中使用 vcpkg](#clion-中使用-vcpkg)
     - [将 vcpkg 作为一个子模块](#将-vcpkg-作为一个子模块)
-- [Tab补全/自动补全](#tab补全自动补全)
+- [Tab补全/自动补全](#tab-补全自动补全)
 - [示例](#示例)
 - [贡献](#贡献)
 - [开源协议](#开源协议)
@@ -48,11 +48,7 @@ vcpkg 团队和贡献者可以在这里看到它，
 并可能将这个库添加到 vcpkg。
 
 安装并运行 vcpkg 后，
-您可能希望将 [TAB 补全](#tab补全自动补全) 添加到您的 Shell 中。
-
-最后，如果您对 vcpkg 的未来感兴趣，请查看 [清单][getting-started:manifest-spec]！
-这是一项实验性功能，可能会出现错误。
-因此，请尝试一下并[打开所有问题][contributing:submit-issue]!
+您可能希望将 [TAB 补全](#tab-补全自动补全) 添加到您的 Shell 中。
 
 ## 快速开始: Windows
 
@@ -114,8 +110,6 @@ vcpkg 团队和贡献者可以在这里看到它，
 
 在 CMake 中，您仍需通过 `find_package` 来使用 vcpkg 中已安装的库。
 请查阅 [CMake 章节](#在-cmake-中使用-vcpkg) 获取更多信息，其中包含了在 IDE 中使用 CMake 的内容。
-
-对于其他工具 (包括 Visual Studio Code)，请查阅 [集成指南][getting-started:integration]。
 
 ## 快速开始: Unix
 
@@ -267,7 +261,7 @@ $ ./vcpkg integrate bash # 或 zsh
 
 然后重新启动控制台。
 
-## 示例
+# 示例
 
 请查看 [文档](https://learn.microsoft.com/vcpkg) 获取具体示例，
 其包含 [安装并使用包](https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages)，
@@ -279,7 +273,7 @@ $ ./vcpkg integrate bash # 或 zsh
 
 观看 4 分钟 [demo 视频](https://www.youtube.com/watch?v=y41WFKbQFTw)。
 
-## 贡献
+# 贡献
 
 Vcpkg是一个开源项目，并通过您的贡献不断发展。
 下面是一些您可以贡献的方式:


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/32883

1. Fix the broken link in README_xx.md.
2. Fix the table of contents jump issue in README_zh_CN.md.
3. Update the content in README_zh_CN.md.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
