### PR TITLE
[cairomm] Remove unnecessary dependencies

### DIFF
--- a/ports/cairomm/vcpkg.json
+++ b/ports/cairomm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cairomm",
   "version": "1.17.1",
+  "port-version": 1,
   "description": "A C++ wrapper for the cairo graphics library",
   "homepage": "https://www.cairographics.org",
   "license": "LGPL-2.0-only",
@@ -8,10 +9,6 @@
   "dependencies": [
     "cairo",
     "libsigcpp",
-    {
-      "name": "pkgconf",
-      "host": true
-    },
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1390,7 +1390,7 @@
     },
     "cairomm": {
       "baseline": "1.17.1",
-      "port-version": 0
+      "port-version": 1
     },
     "calceph": {
       "baseline": "3.5.2",

--- a/versions/c-/cairomm.json
+++ b/versions/c-/cairomm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f6f54756edc3cdf81b1fbac86522410f64bda856",
+      "version": "1.17.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e8edc870e28366ad88709f1232d002ffd9810cf3",
       "version": "1.17.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
