### PR TITLE
[libpebliss] new port

### DIFF
--- a/ports/libpebliss/portfile.cmake
+++ b/ports/libpebliss/portfile.cmake
@@ -1,39 +1,3 @@
-# Common Ambient Variables:
-#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
-#   CURRENT_INSTALLED_DIR     = ${VCPKG_ROOT_DIR}\installed\${TRIPLET}
-#   DOWNLOADS                 = ${VCPKG_ROOT_DIR}\downloads
-#   PORT                      = current port name (zlib, etc)
-#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
-#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
-#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
-#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
-#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
-#   VCPKG_TOOLCHAIN           = ON OFF
-#   TRIPLET_SYSTEM_ARCH       = arm x86 x64
-#   BUILD_ARCH                = "Win32" "x64" "ARM"
-#   DEBUG_CONFIG              = "Debug Static" "Debug Dll"
-#   RELEASE_CONFIG            = "Release Static"" "Release DLL"
-#   VCPKG_TARGET_IS_WINDOWS
-#   VCPKG_TARGET_IS_UWP
-#   VCPKG_TARGET_IS_LINUX
-#   VCPKG_TARGET_IS_OSX
-#   VCPKG_TARGET_IS_FREEBSD
-#   VCPKG_TARGET_IS_ANDROID
-#   VCPKG_TARGET_IS_MINGW
-#   VCPKG_TARGET_EXECUTABLE_SUFFIX
-#   VCPKG_TARGET_STATIC_LIBRARY_SUFFIX
-#   VCPKG_TARGET_SHARED_LIBRARY_SUFFIX
-#
-# 	See additional helpful variables in /docs/maintainers/vcpkg_common_definitions.md
-
-# Also consider vcpkg_from_* functions if you can; the generated code here is for any web accessable
-# source archive.
-#  vcpkg_from_github
-#  vcpkg_from_gitlab
-#  vcpkg_from_bitbucket
-#  vcpkg_from_sourceforge
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/MMitsuha/libpebliss/archive/refs/heads/master.zip"
     FILENAME "libpebliss.zip"
@@ -43,44 +7,14 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
-    # (Optional) A friendly name to use instead of the filename of the archive (e.g.: a version number or tag).
-    # REF 1.0.0
-    # (Optional) Read the docs for how to generate patches at:
-    # https://github.com/Microsoft/vcpkg/blob/master/docs/examples/patching.md
-    # PATCHES
-    #   001_port_fixes.patch
-    #   002_more_port_fixes.patch
 )
-
-# # Check if one or more features are a part of a package installation.
-# # See /docs/maintainers/vcpkg_check_features.md for more details
-# vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-#   FEATURES # <- Keyword FEATURES is required because INVERTED_FEATURES are being used
-#     tbb   WITH_TBB
-#   INVERTED_FEATURES
-#     tbb   ROCKSDB_IGNORE_PACKAGE_TBB
-# )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
 vcpkg_cmake_install()
-
-# # Moves all .cmake files from /debug/share/libpebliss/ to /share/libpebliss/
-# # See /docs/maintainers/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.md for more details
-# When you uncomment "vcpkg_cmake_config_fixup()", you need to add the following to "dependencies" vcpkg.json:
-#{
-#    "name": "vcpkg-cmake-config",
-#    "host": true
-#}
 vcpkg_cmake_config_fixup()
