### PR TITLE
[capnproto]: Update to v1.0.1

### DIFF
--- a/ports/capnproto/disable-C-20-co-routines.patch
+++ b/ports/capnproto/disable-C-20-co-routines.patch
@@ -1,0 +1,25 @@
+From da5b439b558e354a8fc59d09dff6a9eb657f54fd Mon Sep 17 00:00:00 2001
+From: Stig Hornang <shornang@gmail.com>
+Date: Mon, 28 Aug 2023 22:28:43 +0200
+Subject: [PATCH] Disable C++20 co-routines
+
+---
+ c++/src/kj/async-prelude.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/c++/src/kj/async-prelude.h b/c++/src/kj/async-prelude.h
+index 6289bf3f..c9845cdc 100644
+--- a/c++/src/kj/async-prelude.h
++++ b/c++/src/kj/async-prelude.h
+@@ -36,7 +36,7 @@
+ #if (__cpp_impl_coroutine >= 201902L) && __has_include(<coroutine>)
+ // C++20 Coroutines detected.
+ #include <coroutine>
+-#define KJ_HAS_COROUTINE 1
++// #define KJ_HAS_COROUTINE 1
+ #define KJ_COROUTINE_STD_NAMESPACE std
+ #elif (__cpp_coroutines >= 201703L) && __has_include(<experimental/coroutine>)
+ // Coroutines TS detected.
+-- 
+2.41.0.windows.3
+

--- a/ports/capnproto/portfile.cmake
+++ b/ports/capnproto/portfile.cmake
@@ -3,9 +3,12 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO capnproto/capnproto
-    REF v0.10.3
-    SHA512 d8f699220f0738a456238f0e3e638940a340c005f378d6845c805d0e4935d19dc21ba1701710963edb59d8982fefe00aae5e834f912cb734e68cdee10154be01
+    REF v1.0.1
+    SHA512 189d8c483bded3889e903e3998d32d022b5a7bf45d519dc551dc9b2d7909a45a8816a09f4a817aa0fbb14c86c32b838a0c26457c2e89c33ec0eb93bbb93391c0
     HEAD_REF master
+    PATCHES
+        disable-C-20-co-routines.patch
+        undef-KJ_USE_EPOLL-for-ANDROID_PLATFORM-23.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/capnproto/undef-KJ_USE_EPOLL-for-ANDROID_PLATFORM-23.patch
+++ b/ports/capnproto/undef-KJ_USE_EPOLL-for-ANDROID_PLATFORM-23.patch
@@ -1,0 +1,28 @@
+From 306220e57881064da99f89ad4192b3e19c7953a9 Mon Sep 17 00:00:00 2001
+From: Stig Hornang <shornang@gmail.com>
+Date: Thu, 31 Aug 2023 21:20:09 +0200
+Subject: [PATCH] Undef KJ_USE_EPOLL for ANDROID_PLATFORM < 23
+
+---
+ c++/src/kj/async-unix.h | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/c++/src/kj/async-unix.h b/c++/src/kj/async-unix.h
+index 665305ea..c5f195cf 100644
+--- a/c++/src/kj/async-unix.h
++++ b/c++/src/kj/async-unix.h
+@@ -34,7 +34,10 @@
+ KJ_BEGIN_HEADER
+ 
+ #if !defined(KJ_USE_EPOLL) && !defined(KJ_USE_KQUEUE)
+-#if __linux__
++
++// Android NDK less than API version 23 doesn't have sigtimedwait
++// sigtimedwait is used in async-unix.c++ if KJ_USE_EPOLL is defined
++#if __linux__ && !(__ANDROID__ && __ANDROID_API__ < 23)
+ // Default to epoll on Linux.
+ #define KJ_USE_EPOLL 1
+ #elif __APPLE__ || __FreeBSD__ || __OpenBSD__ || __NetBSD__ || __DragonFly__
+-- 
+2.41.0.windows.3
+

--- a/ports/capnproto/vcpkg.json
+++ b/ports/capnproto/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "capnproto",
-  "version": "0.10.3",
+  "version": "1.0.1",
   "description": "Data interchange format and capability-based RPC system",
   "homepage": "https://capnproto.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1401,7 +1401,7 @@
       "port-version": 0
     },
     "capnproto": {
-      "baseline": "0.10.3",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "capstone": {

--- a/versions/c-/capnproto.json
+++ b/versions/c-/capnproto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a615543c6406b84fc52a931335d7fdb70037627",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "928a9a658c34e9a664531e0a6762a60408737e54",
       "version": "0.10.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #33430

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
