### PR TITLE
[c-ares] Update to 1.19.1

### DIFF
--- a/ports/c-ares/fix-uwp.patch
+++ b/ports/c-ares/fix-uwp.patch
@@ -20,8 +20,8 @@ index 7940ecd..aacfa52 100644
                                         unsigned short port,
                                         struct ares_addrinfo_node **nodes)
  {
--#if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600
-+#if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && !defined(WINRT)
+-#if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && !defined(__WATCOMC__)
++#if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && !defined(__WATCOMC__) && !defined(WINRT)
    PMIB_UNICASTIPADDRESS_TABLE table;
    unsigned int i;
    int status;
@@ -74,21 +74,12 @@ diff --git a/src/lib/ares_init.c b/src/lib/ares_init.c
 index 3f9cec6..63143e0 100644
 --- a/src/lib/ares_init.c
 +++ b/src/lib/ares_init.c
-@@ -745,6 +745,9 @@ static ULONG getBestRouteMetric(IF_LUID * const luid, /* Can't be const :( */
-                                 const SOCKADDR_INET * const dest,
+@@ -745,7 +745,7 @@ static ULONG getBestRouteMetric(IF_LUID * const luid, /* Can't be const :( */
                                  const ULONG interfaceMetric)
  {
-+#ifdef WINRT
-+  return (ULONG)-1;
-+#else
    /* On this interface, get the best route to that destination. */
-   MIB_IPFORWARD_ROW2 row;
-   SOCKADDR_INET ignored;
-@@ -778,6 +781,7 @@ static ULONG getBestRouteMetric(IF_LUID * const luid, /* Can't be const :( */
-    * which describes the combination as a "sum".
-    */
-   return row.Metric + interfaceMetric;
-+#endif
- }
- 
- /*
+-#if defined(__WATCOMC__)
++#if defined(__WATCOMC__) || defined(WINRT)
+   /* OpenWatcom's builtin Windows SDK does not have a definition for
+    * MIB_IPFORWARD_ROW2, and also does not allow the usage of SOCKADDR_INET
+    * as a variable. Let's work around this by returning the worst possible

--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -1,8 +1,13 @@
+string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _c_ares_version "${VERSION}")
+set(_c_ares_version_major "${CMAKE_MATCH_1}")
+set(_c_ares_version_minor "${CMAKE_MATCH_2}")
+set(_c_ares_version_patch "${CMAKE_MATCH_3}")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
-    REF cares-1_19_0
-    SHA512 d6bd7183b9ddf418222357ca61e3ffe0a3e49cbd5d83046bb76146e23bb578b5c7e4a5d89e1c427e7163880323de8ee0962ba75c571102efdf8c0b5742e28f82
+    REF "cares-${_c_ares_version_major}_${_c_ares_version_minor}_${_c_ares_version_patch}"
+    SHA512 73b5ee9d7e5ada6dd95dc32606821ea1307f30552242491e738f673d1ab9de1fdb3360d7a67c66a4a801b0e81ffb7382bfd93dbca836460dae515dd631ec6b91
     HEAD_REF main
     PATCHES
         avoid-docs.patch

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c-ares",
-  "version-semver": "1.19.0",
+  "version-semver": "1.19.1",
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1345,7 +1345,7 @@
       "port-version": 5
     },
     "c-ares": {
-      "baseline": "1.19.0",
+      "baseline": "1.19.1",
       "port-version": 0
     },
     "c-dbg-macro": {

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55836d9576708f8126f2070e2a698afe72f5f948",
+      "version-semver": "1.19.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a38a19b569f3763e2e63957687d4af9dcf19bd3e",
       "version-semver": "1.19.0",
       "port-version": 0


### PR DESCRIPTION
https://github.com/c-ares/c-ares/releases/tag/cares-1_19_1

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
