### PR TITLE
[ignition-plugin1] bump version to 1.4.0

### DIFF
--- a/ports/ignition-plugin1/portfile.cmake
+++ b/ports/ignition-plugin1/portfile.cmake
@@ -1,5 +1,5 @@
-set(PACKAGE_VERSION "1.1.0")
+set(PACKAGE_VERSION "1.4.0")
 ignition_modular_library(NAME plugin
                          VERSION ${PACKAGE_VERSION}
                          REF "ignition-plugin_${PACKAGE_VERSION}"
-                         SHA512 e932dd7e7b042e9fb4c0569cb8b4028e54c394228aadf6523fa60ab1b9f7f9a17d14c79886a76365e2c47423c221aaef9ca77df638d87e2b6edb82eea10c0a3d)
+                         SHA512 bc8d8012ae2a5f4cee26560323f65e40873fb9d1d014a9946317bf941953a7e5018bc08763f87fc624792cb02aebe289286265796697559eeaf41e28e9b05abb)

--- a/ports/ignition-plugin1/vcpkg.json
+++ b/ports/ignition-plugin1/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ignition-plugin1",
-  "version": "1.1.0",
-  "port-version": 2,
+  "version": "1.4.0",
   "description": "Library for registering plugin libraries and dynamically loading them at runtime",
   "homepage": "https://ignitionrobotics.org/libs/plugin",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3321,8 +3321,8 @@
       "port-version": 5
     },
     "ignition-plugin1": {
-      "baseline": "1.1.0",
-      "port-version": 2
+      "baseline": "1.4.0",
+      "port-version": 0
     },
     "ignition-tools": {
       "baseline": "1.5.0",

--- a/versions/i-/ignition-plugin1.json
+++ b/versions/i-/ignition-plugin1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "193fcc24d2558a5edd5b4907344048e8562bc669",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f04ba4b936f3f2885c7a463d2a86a1359990931",
       "version": "1.1.0",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
