### PR TITLE
[vcpkg baseline][gdal] Fix  quote variable error

### DIFF
--- a/ports/gdal/Fix-quote-variable.patch
+++ b/ports/gdal/Fix-quote-variable.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/modules/packages/FindSPATIALITE.cmake b/cmake/modules/packages/FindSPATIALITE.cmake
+index fa72773..813cca3 100644
+--- a/cmake/modules/packages/FindSPATIALITE.cmake
++++ b/cmake/modules/packages/FindSPATIALITE.cmake
+@@ -64,7 +64,7 @@ if(SPATIALITE_LIBRARY AND SPATIALITE_INCLUDE_DIR
+    AND NOT SPATIALITE_VERSION_STRING)
+     file(STRINGS "${SPATIALITE_INCLUDE_DIR}/spatialite.h" _spatialite_h_ver
+          REGEX "^[ \t]version[ \t]([0-9]+\\.[0-9]+),.*")
+-    string(REGEX REPLACE "[ \t]version[ \t]([0-9]+\\.[0-9]+),.*" "\\1" _spatialite_h_ver ${_spatialite_h_ver})
++    string(REGEX REPLACE "[ \t]version[ \t]([0-9]+\\.[0-9]+),.*" "\\1" _spatialite_h_ver "${_spatialite_h_ver}")
+     set(SPATIALITE_VERSION_STRING "${_spatialite_h_ver}")
+ endif()
+ 

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         find-link-libraries.patch
         fix-gdal-target-interfaces.patch
         libkml.patch
+        Fix-quote-variable.patch
 )
 # `vcpkg clean` stumbles over one subdir
 file(REMOVE_RECURSE "${SOURCE_PATH}/autotest")

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.7.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2790,7 +2790,7 @@
     },
     "gdal": {
       "baseline": "3.7.1",
-      "port-version": 2
+      "port-version": 3
     },
     "gdcm": {
       "baseline": "3.0.22",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1bffcf8c8f2b02ed041a099723115cbbd0c39b2c",
+      "version-semver": "3.7.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "fe574600c39e044d7aa3f4a0e58c1de47f95a430",
       "version-semver": "3.7.1",
       "port-version": 2


### PR DESCRIPTION
Fix CI issue:
````
REGRESSION: libosmium:x64-windows-static failed with BUILD_FAILED
````
````
CMake Error at D:/installed/x64-windows-static/share/gdal/packages/FindSPATIALITE.cmake:67 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
