### PR TITLE
[yaml-cpp] Update to 0.8.0

### DIFF
--- a/ports/yaml-cpp/portfile.cmake
+++ b/ports/yaml-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jbeder/yaml-cpp
-    REF 0579ae3d976091d7d664aa9d2527e0d0cff25763 # yaml-cpp-0.7.0
-    SHA512 930f13737c23faf06be3fa9821492d6c677359e532212ced495173367a8aec45f87fbf3a5da47d4d1b61a95c25e0101bc7f8d175752434c63b25e097186e1745
+    REF "${VERSION}"
+    SHA512 aae9d618f906117d620d63173e95572c738db518f4ff1901a06de2117d8deeb8045f554102ca0ba4735ac0c4d060153a938ef78da3e0da3406d27b8298e5f38e
     HEAD_REF master
 )
 
@@ -19,24 +19,20 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/yaml-cpp")
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/yaml-cpp.pc" "-lyaml-cpp" "-lyaml-cppd")
 endif()
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
 vcpkg_fixup_pkgconfig()
 
-# Remove debug include and pkgconfig files
+# Remove debug include
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/yaml-cpp/dll.h" "#ifdef YAML_CPP_DLL" "#if 1")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/yaml-cpp/dll.h" "#ifdef YAML_CPP_STATIC_DEFINE" "#if 0")
 else()
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/yaml-cpp/dll.h" "#ifdef YAML_CPP_DLL" "#if 0")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/yaml-cpp/dll.h" "#ifdef YAML_CPP_STATIC_DEFINE" "#if 1")
 endif()
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/yaml-cpp/portfile.cmake
+++ b/ports/yaml-cpp/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 aae9d618f906117d620d63173e95572c738db518f4ff1901a06de2117d8deeb8045f554102ca0ba4735ac0c4d060153a938ef78da3e0da3406d27b8298e5f38e
     HEAD_REF master
+    PATCHES
+        "yaml-cpp-pr-1212.patch"
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" YAML_BUILD_SHARED_LIBS)
@@ -14,12 +16,13 @@ vcpkg_cmake_configure(
         -DYAML_CPP_BUILD_TOOLS=OFF
         -DYAML_CPP_BUILD_TESTS=OFF
         -DYAML_BUILD_SHARED_LIBS=${YAML_BUILD_SHARED_LIBS}
+        -DYAML_CPP_INSTALL_CMAKEDIR=share/${PORT}
 )
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/yaml-cpp")
+vcpkg_cmake_config_fixup()
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/yaml-cpp.pc" "-lyaml-cpp" "-lyaml-cppd")
 endif()

--- a/ports/yaml-cpp/vcpkg.json
+++ b/ports/yaml-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "yaml-cpp",
-  "version-semver": "0.7.0",
-  "port-version": 1,
+  "version-semver": "0.8.0",
   "description": "yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec.",
   "homepage": "https://github.com/jbeder/yaml-cpp",
   "documentation": "https://codedocs.xyz/jbeder/yaml-cpp/index.html",

