### PR TITLE
[ecal] Add new port

### DIFF
--- a/ports/ecal/0001-disable-app-plugins.patch
+++ b/ports/ecal/0001-disable-app-plugins.patch
@@ -6,7 +6,7 @@ index 4ea1fb066..351fe6c3f 100644
  # --------------------------------------------------------
  # ecal rec addon sdk
  # --------------------------------------------------------
-+if (DBUILD_APPS)
++if (BUILD_APPS)
  add_subdirectory(app/rec/rec_addon_core)
  add_subdirectory(app/rec/rec_addon_dummy)
 +endif()

--- a/ports/ecal/0001-disable-app-plugins.patch
+++ b/ports/ecal/0001-disable-app-plugins.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ea1fb066..351fe6c3f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -351,8 +351,10 @@ endif(HAS_QT5)
+ # --------------------------------------------------------
+ # ecal rec addon sdk
+ # --------------------------------------------------------
++if (DBUILD_APPS)
+ add_subdirectory(app/rec/rec_addon_core)
+ add_subdirectory(app/rec/rec_addon_dummy)
++endif()
+ 
+ # --------------------------------------------------------
+ # ecal time

--- a/ports/ecal/0002-fix-build.patch
+++ b/ports/ecal/0002-fix-build.patch
@@ -1,0 +1,166 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 351fe6c3f..64d5bb384 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -27,7 +27,8 @@ endif (POLICY CMP0077)
+ 
+ list(APPEND CMAKE_MODULE_PATH
+   ${CMAKE_CURRENT_SOURCE_DIR}/cmake
+-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
++  # Removed project specific Module overrides
++)
+ 
+ project(eCAL)
+ set(ECAL_PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}")
+@@ -212,11 +213,13 @@ foreach (dep IN LISTS possible_subprojects)
+   endif ()
+ endforeach()
+ 
++if(NOT DISABLE_FIND_PACKAGE_OVERLOAD)
+ macro(find_package)
+   if(NOT "${ARGV0}" IN_LIST as_subproject)
+     _find_package(${ARGV})
+   endif()
+ endmacro()
++endif()
+ 
+ # if a package does need to be build, include the cmake file with build instructions
+ foreach (dep IN LISTS possible_subprojects)
+@@ -232,7 +235,6 @@ if(MSVC)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_OLD}")
+ endif()
+ 
+-find_package(CMakeFunctions REQUIRED)
+ 
+ git_revision_information(DEFAULT ${ECAL_BUILD_VERSION})
+ set(eCAL_VERSION_MAJOR  ${GIT_REVISION_MAJOR})
+@@ -330,7 +332,9 @@ add_subdirectory(ecal/core)
+ # custom libs
+ # --------------------------------------------------------
+ add_subdirectory(lib/ThreadingUtils)
+-add_subdirectory(lib/CustomTclap)
++# Removed due to only being used by the apps, which are disabled, and for
++# publicly linking tclap::tclap which doesn't exist outside of eCAL
++# add_subdirectory(lib/CustomTclap)
+ add_subdirectory(lib/ecal_utils)
+ 
+ if(HAS_QT5)
+@@ -549,7 +553,9 @@ endif()
+ # --------------------------------------------------------
+ # create package
+ # --------------------------------------------------------
++if(CPACK_PACK_WITH_INNOSETUP)
+ include(cpack/cpack_variables.cmake)
++endif()
+ 
+ message(STATUS "Build Options:")
+ message(STATUS "--------------------------------------------------------------------------------")
+diff --git a/contrib/ecalhdf5/CMakeLists.txt b/contrib/ecalhdf5/CMakeLists.txt
+index 080c40e28..c167bacd4 100644
+--- a/contrib/ecalhdf5/CMakeLists.txt
++++ b/contrib/ecalhdf5/CMakeLists.txt
+@@ -58,7 +58,12 @@ set(ecalhdf5_header_base
+     include/ecalhdf5/eh5_types.h   
+ )
+ 
++if (WIN32)
++# This library, ecal::hdf5 does not export any symbols on Windows. Must be static
++ecal_add_static_library(${PROJECT_NAME} ${ecalhdf5_src} ${ecalhdf5_header_base})
++else()
+ ecal_add_library(${PROJECT_NAME} ${ecalhdf5_src} ${ecalhdf5_header_base})
++endif()
+ add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+ 
+ target_include_directories(${PROJECT_NAME}
+diff --git a/contrib/ecalproto/CMakeLists.txt b/contrib/ecalproto/CMakeLists.txt
+index 04f1a1b9a..58df32705 100644
+--- a/contrib/ecalproto/CMakeLists.txt
++++ b/contrib/ecalproto/CMakeLists.txt
+@@ -37,7 +37,12 @@ set(ecal_protobuf_header
+     include/ecal/protobuf/ecal_proto_visitor.h
+ )
+ 
++if (WIN32)
++# This library, ecal::proto does not export any symbols on Windows. Must be static
++ecal_add_static_library(${PROJECT_NAME} ${ecal_protobuf_src} ${ecal_protobuf_header})
++else()
+ ecal_add_library(${PROJECT_NAME} ${ecal_protobuf_src} ${ecal_protobuf_header})
++endif()
+ add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+ target_include_directories(${PROJECT_NAME} PUBLIC 
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+diff --git a/ecal/core/CMakeLists.txt b/ecal/core/CMakeLists.txt
+index 5c2b6e33d..3c7d57189 100644
+--- a/ecal/core/CMakeLists.txt
++++ b/ecal/core/CMakeLists.txt
+@@ -20,8 +20,6 @@ project(core VERSION ${eCAL_VERSION_STRING})
+ 
+ find_package(Threads      REQUIRED)
+ find_package(asio         REQUIRED)
+-find_package(tclap        REQUIRED)
+-find_package(simpleini    REQUIRED)
+ find_package(tcp_pubsub   REQUIRED)
+ if (ECAL_NPCAP_SUPPORT)
+   find_package(udpcap REQUIRED)
+@@ -492,14 +490,20 @@ target_link_libraries(${PROJECT_NAME}
+     $<$<BOOL:${WIN32}>:wsock32>
+     $<$<BOOL:${QNXNTO}>:socket>
+     asio::asio
+-    tclap::tclap
+-    simpleini::simpleini
+     eCAL::core_pb
+     Threads::Threads
+     eCAL::ecal-utils
+     tcp_pubsub::tcp_pubsub
+ )
+ 
++# tclap is header only and only used for implementation
++find_path(TCLAP_INCLUDE_DIRS "tclap/Arg.h")
++target_include_directories(${PROJECT_NAME}  PRIVATE ${TCLAP_INCLUDE_DIRS})
++
++# simpleini is header only and only used for implementation
++find_path(SIMPLEINI_INCLUDE_DIRS "ConvertUTF.c")
++target_include_directories(${PROJECT_NAME} PRIVATE ${SIMPLEINI_INCLUDE_DIRS})
++
+ set_property(TARGET ${PROJECT_NAME}   PROPERTY FOLDER ecal/core)
+ set_property(TARGET ${PROJECT_NAME}_c PROPERTY FOLDER ecal/core)
+ 
+diff --git a/thirdparty/cmake_functions/CMakeLists.txt b/thirdparty/cmake_functions/CMakeLists.txt
+index b3e93261a..3ba185a97 100644
+--- a/thirdparty/cmake_functions/CMakeLists.txt
++++ b/thirdparty/cmake_functions/CMakeLists.txt
+@@ -40,4 +40,6 @@ foreach (f ${file_list})
+   install( FILES ${f} DESTINATION "${cmake_functions_install_cmake_dir}/${dir}" )
+ endforeach()
+ 
++if(CPACK_PACK_WITH_INNOSETUP)
+ include(cmake/cpack_variables.cmake)
++endif()
+diff --git a/thirdparty/cmake_functions/cmake_functions.cmake b/thirdparty/cmake_functions/cmake_functions.cmake
+index 0c3659e5c..127eb14e6 100644
+--- a/thirdparty/cmake_functions/cmake_functions.cmake
++++ b/thirdparty/cmake_functions/cmake_functions.cmake
+@@ -5,23 +5,12 @@ set (file_list_include
+   target_definitions/targets_protobuf.cmake
+ )
+ 
+-if(WIN32)
+-  list(APPEND file_list_include
+-    qt/qt_msvc_path.cmake
+-    qt/qt_windeployqt.cmake
+-  )
+-endif()
+ 
+ set(file_list_no_include
+   protoc_functions/protoc_generate_cpp.cmake
+   protoc_functions/protoc_generate_python.cmake
+ )
+ 
+-if(WIN32)
+-  list(APPEND file_list_no_include
+-    qt/qt_windeployqt_threadsafe_cmake.bat.in
+-  )
+-endif()
+ 
+ # Set list of all files to be installed by CMake Script.
+ set(file_list

--- a/ports/ecal/0003-fix-dependencies.patch
+++ b/ports/ecal/0003-fix-dependencies.patch
@@ -1,0 +1,20 @@
+diff --git a/contrib/ecalhdf5/CMakeLists.txt b/contrib/ecalhdf5/CMakeLists.txt
+index c167bacd4..45e754340 100644
+--- a/contrib/ecalhdf5/CMakeLists.txt
++++ b/contrib/ecalhdf5/CMakeLists.txt
+@@ -18,9 +18,14 @@
+ 
+ project(hdf5 LANGUAGES C CXX)
+ 
+-if(NOT CMAKE_CROSSCOMPILING)
++if(1)
+   find_package(HDF5 COMPONENTS C REQUIRED)
+   find_package(Threads REQUIRED)
++  if (TARGET hdf5::hdf5-shared)
++    set(ECAL_LINK_HDF5_SHARED 1)
++  else()
++    set(ECAL_LINK_HDF5_SHARED 0)
++  endif()
+ else()
+   find_library(hdf5_path NAMES hdf5 REQUIRED PATH_SUFFIXES hdf5/serial)
+   find_path(hdf5_include NAMES hdf5.h PATH_SUFFIXES hdf5/serial REQUIRED)  

--- a/ports/ecal/0004-install-cmake-files-to-share.patch
+++ b/ports/ecal/0004-install-cmake-files-to-share.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 64d5bb384..1f08d4bab 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -274,7 +274,7 @@ set(eCAL_install_app_dir           ${CMAKE_INSTALL_BINDIR})
+ set(eCAL_install_archive_dir       ${CMAKE_INSTALL_LIBDIR})
+ set(eCAL_install_archive_dyn_dir   ${CMAKE_INSTALL_LIBDIR})
+ set(eCAL_install_bin_dir           ${CMAKE_INSTALL_BINDIR})
+-set(eCAL_install_cmake_dir         ${CMAKE_INSTALL_LIBDIR}/cmake/eCAL)
++set(eCAL_install_cmake_dir         share/eCAL)
+ set(eCAL_install_config_dir        ${CMAKE_INSTALL_SYSCONFDIR}/ecal)
+ set(eCAL_install_doc_dir           ${CMAKE_INSTALL_DOCDIR})
+ set(eCAL_install_include_dir       ${CMAKE_INSTALL_INCLUDEDIR})
+diff --git a/thirdparty/cmake_functions/CMakeLists.txt b/thirdparty/cmake_functions/CMakeLists.txt
+index 3ba185a97..aa9e8a736 100644
+--- a/thirdparty/cmake_functions/CMakeLists.txt
++++ b/thirdparty/cmake_functions/CMakeLists.txt
+@@ -4,12 +4,8 @@ include(cmake_functions.cmake)
+ 
+ project(CMakeFunctions VERSION 0.4.1)
+ 
+-if (MSVC)
+-# Variable definitions
+-set(cmake_functions_install_cmake_dir   cmake)
+-else (MSVC)
+-set(cmake_functions_install_cmake_dir   lib/cmake/${PROJECT_NAME}-${PROJECT_VERSION})
+-endif (MSVC)
++set(cmake_functions_install_cmake_dir "share/${PROJECT_NAME}")
++
+ set(cmake_functions_config              ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake)
+ set(cmake_functions_config_version      ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake)
+ 

--- a/ports/ecal/0005-remove-install-prefix-macro-value.patch
+++ b/ports/ecal/0005-remove-install-prefix-macro-value.patch
@@ -1,0 +1,12 @@
+diff --git a/ecal/core/src/ecal_defs.h.in b/ecal/core/src/ecal_defs.h.in
+index c792a26d1..e5119582b 100644
+--- a/ecal/core/src/ecal_defs.h.in
++++ b/ecal/core/src/ecal_defs.h.in
+@@ -39,6 +39,6 @@
+ #define ECAL_INSTALL_LIB_DIR     "@eCAL_install_lib_dir@"
+ #define ECAL_INSTALL_CONFIG_DIR  "@eCAL_install_config_dir@"
+ #define ECAL_INSTALL_INCLUDE_DIR "@eCAL_install_include_dir@"
+-#define ECAL_INSTALL_PREFIX      "@CMAKE_INSTALL_PREFIX@"
++#define ECAL_INSTALL_PREFIX      ""
+ 
+ #endif // ecal_defs_h_included

--- a/ports/ecal/0006-use-find_dependency-in-cmake-config.patch
+++ b/ports/ecal/0006-use-find_dependency-in-cmake-config.patch
@@ -1,0 +1,36 @@
+diff --git a/cmake/eCALConfig.cmake.in b/cmake/eCALConfig.cmake.in
+index 704da4de8..e8cfb765c 100644
+--- a/cmake/eCALConfig.cmake.in
++++ b/cmake/eCALConfig.cmake.in
+@@ -25,12 +25,21 @@ set(eCAL_VERSION_MAJOR  @eCAL_VERSION_MAJOR@)
+ set(eCAL_VERSION_MINOR  @eCAL_VERSION_MINOR@)
+ set(eCAL_VERSION_PATCH  @eCAL_VERSION_PATCH@)
+ set(eCAL_VERSION_STRING @eCAL_VERSION_STRING@)
++set(eCAL_IS_SHARED @BUILD_SHARED_LIBS@)
+ 
+ # eCAL is provided only with Release and Debug Version, thus map the other configs to Release build.
+ set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release "")
+ set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release "")
+ 
+-find_package(Protobuf REQUIRED)
++include(CMakeFindDependencyMacro)
++find_dependency(Protobuf CONFIG)
++
++# Ensure transitive dependencies are present for static builds
++if(NOT eCAL_IS_SHARED)
++  find_dependency(asio)
++  find_dependency(tcp_pubsub)
++  find_dependency(HDF5)
++endif()
+ 
+ include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_add_functions.cmake")
+ include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_helper_functions.cmake")
+@@ -44,6 +53,6 @@ include("@PACKAGE_eCAL_install_cmake_dir@/eCALTargets.cmake")
+ #  list(APPEND CMAKE_PREFIX_PATH "${PACKAGE_PREFIX_DIR}/../../../../cmake")
+ #endif()
+ 
+-find_package(CMakeFunctions REQUIRED)
++find_dependency(CMakeFunctions CONFIG)
+ 
+-find_package(Threads REQUIRED)
++find_dependency(Threads)

--- a/ports/ecal/0007-allow-static-build-of-core.patch
+++ b/ports/ecal/0007-allow-static-build-of-core.patch
@@ -1,0 +1,74 @@
+diff --git a/ecal/core/CMakeLists.txt b/ecal/core/CMakeLists.txt
+index 3c7d57189..775f8a7c8 100644
+--- a/ecal/core/CMakeLists.txt
++++ b/ecal/core/CMakeLists.txt
+@@ -397,7 +397,7 @@ set(ecal_header_base
+     ${ecal_header_msg}
+ )
+ 
+-ecal_add_ecal_shared_library(${PROJECT_NAME} 
++ecal_add_library(${PROJECT_NAME} 
+     ${ecal_custom_tclap_cpp_src}
+     ${ecal_io_cpp_src} 
+     ${ecal_io_mem_cpp_src} 
+@@ -433,7 +433,7 @@ if(UNIX)
+   set_source_files_properties(src/convert_utf.cpp PROPERTIES COMPILE_FLAGS -Wno-implicit-fallthrough)
+ endif()
+ 
+-ecal_add_ecal_shared_library(${PROJECT_NAME}_c ${ecal_c_src} ${ecal_c_win_src})
++ecal_add_library(${PROJECT_NAME}_c ${ecal_c_src} ${ecal_c_win_src})
+ 
+ add_library(eCAL::${PROJECT_NAME}   ALIAS ${PROJECT_NAME})
+ add_library(eCAL::${PROJECT_NAME}_c ALIAS ${PROJECT_NAME}_c)
+@@ -457,6 +457,11 @@ target_compile_definitions(${PROJECT_NAME}
+     $<$<BOOL:${ECAL_HAS_ROBUST_MUTEX}>:ECAL_HAS_ROBUST_MUTEX>
+     $<$<BOOL:${ECAL_USE_CLOCKLOCK_MUTEX}>:ECAL_USE_CLOCKLOCK_MUTEX>)
+ 
++if(BUILD_SHARED_LIBS)
++  target_compile_definitions(${PROJECT_NAME}_c PUBLIC eCAL_SHARED_LIB)
++  target_compile_definitions(${PROJECT_NAME}   PUBLIC eCAL_SHARED_LIB)
++endif()
++
+ if(ECAL_NPCAP_SUPPORT)
+   target_compile_definitions(${PROJECT_NAME}
+     PRIVATE ECAL_NPCAP_SUPPORT)
+@@ -507,8 +512,8 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${SIMPLEINI_INCLUDE_DIRS})
+ set_property(TARGET ${PROJECT_NAME}   PROPERTY FOLDER ecal/core)
+ set_property(TARGET ${PROJECT_NAME}_c PROPERTY FOLDER ecal/core)
+ 
+-ecal_install_ecal_shared_library(${PROJECT_NAME}_c)
+-ecal_install_ecal_shared_library(${PROJECT_NAME})
++ecal_install_ecal_library(${PROJECT_NAME}_c)
++ecal_install_ecal_library(${PROJECT_NAME})
+ 
+ install(DIRECTORY
+    "include/" DESTINATION "${INSTALL_INCLUDE_DIR}" COMPONENT sdk
+diff --git a/ecal/core/include/ecal/ecal_os.h b/ecal/core/include/ecal/ecal_os.h
+index a962036f2..5d466cc86 100644
+--- a/ecal/core/include/ecal/ecal_os.h
++++ b/ecal/core/include/ecal/ecal_os.h
+@@ -47,7 +47,7 @@
+ #define ECAL_OS_FREEBSD
+ #endif
+ 
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) && defined(eCAL_SHARED_LIB)
+   #ifdef eCAL_EXPORTS
+     #define ECALC_API __declspec(dllexport)
+   #else /* eCAL_EXPORTS */
+@@ -64,11 +64,15 @@
+ #endif
+ 
+ #ifdef _MSC_VER
++  #ifdef eCAL_SHARED_LIB
+   #ifdef eCAL_EXPORTS
+     #define ECALC_API_DEPRECATED __declspec(dllexport deprecated)
+   #else /* eCAL_EXPORTS */
+     #define ECALC_API_DEPRECATED __declspec(dllimport deprecated)
+   #endif /* eCAL_EXPORTS */
++  #else
++    #define ECALC_API_DEPRECATED  
++  #endif
+ #elif defined(__GNUC__) || defined(__clang__)
+   #define ECALC_API_DEPRECATED __attribute__((deprecated))
+ #else

--- a/ports/ecal/portfile.cmake
+++ b/ports/ecal/portfile.cmake
@@ -1,0 +1,78 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO eclipse-ecal/ecal
+    REF v${VERSION}
+    SHA512 e9bc6c579a5331bdecc0384fb1cbac6bf63cb3910e26a4004d48c3a25528fed66413a2c80f4d866d3958d3800579c57a7298e61fca20adf9b24f5daa2e07ed3d
+    HEAD_REF master
+    PATCHES
+        0001-disable-app-plugins.patch
+        0002-fix-build.patch
+        0003-fix-dependencies.patch
+        0004-install-cmake-files-to-share.patch
+        0005-remove-install-prefix-macro-value.patch
+        0006-use-find_dependency-in-cmake-config.patch
+        0007-allow-static-build-of-core.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DHAS_HDF5=ON
+        -DHAS_QT5=OFF
+        -DHAS_CURL=OFF
+        -DHAS_CAPNPROTO=OFF
+        -DHAS_FTXUI=OFF
+        -DBUILD_DOCS=OFF
+        -DBUILD_APPS=OFF
+        -DBUILD_SAMPLES=OFF
+        -DBUILD_TIME=OFF
+        -DBUILD_PY_BINDING=OFF
+        -DBUILD_CSHARP_BINDING=OFF
+        -DBUILD_ECAL_TESTS=OFF
+        -DECAL_INCLUDE_PY_SAMPLES=OFF
+        -DECAL_INSTALL_SAMPLE_SOURCES=OFF
+        -DECAL_JOIN_MULTICAST_TWICE=OFF
+        -DECAL_NPCAP_SUPPORT=OFF
+        -DECAL_THIRDPARTY_BUILD_CMAKE_FUNCTIONS=ON
+        -DECAL_THIRDPARTY_BUILD_SPDLOG=OFF
+        -DECAL_THIRDPARTY_BUILD_TINYXML2=OFF
+        -DECAL_THIRDPARTY_BUILD_FINEFTP=OFF
+        -DECAL_THIRDPARTY_BUILD_TERMCOLOR=OFF
+        -DECAL_THIRDPARTY_BUILD_TCP_PUBSUB=OFF
+        -DECAL_THIRDPARTY_BUILD_RECYCLE=OFF
+        -DECAL_THIRDPARTY_BUILD_FTXUI=OFF
+        -DECAL_THIRDPARTY_BUILD_GTEST=OFF
+        -DECAL_THIRDPARTY_BUILD_UDPCAP=OFF
+        -DECAL_THIRDPARTY_BUILD_PROTOBUF=OFF
+        -DECAL_THIRDPARTY_BUILD_YAML-CPP=OFF
+        -DECAL_THIRDPARTY_BUILD_CURL=OFF
+        -DECAL_THIRDPARTY_BUILD_HDF5=OFF
+        -DCPACK_PACK_WITH_INNOSETUP=OFF
+        -DDISABLE_FIND_PACKAGE_OVERLOAD=ON # From patch, disable find_package macro
+        -DECAL_BUILD_VERSION="${VERSION}"
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME eCAL           CONFIG_PATH share/eCAL)
+vcpkg_cmake_config_fixup(PACKAGE_NAME CMakeFunctions CONFIG_PATH share/CMakeFunctions)
+
+# Remove extra debug files
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# global ini files not strictly required
+if (VCPKG_TARGET_IS_WINDOWS)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cfg" "${CURRENT_PACKAGES_DIR}/debug/cfg")
+else()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/etc" "${CURRENT_PACKAGES_DIR}/debug/etc")
+endif()
+
+# Install copyright and usage
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/ecal/usage
+++ b/ports/ecal/usage
@@ -1,0 +1,4 @@
+The package eCAL provides CMake targets:
+
+    find_package(eCAL CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE eCAL::core eCAL::core_c eCAL::core_pb eCAL::hdf5)

--- a/ports/ecal/vcpkg.json
+++ b/ports/ecal/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "ecal",
+  "version-semver": "5.12.0",
+  "description": "eCAL - enhanced Communication Abstraction Layer",
+  "homepage": "https://eclipse-ecal.github.io/ecal/",
+  "license": "Apache-2.0",
+  "supports": "!emscripten",
+  "dependencies": [
+    "asio",
+    {
+      "name": "hdf5",
+      "default-features": false
+    },
+    {
+      "name": "protobuf",
+      "default-features": false
+    },
+    "simpleini",
+    "tclap",
+    "tcp-pubsub",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2300,6 +2300,10 @@
       "baseline": "1.4.4",
       "port-version": 1
     },
+    "ecal": {
+      "baseline": "5.12.0",
+      "port-version": 0
+    },
     "ecm": {
       "baseline": "5.98.0",
       "port-version": 0

--- a/versions/e-/ecal.json
+++ b/versions/e-/ecal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fe257c2e6381de7721cd905793451f67a286631f",
+      "git-tree": "cfba9f382140cce351a69ed174cc1b93d0c97483",
       "version-semver": "5.12.0",
       "port-version": 0
     }

--- a/versions/e-/ecal.json
+++ b/versions/e-/ecal.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fe257c2e6381de7721cd905793451f67a286631f",
+      "version-semver": "5.12.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Continues: #19802
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.

Important notes:
- Port is static only on Windows due to total lack of dllexport in some components
- Core libraries are now built according to `BUILD_SHARED_LIBS` (previously shared only)
- No apps or plugins are built.
  - Not required for MVP
  - How to handle the plugins correctly was not obvious
- eCAL config files were removed
  - Defaults are used if the file cannot be found
- Value of `ECAL_INSTALL_PREFIX` cleared. The value of this define tells eCAL where to look for plugins and the config file.
  - It needs to resolve to the vcpkg install directory but:
    - It can't be an absolute path
    - It gets resolved relative to the running application
  - I currently do not see a solution to this.
- Yes, this port also installs a CMake package called `CMakeFunctions` hence the two `vcpkg_cmake_config_fixup` calls.
  - The package is provided by eCAL and is expected by users.
  - It does not appear to exist outside of eCAL despite being in a "thirdparty" folder...
- The usage text omits some targets that exist but are more utility targets for eCAL.