### PR TITLE
[xtensor] Fix xsimd version mismatch

### DIFF
--- a/ports/xtensor/fix-find-xsimd.patch
+++ b/ports/xtensor/fix-find-xsimd.patch
@@ -1,13 +1,31 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5758320..522a94c 100644
+index 5c93655..f02dc48 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -59,7 +59,7 @@ if(XTENSOR_USE_TBB AND XTENSOR_USE_OPENMP)
+@@ -69,7 +69,12 @@ if(XTENSOR_USE_XSIMD)
+             message(STATUS "Found xsimd v${xsimd_VERSION}")
+         endif()
+     else()
+-        find_package(xsimd ${xsimd_REQUIRED_VERSION} REQUIRED)
++        find_package(xsimd CONFIG REQUIRED)
++        if(${xsimd_VERSION} GREATER_EQUAL ${xsimd_REQUIRED_VERSION})
++            set(xsimd_REQUIRED_VERSION ${xsimd_VERSION})
++        else()
++            message(ERROR "Mismatch xsimd versions. Found '${xsimd_VERSION}' but requires: '${xsimd_REQUIRED_VERSION}'")
++        endif()
+         message(STATUS "Found xsimd: ${xsimd_INCLUDE_DIRS}/xsimd")
+     endif()
+ endif()
+diff --git a/xtensorConfig.cmake.in b/xtensorConfig.cmake.in
+index ec72abb..7825612 100644
+--- a/xtensorConfig.cmake.in
++++ b/xtensorConfig.cmake.in
+@@ -25,7 +25,7 @@ if(NOT TARGET @PROJECT_NAME@)
  endif()
  
  if(XTENSOR_USE_XSIMD)
--    set(xsimd_REQUIRED_VERSION 10.0.0)
-+    set(xsimd_REQUIRED_VERSION 11.0.1)
-     if(TARGET xsimd)
-         set(xsimd_VERSION ${XSIMD_VERSION_MAJOR}.${XSIMD_VERSION_MINOR}.${XSIMD_VERSION_PATCH})
-         # Note: This is not SEMVER compatible comparison
+-    find_dependency(xsimd @xsimd_REQUIRED_VERSION@)
++    find_dependency(xsimd @xsimd_REQUIRED_VERSION@ CONFIG)
+     target_link_libraries(@PROJECT_NAME@ INTERFACE xsimd)
+     target_compile_definitions(@PROJECT_NAME@ INTERFACE XTENSOR_USE_XSIMD)
+ endif()

--- a/ports/xtensor/fix-find-xsimd.patch
+++ b/ports/xtensor/fix-find-xsimd.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5758320..522a94c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,7 +59,7 @@ if(XTENSOR_USE_TBB AND XTENSOR_USE_OPENMP)
+ endif()
+ 
+ if(XTENSOR_USE_XSIMD)
+-    set(xsimd_REQUIRED_VERSION 10.0.0)
++    set(xsimd_REQUIRED_VERSION 11.0.1)
+     if(TARGET xsimd)
+         set(xsimd_VERSION ${XSIMD_VERSION_MAJOR}.${XSIMD_VERSION_MINOR}.${XSIMD_VERSION_PATCH})
+         # Note: This is not SEMVER compatible comparison

--- a/ports/xtensor/portfile.cmake
+++ b/ports/xtensor/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-find-tbb-and-install-destination.patch
+        fix-find-xsimd.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/xtensor/vcpkg.json
+++ b/ports/xtensor/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "xtensor",
   "version": "0.24.6",
+  "port-version": 1,
   "description": "C++ tensors with broadcasting and lazy computing",
   "homepage": "https://github.com/xtensor-stack/xtensor",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8922,7 +8922,7 @@
     },
     "xtensor": {
       "baseline": "0.24.6",
-      "port-version": 0
+      "port-version": 1
     },
     "xtensor-blas": {
       "baseline": "0.20.0",

--- a/versions/x-/xtensor.json
+++ b/versions/x-/xtensor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f45c9f7970a7a556d00e78ba35764b2f85bb50c",
+      "version": "0.24.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "aeb0efc2bdf326191f5dff18bb2506690902b162",
       "version": "0.24.6",
       "port-version": 0

--- a/versions/x-/xtensor.json
+++ b/versions/x-/xtensor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3f45c9f7970a7a556d00e78ba35764b2f85bb50c",
+      "git-tree": "3243d2557778b77adbd7b2dbc83ade2456e8fe5c",
       "version": "0.24.6",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33045

This issue was caused by an [update](https://github.com/microsoft/vcpkg/pull/32956) of xsimd two days ago.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
