### PR TITLE
Update cgal to v5.6

### DIFF
--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_buildpath_length_warning(37)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CGAL/cgal
-    REF v5.5.3
-    SHA512 9353f42b892a7a331a1c12888c25523340d2f3643c520b58b5bfba5c9d8ce492727060ea56fef47cf5947d4e3e50a2b101fe28cf11680f28f238914f27022207
+    REF v5.6
+    SHA512 87817169f49c30d8dc4fa5e61ce9b28be5b1f0a9fcd3ebe0cb08b044631a2455de76c53d3cffaa1984f033f5fe21c9b55f54628fc431b7d3a34b3b3e18ad206d
     HEAD_REF master
 )
 

--- a/ports/cgal/vcpkg.json
+++ b/ports/cgal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cgal",
-  "version": "5.5.3",
+  "version": "5.6",
   "description": "The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.",
   "homepage": "https://github.com/CGAL/cgal",
   "license": "GPL-3.0-or-later AND LGPL-3.0-or-later AND BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1469,7 +1469,7 @@
       "port-version": 3
     },
     "cgal": {
-      "baseline": "5.5.3",
+      "baseline": "5.6",
       "port-version": 0
     },
     "cgicc": {

--- a/versions/c-/cgal.json
+++ b/versions/c-/cgal.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "git-tree": "2361640f4f9d33c828b66c32b900beda59a63036",
+      "version": "5.6",
+      "port-version": 0
+    },
+    {
+      "git-tree": "2361640f4f9d33c828b66c32b900beda59a63036",
       "version": "5.5.3",
       "port-version": 0
     },

--- a/versions/c-/cgal.json
+++ b/versions/c-/cgal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2361640f4f9d33c828b66c32b900beda59a63036",
+      "git-tree": "30472d20d793f979d0e02326cb1759bc042b45f5",
       "version": "5.6",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
