### PR TITLE
[ignition-cmake2] fix pkgconfig usage for finding OGRE

### DIFF
--- a/ports/ignition-cmake2/fix-findogre-pkgconfig.patch
+++ b/ports/ignition-cmake2/fix-findogre-pkgconfig.patch
@@ -1,0 +1,52 @@
+diff --git a/cmake/FindIgnOGRE.cmake b/cmake/FindIgnOGRE.cmake
+index e00f619..6825eb2 100644
+--- a/cmake/FindIgnOGRE.cmake
++++ b/cmake/FindIgnOGRE.cmake
+@@ -99,15 +99,12 @@ if (NOT WIN32)
+         set (OGRE_FOUND false)
+       else ()
+         # set library dirs if the value is empty
+-        if (NOT ${OGRE_LIBRARY_DIRS} OR ${OGRE_LIBRARY_DIRS} STREQUAL "")
+-          execute_process(COMMAND pkg-config --variable=libdir OGRE
+-                          OUTPUT_VARIABLE _pkgconfig_invoke_result
+-                          RESULT_VARIABLE _pkgconfig_failed)
+-          if(_pkgconfig_failed)
++        if (NOT OGRE_LIBRARY_DIRS)
++          pkg_get_variable(OGRE_LIBRARY_DIRS OGRE libdir)
++          if(NOT OGRE_LIBRARY_DIRS)
+             IGN_BUILD_WARNING ("Failed to find OGRE's library directory.  The build will succeed, but there will likely be run-time errors.")
+           else()
+-            # set ogre library dir and strip line break
+-            set(OGRE_LIBRARY_DIRS ${_pkgconfig_invoke_result})
++            # strip line break
+             string(REGEX REPLACE "\n$" "" OGRE_LIBRARY_DIRS "${OGRE_LIBRARY_DIRS}")
+ 
+             string(FIND "${OGRE_LIBRARIES}" "${OGRE_LIBRARY_DIRS}" substr_found)
+@@ -147,22 +144,18 @@ if (NOT WIN32)
+       endif()
+     endforeach()
+ 
+-    execute_process(COMMAND pkg-config --variable=plugindir OGRE
+-                    OUTPUT_VARIABLE _pkgconfig_invoke_result
+-                    RESULT_VARIABLE _pkgconfig_failed)
+-    if(_pkgconfig_failed)
++    pkg_get_variable(OGRE_PLUGINDIR OGRE plugindir)
++    if(NOT OGRE_PLUGINDIR)
+       IGN_BUILD_WARNING ("Failed to find OGRE's plugin directory.  The build will succeed, but there will likely be run-time errors.")
+     else()
+-      # This variable will be substituted into cmake/setup.sh.in
+-      set(OGRE_PLUGINDIR ${_pkgconfig_invoke_result})
++      # Seems that OGRE_PLUGINDIR can end in a newline, which will cause problems
++      # when we pass it to the compiler later.
++      string(REPLACE "\n" "" OGRE_PLUGINDIR ${OGRE_PLUGINDIR})
+     endif()
+ 
+     ign_pkg_config_library_entry(IgnOGRE OgreMain)
+ 
+     set(OGRE_RESOURCE_PATH ${OGRE_PLUGINDIR})
+-    # Seems that OGRE_PLUGINDIR can end in a newline, which will cause problems
+-    # when we pass it to the compiler later.
+-    string(REPLACE "\n" "" OGRE_RESOURCE_PATH ${OGRE_RESOURCE_PATH})
+   endif()
+ 
+   #reset pkg config path

--- a/ports/ignition-cmake2/portfile.cmake
+++ b/ports/ignition-cmake2/portfile.cmake
@@ -4,7 +4,8 @@ ignition_modular_library(NAME cmake
                          VERSION ${PACKAGE_VERSION}
                          SHA512 6ee64ff6c82c657678188be459c50a4255fd3881d758906d93361425702d04854a13a46124b20e058069f314077ba7e6c15a058153b615b3245084f066d1cbae
                          PATCHES
-                            add-pkgconfig-and-remove-privatefor-limit.patch)
+                            add-pkgconfig-and-remove-privatefor-limit.patch
+                            fix-findogre-pkgconfig.patch)
 
 # Install custom usage
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)

--- a/ports/ignition-cmake2/vcpkg.json
+++ b/ports/ignition-cmake2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ignition-cmake2",
   "version": "2.16.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "CMake helper functions for building robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/cmake",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3278,7 +3278,7 @@
     },
     "ignition-cmake2": {
       "baseline": "2.16.0",
-      "port-version": 1
+      "port-version": 2
     },
     "ignition-common1": {
       "baseline": "1.1.1",

--- a/versions/i-/ignition-cmake2.json
+++ b/versions/i-/ignition-cmake2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b27712039b4d79cf56407894ede3681292712649",
+      "version": "2.16.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "fefe057cb14c0f698b0ebb1a717b5bba189ab355",
       "version": "2.16.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Add patch for FindIgnOGRE.cmake to be able to find vcpkg build OGRE on non-windows platforms.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] ~~SHA512s are updated for each updated download~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
