### PR TITLE
[drlibs] Update to 2023-08-16

### DIFF
--- a/ports/drlibs/portfile.cmake
+++ b/ports/drlibs/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mackron/dr_libs
-    REF dd762b861ecadf5ddd5fb03e9ca1db6707b54fbb
-    SHA512 4ec10ea1d9622879b5bdb61a11768e36b56a558d32aac6f8c8a52168ab401f9d53db0eeba074fe56de39f3809fb0bd73e2e6c5ef4ea8fd158abeb45e18285f08
+    REF d35a3bc5efd02455d98cbe12b94647136f09b42d
+    SHA512 34126c8eb65f0735b77f058db9f1618b3c4e820698804b47f7a629c47df571e9cbbeefd4cce193409ebd715d37ed5faf1c3c27a7240e0f5418089cffe853f1ea
     HEAD_REF master
 )
 
@@ -11,5 +11,4 @@ vcpkg_from_github(
 file(GLOB HEADER_FILES "${SOURCE_PATH}/*.h")
 file(COPY ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-# Put the licence file where vcpkg expects it
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/drlibs/vcpkg.json
+++ b/ports/drlibs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "drlibs",
-  "version-date": "2022-09-26",
+  "version-date": "2023-08-16",
   "description": "Single-file audio decoding libraries for C/C++",
   "homepage": "https://github.com/mackron/dr_libs",
   "license": "Unlicense OR MIT-0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2213,7 +2213,7 @@
       "port-version": 0
     },
     "drlibs": {
-      "baseline": "2022-09-26",
+      "baseline": "2023-08-16",
       "port-version": 0
     },
     "drogon": {

--- a/versions/d-/drlibs.json
+++ b/versions/d-/drlibs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54c4836e6d8403c42520823d58b89c4632201f61",
+      "version-date": "2023-08-16",
+      "port-version": 0
+    },
+    {
       "git-tree": "2b4bfd32103ed7afb27e12281caf95c81930c955",
       "version-date": "2022-09-26",
       "port-version": 0


### PR DESCRIPTION
Updates drlibs to 2023-08-16

* [x]  Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
* [x]  SHA512s are updated for each updated download
* [x]  The "supports" clause reflects platforms that may be fixed by this new version
* [x]  Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
* [x]  Any patches that are no longer applied are deleted from the port's directory.
* [x]  The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
* [x]  Only one version is added to each modified port's versions file.