### PR TITLE
[rapidfuzz] update to 2.0.0

### DIFF
--- a/ports/rapidfuzz/portfile.cmake
+++ b/ports/rapidfuzz/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO maxbachmann/rapidfuzz-cpp
-    REF 87ee0dd61289fa6d7d0d2b5716f5363ee6b38fb7 # rapidfuzz-1.8.0
-    SHA512 c1d7c69a291e381453ccad4053353c75fa94288e850183f0b133f617e2b77cae80c9989753fed236e196eb445d821af5dd7e329acbe4994d5a96ab1318af9cf9
+    REF "v${VERSION}"
+    SHA512 02af141b123545303d634ffe84fbe83e635f06c9ffa3a6506661e53beb22fe7221942b3e46d33b2a49ef929c5de9acfb00c48cb5685c760506c5fcf37c716f9a
     HEAD_REF master
 )
 
@@ -15,4 +15,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rapidfuzz/vcpkg.json
+++ b/ports/rapidfuzz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rapidfuzz",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "description": "Rapid fuzzy string matching library for C++17 using the Levenshtein Distance.",
   "homepage": "https://github.com/maxbachmann/rapidfuzz-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7101,7 +7101,7 @@
       "port-version": 0
     },
     "rapidfuzz": {
-      "baseline": "1.8.0",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "rapidjson": {

--- a/versions/r-/rapidfuzz.json
+++ b/versions/r-/rapidfuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5adbaf988800a6554ee8fcada97f56a62d89e722",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e4ccc785af13a54ced4b4333612323f98a85b68b",
       "version": "1.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.