### PR TITLE
[mongo-cxx-driver] Update port to v3.8.0

### DIFF
--- a/ports/libbson/disable-dynamic-when-static.patch
+++ b/ports/libbson/disable-dynamic-when-static.patch
@@ -1,36 +1,36 @@
 diff --git a/src/libbson/CMakeLists.txt b/src/libbson/CMakeLists.txt
-index d6df66f..88de79a 100644
+index 61e926747..6b4c5a911 100644
 --- a/src/libbson/CMakeLists.txt
 +++ b/src/libbson/CMakeLists.txt
-@@ -209,6 +209,7 @@ set (HEADERS_FORWARDING
+@@ -205,6 +205,7 @@ set (HEADERS_FORWARDING
     ${PROJECT_SOURCE_DIR}/src/bson/forwarding/bson.h
  )
- 
+
 +if(NOT MONGOC_ENABLE_STATIC_BUILD)
  add_library (bson_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
- set (CMAKE_CXX_VISIBILITY_PRESET hidden)
- target_compile_definitions (bson_shared
-@@ -275,6 +276,7 @@ if (WIN32)
+ if (MSVC AND MSVC_VERSION VERSION_LESS 1900)
+    message (STATUS "Disabling warning C4756 for VS 2013 and older")
+@@ -282,6 +283,7 @@ if (WIN32)
     # must be handled specially since we can't resolve them
     set (BSON_SYSTEM_LIBRARIES ${BSON_SYSTEM_LIBRARIES} ws2_32)
  endif ()
 +endif()
- 
+
  if (MONGOC_ENABLE_STATIC_BUILD)
     add_library (bson_static STATIC ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
-@@ -349,7 +351,7 @@ set (BSON_HEADER_INSTALL_DIR
+@@ -367,7 +369,7 @@ set (BSON_HEADER_INSTALL_DIR
  )
- 
+
  if (MONGOC_ENABLE_STATIC_INSTALL)
 -   set (TARGETS_TO_INSTALL bson_shared bson_static)
 +   set (TARGETS_TO_INSTALL bson_static)
  else ()
     set (TARGETS_TO_INSTALL bson_shared)
  endif ()
-@@ -400,12 +402,14 @@ configure_file (
+@@ -418,12 +420,14 @@ configure_file (
     ${CMAKE_CURRENT_BINARY_DIR}/src/libbson-1.0.pc
     @ONLY)
- 
+
 +if(NOT MONGOC_ENABLE_STATIC_INSTALL)
  install (
     FILES
@@ -39,6 +39,6 @@ index d6df66f..88de79a 100644
        ${CMAKE_INSTALL_LIBDIR}/pkgconfig
  )
 +endif()
- 
+
  if (MONGOC_ENABLE_STATIC_INSTALL)
     configure_file (

--- a/ports/libbson/fix-missing-header.patch
+++ b/ports/libbson/fix-missing-header.patch
@@ -1,0 +1,12 @@
+diff --git a/src/libbson/CMakeLists.txt b/src/libbson/CMakeLists.txt
+index 61e926747..715b304c0 100644
+--- a/src/libbson/CMakeLists.txt
++++ b/src/libbson/CMakeLists.txt
+@@ -181,6 +181,7 @@ set (HEADERS
+    ${PROJECT_SOURCE_DIR}/src/bson/bson-compat.h
+    ${PROJECT_SOURCE_DIR}/src/bson/bson-context.h
+    ${PROJECT_SOURCE_DIR}/src/bson/bson-decimal128.h
++   ${PROJECT_SOURCE_DIR}/src/bson/bson-dsl.h  # mongo-c-driver build time only
+    ${PROJECT_SOURCE_DIR}/src/bson/bson-endian.h
+    ${PROJECT_SOURCE_DIR}/src/bson/bson-error.h
+    ${PROJECT_SOURCE_DIR}/src/bson/bson.h

--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES
         disable-dynamic-when-static.patch
         fix-include-directory.patch # vcpkg legacy decision
+        fix-missing-header.patch  # for building mongo-c-driver
 )
 file(WRITE "${SOURCE_PATH}/VERSION_CURRENT" "${VERSION}")
 

--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 36cd8844b1cc9a935c50afc240523f9aaac7cffa58a5d0f9850848f22ab0f1f5a7202ec9b56b0a7d15f075f665bcecbec63b28d2074d35a7cf25065f9075c15e
+    SHA512 242416638bf6722ccda67ecc15cf78f8531f1a4ae0e89fd66cde74221d7b98b859442f5b70628802972961e69156fd7afcc916d7a83cc134d5723eb0b6e15cc9
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.22.2",
+  "version": "1.24.3",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/disable-dynamic-when-static.patch
+++ b/ports/mongo-c-driver/disable-dynamic-when-static.patch
@@ -1,36 +1,36 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 7fcdd86..1b32e6c 100644
+index bf95bd0c1..c9900b7fa 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -758,6 +758,7 @@ if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
-    endif()
+@@ -745,6 +745,7 @@ if (MONGOC_ENABLE_STATIC_BUILD)
+    set_target_properties (mcd_rpc PROPERTIES OUTPUT_NAME "mcd-rpc")
  endif ()
- 
+
 +if (NOT MONGOC_ENABLE_STATIC_BUILD)
  add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
  set_target_properties (mongoc_shared PROPERTIES CMAKE_CXX_VISIBILITY_PRESET hidden)
  target_link_libraries (mongoc_shared PRIVATE ${LIBRARIES} PUBLIC ${BSON_LIBRARIES})
-@@ -796,7 +797,7 @@ target_include_directories (
+@@ -786,7 +787,7 @@ target_include_directories (
  set_target_properties (mongoc_shared PROPERTIES VERSION 0.0.0 SOVERSION 0)
  set_target_properties (mongoc_shared PROPERTIES OUTPUT_NAME "${MONGOC_OUTPUT_BASENAME}-${MONGOC_API_VERSION}")
- 
+
 -if (MONGOC_ENABLE_STATIC_BUILD)
-+else ()
++else()
     add_library (mongoc_static STATIC ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
-    target_link_libraries (mongoc_static PUBLIC ${STATIC_LIBRARIES} ${BSON_STATIC_LIBRARIES})
-    if (NOT WIN32 AND ENABLE_PIC)
-@@ -847,7 +848,11 @@ if (ENABLE_APPLE_FRAMEWORK)
+    if(ENABLE_COVERAGE)
+       target_compile_options(mongoc_static PRIVATE --coverage)
+@@ -840,7 +841,11 @@ if (ENABLE_APPLE_FRAMEWORK)
  endif ()
- 
+
  add_executable (mongoc-stat ${PROJECT_SOURCE_DIR}/../../src/tools/mongoc-stat.c)
 +if (NOT MONGOC_ENABLE_STATIC_BUILD)
  target_link_libraries (mongoc-stat mongoc_shared ${LIBRARIES})
 +else()
 +target_link_libraries (mongoc-stat mongoc_static ${LIBRARIES})
 +endif()
- 
+
  # mongoc-stat works if shared memory performance counters are enabled.
- if (ENABLE_SHM_COUNTERS STREQUAL "ON")
+ if (ENABLE_SHM_COUNTERS)
 @@ -1161,7 +1166,7 @@ file (COPY ${PROJECT_SOURCE_DIR}/tests/x509gen DESTINATION ${PROJECT_BINARY_DIR}
  file (COPY ${PROJECT_SOURCE_DIR}/tests/release_files DESTINATION ${PROJECT_BINARY_DIR}/tests)
  

--- a/ports/mongo-c-driver/fix-dependencies.patch
+++ b/ports/mongo-c-driver/fix-dependencies.patch
@@ -18,23 +18,23 @@ diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
 index d108e5d..a097016 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -55,7 +55,7 @@ configure_file (
+@@ -51,7 +51,7 @@ configure_file (
  set (ZLIB_INCLUDE_DIRS "")
  if (ENABLE_ZLIB MATCHES "SYSTEM|AUTO")
     message (STATUS "Searching for zlib CMake packages")
 -   include (FindZLIB)
 +   find_package(ZLIB REQUIRED)
     if (ZLIB_FOUND)
-       message ("--   zlib found version \"${ZLIB_VERSION_STRING}\"")
-       message ("--   zlib include path \"${ZLIB_INCLUDE_DIRS}\"")
-@@ -150,7 +150,7 @@ if (NOT ENABLE_SSL STREQUAL OFF)
+       message (STATUS "   zlib found version \"${ZLIB_VERSION_STRING}\"")
+       message (STATUS "   zlib include path \"${ZLIB_INCLUDE_DIRS}\"")
+@@ -146,7 +146,7 @@ if (NOT ENABLE_SSL STREQUAL OFF)
     if (ENABLE_SSL STREQUAL "OPENSSL"
         OR (NOT APPLE AND NOT WIN32 AND ENABLE_SSL STREQUAL "AUTO"))
        # Sets OPENSSL_FOUND on success.
 -      include (FindOpenSSL)
 +      find_package(OpenSSL REQUIRED)
     endif ()
- 
+
     if (ENABLE_SSL STREQUAL LIBRESSL)
 @@ -364,10 +364,10 @@ else ()
  endif ()

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 36cd8844b1cc9a935c50afc240523f9aaac7cffa58a5d0f9850848f22ab0f1f5a7202ec9b56b0a7d15f075f665bcecbec63b28d2074d35a7cf25065f9075c15e
+    SHA512 242416638bf6722ccda67ecc15cf78f8531f1a4ae0e89fd66cde74221d7b98b859442f5b70628802972961e69156fd7afcc916d7a83cc134d5723eb0b6e15cc9
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch
@@ -48,7 +48,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${OPTIONS}
-        -DENABLE_BSON=SYSTEM
+        -DUSE_SYSTEM_LIBBSON=ON
         -DENABLE_EXAMPLES=OFF
         -DENABLE_SHM_COUNTERS=OFF
         -DENABLE_STATIC=${ENABLE_STATIC}

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.22.2",
+  "version": "1.24.3",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,

--- a/ports/mongo-cxx-driver/fix-dependencies.patch
+++ b/ports/mongo-cxx-driver/fix-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
-index d87d588..16ba095 100644
+index f30aea836..50610ffb1 100644
 --- a/src/bsoncxx/CMakeLists.txt
 +++ b/src/bsoncxx/CMakeLists.txt
-@@ -218,6 +221,9 @@ if(BSONCXX_BUILD_STATIC)
+@@ -215,6 +215,9 @@ if(BSONCXX_BUILD_STATIC)
      bsoncxx_install_deprecated_cmake(bsoncxx-static)
      list(APPEND bsoncxx_target_list bsoncxx_static)
      set(bsoncxx_pkg_dep "find_dependency(bson-1.0 REQUIRED)")
@@ -10,5 +10,5 @@ index d87d588..16ba095 100644
 +        string(APPEND bsoncxx_pkg_dep "\nfind_dependency(Boost)")
 +    endif()
  endif()
- bsoncxx_install("${bsoncxx_target_list}" "${bsoncxx_pkg_dep}")
- 
+ if(BSONCXX_POLY_USE_BOOST)
+     set(bsoncxx_boost_pkg_dep "find_dependency(Boost 1.56.0 REQUIRED)")

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-cxx-driver
     REF "r${VERSION}"
-    SHA512 de4737fab399e342c8153b2a14d097e54250fd66ca58c3120634bc08cb1943dc2808b81adf8e7a2f7edeb12607ae418c887667548600eee585ba5b27ebdf16b5
+    SHA512 f9f0d83ee2ef1f3c2dae1f3663b893d819737d4e646d0137fb623b84663382eb93ab36123c2a85247f43ae979a95276fa231d5da8ad62a6da002ab9daecaa0d4
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/mongo-cxx-driver/vcpkg.json
+++ b/ports/mongo-cxx-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-cxx-driver",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "description": "MongoDB C++ Driver.",
   "homepage": "https://github.com/mongodb/mongo-cxx-driver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3937,7 +3937,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.22.2",
+      "baseline": "1.24.3",
       "port-version": 0
     },
     "libcaer": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5433,7 +5433,7 @@
       "port-version": 0
     },
     "mongo-cxx-driver": {
-      "baseline": "3.7.2",
+      "baseline": "3.8.0",
       "port-version": 0
     },
     "mongoose": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5429,7 +5429,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.22.2",
+      "baseline": "1.24.3",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0ffcecec891ce453f1d8c7511ef7124449cda1f8",
+      "version": "1.24.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "c50f1bbb02e6ac4f6b6f928f4c931922017997d9",
       "version": "1.22.2",
       "port-version": 0

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0ffcecec891ce453f1d8c7511ef7124449cda1f8",
+      "git-tree": "3a3f08e9e91a77ee7b6b56f88d1e0013349c34e1",
       "version": "1.24.3",
       "port-version": 0
     },

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c9ddb78bc06cb779848d6afffa88938870ae8a7b",
+      "version": "1.24.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "b840350590e947daec430cfea1445d958ae6f5fa",
       "version": "1.22.2",
       "port-version": 0

--- a/versions/m-/mongo-cxx-driver.json
+++ b/versions/m-/mongo-cxx-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8fc862744aad29acd0e6a0d947fc5b561d3f5f7",
+      "version": "3.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "00588be07af8844394ca81106324a42f5d29d684",
       "version": "3.7.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Also updated mongo-c-driver and libbson to v1.24.3 as well. There are version pin between them. 
Tested `boost` feature with `x64-windows` and `x64-windows-static`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
