### PR TITLE
[glib] Support cross-compiling Objective C code using Meson

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -13,6 +13,10 @@ vcpkg_extract_source_archive(SOURCE_PATH
         fix-build-race-on-gio.patch # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3512
 )
 
+if(APPLE)
+    list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS "-DVCPKG_ENABLE_OBJC=1")
+endif()
+
 vcpkg_list(SET OPTIONS)
 if (selinux IN_LIST FEATURES)
     if(NOT EXISTS "/usr/include/selinux")
@@ -38,6 +42,7 @@ endif()
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
+    LANGUAGES C CXX OBJC OBJCXX
     ADDITIONAL_BINARIES
         ${ADDITIONAL_BINARIES}
     OPTIONS

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glib",
   "version": "2.76.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/scripts/get_cmake_vars/CMakeLists.txt
+++ b/scripts/get_cmake_vars/CMakeLists.txt
@@ -11,6 +11,9 @@ else()
 endif()
 
 set(VCPKG_LANGUAGES "C;CXX" CACHE STRING "Languages to enables for this project")
+if(VCPKG_ENABLE_OBJC)
+    list(APPEND VCPKG_LANGUAGES "OBJC")
+endif()
 
 project(get_cmake_vars LANGUAGES ${VCPKG_LANGUAGES})
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2910,7 +2910,7 @@
     },
     "glib": {
       "baseline": "2.76.3",
-      "port-version": 2
+      "port-version": 3
     },
     "glibmm": {
       "baseline": "2.76.0",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac7af1a224e7dfe9c18e629bf8de7798a0cda932",
+      "version": "2.76.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "c4aa04cd3294219ddd4b43c2f02b95c100683156",
       "version": "2.76.3",
       "port-version": 2


### PR DESCRIPTION
The glib port uses Objective C code and the Meson build system. You'll end up cross compiling glib when compiling for x64 osx on an arm64 osx machine, or vice versa.

For this to work, an Objective C compiler needs to be set in the Meson cross file.

vcpkg generates this file based on the
`scripts/buildsystems/meson/meson.template.in` template, and expects the `MESON_OBJC` CMake variable to be set.

That's the job of `z_vcpkg_meson_set_proglist_variables` in `scripts/cmake/vcpkg_configure_meson.cmake`.  It will only generate data for an Objective C compiler if:

- The `Languages` argument includes `OBJC`
- CMake has detected a Objective C compiler, and has set `VCPKG_DETECTED_CMAKE_OBJC_COMPILER`

To make this work, this patch:
- Enables the OBJC and OBJCXX language on Apple platforms
- Updates the call to `vcpkg_configure_meson` in the glib port file to include the OBJC OBJCXX languages.

Fixes https://github.com/microsoft/vcpkg/issues/26147 Fixes https://github.com/microsoft/vcpkg/issues/20341 Based on https://github.com/microsoft/vcpkg/pull/26259 Based on https://github.com/TechSmith/vcpkg/commit/27dee354e4a4b267b8ad963870981b16f6ada6c5

Tested on an arm64 mac to compile glib for x64 macos