### PR TITLE
[libusb] Use /Z7 to embed the PDB into the executable

### DIFF
--- a/ports/libusb/portfile.cmake
+++ b/ports/libusb/portfile.cmake
@@ -26,6 +26,13 @@ function(replace_runtime_library PROJ_FILE)
 endfunction(replace_runtime_library)
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+  # Use /Z7 to embed debug information into the executable
+  vcpkg_replace_string(
+      "${SOURCE_PATH}/msvc/Base.props"
+      "<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>"
+      "<DebugInformationFormat>OldStyle</DebugInformationFormat>"
+  )
+
   if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
       set(LIBUSB_PROJECT_TYPE dll)
   else()

--- a/ports/libusb/vcpkg.json
+++ b/ports/libusb/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libusb",
   "version": "1.0.26.11791",
-  "port-version": 1,
+  "port-version": 2,
   "description": "a cross-platform library to access USB devices",
   "homepage": "https://github.com/libusb/libusb",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4750,7 +4750,7 @@
     },
     "libusb": {
       "baseline": "1.0.26.11791",
-      "port-version": 1
+      "port-version": 2
     },
     "libusb-win32": {
       "baseline": "1.2.6.0",

--- a/versions/l-/libusb.json
+++ b/versions/l-/libusb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "87cd196b403364febf719d64fe6f08ab0bf6b285",
+      "version": "1.0.26.11791",
+      "port-version": 2
+    },
+    {
       "git-tree": "653d47743e90abaa28a3d17b49fe479a0096f8ef",
       "version": "1.0.26.11791",
       "port-version": 1


### PR DESCRIPTION
Fixes #33003.

When building statically on Windows, vcpkg will remove the files in the `bin/` directory, including PDB. This resulted in warnings about missing `PDB`, so I replaced the specified compile option with `/Z7` to embed debug information into the resulting executable.

* The original string `<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>` indicates the use of "program database" (Program Database, PDB) files to store debugging information.

* The replaced string `<DebugInformationFormat>OldStyle</DebugInformationFormat>` embeds the debug information directly into the generated executable.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
