### PR TITLE
[volk] Bump to 1.3.250

### DIFF
--- a/ports/volk/portfile.cmake
+++ b/ports/volk/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeux/volk
-    REF 97e029bea37ae8ef443a1de684207127717de606
-    SHA512 a50b2c90499688b66bfa88a7cde438aa78dd27a43a6fe375f348b2587e321540306d0c383272091b7f78a64a8415cfe9e908d0dfc949562dfee8e0e3b4380acc
+    REF "${VERSION}"
+    SHA512 a273ecbd68ade7677bd4cc2cf32d0f728ac959ad48c506beff413dc7e6b11b1d5f74ee1d213a71f1452980b291d6ef41ad8e3a4a0c4e6839e9918594d1f98715
     HEAD_REF master
 )
 
@@ -21,4 +21,5 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/volk)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/volk/usage
+++ b/ports/volk/usage
@@ -1,0 +1,4 @@
+volk provides CMake targets:
+
+    find_package(volk CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE volk::volk volk::volk_headers)

--- a/ports/volk/vcpkg.json
+++ b/ports/volk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "volk",
-  "version": "1.3.233",
-  "port-version": 1,
+  "version": "1.3.250",
   "description": [
     "Meta loader for Vulkan API.",
     "Note that the static library target volk::volk is built without platform-specific defines.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8573,8 +8573,8 @@
       "port-version": 0
     },
     "volk": {
-      "baseline": "1.3.233",
-      "port-version": 1
+      "baseline": "1.3.250",
+      "port-version": 0
     },
     "vowpal-wabbit": {
       "baseline": "9.8.0",

--- a/versions/v-/volk.json
+++ b/versions/v-/volk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8b2d72fd71caeb51d471a390221f70dfe27fd803",
+      "version": "1.3.250",
+      "port-version": 0
+    },
+    {
       "git-tree": "0b1961a45b266c648b63febbe13d717ec65007c3",
       "version": "1.3.233",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
