### PR TITLE
[gperftools] Update version to 2.10

### DIFF
--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gperftools/gperftools
-    REF fe62a0baab87ba3abca12f4a621532bf67c9a7d2
-    SHA512 fc0fb2c56d38046ac7bc2d36863dabf073b7aede7ce18916228d7b9f64cf33ae754708bff028353ada52bf4b79a7cd3e3334c1558a9ba64b06326b1537faf690
+    REF gperftools-2.10
+    SHA512 4400711723be9401f519d85b3b69c026e4715473cbed48ab0573df17abdf895fb971ee969875fe5127a2e8b9aba90d858285e50c8e012384c2c36d5a76b1f0c4
     HEAD_REF master
 )
 

--- a/ports/gperftools/vcpkg.json
+++ b/ports/gperftools/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gperftools",
-  "version-date": "2019-09-02",
-  "port-version": 5,
+  "version": "2.10",
   "description": "A set of tools for performance profiling and memory checking",
   "homepage": "https://github.com/gperftools/gperftools",
   "supports": "!(arm & windows) & !uwp & !android",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2977,8 +2977,8 @@
       "port-version": 5
     },
     "gperftools": {
-      "baseline": "2019-09-02",
-      "port-version": 5
+      "baseline": "2.10",
+      "port-version": 0
     },
     "gpgme": {
       "baseline": "1.18.0",

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3e7b08a6dcd261b62d0fee3d7f00de84c3b0094",
+      "version": "2.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "0840bfaf247735ffd902de5536b4ce2f411a77e3",
       "version-date": "2019-09-02",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.