### PR TITLE
[seasocks] New port

### DIFF
--- a/ports/seasocks/0001-fix-x86-build.patch
+++ b/ports/seasocks/0001-fix-x86-build.patch
@@ -1,0 +1,33 @@
+diff --git a/src/main/c/HybiPacketDecoder.cpp b/src/main/c/HybiPacketDecoder.cpp
+--- a/src/main/c/HybiPacketDecoder.cpp
++++ b/src/main/c/HybiPacketDecoder.cpp
+@@ -66,7 +66,7 @@ HybiPacketDecoder::MessageState HybiPacketDecoder::decodeNextMessage(
+     deflateNeeded = !!(reservedBits & 0x40);
+ 
+     auto opcode = static_cast<Opcode>(_buffer[_messageStart] & 0xf);
+-    size_t payloadLength = _buffer[_messageStart + 1] & 0x7fu;
++    uint64_t payloadLength = _buffer[_messageStart + 1] & 0x7fu;
+     auto maskBit = _buffer[_messageStart + 1] & 0x80;
+     auto ptr = _messageStart + 2;
+     if (payloadLength == 126) {
+@@ -103,7 +103,7 @@ HybiPacketDecoder::MessageState HybiPacketDecoder::decodeNextMessage(
+     }
+ 
+     messageOut.clear();
+-    messageOut.reserve(payloadLength);
++    messageOut.reserve(static_cast<size_t>(payloadLength));
+     for (auto i = 0u; i < payloadLength; ++i) {
+         auto byteShift = (3 - (i & 3)) * 8;
+         messageOut.push_back(static_cast<uint8_t>((_buffer[ptr++] ^ (mask >> byteShift)) & 0xff));
+diff --git a/src/main/c/seasocks/StreamingResponse.cpp b/src/main/c/seasocks/StreamingResponse.cpp
+--- a/src/main/c/seasocks/StreamingResponse.cpp
++++ b/src/main/c/seasocks/StreamingResponse.cpp
+@@ -51,7 +51,7 @@ void StreamingResponse::handle(std::shared_ptr<ResponseWriter> writer) {
+         bool isGood = stream->good();
+         if (isGood || isEof) {
+             // everything is fine, push data to client
+-            writer->payload(buffer.get(), stream->gcount(), flush);
++            writer->payload(buffer.get(), static_cast<size_t>(stream->gcount()), flush);
+         }
+ 
+         if (!isGood) {

--- a/ports/seasocks/portfile.cmake
+++ b/ports/seasocks/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 733e12e57db025797016a49fa191facb72a0aa57625545c613862f407b21f8c19f78fc633a9a004d7ff15ded87e9a9a379c5fff2f92a14ccf83f0ff7d2308561
     HEAD_REF master
+    PATCHES
+        0001-fix-x86-build.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/seasocks/portfile.cmake
+++ b/ports/seasocks/portfile.cmake
@@ -1,0 +1,40 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mattgodbolt/seasocks
+    REF "v${VERSION}"
+    SHA512 733e12e57db025797016a49fa191facb72a0aa57625545c613862f407b21f8c19f78fc633a9a004d7ff15ded87e9a9a379c5fff2f92a14ccf83f0ff7d2308561
+    HEAD_REF master
+)
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
+vcpkg_add_to_path("${PYTHON3_DIR}")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        zlib DEFLATE_SUPPORT
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DUNITTESTS=OFF
+        -DSEASOCKS_EXAMPLE_APP=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/Seasocks")
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/licenses")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/seasocks/vcpkg.json
+++ b/ports/seasocks/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "seasocks",
+  "version": "1.4.5",
+  "description": "Simple, small, C++ embeddable webserver with WebSockets support",
+  "homepage": "https://github.com/mattgodbolt/seasocks",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "zlib"
+  ],
+  "features": {
+    "zlib": {
+      "description": "Build with Deflate support via zlib",
+      "dependencies": [
+        "zlib"
+      ]
+    }
+  }
+}

--- a/ports/seasocks/vcpkg.json
+++ b/ports/seasocks/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Simple, small, C++ embeddable webserver with WebSockets support",
   "homepage": "https://github.com/mattgodbolt/seasocks",
   "license": "BSD-2-Clause",
-  "supports": "!osx & !android",
+  "supports": "!windows & !osx & !android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/seasocks/vcpkg.json
+++ b/ports/seasocks/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Simple, small, C++ embeddable webserver with WebSockets support",
   "homepage": "https://github.com/mattgodbolt/seasocks",
   "license": "BSD-2-Clause",
+  "supports": "!osx & !android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7508,6 +7508,10 @@
       "baseline": "4.1.1",
       "port-version": 0
     },
+    "seasocks": {
+      "baseline": "1.4.5",
+      "port-version": 0
+    },
     "secp256k1": {
       "baseline": "2022-07-11",
       "port-version": 1

--- a/versions/s-/seasocks.json
+++ b/versions/s-/seasocks.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fef5987909e83ca2ec06aa1058f492c038ed4368",
+      "git-tree": "3fccf932ff8423ef9e626f3f7e930a244bd1c990",
       "version": "1.4.5",
       "port-version": 0
     }

--- a/versions/s-/seasocks.json
+++ b/versions/s-/seasocks.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e94d5896667413243804103a3896cd9832bfd86d",
+      "git-tree": "fef5987909e83ca2ec06aa1058f492c038ed4368",
       "version": "1.4.5",
       "port-version": 0
     }

--- a/versions/s-/seasocks.json
+++ b/versions/s-/seasocks.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3fccf932ff8423ef9e626f3f7e930a244bd1c990",
+      "git-tree": "2477e55b543e20d96c95546ff5a362d8a1a72044",
       "version": "1.4.5",
       "port-version": 0
     }

--- a/versions/s-/seasocks.json
+++ b/versions/s-/seasocks.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e94d5896667413243804103a3896cd9832bfd86d",
+      "version": "1.4.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
