### PR TITLE
[libsndfile] Fix cmake config not exist

### DIFF
--- a/ports/libsndfile/portfile.cmake
+++ b/ports/libsndfile/portfile.cmake
@@ -39,7 +39,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-if(WIN32 AND (NOT MINGW) AND (NOT CYGWIN))
+if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
     set(CONFIG_PATH cmake)
 else()
     set(CONFIG_PATH lib/cmake/SndFile)

--- a/ports/libsndfile/vcpkg.json
+++ b/ports/libsndfile/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsndfile",
   "version-semver": "1.2.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for reading and writing audio files",
   "homepage": "https://github.com/erikd/libsndfile",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4602,7 +4602,7 @@
     },
     "libsndfile": {
       "baseline": "1.2.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libsnoretoast": {
       "baseline": "0.8.0",

--- a/versions/l-/libsndfile.json
+++ b/versions/l-/libsndfile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f78736afe548520c2bd5675eec91a9c15112a0fb",
+      "version-semver": "1.2.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "6f4a276bfb9911abd9901cb6c977d7a132eff35d",
       "version-semver": "1.2.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix #33028