### PR TITLE
[cpuinfo] use supports expression

### DIFF
--- a/ports/cpuinfo/vcpkg.json
+++ b/ports/cpuinfo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpuinfo",
   "version-date": "2022-07-19",
-  "port-version": 2,
+  "port-version": 3,
   "description": "CPU INFOrmation library (x86/x86-64/ARM/ARM64, Linux/Windows/Android/macOS/iOS)",
   "homepage": "https://github.com/pytorch/cpuinfo",
   "license": "BSD-2-Clause",
@@ -18,7 +18,8 @@
   ],
   "features": {
     "tools": {
-      "description": "Build cpuinfo command-line tools"
+      "description": "Build cpuinfo command-line tools",
+      "supports": "!uwp"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1890,7 +1890,7 @@
     },
     "cpuinfo": {
       "baseline": "2022-07-19",
-      "port-version": 2
+      "port-version": 3
     },
     "cr": {
       "baseline": "2020-04-26",

--- a/versions/c-/cpuinfo.json
+++ b/versions/c-/cpuinfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1b7e10e1de1dcd09118adc19c5bc831417dcc8c",
+      "version-date": "2022-07-19",
+      "port-version": 3
+    },
+    {
       "git-tree": "b48fc0cf93034d06bb34c5f83da8be921006b283",
       "version-date": "2022-07-19",
       "port-version": 2


### PR DESCRIPTION
In general on uwp:
```
CMake Warning at CMakeLists.txt:82 (MESSAGE):
  Target operating system "WindowsStore" is not supported in cpuinfo.
  cpuinfo will compile, but cpuinfo_initialize() will always fail.
```
Because of that, you can not build the tools on uwp 