### PR TITLE
[pybind11] Update to 2.11.1

### DIFF
--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
     REF "v${VERSION}"
-    SHA512 10edfdc499ed70234de0796f79b9f3a7a14d4baf01fb09fedbd9126e0a13d9cdeb213950c53a8f7a67cd6049b1db31efacfe2192098236b242ad3685967ea907
+    SHA512 ed1512ff0bca3bc0a45edc2eb8c77f8286ab9389f6ff1d5cb309be24bc608abbe0df6a7f5cb18c8f80a3bfa509058547c13551c3cd6a759af708fd0cdcdd9e95
     HEAD_REF master
     PATCHES
         fix-debug-link.patch

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pybind11",
-  "version": "2.11.0",
-  "port-version": 1,
+  "version": "2.11.1",
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6593,8 +6593,8 @@
       "port-version": 0
     },
     "pybind11": {
-      "baseline": "2.11.0",
-      "port-version": 1
+      "baseline": "2.11.1",
+      "port-version": 0
     },
     "pystring": {
       "baseline": "1.1.4",

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7001887fb9e72bb5590da8407998dedbb4aa2719",
+      "version": "2.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3aeca2d8bc4821ab8e508e9097386fdaa6f12eef",
       "version": "2.11.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
