### PR TITLE
First `versioned` version of curl is 7.74, not 7.48. Reset base version to 7.74.

### DIFF
--- a/ports/azure-core-cpp/vcpkg.json
+++ b/ports/azure-core-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-core-cpp",
   "version-semver": "1.10.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "Microsoft Azure Core SDK for C++",
     "This library provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C++."

--- a/ports/azure-core-cpp/vcpkg.json
+++ b/ports/azure-core-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-core-cpp",
   "version-semver": "1.10.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "Microsoft Azure Core SDK for C++",
     "This library provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C++."
@@ -39,7 +39,7 @@
           "features": [
             "ssl"
           ],
-          "version>=": "7.48.0"
+          "version>=": "7.74.0"
         }
       ]
     },

--- a/ports/azure-core-cpp/vcpkg.json
+++ b/ports/azure-core-cpp/vcpkg.json
@@ -38,8 +38,7 @@
           "default-features": false,
           "features": [
             "ssl"
-          ],
-          "version>=": "7.74.0"
+          ]
         }
       ]
     },

--- a/ports/azure-core-cpp/vcpkg.json
+++ b/ports/azure-core-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-core-cpp",
   "version-semver": "1.10.2",
-  "port-version": 4,
+  "port-version": 3,
   "description": [
     "Microsoft Azure Core SDK for C++",
     "This library provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C++."

--- a/versions/a-/azure-core-cpp.json
+++ b/versions/a-/azure-core-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "425b40e801b51a731d99209a05aae1ab1fdb82e2",
+      "version-semver": "1.10.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "0988f8606d4a1ee55446b680b6ea134cfae20569",
       "version-semver": "1.10.2",
       "port-version": 2

--- a/versions/a-/azure-core-cpp.json
+++ b/versions/a-/azure-core-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db976e05847ef9b5f9a0ab9668f34add5cef3d79",
+      "version-semver": "1.10.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "425b40e801b51a731d99209a05aae1ab1fdb82e2",
       "version-semver": "1.10.2",
       "port-version": 3

--- a/versions/a-/azure-core-cpp.json
+++ b/versions/a-/azure-core-cpp.json
@@ -6,7 +6,7 @@
       "port-version": 4
     },
     {
-      "git-tree": "425b40e801b51a731d99209a05aae1ab1fdb82e2",
+      "git-tree": "371ce124f91e0b9d64a44e47b573b5a3f4602498",
       "version-semver": "1.10.2",
       "port-version": 3
     },

--- a/versions/a-/azure-core-cpp.json
+++ b/versions/a-/azure-core-cpp.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "db976e05847ef9b5f9a0ab9668f34add5cef3d79",
-      "version-semver": "1.10.2",
-      "port-version": 4
-    },
-    {
       "git-tree": "371ce124f91e0b9d64a44e47b573b5a3f4602498",
       "version-semver": "1.10.2",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -410,7 +410,7 @@
     },
     "azure-core-cpp": {
       "baseline": "1.10.2",
-      "port-version": 4
+      "port-version": 3
     },
     "azure-core-tracing-opentelemetry-cpp": {
       "baseline": "1.0.0-beta.4",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -410,7 +410,7 @@
     },
     "azure-core-cpp": {
       "baseline": "1.10.2",
-      "port-version": 2
+      "port-version": 3
     },
     "azure-core-tracing-opentelemetry-cpp": {
       "baseline": "1.0.0-beta.4",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -410,7 +410,7 @@
     },
     "azure-core-cpp": {
       "baseline": "1.10.2",
-      "port-version": 3
+      "port-version": 4
     },
     "azure-core-tracing-opentelemetry-cpp": {
       "baseline": "1.0.0-beta.4",


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
