### PR TITLE
[xmlsec] Public XMLSEC_NO_SIZE_T XMLSEC_NO_XSLT

### DIFF
--- a/ports/xmlsec/CMakeLists.txt
+++ b/ports/xmlsec/CMakeLists.txt
@@ -87,6 +87,10 @@ add_compile_definitions(_UNICODE)
 add_compile_definitions(_MBCS)
 add_compile_definitions(_REENTRANT)
 
+target_compile_definitions(xmlsec1-openssl PRIVATE
+    -DXMLSEC_CRYPTO_OPENSSL
+)
+
 set_target_properties(xmlsec1 PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
 set_target_properties(xmlsec1-openssl PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
 
@@ -98,12 +102,8 @@ else()
     set(XMLSEC_OPENSSL_CFLAGS ${XMLSEC_CORE_CFLAGS})
 endif()
 
-target_compile_definitions(xmlsec1
-    PRIVATE ${XMLSEC_CORE_CFLAGS}
-    PUBLIC XMLSEC_NO_SIZE_T XMLSEC_NO_XSLT)
-target_compile_definitions(xmlsec1-openssl
-    PRIVATE ${XMLSEC_OPENSSL_CFLAGS}
-    PUBLIC XMLSEC_NO_SIZE_T XMLSEC_NO_XSLT XMLSEC_CRYPTO_OPENSSL)
+target_compile_definitions(xmlsec1 PRIVATE ${XMLSEC_CORE_CFLAGS})
+target_compile_definitions(xmlsec1-openssl PRIVATE ${XMLSEC_OPENSSL_CFLAGS}
 
 install(TARGETS xmlsec1 xmlsec1-openssl
     EXPORT xmlsecExport

--- a/ports/xmlsec/CMakeLists.txt
+++ b/ports/xmlsec/CMakeLists.txt
@@ -79,9 +79,11 @@ add_compile_definitions(HAVE_STRING_H)
 add_compile_definitions(HAVE_CTYPE_H)
 add_compile_definitions(HAVE_MALLOC_H)
 add_compile_definitions(HAVE_MEMORY_H)
+add_compile_definitions(XMLSEC_NO_XSLT=1)
 add_compile_definitions(XMLSEC_DEFAULT_CRYPTO="openssl")
 add_compile_definitions(XMLSEC_NO_GOST)
 add_compile_definitions(XMLSEC_NO_GOST2012)
+add_compile_definitions(XMLSEC_NO_SIZE_T)
 add_compile_definitions(UNICODE)
 add_compile_definitions(_UNICODE)
 add_compile_definitions(_MBCS)
@@ -103,7 +105,7 @@ else()
 endif()
 
 target_compile_definitions(xmlsec1 PRIVATE ${XMLSEC_CORE_CFLAGS})
-target_compile_definitions(xmlsec1-openssl PRIVATE ${XMLSEC_OPENSSL_CFLAGS}
+target_compile_definitions(xmlsec1-openssl PRIVATE ${XMLSEC_OPENSSL_CFLAGS})
 
 install(TARGETS xmlsec1 xmlsec1-openssl
     EXPORT xmlsecExport

--- a/ports/xmlsec/CMakeLists.txt
+++ b/ports/xmlsec/CMakeLists.txt
@@ -79,19 +79,13 @@ add_compile_definitions(HAVE_STRING_H)
 add_compile_definitions(HAVE_CTYPE_H)
 add_compile_definitions(HAVE_MALLOC_H)
 add_compile_definitions(HAVE_MEMORY_H)
-add_compile_definitions(XMLSEC_NO_XSLT=1)
 add_compile_definitions(XMLSEC_DEFAULT_CRYPTO="openssl")
 add_compile_definitions(XMLSEC_NO_GOST)
 add_compile_definitions(XMLSEC_NO_GOST2012)
-add_compile_definitions(XMLSEC_NO_SIZE_T)
 add_compile_definitions(UNICODE)
 add_compile_definitions(_UNICODE)
 add_compile_definitions(_MBCS)
 add_compile_definitions(_REENTRANT)
-
-target_compile_definitions(xmlsec1-openssl PRIVATE
-    -DXMLSEC_CRYPTO_OPENSSL
-)
 
 set_target_properties(xmlsec1 PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
 set_target_properties(xmlsec1-openssl PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
@@ -104,8 +98,12 @@ else()
     set(XMLSEC_OPENSSL_CFLAGS ${XMLSEC_CORE_CFLAGS})
 endif()
 
-target_compile_definitions(xmlsec1 PRIVATE ${XMLSEC_CORE_CFLAGS})
-target_compile_definitions(xmlsec1-openssl PRIVATE ${XMLSEC_OPENSSL_CFLAGS})
+target_compile_definitions(xmlsec1
+    PRIVATE ${XMLSEC_CORE_CFLAGS}
+    PUBLIC XMLSEC_NO_SIZE_T XMLSEC_NO_XSLT)
+target_compile_definitions(xmlsec1-openssl
+    PRIVATE ${XMLSEC_OPENSSL_CFLAGS}
+    PUBLIC XMLSEC_NO_SIZE_T XMLSEC_NO_XSLT XMLSEC_CRYPTO_OPENSSL)
 
 install(TARGETS xmlsec1 xmlsec1-openssl
     EXPORT xmlsecExport

--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -23,6 +23,14 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-xmlsec)
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+  vcpkg_replace_string(
+    "${CURRENT_PACKAGES_DIR}/include/xmlsec/xmlsec.h"
+    "ifdef XMLSEC_NO_SIZE_T"
+    "if 1 //ifdef XMLSEC_NO_SIZE_T"
+  )
+endif()
+
 # unofficial legacy usage
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/xmlsec-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "xmlsec",
   "version": "1.2.37",
-  "port-version": 1,
+  "port-version": 2,
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8886,7 +8886,7 @@
     },
     "xmlsec": {
       "baseline": "1.2.37",
-      "port-version": 1
+      "port-version": 2
     },
     "xnnpack": {
       "baseline": "2022-02-17",

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c75b7b5d0f3c316ea8e8e6c2ff2e1a107dccd9a0",
+      "git-tree": "d23f51e9b1e5d664b00936f085479d94c5f50417",
       "version": "1.2.37",
       "port-version": 2
     },

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d23f51e9b1e5d664b00936f085479d94c5f50417",
+      "git-tree": "716c1bdec11ab1f1053e76b14604a5d166484465",
       "version": "1.2.37",
       "port-version": 2
     },

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c75b7b5d0f3c316ea8e8e6c2ff2e1a107dccd9a0",
+      "version": "1.2.37",
+      "port-version": 2
+    },
+    {
       "git-tree": "19b8aab695c131f0dcbb7498f0d6a10517d01b70",
       "version": "1.2.37",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/31866
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
