### PR TITLE
[restinio] Update to 0.6.19

### DIFF
--- a/ports/restinio/portfile.cmake
+++ b/ports/restinio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stiffstream/restinio
     REF "v.${VERSION}"
-    SHA512 8a535ebcdfb53ef9f669bbd007d11b6d95bae87b1a8b8403556910e4904483bfcaeb88fa2ee5522c9bef048a9276cbdb1fa15ec62b5bd158fc585b0e84cf046b
+    SHA512 0d69567a68f17f3ad30978f1ee165e673f77332f519c2e9429284d87886f90c0dea46b8dcaedb55cf4c1611eca79b9196178e37deb56ad89272ca19382f290bc
     PATCHES
         fix-cmake-config.diff
         fix-project.diff

--- a/ports/restinio/vcpkg.json
+++ b/ports/restinio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "restinio",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "A header-only C++14 library that gives you an embedded HTTP/Websocket server targeted primarily for asynchronous processing of HTTP-requests.",
   "homepage": "https://github.com/Stiffstream/restinio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7217,7 +7217,7 @@
       "port-version": 0
     },
     "restinio": {
-      "baseline": "0.6.18",
+      "baseline": "0.6.19",
       "port-version": 0
     },
     "rexo": {

--- a/versions/r-/restinio.json
+++ b/versions/r-/restinio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa95495106621bad74854c9f376a2c5e1b936f05",
+      "version": "0.6.19",
+      "port-version": 0
+    },
+    {
       "git-tree": "f749e69b703a537f74f52fcef9327950e7d56ea9",
       "version": "0.6.18",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- ~~[ ] The "supports" clause reflects platforms that may be fixed by this new version~~
- ~~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file~~.
- ~~[ ] Any patches that are no longer applied are deleted from the port's directory~~.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
