### PR TITLE
[Thorvg] Update Thorvg port to v0.10.0

### DIFF
--- a/ports/thorvg/install-tools.patch
+++ b/ports/thorvg/install-tools.patch
@@ -1,22 +1,21 @@
 diff --git a/src/bin/svg2png/meson.build b/src/bin/svg2png/meson.build
-index ed21489e..c3fb3188 100644
+index c9fe63b6..92bfdda4 100644
 --- a/src/bin/svg2png/meson.build
 +++ b/src/bin/svg2png/meson.build
-@@ -4,4 +4,5 @@ executable('svg2png',
-            svg2png_src,
+@@ -5,4 +5,4 @@ executable('svg2png',
             include_directories : headers,
-            cpp_args: compiler_flags,
+            cpp_args : compiler_flags,
+            install : true,
 -           link_with : thorvg_lib)
-+           link_with : thorvg_lib,
-+           install : true, install_dir : get_option('bindir'))
++           link_with : thorvg_lib , install_dir : get_option('bindir'))
+\ No newline at end of file
 diff --git a/src/bin/svg2tvg/meson.build b/src/bin/svg2tvg/meson.build
-index a40111aa..a02f4b8a 100644
+index 158376b5..8d960aec 100644
 --- a/src/bin/svg2tvg/meson.build
 +++ b/src/bin/svg2tvg/meson.build
-@@ -4,4 +4,5 @@ executable('svg2tvg',
-            svg2tvg_src,
+@@ -5,4 +5,4 @@ executable('svg2tvg',
             include_directories : headers,
-            cpp_args: compiler_flags,
+            cpp_args : compiler_flags,
+            install : true,
 -           link_with : thorvg_lib)
-+           link_with : thorvg_lib,
-+           install : true, install_dir : get_option('bindir'))
++           link_with : thorvg_lib , install_dir : get_option('bindir'))

--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO thorvg/thorvg
-    REF v0.9.0
-    SHA512 c0294a60f0b2e432bec62e1c44f0cb632420ec5c9390df210c8b8db5507fa8f5946bdc8a7879007e4e54865dc4538f4bf1e26d76f90a324cc5edd5cdf61c0fc0
+    REF v0.10.0
+    SHA512 63e0df26be141eeabf0c7204a75f55c57b59f0f2514d896ee6c73c17453e9e1b606434fa93bbbebc6a2671389ecd7ec39c1099ef25c2e9459932e9cc4d8b1241
     HEAD_REF master
     PATCHES
         install-tools.patch

--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         install-tools.patch
+        windows-build-option.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "thorvg",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",
-  "supports": "!(windows & arm & !uwp)",
+  "supports": "!(arm & uwp) & !windows",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",
-  "supports": "!(windows & arm) & !uwp",
+  "supports": "!(windows & arm & !uwp)",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",
-  "supports": "!(arm & uwp) & !windows",
+  "supports": "!(arm & uwp)",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",
-  "supports": "!(arm & uwp)",
+  "supports": "!(windows & arm) & !uwp",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/ports/thorvg/windows-build-option.patch
+++ b/ports/thorvg/windows-build-option.patch
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index a04a9546..cfaceb35 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,6 +1,6 @@
+ project('thorvg',
+         'cpp',
+-        default_options : ['buildtype=debugoptimized', 'b_sanitize=none', 'werror=false', 'optimization=s', 'cpp_std=c++14', 'strip=true'],
++        default_options : ['buildtype=debugoptimized', 'b_sanitize=none', 'werror=false', 'optimization=s', 'cpp_std=c++14'],
+         version : '0.10.0',
+         license : 'MIT')
+ 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8053,7 +8053,7 @@
       "port-version": 0
     },
     "thorvg": {
-      "baseline": "0.9.0",
+      "baseline": "0.10.0",
       "port-version": 0
     },
     "threadpool": {

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c70992aa498daf7d7eb245bff27f23049537223b",
+      "git-tree": "17c9f6d3adb87382db676ff3d4751597a755b05e",
       "version": "0.10.0",
       "port-version": 0
     },

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "17c9f6d3adb87382db676ff3d4751597a755b05e",
+      "git-tree": "4614b6b2399a749c1ac0699429f38e35d9faee9a",
       "version": "0.10.0",
       "port-version": 0
     },

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "137ed088f111f7e852cb30246507d9e0e9d80673",
+      "version": "0.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e0dd9030c6e211cbf558dae00ea87e9591a09f8",
       "version": "0.9.0",
       "port-version": 0

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "137ed088f111f7e852cb30246507d9e0e9d80673",
+      "git-tree": "45026a03d33e5dfccb927bf9c89a1e4790749575",
       "version": "0.10.0",
       "port-version": 0
     },

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "45026a03d33e5dfccb927bf9c89a1e4790749575",
+      "git-tree": "c70992aa498daf7d7eb245bff27f23049537223b",
       "version": "0.10.0",
       "port-version": 0
     },


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

