### PR TITLE
[fastio] Bump to 2023-07-06

### DIFF
--- a/ports/fastio/portfile.cmake
+++ b/ports/fastio/portfile.cmake
@@ -2,10 +2,12 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cppfastio/fast_io
-    REF 88c3c87290f07bd97b31c71fbd815b7d20ab66d9
-    SHA512 da356498797d2bc50671e5a12099e9a9c50f1f1c570cd7ed68ef32082e1778d86efeeddea57c84a116fb817572d9fbbd33d8e44fef6a38b760fcb8ab8edbe6ab
+    REF e3df753a74a27e00bcb288bc97ab203645ed9579
+    SHA512 9afe554570241a64e6f155419635aa6c0f97898902f7e4fcace883ed532142174e8b584e300223e0b8f2fa9831ee031f92465b2d5ffd9466de323b59efd37b59
     HEAD_REF master
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -13,6 +15,6 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license.txt")

--- a/ports/fastio/vcpkg.json
+++ b/ports/fastio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastio",
-  "version-date": "2022-11-14",
+  "version-date": "2023-07-06",
   "description": "fast_io is an extremely fast C++20 input/output library aiming to replace <iostream> and <cstdio>. It supports networking, NT apis, pipe, filesystem, winrt hstring, Qt, OpenSSL, cryptography. It is freestanding and it works on any platform, including dos, win95, wasm, linux kernel, windows kernel or your own operating system kernel. It has no dependencies.",
   "homepage": "https://github.com/cppfastio/fast_io",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2473,7 +2473,7 @@
       "port-version": 1
     },
     "fastio": {
-      "baseline": "2022-11-14",
+      "baseline": "2023-07-06",
       "port-version": 0
     },
     "fastlz": {

--- a/versions/f-/fastio.json
+++ b/versions/f-/fastio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3cfcdfee62b62a815b8ea72c22e41a40b6c24610",
+      "version-date": "2023-07-06",
+      "port-version": 0
+    },
+    {
       "git-tree": "03ff13377e65b89408d2b0eba2b7ad1f34201641",
       "version-date": "2022-11-14",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
