### PR TITLE
[sfml] Fix specify c++ library on macOS

### DIFF
--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_cmake_configure(
         -DSFML_USE_SYSTEM_DEPS=ON
         -DSFML_MISC_INSTALL_PREFIX=share/sfml
         -DSFML_GENERATE_PDB=OFF
-		-DSFML_WARNINGS_AS_ERRORS=OFF #Remove in the next version
+        -DSFML_WARNINGS_AS_ERRORS=OFF #Remove in the next version
 )
 
 vcpkg_cmake_install()

--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_cmake_configure(
         -DSFML_USE_SYSTEM_DEPS=ON
         -DSFML_MISC_INSTALL_PREFIX=share/sfml
         -DSFML_GENERATE_PDB=OFF
+		-DSFML_WARNINGS_AS_ERRORS=OFF #Remove in the next version
 )
 
 vcpkg_cmake_install()

--- a/ports/sfml/vcpkg.json
+++ b/ports/sfml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sfml",
   "version": "2.6.0",
-  "port-version": 17,
+  "port-version": 18,
   "description": "Simple and fast multimedia library",
   "homepage": "https://github.com/SFML/SFML",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7514,7 +7514,7 @@
     },
     "sfml": {
       "baseline": "2.6.0",
-      "port-version": 17
+      "port-version": 18
     },
     "sfsexp": {
       "baseline": "1.3.1",

--- a/versions/s-/sfml.json
+++ b/versions/s-/sfml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73e4e0a33324f5962b47c21ce9e337799e1a3800",
+      "version": "2.6.0",
+      "port-version": 18
+    },
+    {
       "git-tree": "8d61263f546c87d3c26f45ade4f92d65f1203816",
       "version": "2.6.0",
       "port-version": 17

--- a/versions/s-/sfml.json
+++ b/versions/s-/sfml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "73e4e0a33324f5962b47c21ce9e337799e1a3800",
+      "git-tree": "7712e31893217c566173961ad3681c19856e69e6",
       "version": "2.6.0",
       "port-version": 18
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/32574
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
```
clang: error: argument unused during compilation: '-stdlib=libc++' [-Werror,-Wunused-command-line-argument]
```
This issue has been resolved by the upstream PR: https://github.com/SFML/SFML/pull/2625 . According to the upstream author's suggestion, temporarily set `WARNINGS_AS_ERRORS`  to `OFF`  to solve this problem. It will be removed in the next version update.

Related Upstream issue https://github.com/SFML/SFML/issues/2623
<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
