### PR TITLE
[vcpkg baseline] [opencv4] Fix build error about flatbuffers

### DIFF
--- a/ports/opencv4/0016-fix-flatbuffers.patch
+++ b/ports/opencv4/0016-fix-flatbuffers.patch
@@ -19,15 +19,17 @@ index 537b738..6dba0fb 100644
  
  if(WITH_FLATBUFFERS OR HAVE_FLATBUFFERS)
 diff --git a/modules/dnn/misc/tflite/schema_generated.h b/modules/dnn/misc/tflite/schema_generated.h
-index 44162ee..9761414 100644
+index 44162ee..b2633d6 100644
 --- a/modules/dnn/misc/tflite/schema_generated.h
 +++ b/modules/dnn/misc/tflite/schema_generated.h
-@@ -10,7 +10,7 @@
+@@ -8,10 +8,6 @@
+ 
+ // Ensure the included flatbuffers.h is the same version as when this file was
  // generated, otherwise it may not be compatible.
- static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-               FLATBUFFERS_VERSION_MINOR == 5 &&
+-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
+-              FLATBUFFERS_VERSION_MINOR == 5 &&
 -              FLATBUFFERS_VERSION_REVISION == 9,
-+              FLATBUFFERS_VERSION_REVISION == 26,
-              "Non-compatible flatbuffers version included");
+-             "Non-compatible flatbuffers version included");
  
  namespace opencv_tflite {
+ 

--- a/ports/opencv4/0016-fix-flatbuffers.patch
+++ b/ports/opencv4/0016-fix-flatbuffers.patch
@@ -1,0 +1,33 @@
+diff --git a/cmake/OpenCVDetectFlatbuffers.cmake b/cmake/OpenCVDetectFlatbuffers.cmake
+index 537b738..6dba0fb 100644
+--- a/cmake/OpenCVDetectFlatbuffers.cmake
++++ b/cmake/OpenCVDetectFlatbuffers.cmake
+@@ -1,9 +1,11 @@
+ if(WITH_FLATBUFFERS)
+   set(HAVE_FLATBUFFERS 1)
+-  set(flatbuffers_VERSION "23.5.9")
+-  ocv_install_3rdparty_licenses(flatbuffers "${OpenCV_SOURCE_DIR}/3rdparty/flatbuffers/LICENSE.txt")
+-  ocv_add_external_target(flatbuffers "${OpenCV_SOURCE_DIR}/3rdparty/flatbuffers/include" "" "HAVE_FLATBUFFERS=1")
+-  set(CUSTOM_STATUS_flatbuffers "    Flatbuffers:" "builtin/3rdparty (${flatbuffers_VERSION})")
++  set(flatbuffers_VERSION "23.5.26")
++  #ocv_install_3rdparty_licenses(flatbuffers "${OpenCV_SOURCE_DIR}/3rdparty/flatbuffers/LICENSE.txt")
++  find_path(FLATBUFFERS_INCLUDE_DIR flatbuffers.h PATH_SUFFIXES flatbuffers)
++  get_filename_component(FLATBUFFERS_INCLUDE_DIR "${FLATBUFFERS_INCLUDE_DIR}" PATH)
++  ocv_add_external_target(flatbuffers "${FLATBUFFERS_INCLUDE_DIR}" "" "HAVE_FLATBUFFERS=1")
++  #set(CUSTOM_STATUS_flatbuffers "    Flatbuffers:" "builtin/3rdparty (${flatbuffers_VERSION})")
+ endif()
+ 
+ if(WITH_FLATBUFFERS OR HAVE_FLATBUFFERS)
+diff --git a/modules/dnn/misc/tflite/schema_generated.h b/modules/dnn/misc/tflite/schema_generated.h
+index 44162ee..9761414 100644
+--- a/modules/dnn/misc/tflite/schema_generated.h
++++ b/modules/dnn/misc/tflite/schema_generated.h
+@@ -10,7 +10,7 @@
+ // generated, otherwise it may not be compatible.
+ static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
+               FLATBUFFERS_VERSION_MINOR == 5 &&
+-              FLATBUFFERS_VERSION_REVISION == 9,
++              FLATBUFFERS_VERSION_REVISION == 26,
+              "Non-compatible flatbuffers version included");
+ 
+ namespace opencv_tflite {

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -27,9 +27,11 @@ vcpkg_from_github(
       0012-fix-zlib.patch
       0015-fix-freetype.patch
       "${ARM64_WINDOWS_FIX}"
+      0016-fix-flatbuffers.patch
 )
 # Disallow accidental build of vendored copies
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/openexr")
+file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/flatbuffers")
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
   set(TARGET_IS_AARCH64 1)
@@ -49,33 +51,34 @@ set(ADE_DIR ${CURRENT_INSTALLED_DIR}/share/ade CACHE PATH "Path to existing ADE 
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  FEATURES
- "ade"       WITH_ADE
- "contrib"   WITH_CONTRIB
- "cuda"      WITH_CUBLAS
- "cuda"      WITH_CUDA
- "cudnn"     WITH_CUDNN
- "dnn-cuda"  OPENCV_DNN_CUDA
- "eigen"     WITH_EIGEN
- "ffmpeg"    WITH_FFMPEG
- "freetype"  WITH_FREETYPE
- "gdcm"      WITH_GDCM
- "gstreamer" WITH_GSTREAMER
- "gtk"       WITH_GTK
- "halide"    WITH_HALIDE
- "jasper"    WITH_JASPER
- "jpeg"      WITH_JPEG
- "lapack"    WITH_LAPACK
- "nonfree"   OPENCV_ENABLE_NONFREE
- "openexr"   WITH_OPENEXR
- "opengl"    WITH_OPENGL
- "png"       WITH_PNG
- "quirc"     WITH_QUIRC
- "sfm"       BUILD_opencv_sfm
- "tiff"      WITH_TIFF
- "vtk"       WITH_VTK
- "webp"      WITH_WEBP
- "world"     BUILD_opencv_world
- "dc1394"    WITH_1394
+ "ade"          WITH_ADE
+ "contrib"      WITH_CONTRIB
+ "cuda"         WITH_CUBLAS
+ "cuda"         WITH_CUDA
+ "cudnn"        WITH_CUDNN
+ "dc1394"       WITH_1394
+ "dnn-cuda"     OPENCV_DNN_CUDA
+ "eigen"        WITH_EIGEN
+ "ffmpeg"       WITH_FFMPEG
+ "flatbuffers"  WITH_FLATBUFFERS
+ "freetype"     WITH_FREETYPE
+ "gdcm"         WITH_GDCM
+ "gstreamer"    WITH_GSTREAMER
+ "gtk"          WITH_GTK
+ "halide"       WITH_HALIDE
+ "jasper"       WITH_JASPER
+ "jpeg"         WITH_JPEG
+ "lapack"       WITH_LAPACK
+ "nonfree"      OPENCV_ENABLE_NONFREE
+ "openexr"      WITH_OPENEXR
+ "opengl"       WITH_OPENGL
+ "png"          WITH_PNG
+ "quirc"        WITH_QUIRC
+ "sfm"          BUILD_opencv_sfm
+ "tiff"         WITH_TIFF
+ "vtk"          WITH_VTK
+ "webp"         WITH_WEBP
+ "world"        BUILD_opencv_world
 )
 
 # Cannot use vcpkg_check_features() for "dnn", "gtk", ipp", "openmp", "ovis", "python", "qt", "tbb"

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
+  "port-version": 1,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -137,6 +138,12 @@
             "swscale"
           ]
         }
