### PR TITLE
[libffi] Fix compile option -fPIC

### DIFF
--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -215,8 +215,7 @@ if(CMAKE_STATIC_LIBRARY_PREFIX STREQUAL "lib")
 endif()
 
 if(NOT WIN32)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    string(APPEND CMAKE_ASM_FLAGS " -fPIC")
 endif()
 
 install(TARGETS libffi

--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -214,6 +214,10 @@ if(CMAKE_STATIC_LIBRARY_PREFIX STREQUAL "lib")
     set_target_properties(libffi PROPERTIES OUTPUT_NAME ffi)
 endif()
 
+if(NOT WIN32)
+    target_compile_options(libffi PUBLIC -fPIC)
+endif()
+
 install(TARGETS libffi
     EXPORT ${PROJECT_NAME}Targets
     RUNTIME DESTINATION bin

--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -215,7 +215,8 @@ if(CMAKE_STATIC_LIBRARY_PREFIX STREQUAL "lib")
 endif()
 
 if(NOT WIN32)
-    target_compile_options(libffi PUBLIC -fPIC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
 install(TARGETS libffi

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libffi",
   "version": "3.4.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4090,7 +4090,7 @@
     },
     "libffi": {
       "baseline": "3.4.4",
-      "port-version": 2
+      "port-version": 3
     },
     "libfido2": {
       "baseline": "1.13.0",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c74f4ef72574f7bc29aebf276ef6a6d0165b9996",
+      "git-tree": "edcfc87c8441f1c03c2f03edb8d537d65173aa57",
       "version": "3.4.4",
       "port-version": 3
     },

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2da2521266e0f4e08a8d90f4e1c5b3efb7be699b",
+      "git-tree": "c74f4ef72574f7bc29aebf276ef6a6d0165b9996",
       "version": "3.4.4",
       "port-version": 3
     },

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2da2521266e0f4e08a8d90f4e1c5b3efb7be699b",
+      "version": "3.4.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "df29b345dbd3f713c6bad15ca3d5f19ec961d79f",
       "version": "3.4.4",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/29660
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
cc @HoMiGT @872448677 @dominique120  Please test this. 
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
