### PR TITLE
[cpu-features] Bump to 0.8.0

### DIFF
--- a/ports/cpu-features/fix-windows.patch
+++ b/ports/cpu-features/fix-windows.patch
@@ -1,13 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3e382a4..457531b 100644
+index 3e382a4..63ef346 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -61,7 +61,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
+@@ -57,11 +57,11 @@ set(PROCESSOR_IS_RISCV FALSE)
+ 
+ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^mips")
+   set(PROCESSOR_IS_MIPS TRUE)
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
++elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)")
    set(PROCESSOR_IS_AARCH64 TRUE)
  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
    set(PROCESSOR_IS_ARM TRUE)
 -elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(AMD64|amd64)|(^i.86$)")
++elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(x86_64)|(AMD64|amd64)|(^i.86$)")
    set(PROCESSOR_IS_X86 TRUE)
  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)")
    set(PROCESSOR_IS_POWER TRUE)

--- a/ports/cpu-features/make_list_cpu_features_optional.patch
+++ b/ports/cpu-features/make_list_cpu_features_optional.patch
@@ -1,47 +1,30 @@
-From 68ece3bba0d79ab721a0c50ee1e6014a37f759dc Mon Sep 17 00:00:00 2001
-From: Wei Dai <wei.dai@microsoft.com>
-Date: Mon, 24 May 2021 10:02:07 -0700
-Subject: [PATCH] Added an option to disable the executable target
- list_cpu_feature.
-
----
- CMakeLists.txt | 23 ++++++++++++++++++-----
- 1 file changed, 18 insertions(+), 5 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f9daeac..48eea0e 100644
+index bcc9bb0..3e382a4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -17,6 +17,8 @@ if(NOT CMAKE_BUILD_TYPE)
+@@ -17,6 +17,9 @@ if(NOT CMAKE_BUILD_TYPE)
        FORCE)
  endif(NOT CMAKE_BUILD_TYPE)
  
 +# An option to disable the executable target list_cpu_features.
 +option(BUILD_EXECUTABLE "Build list_cpu_features executable." ON)
++
  # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make
  # it prominent in the GUI.
  # cpu_features uses bit-fields which are - to some extends - implementation-defined (see https://en.cppreference.com/w/c/language/bit_field).
-@@ -157,9 +159,11 @@ add_library(CpuFeature::cpu_features ALIAS cpu_features)
+@@ -158,9 +161,11 @@ add_library(CpuFeature::cpu_features ALIAS cpu_features)
  # program : list_cpu_features
  #
  
--add_executable(list_cpu_features ${PROJECT_SOURCE_DIR}/src/utils/list_cpu_features.c)
--target_link_libraries(list_cpu_features PRIVATE cpu_features)
--add_executable(CpuFeature::list_cpu_features ALIAS list_cpu_features)
 +if(BUILD_EXECUTABLE)
-+  add_executable(list_cpu_features ${PROJECT_SOURCE_DIR}/src/utils/list_cpu_features.c)
-+  target_link_libraries(list_cpu_features PRIVATE cpu_features)
-+  add_executable(CpuFeature::list_cpu_features ALIAS list_cpu_features)
+ add_executable(list_cpu_features ${PROJECT_SOURCE_DIR}/src/utils/list_cpu_features.c)
+ target_link_libraries(list_cpu_features PRIVATE cpu_features)
+ add_executable(CpuFeature::list_cpu_features ALIAS list_cpu_features)
 +endif()
  
  #
  # ndk_compat
-@@ -223,18 +227,28 @@ if(BUILD_TESTING)
- endif()
- 
- #
--# Install cpu_features and list_cpu_features
-+# Install cpu_features and optionally list_cpu_features
+@@ -228,7 +233,7 @@ endif()
  #
  
  include(GNUInstallDirs)
@@ -50,7 +33,7 @@ index f9daeac..48eea0e 100644
    EXPORT CpuFeaturesTargets
    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpu_features
    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+@@ -236,6 +241,16 @@ install(TARGETS cpu_features list_cpu_features
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
    BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
  )
