### PR TITLE
[gmsh] update to 4.11.1

### DIFF
--- a/ports/gmsh/portfile.cmake
+++ b/ports/gmsh/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.onelab.info
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gmsh/gmsh
-    REF gmsh_4_9_0
-    SHA512 e70a09741a86a9131094e77742078aec1cc94517e1d7c855c257bc93c21c057e25c7ac5168d31ec4d905d78f31d5704faf63bfd3a81b4b9e2ebbcfacf2fdaa8b
+    REF gmsh_4_11_1
+    SHA512 4c10a41659ee4f70ba5091f9ae1c4c3ee285ccf217c3de1157a0d6d694e6f1df9a6b1329b2b24029dd52f945dd7605e477302bdb358106a8d97e903eaba425dc
     HEAD_REF master
     PATCHES fix-install.patch
 )

--- a/ports/gmsh/portfile.cmake
+++ b/ports/gmsh/portfile.cmake
@@ -108,4 +108,4 @@ vcpkg_copy_tools(TOOL_NAMES gmsh AUTO_CLEAN)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/gmsh/vcpkg.json
+++ b/ports/gmsh/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "gmsh",
-  "version": "4.9.0",
+  "version": "4.11.1",
   "description": "Gmsh is an open source 3D finite element mesh generator with a built-in CAD engine and post-processor.",
   "homepage": "https://gmsh.info",
+  "license": "LGPL-2.0-or-later",
   "supports": "!uwp",
   "dependencies": [
     "blas",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2953,7 +2953,7 @@
       "port-version": 21
     },
     "gmsh": {
-      "baseline": "4.9.0",
+      "baseline": "4.11.1",
       "port-version": 0
     },
     "gobject-introspection": {

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8ed958f730e9f2651c19e85163f3ede2ab3aa633",
+      "git-tree": "4b2ce12dd16815e31348c4dba93b40ec10e815f3",
       "version": "4.11.1",
       "port-version": 0
     },

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ed958f730e9f2651c19e85163f3ede2ab3aa633",
+      "version": "4.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d01377e2003c3ea5ef7a6b9fb215a086e5f75eed",
       "version": "4.9.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #33156

Update port gmsh to the latest version.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Tested feature `graphics`,`occ`,`zipper` successfully in the following triplet:
- x64-windows
- x64-windows-static

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
