### PR TITLE
[anari] fix incorrect internal hash

### DIFF
--- a/ports/anari/fix-hash.patch
+++ b/ports/anari/fix-hash.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/helide/external/embree/CMakeLists.txt b/libs/helide/external/embree/CMakeLists.txt
+index 8bc9d00..14a0c34 100644
+--- a/libs/helide/external/embree/CMakeLists.txt
++++ b/libs/helide/external/embree/CMakeLists.txt
+@@ -30,7 +30,7 @@ set(EMBREE_TASKING_SYSTEM "INTERNAL" CACHE STRING "" FORCE)
+ anari_sdk_fetch_project(
+   NAME anari_helide_embree
+   URL "https://github.com/embree/embree/archive/refs/tags/v3.13.5.zip"
+-  MD5 d87ce56557a38e332cb3e0fa5cac8cfd
++  MD5 5df9e14b67612bc17bbca6b285471258
+   ADD_SUBDIR
+ )
+ 

--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
   REF "v${VERSION}"
   SHA512 51937d160a9508c56cf123eda13002c705acff501366710f83da1c62d875f8427cec27f10ea2d05f4637be141fb9a87935f4b0b9f0fabb6bd6a7cca6a4f48ee1
   HEAD_REF main
+  PATCHES fix-hash.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "anari",
   "version": "0.7.0",
+  "port-version": 1,
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03b62f97be9c25515d10f28262882dd872a74669",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cf756ca650e9d72324024441ad48b760fb587f86",
       "version": "0.7.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -118,7 +118,7 @@
     },
     "anari": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "anax": {
       "baseline": "2.1.0",


### PR DESCRIPTION
Fix configure issue:
```
-- verifying file...
       file='/mnt/vcpkg-ci/buildtrees/anari/src/v0.7.0-e162e53a3f.clean/.anari_deps/anari_helide_embree/v3.13.5.zip'
-- MD5 hash of
    /mnt/vcpkg-ci/buildtrees/anari/src/v0.7.0-e162e53a3f.clean/.anari_deps/anari_helide_embree/v3.13.5.zip
  does not match expected value
    expected: 'd87ce56557a38e332cb3e0fa5cac8cfd'
      actual: '5df9e14b67612bc17bbca6b285471258'
```