### PR TITLE
[mmloader] Fix feature shellcode Build failure

### DIFF
--- a/ports/mmloader/fix-platform-name.patch
+++ b/ports/mmloader/fix-platform-name.patch
@@ -16,16 +16,3 @@ index b672037..f9a6a15 100644
  message(STATUS "CMAKE_VS_PLATFORM_NAME=" ${CMAKE_VS_PLATFORM_NAME})
  string(COMPARE EQUAL "${CMAKE_VS_PLATFORM_NAME}" Win32 BUILD_ARC_X8632)
  string(COMPARE EQUAL "${CMAKE_VS_PLATFORM_NAME}" x64 BUILD_ARC_X8664)
-diff --git a/tools/shellcode-generator/CMakeLists.txt b/tools/shellcode-generator/CMakeLists.txt
-index 61131c7..dc704cb 100644
---- a/tools/shellcode-generator/CMakeLists.txt
-+++ b/tools/shellcode-generator/CMakeLists.txt
-@@ -42,7 +42,7 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
- 
- # install lib and header files
- install(TARGETS ${PROJECT_NAME}
--    RUNTIME DESTINATION tools
-+    RUNTIME DESTINATION bin
- )
- 
- if (BUILD_ARC_X8632)

--- a/ports/mmloader/fix-platform-name.patch
+++ b/ports/mmloader/fix-platform-name.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b672037..f9a6a15 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,6 +14,13 @@ if ((NOT DEFINED CMAKE_VS_PLATFORM_NAME) OR (CMAKE_VS_PLATFORM_NAME STREQUAL "")
+     message(STATUS "CMAKE_VS_PLATFORM_NAME is empty, use default: Win32")
+     set(CMAKE_VS_PLATFORM_NAME Win32)
+ endif()
++
++if(VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
++    set(CMAKE_VS_PLATFORM_NAME "Win32")
++else()
++    set(CMAKE_VS_PLATFORM_NAME "${VCPKG_TARGET_ARCHITECTURE}")
++endif()
++
+ message(STATUS "CMAKE_VS_PLATFORM_NAME=" ${CMAKE_VS_PLATFORM_NAME})
+ string(COMPARE EQUAL "${CMAKE_VS_PLATFORM_NAME}" Win32 BUILD_ARC_X8632)
+ string(COMPARE EQUAL "${CMAKE_VS_PLATFORM_NAME}" x64 BUILD_ARC_X8664)
+diff --git a/tools/shellcode-generator/CMakeLists.txt b/tools/shellcode-generator/CMakeLists.txt
+index 61131c7..dc704cb 100644
+--- a/tools/shellcode-generator/CMakeLists.txt
++++ b/tools/shellcode-generator/CMakeLists.txt
+@@ -42,7 +42,7 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+ 
+ # install lib and header files
+ install(TARGETS ${PROJECT_NAME}
+-    RUNTIME DESTINATION tools
++    RUNTIME DESTINATION bin
+ )
+ 
+ if (BUILD_ARC_X8632)

--- a/ports/mmloader/portfile.cmake
+++ b/ports/mmloader/portfile.cmake
@@ -27,4 +27,4 @@ vcpkg_copy_tools(TOOL_NAMES mmloader-shellcode-generator AUTO_CLEAN)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License")

--- a/ports/mmloader/portfile.cmake
+++ b/ports/mmloader/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF 1.0.1
     SHA512 a41749e1b62d5549b821429a03e456a0cb41fbc1ea3fe5e8067f80994fb4645c3145dd1e2a3ccaed13b091ec24338d4e542849628d346f26d2275b0cbff8f4c6
     HEAD_REF master
+    PATCHES
+        fix-platform-name.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -21,6 +23,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install(DISABLE_PARALLEL)
 
+vcpkg_copy_tools(TOOL_NAMES mmloader-shellcode-generator AUTO_CLEAN)
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/License" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License)

--- a/ports/mmloader/portfile.cmake
+++ b/ports/mmloader/portfile.cmake
@@ -23,8 +23,6 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install(DISABLE_PARALLEL)
 
-vcpkg_copy_tools(TOOL_NAMES mmloader-shellcode-generator AUTO_CLEAN)
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License")

--- a/ports/mmloader/vcpkg.json
+++ b/ports/mmloader/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mmloader",
   "version": "1.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A library for loading dll module bypassing windows PE loader from memory (x86/x64)",
   "homepage": "http://tishion.github.io/mmLoader/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5418,7 +5418,7 @@
     },
     "mmloader": {
       "baseline": "1.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "mmx": {
       "baseline": "2022-03-27",

--- a/versions/m-/mmloader.json
+++ b/versions/m-/mmloader.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9380775cc83573ffa539d6b008cd3a126897de99",
+      "git-tree": "8f73c54685c38e7d210174f134723badde70879d",
       "version": "1.0.1",
       "port-version": 3
     },

--- a/versions/m-/mmloader.json
+++ b/versions/m-/mmloader.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "61702fe32f636bd5ad40afdec56f107650c23057",
+      "git-tree": "9380775cc83573ffa539d6b008cd3a126897de99",
       "version": "1.0.1",
       "port-version": 3
     },

--- a/versions/m-/mmloader.json
+++ b/versions/m-/mmloader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61702fe32f636bd5ad40afdec56f107650c23057",
+      "version": "1.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "4b102ccdbd92919d2f3f62fff55b2a51839199ad",
       "version": "1.0.1",
       "port-version": 2


### PR DESCRIPTION
Fixes #33321

Fix error:
````
CMake Error at tools/shellcode-generator/cmake_install.cmake:41 (file):
  file INSTALL cannot find
  "C:/v/vcpkg3/buildtrees/mmloader/src/1.0.1-0d8279db98.clean/output/mmloader/include/mmLoaderShellCode-x86-Debug.h":
  File exists.
Call Stack (most recent call first):
  cmake_install.cmake:45 (include)
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Tested feature `shellcode` successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
