### PR TITLE
[magic-enum] Bump to 0.9.3

### DIFF
--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -1,12 +1,12 @@
-# header-only library
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/magic_enum
-    REF v0.9.2
-    SHA512 5c88ebcb30282bea5c2b38d17a6ee6a9014e5d282f2c08e92f398f30d9846cbd5a09599270afe82e927069bad9c50d691fa53a82da059f77dc1c01b179e65689
+    REF "v${VERSION}"
+    SHA512 0bee01840d69a102f9c07e063a8314f40593bd476545176ba2895549b899d6c619d76588e2d55e2c71c2812cd41c1f802e0718461e8b31d37ac6264273001236
     HEAD_REF master
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -20,7 +20,8 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/magic_enum PACKAGE_NAME magic_enum)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 # Handle copyright
 configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/magic-enum/usage
+++ b/ports/magic-enum/usage
@@ -1,0 +1,4 @@
+magic-enum provides CMake targets:
+
+    find_package(magic_enum CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE magic_enum::magic_enum)

--- a/ports/magic-enum/vcpkg.json
+++ b/ports/magic-enum/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-enum",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.",
   "homepage": "https://github.com/Neargye/magic_enum",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5141,7 +5141,7 @@
       "port-version": 0
     },
     "magic-enum": {
-      "baseline": "0.9.2",
+      "baseline": "0.9.3",
       "port-version": 0
     },
     "magic-get": {

--- a/versions/m-/magic-enum.json
+++ b/versions/m-/magic-enum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2261a86b9d2e1ff3f42c80919f58d59e4e4335c",
+      "version": "0.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "52780f8b8e0c2f55c3841e133c813f2bc739abcc",
       "version": "0.9.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
