### PR TITLE
[mecab] Include functional to fix error C2039 and C2504

### DIFF
--- a/ports/mecab/fix-missing-functional.patch
+++ b/ports/mecab/fix-missing-functional.patch
@@ -1,0 +1,12 @@
+diff --git a/mecab/src/dictionary.h b/mecab/src/dictionary.h
+index 7046023..32ad358 100644
+--- a/mecab/src/dictionary.h
++++ b/mecab/src/dictionary.h
+@@ -10,6 +10,7 @@
+ #include "mmap.h"
+ #include "darts.h"
+ #include "char_property.h"
++#include <functional>
+ 
+ namespace MeCab {
+ 

--- a/ports/mecab/portfile.cmake
+++ b/ports/mecab/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
 	HEAD_REF master
 	PATCHES
 		fix_wpath_unsigned.patch
+        fix-missing-functional.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}/mecab/src")
@@ -25,4 +26,4 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/mecab/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/mecab/COPYING")

--- a/ports/mecab/portfile.cmake
+++ b/ports/mecab/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
 	HEAD_REF master
 	PATCHES
 		fix_wpath_unsigned.patch
-        fix-missing-functional.patch
+		fix-missing-functional.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}/mecab/src")

--- a/ports/mecab/vcpkg.json
+++ b/ports/mecab/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mecab",
   "version-date": "2019-09-25",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A morphological analysis engine based on CRF",
   "supports": "!(uwp | arm | arm64)",
   "dependencies": [

--- a/ports/mecab/vcpkg.json
+++ b/ports/mecab/vcpkg.json
@@ -3,7 +3,7 @@
   "version-date": "2019-09-25",
   "port-version": 5,
   "description": "A morphological analysis engine based on CRF",
-  "supports": "!(uwp | arm | arm64)",
+  "supports": "!uwp & !(arm & windows)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5294,7 +5294,7 @@
     },
     "mecab": {
       "baseline": "2019-09-25",
-      "port-version": 4
+      "port-version": 5
     },
     "memorymodule": {
       "baseline": "2019-12-31",

--- a/versions/m-/mecab.json
+++ b/versions/m-/mecab.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5ba641b626dd046f7098bdb773c03980c05f46d3",
+      "git-tree": "66081fbeecacd152e3964b0f64f25e0f0b10d461",
       "version-date": "2019-09-25",
       "port-version": 5
     },

--- a/versions/m-/mecab.json
+++ b/versions/m-/mecab.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0cf241c44486e30e6a6a1c6b02cb527eb68e7d47",
+      "version-date": "2019-09-25",
+      "port-version": 5
+    },
+    {
       "git-tree": "d5f64d85fddc71ff872f675cda3ed8ee767193f1",
       "version-date": "2019-09-25",
       "port-version": 4

--- a/versions/m-/mecab.json
+++ b/versions/m-/mecab.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0cf241c44486e30e6a6a1c6b02cb527eb68e7d47",
+      "git-tree": "5ba641b626dd046f7098bdb773c03980c05f46d3",
       "version-date": "2019-09-25",
       "port-version": 5
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33323
Error:
```
   error C2143: syntax error: missing ',' before '<' 
   error C2039: 'binary_function': is not a member of 'std'
   error C2504: 'binary_function': base class undefined 
```
The reason is new STL change, need include <functional> to fix them.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
