### PR TITLE
[SI] New port

### DIFF
--- a/ports/si/portfile.cmake
+++ b/ports/si/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bernedom/SI
+    REF "${VERSION}"
+    SHA512 499bf6cd1c68cf5195f15b94910d4f3973a040c2d217aab4eacaa29bfefc031b441639272cffb4b810fd27ff3a664d55284c1252da5e4504ebc768d1a3567f78
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSI_INSTALL_LIBRARY=ON
+        -DSI_BUILD_TESTING=OFF
+        -DSI_BUILD_DOC=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME SI CONFIG_PATH share/SI/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/si/usage
+++ b/ports/si/usage
@@ -1,0 +1,4 @@
+si provides CMake targets:
+
+    find_package(SI CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE SI::SI)

--- a/ports/si/vcpkg.json
+++ b/ports/si/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "si",
+  "version": "2.5.1",
+  "description": "A header only C++ library that provides type safety and user defined literals for physical units",
+  "homepage": "https://si.dominikberner.ch/doc/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7592,6 +7592,10 @@
       "baseline": "6.1.4",
       "port-version": 9
     },
+    "si": {
+      "baseline": "2.5.1",
+      "port-version": 0
+    },
     "signalrclient": {
       "baseline": "1.0.0-beta1-9",
       "port-version": 5

--- a/versions/s-/si.json
+++ b/versions/s-/si.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "288cfb02ca17822810538628dab87c6773081160",
+      "version": "2.5.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