-
-# Uncomment the line below if necessary to install the license file for the port
-# as a file named `copyright` to the directory `${CURRENT_PACKAGES_DIR}/share/${PORT}`
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libpebliss/portfile.cmake
+++ b/ports/libpebliss/portfile.cmake
@@ -1,0 +1,86 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   CURRENT_INSTALLED_DIR     = ${VCPKG_ROOT_DIR}\installed\${TRIPLET}
+#   DOWNLOADS                 = ${VCPKG_ROOT_DIR}\downloads
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#   VCPKG_TOOLCHAIN           = ON OFF
+#   TRIPLET_SYSTEM_ARCH       = arm x86 x64
+#   BUILD_ARCH                = "Win32" "x64" "ARM"
+#   DEBUG_CONFIG              = "Debug Static" "Debug Dll"
+#   RELEASE_CONFIG            = "Release Static"" "Release DLL"
+#   VCPKG_TARGET_IS_WINDOWS
+#   VCPKG_TARGET_IS_UWP
+#   VCPKG_TARGET_IS_LINUX
+#   VCPKG_TARGET_IS_OSX
+#   VCPKG_TARGET_IS_FREEBSD
+#   VCPKG_TARGET_IS_ANDROID
+#   VCPKG_TARGET_IS_MINGW
+#   VCPKG_TARGET_EXECUTABLE_SUFFIX
+#   VCPKG_TARGET_STATIC_LIBRARY_SUFFIX
+#   VCPKG_TARGET_SHARED_LIBRARY_SUFFIX
+#
+# 	See additional helpful variables in /docs/maintainers/vcpkg_common_definitions.md
+
+# Also consider vcpkg_from_* functions if you can; the generated code here is for any web accessable
+# source archive.
+#  vcpkg_from_github
+#  vcpkg_from_gitlab
+#  vcpkg_from_bitbucket
+#  vcpkg_from_sourceforge
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/MMitsuha/libpebliss/archive/refs/heads/master.zip"
+    FILENAME "libpebliss.zip"
+    SHA512 7eb7d6b0e55aa8d9e9bcc7e55b04ee4ed428517b00406708f8952f69e128223bebf39819613d93dc9221b5083129a93cf6a35ee3a061c5db863ff7b4fd3a17c9
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    # (Optional) A friendly name to use instead of the filename of the archive (e.g.: a version number or tag).
+    # REF 1.0.0
+    # (Optional) Read the docs for how to generate patches at:
+    # https://github.com/Microsoft/vcpkg/blob/master/docs/examples/patching.md
+    # PATCHES
+    #   001_port_fixes.patch
+    #   002_more_port_fixes.patch
+)
+
+# # Check if one or more features are a part of a package installation.
+# # See /docs/maintainers/vcpkg_check_features.md for more details
+# vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+#   FEATURES # <- Keyword FEATURES is required because INVERTED_FEATURES are being used
+#     tbb   WITH_TBB
+#   INVERTED_FEATURES
+#     tbb   ROCKSDB_IGNORE_PACKAGE_TBB
+# )
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_cmake_install()
+
+# # Moves all .cmake files from /debug/share/libpebliss/ to /share/libpebliss/
+# # See /docs/maintainers/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.md for more details
+# When you uncomment "vcpkg_cmake_config_fixup()", you need to add the following to "dependencies" vcpkg.json:
+#{
+#    "name": "vcpkg-cmake-config",
+#    "host": true
+#}
+vcpkg_cmake_config_fixup()
+
+# Uncomment the line below if necessary to install the license file for the port
+# as a file named `copyright` to the directory `${CURRENT_PACKAGES_DIR}/share/${PORT}`
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libpebliss/vcpkg.json
+++ b/ports/libpebliss/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "libpebliss",
+  "version": "1.0.0",
+  "homepage": "https://github.com/MMitsuha/libpebliss",
+  "description": "Cross-Platform PE Manipulating Library",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libpebliss/vcpkg.json
+++ b/ports/libpebliss/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Cross-Platform PE Manipulating Library",
   "homepage": "https://github.com/MMitsuha/libpebliss",
-  "supports": "x64 | x86",
+  "supports": "(x64 | x86) & windows",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libpebliss/vcpkg.json
+++ b/ports/libpebliss/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libpebliss",
   "version": "1.0.0",
-  "homepage": "https://github.com/MMitsuha/libpebliss",
   "description": "Cross-Platform PE Manipulating Library",
+  "homepage": "https://github.com/MMitsuha/libpebliss",
+  "supports": "x64 | x86",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4460,6 +4460,10 @@
       "baseline": "1.10.1",
       "port-version": 3
     },
+    "libpebliss": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "libpff": {
       "baseline": "2021-11-14",
       "port-version": 2

--- a/versions/l-/libpebliss.json
+++ b/versions/l-/libpebliss.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "55f120622e0203ad6fe4133d83911b6030e78da9",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libpebliss.json
+++ b/versions/l-/libpebliss.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "55f120622e0203ad6fe4133d83911b6030e78da9",
+      "git-tree": "672df3ed4d394544605cbc70e4b030b50be7043e",
       "version": "1.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x]  Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
