### PR TITLE
[anari] Added ANARI port.

### DIFF
--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -1,9 +1,7 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # For ${PORT} and ${VERSION}.
-
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KhronosGroup/ANARI-SDK
-  REF v${VERSION}
+  REF "v${VERSION}"
   SHA512 51937d160a9508c56cf123eda13002c705acff501366710f83da1c62d875f8427cec27f10ea2d05f4637be141fb9a87935f4b0b9f0fabb6bd6a7cca6a4f48ee1
   HEAD_REF main
 )

--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -9,7 +9,9 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS
+    -DBUILD_CTS=OFF
     -DBUILD_EXAMPLES=OFF
+    -DBUILD_HELIDE_DEVICE=OFF # Default implementation is disabled because it depends on an internal version of Embree.
     -DBUILD_TESTING=OFF
     -DBUILD_VIEWER=OFF
 )

--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -11,7 +11,6 @@ vcpkg_cmake_configure(
   OPTIONS
     -DBUILD_CTS=OFF
     -DBUILD_EXAMPLES=OFF
-    -DBUILD_HELIDE_DEVICE=OFF # Default implementation is disabled because it depends on an internal version of Embree.
     -DBUILD_TESTING=OFF
     -DBUILD_VIEWER=OFF
 )

--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -6,6 +6,10 @@ vcpkg_from_github(
   HEAD_REF main
 )
 
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
+vcpkg_add_to_path(${PYTHON3_DIR})
+
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS
@@ -13,6 +17,7 @@ vcpkg_cmake_configure(
     -DBUILD_EXAMPLES=OFF
     -DBUILD_TESTING=OFF
     -DBUILD_VIEWER=OFF
+    -DPYTHON_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_cmake_install()

--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # For ${PORT} and ${VERSION}.
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO KhronosGroup/ANARI-SDK
+  REF v${VERSION}
+  SHA512 51937d160a9508c56cf123eda13002c705acff501366710f83da1c62d875f8427cec27f10ea2d05f4637be141fb9a87935f4b0b9f0fabb6bd6a7cca6a4f48ee1
+  HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    -DBUILD_EXAMPLES=OFF
+    -DBUILD_TESTING=OFF
+    -DBUILD_VIEWER=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  CONFIG_PATH "lib/cmake/${PORT}-${VERSION}")
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE 
+  "${CURRENT_PACKAGES_DIR}/debug/include" 
+  "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(
+  FILE_LIST "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -18,13 +18,15 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
-  CONFIG_PATH "lib/cmake/${PORT}-${VERSION}")
+  CONFIG_PATH "lib/cmake/${PORT}-${VERSION}"
+)
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE 
   "${CURRENT_PACKAGES_DIR}/debug/include" 
