### PR TITLE
[gperf] Fix error in cpp17 mode

### DIFF
--- a/ports/gperf/portfile.cmake
+++ b/ports/gperf/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE ${ARCHIVE}
+    PATCHES 
+    	remove_register_keyword_cpp17.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/gperf/remove_register_keyword_cpp17.patch
+++ b/ports/gperf/remove_register_keyword_cpp17.patch
@@ -1,0 +1,19 @@
+commit a5ff738a4b545ad25640753b651a6322b463c7b0
+Author: rdh <ridwanabdulhafidh@gmail.com>
+Date:   Wed Aug 2 05:04:58 2023 -0400
+
+    update cpp
+
+diff --git a/lib/getline.cc b/lib/getline.cc
+index c57c633..0984a7c 100644
+--- a/lib/getline.cc
++++ b/lib/getline.cc
+@@ -55,7 +55,7 @@ getstr (char **lineptr, size_t *n, FILE *stream, char terminator, size_t offset)
+ 
+   for (;;)
+     {
+-      register int c = getc (stream);
++      int c = getc (stream);
+ 
+       /* We always want at least one char left in the buffer, since we
+          always (unless we get an error while reading the first char)

--- a/ports/gperf/remove_register_keyword_cpp17.patch
+++ b/ports/gperf/remove_register_keyword_cpp17.patch
@@ -1,9 +1,3 @@
-commit a5ff738a4b545ad25640753b651a6322b463c7b0
-Author: rdh <ridwanabdulhafidh@gmail.com>
-Date:   Wed Aug 2 05:04:58 2023 -0400
-
-    update cpp
-
 diff --git a/lib/getline.cc b/lib/getline.cc
 index c57c633..0984a7c 100644
 --- a/lib/getline.cc

--- a/ports/gperf/vcpkg.json
+++ b/ports/gperf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gperf",
   "version": "3.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "GNU perfect hash function generator",
   "homepage": "https://www.gnu.org/software/gperf/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2966,7 +2966,7 @@
     },
     "gperf": {
       "baseline": "3.1",
-      "port-version": 5
+      "port-version": 6
     },
     "gperftools": {
       "baseline": "2019-09-02",

--- a/versions/g-/gperf.json
+++ b/versions/g-/gperf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ef4a25070d082723213d25e535499902db1e3731",
+      "git-tree": "f2b89ce69481e9a4b5c9c26b49e92c38c2de9561",
       "version": "3.1",
       "port-version": 6
     },

--- a/versions/g-/gperf.json
+++ b/versions/g-/gperf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f2b89ce69481e9a4b5c9c26b49e92c38c2de9561",
+      "git-tree": "590e19515bff5b0abc6d9f73ba20a19a71555a32",
       "version": "3.1",
       "port-version": 6
     },

--- a/versions/g-/gperf.json
+++ b/versions/g-/gperf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef4a25070d082723213d25e535499902db1e3731",
+      "version": "3.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "c1dc7145f2a0607798bfdaede7bf064b88e908ac",
       "version": "3.1",
       "port-version": 5


### PR DESCRIPTION

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

fixes https://github.com/microsoft/vcpkg/issues/32979

