### PR TITLE
[openimageio] Updated version fixes oiiotool.exe functionality

### DIFF
--- a/ports/imath/portfile.cmake
+++ b/ports/imath/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DIMATH_INSTALL_SYM_LINK=OFF
         -DBUILD_TESTING=OFF
+        -DIMATH_INSTALL_PKG_CONFIG=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/imath/vcpkg.json
+++ b/ports/imath/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imath",
   "version": "3.1.9",
+  "port-version": 1,
   "description": "Imath is a C++ and Python library of 2D and 3D vector, matrix, and math operations for computer graphics.",
   "homepage": "https://github.com/AcademySoftwareFoundation/Imath",
   "license": "BSD-3-Clause",

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -30,6 +30,7 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DMZ_FETCH_LIBS=OFF
         -DMZ_LIB_SUFFIX=-ng
+        -DMZ_ICONV=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "minizip-ng",
   "version": "4.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "license": "Zlib",

--- a/ports/opencolorio/fix-del-install-file.patch
+++ b/ports/opencolorio/fix-del-install-file.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 17e188d..c6c5ff5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -341,11 +341,7 @@ if (NOT BUILD_SHARED_LIBS)
+ 
+     # Install custom Find modules.
+     install(FILES
+-        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findexpat.cmake
+-        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/FindImath.cmake
+-        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findpystring.cmake
+         ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findminizip-ng.cmake
+-        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findyaml-cpp.cmake
+         DESTINATION ${OCIO_CUSTOM_FIND_MODULE_DIR}
+     )
+ endif()

--- a/ports/opencolorio/fix-dependency.patch
+++ b/ports/opencolorio/fix-dependency.patch
@@ -1,17 +1,17 @@
 diff --git a/share/cmake/modules/FindExtPackages.cmake b/share/cmake/modules/FindExtPackages.cmake
-index 8787b87..f953ceb 100644
+index 5455a08..3b9530e 100644
 --- a/share/cmake/modules/FindExtPackages.cmake
 +++ b/share/cmake/modules/FindExtPackages.cmake
-@@ -26,15 +26,15 @@ set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON CACHE BOOL
+@@ -37,20 +37,20 @@ endif()
  
  # expat
  # https://github.com/libexpat/libexpat
--find_package(expat 2.2.8 REQUIRED)
+-find_package(expat 2.4.1 REQUIRED)
 +find_package(expat CONFIG REQUIRED)
  
  # yaml-cpp
  # https://github.com/jbeder/yaml-cpp
--find_package(yaml-cpp 0.6.3 REQUIRED)
+-find_package(yaml-cpp 0.7.0 REQUIRED)
 +find_package(yaml-cpp CONFIG REQUIRED)
  
  # pystring
@@ -19,27 +19,24 @@ index 8787b87..f953ceb 100644
 -find_package(pystring 1.1.3 REQUIRED)
 +find_package(pystring CONFIG REQUIRED)
  
- # Half
- # NOTE: OCIO_USE_IMATH_HALF needs to be an integer for use in utils/Half.h.in
-@@ -42,7 +42,7 @@ if(NOT OCIO_USE_OPENEXR_HALF)
+ # Imath (>=3.1)
+ # https://github.com/AcademySoftwareFoundation/Imath
+ set(_Imath_ExternalProject_VERSION "3.1.5")
+-find_package(Imath 3.0 REQUIRED)
++find_package(Imath CONFIG REQUIRED)
  
-     # Imath (>=3.0)
-     # https://github.com/AcademySoftwareFoundation/Imath
--    find_package(Imath 3.1.2 REQUIRED)
-+    find_package(Imath CONFIG REQUIRED)
-     
-     set(OCIO_HALF_LIB Imath::Imath CACHE STRING "Half library target" FORCE)
-     set(OCIO_USE_IMATH_HALF "1" CACHE STRING "Whether 'half' type will be sourced from the Imath library (>=v3.0)" FORCE)
-@@ -50,7 +50,7 @@ else()
+ ###############################################################################
+ ### ZLIB (https://github.com/madler/zlib)
+@@ -138,7 +138,7 @@ endif()
  
-     # OpenEXR/IlmBase (<=2.5)
-     # https://github.com/AcademySoftwareFoundation/openexr
--    find_package(Half 2.4.0 REQUIRED)
-+    find_package(Half CONFIG REQUIRED)
+ # minizip-ng
+ # https://github.com/zlib-ng/minizip-ng
+-find_package(minizip-ng 3.0.7 REQUIRED)
++find_package(minizip-ng CONFIG REQUIRED)
  
