### PR TITLE
[snap7] Fix snap7.h and snap7.cpp missing

### DIFF
--- a/ports/snap7/CMakeLists.txt
+++ b/ports/snap7/CMakeLists.txt
@@ -37,6 +37,8 @@ add_library(${PROJECT_NAME} SHARED "core/s7_client.cpp"
                                    "sys/sol_threads.h"
                                    "sys/unix_threads.h"
                                    "sys/win_threads.h"
+                                   "../release/Wrappers/c-cpp/snap7.h"
+                                   "../release/Wrappers/c-cpp/snap7.cpp"
                                    )
 
 if(MSVC)
@@ -49,6 +51,7 @@ add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/core> $<INSTALL_INTERFACE:include>)
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib> $<INSTALL_INTERFACE:include>)
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sys> $<INSTALL_INTERFACE:include>)
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../release/Wrappers/c-cpp> $<INSTALL_INTERFACE:include>)
 
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME})
 
@@ -63,4 +66,5 @@ if(NOT DISABLE_INSTALL_HEADERS)
   install(DIRECTORY "core/" DESTINATION include/${PROJECT_NAME} FILES_MATCHING PATTERN "*.h")
   install(DIRECTORY "lib/" DESTINATION include/${PROJECT_NAME} FILES_MATCHING PATTERN "*.h")
   install(DIRECTORY "sys/" DESTINATION include/${PROJECT_NAME} FILES_MATCHING PATTERN "*.h")
+  install(DIRECTORY "../release/Wrappers/c-cpp/" DESTINATION include/${PROJECT_NAME} FILES_MATCHING PATTERN "*.h")
 endif()

--- a/ports/snap7/portfile.cmake
+++ b/ports/snap7/portfile.cmake
@@ -21,4 +21,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/snap7/__history")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(INSTALL "${SOURCE_PATH}/lgpl-3.0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/lgpl-3.0.txt")

--- a/ports/snap7/vcpkg.json
+++ b/ports/snap7/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "snap7",
   "version": "1.4.2",
+  "port-version": 1,
   "description": "Snap7",
   "homepage": "https://snap7.sourceforge.net/",
   "license": "LGPL-3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7678,7 +7678,7 @@
     },
     "snap7": {
       "baseline": "1.4.2",
-      "port-version": 0
+      "port-version": 1
     },
     "snappy": {
       "baseline": "1.1.10",

--- a/versions/s-/snap7.json
+++ b/versions/s-/snap7.json
@@ -1,9 +1,14 @@
 {
-    "versions": [
-      {
-        "git-tree": "7239966c661f1446977b064f7dec762248edf8d4",
-        "version": "1.4.2",
-        "port-version": 0
-      }
-    ]
+  "versions": [
+    {
+      "git-tree": "9183c4fc6d65ae695c68f0481e5a7dc0067f65fe",
+      "version": "1.4.2",
+      "port-version": 1
+    },
+    {
+      "git-tree": "7239966c661f1446977b064f7dec762248edf8d4",
+      "version": "1.4.2",
+      "port-version": 0
+    }
+  ]
 }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33285
No feature needs to test.
Usage tested pass on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
