### PR TITLE
[libxml2] Update to 2.11.5

### DIFF
--- a/ports/libxml2/disable-docs.patch
+++ b/ports/libxml2/disable-docs.patch
@@ -1,9 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 834b35d3..9701bdc0 100644
+index f922d5ab..70466bc7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -571,16 +571,6 @@ if(LIBXML2_WITH_PYTHON)
- 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxml2.py DESTINATION ${LIBXML2_PYTHON_INSTALL_DIR} COMPONENT runtime)
+@@ -599,15 +599,5 @@ if(LIBXML2_WITH_PYTHON)
  endif()
  
 -install(FILES doc/xml2-config.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)

--- a/ports/libxml2/disable-docs.patch
+++ b/ports/libxml2/disable-docs.patch
@@ -1,8 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f922d5ab..70466bc7 100644
+index 834b35d3..9701bdc0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -599,15 +599,5 @@ if(LIBXML2_WITH_PYTHON)
+@@ -571,16 +571,6 @@ if(LIBXML2_WITH_PYTHON)
+ 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxml2.py DESTINATION ${LIBXML2_PYTHON_INSTALL_DIR} COMPONENT runtime)
  endif()
  
 -install(FILES doc/xml2-config.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)

--- a/ports/libxml2/fix_cmakelist.patch
+++ b/ports/libxml2/fix_cmakelist.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f922d5ab..685964b3 100644
+index 834b35d3..685a4403 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -420,15 +420,15 @@ endif()
+@@ -393,15 +393,15 @@ endif()
  if(LIBXML2_WITH_ICU)
  	target_link_libraries(LibXml2 PRIVATE ICU::data ICU::i18n ICU::uc)
  	if(WIN32)
@@ -21,7 +21,7 @@ index f922d5ab..685964b3 100644
  endif()
  
  if(LIBXML2_WITH_THREADS)
-@@ -438,7 +438,7 @@ endif()
+@@ -411,7 +411,7 @@ endif()
  
  if(LIBXML2_WITH_ZLIB)
  	target_link_libraries(LibXml2 PRIVATE ZLIB::ZLIB)
@@ -30,7 +30,7 @@ index f922d5ab..685964b3 100644
  endif()
  
  set_target_properties(
-@@ -490,23 +490,9 @@ set_target_properties(
+@@ -425,23 +425,9 @@ set_target_properties(
          SOVERSION ${LIBXML_MAJOR_VERSION}
  )
  
@@ -56,7 +56,7 @@ index f922d5ab..685964b3 100644
  endif()
  
  install(FILES ${LIBXML2_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libxml2/libxml COMPONENT development)
-@@ -654,30 +640,30 @@ install(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/libxml2 COMPONEN
+@@ -584,30 +570,30 @@ install(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT documentati
  
  configure_package_config_file(
  	libxml2-config.cmake.cmake.in libxml2-config.cmake
@@ -93,7 +93,7 @@ index f922d5ab..685964b3 100644
  	FILE libxml2-export.cmake
  	COMPONENT development
 diff --git a/libxml-2.0.pc.in b/libxml-2.0.pc.in
-index 2653a7c5..2eb2f362 100644
+index 88e3963b..0d1706c9 100644
 --- a/libxml-2.0.pc.in
 +++ b/libxml-2.0.pc.in
 @@ -8,6 +8,7 @@ Name: libXML

--- a/ports/libxml2/fix_cmakelist.patch
+++ b/ports/libxml2/fix_cmakelist.patch
@@ -104,5 +104,5 @@ index 88e3963b..0d1706c9 100644
 -Libs.private: @XML_PRIVATE_LIBS@ @LIBS@
 +Requires.private: @ICU_LIBS@ @Z_LIBS@ @LZMA_LIBS@
 +Libs: -L${libdir} -l@XML_LIB_NAME@
-+Libs.private: @THREAD_LIBS@ @ICONV_LIBS@ @LIBM@ @WIN32_EXTRA_LIBADD@ @LIBS@
++Libs.private: @THREAD_LIBS@ @ICONV_LIBS@ @LIBM@ @WINSOCK_LIBS@ @LIBS@
  Cflags: @XML_INCLUDEDIR@ @XML_CFLAGS@

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.gnome.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxml2
-    REF v2.11.5
+    REF "v${VERSION}"
     SHA512 527e66f6260a399318cfacc06db3ede4b16178ef17492ed0d515884aa00fce685f9e6932cd117df0d83e2440b5a5392c3d5fbe187b601cf19769b495e0865c87
     HEAD_REF master
     PATCHES

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.gnome.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxml2
-    REF f507d167f1755b7eaea09fb1a44d29aab828b6d1
-    SHA512 2ac3dcab31111f608a3fe33dde492c9653ad2bd49a792373acdd03d2787e1a4ef70eeb7a3d47cf67eefd43aee2ab75ec50b36cdcd124445ca206de924abb6021
+    REF v2.11.5
+    SHA512 527e66f6260a399318cfacc06db3ede4b16178ef17492ed0d515884aa00fce685f9e6932cd117df0d83e2440b5a5392c3d5fbe187b601cf19769b495e0865c87
     HEAD_REF master
     PATCHES
         disable-docs.patch
@@ -39,7 +39,6 @@ vcpkg_cmake_configure(
         -DLIBXML2_WITH_PYTHON=OFF
         -DLIBXML2_WITH_READER=ON
         -DLIBXML2_WITH_REGEXPS=ON
-        -DLIBXML2_WITH_RUN_DEBUG=OFF
         -DLIBXML2_WITH_SAX1=ON
         -DLIBXML2_WITH_SCHEMAS=ON
         -DLIBXML2_WITH_SCHEMATRON=ON

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxml2",
-  "version": "2.10.3",
-  "port-version": 1,
+  "version": "2.11.5",
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4889,8 +4889,8 @@
       "port-version": 2
     },
     "libxml2": {
-      "baseline": "2.10.3",
-      "port-version": 1
+      "baseline": "2.11.5",
+      "port-version": 0
     },
     "libxmlmm": {
       "baseline": "0.6.0",

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "938e17a2af5d284f8523b3943fc626f115aeee40",
+      "git-tree": "a8c20b561ed09ee9bd274071751dafbf8c0825ed",
       "version": "2.11.5",
       "port-version": 0
     },

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "938e17a2af5d284f8523b3943fc626f115aeee40",
+      "version": "2.11.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "fd1e750ce7851d72bf39c0b6d30a4a8d1d717c45",
       "version": "2.10.3",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
