### PR TITLE
[libsodium] Add pkgconfig file

### DIFF
--- a/ports/libsodium/CMakeLists.txt
+++ b/ports/libsodium/CMakeLists.txt
@@ -44,6 +44,14 @@ if (ENABLE_MINIMAL)
     set(SODIUM_LIBRARY_MINIMAL_DEF "#define SODIUM_LIBRARY_MINIMAL 1")
 endif ()
 
+set(prefix "${CMAKE_INSTALL_PREFIX}")
+set(exec_prefix "\${prefix}")
+set(libdir "\${prefix}/lib")
+set(includedir "\${prefix}/include")
+
+set(PACKAGE_NAME "${PROJECT_NAME}")
+set(PACKAGE_VERSION "${VERSION}")
+
 configure_file(
     src/libsodium/include/sodium/version.h.in
     ${CMAKE_BINARY_DIR}/sodium/version.h
@@ -1080,6 +1088,9 @@ if (BUILD_TESTING)
         )
     endforeach ()
 endif ()
+
+configure_file ("${CMAKE_SOURCE_DIR}/libsodium.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libsodium.pc" @ONLY)
+install (FILES "${CMAKE_CURRENT_BINARY_DIR}/libsodium.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
 
 install(DIRECTORY src/libsodium/include/
     DESTINATION include/

--- a/ports/libsodium/portfile.cmake
+++ b/ports/libsodium/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jedisct1/libsodium
-    REF 1.0.18
+    REF ${VERSION}
     SHA512 727fe50a5fb1df86ec5d807770f408a52609cbeb8510b4f4183b2a35a537905719bdb6348afcb103ff00ce946a8094ac9559b6e3e5b2ccc2a2d0c08f75577eeb
     HEAD_REF master
 )
@@ -26,6 +26,7 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME unofficial-sodium
 )
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
@@ -40,4 +41,4 @@ configure_file(
     @ONLY
 )
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libsodium/vcpkg.json
+++ b/ports/libsodium/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsodium",
   "version": "1.0.18",
-  "port-version": 8,
+  "port-version": 9,
   "description": "A modern and easy-to-use crypto library",
   "homepage": "https://github.com/jedisct1/libsodium",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4598,7 +4598,7 @@
     },
     "libsodium": {
       "baseline": "1.0.18",
-      "port-version": 8
+      "port-version": 9
     },
     "libsonic": {
       "baseline": "0.2.0",

--- a/versions/l-/libsodium.json
+++ b/versions/l-/libsodium.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c75abf2ec95a8c9b498d2e18e9f854d75941048",
+      "version": "1.0.18",
+      "port-version": 9
+    },
+    {
       "git-tree": "72748d8d6030aac034e5b74229898016f833b33a",
       "version": "1.0.18",
       "port-version": 8


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
For https://github.com/microsoft/vcpkg/issues/19317
export the .pc file.
Tested usage on x64-windows via:

```
find_package(PkgConfig REQUIRED)
pkg_check_modules(libsodium REQUIRED IMPORTED_TARGET libsodium)
target_link_libraries(CMakeTest PkgConfig::libsodium)
```

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
