### PR TITLE
[libffi] disable multi-os directory for the libraries

### DIFF
--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -48,6 +48,7 @@ vcpkg_configure_make(
     OPTIONS
         --enable-portable-binary
         --disable-docs
+        --disable-multi-os-directory
         ${options}
 )
 

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libffi",
   "version": "3.4.4",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4094,7 +4094,7 @@
     },
     "libffi": {
       "baseline": "3.4.4",
-      "port-version": 3
+      "port-version": 4
     },
     "libfido2": {
       "baseline": "1.13.0",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d189744d6e4f29ab0a2f88f3c75f01d0c3719618",
+      "version": "3.4.4",
+      "port-version": 4
+    },
+    {
       "git-tree": "5229da2e57e35c0ab7d043b27c19a29355e0a2c2",
       "version": "3.4.4",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #33426.

In the `quay.io/pypa/manylinux2014_x86_64` container, libffi installed in the `lib64` folder. This causes `python3` to not link against libffi, resulting in errors.

Solve this by disabling multi-os directories, making it use `lib`. With this patch, Python3 can be compiled successful on the above mentioned host.

Tnx to @Neumann-A for pointing out the solution in #33203.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
