### PR TITLE
[vulkan-hpp] deprecate vulkan-hpp

### DIFF
--- a/ports/vulkan-hpp/portfile.cmake
+++ b/ports/vulkan-hpp/portfile.cmake
@@ -1,14 +1,2 @@
-# header-only library
-
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO KhronosGroup/Vulkan-Hpp
-    REF "v${VERSION}"
-    SHA512 3783268de9c137218453431d03d4bb30a222dc7e94d7ca4eeab896884c8cada3e7a095f432e939efe8c6341773e64656dc141c5ce0f5ef0f49e77f7322e232f6
-    HEAD_REF master
-)
-
-file(COPY "${SOURCE_PATH}/vulkan/vulkan.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/vulkan")
-
-# Handle copyright
-configure_file("${SOURCE_PATH}/LICENSE.txt" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/vulkan-hpp/usage
+++ b/ports/vulkan-hpp/usage
@@ -1,0 +1,5 @@
+vulkan-hpp is deprecated. Please use port vulkan-headers instead.
+vulkan-hpp can be used with CMake:
+
+    find_package(VulkanHeaders CONFIG)
+    target_link_libraries(main PRIVATE Vulkan::Headers)

--- a/ports/vulkan-hpp/vcpkg.json
+++ b/ports/vulkan-hpp/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "vulkan-hpp",
-  "version": "1.3.259",
-  "port-version": 1,
-  "description": "Header only C++ bindings for the Vulkan C API",
-  "license": "Apache-2.0",
+  "version": "1.3.260",
+  "description": "[deprecated] Header only C++ bindings for the Vulkan C API",
+  "license": null,
   "supports": "!uwp & !xbox",
   "dependencies": [
-    "vulkan"
+    "vulkan-headers"
   ]
 }

--- a/ports/vulkan-hpp/vcpkg.json
+++ b/ports/vulkan-hpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vulkan-hpp",
-  "version": "1.3.260",
+  "version-string": "deprecated",
   "description": "[deprecated] Header only C++ bindings for the Vulkan C API",
   "license": null,
   "supports": "!uwp & !xbox",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8613,7 +8613,7 @@
       "port-version": 0
     },
     "vulkan-hpp": {
-      "baseline": "1.3.260",
+      "baseline": "deprecated",
       "port-version": 0
     },
     "vulkan-memory-allocator": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8613,8 +8613,8 @@
       "port-version": 0
     },
     "vulkan-hpp": {
-      "baseline": "1.3.259",
-      "port-version": 1
+      "baseline": "1.3.260",
+      "port-version": 0
     },
     "vulkan-memory-allocator": {
       "baseline": "3.0.1",

--- a/versions/v-/vulkan-hpp.json
+++ b/versions/v-/vulkan-hpp.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "688ded454d59c14cf7aac0a129e247c7b357d782",
-      "version": "1.3.260",
+      "git-tree": "2ab29397d55ec0c9b71cb790c30656e4903a996c",
+      "version-string": "deprecated",
       "port-version": 0
     },
     {

--- a/versions/v-/vulkan-hpp.json
+++ b/versions/v-/vulkan-hpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "688ded454d59c14cf7aac0a129e247c7b357d782",
+      "version": "1.3.260",
+      "port-version": 0
+    },
+    {
       "git-tree": "a9a9d60278b58e9bd4b8c301247f4a0e10076136",
       "version": "1.3.259",
       "port-version": 1


### PR DESCRIPTION
fix #32970

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.