### PR TITLE
[args] Bump to 6.4.6

### DIFF
--- a/ports/args/portfile.cmake
+++ b/ports/args/portfile.cmake
@@ -1,24 +1,25 @@
-#header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Taywee/args
-    REF 6.3.0
-    SHA512 7d554719781d5a096883e37cd5c1706782d06c2c4d7a9598142aec7f2e38d63438e82960b60a705baeb2aa5d31143c83fa6c0d1331a36b16f564a5ea56ad451d
+    REF "${VERSION}"
+    SHA512 5b433845ce4a8590e72c045a40ab62602b798dad46eb192210815c11507700026073a6a8a528aaf567786931d587ef58f90b459a747a91856ce1cc4f2835b0e9
     HEAD_REF master
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-    -DARGS_BUILD_UNITTESTS=OFF
-    -DARGS_BUILD_EXAMPLE=OFF
+        -DARGS_BUILD_UNITTESTS=OFF
+        -DARGS_BUILD_EXAMPLE=OFF
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 
-# Put the licence file where vcpkg expects it
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/args/usage
+++ b/ports/args/usage
@@ -1,0 +1,4 @@
+args provides CMake targets:
+
+    find_package(args CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE taywee::args)

--- a/ports/args/vcpkg.json
+++ b/ports/args/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "args",
-  "version": "6.3.0",
+  "version": "6.4.6",
   "description": "A simple header-only C++ argument parser library.",
   "homepage": "https://github.com/Taywee/args",
   "license": "MIT",

--- a/versions/a-/args.json
+++ b/versions/a-/args.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b8449188caa97cb07c87641c977a969846153f5",
+      "version": "6.4.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "6da2a8e30a8640e0cb9fe55decd3a634d8c42cb6",
       "version": "6.3.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -197,7 +197,7 @@
       "port-version": 0
     },
     "args": {
-      "baseline": "6.3.0",
+      "baseline": "6.4.6",
       "port-version": 0
     },
     "argtable2": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
