### PR TITLE
[tomlplusplus] Migrate build to CMake

### DIFF
--- a/ports/tomlplusplus/portfile.cmake
+++ b/ports/tomlplusplus/portfile.cmake
@@ -6,20 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_configure_meson(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -Dgenerate_cmake_config=true
-        -Dbuild_tests=false
-        -Dbuild_examples=false
-)
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/tomlplusplus)
 
-vcpkg_install_meson()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/tomlplusplus)
-cmake_path(NATIVE_PATH SOURCE_PATH native_source_path)
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/tomlplusplus/tomlplusplusConfig.cmake" "${native_source_path}" "")
-vcpkg_fixup_pkgconfig()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/include/meson.build")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/tomlplusplus/vcpkg.json
+++ b/ports/tomlplusplus/vcpkg.json
@@ -1,17 +1,18 @@
 {
   "name": "tomlplusplus",
   "version": "3.1.0",
+  "port-version": 1,
   "description": "Header-only TOML config file parser and serializer for modern C++.",
   "homepage": "https://marzer.github.io/tomlplusplus/",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
     {
-      "name": "vcpkg-cmake-config",
+      "name": "vcpkg-cmake",
       "host": true
     },
     {
-      "name": "vcpkg-tool-meson",
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8270,7 +8270,7 @@
     },
     "tomlplusplus": {
       "baseline": "3.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "torch-th": {
       "baseline": "2019-04-19",

--- a/versions/t-/tomlplusplus.json
+++ b/versions/t-/tomlplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0b9f3047ec2a403aceeca9442b0b9e40ec0d0ac",
+      "version": "3.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf80fe2b73187c7a5ae1ea2d32cba894c13f7224",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
Migrates the build of tomlplusplus to CMake from meson.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.