### PR TITLE
[vcpkg baseline][sdformat13] Fix find dependency urdfdom

### DIFF
--- a/ports/sdformat13/fix-find-urdfdom.patch
+++ b/ports/sdformat13/fix-find-urdfdom.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e797e8a..0f652d7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -56,7 +56,18 @@ if (BUILD_SDF)
+   #  2. if USE_INTERNAL_URDF is set to True, use the internal copy
+   #  3. if USE_INTERNAL_URDF is set to False, force to search system installation, fail on error
+   if (NOT DEFINED USE_INTERNAL_URDF OR NOT USE_INTERNAL_URDF)
+-    gz_find_package(GzURDFDOM)
++    find_package(urdfdom CONFIG REQUIRED)
++    add_library(GzURDFDOM::GzURDFDOM INTERFACE IMPORTED)
++    target_link_libraries(GzURDFDOM::GzURDFDOM
++      INTERFACE
++        urdfdom::urdfdom_model
++        urdfdom::urdfdom_world
++        urdfdom::urdfdom_sensor
++        urdfdom::urdfdom_model_state
++    )
++    include(FindPackageHandleStandardArgs)
++    find_package_handle_standard_args(GzURDFDOM DEFAULT_MSG)
++    
+     if (NOT GzURDFDOM_FOUND)
+       if (NOT DEFINED USE_INTERNAL_URDF)
+         # fallback to internal urdf

--- a/ports/sdformat13/portfile.cmake
+++ b/ports/sdformat13/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         no-absolute.patch
         cmake-config.patch
+        fix-find-urdfdom.patch
 )
 
 # Ruby is required by the sdformat build process
@@ -20,7 +21,6 @@ vcpkg_cmake_configure(
         -DSKIP_PYBIND11=ON
         -DUSE_INTERNAL_URDF=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
-        -DCMAKE_REQUIRE_FIND_PACKAGE_GzURDFDOM=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Python3=ON
 )
 

--- a/ports/sdformat13/portfile.cmake
+++ b/ports/sdformat13/portfile.cmake
@@ -28,6 +28,19 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sdformat13")
 vcpkg_fixup_pkgconfig()
 
+# fix dependency urdfdom
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/sdformat13-config.cmake" "find_package(TINYXML2" [[
+find_package(urdfdom CONFIG ${gz_package_quiet} ${gz_package_required})
+add_library(GzURDFDOM::GzURDFDOM INTERFACE IMPORTED)
+target_link_libraries(GzURDFDOM::GzURDFDOM
+  INTERFACE
+    urdfdom::urdfdom_model
+    urdfdom::urdfdom_world
+    urdfdom::urdfdom_sensor
+    urdfdom::urdfdom_model_state
+)
+find_package(TINYXML2]])
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
                     "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/sdformat13/portfile.cmake
+++ b/ports/sdformat13/portfile.cmake
@@ -30,15 +30,17 @@ vcpkg_fixup_pkgconfig()
 
 # fix dependency urdfdom
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/sdformat13-config.cmake" "find_package(TINYXML2" [[
-find_package(urdfdom CONFIG ${gz_package_quiet} ${gz_package_required})
-add_library(GzURDFDOM::GzURDFDOM INTERFACE IMPORTED)
-target_link_libraries(GzURDFDOM::GzURDFDOM
-  INTERFACE
-    urdfdom::urdfdom_model
-    urdfdom::urdfdom_world
-    urdfdom::urdfdom_sensor
-    urdfdom::urdfdom_model_state
-)
+if (NOT TARGET GzURDFDOM::GzURDFDOM)
+    find_package(urdfdom CONFIG ${gz_package_quiet} ${gz_package_required})
+    add_library(GzURDFDOM::GzURDFDOM INTERFACE IMPORTED)
+    target_link_libraries(GzURDFDOM::GzURDFDOM
+        INTERFACE
+        urdfdom::urdfdom_model
+        urdfdom::urdfdom_world
+        urdfdom::urdfdom_sensor
+        urdfdom::urdfdom_model_state
+    )
+endif()
 find_package(TINYXML2]])
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/sdformat13/vcpkg.json
+++ b/ports/sdformat13/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdformat13",
   "version": "13.5.0",
+  "port-version": 1,
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7446,7 +7446,7 @@
     },
     "sdformat13": {
       "baseline": "13.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sdformat6": {
       "baseline": "6.2.0",

--- a/versions/s-/sdformat13.json
+++ b/versions/s-/sdformat13.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e2dba5697aa2b33815312dec9db99906af356c5",
+      "version": "13.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b8f7d3bdbefa0795808f6c9a42764584d6e96f2c",
       "version": "13.5.0",
       "port-version": 0

--- a/versions/s-/sdformat13.json
+++ b/versions/s-/sdformat13.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8f24966bb1f13cdd89e2cc523b9ab8d37a57f08f",
+      "git-tree": "88424090fdd3b2122094e75be5c68b3f2f58cda5",
       "version": "13.5.0",
       "port-version": 1
     },

--- a/versions/s-/sdformat13.json
+++ b/versions/s-/sdformat13.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e2dba5697aa2b33815312dec9db99906af356c5",
+      "git-tree": "8f24966bb1f13cdd89e2cc523b9ab8d37a57f08f",
       "version": "13.5.0",
       "port-version": 1
     },


### PR DESCRIPTION
Fix configure error:
```
-- Checking for module 'urdfdom'
--   Package 'console_bridge', required by 'urdfdom', not found
CMake Error at D:/downloads/tools/cmake-3.27.1-windows/cmake-3.27.1-windows-i386/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find GzURDFDOM (missing: GzURDFDOM_FOUND)
```

Related: https://github.com/microsoft/vcpkg/pull/33330/