### PR TITLE
[python3] Don't set PYTHON_FOR_REGEN for host builds

### DIFF
--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -250,9 +250,6 @@ else()
     if(VCPKG_CROSSCOMPILING)
         set(_python_for_build "${CURRENT_HOST_INSTALLED_DIR}/tools/python3/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
         list(APPEND OPTIONS "--with-build-python=${_python_for_build}")
-    else()
-        vcpkg_find_acquire_program(PYTHON3)
-        list(APPEND OPTIONS "ac_cv_prog_PYTHON_FOR_REGEN=${PYTHON3}")
     endif()
 
     vcpkg_configure_make(

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.11.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6602,7 +6602,7 @@
     },
     "python3": {
       "baseline": "3.11.4",
-      "port-version": 1
+      "port-version": 2
     },
     "qca": {
       "baseline": "2.3.5",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f49a2d2249cb9f81e3a5c83329f383de36faf16",
+      "version": "3.11.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "531061b4485adebb80364473d227b0edf4ee8ed9",
       "version": "3.11.4",
       "port-version": 1


### PR DESCRIPTION
Fixes #33131 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.