### PR TITLE
[opencv4] fix feature python

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -585,6 +585,12 @@ if(VCPKG_TARGET_IS_ANDROID)
   file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/README.android")
 endif()
 
+if("python" IN_LIST FEATURES)
+  file(GLOB python_dir LIST_DIRECTORIES true RELATIVE "${CURRENT_PACKAGES_DIR}/lib/" "${CURRENT_PACKAGES_DIR}/lib/python*")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/${python_dir}/site-packages/cv2/typing")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/${python_dir}/site-packages/cv2/typing")
+endif()
+
 vcpkg_fixup_pkgconfig()
 
 configure_file("${CURRENT_PORT_DIR}/usage.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6014,7 +6014,7 @@
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89d6da3b45b7e1667bdc3083f9641e57ad4930a9",
+      "version": "4.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "78f4556a682ebb41e2ff3f26090ef51cafe5a66c",
       "version": "4.8.0",
       "port-version": 1


### PR DESCRIPTION
Fixes the error: 
```
-- Performing post-build validation
warning: There should be no empty directories in /Users/leanderSchulten/git_projekte/vcpkg/packages/opencv4_arm64-osx. The following empty directories were found:

    /Users/leanderSchulten/git_projekte/vcpkg/packages/opencv4_arm64-osx/lib/python3.11/site-packages/cv2/typing
    /Users/leanderSchulten/git_projekte/vcpkg/packages/opencv4_arm64-osx/debug/lib/python3.11/site-packages/cv2/typing

warning: If a directory should be populated but is not, this might indicate an error in the portfile.
If the directories are not needed and their creation cannot be disabled, use something like this in the portfile to remove them:
    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/python3.11/site-packages/cv2/typing" "${CURRENT_PACKAGES_DIR}/debug/lib/python3.11/site-packages/cv2/typing")

error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: /Users/leanderSchulten/git_projekte/vcpkg/ports/opencv4/portfile.cmake
error: building opencv4:arm64-osx failed with: POST_BUILD_CHECKS_FAILED
```