### PR TITLE
[imgui-sfml] fix build error with triplet x64-mingw-dynamic

### DIFF
--- a/ports/imgui-sfml/0001-fix_find_package.patch
+++ b/ports/imgui-sfml/0001-fix_find_package.patch
@@ -39,11 +39,10 @@ index 3a974c4..8a1c6cd 100644
  
  if (IMGUI_SFML_IMGUI_DEMO)
      list(APPEND IMGUI_SOURCES ${IMGUI_DEMO_SOURCES})
-@@ -92,7 +72,7 @@ add_library(ImGui-SFML
- add_library(ImGui-SFML::ImGui-SFML ALIAS ImGui-SFML)
+@@ -93,6 +73,7 @@ add_library(ImGui-SFML::ImGui-SFML ALIAS ImGui-SFML)
  
  target_link_libraries(ImGui-SFML
--  PUBLIC
+   PUBLIC
 +    imgui::imgui
      sfml-graphics
      sfml-system

--- a/ports/imgui-sfml/vcpkg.json
+++ b/ports/imgui-sfml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "imgui-sfml",
   "version": "2.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "ImGui binding for use with SFML",
   "homepage": "https://github.com/eliasdaler/imgui-sfml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3378,7 +3378,7 @@
     },
     "imgui-sfml": {
       "baseline": "2.5",
-      "port-version": 3
+      "port-version": 4
     },
     "imguizmo": {
       "baseline": "1.83",

--- a/versions/i-/imgui-sfml.json
+++ b/versions/i-/imgui-sfml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c80ec5c8bd3637b2a9a221a5f83f9cb973c9e60e",
+      "version": "2.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "824afd9c0aaca961fb9346dff3a957b26ee5eb2c",
       "version": "2.5",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #32977

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


