### PR TITLE
[gmp] Avoid libm for x86 msvc host

### DIFF
--- a/ports/gmp/portfile.cmake
+++ b/ports/gmp/portfile.cmake
@@ -35,6 +35,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     vcpkg_list(APPEND OPTIONS
         "ac_cv_func_memset=yes"
         "gmp_cv_asm_w32=.word"
+        "gmp_cv_check_libm_for_build=no"
     )
 endif()
 

--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gmp",
   "version": "6.2.1",
-  "port-version": 20,
+  "port-version": 21,
   "description": "The GNU Multiple Precision Arithmetic Library",
   "homepage": "https://gmplib.org",
   "license": "LGPL-3.0-only OR GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2946,7 +2946,7 @@
     },
     "gmp": {
       "baseline": "6.2.1",
-      "port-version": 20
+      "port-version": 21
     },
     "gmsh": {
       "baseline": "4.9.0",

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "726604ff590362102d805e16508ae20730583101",
+      "version": "6.2.1",
+      "port-version": 21
+    },
+    {
       "git-tree": "5925ffa7bf1165b7ca3144e4253a19dcfc47a5ad",
       "version": "6.2.1",
       "port-version": 20


### PR DESCRIPTION
Fixes #32518.