### PR TITLE
[azure-core-cpp] Don't refer to versions of curl that don't exist.

### DIFF
--- a/ports/azure-core-cpp/vcpkg.json
+++ b/ports/azure-core-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-core-cpp",
   "version-semver": "1.10.2",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Core SDK for C++",
     "This library provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C++."
@@ -38,7 +39,7 @@
           "features": [
             "ssl"
           ],
-          "version>=": "7.44"
+          "version>=": "7.48"
         }
       ]
     },

--- a/versions/a-/azure-core-cpp.json
+++ b/versions/a-/azure-core-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bfb8b85899d4e6783f93392104d7ee80c8d0a89c",
+      "version-semver": "1.10.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "d3a1b3382bddaf219a0fef6dafd6a31c43d28e02",
       "version-semver": "1.10.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -410,7 +410,7 @@
     },
     "azure-core-cpp": {
       "baseline": "1.10.2",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-core-tracing-opentelemetry-cpp": {
       "baseline": "1.0.0-beta.4",


### PR DESCRIPTION
There's a "version>=" against a version of curl that does not exist in the version database. This causes customers that use versioning with Azure components to fail to resolve a version; versions need to be in the version database for us to be able to compare them.
