### PR TITLE
[azure-kinect-sensor-sdk] fix imgui delete function

### DIFF
--- a/ports/azure-kinect-sensor-sdk/fix-build-imgui.patch
+++ b/ports/azure-kinect-sensor-sdk/fix-build-imgui.patch
@@ -11,3 +11,47 @@ index 4289f71..407e912 100644
      }
  
      ImGui::EndChild();
+diff --git a/tools/k4aviewer/k4adevicedockcontrol.cpp b/tools/k4aviewer/k4adevicedockcontrol.cpp
+index 8fe5687..6d1e95a 100644
+--- a/tools/k4aviewer/k4adevicedockcontrol.cpp
++++ b/tools/k4aviewer/k4adevicedockcontrol.cpp
+@@ -333,7 +333,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
+
+     if (m_firstRun || depthEnabledStateChanged)
+     {
+-        ImGui::SetNextTreeNodeOpen(m_config.EnableDepthCamera);
++        ImGui::SetNextItemOpen(m_config.EnableDepthCamera);
+     }
+
+     ImGui::Indent();
+@@ -376,7 +376,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
+
+     if (m_firstRun || colorEnableStateChanged)
+     {
+-        ImGui::SetNextTreeNodeOpen(m_config.EnableColorCamera);
++        ImGui::SetNextItemOpen(m_config.EnableColorCamera);
+     }
+
+     ImGui::Indent();
+@@ -710,7 +710,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
+
+     if (m_firstRun && (m_syncInConnected || m_syncOutConnected))
+     {
+-        ImGui::SetNextTreeNodeOpen(true);
++        ImGui::SetNextItemOpen(true);
+     }
+     if (ImGui::TreeNode("External Sync"))
+     {
+diff --git a/tools/k4aviewer/k4asourceselectiondockcontrol.cpp b/tools/k4aviewer/k4asourceselectiondockcontrol.cpp
+index 812608b..31e961d 100644
+--- a/tools/k4aviewer/k4asourceselectiondockcontrol.cpp
++++ b/tools/k4aviewer/k4asourceselectiondockcontrol.cpp
+@@ -34,7 +34,7 @@ K4ASourceSelectionDockControl::K4ASourceSelectionDockControl()
+
+ K4ADockControlStatus K4ASourceSelectionDockControl::Show()
+ {
+-    ImGui::SetNextTreeNodeOpen(true, ImGuiCond_FirstUseEver);
++    ImGui::SetNextItemOpen(true, ImGuiCond_FirstUseEver);
+     if (ImGui::TreeNode("Open Device"))
+     {
+         ImGuiExtensions::K4AComboBox("Device S/N",

--- a/ports/azure-kinect-sensor-sdk/portfile.cmake
+++ b/ports/azure-kinect-sensor-sdk/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
         fix-dependency-imgui.patch
         fix-linux.patch
         fix-calibration-c.patch
-        fix-build-imgui.patch
+        fix-build-imgui.patch #https://github.com/microsoft/Azure-Kinect-Sensor-SDK/pull/1945
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/azure-kinect-sensor-sdk/vcpkg.json
+++ b/ports/azure-kinect-sensor-sdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-kinect-sensor-sdk",
   "version": "1.4.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Azure Kinect SDK is a cross platform (Linux and Windows) user mode SDK to read data from your Azure Kinect device.",
   "homepage": "https://github.com/microsoft/Azure-Kinect-Sensor-SDK",
   "supports": "linux | windows",

--- a/versions/a-/azure-kinect-sensor-sdk.json
+++ b/versions/a-/azure-kinect-sensor-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c18d1979e92816401a8f8c529fc69f6fdca27d63",
+      "version": "1.4.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "e2a1e6a1a145f9436731cbcc9019f807325298c1",
       "version": "1.4.1",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -426,7 +426,7 @@
     },
     "azure-kinect-sensor-sdk": {
       "baseline": "1.4.1",
-      "port-version": 5
+      "port-version": 6
     },
     "azure-macro-utils-c": {
       "baseline": "2022-01-21",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/33137
```
buildtrees\azure-kinect-sensor-sdk\src\v1.4.1-4fd9fcd081.clean\tools\k4aviewer\k4adevicedockcontrol.cpp(336): error C2039: 'SetNextTreeNodeOpen': is not a member of 'ImGui'
buildtrees\azure-kinect-sensor-sdk\src\v1.4.1-4fd9fcd081.clean\tools\k4aviewer\k4asourceselectiondockcontrol.cpp(37): error C2039: 'SetNextTreeNodeOpen': is not a member of 'ImGui'
```
Replace the deleted function SetNextTreeNodeOpen in imgui with SetNextItemOpen.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```