### PR TITLE
[sqlcipher] Update to 4.5.4

### DIFF
--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sqlcipher/sqlcipher
     REF "v${VERSION}"
-    SHA512 27dcc83c8088ea32a2bbc3d5493d070e29976dc54ccf91d849df67be19cb553761a32b3613e293a07f50128aeb808d54f363ad12a58a47f06a61a1cc4e1eb0cd
+    SHA512 deb592d6f27e7cc02bd641bb8f6e07b242f0dc6c7d8732e7a1e70e457eadd487add7d95c881fe9afbff516f4641a6e603473e47c63afa8396a0ddf007a5818fd
     HEAD_REF master
 )
 

--- a/ports/sqlcipher/vcpkg.json
+++ b/ports/sqlcipher/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sqlcipher",
-  "version": "4.5.3",
-  "port-version": 2,
+  "version": "4.5.4",
   "description": "SQLCipher extends the SQLite database library to add security enhancements that make it more suitable for encrypted local data storage.",
   "homepage": "https://www.zetetic.net/sqlcipher",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7841,8 +7841,8 @@
       "port-version": 3
     },
     "sqlcipher": {
-      "baseline": "4.5.3",
-      "port-version": 2
+      "baseline": "4.5.4",
+      "port-version": 0
     },
     "sqlite-modern-cpp": {
       "baseline": "3.2-936cd0c8",

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81b4c14ac8275c922f1a972db7452c98b002526b",
+      "version": "4.5.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "d270ac9cc648113c540f9f29e9ab0ebece65e369",
       "version": "4.5.3",
       "port-version": 2


### PR DESCRIPTION
[x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
[x] SHA512s are updated for each updated download
[x] The "supports" clause reflects platforms that may be fixed by this new version
[x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
[x] Any patches that are no longer applied are deleted from the port's directory.
[x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
[x] Only one version is added to each modified port's versions file.