-     set(OCIO_HALF_LIB IlmBase::Half CACHE STRING "Half library target" FORCE)
-     set(OCIO_USE_IMATH_HALF "0" CACHE STRING "Whether 'half' type will be sourced from the Imath library (>=v3.0)" FORCE)
-@@ -65,7 +65,7 @@ if(OCIO_BUILD_APPS)
+ if(OCIO_BUILD_APPS)
+ 
+@@ -149,7 +149,7 @@ if(OCIO_BUILD_APPS)
  
      # lcms2
      # https://github.com/mm2/Little-CMS
@@ -48,34 +45,18 @@ index 8787b87..f953ceb 100644
  endif()
  
  if(OCIO_BUILD_OPENFX)
-diff --git a/src/OpenColorIO/CMakeLists.txt b/src/OpenColorIO/CMakeLists.txt
-index 034185d..b992bbc 100755
---- a/src/OpenColorIO/CMakeLists.txt
-+++ b/src/OpenColorIO/CMakeLists.txt
-@@ -226,9 +226,9 @@ target_link_libraries(OpenColorIO
-         expat::expat
-         ${OCIO_HALF_LIB}
-         pystring::pystring
--        sampleicc::sampleicc
--        utils::from_chars
--        utils::strings
-+        "$<BUILD_INTERFACE:sampleicc::sampleicc>"
-+        "$<BUILD_INTERFACE:utils::from_chars>"
-+        "$<BUILD_INTERFACE:utils::strings>"
-         yaml-cpp
- )
- 
 diff --git a/src/cmake/Config.cmake.in b/src/cmake/Config.cmake.in
-index eebb2c1..7147dc3 100644
+index 6a4932a..b8298f0 100644
 --- a/src/cmake/Config.cmake.in
 +++ b/src/cmake/Config.cmake.in
-@@ -2,4 +2,9 @@
+@@ -1,6 +1,10 @@
+ @PACKAGE_INIT@
  
  include(CMakeFindDependencyMacro)
- 
 +find_dependency(expat CONFIG)
 +find_dependency(Imath CONFIG)
 +find_dependency(pystring CONFIG)
 +find_dependency(yaml-cpp CONFIG)
-+
- include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+ 
+ if (NOT @BUILD_SHARED_LIBS@) # NOT @BUILD_SHARED_LIBS@
+     if (APPLE)

