### PR TITLE
[nanobench] Bump to 4.3.11

### DIFF
--- a/ports/nanobench/portfile.cmake
+++ b/ports/nanobench/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinus/nanobench
-    REF v${VERSION}
-    SHA512 aa00dfc585445fda63b3ba1a802da259993b6b99d0bc2c9bb5f8a9dac64d25e9a61f072846d8f70ee2fea58482431749189179520ba7f6e075dbb223574a3a4d
+    REF "v${VERSION}"
+    SHA512 88697cc87e99b8c17f004dbd39efee664145b86d9feec02f5dba0d84be88e9bd272e537f392e670445d849f0d3c852b9870aea650d84968ee6fbc23a56bcff64
     HEAD_REF master
 )
 

--- a/ports/nanobench/vcpkg.json
+++ b/ports/nanobench/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nanobench",
-  "version": "4.3.10",
-  "port-version": 1,
+  "version": "4.3.11",
   "description": "Simple, fast, accurate single-header microbenchmarking functionality for C++11/14/17/20",
   "homepage": "https://nanobench.ankerl.com",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5589,8 +5589,8 @@
       "port-version": 2
     },
     "nanobench": {
-      "baseline": "4.3.10",
-      "port-version": 1
+      "baseline": "4.3.11",
+      "port-version": 0
     },
     "nanodbc": {
       "baseline": "2.13.0",

--- a/versions/n-/nanobench.json
+++ b/versions/n-/nanobench.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "811f5b66a36111a71c33f7b7ed5924f04caba4d8",
+      "version": "4.3.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "90dbaf4276576bc0ae73f4af33109639f01d698a",
       "version": "4.3.10",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
