### PR TITLE
[xsimd] Bump to 11.1.0

### DIFF
--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -1,10 +1,8 @@
-# header-only library
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xsimd
     REF "${VERSION}"
-    SHA512 bd7a363bbebc9196954c8c87271f14f05ca177569fcf080dac91be06ad2801c43fccbb385afd700b80d58c83d77f26ba199a7105672e4a1e55c517d15dd6e8e3
+    SHA512 3a6141dfa4d95a977f4222880dfd06197613d153a78a84653022423279eec037ea9def08ae225aba7231c0b2c434ab7c907c965f8367fb0db9b96113980b51f3
     HEAD_REF master
 )
 
@@ -13,12 +11,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         xcomplex ENABLE_XTL_COMPLEX
 )
 
+set(VCPKG_BUILD_TYPE release) # header-only port
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DENABLE_FALLBACK=OFF
         -DBUILD_TESTS=OFF
-        -DDOWNLOAD_GTEST=OFF
         ${FEATURE_OPTIONS}
 )
 
@@ -26,6 +24,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/xsimd/usage
+++ b/ports/xsimd/usage
@@ -1,0 +1,4 @@
+xsimd provides CMake targets:
+
+    find_package(xsimd CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE xsimd)

--- a/ports/xsimd/vcpkg.json
+++ b/ports/xsimd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xsimd",
-  "version": "10.0.0",
+  "version": "11.1.0",
   "description": "Modern, portable C++ wrappers for SIMD intrinsics",
   "homepage": "https://github.com/xtensor-stack/xsimd",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8901,7 +8901,7 @@
       "port-version": 2
     },
     "xsimd": {
-      "baseline": "10.0.0",
+      "baseline": "11.1.0",
       "port-version": 0
     },
     "xtensor": {

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55021644d976597e734aa0e9b678f369625b14c1",
+      "version": "11.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0c67f06803f30a45e0dc0db77378869d4c3067a0",
       "version": "10.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
