### PR TITLE
[ignition-utils1] bump version to 1.5.1

### DIFF
--- a/ports/ignition-utils1/portfile.cmake
+++ b/ports/ignition-utils1/portfile.cmake
@@ -1,29 +1,6 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO gazebosim/gz-utils
-    REF ignition-utils1_1.4.0
-    SHA512 f7c841391b0f523ed631c00d8053c52c3a52f409fb76faf68565ae2db96424c79e91a4bdcab650acfc35c17fe7f1df6881de4b59d5210539ebe8e9cfef991461
-    HEAD_REF ign-utils1
-)
+set(PACKAGE_VERSION "1.5.1")
+ignition_modular_library(NAME utils
+                         VERSION ${PACKAGE_VERSION}
+                         REF "ignition-utils1_${PACKAGE_VERSION}"
+                         SHA512 ede208d98b0b4bc4bfe38e248e8eb89da8feaced547e968a2a733992d86c632a9fae724c7c97e4a962ba36e23663a5872017eeae0b818492fcd1eca9d9643653)
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS 
-        -DBUILD_TESTING=OFF
-)
-
-vcpkg_cmake_install()
-
-# Fix cmake targets and pkg-config file location
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ignition-utils1")
-vcpkg_fixup_pkgconfig()
-
-# Remove debug files
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
-                    "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
-                    "${CURRENT_PACKAGES_DIR}/debug/share"
-                    "${CURRENT_PACKAGES_DIR}/include/ignition/utils1/ignition/utils/cli"
-)
-
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/ignition-utils1/vcpkg.json
+++ b/ports/ignition-utils1/vcpkg.json
@@ -1,17 +1,13 @@
 {
   "name": "ignition-utils1",
-  "version": "1.4.0",
+  "version": "1.5.1",
   "description": "Ignition Utils, a component of Ignition Robotics, provides general purpose classes and functions designed for robotic applications.",
   "homepage": "https://gazebosim.org",
   "license": "Apache-2.0",
   "dependencies": [
     "ignition-cmake2",
     {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
+      "name": "ignition-modularscripts",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3341,7 +3341,7 @@
       "port-version": 4
     },
     "ignition-utils1": {
-      "baseline": "1.4.0",
+      "baseline": "1.5.1",
       "port-version": 0
     },
     "igraph": {

--- a/versions/i-/ignition-utils1.json
+++ b/versions/i-/ignition-utils1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7d8c75978b3991ee12215ce61e06993e30634aa",
+      "version": "1.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "020c2c9b24d3d0a0d627a762e4c780ba1af2e154",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
