### PR TITLE
[qcoro-qt5] New port

### DIFF
--- a/ports/qcoro-qt5/portfile.cmake
+++ b/ports/qcoro-qt5/portfile.cmake
@@ -1,0 +1,59 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO danvratil/qcoro
+    REF "v0.9.0"
+    SHA512 f708e1a82861c39434d6934172246c3280864e933b333b56c0471f1a629f9da65554d1508af4291ac2257ad8df2040655394ae5525d728710de5bd83cef8fbee
+    HEAD_REF main
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS EXTRA_OPTIONS
+    FEATURES
+        dbus        QCORO_WITH_QTDBUS
+        network     QCORO_WITH_QTNETWORK
+        websockets  QCORO_WITH_QTWEBSOCKETS
+        quick       QCORO_WITH_QTQUICK
+        qml         QCORO_WITH_QML
+        test        QCORO_WITH_QTTEST
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DUSE_QT_VERSION=5
+        -DBUILD_TESTING=OFF
+        -DQCORO_BUILD_EXAMPLES=OFF
+        ${EXTRA_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+if (QCORO_WITH_QTDBUS)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME QCoro5DBus DO_NOT_DELETE_PARENT_CONFIG_PATH CONFIG_PATH lib/cmake/QCoro5DBus)
+endif()
+if (QCORO_WITH_QTNETWORK)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME QCoro5Network DO_NOT_DELETE_PARENT_CONFIG_PATH CONFIG_PATH lib/cmake/QCoro5Network)
+endif()
+if (QCORO_WITH_QTWEBSOCKETS)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME QCoro5WebSockets DO_NOT_DELETE_PARENT_CONFIG_PATH CONFIG_PATH lib/cmake/QCoro5WebSockets)
+endif()
+if (QCORO_WITH_QTQUICK)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME QCoro5Quick DO_NOT_DELETE_PARENT_CONFIG_PATH CONFIG_PATH lib/cmake/QCoro5Quick)
+endif()
+if (QCORO_WITH_QML)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME QCoro5Qml DO_NOT_DELETE_PARENT_CONFIG_PATH CONFIG_PATH lib/cmake/QCoro5Qml)
+endif()
+if (QCORO_WITH_QTTEST)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME QCoro5Test DO_NOT_DELETE_PARENT_CONFIG_PATH CONFIG_PATH lib/cmake/QCoro5Test)
+endif()
+vcpkg_cmake_config_fixup(PACKAGE_NAME QCoro5 DO_NOT_DELETE_PARENT_CONFIG_PATH CONFIG_PATH lib/cmake/QCoro5)
+vcpkg_cmake_config_fixup(PACKAGE_NAME QCoro5Core CONFIG_PATH lib/cmake/QCoro5Core)
+
+# Remove debug includes
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+# Remove mkspec files (not needed here and they would conflict with QCoro6 mkspecs)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/mkspecs")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/mkspecs")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/qcoro-qt5/usage
+++ b/ports/qcoro-qt5/usage
@@ -1,0 +1,25 @@
+qcoro-qt6 provides CMake targets:
+
+    find_package(QCoro6Core CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE QCoro6::Core)
+
+    find_package(QCoro6DBus CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE QCoro6::DBus)
+
+    find_package(QCoro6Network CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE QCoro6::Network)
+
+    find_package(QCoro6Qml CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE QCoro6::Qml)
+
+    find_package(QCoro6Quick CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE QCoro6::Quick)
+
+    find_package(QCoro6Test CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE QCoro6::Test)
+
+    find_package(QCoro6WebSockets CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE QCoro6::WebSockets)
+
+You can also use `QCoro` target namespace for transparent
+support of both Qt5 and Qt6.

--- a/ports/qcoro-qt5/vcpkg.json
+++ b/ports/qcoro-qt5/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "qcoro-qt5",
+  "version": "0.9.0",
+  "description": "Coroutine support for Qt5",
+  "homepage": "https://www.github.com/danvratil/qcoro",
+  "documentation": "https://qcoro.dvratil.cz",
+  "license": "MIT",
+  "supports": "!osx",
+  "dependencies": [
+    "qt5-base",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "dbus",
+    "network",
+    "qml",
+    "quick",
+    "test",
+    "websockets"
+  ],
+  "features": {
+    "dbus": {
+      "description": "Coroutine support for QtDBus module"
+    },
+    "network": {
+      "description": "Coroutine support for QtNetwork module"
+    },
+    "qml": {
+      "description": "Coroutine support for QtQml module",
+      "dependencies": [
+        "qt5-declarative"
+      ]
+    },
+    "quick": {
+      "description": "Coroutine support for QtQuick module",
+      "dependencies": [
+        "qt5-declarative"
+      ]
+    },
+    "test": {
+      "description": "Support code for easier testing of coroutines with QtTest."
+    },
+    "websockets": {
+      "description": "Coroutine support for QtWebSockets module",
+      "dependencies": [
+        "qt5-websockets"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6616,6 +6616,10 @@
       "baseline": "2.3.5",
       "port-version": 2
     },
+    "qcoro-qt5": {
+      "baseline": "0.9.0",
+      "port-version": 0
+    },
     "qcustomplot": {
       "baseline": "2.1.1",
       "port-version": 1

--- a/versions/q-/qcoro-qt5.json
+++ b/versions/q-/qcoro-qt5.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "106250492367a2546176a3a0070dd858ead5e7d4",
+      "version": "0.9.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
