### PR TITLE
[google-cloud-cpp] fix opentelemetry feature

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -65,7 +65,7 @@ foreach(feature IN LISTS FEATURES)
 endforeach()
 # These packages are automatically installed depending on what features are
 # enabled.
-foreach(suffix common googleapis grpc_utils rest_internal dialogflow_cx dialogflow_es)
+foreach(suffix common googleapis grpc_utils rest_internal opentelemetry dialogflow_cx dialogflow_es)
     set(config_path "lib/cmake/google_cloud_cpp_${suffix}")
     if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
         continue()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.14.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2954,7 +2954,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.14.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d32a3fa190564c35057874f3912f61ebf07852b7",
+      "version": "2.14.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "696c1d17cd2174ffde1c0d53779b76e8d98d924a",
       "version": "2.14.0",
       "port-version": 0


### PR DESCRIPTION
cc @coryan - I goofed the original PR.

I only verified that `opentelemetry-cpp` was being installed as a dep. I did not verify that `google_cloud_cpp_opentelemetry` was installed.

Previously, `google_cloud_cpp_opentelemetry` was not listed as a target nor installed.

Now:

```sh
$ ./vcpkg install google-cloud-cpp[core,experimental-opentelemetry]
# <omitted>
google-cloud-cpp provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(google_cloud_cpp_common CONFIG REQUIRED)
    target_link_libraries(main PRIVATE google-cloud-cpp::common)

    find_package(google_cloud_cpp_googleapis CONFIG REQUIRED)
    # note: 74 additional targets are not displayed.
    target_link_libraries(main PRIVATE gRPC::grpc gRPC::grpc++ google-cloud-cpp::iam_protos google-cloud-cpp::pubsub_protos)

    find_package(google_cloud_cpp_grpc_utils CONFIG REQUIRED)
    target_link_libraries(main PRIVATE google-cloud-cpp::grpc_utils)

    find_package(google_cloud_cpp_opentelemetry CONFIG REQUIRED)
    target_link_libraries(main PRIVATE google-cloud-cpp::experimental-opentelemetry)

    find_package(google_cloud_cpp_rest_internal CONFIG REQUIRED)
    target_link_libraries(main PRIVATE google-cloud-cpp::rest_internal)

    find_package(google_cloud_cpp_trace CONFIG REQUIRED)
    target_link_libraries(main PRIVATE google-cloud-cpp::trace google-cloud-cpp::trace_protos)

$ ls installed/x64-linux/share/ | grep google_cloud_cpp
google_cloud_cpp_common
google_cloud_cpp_googleapis
google_cloud_cpp_grpc_utils
google_cloud_cpp_opentelemetry
google_cloud_cpp_rest_internal
google_cloud_cpp_trace
```

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.