### PR TITLE
[stale workflow] ignore other labels to not reach operations-per-run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/stale@v6
         with:
           stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 180 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
-          exempt-issue-labels: 'no-stale'
+          exempt-issue-labels: 'no-stale,category:new-port,category:question,requires:repro,requires:more-information'
           days-before-issue-stale: 180
           days-before-pr-stale: -1
           days-before-close: 14


### PR DESCRIPTION
Otherwise the run checks the already marked issues from the other steps and has no steps left over for his own step. See https://github.com/microsoft/vcpkg/actions/runs/5988200017/job/16243151207#step:4:9976