### PR TITLE
[cista] Bump to 0.14

### DIFF
--- a/ports/cista/portfile.cmake
+++ b/ports/cista/portfile.cmake
@@ -1,12 +1,12 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO felixguendling/cista
     REF "v${VERSION}"
-    SHA512 303d622416e72f771b6fa2b1c7b7ca4cfed3091d89409c96262571162754c9d6d99b62a930c137e01fd8c74a8f46b76ac3a1d86387c918414e26c8a2a8ffd930
+    SHA512 bf5c5f527eb2b63775fd9f2e99f60a0ed19bd9805f38bf3e55f4995e01ecaf31c95dcd555520e12b3a1b9d039f702b9c9a4fdec74b9547136e336b5adf78689d
     HEAD_REF master
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -18,9 +18,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/cista)
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug"
-    "${CURRENT_PACKAGES_DIR}/lib"
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cista/usage
+++ b/ports/cista/usage
@@ -1,0 +1,4 @@
+cista provides CMake targets:
+
+    find_package(cista CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE cista::cista)

--- a/ports/cista/vcpkg.json
+++ b/ports/cista/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cista",
-  "version": "0.11",
+  "version": "0.14",
   "description": "Cista is a simple, high-performance, zero-copy C++ serialization & reflection library.",
   "homepage": "https://github.com/felixguendling/cista",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1545,7 +1545,7 @@
       "port-version": 0
     },
     "cista": {
-      "baseline": "0.11",
+      "baseline": "0.14",
       "port-version": 0
     },
     "cityhash": {

--- a/versions/c-/cista.json
+++ b/versions/c-/cista.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fa4647485a95f3a0c72bf81938a4307ef0fa694",
+      "version": "0.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d9245928fb19ec93b7c1e98bd5acc2e8e56faa3",
       "version": "0.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
