### PR TITLE
[openal-soft] fix cmake deprecation warning

### DIFF
--- a/ports/openal-soft/fix-cmake-deprecated-warning.patch
+++ b/ports/openal-soft/fix-cmake-deprecated-warning.patch
@@ -1,0 +1,10 @@
+diff --git a/OpenALConfig.cmake.in b/OpenALConfig.cmake.in
+index 128c1a4..35e55a5 100644
+--- a/OpenALConfig.cmake.in
++++ b/OpenALConfig.cmake.in
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.1...3.27)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/OpenALTargets.cmake")
+ 

--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
       c12ada68951ea67a59bef7d4fcdf22334990c12a.patch # Merged upstream, remove in next version
+      fix-cmake-deprecated-warning.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openal-soft",
   "version": "1.23.1",
+  "port-version": 1,
   "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
   "homepage": "https://github.com/kcat/openal-soft",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5966,7 +5966,7 @@
     },
     "openal-soft": {
       "baseline": "1.23.1",
-      "port-version": 0
+      "port-version": 1
     },
     "openblas": {
       "baseline": "0.3.23",

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f9cd01e6e8f93895306bb2d72fbca756d2c27c56",
+      "version": "1.23.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d23d6573247830bd439e418fe0e31321de778d85",
       "version": "1.23.1",
       "port-version": 0


### PR DESCRIPTION
Newer CMake versions deprecate support for versions before 3.5, and warn about it quite loudly:

```
CMake Deprecation Warning at build/vcpkg_installed/x64-linux-dynamic/share/openal-soft/OpenALConfig.cmake:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
Call Stack (most recent call first):
  vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  CMakeLists.txt:44 (find_package)
```

This adds a patch to fix the issue.