### PR TITLE
[lazy-importer] Bump to 2023-08-03

### DIFF
--- a/ports/lazy-importer/portfile.cmake
+++ b/ports/lazy-importer/portfile.cmake
@@ -3,12 +3,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO JustasMasiulis/lazy_importer
-    REF edac6afddb9e0df2e3affa8b2d631caafcba69ed
-    SHA512 45f024c34fa1c8854b8b77706934ce95449b2416a5c1dcab970d0df068c9b5bf0de12994c13ac215e629f8ae21fdab75b4ce6535f56ca7508f490a4c664e5b1a
+    REF 4810f51d63438865e508c2784ea00811d9beb2ea
+    SHA512 1b2f330586cb80d8ecf13dd27c5a407c778c3a12aeffa493d31b75fa9c3186ed9f67838164c48c64e2bb4a9fe804a77625dd1cd996d661545580e29d57c3494b
     HEAD_REF master
 )
 
 file(COPY "${SOURCE_PATH}/include/lazy_importer.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-# Handle copyright
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/lazy-importer/vcpkg.json
+++ b/ports/lazy-importer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lazy-importer",
-  "version-date": "2022-02-09",
+  "version-date": "2023-08-03",
   "description": "Library for importing functions from dlls in a hidden, reverse engineer unfriendly way",
   "homepage": "https://github.com/JustasMasiulis/lazy_importer"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3837,7 +3837,7 @@
       "port-version": 0
     },
     "lazy-importer": {
-      "baseline": "2022-02-09",
+      "baseline": "2023-08-03",
       "port-version": 0
     },
     "lcm": {

--- a/versions/l-/lazy-importer.json
+++ b/versions/l-/lazy-importer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc2b18f5f193267ac091e6495ea097e67d60d33b",
+      "version-date": "2023-08-03",
+      "port-version": 0
+    },
+    {
       "git-tree": "ba952940f6531135428e3827d0610d3596b683cb",
       "version-date": "2022-02-09",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