-  "${CURRENT_PACKAGES_DIR}/debug/share")
+  "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
 vcpkg_install_copyright(
   FILE_LIST "${SOURCE_PATH}/LICENSE"

--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
 
 vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path(${PYTHON3_DIR})
+vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -17,7 +17,6 @@ vcpkg_cmake_configure(
     -DBUILD_EXAMPLES=OFF
     -DBUILD_TESTING=OFF
     -DBUILD_VIEWER=OFF
-    -DPYTHON_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_cmake_install()
@@ -31,6 +30,13 @@ file(REMOVE_RECURSE
   "${CURRENT_PACKAGES_DIR}/debug/include" 
   "${CURRENT_PACKAGES_DIR}/debug/share"
 )
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/bin" 
+    "${CURRENT_PACKAGES_DIR}/debug/bin"
+  )
+endif()
 
 vcpkg_install_copyright(
   FILE_LIST "${SOURCE_PATH}/LICENSE"

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -6,8 +6,10 @@
   "license": "Apache-2.0",
   "dependencies": [
     "glm",
-    "pthreads",
-    "python3",
+    {
+      "name": "python3",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",
-  "supports": "!(arm64 & windows)",
   "dependencies": [
     "glm",
     "python3",

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",
-  "supports": "!android & !(arm64 & windows)",
+  "supports": "!(arm64 & windows)",
   "dependencies": [
     "glm",
     "python3",

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -12,6 +12,10 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    },
+    {
+      "name": "glm",
+      "host": true
     }
   ]
 }

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",
+  "supports": "!(arm64&windows)",
   "dependencies": [
     "glm",
     "python3",

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -6,15 +6,15 @@
   "license": "Apache-2.0",
   "dependencies": [
     {
+      "name": "glm",
+      "host": true
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
-      "host": true
-    },
-    {
-      "name": "glm",
       "host": true
     }
   ]

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",
-  "supports": "!(arm64 & windows)",
+  "supports": "!android & !(arm64 & windows)",
   "dependencies": [
     "glm",
     "python3",

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -6,7 +6,6 @@
   "license": "Apache-2.0",
   "dependencies": [
     "glm",
-    "python3",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",
-  "supports": "!(arm64&windows)",
+  "supports": "!(arm64 & windows)",
   "dependencies": [
     "glm",
     "python3",

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -5,10 +5,7 @@
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",
   "dependencies": [
-    {
-      "name": "glm",
-      "host": true
-    },
+    "glm",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": [
     "glm",
+    "python3",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": [
     "glm",
+    "pthreads",
     "python3",
     {
       "name": "vcpkg-cmake",

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -1,9 +1,9 @@
 {
-  "name"        : "anari",
-  "version"     : "0.7.0",
-  "description" : "Cross-Platform 3D Rendering Engine API.",
-  "homepage"    : "https://www.khronos.org/anari",
-  "license"     : "Apache-2.0",
+  "name": "anari",
+  "version": "0.7.0",
+  "description": "Cross-Platform 3D Rendering Engine API.",
+  "homepage": "https://www.khronos.org/anari",
+  "license": "Apache-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -6,10 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": [
     "glm",
-    {
-      "name": "python3",
-      "host": true
-    },
+    "python3",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name"        : "anari",
+  "version"     : "0.7.0",
+  "description" : "Cross-Platform 3D Rendering Engine API.",
+  "homepage"    : "https://www.khronos.org/anari",
+  "license"     : "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -46,6 +46,7 @@ allegro5:arm-neon-android=fail
 allegro5:arm64-android=fail
 allegro5:x64-android=fail
 ampl-asl:x64-android=fail
+anari:arm64-windows=fail
 apr:arm-neon-android=fail
 apr:arm64-android=fail
 apr:x64-android=fail

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b4d46d64feb15c77963c539eac613274295d644b",
+      "git-tree": "cf756ca650e9d72324024441ad48b760fb587f86",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2ec964d7d6684b9b71c2b6bf8994c8e1959bec4f",
+      "git-tree": "8c9a5ccfc715db4d1db2d56fb130ac7f5d592581",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b874b4ea0584a9038e9455202219b959f63d31f4",
+      "git-tree": "a7c9c2092c5c10ccbeccad18f5cb05c4c73ff813",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "edaf1226ffd8aa6e63f4fb0ba8147bf697d33edb",
+      "git-tree": "2ec964d7d6684b9b71c2b6bf8994c8e1959bec4f",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f3f66fe9c4b719a558dbb54a9aae56f6093b4fb",
+      "git-tree": "b874b4ea0584a9038e9455202219b959f63d31f4",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b4d46d64feb15c77963c539eac613274295d644b",
+      "git-tree": "02ec5dbc9509d48c593f4c48ff31080050790fe3",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9956dbaa7b7acf634b5fa5f1b21f570d5367a006",
+      "version": "0.7.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f3f66fe9c4b719a558dbb54a9aae56f6093b4fb",
+      "git-tree": "08f58a0dce4063dd0bb42d5f94efbd6453ebe660",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7c9c2092c5c10ccbeccad18f5cb05c4c73ff813",
+      "git-tree": "2f3f66fe9c4b719a558dbb54a9aae56f6093b4fb",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c76cb8c7446ca1fa8d6c51fce18128e22dff2a38",
+      "git-tree": "2f3f66fe9c4b719a558dbb54a9aae56f6093b4fb",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9956dbaa7b7acf634b5fa5f1b21f570d5367a006",
+      "git-tree": "5d47fbbe96a50b923e81c246d9329a577de8c943",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8c9a5ccfc715db4d1db2d56fb130ac7f5d592581",
+      "git-tree": "c76cb8c7446ca1fa8d6c51fce18128e22dff2a38",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3520448bbc860740b74957ab434263f050894462",
+      "git-tree": "cf756ca650e9d72324024441ad48b760fb587f86",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cf756ca650e9d72324024441ad48b760fb587f86",
+      "git-tree": "b4d46d64feb15c77963c539eac613274295d644b",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "08f58a0dce4063dd0bb42d5f94efbd6453ebe660",
+      "git-tree": "3520448bbc860740b74957ab434263f050894462",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5d47fbbe96a50b923e81c246d9329a577de8c943",
+      "git-tree": "edaf1226ffd8aa6e63f4fb0ba8147bf697d33edb",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "02ec5dbc9509d48c593f4c48ff31080050790fe3",
+      "git-tree": "b4d46d64feb15c77963c539eac613274295d644b",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -116,6 +116,10 @@
       "baseline": "4.3.23",
       "port-version": 0
     },
+    "anari": {
+      "baseline": "0.7.0",
+      "port-version": 0
+    },
     "anax": {
       "baseline": "2.1.0",
       "port-version": 8


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
