### PR TITLE
[rtabmap] don't depend on nonexistent features

### DIFF
--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rtabmap",
   "version": "0.21.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Real-Time Appearance-Based Mapping",
   "homepage": "https://introlab.github.io/rtabmap/",
   "license": "BSD-3-Clause",
@@ -119,10 +119,7 @@
       "dependencies": [
         {
           "name": "realsense2",
-          "default-features": false,
-          "features": [
-            "tm2"
-          ]
+          "default-features": false
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7298,7 +7298,7 @@
     },
     "rtabmap": {
       "baseline": "0.21.0",
-      "port-version": 1
+      "port-version": 2
     },
     "rtaudio": {
       "baseline": "2021-11-16",

--- a/versions/r-/rtabmap.json
+++ b/versions/r-/rtabmap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63d580588bb49ec2767eed209af0c854cc2d5da2",
+      "version": "0.21.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "6a0ba7b4b9ea0239aa474d40263d96919a81958c",
       "version": "0.21.0",
       "port-version": 1


### PR DESCRIPTION
There is no feature "tm2" in realsense2 (there was in a previous version)

Detected by https://github.com/microsoft/vcpkg-tool/pull/802