### PR TITLE
[polyhook2] fix core feature

### DIFF
--- a/ports/polyhook2/vcpkg.json
+++ b/ports/polyhook2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "polyhook2",
   "version-date": "2023-05-16",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++17, x86/x64 Hooking Library v2.0",
   "homepage": "https://github.com/stevemk14ebr/PolyHook_2_0",
   "license": "MIT",
@@ -14,7 +14,8 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "zydis"
   ],
   "default-features": [
     "detours",
@@ -28,8 +29,7 @@
       "description": "Implement detour functionality",
       "dependencies": [
         "asmjit",
-        "asmtk",
-        "zydis"
+        "asmtk"
       ]
     },
     "exception": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6462,7 +6462,7 @@
     },
     "polyhook2": {
       "baseline": "2023-05-16",
-      "port-version": 1
+      "port-version": 2
     },
     "polymorphic-value": {
       "baseline": "1.3.0",

--- a/versions/p-/polyhook2.json
+++ b/versions/p-/polyhook2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "def3f21d5fdcf75184eff747c70e7dcf5be18517",
+      "version-date": "2023-05-16",
+      "port-version": 2
+    },
+    {
       "git-tree": "4d6b2480d856d0e6009923d176fb68392e201ac8",
       "version-date": "2023-05-16",
       "port-version": 1


### PR DESCRIPTION
`zydis` was actually a dependency of the core feature. 