### PR TITLE
[imgui] use supports expression

### DIFF
--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui",
   "version": "1.89.7",
+  "port-version": 1,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",
@@ -69,7 +70,8 @@
       "supports": "osx"
     },
     "opengl2-binding": {
-      "description": "Make available OpenGL (legacy) binding"
+      "description": "Make available OpenGL (legacy) binding",
+      "supports": "!uwp"
     },
     "opengl3-binding": {
       "description": "Make available OpenGL3/ES/ES2 (modern) binding"
@@ -101,7 +103,7 @@
     },
     "win32-binding": {
       "description": "Make available Win32 binding",
-      "supports": "windows"
+      "supports": "windows & !uwp"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3382,7 +3382,7 @@
     },
     "imgui": {
       "baseline": "1.89.7",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui-sfml": {
       "baseline": "2.5",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5be94cd09a52d92e1ad194fa7f29846619529be2",
+      "version": "1.89.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "9b44fd53ec5a9aa2f9b272bab4a9a5d97e0aa82f",
       "version": "1.89.7",
       "port-version": 0


### PR DESCRIPTION
`opengl2-binding` fails with 
```
C:\v\vcpkg4\buildtrees\imgui\src\v1.89.7-a1b81a75ab.clean\backends\imgui_impl_opengl2.cpp(120): error C2065: 'GL_BLEND': undeclared identifier
```
`win32-binding` fails with
```
C:\v\vcpkg4\buildtrees\imgui\src\v1.89.7-a1b81a75ab.clean\backends\imgui_impl_win32.cpp(208): error C2039: 'SetCursor': is not a member of '`global namespace''
```