### PR TITLE
[qoixx] New port

### DIFF
--- a/ports/qoixx/portfile.cmake
+++ b/ports/qoixx/portfile.cmake
@@ -1,3 +1,5 @@
+#header-only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wx257osn2/qoixx

--- a/ports/qoixx/portfile.cmake
+++ b/ports/qoixx/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wx257osn2/qoixx
+    REF eac3b33fbcb96a2664c00c24fe4e3e0d35cc7a7e # committed on 2022-12-07
+    SHA512 5dd379036e064527cb25376864fb6e6cb3d461baf95a6c98148202a8072f049ae0edfbac17bf76550eeb1f367d2426b6edd0a86b9231d50bb66771878df207c4
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/include/qoixx.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qoixx/vcpkg.json
+++ b/ports/qoixx/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "qoixx",
+  "version-date": "2022-12-07",
+  "description": "Single Header Quite Fast QOI(Quite OK Image Format) Implementation written in C++20",
+  "homepage": "https://github.com/wx257osn2/qoixx",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6628,6 +6628,10 @@
       "baseline": "2023-08-10",
       "port-version": 0
     },
+    "qoixx": {
+      "baseline": "2022-12-07",
+      "port-version": 0
+    },
     "qpid-proton": {
       "baseline": "0.38.0",
       "port-version": 1

--- a/versions/q-/qoixx.json
+++ b/versions/q-/qoixx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6f87694d4959ad4f4cd207b7225b73c113157855",
+      "version-date": "2022-12-07",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
