### PR TITLE
[hpx] Adding support for HPX release v1.9.1

### DIFF
--- a/ports/hpx/portfile.cmake
+++ b/ports/hpx/portfile.cmake
@@ -6,8 +6,8 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" HPX_WITH_STATIC_LINKING
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO STEllAR-GROUP/hpx
-    REF "${VERSION}"
-    SHA512 af2471a04dd0a3c414907ed06661ab1c6f6a49cc09d1ed3ae5d5587ca365270797a1d2ce9d0320dc7d7f9ff2c6d29037c7fbb84fa6d9c0033628ba7036f12986
+    REF "v${VERSION}"
+    SHA512 a7972beada950cf6ef3b61f20496a08b220e4f48c28c11d57c20683906ca5124a9f36ac2552318883a5ab1db6efdbf63d1141b6e0c484c560a8c1311ae2d7090
     HEAD_REF stable
     PATCHES
         fix-dependency-hwloc.patch
@@ -90,9 +90,11 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/hpxcxx" "${CURRENT_PACKAGES_DIR}/debug/bin/hpxcxx")
 
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-file(RENAME "${CURRENT_PACKAGES_DIR}/bin/hpxrun.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/hpxrun.py")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/hpxrun.py" "'${CURRENT_INSTALLED_DIR}/tools/openmpi/bin/mpiexec'" "'mpiexec'")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/hpxrun.py")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/hpxrun.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/hpxrun.py")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/hpxrun.py" "'${CURRENT_INSTALLED_DIR}/tools/openmpi/bin/mpiexec'" "'mpiexec'")
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/hpx/vcpkg.json
+++ b/ports/hpx/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "hpx",
-  "version": "1.8.1",
+  "version": "1.9.1",
   "description": [
     "The C++ Standards Library for Concurrency and Parallelism",
     "HPX is a C++ Standards Library for Concurrency and Parallelism. It implements all of the corresponding facilities as defined by the C++ Standard. Additionally, in HPX we implement functionalities proposed as part of the ongoing C++ standardization process. We also extend the C++ Standard APIs to the distributed case."
   ],
   "homepage": "https://github.com/STEllAR-GROUP/hpx",
   "license": "BSL-1.0",
+  "supports": "!(windows & x86)",
   "dependencies": [
     "asio",
     "boost-accumulators",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3217,7 +3217,7 @@
       "port-version": 0
     },
     "hpx": {
-      "baseline": "1.8.1",
+      "baseline": "1.9.1",
       "port-version": 0
     },
     "http-parser": {

--- a/versions/h-/hpx.json
+++ b/versions/h-/hpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "94d5f165d483752d4b7996bd1414497c5299208f",
+      "version": "1.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2d21a35d6723060eccbe376e9e694991cadb90b2",
       "version": "1.8.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
