### PR TITLE
[opentelemetry-cpp] Update to 1.10.0

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-telemetry/opentelemetry-cpp
     REF "v${VERSION}"
-    SHA512 86cf0320f9ee50bc1aa2b7a8b254fb0df25d1bd1f5f01ebc3630ab7fe2f6ca5e53ca8e042518b4e7096dbb102c0b880e9a25fcdf5f668d24ff57d9247237bf62
+    SHA512 5bd1a376ffb5a0f8c5706a8088230ee2506eb1858c206d98ba7b1b52949e1072afd98c1323c1c5eb6a3787143bcbe689bb52e55551e7cbc7076431864e212926
     HEAD_REF main
     PATCHES
         # Use the compiler's default C++ version. Picking a version with
@@ -26,15 +26,13 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         zipkin WITH_ZIPKIN
         prometheus WITH_PROMETHEUS
         elasticsearch WITH_ELASTICSEARCH
-        jaeger WITH_JAEGER
-        otlp WITH_OTLP
         otlp-http WITH_OTLP_HTTP
         zpages WITH_ZPAGES
         otlp-grpc WITH_OTLP_GRPC
 )
 
 # opentelemetry-proto is a third party submodule and opentelemetry-cpp release did not pack it.
-if(WITH_OTLP)
+if(WITH_OTLP_HTTP OR WITH_OTLP_GRPC)
     set(OTEL_PROTO_VERSION "0.19.0")
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/open-telemetry/opentelemetry-proto/archive/v${OTEL_PROTO_VERSION}.tar.gz"

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
-  "version-semver": "1.9.1",
+  "version-semver": "1.10.0",
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."
@@ -29,18 +29,6 @@
       "description": "Whether to include the ETW Exporter in the SDK",
       "supports": "windows"
     },
-    "jaeger": {
-      "description": "Whether to include the Jaeger exporter",
-      "dependencies": [
-        "thrift"
-      ]
-    },
-    "otlp": {
-      "description": "Whether to include the OpenTelemetry Protocol in the SDK",
-      "dependencies": [
-        "protobuf"
-      ]
-    },
     "otlp-grpc": {
       "description": "Whether to include the OTLP gRPC exporter in the SDK",
       "dependencies": [
@@ -49,26 +37,14 @@
           "name": "grpc",
           "host": true
         },
-        {
-          "name": "opentelemetry-cpp",
-          "default-features": false,
-          "features": [
-            "otlp"
-          ]
-        }
+        "protobuf"
       ]
     },
     "otlp-http": {
       "description": "Whether to include the OpenTelemetry Protocol over HTTP in the SDK",
       "dependencies": [
         "curl",
-        {
-          "name": "opentelemetry-cpp",
-          "default-features": false,
-          "features": [
-            "otlp"
-          ]
-        }
+        "protobuf"
       ]
     },
     "prometheus": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6105,7 +6105,7 @@
       "port-version": 0
     },
     "opentelemetry-cpp": {
-      "baseline": "1.9.1",
+      "baseline": "1.10.0",
       "port-version": 0
     },
     "opentelemetry-fluentd": {

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "033e5e21f1190781438cc2dd8cd2aeadacad95ea",
+      "version-semver": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "47c5c172ee9a7c663746a3c1cbabb359a1cbaf56",
       "version-semver": "1.9.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #33177, update `opentelemetry-cpp` to 1.10.0.

* Remove deprecated option `WITH_OTLP`: [CHANGELOG.md#L38-L39](https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.10.0/CHANGELOG.md?plain=1#L38-L39)

* Remove deprecated option `WITH_JAEGER`: [CHANGELOG.md?#L145-L148](https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.10.0/CHANGELOG.md?plain=1#L145-L148), [DEPRECATED.md#jaeger-propagator](https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.10.0/DEPRECATED.md#jaeger-propagator)

* All features are tested successfully in the following triplet:
  ```
  x86-windows
  x64-windows
  x64-windows-static
  ```


* The usage test passed on `x64-windows` (header files found):
  ```
  opentelemetry-cpp provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(opentelemetry-cpp CONFIG REQUIRED)
    # note: 26 additional targets are not displayed.
    target_link_libraries(main PRIVATE opentelemetry-cpp::api opentelemetry-cpp::ext opentelemetry-cpp::sdk opentelemetry-cpp::logs)
  ```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
