### PR TITLE
[qoi] New port

### DIFF
--- a/ports/qoi/portfile.cmake
+++ b/ports/qoi/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO phoboslab/qoi
+    REF 19b3b4087b66963a3699ee45f05ec9ef205d7c0e # committed on 2023-08-10
+    SHA512 8131031ba4b3b3c50838eb83db44bed0bf2e3fc820f18a9e48202801aebef4179f9b465354487070d7bc1feea79461abe581eecde00d61a21e27fe2b8a52699f
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/qoi.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qoi/portfile.cmake
+++ b/ports/qoi/portfile.cmake
@@ -1,3 +1,5 @@
+#header-only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO phoboslab/qoi

--- a/ports/qoi/vcpkg.json
+++ b/ports/qoi/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "qoi",
+  "version-date": "2023-08-10",
+  "homepage": "https://qoiformat.org/",
+  "description": "The Quite OK Image Format for fast, lossless image compression",
+  "license": "MIT"
+}

--- a/ports/qoi/vcpkg.json
+++ b/ports/qoi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qoi",
   "version-date": "2023-08-10",
-  "homepage": "https://qoiformat.org/",
   "description": "The Quite OK Image Format for fast, lossless image compression",
+  "homepage": "https://qoiformat.org/",
   "license": "MIT"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6620,6 +6620,10 @@
       "baseline": "2021-02-26",
       "port-version": 3
     },
+    "qoi": {
+      "baseline": "2023-08-10",
+      "port-version": 0
+    },
     "qpid-proton": {
       "baseline": "0.38.0",
       "port-version": 1

--- a/versions/q-/qoi.json
+++ b/versions/q-/qoi.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d52130b05515783f0a3cb0bba739c30cf2521881",
+      "version-date": "2023-08-10",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/q-/qoi.json
+++ b/versions/q-/qoi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d52130b05515783f0a3cb0bba739c30cf2521881",
+      "git-tree": "2501f06dad0450b48676652e4f8b053071f874fb",
       "version-date": "2023-08-10",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