@@ -67,6 +50,3 @@ index f9daeac..48eea0e 100644
  install(EXPORT CpuFeaturesTargets
    NAMESPACE CpuFeatures::
    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CpuFeatures
--- 
-2.25.1
-

--- a/ports/cpu-features/portfile.cmake
+++ b/ports/cpu-features/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/cpu_features
-    REF v0.7.0
-    SHA512 e602c88c4a104d69dff0297a4c4f8e26d02d548fc35ce2616429ff8280f2a37e9eaa99451a38b7c302907352cf15bdf8c09c2e0e52b09bf4cd3b7e2b21f8ddb0
+    REF "v${VERSION}"
+    SHA512 43085d11f58f314d696276c8543561d411a4156aa546d1e14ed3d8adffded5818f1ad4259b3ad38bb5d4167bd9084f78c725eb53509999a2349a749b9eb47007
     HEAD_REF master
     PATCHES
         make_list_cpu_features_optional.patch
@@ -35,4 +35,9 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+if(VCPKG_TARGET_IS_ANDROID)
+    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage_android" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "usage")
+else()
+    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+endif()

--- a/ports/cpu-features/portfile.cmake
+++ b/ports/cpu-features/portfile.cmake
@@ -27,7 +27,12 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "CpuFeatures" CONFIG_PATH "lib/cmake/CpuFeatures")
+if(VCPKG_TARGET_IS_ANDROID)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME "CpuFeatures" CONFIG_PATH "lib/cmake/CpuFeatures" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME "CpuFeaturesNdkCompat" CONFIG_PATH "lib/cmake/CpuFeaturesNdkCompat")
+else()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME "CpuFeatures" CONFIG_PATH "lib/cmake/CpuFeatures")
+endif()
 
 if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES "list_cpu_features" AUTO_CLEAN)

--- a/ports/cpu-features/portfile.cmake
+++ b/ports/cpu-features/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         make_list_cpu_features_optional.patch
-        windows-x86-fix.patch
+        fix-windows.patch
 )
 
 # If feature "tools" is not specified, disable building/exporting executable targets.

--- a/ports/cpu-features/usage
+++ b/ports/cpu-features/usage
@@ -1,0 +1,4 @@
+cpu-features provides CMake targets:
+
+    find_package(CpuFeatures CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CpuFeatures::cpu_features)

--- a/ports/cpu-features/usage_android
+++ b/ports/cpu-features/usage_android
@@ -1,0 +1,4 @@
+cpu-features provides CMake targets:
+
+    find_package(CpuFeatures CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CpuFeatures::cpu_features CpuFeatures::ndk_compat)

--- a/ports/cpu-features/usage_android
+++ b/ports/cpu-features/usage_android
@@ -1,4 +1,7 @@
 cpu-features provides CMake targets:
 
     find_package(CpuFeatures CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE CpuFeatures::cpu_features CpuFeatures::ndk_compat)
+    target_link_libraries(main PRIVATE CpuFeatures::cpu_features)
+
+    find_package(CpuFeaturesNdkCompat CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CpuFeatures::ndk_compat)

--- a/ports/cpu-features/vcpkg.json
+++ b/ports/cpu-features/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "cpu-features",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A cross-platform C library to retrieve CPU features (such as available instructions) at runtime",
   "homepage": "https://github.com/google/cpu_features",
   "license": "Apache-2.0",
-  "supports": "!(arm | uwp)",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/cpu-features/windows-x86-fix.patch
+++ b/ports/cpu-features/windows-x86-fix.patch
@@ -1,9 +1,8 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3e382a4..457531b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -60,13 +60,13 @@
- if(CMAKE_SYSTEM_PROCESSOR MATCHES "^mips")
-   set(PROCESSOR_IS_MIPS TRUE)
- elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
+@@ -61,7 +61,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
    set(PROCESSOR_IS_AARCH64 TRUE)
  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
    set(PROCESSOR_IS_ARM TRUE)
@@ -12,6 +11,3 @@
    set(PROCESSOR_IS_X86 TRUE)
  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)")
    set(PROCESSOR_IS_POWER TRUE)
- endif()
- 
- macro(add_cpu_features_headers_and_sources HDRS_LIST_NAME SRCS_LIST_NAME)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1881,7 +1881,7 @@
       "port-version": 0
     },
     "cpu-features": {
-      "baseline": "0.7.0",
+      "baseline": "0.8.0",
       "port-version": 0
     },
     "cpuid": {

--- a/versions/c-/cpu-features.json
+++ b/versions/c-/cpu-features.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "408a04685ddac613cc47410fef90b2375a62655a",
+      "git-tree": "555eaf76bc0bb96fc8abec90b9481d25e77a397b",
       "version": "0.8.0",
       "port-version": 0
     },

--- a/versions/c-/cpu-features.json
+++ b/versions/c-/cpu-features.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "408a04685ddac613cc47410fef90b2375a62655a",
+      "version": "0.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "389a30511ba8ab8c2891ee40ad9cc6ae89561739",
       "version": "0.7.0",
       "port-version": 0

--- a/versions/c-/cpu-features.json
+++ b/versions/c-/cpu-features.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "555eaf76bc0bb96fc8abec90b9481d25e77a397b",
+      "git-tree": "b7b519ccb7eebe02086e062e34a6d3d6b0f54cde",
       "version": "0.8.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Close #33402