--- a/ports/yaml-cpp/yaml-cpp-pr-1212.patch
+++ b/ports/yaml-cpp/yaml-cpp-pr-1212.patch
@@ -1,0 +1,77 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 46dc180..5055c24 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,6 +31,8 @@ cmake_dependent_option(YAML_CPP_BUILD_TESTS
+ cmake_dependent_option(YAML_MSVC_SHARED_RT
+   "MSVC: Build yaml-cpp with shared runtime libs (/MD)" ON
+   "CMAKE_SYSTEM_NAME MATCHES Windows" OFF)
++set(YAML_CPP_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/yaml-cpp"
++  CACHE STRING "Path to install the CMake package to")
+  
+ if (YAML_CPP_FORMAT_SOURCE)
+     find_program(YAML_CPP_CLANG_FORMAT_EXE NAMES clang-format)
+@@ -143,13 +145,12 @@ set_target_properties(yaml-cpp PROPERTIES
+   PROJECT_LABEL "yaml-cpp ${yaml-cpp-label-postfix}"
+   DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
+ 
+-set(CONFIG_EXPORT_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/yaml-cpp")
+-set(EXPORT_TARGETS yaml-cpp)
++set(EXPORT_TARGETS yaml-cpp::yaml-cpp)
+ configure_package_config_file(
+   "${PROJECT_SOURCE_DIR}/yaml-cpp-config.cmake.in"
+   "${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
+-  INSTALL_DESTINATION "${CONFIG_EXPORT_DIR}"
+-  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR CONFIG_EXPORT_DIR YAML_BUILD_SHARED_LIBS)
++  INSTALL_DESTINATION "${YAML_CPP_INSTALL_CMAKEDIR}"
++  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR)
+ unset(EXPORT_TARGETS)
+ 
+ write_basic_package_version_file(
+@@ -169,15 +170,14 @@ if (YAML_CPP_INSTALL)
+                 FILES_MATCHING PATTERN "*.h")
+   install(EXPORT yaml-cpp-targets
+     NAMESPACE yaml-cpp::
+-    DESTINATION "${CONFIG_EXPORT_DIR}")
++    DESTINATION "${YAML_CPP_INSTALL_CMAKEDIR}")
+   install(FILES
+       "${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
+       "${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
+-    DESTINATION "${CONFIG_EXPORT_DIR}")
++    DESTINATION "${YAML_CPP_INSTALL_CMAKEDIR}")
+   install(FILES "${PROJECT_BINARY_DIR}/yaml-cpp.pc"
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ endif()
+-unset(CONFIG_EXPORT_DIR)
+ 
+ if(YAML_CPP_BUILD_TESTS)
+   add_subdirectory(test)
+
+diff --git a/yaml-cpp-config.cmake.in b/yaml-cpp-config.cmake.in
+index 799b9b418..f71e13b8f 100644
+--- a/yaml-cpp-config.cmake.in
++++ b/yaml-cpp-config.cmake.in
+@@ -11,12 +11,20 @@ set_and_check(YAML_CPP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+ set_and_check(YAML_CPP_LIBRARY_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
+ 
+ # Are we building shared libraries?
+-set(YAML_CPP_SHARED_LIBS_BUILT "@PACKAGE_YAML_BUILD_SHARED_LIBS@")
++set(YAML_CPP_SHARED_LIBS_BUILT @YAML_BUILD_SHARED_LIBS@)
+ 
+ # Our library dependencies (contains definitions for IMPORTED targets)
+-include(@PACKAGE_CONFIG_EXPORT_DIR@/yaml-cpp-targets.cmake)
++include("${CMAKE_CURRENT_LIST_DIR}/yaml-cpp-targets.cmake")
+ 
+ # These are IMPORTED targets created by yaml-cpp-targets.cmake
+ set(YAML_CPP_LIBRARIES "@EXPORT_TARGETS@")
+ 
+-check_required_components(@EXPORT_TARGETS@)
++add_library(yaml-cpp INTERFACE IMPORTED)
++target_link_libraries(yaml-cpp INTERFACE yaml-cpp::yaml-cpp)
++if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
++  set_target_properties(yaml-cpp PROPERTIES 
++    DEPRECATION "The target yaml-cpp is deprecated and will be removed in version 0.10.0. Use the yaml-cpp::yaml-cpp target instead."
++  )
++endif()
++
++check_required_components(yaml-cpp)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9197,8 +9197,8 @@
       "port-version": 4
     },
     "yaml-cpp": {
-      "baseline": "0.7.0",
-      "port-version": 1
+      "baseline": "0.8.0",
+      "port-version": 0
     },
     "yara": {
       "baseline": "4.3.2",

--- a/versions/y-/yaml-cpp.json
+++ b/versions/y-/yaml-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "595f95f94e93c518b99e8c0e83ef35ced9e7867a",
+      "version-semver": "0.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a79d9c026aefee69214dbd39294da49398b07c7b",
       "version-semver": "0.7.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

A few additional tweaks were made to the portfile, notably:
- The install location for the CMake configs and pkg-config files were moved from `share` to `lib`, so moving the pc files manually is no longer needed.
- `YAML_CPP_DLL` is no longer used in `dll.h`, instead replaced with `YAML_CPP_STATIC_DEFINE`. The inline patch was updated as such. Moreover, it was extended to non-Windows platforms as it also applies to them.