### PR TITLE
openvino: rename dnnl to onednn_cpu to avoid conflicts in packages

### DIFF
--- a/ports/openvino/007-dnnl-library-rename.patch
+++ b/ports/openvino/007-dnnl-library-rename.patch
@@ -1,0 +1,57 @@
+diff --git a/src/plugins/intel_cpu/CMakeLists.txt b/src/plugins/intel_cpu/CMakeLists.txt
+index d1150fdab0..cb2881301f 100644
+--- a/src/plugins/intel_cpu/CMakeLists.txt
++++ b/src/plugins/intel_cpu/CMakeLists.txt
+@@ -85,11 +85,11 @@ endif()
+ 
+ ie_mark_target_as_cc(${TARGET_NAME})
+ 
+-target_link_libraries(${TARGET_NAME} PRIVATE dnnl
++target_link_libraries(${TARGET_NAME} PRIVATE ${DNNL_LIBRARY_NAME}
+                                              ov_shape_inference
+                                              inference_engine_snippets)
+ 
+-target_include_directories(${TARGET_NAME} SYSTEM PRIVATE $<TARGET_PROPERTY:dnnl,INCLUDE_DIRECTORIES>)
++target_include_directories(${TARGET_NAME} SYSTEM PRIVATE $<TARGET_PROPERTY:${DNNL_LIBRARY_NAME},INCLUDE_DIRECTORIES>)
+ target_compile_definitions(${TARGET_NAME} PRIVATE IMPLEMENT_INFERENCE_EXTENSION_API)
+ target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+ 
+@@ -119,7 +119,7 @@ set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_REL
+ 
+ if(BUILD_SHARED_LIBS)
+     add_library(${TARGET_NAME}_obj OBJECT ${SOURCES} ${HEADERS})
+-    link_system_libraries(${TARGET_NAME}_obj PUBLIC dnnl openvino::pugixml)
++    link_system_libraries(${TARGET_NAME}_obj PUBLIC ${DNNL_LIBRARY_NAME} openvino::pugixml)
+ 
+     ov_add_version_defines(src/plugin.cpp ${TARGET_NAME}_obj)
+ 
+@@ -133,7 +133,7 @@ if(BUILD_SHARED_LIBS)
+             ${CMAKE_CURRENT_SOURCE_DIR}/src
+             $<TARGET_PROPERTY:openvino::conditional_compilation,INTERFACE_INCLUDE_DIRECTORIES>)
+ 
+-    target_include_directories(${TARGET_NAME}_obj SYSTEM PUBLIC $<TARGET_PROPERTY:dnnl,INCLUDE_DIRECTORIES>)
++    target_include_directories(${TARGET_NAME}_obj SYSTEM PUBLIC $<TARGET_PROPERTY:${DNNL_LIBRARY_NAME},INCLUDE_DIRECTORIES>)
+ 
+     set_ie_threading_interface_for(${TARGET_NAME}_obj)
+ 
+diff --git a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+index 19e453d6b4..f25b7d3db7 100644
+--- a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
++++ b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+@@ -36,6 +36,7 @@ function(ov_add_onednn)
+     # select needed primitives
+     set(DNNL_ENABLE_PRIMITIVE "CONVOLUTION;DECONVOLUTION;CONCAT;LRN;INNER_PRODUCT;MATMUL;POOLING;REDUCTION;REORDER;RNN;SOFTMAX" CACHE STRING "" FORCE)
+     set(DNNL_ENABLE_WORKLOAD "INFERENCE" CACHE STRING "" FORCE)
++    set(DNNL_LIBRARY_NAME "onednn_cpu" CACHE STRING "" FORCE)
+ 
+     # Allow to enable oneDNN verbose with CPU_DEBUG_CAPS and rely on oneDNN default configuration otherwise
+     if(ENABLE_CPU_DEBUG_CAPS)
+@@ -116,7 +117,7 @@ function(ov_add_onednn)
+     add_subdirectory(onednn EXCLUDE_FROM_ALL)
+ 
+     # install static libraries
+-    ov_install_static_lib(dnnl cpu)
++    ov_install_static_lib(${DNNL_LIBRARY_NAME} cpu)
+ 
+     if(DNNL_USE_ACL AND NOT BUILD_SHARED_LIBS)
+         # use ACLConfig.cmake in OpenVINOConfig.cmake in case of static build

--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         003-fix-find-onnx.patch
         004-onednn-build.patch
         005-rename-utils.patch
+        007-dnnl-library-rename.patch
     HEAD_REF master)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
   "version-date": "2023-06-11",
-  "port-version": 5,
+  "port-version": 6,
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6126,7 +6126,7 @@
     },
     "openvino": {
       "baseline": "2023-06-11",
-      "port-version": 5
+      "port-version": 6
     },
     "openvpn3": {
       "baseline": "3.7.0",

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad00a0dadb3ecf1eff66f9de71017808ade00d0f",
+      "version-date": "2023-06-11",
+      "port-version": 6
+    },
+    {
       "git-tree": "7737d9d905aa9a31e47e32abf5ef420bd1446def",
       "version-date": "2023-06-11",
       "port-version": 5


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
