### PR TITLE
[nlohmann-json] Delete the docs folder to reduce open source vulnerability alerts.

### DIFF
--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -15,6 +15,11 @@ FEATURES
     "diagnostics"           JSON_Diagnostics
 )
 
+# Remove the docs folder to avoid false positives for scanners that look for vulnerable open source dependencies.
+# The docs use a number of Python components that have historically caused several vulnerability alerts, but they
+# are not needed for customers using Nlohmann JSON through Vcpkg.
+file(REMOVE_RECURSE "${SOURCE_PATH}/docs")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}

--- a/ports/nlohmann-json/vcpkg.json
+++ b/ports/nlohmann-json/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nlohmann-json",
   "version-semver": "3.11.2",
+  "port-version": 1,
   "description": "JSON for Modern C++",
   "homepage": "https://github.com/nlohmann/json",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5730,7 +5730,7 @@
     },
     "nlohmann-json": {
       "baseline": "3.11.2",
-      "port-version": 0
+      "port-version": 1
     },
     "nlopt": {
       "baseline": "2.7.1",

--- a/versions/n-/nlohmann-json.json
+++ b/versions/n-/nlohmann-json.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d3961fafa957e64f046adfba4178b3615a77650",
+      "version-semver": "3.11.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "caa64b8c731ac2457575ea3c5f1827bc82ecac84",
       "version-semver": "3.11.2",
       "port-version": 0

--- a/versions/n-/nlohmann-json.json
+++ b/versions/n-/nlohmann-json.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d3961fafa957e64f046adfba4178b3615a77650",
+      "git-tree": "20ed3284732a9e22ccf3b1643e29c3a292d27d9f",
       "version-semver": "3.11.2",
       "port-version": 1
     },


### PR DESCRIPTION
My project has a process that scans for open source dependencies with known security vulnerabilities. When one is detected, it creates an alert which must be either addressed or dismissed as a false positive. I have often received alerts due to vulnerabilities in the Python components used within the "docs" folder for Nlohmann JSON. However, these are always false positives because I'm just using the C++ code from this repo and not building the documentation. I'd like to stop these alerts once and for all by having Vcpkg simply delete the docs folder from the Nlohmann JSON source code before it runs CMake. This will remove the code which generates so many alerts so the vulnerability detector will quit raising alerts for it.

Checklist:
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
