### PR TITLE
[llhttp] Fix usage build failure 

### DIFF
--- a/ports/llhttp/fix-usage.patch
+++ b/ports/llhttp/fix-usage.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 65484a7..c13d84e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -75,11 +75,16 @@ function(config_library target)
+         FILE llhttp-config.cmake
+         NAMESPACE llhttp::
+         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp)
++		
++  target_include_directories(${target}
++    PRIVATE include ${CMAKE_CURRENT_BINARY_DIR}
++    INTERFACE $<INSTALL_INTERFACE:include>
++)
+ endfunction(config_library target)
+ 
+ if(BUILD_SHARED_LIBS)
+-  add_library(llhttp_shared SHARED
+-      ${llhttp_src}
++  add_library(llhttp_shared
++      ${LLHTTP_SOURCES}
+   )
+   add_library(llhttp::llhttp ALIAS llhttp_shared)
+   config_library(llhttp_shared)
+@@ -87,13 +92,9 @@ endif()
+ 
+ if(BUILD_STATIC_LIBS)
+   add_library(llhttp_static STATIC
+-      ${llhttp_src}
++      ${LLHTTP_SOURCES}
+   )
+-  if(BUILD_SHARED_LIBS)
+-    add_library(llhttp::llhttp ALIAS llhttp_shared)
+-  else()
+-    add_library(llhttp::llhttp ALIAS llhttp_static)
+-  endif()
++  add_library(llhttp::llhttp ALIAS llhttp_static)
+   config_library(llhttp_static)
+ endif()
+ 

--- a/ports/llhttp/fix-usage.patch
+++ b/ports/llhttp/fix-usage.patch
@@ -1,12 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 65484a7..c13d84e 100644
+index 65484a7..a6c02c2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -75,11 +75,16 @@ function(config_library target)
+@@ -75,6 +75,10 @@ function(config_library target)
          FILE llhttp-config.cmake
          NAMESPACE llhttp::
          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp)
-+		
 +  target_include_directories(${target}
 +    PRIVATE include ${CMAKE_CURRENT_BINARY_DIR}
 +    INTERFACE $<INSTALL_INTERFACE:include>
@@ -14,26 +13,3 @@ index 65484a7..c13d84e 100644
  endfunction(config_library target)
  
  if(BUILD_SHARED_LIBS)
--  add_library(llhttp_shared SHARED
--      ${llhttp_src}
-+  add_library(llhttp_shared
-+      ${LLHTTP_SOURCES}
-   )
-   add_library(llhttp::llhttp ALIAS llhttp_shared)
-   config_library(llhttp_shared)
-@@ -87,13 +92,9 @@ endif()
- 
- if(BUILD_STATIC_LIBS)
-   add_library(llhttp_static STATIC
--      ${llhttp_src}
-+      ${LLHTTP_SOURCES}
-   )
--  if(BUILD_SHARED_LIBS)
--    add_library(llhttp::llhttp ALIAS llhttp_shared)
--  else()
--    add_library(llhttp::llhttp ALIAS llhttp_static)
--  endif()
-+  add_library(llhttp::llhttp ALIAS llhttp_static)
-   config_library(llhttp_static)
- endif()
- 

--- a/ports/llhttp/portfile.cmake
+++ b/ports/llhttp/portfile.cmake
@@ -1,8 +1,12 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nodejs/llhttp
     REF refs/tags/release/v8.1.0
     SHA512 3b79555f734a6a200a790f04f10be6d3ce5bd999c027a43c0900bb408e7d64be38fe4bbe9f15e57e389f07ba26b8089fc6ba5eef3b497742484f0719e92e9722
+    PATCHES
+        fix-usage.patch
 )
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LLHTTP_BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LLHTTP_BUILD_SHARED)
@@ -21,6 +25,7 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(
     CONFIG_PATH "/lib/cmake/${PORT}"
 )
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-MIT")
 

--- a/ports/llhttp/portfile.cmake
+++ b/ports/llhttp/portfile.cmake
@@ -25,7 +25,6 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(
     CONFIG_PATH "/lib/cmake/${PORT}"
 )
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-MIT")
 

--- a/ports/llhttp/vcpkg.json
+++ b/ports/llhttp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llhttp",
   "version": "8.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Port of http_parser to llparse.",
   "homepage": "https://github.com/nodejs/llhttp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5018,7 +5018,7 @@
     },
     "llhttp": {
       "baseline": "8.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "llvm": {
       "baseline": "15.0.7",

--- a/versions/l-/llhttp.json
+++ b/versions/l-/llhttp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f948680a60658154737148ca5917d75db5a7446",
+      "version": "8.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "655fdc5f25da19400df907e4d82fc0b148f02e9d",
       "version": "8.1.0",
       "port-version": 1

--- a/versions/l-/llhttp.json
+++ b/versions/l-/llhttp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4f948680a60658154737148ca5917d75db5a7446",
+      "git-tree": "02d4bf2e1a15712c39a825aa81791f032b06fd10",
       "version": "8.1.0",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes #33237

Fix build error:
````
1> [CMake] CMake Error at out/build/x64-Debug/vcpkg_installed/x64-windows/share/llhttp/llhttp-config.cmake:75 (message):
1> [CMake] The imported target "llhttp::llhttp_shared" references the file
1> [CMake]
1> [CMake] "E:/work_e/others/start-cpp-vcpkg/out/build/x64-Debug/vcpkg_installed/x64-windows/debug/lib/llhttp.lib"
1> [CMake]
1> [CMake] but this file does not exist. Possible reasons include:
1> [CMake]
1> [CMake] * The file was deleted, renamed, or moved to another location.
1> [CMake]
1> [CMake] * An install or uninstall procedure did not complete successfully.
1> [CMake]
1> [CMake] * The installation package was faulty and contained
1> [CMake]
1> [CMake] "E:/work_e/others/start-cpp-vcpkg/out/build/x64-Debug/vcpkg_installed/x64-windows/share/llhttp/llhttp-config.cmake"
1> [CMake]
1> [CMake] but not all the files it references.
1> [CMake]
1> [CMake] Call Stack (most recent call first):
1> [CMake] vcpkg/scripts/buildsystems/vcpkg.cmake:852 (_find_package)
1> [CMake] src/sample-net/CMakeLists.txt:18 (find_package)
1> [CMake] -- Configuring incomplete, errors occurred!
1> [CMake] See also "E:/work_e/others/start-cpp-vcpkg/out/build/x64-Debug/CMakeFiles/CMakeOutput.log".
````
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



Tested usage successfully by llhttp:x64-windows:
````
llhttp provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(llhttp CONFIG REQUIRED)
    target_link_libraries(main PRIVATE llhttp::llhttp_static)
````
