### PR TITLE
[highway] Bump to 1.0.6 & fix usage

### DIFF
--- a/ports/highway/portfile.cmake
+++ b/ports/highway/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/highway
     REF "${VERSION}"
-    SHA512 75aaa0a3f97c6b044acb146ac4db20c1d813c4215b9c1620e72352d00c136939db7059f599122d6600e385bffa8b24d7fd9c1fe09772f4941e5300767a8c68dd
+    SHA512 9d42ebae81240f75a0cd15030875f8405875e4f31690a16ae039df0ead2f4f483f76d269fb6d74af57680ee4593cb2475c7adf5937ffe367d71d424b193dc4d4
     HEAD_REF master
 )
 
@@ -15,23 +15,20 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        -DHWY_ENABLE_INSTALL=ON
         -DHWY_ENABLE_EXAMPLES=OFF
         -DHWY_ENABLE_TESTS=OFF
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/hwy)
+vcpkg_cmake_config_fixup(PACKAGE_NAME hwy CONFIG_PATH lib/cmake/hwy)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/hwy/highway_export.h" "defined(HWY_SHARED_DEFINE)" "1")
 endif()
 
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/include"
-    # remove test-related pkg-config files that break vcpkg_fixup_pkgconfig
-    "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libhwy-test.pc"
-    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libhwy-test.pc"
-)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/highway/usage
+++ b/ports/highway/usage
@@ -1,0 +1,4 @@
+highway provides CMake targets:
+
+    find_package(hwy CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE hwy::hwy)

--- a/ports/highway/vcpkg.json
+++ b/ports/highway/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "highway",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Performance-portable, length-agnostic SIMD with runtime dispatch",
   "homepage": "https://github.com/google/highway",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3197,7 +3197,7 @@
       "port-version": 0
     },
     "highway": {
-      "baseline": "1.0.4",
+      "baseline": "1.0.6",
       "port-version": 0
     },
     "hikogui": {

--- a/versions/h-/highway.json
+++ b/versions/h-/highway.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "221bc90fda5b814132f77cac6e28750dc7525323",
+      "version": "1.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "d516ee6b19d52dce62aae1d9ced2b7d9b18cb5cf",
       "version": "1.0.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
