### PR TITLE
[entt] Bump to 3.12.2

### DIFF
--- a/ports/entt/portfile.cmake
+++ b/ports/entt/portfile.cmake
@@ -1,38 +1,26 @@
-if ("experimental" IN_LIST FEATURES)
-    vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO skypjack/entt
-        HEAD_REF experimental
-    )
-else()
-    vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO skypjack/entt
-        REF "v${VERSION}"
-        SHA512 51fe70e68cbb7d3a5a9ca6b5ff974d324e34248a13a1c828b6c5876461a173861ab26f1bfd0bac7287f8499d07b93bdb73622b579d11a65c916aad7b642dc6e0
-        HEAD_REF master
-    )
-endif()
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO skypjack/entt
+    REF "v${VERSION}"
+    SHA512 8382092339476fa187e0110ec4ba9a0ff93966a31263b28d9edb25068705815d120520b55c640bc3ced852a91762abed6da2bd9a50eaf274272605a8b5b493b9
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DENTT_BUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/EnTT/cmake)
 
-if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
-    vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
-else()
-    vcpkg_cmake_config_fixup(CONFIG_PATH lib/EnTT/cmake)
-endif()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 # Install natvis files
 file(INSTALL "${SOURCE_PATH}/natvis/entt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/natvis")
 
-# Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/entt/usage
+++ b/ports/entt/usage
@@ -1,0 +1,4 @@
+entt provides CMake targets:
+
+    find_package(EnTT CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE EnTT::EnTT)

--- a/ports/entt/vcpkg.json
+++ b/ports/entt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "entt",
-  "version": "3.12.0",
+  "version": "3.12.2",
   "description": "Gaming meets modern C++ - a fast and reliable entity-component system and much more",
   "homepage": "https://github.com/skypjack/entt",
   "license": "MIT",
@@ -13,10 +13,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "experimental": {
-      "description": "Use experimental features right away"
-    }
-  }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2365,7 +2365,7 @@
       "port-version": 5
     },
     "entt": {
-      "baseline": "3.12.0",
+      "baseline": "3.12.2",
       "port-version": 0
     },
     "epsilon": {

--- a/versions/e-/entt.json
+++ b/versions/e-/entt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "556ac85a20d7294c42222cb292a2753113953015",
+      "version": "3.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "715488654a998a72da8fff6596cbeedf1962fa56",
       "version": "3.12.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