--- a/ports/opencolorio/fix-func-param.patch
+++ b/ports/opencolorio/fix-func-param.patch
@@ -1,0 +1,49 @@
+diff --git a/src/OpenColorIO/OCIOZArchive.cpp b/src/OpenColorIO/OCIOZArchive.cpp
+index 85fc7bb..e07ed23 100644
+--- a/src/OpenColorIO/OCIOZArchive.cpp
++++ b/src/OpenColorIO/OCIOZArchive.cpp
+@@ -225,7 +225,7 @@ void archiveConfig(std::ostream & ostream, const Config & config, const char * c
+     std::string configStr = ss.str();
+ 
+     // Write zip to memory stream.
+-    mz_stream_mem_create(&write_mem_stream);
++    mz_stream_mem_create();
+     mz_stream_mem_set_grow_size(write_mem_stream, 128 * 1024);
+     mz_stream_open(write_mem_stream, NULL, MZ_OPEN_MODE_CREATE);
+ 
+@@ -237,7 +237,7 @@ void archiveConfig(std::ostream & ostream, const Config & config, const char * c
+     options.compress_level  = ArchiveCompressionLevels::BEST;
+ 
+     // Create the writer handle.
+-    mz_zip_writer_create(&archiver);
++    mz_zip_writer_create();
+ 
+     // Archive options.
+     // Compression method
+@@ -332,7 +332,7 @@ void ExtractOCIOZArchive(const char * archivePath, const char * destination)
+     std::string outputDestination = pystring::os::path::normpath(destination);
+ 
+     // Create zip reader.
+-    mz_zip_reader_create(&extracter);
++    mz_zip_reader_create();
+ 
+     MinizipNgHandlerGuard extracterGuard(extracter, false, false);
+ 
+@@ -450,7 +450,7 @@ std::vector<uint8_t> getFileStringFromArchiveFile(const std::string & filepath,
+     std::vector<uint8_t> buffer;
+ 
+     // Create the reader object.
+-    mz_zip_reader_create(&reader);
++    mz_zip_reader_create();
+ 
+     MinizipNgHandlerGuard extracterGuard(reader, false, true);
+ 
+@@ -510,7 +510,7 @@ void getEntriesMappingFromArchiveFile(const std::string & archivePath,
+     void *reader = NULL;
+ 
+     // Create the reader object.
+-    mz_zip_reader_create(&reader);
++    mz_zip_reader_create();
+ 
+     MinizipNgHandlerGuard extracterGuard(reader, false, false);
+ 

--- a/ports/opencolorio/fix-func-param.patch
+++ b/ports/opencolorio/fix-func-param.patch
@@ -47,3 +47,20 @@ index 85fc7bb..e07ed23 100644
  
      MinizipNgHandlerGuard extracterGuard(reader, false, false);
  
+diff --git a/src/OpenColorIO/OCIOZArchive.cpp b/src/OpenColorIO/OCIOZArchive.cpp
+index 85fc7bb..45416cd 100644
+--- a/src/OpenColorIO/OCIOZArchive.cpp
++++ b/src/OpenColorIO/OCIOZArchive.cpp
+@@ -24,9 +24,11 @@
+ #include "mz_strm_mem.h"
+ #include "mz_strm_os.h"
+ #include "mz_strm_split.h"
+-#include "mz_strm_zlib.h"
+ #include "mz_zip.h"
+ #include "mz_zip_rw.h"
++#ifndef __APPLE__
++#include "mz_strm_zlib.h"
++#endif
+
+ namespace OCIO_NAMESPACE
+ {

--- a/ports/opencolorio/fix-pkgconfig.patch
+++ b/ports/opencolorio/fix-pkgconfig.patch
@@ -7,4 +7,4 @@ index f25c280..d9a450b 100644
  Libs: -L${libdir} -l@PROJECT_NAME@
  Cflags: -I${includedir}
 +Libs.private: -lpystring
-+Requires.private: expat Imath yaml-cpp
++Requires.private: expat Imath yaml-cpp minizip-ng

--- a/ports/opencolorio/fix-pkgconfig.patch
+++ b/ports/opencolorio/fix-pkgconfig.patch
@@ -7,4 +7,4 @@ index f25c280..d9a450b 100644
  Libs: -L${libdir} -l@PROJECT_NAME@
  Cflags: -I${includedir}
 +Libs.private: -lpystring
-+Requires.private: expat Imath yaml-cpp
++Requires.private: expat yaml-cpp

--- a/ports/opencolorio/portfile.cmake
+++ b/ports/opencolorio/portfile.cmake
@@ -1,18 +1,16 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/OpenColorIO
-    REF v2.1.2
-    SHA512 594e808fb1c175d5b14eb540be0dfb6f41cd37b5bf7df8c2d24d44dfe4986643ea68e52d0282eb3b25283489789001a57a201de1eecc1560fc9461780c7da353
+    REF "v${VERSION}"
+    SHA512 d5f3a4b5bd661af7336c015d07e0feccb286464a08239a3c259a97217001161e7571f5137475fc2f4d1b9af6381bbfa03c0b60f41de282f114307961b8d84fc9
     HEAD_REF master
     PATCHES
         fix-dependency.patch
+        fix-del-install-file.patch
+        fix-func-param.patch
         fix-pkgconfig.patch
 )
 
-file(REMOVE "${SOURCE_PATH}/share/cmake/modules/Findexpat.cmake")
-file(REMOVE "${SOURCE_PATH}/share/cmake/modules/FindImath.cmake")
-file(REMOVE "${SOURCE_PATH}/share/cmake/modules/Findpystring.cmake")
-file(REMOVE "${SOURCE_PATH}/share/cmake/modules/Findyaml-cpp.cmake")
 file(REMOVE "${SOURCE_PATH}/share/cmake/modules/Findlcms2.cmake")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -36,6 +34,7 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
     MAYBE_UNUSED_VARIABLES
         CMAKE_DISABLE_FIND_PACKAGE_OpenImageIO
+        OCIO_USE_OPENEXR_HALF
 )
 
 vcpkg_cmake_install()

--- a/ports/opencolorio/vcpkg.json
+++ b/ports/opencolorio/vcpkg.json
@@ -8,6 +8,7 @@
   "dependencies": [
     "expat",
     "imath",
+    "minizip-ng",
     "pystring",
     {
       "name": "vcpkg-cmake",
@@ -17,8 +18,7 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "yaml-cpp",
-    "minizip-ng"
+    "yaml-cpp"
   ],
   "features": {
     "tools": {

--- a/ports/opencolorio/vcpkg.json
+++ b/ports/opencolorio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "opencolorio",
-  "version-semver": "2.1.2",
+  "version-semver": "2.2.1",
   "description": "OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.",
   "homepage": "https://opencolorio.org/",
   "license": "BSD-3-Clause",
@@ -17,7 +17,8 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "yaml-cpp"
+    "yaml-cpp",
+    "minizip-ng"
   ],
   "features": {
     "tools": {

--- a/ports/openimageio/fix-openexr-dll.patch
+++ b/ports/openimageio/fix-openexr-dll.patch
@@ -1,8 +1,8 @@
 diff --git a/src/cmake/externalpackages.cmake b/src/cmake/externalpackages.cmake
-index dad053c..4d7e11c 100644
+index 0ca1fe6..1eeb5ab 100644
 --- a/src/cmake/externalpackages.cmake
 +++ b/src/cmake/externalpackages.cmake
-@@ -103,7 +103,7 @@ checked_find_package (OpenEXR REQUIRED
+@@ -105,7 +105,7 @@ checked_find_package (OpenEXR REQUIRED
  # building against Imath/OpenEXR 3.x when there is still a system-level
  # install version of 2.x.
  include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
@@ -10,4 +10,4 @@ index dad053c..4d7e11c 100644
 +if (WIN32 AND BUILD_SHARED_LIBS)
      add_definitions (-DOPENEXR_DLL) # Is this needed for new versions?
  endif ()
- if (OPENEXR_VERSION VERSION_GREATER_EQUAL 3.0)
+ if (OpenEXR_VERSION VERSION_GREATER_EQUAL 3.0)

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenImageIO/oiio
     REF "v${VERSION}"
-    SHA512 9325beefce55b66a58fcfc2ce93e1406558ed5f6cc37cb1e8e04aee470c4f30a14483bebfb311c329f7868afb6c508a052661c6b12d819a69f707c1a30cd9549 
+    SHA512 59c38667ae792f5c5cc6f7f9655159e9b0e048d99f1232766407c01ab635a319ad4ba28cd3c6a115924ea0e4ec994d4c1bdb2f6301fbb9ae11b2820768bd1ff1
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openimageio",
-  "version": "2.4.13.0",
+  "version": "2.4.14.0",
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3374,7 +3374,7 @@
     },
     "imath": {
       "baseline": "3.1.9",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui": {
       "baseline": "1.89.7",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5981,7 +5981,7 @@
       "port-version": 2
     },
     "opencolorio": {
-      "baseline": "2.1.2",
+      "baseline": "2.2.1",
       "port-version": 0
     },
     "opencolorio-tools": {
@@ -6041,7 +6041,7 @@
       "port-version": 4
     },
     "openimageio": {
-      "baseline": "2.4.13.0",
+      "baseline": "2.4.14.0",
       "port-version": 0
     },
     "openjpeg": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5394,7 +5394,7 @@
     },
     "minizip-ng": {
       "baseline": "4.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "mio": {
       "baseline": "2023-03-03",

--- a/versions/i-/imath.json
+++ b/versions/i-/imath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47c02f0c550c3639178d554a27475f376c2fdcbc",
+      "version": "3.1.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "1853273c56448fff5ec5e2c9133895922df682bd",
       "version": "3.1.9",
       "port-version": 0

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89c9968274d731d513a3eadc259c73c95cfe058c",
+      "version": "4.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "1e55bf50acfd71d5f37f98bee270ff687f65219f",
       "version": "4.0.0",
       "port-version": 1

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d728bb2681e89ffbe9c6e1ec2811d5d194d9fd09",
+      "git-tree": "9569944b76966b78bec5ef83672899acd7e4febe",
       "version-semver": "2.1.2",
       "port-version": 0
     },

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1a947849587bac230890f7ff379721027d137c95",
+      "git-tree": "d5c69dc2c181e658e67ba57e3836a548c469477a",
       "version-semver": "2.2.1",
       "port-version": 0
     },

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2b5a352d946df3856029bbf6e2062feca3cc290",
+      "version-semver": "2.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d728bb2681e89ffbe9c6e1ec2811d5d194d9fd09",
       "version-semver": "2.1.2",
       "port-version": 0

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,16 +1,12 @@
 {
   "versions": [
     {
-<<<<<<< HEAD
       "git-tree": "1a947849587bac230890f7ff379721027d137c95",
       "version-semver": "2.2.1",
       "port-version": 0
     },
     {
-      "git-tree": "d728bb2681e89ffbe9c6e1ec2811d5d194d9fd09",
-=======
       "git-tree": "9569944b76966b78bec5ef83672899acd7e4febe",
->>>>>>> master
       "version-semver": "2.1.2",
       "port-version": 0
     },

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e2b5a352d946df3856029bbf6e2062feca3cc290",
+      "git-tree": "6e4a0bfc08e504def77dd1cf12833b94d69d06ef",
       "version-semver": "2.2.1",
       "port-version": 0
     },

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6e4a0bfc08e504def77dd1cf12833b94d69d06ef",
+      "git-tree": "1a947849587bac230890f7ff379721027d137c95",
       "version-semver": "2.2.1",
       "port-version": 0
     },

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "965f6cf8bde18cb53a219f9b61b5099105b7fd2f",
+      "version": "2.4.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1d6d564f1848ae68ece423fa0597c8a5fe6c9d5d",
       "version": "2.4.13.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/14132
1.Update `opencolorio` to 2.2.1, update `openimageio` to 2.4.14.0.
2.Fix oiiotool.exe --help command output error.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```