### PR TITLE
[rsm-binary-io] Update to 2.0.6

### DIFF
--- a/ports/rsm-binary-io/portfile.cmake
+++ b/ports/rsm-binary-io/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Ryan-rsm-McKenzie/binary_io
-    REF 2.0.5
-    SHA512 787833487b9e2b64aeb73842024a52a6ad646d2609342983ebf1539878b96565bf329c8b05afca0fb35a1e40a91174131ad7a0bdc79b168a12bf02f3d6e0cd6d
+    REF 2.0.6
+    SHA512 055290ee81e93aa8a8cda567eea848c76a830d78afb1c40bc3ba0e23b41bf80364fc8621ddaf8d48678acc4b5b7fd1ba2075e2bd23995655131954f580bdd4ae
     HEAD_REF main
 )
 

--- a/ports/rsm-binary-io/vcpkg.json
+++ b/ports/rsm-binary-io/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rsm-binary-io",
-  "version-semver": "2.0.5",
+  "version-semver": "2.0.6",
   "description": "A binary i/o library for C++, without the agonizing pain",
   "homepage": "https://github.com/Ryan-rsm-McKenzie/binary_io",
   "documentation": "https://ryan-rsm-mckenzie.github.io/binary_io/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7265,7 +7265,7 @@
       "port-version": 0
     },
     "rsm-binary-io": {
-      "baseline": "2.0.5",
+      "baseline": "2.0.6",
       "port-version": 0
     },
     "rsm-bsa": {

--- a/versions/r-/rsm-binary-io.json
+++ b/versions/r-/rsm-binary-io.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f89c1962171e765068e679e0e89c4607f97ce8cb",
+      "version-semver": "2.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "a170dd2013d45c86b272169552cf4ac52a5d1c79",
       "version-semver": "2.0.5",
       "port-version": 0


### PR DESCRIPTION
This PR updates the port `rsm-binary-io` to the latest release [v2.0.6](https://github.com/Ryan-rsm-McKenzie/binary_io/releases/tag/2.0.6)

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
