### PR TITLE
[Bison] Add new port

### DIFF
--- a/ports/bison/clang-fortify.patch
+++ b/ports/bison/clang-fortify.patch
@@ -1,0 +1,47 @@
+diff --git a/lib/cdefs.h b/lib/cdefs.h
+index 4dac9d2..6612306 100644
+--- a/lib/cdefs.h
++++ b/lib/cdefs.h
+@@ -137,6 +137,7 @@
+ #endif
+ 
+ 
++#ifndef __GNULIB_CDEFS
+ /* Fortify support.  */
+ #define __bos(ptr) __builtin_object_size (ptr, __USE_FORTIFY_LEVEL > 1)
+ #define __bos0(ptr) __builtin_object_size (ptr, 0)
+@@ -150,6 +151,8 @@
+ # define __glibc_objsize(__o) __bos (__o)
+ #endif
+ 
++#endif
++
+ #if __GNUC_PREREQ (4,3)
+ # define __warnattr(msg) __attribute__((__warning__ (msg)))
+ # define __errordecl(name, msg) \
+diff --git a/lib/libc-config.h b/lib/libc-config.h
+index 886c11f..ea9a22f 100644
+--- a/lib/libc-config.h
++++ b/lib/libc-config.h
+@@ -135,8 +135,10 @@
+ # undef __attribute_returns_twice__
+ # undef __attribute_used__
+ # undef __attribute_warn_unused_result__
++# ifndef __GNULIB_CDEFS
+ # undef __bos
+ # undef __bos0
++# endif
+ # undef __errordecl
+ # undef __extension__
+ # undef __extern_always_inline
+@@ -149,8 +151,10 @@
+ # undef __glibc_has_extension
+ # undef __glibc_macro_warning
+ # undef __glibc_macro_warning1
++# ifndef __GNULIB_CDEFS
+ # undef __glibc_objsize
+ # undef __glibc_objsize0
++# endif
+ # undef __glibc_unlikely
+ # undef __inline
+ # undef __ptr_t

--- a/ports/bison/ffsl.patch
+++ b/ports/bison/ffsl.patch
@@ -1,0 +1,30 @@
+diff --git a/m4/ffsl.m4 b/m4/ffsl.m4
+index 45d8f14..06bd881 100644
+--- a/m4/ffsl.m4
++++ b/m4/ffsl.m4
+@@ -8,11 +8,20 @@ AC_DEFUN([gl_FUNC_FFSL],
+ [
+   AC_REQUIRE([gl_STRING_H_DEFAULTS])
+ 
+-  dnl Persuade glibc <string.h> to declare ffsl().
+-  AC_REQUIRE([AC_USE_SYSTEM_EXTENSIONS])
+-
+-  AC_CHECK_FUNCS_ONCE([ffsl])
+-  if test $ac_cv_func_ffsl = no; then
++  AC_CACHE_CHECK([for ffsl], [gl_cv_func_ffsl],
++    [AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++        [[#include <strings.h>
++          long x;
++        ]],
++        [[int (*func) (long) = ffsl;
++          return func(x);
++        ]])
++      ],
++      [gl_cv_func_ffsl=yes],
++      [gl_cv_func_ffsl=no])
++    ])
++  if test $gl_cv_func_ffsl = no; then
+     HAVE_FFSL=0
+   fi
+ ])

--- a/ports/bison/portfile.cmake
+++ b/ports/bison/portfile.cmake
@@ -1,0 +1,34 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+if(VCPKG_CROSSCOMPILING)
+	message(FATAL_ERROR  "bison is a host-only port; please mark it as a host port in your dependencies.")
+endif()
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://ftp.gnu.org/gnu/bison/bison-3.8.1.tar.gz"
+    FILENAME "bison-3.8.1.tar.gz"
+    SHA512 ac4e1ba999da707960ffbe7cada792e1a82147fc70c8738cf08c1e2e9098b9439d4506ebfa1c727541d217788896b38a6bc180b835b365e76eb6707fb5b5b148
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+      clang-fortify.patch # ported from https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=522aea1093a598246346b3e1c426505c344fe19a
+      ffsl.patch
+)
+
+set(BUILD_OPTS --disable-yacc --disable-nls)
+set(ENV{AUTOPOINT} true) # true, the program
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS ${BUILD_OPTS}
+)
+
+vcpkg_install_make()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/bison/vcpkg.json
+++ b/ports/bison/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "bison",
+  "version": "3.8.1",
+  "description": "GNU Bison is a general-purpose parser generator that converts an annotated context-free grammar into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables.  Bison can also generate IELR(1) or canonical LR(1) parser tables.  Once you are proficient with Bison, you can use it to develop a wide range of language parsers, from those used in simple desk calculators to complex programming languages.",
+  "homepage": "https://www.gnu.org/software/bison/",
+  "license": "GPL-3.0-or-later",
+  "supports": "native"
+}

--- a/versions/b-/bison.json
+++ b/versions/b-/bison.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ff4c29237c6b933384d02c59b1366a95928b146a",
+      "version": "3.8.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -580,6 +580,10 @@
       "baseline": "3.0",
       "port-version": 3
     },
+    "bison": {
+      "baseline": "3.8.1",
+      "port-version": 0
+    },
     "bitmagic": {
       "baseline": "7.12.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #24905

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
