### PR TITLE
[cpprestsdk] use platform expressions in default-features

### DIFF
--- a/ports/cpprestsdk/vcpkg.json
+++ b/ports/cpprestsdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpprestsdk",
   "version": "2.10.18",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "C++11 JSON, REST, and OAuth library",
     "The C++ REST SDK is a Microsoft project for cloud-based client-server communication in native code using a modern asynchronous C++ API design. This project aims to help C++ developers connect to and interact with services."
@@ -55,7 +55,11 @@
     }
   ],
   "default-features": [
-    "default-features"
+    {
+      "name": "brotli",
+      "platform": "windows"
+    },
+    "compression"
   ],
   "features": {
     "brotli": {
@@ -75,25 +79,6 @@
       "description": "HTTP Compression support",
       "dependencies": [
         "zlib"
-      ]
-    },
-    "default-features": {
-      "description": "Features installed by default",
-      "dependencies": [
-        {
-          "name": "cpprestsdk",
-          "default-features": false,
-          "features": [
-            "compression"
-          ]
-        },
-        {
-          "name": "cpprestsdk",
-          "features": [
-            "brotli"
-          ],
-          "platform": "windows"
-        }
       ]
     },
     "websockets": {

--- a/ports/microsoft-signalr/vcpkg.json
+++ b/ports/microsoft-signalr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-signalr",
   "version": "0.1.0-alpha4",
-  "port-version": 6,
+  "port-version": 7,
   "description": "C++ Client for ASP.NET Core SignalR.",
   "homepage": "https://github.com/aspnet/SignalR-Client-Cpp",
   "dependencies": [
@@ -16,7 +16,10 @@
     }
   ],
   "default-features": [
-    "default-features"
+    {
+      "name": "cpprestsdk",
+      "platform": "!uwp"
+    }
   ],
   "features": {
     "cpprestsdk": {
@@ -25,21 +28,8 @@
         {
           "name": "cpprestsdk",
           "features": [
-            "default-features",
             "websockets"
           ]
-        }
-      ]
-    },
-    "default-features": {
-      "description": "Features installed by default",
-      "dependencies": [
-        {
-          "name": "microsoft-signalr",
-          "features": [
-            "cpprestsdk"
-          ],
-          "platform": "!uwp"
         }
       ]
     },

--- a/ports/signalrclient/vcpkg.json
+++ b/ports/signalrclient/vcpkg.json
@@ -1,14 +1,13 @@
 {
   "name": "signalrclient",
   "version": "1.0.0-beta1-9",
-  "port-version": 4,
+  "port-version": 5,
   "description": "C++ client for SignalR.",
   "homepage": "https://github.com/SignalR/SignalR-Client-Cpp",
   "dependencies": [
     {
       "name": "cpprestsdk",
       "features": [
-        "default-features",
         "websockets"
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7566,7 +7566,7 @@
     },
     "signalrclient": {
       "baseline": "1.0.0-beta1-9",
-      "port-version": 4
+      "port-version": 5
     },
     "sigslot": {
       "baseline": "1.0.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5326,7 +5326,7 @@
     },
     "microsoft-signalr": {
       "baseline": "0.1.0-alpha4",
-      "port-version": 6
+      "port-version": 7
     },
     "mikktspace": {
       "baseline": "2020-10-06",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1838,7 +1838,7 @@
     },
     "cpprestsdk": {
       "baseline": "2.10.18",
-      "port-version": 2
+      "port-version": 3
     },
     "cppslippi": {
       "baseline": "1.0.3.14",

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53f896a9d80f0fd51e2645ee7deccbc0c955859a",
+      "version": "2.10.18",
+      "port-version": 3
+    },
+    {
       "git-tree": "e1fb46f5d043e3a354bfbc6f77df5df3b321f74b",
       "version": "2.10.18",
       "port-version": 2

--- a/versions/m-/microsoft-signalr.json
+++ b/versions/m-/microsoft-signalr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "777629bd31d9a4885b696623304b030c29b552c4",
+      "version": "0.1.0-alpha4",
+      "port-version": 7
+    },
+    {
       "git-tree": "9a366b0a8f7b8177b0c91de00d652dfac38ed927",
       "version": "0.1.0-alpha4",
       "port-version": 6

--- a/versions/s-/signalrclient.json
+++ b/versions/s-/signalrclient.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28135a6a807825f1fdfbb1e086c10569d385482c",
+      "version": "1.0.0-beta1-9",
+      "port-version": 5
+    },
+    {
       "git-tree": "c2981e91dbe37fc7ab10d1c071d4a47b1388eb3b",
       "version": "1.0.0-beta1-9",
       "port-version": 4


### PR DESCRIPTION
This uses the new feature from https://github.com/microsoft/vcpkg-tool/pull/813. 

One "problem" is that people with old vcpkg-tool versions will get an error if they want to use the port and there is afaik not way to tell them that they have to update vcpkg-tool. 