### PR TITLE
Update gperftools

### DIFF
--- a/ports/gperftools/pkg-config.patch
+++ b/ports/gperftools/pkg-config.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index a46f149..e5b7cc3 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1400,7 +1400,7 @@ libtcmalloc.pc: Makefile
+ 	echo '' >> "$@".tmp
+ 	echo 'Name: $(PACKAGE)' >> "$@".tmp
+ 	echo 'Version: $(VERSION)' >> "$@".tmp
+-	echo 'Summary: Performance tools for C++' >> "$@".tmp
++	echo 'Description: Performance tools for C++' >> "$@".tmp
+ 	echo 'URL: https://github.com/gperftools/gperftools' >> "$@".tmp
+ 	echo 'Requires:' >> "$@".tmp
+ 	echo 'Libs: -L$${libdir} -ltcmalloc' >> "$@".tmp

--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -1,9 +1,10 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gperftools/gperftools
-    REF gperftools-2.10
-    SHA512 4400711723be9401f519d85b3b69c026e4715473cbed48ab0573df17abdf895fb971ee969875fe5127a2e8b9aba90d858285e50c8e012384c2c36d5a76b1f0c4
+    REF gperftools-2.11
+    SHA512 890599dde997266f3cb110d45f59b1227ad3c65f4e964b9cb18bebf1df0d086ee049ea1fb1b653abcd71f921b93d105fa382eb26fcbba992a333878e69d9196c
     HEAD_REF master
+    PATCHES pkg-config.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/gperftools/vcpkg.json
+++ b/ports/gperftools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gperftools",
-  "version": "2.10",
+  "version": "2.11",
   "description": "A set of tools for performance profiling and memory checking",
   "homepage": "https://github.com/gperftools/gperftools",
   "supports": "!(arm & windows) & !uwp & !android",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2985,7 +2985,7 @@
       "port-version": 6
     },
     "gperftools": {
-      "baseline": "2.10",
+      "baseline": "2.11",
       "port-version": 0
     },
     "gpgme": {

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a43d0d504a356a911f8f8685c015349212e4faf",
+      "version": "2.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "a3e7b08a6dcd261b62d0fee3d7f00de84c3b0094",
       "version": "2.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.