### PR TITLE
[xmlsec] Update to 1.3.1

### DIFF
--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -1,11 +1,11 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
-string(REPLACE "." "_" release_tag "xmlsec-${VERSION}")
+string(REPLACE "." "_" release_tag "xmlsec_${VERSION}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lsh123/xmlsec
     REF "${release_tag}"
-    SHA512 4e4a9d6be76582e207c6c678feeaf1d572e2eac04fb032fa742e059e45f1eeebf664535d723e27cefb7026604cb445faecec0a801dcf65c95ae6d5cf046a0d1f
+    SHA512 c7b867edc23cb6cf08228f9737fc50e3bd08ac7baedc43e26d3cfd113ea54256ff357335b23aea7b5e49cd24809c3de9da1c9314eb5ab90727aa821530b72ef8
     HEAD_REF master
     PATCHES 
         pkgconfig_fixes.patch

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xmlsec",
-  "version": "1.2.37",
-  "port-version": 2,
+  "version": "1.3.1",
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8905,8 +8905,8 @@
       "port-version": 0
     },
     "xmlsec": {
-      "baseline": "1.2.37",
-      "port-version": 2
+      "baseline": "1.3.1",
+      "port-version": 0
     },
     "xnnpack": {
       "baseline": "2022-02-17",

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ca82fa3b389ead91f8abe51fb628fc1959cf29b",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "716c1bdec11ab1f1053e76b14604a5d166484465",
       "version": "1.2.37",
       "port-version": 2


### PR DESCRIPTION
[x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
[x] SHA512s are updated for each updated download
[x] The "supports" clause reflects platforms that may be fixed by this new version
[x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
[x] Any patches that are no longer applied are deleted from the port's directory.
[x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
[x] Only one version is added to each modified port's versions file.
