### PR TITLE
[status-code] Bump to 2023-07-22

### DIFF
--- a/ports/status-code/add-missing-include.patch
+++ b/ports/status-code/add-missing-include.patch
@@ -1,5 +1,5 @@
 diff --git a/wg21/file_io_error.cpp b/wg21/file_io_error.cpp
-index 41f23a1..fe69458 100644
+index 1933566..710d534 100644
 --- a/wg21/file_io_error.cpp
 +++ b/wg21/file_io_error.cpp
 @@ -24,6 +24,7 @@ http://www.boost.org/LICENSE_1_0.txt)
@@ -8,5 +8,5 @@ index 41f23a1..fe69458 100644
  #include <stdio.h>  // for sprintf
 +#include <utility>  // for std::move
  
+ #include "status-code/nested_status_code.hpp"
  #include "status-code/system_error2.hpp"
- 

--- a/ports/status-code/portfile.cmake
+++ b/ports/status-code/portfile.cmake
@@ -1,21 +1,21 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ned14/status-code
-    REF 5be338838d278e730b78c07f6306ae71f6c1959c
-    SHA512 61685b7ba40fd2e8a985a8135065b335655aac7aee7778ca3317004c9730078361cfa4bd1b9ac2f9002efc707bfb6168c0275f11e0c5a6b079d42c8240528a90
+    REF 6bd2d565fd4377e16614c6c5beb495c33bfa835b
+    SHA512 48f566f18643f6014e2fa542884fe077820c751cd0c03c9003e125ee547fa8e78963301e61b6ebdb834a12e7cec7fa3551268ef5ae9a434328321d6825aa72e3
     HEAD_REF master
     PATCHES
         add-missing-include.patch
 )
 
-# Because status-code's deployed files are header-only, the debug build is not necessary
-set(VCPKG_BUILD_TYPE release)
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DPROJECT_IS_DEPENDENCY=On
         -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_DISABLE_FIND_PACKAGE_Boost
 )
 
 vcpkg_cmake_install()

--- a/ports/status-code/vcpkg.json
+++ b/ports/status-code/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "status-code",
-  "version-date": "2023-01-27",
-  "port-version": 2,
+  "version-date": "2023-07-22",
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7873,8 +7873,8 @@
       "port-version": 0
     },
     "status-code": {
-      "baseline": "2023-01-27",
-      "port-version": 2
+      "baseline": "2023-07-22",
+      "port-version": 0
     },
     "status-value-lite": {
       "baseline": "1.1.0",

--- a/versions/s-/status-code.json
+++ b/versions/s-/status-code.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f67244be5b0138903c2f9393e9ef25288bf8924d",
+      "version-date": "2023-07-22",
+      "port-version": 0
+    },
+    {
       "git-tree": "40d6b3bdc23cdb7de14e9f07eb229d0124b9c550",
       "version-date": "2023-01-27",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
