### PR TITLE
[ignition-common4] New port (v4.7.0)

### DIFF
--- a/ports/ignition-common4/fix-dependencies.patch
+++ b/ports/ignition-common4/fix-dependencies.patch
@@ -1,0 +1,81 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9355a5f..ec6d679 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -61,7 +61,7 @@ set(IGN_UTILS_VER ${ignition-utils1_VERSION_MAJOR})
+ #--------------------------------------
+ # Find Tinyxml2
+ if(USE_EXTERNAL_TINYXML2)
+-  ign_find_package(TINYXML2 PRETTY tinyxml2
++  ign_find_package(tinyxml2 EXTRA_ARGS CONFIG
+     REQUIRED_BY graphics
+     PRIVATE_FOR graphics)
+ else()
+@@ -79,13 +79,13 @@ if(NOT MSVC)
+ 
+   #------------------------------------
+   # Find uuid
+-  ign_find_package(UUID REQUIRED PRETTY uuid)
++  ign_find_package(UUID REQUIRED PRETTY uuid REQUIRED_BY graphic)
+ 
+ endif()
+ 
+ #------------------------------------
+ # Find Freeimage
+-ign_find_package(FreeImage VERSION 3.9
++ign_find_package(freeimage EXTRA_ARGS CONFIG
+   REQUIRED_BY graphics
+   PRIVATE_FOR graphics)
+ 
+@@ -93,6 +93,7 @@ ign_find_package(FreeImage VERSION 3.9
+ # Find GNU Triangulation Surface Library
+ ign_find_package(
+   GTS PRETTY gts PURPOSE "GNU Triangulation Surface library"
++  BY_PKGCONFIG gts
+   REQUIRED_BY graphics
+   PRIVATE_FOR graphics)
+ 
+diff --git a/graphics/src/CMakeLists.txt b/graphics/src/CMakeLists.txt
+index 461c993..9b084f8 100644
+--- a/graphics/src/CMakeLists.txt
++++ b/graphics/src/CMakeLists.txt
+@@ -17,8 +17,10 @@ target_link_libraries(${graphics_target}
+     ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER}
+     ignition-utils${IGN_UTILS_VER}::ignition-utils${IGN_UTILS_VER}
+   PRIVATE
+-    GTS::GTS
+-    FreeImage::FreeImage)
++    ${GTS_LINK_LIBRARIES}
++    ${freeimage_LIBRARIES})
++  
++target_include_directories(${graphics_target} PRIVATE ${GTS_INCLUDE_DIRS})
+ 
+ ign_build_tests(TYPE UNIT SOURCES ${gtest_sources}
+   LIB_DEPS ${graphics_target})
+@@ -28,13 +30,13 @@ if(USE_EXTERNAL_TINYXML2)
+   # If we are using an external copy of tinyxml2, add its imported target
+   target_link_libraries(${graphics_target}
+     PRIVATE
+-      TINYXML2::TINYXML2)
++      tinyxml2::tinyxml2)
+ 
+     # The collada exporter test uses tinyxml2, so we must link it if we're using
+     # an external copy. The graphics target considers tinyxml2 to be a private
+     # dependency, so it will not automatically get linked to this test.
+     if(TARGET UNIT_ColladaExporter_TEST)
+-      target_link_libraries(UNIT_ColladaExporter_TEST TINYXML2::TINYXML2)
++      target_link_libraries(UNIT_ColladaExporter_TEST tinyxml2::tinyxml2)
+     endif()
+ 
+ else()
+@@ -62,8 +64,8 @@ endif()
+ 
+ # define of tinxml2 major version >= 6
+ # https://github.com/ignitionrobotics/ign-common/issues/28
+-if (NOT TINYXML2_VERSION VERSION_LESS "6.0.0")
+-  message(STATUS "TINYXML2_VERSION ${TINYXML2_VERSION} >= 6.0.0")
++if (NOT tinyxml2_VERSION VERSION_LESS "6.0.0")
++  message(STATUS "TINYXML2_VERSION ${tinyxml2_VERSION} >= 6.0.0")
+   target_compile_definitions(${graphics_target}
+     PRIVATE "TINYXML2_MAJOR_VERSION_GE_6")
+ endif()

--- a/ports/ignition-common4/portfile.cmake
+++ b/ports/ignition-common4/portfile.cmake
@@ -1,0 +1,9 @@
+ignition_modular_library(NAME common
+                         VERSION "4.7.0"
+                         SHA512 05aebe014f14afd540abe205a1b3459cb7ef6b6d93289c0672182ee586030ea32cbcc7ce67ba823f8f4233b9cbb027678e0e5f1b6fbc2ce21962690211399cd5
+                         OPTIONS -DUSE_EXTERNAL_TINYXML2=ON
+                         PATCHES fix-dependencies.patch)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+   file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()

--- a/ports/ignition-common4/vcpkg.json
+++ b/ports/ignition-common4/vcpkg.json
@@ -1,0 +1,33 @@
+{
+  "name": "ignition-common4",
+  "version": "4.7.0",
+  "description": "Common libraries for robotics applications",
+  "homepage": "https://ignitionrobotics.org/libs/common",
+  "license": null,
+  "dependencies": [
+    {
+      "name": "dlfcn-win32",
+      "platform": "windows | uwp"
+    },
+    "ffmpeg",
+    "freeimage",
+    "gts",
+    {
+      "name": "ignition-cmake2",
+      "version>=": "2.16.0#2"
+    },
+    {
+      "name": "ignition-math6",
+      "version>=": "6.14.0"
+    },
+    {
+      "name": "ignition-modularscripts",
+      "host": true
+    },
+    {
+      "name": "libuuid",
+      "platform": "!windows & !uwp & !osx"
+    },
+    "tinyxml2"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3296,6 +3296,10 @@
       "baseline": "3.14.1",
       "port-version": 0
     },
+    "ignition-common4": {
+      "baseline": "4.7.0",
+      "port-version": 0
+    },
     "ignition-fuel-tools1": {
       "baseline": "1.2.0",
       "port-version": 4

--- a/versions/i-/ignition-common4.json
+++ b/versions/i-/ignition-common4.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6e3d8f98750f38836820b62bd6dabfe9d5e27897",
+      "version": "4.7.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION


- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
