### PR TITLE
[vulkan-headers] Bump to 1.3.260

### DIFF
--- a/ports/vulkan-headers/portfile.cmake
+++ b/ports/vulkan-headers/portfile.cmake
@@ -1,14 +1,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/Vulkan-Headers
-    REF bae9700cd9425541a0f6029957f005e5ad3ef660
-    SHA512 b1a51cb868563bf044c65cab8411547b8a08ea21998f01e5be53027217ddd18ff6907d78490c08e3f14865c53436ddf092811726ae3df23a29f8edd614bdb95b
-    HEAD_REF v1.3.250
+    REF "v${VERSION}"
+    SHA512 afd3a617fdd83d3e11559b4530e249dea4dbed66a44aba4fe1a39af2220ddcb8c45e49eaa087bbd62454709015b659eccfcdd6c3ad7950a2a7b1b674cf65e957
+    HEAD_REF main
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/vulkan-headers/vcpkg.json
+++ b/ports/vulkan-headers/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "vulkan-headers",
-  "version": "1.3.250",
-  "port-version": 2,
+  "version": "1.3.260",
   "description": "Vulkan header files and API registry",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Headers",
-  "license": "Apache-2.0",
+  "license": "Apache-2.0 OR MIT",
   "supports": "!uwp & !xbox",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8597,8 +8597,8 @@
       "port-version": 6
     },
     "vulkan-headers": {
-      "baseline": "1.3.250",
-      "port-version": 2
+      "baseline": "1.3.260",
+      "port-version": 0
     },
     "vulkan-hpp": {
       "baseline": "1.3.259",

--- a/versions/v-/vulkan-headers.json
+++ b/versions/v-/vulkan-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a67e5648f3203af599c115390d12fceb828b8fa",
+      "version": "1.3.260",
+      "port-version": 0
+    },
+    {
       "git-tree": "58c480d0beaa5a34988bd99c452a6fcbfe08721a",
       "version": "1.3.250",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
