### PR TITLE
[arg-router] Update to v1.4.0

### DIFF
--- a/ports/arg-router/portfile.cmake
+++ b/ports/arg-router/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO cmannett85/arg_router
     REF v${VERSION}
     HEAD_REF main
-    SHA512 b14f4fadf93ee405d3a0da919c74a5c7e83e012a811246802b05114f466b1d15031c8b912d064d0ea29b3cb86c1bd8fe184e9c80e1700b230e1880f94f204971
+    SHA512 0348a39c0e091b1b0d6887528f6d48372162ed2526fb81935761cf93ff006fc685bbf834d44cea60cdaf4d8b2e947b6cb1a81c901c02aaba68a0dfd16a12ca20
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port

--- a/ports/arg-router/vcpkg.json
+++ b/ports/arg-router/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arg-router",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "C++ command line argument parsing and routing.",
   "homepage": "https://github.com/cmannett85/arg_router",
   "documentation": "https://cmannett85.github.io/arg_router/",

--- a/versions/a-/arg-router.json
+++ b/versions/a-/arg-router.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0415ac98a98ec00c2c579c6925588b089bdc158",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0342b5a6a038dcb69eb623a70adf911d1e94d523",
       "version": "1.3.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -177,7 +177,7 @@
       "port-version": 2
     },
     "arg-router": {
-      "baseline": "1.3.0",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "argagg": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.