### PR TITLE
[tuplet] New port

### DIFF
--- a/ports/tuplet/portfile.cmake
+++ b/ports/tuplet/portfile.cmake
@@ -1,0 +1,22 @@
+# Header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO codeinred/tuplet
+    REF "v${VERSION}"
+    SHA512 afab0ad34e9e15909c43112b77014821607ec8d429c395b882eea74873432204fca2b5a2c2e04f84cf6193e19bc0a9dcb7702d1e97668a32ec1541e02b6e798a
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DCMAKE_INSTALL_INCLUDEDIR=include
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME tuplet CONFIG_PATH share/tuplet/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug"
+)
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tuplet/vcpkg.json
+++ b/ports/tuplet/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "tuplet",
+  "version": "2.1.1",
+  "description": "A Lightweight Tuple Library for Modern C++",
+  "homepage": "https://github.com/codeinred/tuplet",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8296,6 +8296,10 @@
       "baseline": "0.5.0",
       "port-version": 2
     },
+    "tuplet": {
+      "baseline": "2.1.1",
+      "port-version": 0
+    },
     "turbobase64": {
       "baseline": "2020-01-12",
       "port-version": 3

--- a/versions/t-/tuplet.json
+++ b/versions/t-/tuplet.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "74fcd4cc246f7511749c6172bbbe333c0fa012d7",
+      "version": "2.1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33005
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
