### PR TITLE
[libmodbus] update to 3.1.10

### DIFF
--- a/ports/libmodbus/portfile.cmake
+++ b/ports/libmodbus/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephane/libmodbus
-    REF v3.1.6
-    SHA512 9eaa395c75e1170e703e01f8c52c6e6e87efe4eaa22adfc3b51153fd5535d545aea35cf68e1aba29720a6c1dd13d9c60b6b08a5c8098dccd13ccfdc6944420a9
+    REF "v${VERSION}"
+    SHA512 6a01da1f8b486e356ff44874f1479d9d121463958a5ed06e60d910328ccc9b2d431b4a1fd72861c5c645c97b5887a076b763ad6a9ae6b18402dd043ec525b1e2
     HEAD_REF master
     PATCHES fix-static-linkage.patch
 )
@@ -26,6 +26,6 @@ if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
 endif()
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING.LESSER" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LESSER")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libmodbus/vcpkg.json
+++ b/ports/libmodbus/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmodbus",
-  "version": "3.1.6",
-  "port-version": 5,
+  "version": "3.1.10",
   "description": "libmodbus is a free software library to send/receive data with a device which respects the Modbus protocol",
   "homepage": "https://github.com/stephane/libmodbus",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4345,8 +4345,8 @@
       "port-version": 12
     },
     "libmodbus": {
-      "baseline": "3.1.6",
-      "port-version": 5
+      "baseline": "3.1.10",
+      "port-version": 0
     },
     "libmodman": {
       "baseline": "2.0.1",

--- a/versions/l-/libmodbus.json
+++ b/versions/l-/libmodbus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5af2a746eeb644d4c228d03f4bb7854cf4f5691b",
+      "version": "3.1.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "803427a42499df9013b9e6a4dc3501384fc69760",
       "version": "3.1.6",
       "port-version": 5


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33414
No feature needs to test.
Usage tested pass on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
