### PR TITLE
[cpp-httplib] Bump to 0.13.3

### DIFF
--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -1,23 +1,23 @@
-# Header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
     REF "v${VERSION}"
-    SHA512 4a70ebafd0920116a78ea18982606f0bec396e5cdcea9ba583c1da4fd77fa45c5bf30a6ac14eeee9424f3e445a882a560345d731a7113ab4e7dff88f4ef0a436
+    SHA512 5181f185bc0bb37429847e2656534ff25512458c0219631c982b776c65fd6be73e038f88d47e42b4f614324e51577bc8815e80952c7c7ca6e66eca4a16a9f30d
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch
 )
 
+set(VCPKG_BUILD_TYPE release) # header-only port
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
-vcpkg_cmake_install()
 
+vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME httplib CONFIG_PATH lib/cmake/httplib)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib" "${CURRENT_PACKAGES_DIR}/lib")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cpp-httplib/usage
+++ b/ports/cpp-httplib/usage
@@ -1,0 +1,4 @@
+cpp-httplib provides CMake targets:
+
+    find_package(httplib CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE httplib::httplib)

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-httplib",
-  "version": "0.13.1",
+  "version": "0.13.3",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1769,7 +1769,7 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.13.1",
+      "baseline": "0.13.3",
       "port-version": 0
     },
     "cpp-ipc": {

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1a8cffe02efe8a9c92d1aa1e802f12a8d893aa8",
+      "version": "0.13.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "795e219c0d92adb47551a8a8a4a1e800d5fe70a9",
       "version": "0.13.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