+      ]
+    },
+    "flatbuffers": {
+      "description": "Include Flatbuffers support for opencv",
+      "dependencies": [
+        "flatbuffers"
       ]
     },
     "freetype": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6010,7 +6010,7 @@
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "03bb4872fe41a7bea5623728ca86ca54f8b0da54",
+      "git-tree": "5be6cb619632021738967716e95e2fb59dbc15d9",
       "version": "4.8.0",
       "port-version": 1
     },

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03bb4872fe41a7bea5623728ca86ca54f8b0da54",
+      "version": "4.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0bae188d52a71f441df28b25278e5506502dfd03",
       "version": "4.8.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixed [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=92692&view=results) issue:
```
D:\buildtrees\opencv4\src\4.8.0-50001c828e.clean\modules\dnn\misc\tflite\schema_generated.h(12): error C2338: static_assert failed: 'Non-compatible flatbuffers version included'
```
`opencv4` conflicts with `flatbuffers` provided by vcpkg, the reason for the conflict is a version mismatch, `opencv4` uses `flatbuffers` version 23.5.9 of the third party, while vcpkg's `flatbuffers` is version 23.5.26.

Add `flatbuffers` as a feature to `opencv4`, and changed the codes make `opencv4` use the header files from `flatbuffers` provided by vcpkg.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
