### PR TITLE
[vsgxchange] New port

### DIFF
--- a/ports/vsgxchange/portfile.cmake
+++ b/ports/vsgxchange/portfile.cmake
@@ -10,10 +10,10 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         assimp   VSGXCHANGE_WITH_ASSIMP
-		curl     VSGXCHANGE_WITH_CURL
-		freetype VSGXCHANGE_WITH_FREETYPE
-		gdal     VSGXCHANGE_WITH_GDAL
-		openexr  VSGXCHANGE_WITH_OPENEXR
+	curl     VSGXCHANGE_WITH_CURL
+	freetype VSGXCHANGE_WITH_FREETYPE
+	gdal     VSGXCHANGE_WITH_GDAL
+	openexr  VSGXCHANGE_WITH_OPENEXR
 )
 
 vcpkg_cmake_configure(

--- a/ports/vsgxchange/portfile.cmake
+++ b/ports/vsgxchange/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO vsg-dev/vsgXchange
+    REF "v${VERSION}"
+    SHA512 488bdc9fdbd61cc083675b2970cea9ab307827aa80f05220a21d6f831d308e1bb8e65c288f96e37561903759212b9f5f1269eb4fcf898b8c91b1e50733c71c40
+    HEAD_REF master
+    PATCHES require-features.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        assimp   VSGXCHANGE_WITH_ASSIMP
+		curl     VSGXCHANGE_WITH_CURL
+		freetype VSGXCHANGE_WITH_FREETYPE
+		gdal     VSGXCHANGE_WITH_GDAL
+		openexr  VSGXCHANGE_WITH_OPENEXR
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "vsgxchange" CONFIG_PATH "lib/cmake/vsgXchange")
+vcpkg_copy_pdbs()
+
+vcpkg_copy_tools(TOOL_NAMES vsgconv AUTO_CLEAN)
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/vsgconvd${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/vsgxchange/portfile.cmake
+++ b/ports/vsgxchange/portfile.cmake
@@ -22,7 +22,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "vsgxchange" CONFIG_PATH "lib/cmake/vsgXchange")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "vsgXchange" CONFIG_PATH "lib/cmake/vsgXchange")
 vcpkg_copy_pdbs()
 
 vcpkg_copy_tools(TOOL_NAMES vsgconv AUTO_CLEAN)

--- a/ports/vsgxchange/require-features.patch
+++ b/ports/vsgxchange/require-features.patch
@@ -1,0 +1,66 @@
+diff --git a/src/assimp/build_vars.cmake b/src/assimp/build_vars.cmake
+index 1e413fc..49d77d4 100644
+--- a/src/assimp/build_vars.cmake
++++ b/src/assimp/build_vars.cmake
+@@ -1,7 +1,6 @@
+ # add assimp if available
+-find_package(assimp 5.1 QUIET)
+-if(NOT assimp_FOUND)
+-find_package(assimp 5.0 QUIET)
++if (VSGXCHANGE_WITH_ASSIMP)
++find_package(assimp REQUIRED)
+ endif()
+ 
+ 
+diff --git a/src/curl/build_vars.cmake b/src/curl/build_vars.cmake
+index 015b68c..a4afc8a 100644
+--- a/src/curl/build_vars.cmake
++++ b/src/curl/build_vars.cmake
+@@ -1,5 +1,7 @@
+ # add CURL if available
+-find_package(CURL)
++if(VSGXCHANGE_WITH_CURL)
++find_package(CURL REQUIRED)
++endif()
+ 
+ if(CURL_FOUND)
+     OPTION(vsgXchange_curl "Optional CURL support provided" ON)
+diff --git a/src/freetype/build_vars.cmake b/src/freetype/build_vars.cmake
+index cb63a8b..327db9e 100644
+--- a/src/freetype/build_vars.cmake
++++ b/src/freetype/build_vars.cmake
+@@ -1,5 +1,7 @@
+ # add freetype if available
+-find_package(Freetype)
++if(VSGXCHANGE_WITH_FREETYPE)
++find_package(Freetype REQUIRED)
++endif()
+ 
+ if(FREETYPE_FOUND)
+     OPTION(vsgXchange_freetype "Freetype support provided" ON)
+diff --git a/src/gdal/build_vars.cmake b/src/gdal/build_vars.cmake
+index dd240b0..227c6b7 100644
+--- a/src/gdal/build_vars.cmake
++++ b/src/gdal/build_vars.cmake
+@@ -1,5 +1,7 @@
+ # add GDAL if available
+-find_package(GDAL QUIET)
++if(VSGXCHANGE_WITH_GDAL)
++find_package(GDAL REQUIRED)
++endif()
+ 
+ if(GDAL_FOUND)
+     OPTION(vsgXchange_GDAL "GDAL support provided" ON)
+diff --git a/src/openexr/build_vars.cmake b/src/openexr/build_vars.cmake
+index c4c880a..3ab27c8 100644
+--- a/src/openexr/build_vars.cmake
++++ b/src/openexr/build_vars.cmake
+@@ -1,5 +1,7 @@
+ # add openexr if available
+-find_package(OpenEXR QUIET)
++if(VSGXCHANGE_WITH_OPENEXR)
++find_package(OpenEXR REQUIRED)
++endif()
+ 
+ if(OpenEXR_FOUND)
+     OPTION(vsgXchange_openexr "Optional OpenEXR support provided" ON)

--- a/ports/vsgxchange/vcpkg.json
+++ b/ports/vsgxchange/vcpkg.json
@@ -1,0 +1,50 @@
+{
+  "name": "vsgxchange",
+  "version": "1.0.4",
+  "description": "Utility library for converting 3rd party images, models and fonts formats to/from VulkanSceneGraph.",
+  "homepage": "https://github.com/vsg-dev/vsgXchange",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "vsg"
+  ],
+  "features": {
+    "assimp": {
+      "description": "Enable support for reading 3D model formats as vsg::Node via Assimp",
+      "dependencies": [
+        "assimp"
+      ]
+    },
+    "curl": {
+      "description": "Enable support for reading image and model files from http:// and https://",
+      "dependencies": [
+        "curl"
+      ]
+    },
+    "freetype": {
+      "description": "Enable support for reading fonts as vsg::Font via Freetype",
+      "dependencies": [
+        "freetype"
+      ]
+    },
+    "gdal": {
+      "description": "Enable support for reading geospatial data formats as vsg::Data via GDAL",
+      "dependencies": [
+        "gdal"
+      ]
+    },
+    "openexr": {
+      "description": "Enable support for reading EXR files as vsg::Data",
+      "dependencies": [
+        "openexr"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8632,6 +8632,10 @@
       "baseline": "1.0.6",
       "port-version": 0
     },
+    "vsgxchange": {
+      "baseline": "1.0.4",
+      "port-version": 0
+    },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",
       "port-version": 9

--- a/versions/v-/vsgxchange.json
+++ b/versions/v-/vsgxchange.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "082fe12fc41bc78fc13e3dfc307b7113b2a4d7ee",
+      "version": "1.0.4",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/v-/vsgxchange.json
+++ b/versions/v-/vsgxchange.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c24ffec2c3dc4ce9ff624a7809d7bc79b703f98c",
+      "git-tree": "4019eb900d9064c6cb03767678bf82dd9860033e",
       "version": "1.0.4",
       "port-version": 0
     }

--- a/versions/v-/vsgxchange.json
+++ b/versions/v-/vsgxchange.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "082fe12fc41bc78fc13e3dfc307b7113b2a4d7ee",
+      "git-tree": "c24ffec2c3dc4ce9ff624a7809d7bc79b703f98c",
       "version": "1.0.4",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

