### PR TITLE
[rsm-bsa] Update to 4.1.0

### DIFF
--- a/ports/rsm-bsa/portfile.cmake
+++ b/ports/rsm-bsa/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Ryan-rsm-McKenzie/bsa
-    REF 4.0.3
-    SHA512 ec8a2aff1c833d7bffd6345ab989bc57137eee3fb2c5b7509027f068783d42d61bcc4b694b53a7961c1c69ee52834efadef9b3c82e1a739c0c5491af75e8dde7
+    REF 4.1.0
+    SHA512 c488a4f7cffa59064baafd429cf118a8f8a7b5594a0bd49a0ed468572b37af2e7428a83ad83cc7b13b556744a444cb7b8a4591c7018e49cadb1c5d42ae780f51
     HEAD_REF master
 )
 

--- a/ports/rsm-bsa/vcpkg.json
+++ b/ports/rsm-bsa/vcpkg.json
@@ -1,16 +1,13 @@
 {
   "name": "rsm-bsa",
-  "version-semver": "4.0.3",
+  "version-semver": "4.1.0",
   "description": "A C++ library for working with the Bethesda archive file format",
   "homepage": "https://github.com/Ryan-rsm-McKenzie/bsa",
   "documentation": "https://ryan-rsm-mckenzie.github.io/bsa/",
   "license": "MIT",
   "supports": "!x86 & !osx & !uwp",
   "dependencies": [
-    {
-      "name": "directxtex",
-      "platform": "windows"
-    },
+    "directxtex",
     "lz4",
     "rsm-binary-io",
     "rsm-mmio",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7297,7 +7297,7 @@
       "port-version": 0
     },
     "rsm-bsa": {
-      "baseline": "4.0.3",
+      "baseline": "4.1.0",
       "port-version": 0
     },
     "rsm-mmio": {

--- a/versions/r-/rsm-bsa.json
+++ b/versions/r-/rsm-bsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "56763c1c1befe44030f14704e1be0c05424f039e",
+      "version-semver": "4.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f91c3a5ffa0abe0eb4b3dc47421fb302dd258b05",
       "version-semver": "4.0.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

This PR updates the port [rsm-bsa](https://github.com/Ryan-rsm-McKenzie/bsa) to the latest version, [4.1.0](https://github.com/Ryan-rsm-McKenzie/bsa/releases/tag/4.1.0)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
