### PR TITLE
[ignition-math6] Bump to version 6.14.0

### DIFF
--- a/ports/ignition-math6/portfile.cmake
+++ b/ports/ignition-math6/portfile.cmake
@@ -1,4 +1,4 @@
 ignition_modular_library(NAME math
-                         VERSION "6.9.2"
-                         SHA512 87fe43f745a2337e1b4c92abdb98180d55cf6034f9b85e93e42ab1c6e0af645912b9a246589115f919ca1fe7ecb38090fe76cdd0d6726315ffb0f090626c0634
+                         VERSION "6.14.0"
+                         SHA512 ad95160cc1cd137779b9da589c47994d04f829af10865071e9ead4d55c4399d04d5398287d3b294e3f67230205656e1fe243129673e1f8e73f62f3933c314802
                          )

--- a/ports/ignition-math6/vcpkg.json
+++ b/ports/ignition-math6/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ignition-math6",
-  "version": "6.9.2",
-  "port-version": 1,
+  "version": "6.14.0",
   "description": "Math API for robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/math",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3301,8 +3301,8 @@
       "port-version": 3
     },
     "ignition-math6": {
-      "baseline": "6.9.2",
-      "port-version": 1
+      "baseline": "6.14.0",
+      "port-version": 0
     },
     "ignition-modularscripts": {
       "baseline": "2023-05-05",

--- a/versions/i-/ignition-math6.json
+++ b/versions/i-/ignition-math6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc4451a5996b8de09041e1aac247380197feb780",
+      "version": "6.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c64259804945e426650515f5de69bb29107a167",
       "version": "6.9.2",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

