### PR TITLE
[libsrtp] Update to 2.5.0 and remove old patch

### DIFF
--- a/ports/libsrtp/portfile.cmake
+++ b/ports/libsrtp/portfile.cmake
@@ -1,16 +1,9 @@
-vcpkg_download_distfile(CMAKE_PR_PATCH
-    URLS https://patch-diff.githubusercontent.com/raw/cisco/libsrtp/pull/573.diff
-    FILENAME libsrtp-pr-573.patch
-    SHA512 58c07977ccbd3dce114f59583a5e10813bbee907af5ef23ec1961b4cfd0791c14326845a376470430978e878c78fb1f598851898a9e9031225628739fb248176
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cisco/libsrtp
-    REF v2.4.2
-    SHA512 6E4805E6D34B2050A6F68F629B0B42356B1D27F2CBAA6CC6166E56957609C3D9AA6B723DCC674E5C74180D122D27BADD2F9496639CCB1E0C210B9E1F7949D0E2
-    PATCHES 
-        ${CMAKE_PR_PATCH}
+    REF "v${VERSION}"
+    SHA512 bd679ab65ccf22ca30fe867b9649a0b84cfa6fad6e22eb10f081141632f6dd56479a04d525b865f11fd46007303ca211065d9c170e4820d6ea7055403702340a
+    PATCHES
         fix-runtime-destination.patch
 )
 
@@ -18,14 +11,13 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DCMAKE_PROJECT_INCLUDE=${CMAKE_CURRENT_LIST_DIR}/cmake-project-include.cmake"
+        -DTEST_APPS=OFF
 )
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(
-    CONFIG_PATH lib/cmake/libSRTP
-)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libSRTP)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libsrtp" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libsrtp/vcpkg.json
+++ b/ports/libsrtp/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "libsrtp",
-  "version": "2.4.2",
-  "port-version": 3,
+  "version": "2.5.0",
   "description": "This package provides an implementation of the Secure Real-time Transport Protocol (SRTP), the Universal Security Transform (UST), and a supporting cryptographic kernel.",
   "homepage": "https://github.com/cisco/libsrtp/",
-  "license": null,
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4649,8 +4649,8 @@
       "port-version": 3
     },
     "libsrtp": {
-      "baseline": "2.4.2",
-      "port-version": 3
+      "baseline": "2.5.0",
+      "port-version": 0
     },
     "libssh": {
       "baseline": "0.10.5",

--- a/versions/l-/libsrtp.json
+++ b/versions/l-/libsrtp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27c325c9851b5c07e172e74e312e8070af7b9d0b",
+      "version": "2.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d66d808ef040f2802ffa00ec6c4728d5603e76f9",
       "version": "2.4.2",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #33305, update `libsrtp` to 2.5.0 and remove old patch.
Usage test passed on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
