### PR TITLE
[opencascade] Fix usage issue

### DIFF
--- a/ports/opencascade/fix-depend-freetype.patch
+++ b/ports/opencascade/fix-depend-freetype.patch
@@ -8,7 +8,7 @@ index fbcede5..66b127d 100644
      add_definitions (-DHAVE_FREETYPE)
 -    OCCT_INCLUDE_CMAKE_FILE ("adm/cmake/freetype")
 +    find_package(freetype CONFIG REQUIRED)
-+	get_target_property(FREETYPE_INCLUDE_DIR freetype INTERFACE_INCLUDE_DIRECTORIES)
++    get_target_property(FREETYPE_INCLUDE_DIR freetype INTERFACE_INCLUDE_DIRECTORIES)
 +    list (APPEND 3RDPARTY_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR}")
    else()
      OCCT_CHECK_AND_UNSET_GROUP ("3RDPARTY_FREETYPE")

--- a/ports/opencascade/fix-dependence.patch
+++ b/ports/opencascade/fix-dependence.patch
@@ -22,7 +22,7 @@ index c926c49..a0502cc 100644
 +find_dependency(OpenGL)
 +
 +if(@USE_EIGEN@)
-+  find_dependency(Eigen3 REQUIRED)
++  find_dependency(Eigen3)
 +endif()
 +
  # Import OpenCASCADE compile definitions, C and C++ flags for each installed configuration.

--- a/ports/opencascade/fix-dependence.patch
+++ b/ports/opencascade/fix-dependence.patch
@@ -1,16 +1,17 @@
 diff --git a/adm/templates/OpenCASCADEConfig.cmake.in b/adm/templates/OpenCASCADEConfig.cmake.in
-index c926c499..2fbc4023 100644
+index c926c49..a0502cc 100644
 --- a/adm/templates/OpenCASCADEConfig.cmake.in
 +++ b/adm/templates/OpenCASCADEConfig.cmake.in
-@@ -4,6 +4,7 @@
- #
+@@ -5,6 +5,8 @@
  # This file is configured by OpenCASCADE.
  #
-+include(CMakeFindDependencyMacro)
  
++include(CMakeFindDependencyMacro)
++
  if(OpenCASCADE_ALREADY_INCLUDED)
    return()
-@@ -71,6 +72,13 @@ set (OpenCASCADE_WITH_GLES2     @USE_GLES2@)
+ endif()
+@@ -71,6 +73,16 @@ set (OpenCASCADE_WITH_GLES2     @USE_GLES2@)
  @SET_OpenCASCADE_WITH_D3D@
  @SET_OpenCASCADE_WITH_GLX@
  
@@ -19,7 +20,10 @@ index c926c499..2fbc4023 100644
 +endif()
 +
 +find_dependency(OpenGL)
-+find_dependency(Eigen3 REQUIRED)
++
++if(@USE_EIGEN@)
++  find_dependency(Eigen3 REQUIRED)
++endif()
 +
  # Import OpenCASCADE compile definitions, C and C++ flags for each installed configuration.
  file(GLOB CONFIG_FILES "${CMAKE_CURRENT_LIST_DIR}/OpenCASCADECompileDefinitionsAndFlags-*.cmake")

--- a/ports/opencascade/install-include-dir.patch
+++ b/ports/opencascade/install-include-dir.patch
@@ -1,31 +1,19 @@
-From 32c4bdd88555309752215c53842d438cb51bcb62 Mon Sep 17 00:00:00 2001
-From: bloess <josua.bloess@uni-bayreuth.de>
-Date: Mon, 15 Feb 2021 16:26:36 +0100
-Subject: [PATCH] install include-dir
-
----
- CMakeLists.txt | 9 +++++++++
- 1 file changed, 9 insertions(+)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 100d613..464f95a 100644
+index f4ec871..59e5134 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1171,6 +1171,14 @@ foreach (OCCT_MODULE ${OCCT_MODULES})
+@@ -1246,6 +1246,14 @@ foreach (OCCT_MODULE ${OCCT_MODULES})
  endforeach()
  set (OCCT_MODULES_ENABLED ${OCCT_MODULES_ENABLED_SORTED})
  
 +foreach (OCCT_LIBRARY ${OCCT_LIBRARIES})
-+	target_include_directories(
-+		${OCCT_LIBRARY} 
-+		INTERFACE
-+		$<INSTALL_INTERFACE:include>)
-+
++  target_include_directories(
++    ${OCCT_LIBRARY} 
++    INTERFACE
++    $<INSTALL_INTERFACE:include>
++    $<INSTALL_INTERFACE:include/opencascade>)
 +endforeach()
 +
  # Add all targets to the build-tree export set
  export (TARGETS ${OCCT_LIBRARIES} FILE "${CMAKE_BINARY_DIR}/OpenCASCADETargets.cmake")
  
--- 
-2.14.3.windows.1
-

--- a/ports/opencascade/vcpkg.json
+++ b/ports/opencascade/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencascade",
   "version": "7.6.2",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Open CASCADE Technology (OCCT) is an open-source software development platform for 3D CAD, CAM, CAE.",
   "homepage": "https://github.com/Open-Cascade-SAS/OCCT",
   "license": "LGPL-2.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5970,7 +5970,7 @@
     },
     "opencascade": {
       "baseline": "7.6.2",
-      "port-version": 6
+      "port-version": 7
     },
     "opencc": {
       "baseline": "1.1.6",

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b8e93e7c547cc79733f726011d00fdfa49993cb",
+      "version": "7.6.2",
+      "port-version": 7
+    },
+    {
       "git-tree": "3a62400394101d54a0bea8a45ac0c1f68cf27b68",
       "version": "7.6.2",
       "port-version": 6

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9b8e93e7c547cc79733f726011d00fdfa49993cb",
+      "git-tree": "23b7ba4d766b45ff9e93dae282a3f8e461a57dcc",
       "version": "7.6.2",
       "port-version": 7
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33138

1. Add additional header file paths.
2. Add conditions to control whether to search for `eigen3`. Perhaps `eigen3` can be treated as a feature of `opencascade`.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
