### PR TITLE
[many ports] Fix URLS of download patch

### DIFF
--- a/ports/farmhash/portfile.cmake
+++ b/ports/farmhash/portfile.cmake
@@ -2,9 +2,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY) 
 
 vcpkg_download_distfile(WIN_PR_PATCH
-    URLS "https://github.com/google/farmhash/pull/40.diff"
+    URLS "https://github.com/google/farmhash/pull/40.diff?full_index=1"
     FILENAME farmhash-pr-40.patch
-    SHA512 265f5c15c17da2b88c82e6016a181abe73d2d94492cdb0cba892acf67a9d40815d54fa81e07351254fe2a39aea143b125924db0e7df14aac84a7469a78612cbd
+    SHA512 a479450e3e2c4810ef67bb0704c30c2779e12a8768524f179235fae8687d064e62ee225b4b167a30fda59c39de40587629813804f452841badf308e1e76607a7
 )
 
 vcpkg_from_github(

--- a/ports/farmhash/vcpkg.json
+++ b/ports/farmhash/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "farmhash",
   "version": "1.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "FarmHash, a family of hash functions.",
   "homepage": "https://github.com/google/farmhash",
+  "license": "MIT",
   "supports": "!arm"
 }

--- a/ports/gazebo/portfile.cmake
+++ b/ports/gazebo/portfile.cmake
@@ -1,5 +1,5 @@
 vcpkg_download_distfile(gazebo3211
-    URLS "https://patch-diff.githubusercontent.com/raw/osrf/gazebo/pull/3211.diff"
+    URLS "https://patch-diff.githubusercontent.com/raw/osrf/gazebo/pull/3211.diff?full_index=1"
     FILENAME "gazebo3211.diff"
     SHA512 761e254866d4705acc0b81479285f979c436b3b611739a207a575031d8a8daba48de4fc0c8de5edb9a9f89725586c5caeef9e6e1e3d63a2d961ca09df974f7de
 )

--- a/ports/gazebo/vcpkg.json
+++ b/ports/gazebo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gazebo",
   "version-date": "2022-01-20",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Open source robotics simulator.",
   "homepage": "http://gazebosim.org",
   "license": "Apache-2.0",

