### PR TITLE
[cairomm] Bump to 1.17.1

### DIFF
--- a/ports/cairomm/fix_include_path.patch
+++ b/ports/cairomm/fix_include_path.patch
@@ -1,17 +1,17 @@
 diff --git a/meson.build b/meson.build
-index 4522a94..c387148 100644
+index b8c2191..8f280b4 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -271,7 +271,7 @@ mm_conf_data.set('CAIROMM_MINOR_VERSION', cairomm_minor_version)
- mm_conf_data.set('CAIROMM_MICRO_VERSION', cairomm_micro_version)
+@@ -288,7 +288,7 @@ mm_conf_data.set('CAIROMM_MICRO_VERSION', cairomm_micro_version)
  mm_conf_data.set('VERSION', meson.project_version()) # for MSVC_NMake/cairomm/cairomm.rc
  
+ cairommconfig_h_meson = files('cairommconfig.h.meson')
 -install_includeconfigdir = install_libdir / cairomm_pcname / 'include'
 +install_includeconfigdir = install_includedir
- cairommconfig_h = configure_file(
-   input: 'cairommconfig.h.meson',
+ configure_file(
+   input: cairommconfig_h_meson,
    output: 'cairommconfig.h',
-@@ -361,7 +361,7 @@ summary = [
+@@ -380,7 +380,7 @@ summary = [
    'Directories:',
    '                  prefix: @0@'.format(install_prefix),
    '              includedir: @0@'.format(install_prefix / install_includedir),

--- a/ports/cairomm/portfile.cmake
+++ b/ports/cairomm/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.cairographics.org/releases/cairomm-${VERSION}.tar.xz"
     FILENAME "cairomm-${VERSION}.tar.xz"
-    SHA512 61dc639eabe8502e1262c53c92fe57c5647e5ab9931f86ed51e657df1b7d0e3e58c2571910a05236cc0dca8d52f1f693aed99a553430f14d0fb87be1832a6b62
+    SHA512 5484ccefc255b2e8886722c483cde011043c98b8e7ae17ce642f1b67effa236a8499c332771104fa7e547a9066c168fcfbbff6249caa73df3860823b355567d9
 )
 
 vcpkg_extract_source_archive(
@@ -26,8 +26,9 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/cairommconfig.h" "# define CAIROMM_DLL 1" "# undef CAIROMM_DLL\n# define CAIROMM_STATIC_LIB 1")
 endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cairomm/usage
+++ b/ports/cairomm/usage
@@ -1,0 +1,5 @@
+cairomm provides usage:
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(CAIROMM REQUIRED IMPORTED_TARGET cairomm-1.16)
+    target_link_libraries(main PRIVATE PkgConfig::CAIROMM)

--- a/ports/cairomm/vcpkg.json
+++ b/ports/cairomm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cairomm",
-  "version": "1.16.2",
-  "port-version": 4,
+  "version": "1.17.1",
   "description": "A C++ wrapper for the cairo graphics library",
   "homepage": "https://www.cairographics.org",
   "license": "LGPL-2.0-only",
@@ -9,6 +8,10 @@
   "dependencies": [
     "cairo",
     "libsigcpp",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1381,8 +1381,8 @@
       "port-version": 3
     },
     "cairomm": {
-      "baseline": "1.16.2",
-      "port-version": 4
+      "baseline": "1.17.1",
+      "port-version": 0
     },
     "calceph": {
       "baseline": "3.5.2",

--- a/versions/c-/cairomm.json
+++ b/versions/c-/cairomm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8edc870e28366ad88709f1232d002ffd9810cf3",
+      "version": "1.17.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c5804d5f576169610ec03d2803f9d8a03678cc95",
       "version": "1.16.2",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
