### PR TITLE
[libdeflate] Update to 1.18 and fix an issue within the feature options

### DIFF
--- a/ports/libdeflate/portfile.cmake
+++ b/ports/libdeflate/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ebiggers/libdeflate
     REF "v${VERSION}"
-    SHA512 4e2c0f78e55befc8cbc390722ee5e9e7662315eaafe1979e300972990acf4afffc32a1220cca7a6e944d551a430dd13d36b40066dfe8141789de1a5418ac620f
+    SHA512 8a60fa5850f323389370f931579f85a094a35b3db334f2a2afa61bee39ecebc797e93c6fe5deb4178e19d83a1427533975dba6c05ce0b1db88b43c9268d09124
     HEAD_REF master
     PATCHES
         remove_wrong_c_flags_modification.diff
@@ -12,8 +12,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         compression   LIBDEFLATE_COMPRESSION_SUPPORT
         decompression LIBDEFLATE_DECOMPRESSION_SUPPORT
-        gzip          LIBDEFLATE_ZLIB_SUPPORT
-        zlib          LIBDEFLATE_GZIP_SUPPORT
+        gzip          LIBDEFLATE_GZIP_SUPPORT
+        zlib          LIBDEFLATE_ZLIB_SUPPORT
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LIBDEFLATE_BUILD_STATIC)

--- a/ports/libdeflate/vcpkg.json
+++ b/ports/libdeflate/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdeflate",
-  "version": "1.17",
+  "version": "1.18",
   "description": "libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.",
   "homepage": "https://github.com/ebiggers/libdeflate",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4017,7 +4017,7 @@
       "port-version": 2
     },
     "libdeflate": {
-      "baseline": "1.17",
+      "baseline": "1.18",
       "port-version": 0
     },
     "libdisasm": {

--- a/versions/l-/libdeflate.json
+++ b/versions/l-/libdeflate.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a0df33e92ed3be5674c6c0a4fd63faff93dea9d",
+      "version": "1.18",
+      "port-version": 0
+    },
+    {
       "git-tree": "023c8297e1d45d680194366783974818522294bd",
       "version": "1.17",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.