--- a/ports/ginkgo/portfile.cmake
+++ b/ports/ginkgo/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(WINDOWS_SYMBOLS_PATCH
-    URLS https://github.com/ginkgo-project/ginkgo/commit/7481b2fffb51d73492ef9017045450b29b820f81.diff
+    URLS https://github.com/ginkgo-project/ginkgo/commit/7481b2fffb51d73492ef9017045450b29b820f81.diff?full_index=1
     FILENAME 7481b2fffb51d73492ef9017045450b29b820f81.diff
-    SHA512 f81c57aacc30680383ccfb21ca08987d8ea19a23c0c7bbc5ae590c3c7eca4eed72cea84410357e080e5bb35f08f6b57834b3cdace6d91cc3fde0a1930aa4270a
+    SHA512 f2997dc1af55db2a152092b70097238af77d7345329b9033a19301cfc4d8d494c5c41fbbd9a63b3303697764fc5f799dfe93647bafbbefae8981a978ecaa6a68
 )
 
 vcpkg_from_github(

--- a/ports/ginkgo/vcpkg.json
+++ b/ports/ginkgo/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "ginkgo",
   "version-semver": "1.4.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Ginkgo is a high-performance linear algebra library for manycore systems, with a focus on sparse solution of linear systems. Note that the OpenMP feature is not available on Windows.",
+  "homepage": "https://github.com/ginkgo-project/ginkgo",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/minhook/portfile.cmake
+++ b/ports/minhook/portfile.cmake
@@ -11,9 +11,9 @@ endif()
 # Download files to enable CMake support for minhook - Adds CMakeLists.txt and minhook-config.cmake.in
 vcpkg_download_distfile(
     CMAKE_SUPPORT_PATCH
-    URLS https://github.com/TsudaKageyu/minhook/commit/3f2e34976c1685ee372a09f54c0c8c8f4240ef90.patch
+    URLS https://github.com/TsudaKageyu/minhook/commit/3f2e34976c1685ee372a09f54c0c8c8f4240ef90.patch?full_index=1
     FILENAME minhook-cmake-support.patch
-    SHA512 5f353b167e2c31e5e06258420c78fbae0095368cf687ff06a350d6b69b30476824785dde5dbcea3e30ff827e7cdb293727a73e6b1e6875f00aa891b2980c3877
+    SHA512 7863c51a4563fbc3694149595a7ef301500a1b3b324cc5571b0843386c2fdb5ae10b7e830c9b9fcc973dd17f77f386fd1dedcd493ce8475d2dcf2c44bb7306d0
 )
 
 vcpkg_from_github(

--- a/ports/minhook/vcpkg.json
+++ b/ports/minhook/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "minhook",
   "version": "1.3.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The Minimalistic x86/x64 API Hooking Library for Windows.",
+  "homepage": "https://github.com/TsudaKageyu/minhook",
+  "license": "BSD-2-Clause",
   "supports": "windows & !uwp & !arm",
   "dependencies": [
     {

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -2,8 +2,8 @@ set(USE_QT_VERSION "6")
 
 # https://github.com/opencv/opencv/pull/24043
 vcpkg_download_distfile(ARM64_WINDOWS_FIX
-  URLS https://github.com/opencv/opencv/commit/e5e1a3bfdea96bebda2ad963bc8f6cf17930aef7.patch
-  SHA512 b91b45ac49994c3f4481d5ca04d708d9b063239fd2105e2eb1aae26cc70361ff042e99c51edd67beb9463624147ba77fd562097ab20676bba3b8ce068d455dbc
+  URLS https://github.com/opencv/opencv/commit/e5e1a3bfdea96bebda2ad963bc8f6cf17930aef7.patch?full_index=1
+  SHA512 8ae2544e4a7ece19efe21261acc183f91202ac5352c1ac42fb86bf33d698352eff1b8962422b092240f4e8c7a691e9aa5ef20d6070adcd37e92bb94c6010ce56
   FILENAME opencv4-e5e1a3bfdea96bebda2ad963bc8f6cf17930aef7.patch
 )
 

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/ports/vcpkg-tool-ninja/portfile.cmake
+++ b/ports/vcpkg-tool-ninja/portfile.cmake
@@ -2,9 +2,9 @@ set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
 
 vcpkg_download_distfile(
     LONG_PATH_PATCH
-    URLS "https://patch-diff.githubusercontent.com/raw/ninja-build/ninja/pull/2056.diff" # stable?
+    URLS "https://patch-diff.githubusercontent.com/raw/ninja-build/ninja/pull/2056.diff?full_index=1" # stable?
     FILENAME 2056.diff
-    SHA512 90f17c2cbb5e0c5b41de748f75a3fc3e0c9da8837a0507c8570a49affe15ae7258661dc1f1bc201574847d93ea8b7fe4cbecfffd868395d50ca821033c5f295d
+    SHA512 3c840b19d51a2c145561e3026aee503eccffcc2d1f28db6d848a504c8e163b699fd09cafcfd326a1a95e08f76ec3b07860e2658386229af2bc2573b615cf2fed
 )
 
 vcpkg_from_github(

--- a/ports/vcpkg-tool-ninja/vcpkg.json
+++ b/ports/vcpkg-tool-ninja/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vcpkg-tool-ninja",
   "version-date": "2022-03-31",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Ninja is a small build system with a focus on speed.",
   "homepage": "https://ninja-build.org/",
   "license": "Apache-2.0",

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -7,21 +7,21 @@ set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)
 
 vcpkg_download_distfile(
     STRING_PATCH
-    URLS https://gitlab.kitware.com/vtk/vtk/-/commit/bfa3e4c7621ddf5826755536eb07284c86db6474.diff
+    URLS https://gitlab.kitware.com/vtk/vtk/-/commit/bfa3e4c7621ddf5826755536eb07284c86db6474.diff?full_index=1
     FILENAME vtk-string-bfa3e4.diff
     SHA512 c5ccb1193e4e61cf78b63802f87ffb09349c5566ad8a4d51418133953f7acd6b4a206f8d41a426a9eb9be3cf1fd95242e6402973252d7979e5a9cb5e5e480d78
 )
 
 vcpkg_download_distfile(
     MPI4PY_PATCH_1
-    URLS https://gitlab.kitware.com/vtk/vtk/-/commit/c938d30634a284fad026f6ae25c30bc84cadc07e.diff
+    URLS https://gitlab.kitware.com/vtk/vtk/-/commit/c938d30634a284fad026f6ae25c30bc84cadc07e.diff?full_index=1
     FILENAME vtk-mpi4py-update-part1-c938d3.diff
     SHA512 5704c1dd124075bd8f37b0734c5cebd48b470902c74bc23774fd4b69025dbc6bfddf48b7c4511520ed07f03bd666a444d6390569f02a0ab68b5d966ddde3a989
 )
 
 vcpkg_download_distfile(
     MPI4PY_PATCH_2
-    URLS https://gitlab.kitware.com/vtk/vtk/-/commit/53e6ce92ae4591552e7e00344d69803117d56bfe.diff
+    URLS https://gitlab.kitware.com/vtk/vtk/-/commit/53e6ce92ae4591552e7e00344d69803117d56bfe.diff?full_index=1
     FILENAME vtk-mpi4py-update-part2-53e6ce.diff
     SHA512 794a25bff6168fda94d920a6837c3a690bd6d79284ec34dcd67666c55de78962cc7b73c0f074ce58ed78198bb149eab6bf59b2822f29cbfa792e2fe667c9327c
 )

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.2.0-pv5.11.0",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2454,7 +2454,7 @@
     },
     "farmhash": {
       "baseline": "1.1",
-      "port-version": 5
+      "port-version": 6
     },
     "fast-cpp-csv-parser": {
       "baseline": "2021-01-03",
@@ -2782,7 +2782,7 @@
     },
     "gazebo": {
       "baseline": "2022-01-20",
-      "port-version": 4
+      "port-version": 5
     },
     "gcem": {
       "baseline": "1.16.0",
@@ -2870,7 +2870,7 @@
     },
     "ginkgo": {
       "baseline": "1.4.0",
-      "port-version": 1
+      "port-version": 2
     },
     "gklib": {
       "baseline": "2022-07-27",
@@ -8574,7 +8574,7 @@
     },
     "vcpkg-tool-ninja": {
       "baseline": "2022-03-31",
-      "port-version": 1
+      "port-version": 2
     },
     "vcpkg-tool-nodejs": {
       "baseline": "16.18.0",
@@ -8638,7 +8638,7 @@
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",
-      "port-version": 9
+      "port-version": 10
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5358,7 +5358,7 @@
     },
     "minhook": {
       "baseline": "1.3.3",
-      "port-version": 3
+      "port-version": 4
     },
     "miniaudio": {
       "baseline": "0.11.14",
@@ -6018,7 +6018,7 @@
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 3
+      "port-version": 4
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/f-/farmhash.json
+++ b/versions/f-/farmhash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c4cd2b5f5afa61f7192b3e1b175749317189eb9",
+      "version": "1.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "860c81df38a838331a4a2d7895427248d594e5c5",
       "version": "1.1",
       "port-version": 5

--- a/versions/g-/gazebo.json
+++ b/versions/g-/gazebo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c5ff2241343daba9b2e89620fc5502104b459476",
+      "version-date": "2022-01-20",
+      "port-version": 5
+    },
+    {
       "git-tree": "b1f5088e196340aad31ea3700aceae72df1407ae",
       "version-date": "2022-01-20",
       "port-version": 4

--- a/versions/g-/ginkgo.json
+++ b/versions/g-/ginkgo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "779490458d51f75bc22ed324afceffe0c3b0ee12",
+      "version-semver": "1.4.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "8b8d35300c7b2bd3efcd7e645579df0a9e67d86d",
       "version-semver": "1.4.0",
       "port-version": 1

--- a/versions/m-/minhook.json
+++ b/versions/m-/minhook.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c9751daba9242a47e7beb2e21a4211226aee316f",
+      "version": "1.3.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "fea414bee13115e201fe93699ba5b55c7ae031b8",
       "version": "1.3.3",
       "port-version": 3

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d0ef2f6aa4911ca1cf367093c0b6a89cea97fe3",
+      "version": "4.8.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "d22421d8b63a7e2221f91520e9dcfcce1ca7bb48",
       "version": "4.8.0",
       "port-version": 3

--- a/versions/v-/vcpkg-tool-ninja.json
+++ b/versions/v-/vcpkg-tool-ninja.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4000f008484105462069d70c1b70295ab72dafb3",
+      "version-date": "2022-03-31",
+      "port-version": 2
+    },
+    {
       "git-tree": "e4dafd8bf3868653e8e4fa81340dfeaea288a43c",
       "version-date": "2022-03-31",
       "port-version": 1

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6365f197946995803914141a82c1830d165427b3",
+      "version-semver": "9.2.0-pv5.11.0",
+      "port-version": 10
+    },
+    {
       "git-tree": "a2a544c0f17d33ceb785ecd4b263f6f540562974",
       "version-semver": "9.2.0-pv5.11.0",
       "port-version": 9


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix the URLS of download patch, add `?full_index=1` for stable downloads, see https://github.com/microsoft/vcpkg/issues/33305#issuecomment-1687510280.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
