### PR TITLE
[pybind11] Update to 2.11.0

### DIFF
--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
     REF "v${VERSION}"
-    SHA512 7970defbb6d057a44468ed707c80bfa6ef8c9578528fbc084b03aeea20a52dbd681581f82d55ff90af11ee89693379bd79e2ab6603239ba05b0aa8da29dd93c7
+    SHA512 10edfdc499ed70234de0796f79b9f3a7a14d4baf01fb09fedbd9126e0a13d9cdeb213950c53a8f7a67cd6049b1db31efacfe2192098236b242ad3685967ea907
     HEAD_REF master
     PATCHES
         fix-debug-link.patch

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pybind11",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "port-version": 1,
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6589,7 +6589,7 @@
       "port-version": 0
     },
     "pybind11": {
-      "baseline": "2.10.4",
+      "baseline": "2.11.0",
       "port-version": 1
     },
     "pystring": {

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3aeca2d8bc4821ab8e508e9097386fdaa6f12eef",
+      "version": "2.11.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "14db30027dba1e9d7ba976dd0645dac59ec553a8",
       "version": "2.10.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note: Update to 2.11.1 will be in another PR, so user of manifest file can use 2.11.0 in case they have an issue with 2.11.1