### PR TITLE
[zeroc-ice] Fix error C2039: 'binary_function': is not a member of 'std'

### DIFF
--- a/ports/zeroc-ice/fix-missing-functional.patch
+++ b/ports/zeroc-ice/fix-missing-functional.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/include/IceUtil/Timer.h b/cpp/include/IceUtil/Timer.h
+index 177a7f8..19b8c09 100644
+--- a/cpp/include/IceUtil/Timer.h
++++ b/cpp/include/IceUtil/Timer.h
+@@ -12,6 +12,7 @@
+ 
+ #include <set>
+ #include <map>
++#include <functional>
+ 
+ namespace IceUtil
+ {

--- a/ports/zeroc-ice/portfile.cmake
+++ b/ports/zeroc-ice/portfile.cmake
@@ -4,7 +4,10 @@ vcpkg_from_github(
     REPO zeroc-ice/ice
     REF "v${VERSION}"
     SHA512 07d7c439fbe1f69d808d05a11f32e09cdd8d4df2a93b6f253496304e0a521d417212ae688e316b4450dae406b59d1a460025b51ecd0614c69e48d86c0a6f81c5
-    PATCHES mcppd_fix.patch no-werror.patch
+    PATCHES
+        mcppd_fix.patch
+        no-werror.patch
+        fix-missing-functional.patch
 )
 
 set(RELEASE_TRIPLET ${TARGET_TRIPLET}-rel)

--- a/ports/zeroc-ice/vcpkg.json
+++ b/ports/zeroc-ice/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zeroc-ice",
   "version": "3.7.9",
-  "port-version": 1,
+  "port-version": 2,
   "maintainers": "Benjamin Oldenburg <benjamin.oldenburg@ordis.co.th>",
   "description": "Comprehensive RPC framework with support for C++, CSharp, Java, JavaScript, Python and more.",
   "homepage": "https://github.com/zeroc-ice/ice",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9038,7 +9038,7 @@
     },
     "zeroc-ice": {
       "baseline": "3.7.9",
-      "port-version": 1
+      "port-version": 2
     },
     "zeromq": {
       "baseline": "2023-06-20",

--- a/versions/z-/zeroc-ice.json
+++ b/versions/z-/zeroc-ice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc07eee81cdf5c66efc83d606c635e722ef23d39",
+      "version": "3.7.9",
+      "port-version": 2
+    },
+    {
       "git-tree": "bb449d6446b3700170a831c0b155d58be3613a26",
       "version": "3.7.9",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33326
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
