### PR TITLE
[stduuid] Update to 1.2.3

### DIFF
--- a/ports/stduuid/fix-gsl-polyfill.patch
+++ b/ports/stduuid/fix-gsl-polyfill.patch
@@ -1,15 +1,14 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f45a7dc..039ee53 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -37,11 +37,11 @@ if (UUID_TIME_GENERATOR)
+@@ -43,11 +43,11 @@ if (UUID_TIME_GENERATOR)
  endif()
  
  # Using span from std
 -if (NOT UUID_USING_CXX20_SPAN)
 -    target_include_directories(${PROJECT_NAME} INTERFACE
--            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gsl>
--            $<INSTALL_INTERFACE:include/gsl>)
+-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-            $<INSTALL_INTERFACE:include>)
 -    install(DIRECTORY gsl DESTINATION include)
 +if (UUID_USING_CXX20_SPAN)
 +    target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_20)
@@ -18,9 +17,8 @@ index f45a7dc..039ee53 100644
 +    target_link_libraries(${PROJECT_NAME} INTERFACE Microsoft.GSL::GSL)
  endif ()
  
- # Install step and imported target
+ if(UUID_ENABLE_INSTALL)
 diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
-index 7217b72..fb981d2 100644
 --- a/cmake/Config.cmake.in
 +++ b/cmake/Config.cmake.in
 @@ -9,6 +9,10 @@ if (@UUID_SYSTEM_GENERATOR@)

--- a/ports/stduuid/fix-install-directory.patch
+++ b/ports/stduuid/fix-install-directory.patch
@@ -1,8 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fffb92c..f45a7dc 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -11,7 +11,8 @@ option(UUID_USING_CXX20_SPAN "Using span from std instead of gsl" OFF)
+@@ -18,7 +18,8 @@ option(UUID_USING_CXX20_SPAN "Using span from std instead of gsl" OFF)
  add_library(${PROJECT_NAME} INTERFACE)
  target_include_directories(${PROJECT_NAME} INTERFACE
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -12,12 +11,12 @@ index fffb92c..f45a7dc 100644
  
  # Using system uuid generator
  if (UUID_SYSTEM_GENERATOR)
-@@ -44,7 +45,7 @@ if (NOT UUID_USING_CXX20_SPAN)
- endif ()
+@@ -52,7 +52,7 @@
  
- # Install step and imported target
--install(FILES include/uuid.h DESTINATION include)
-+install(FILES include/uuid.h DESTINATION include/stduuid)
- install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets)
- install(EXPORT ${PROJECT_NAME}-targets
-         DESTINATION lib/cmake/${PROJECT_NAME})
+ if(UUID_ENABLE_INSTALL)
+     # Install step and imported target
+-    install(FILES include/uuid.h DESTINATION include)
++    install(FILES include/uuid.h DESTINATION include/stduuid)
+     install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets)
+     install(EXPORT ${PROJECT_NAME}-targets
+             DESTINATION lib/cmake/${PROJECT_NAME})

--- a/ports/stduuid/portfile.cmake
+++ b/ports/stduuid/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mariusbancila/stduuid
-    REF v1.2.2
-    SHA512 30970c25992e1ba35d96e3b2fc8530466c1070b8b913b8c37e9f698f39121a5a74361e2c4db4c2ba2feddb0ce9b2f14b78c4761cdac09b89a6a0117b179b08a7
+    REF "v${VERSION}"
+    SHA512 3d2fb21f680fb12559642d6787a5744d4f4fb48a6284bfef77537cb51f9bdbbe271b24a8c3bb1f954b4c845145f22c6d89a09e663df2f96a2e24d1d6f22fdf22
     HEAD_REF master
     PATCHES
         fix-install-directory.patch
@@ -20,15 +20,16 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         gsl-span UUID_USING_CXX20_SPAN
 )
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
         -DUUID_BUILD_TESTS=OFF
+        -DUUID_ENABLE_INSTALL=ON
         ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/stduuid)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 if("gsl-span" IN_LIST FEATURES)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/stduuid/uuid.h" "#ifdef __cpp_lib_span" "#if 0")
@@ -37,4 +38,4 @@ else()
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/stduuid/uuid.h" "#ifdef __cpp_lib_span" "#if 1")
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/stduuid/portfile.cmake
+++ b/ports/stduuid/portfile.cmake
@@ -28,7 +28,7 @@ vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/stduuid)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 if("gsl-span" IN_LIST FEATURES)

--- a/ports/stduuid/vcpkg.json
+++ b/ports/stduuid/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "stduuid",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A C++17 cross-platform implementation for UUIDs",
+  "homepage": "https://github.com/mariusbancila/stduuid",
   "license": "MIT",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7913,7 +7913,7 @@
       "port-version": 2
     },
     "stduuid": {
-      "baseline": "1.2.2",
+      "baseline": "1.2.3",
       "port-version": 0
     },
     "stftpitchshift": {

--- a/versions/s-/stduuid.json
+++ b/versions/s-/stduuid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f00a1ab28b6ade4a146f4f7dad761f624862222a",
+      "version": "1.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "bd235773c953e5636a7b9f6356437daef6e5010c",
       "version": "1.2.2",
       "port-version": 0

--- a/versions/s-/stduuid.json
+++ b/versions/s-/stduuid.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f00a1ab28b6ade4a146f4f7dad761f624862222a",
+      "git-tree": "a3a58db8b151c363a0f3df4a99e416d3a8dc0b62",
       "version": "1.2.3",
       "port-version": 0
     },


### PR DESCRIPTION
Updates stduuid to 1.2.3

* [x]  Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
* [x]  SHA512s are updated for each updated download
* [x]  The "supports" clause reflects platforms that may be fixed by this new version
* [x]  Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
* [x]  Any patches that are no longer applied are deleted from the port's directory.
* [x]  The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
* [x]  Only one version is added to each modified port's versions file.