### PR TITLE
[directx-dxc] Fix missing dxil.dll install

### DIFF
--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -8,8 +8,8 @@ if (EXISTS "${_dxc_exe}")
 
    add_library(Microsoft::DirectXShaderCompiler SHARED IMPORTED)
    set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
-      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name@"
-      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name@"
+      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxc@; ${_dxc_root}/@dll_dir@/@dll_name_dxil@"
+      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxc@; ${_dxc_root}/@dll_dir@/@dll_name_dxil@"
       IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/@lib_name@"
       IMPORTED_IMPLIB_DEBUG                "${_dxc_root}/lib/@lib_name@"
       IMPORTED_SONAME_RELEASE              "@lib_name@"

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -55,7 +55,8 @@ if (VCPKG_TARGET_IS_LINUX)
     "${PACKAGE_PATH}/bin/dxc"
     DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
 
-  set(dll_name "libdxcompiler.so")
+  set(dll_name_dxc "libdxcompiler.so")
+  set(dll_name_dxil "libdxil.so")
   set(dll_dir  "lib")
   set(lib_name "libdxcompiler.so")
   set(tool_path "bin/dxc")
@@ -96,7 +97,8 @@ else()
     "${PACKAGE_PATH}/bin/${DXC_ARCH}/dxil.dll"
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/")
 
-  set(dll_name "dxcompiler.dll")
+  set(dll_name_dxc "dxcompiler.dll")
+  set(dll_name_dxil "dxil.dll")
   set(dll_dir  "bin")
   set(lib_name "dxcompiler.lib")
   set(tool_path "tools/directx-dxc/dxc.exe")

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "directx-dxc",
   "version-date": "2023-03-01",
-  "port-version": 1,
+  "port-version": 2,
   "description": "DirectX Shader Compiler (LLVM/Clang)",
   "homepage": "https://github.com/microsoft/DirectXShaderCompiler",
   "documentation": "https://github.com/microsoft/DirectXShaderCompiler/wiki",

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "directx-dxc",
   "version-date": "2023-03-01",
-  "port-version": 2,
+  "port-version": 1,
   "description": "DirectX Shader Compiler (LLVM/Clang)",
   "homepage": "https://github.com/microsoft/DirectXShaderCompiler",
   "documentation": "https://github.com/microsoft/DirectXShaderCompiler/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2114,7 +2114,7 @@
     },
     "directx-dxc": {
       "baseline": "2023-03-01",
-      "port-version": 1
+      "port-version": 2
     },
     "directx-headers": {
       "baseline": "1.610.2",

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "af556a04405c1c8a22053d91ee65451c48c5cb84",
-      "version-date": "2023-03-01",
-      "port-version": 2
-    },
-    {
       "git-tree": "d9531dd561af13a58e38e173002e599c7ad1182f",
       "version-date": "2023-03-01",
       "port-version": 1

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78b3f68603497cff8c5609bad6f4c6d72a8769a8",
+      "version-date": "2023-03-01",
+      "port-version": 2
+    },
+    {
       "git-tree": "d9531dd561af13a58e38e173002e599c7ad1182f",
       "version-date": "2023-03-01",
       "port-version": 1

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af556a04405c1c8a22053d91ee65451c48c5cb84",
+      "version-date": "2023-03-01",
+      "port-version": 2
+    },
+    {
       "git-tree": "d9531dd561af13a58e38e173002e599c7ad1182f",
       "version-date": "2023-03-01",
       "port-version": 1

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "78b3f68603497cff8c5609bad6f4c6d72a8769a8",
+      "git-tree": "bdf7371f02d10ea110ecef427916c0f3fd78cd4d",
       "version-date": "2023-03-01",
       "port-version": 2
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.