### PR TITLE
[fast-float] Bump to 5.2.0

### DIFF
--- a/ports/fast-float/portfile.cmake
+++ b/ports/fast-float/portfile.cmake
@@ -2,17 +2,22 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fastfloat/fast_float
     REF "v${VERSION}"
-    SHA512 e3a1941364413f008d4bff190df45f95d7100263e57e714a907dba85b705fd19dcd34ac6db3fc332e5232fd4b67442542f2344a81d296ef04282e3d615dfe0fb
+    SHA512 c703c7cba3c69775317c66a62ce145646fd7d3d063124501e3d6a7deebb8c62c14a2ccdffed18de2d73d9d3a8ba2061ef1d34cc780ee0b6d607935d5f1b1de81
     HEAD_REF master
 )
 
+set(VCPKG_BUILD_TYPE release) # header-only port
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DFASTFLOAT_INSTALL=ON
 )
 
 vcpkg_cmake_install()
-
 vcpkg_cmake_config_fixup(PACKAGE_NAME FastFloat CONFIG_PATH share/cmake/FastFloat)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-MIT")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE" "${SOURCE_PATH}/LICENSE-BOOST" "${SOURCE_PATH}/LICENSE-MIT")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/fast-float/usage
+++ b/ports/fast-float/usage
@@ -1,0 +1,4 @@
+fast-float provides CMake targets:
+
+    find_package(FastFloat CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE FastFloat::fast_float)

--- a/ports/fast-float/vcpkg.json
+++ b/ports/fast-float/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "fast-float",
-  "version": "4.0.0",
+  "version": "5.2.0",
   "description": "Fast and exact implementation of the C++ from_chars functions for float and double types: 4x faster than strtod",
   "homepage": "https://github.com/fastfloat/fast_float",
-  "license": "Apache-2.0 OR MIT",
+  "license": "Apache-2.0 OR BSL-1.0 OR MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2461,7 +2461,7 @@
       "port-version": 2
     },
     "fast-float": {
-      "baseline": "4.0.0",
+      "baseline": "5.2.0",
       "port-version": 0
     },
     "fastcdr": {

--- a/versions/f-/fast-float.json
+++ b/versions/f-/fast-float.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b78d9590504b99e64f96cdddac42bf67fed57feb",
+      "version": "5.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4b3850e475298431083406c88bd1ced0a0c6e740",
       "version": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
