### PR TITLE
[corrade] fix core build when cross compiling

### DIFF
--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -42,6 +42,7 @@ vcpkg_cmake_configure(
         -DBUILD_STATIC=${BUILD_STATIC}
     MAYBE_UNUSED_VARIABLES
         CORRADE_RC_EXECUTABLE
+        UTILITY_USE_ANSI_COLORS
 )
 
 vcpkg_cmake_install()
@@ -51,13 +52,11 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # corrade-rc is not built when CMAKE_CROSSCOMPILING
-if("utility" IN_LIST FEATURES)
-    vcpkg_copy_tools(TOOL_NAMES "corrade-rc" AUTO_CLEAN)
-endif()
+vcpkg_copy_tools(TOOL_NAMES "corrade-rc" AUTO_CLEAN)
 
 # Ensure no empty folders are left behind
-if(NOT FEATURES)
-    # No features, no binaries (only Corrade.h).
+if(FEATURES STREQUAL "core")
+    # No features, no libs (only Corrade.h).
     file(REMOVE_RECURSE
         "${CURRENT_PACKAGES_DIR}/bin"
         "${CURRENT_PACKAGES_DIR}/lib"

--- a/ports/corrade/vcpkg.json
+++ b/ports/corrade/vcpkg.json
@@ -1,17 +1,14 @@
 {
   "name": "corrade",
   "version-string": "2020.06",
-  "port-version": 5,
+  "port-version": 6,
   "description": "C++11/C++14 multiplatform utility library.",
   "homepage": "https://magnum.graphics/corrade/",
   "dependencies": [
     {
       "name": "corrade",
       "host": true,
-      "default-features": false,
-      "features": [
-        "utility"
-      ]
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1766,7 +1766,7 @@
     },
     "corrade": {
       "baseline": "2020.06",
-      "port-version": 5
+      "port-version": 6
     },
     "cpp-async": {
       "baseline": "1.0.1",

--- a/versions/c-/corrade.json
+++ b/versions/c-/corrade.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a278fdbd46715f454e366df7d06410ae2fc9747",
+      "version-string": "2020.06",
+      "port-version": 6
+    },
+    {
       "git-tree": "fed547a7951672a5a7b1c430df8a9b179f674ac6",
       "version-string": "2020.06",
       "port-version": 5


### PR DESCRIPTION
The `utility` feature is a lib and the needed utility is always build. 

When doing cross builds you currently get 
```
-- Performing post-build validation
warning: The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    C:\v\vcpkg3\packages\corrade_x64-windows\bin\corrade-rc.exe

warning: The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    C:\v\vcpkg3\packages\corrade_x64-windows\debug\bin\corrade-rc.exe
```