### PR TITLE
[pkgconf] update to pkgconf-2.0.0

### DIFF
--- a/ports/pkgconf/portfile.cmake
+++ b/ports/pkgconf/portfile.cmake
@@ -1,15 +1,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pkgconf/pkgconf
-    REF cef30268e1a3f79efd607c26abcf556aa314c9c4 
-    SHA512 ea03b81d01521201bdc471a39cdc8b13f9452f7cc78706d5c57056595f3e4e8a3562c022ebb72ce6444f2c7a8dfc778114814ef5064eaef770a70cc294c7f7ee
+    REF "pkgconf-${VERSION}"
+    SHA512 9716f40f78f85c1852743c1ec8e2d8c69199989e40da8ef6a0ab77eed229fa05cb2f6b67f8efa82b8a2f2cffdf1e667840e0f14b4ad5bc82a57bc0478cdfac54
     HEAD_REF master
 )
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     NO_PKG_CONFIG
-    OPTIONS -Dtests=false
+    OPTIONS -Dtests=disabled
 )
 
 set(systemsuffix "")
@@ -79,4 +79,4 @@ endif()
 vcpkg_copy_tools(TOOL_NAMES pkgconf AUTO_CLEAN)
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/pkgconf/vcpkg.json
+++ b/ports/pkgconf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pkgconf",
-  "version": "1.8.0",
-  "port-version": 5,
+  "version": "2.0.0",
   "description": "pkgconf is a program which helps to configure compiler and linker flags for development libraries. It is similar to pkg-config from freedesktop.org.",
   "homepage": "https://github.com/pkgconf/pkgconf",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6365,8 +6365,8 @@
       "port-version": 2
     },
     "pkgconf": {
-      "baseline": "1.8.0",
-      "port-version": 5
+      "baseline": "2.0.0",
+      "port-version": 0
     },
     "plasma-wayland-protocols": {
       "baseline": "1.8.0",

--- a/versions/p-/pkgconf.json
+++ b/versions/p-/pkgconf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6172c53d978ec4b57455e45166a87ab7cd8746c3",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8848e56b32837456dfb872f6ca3cc9953558d453",
       "version": "1.8.0",
       "port-version": 5


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixing https://github.com/microsoft/vcpkg/issues/33032
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
