### PR TITLE
[rlottie] New port

### DIFF
--- a/ports/rlottie/patches/01_fix_install.patch
+++ b/ports/rlottie/patches/01_fix_install.patch
@@ -1,0 +1,84 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c111dac..35b8a43 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required( VERSION 3.3 )
++cmake_minimum_required( VERSION 3.27 )
+ 
+ #declare project
+ project( rlottie VERSION 0.2 LANGUAGES C CXX ASM)
+@@ -83,9 +83,9 @@ target_link_libraries(rlottie
+                      )
+ 
+ if (NOT APPLE AND NOT WIN32)
+-    target_link_libraries(rlottie
++    target_link_options(rlottie
+                         PRIVATE
+-                            "-Wl,--version-script=${CMAKE_SOURCE_DIR}/rlottie.expmap"
++                            $<COMPILE_ONLY:-Wl,--version-script=${CMAKE_SOURCE_DIR}/rlottie.expmap>
+                           )
+ endif()
+ 
+@@ -124,10 +124,6 @@ if (LOTTIE_ASAN)
+     target_link_options(rlottie PUBLIC  -fsanitize=address)
+ endif()
+ 
+-if (NOT LIB_INSTALL_DIR)
+-    set (LIB_INSTALL_DIR "/usr/lib")
+-endif (NOT LIB_INSTALL_DIR)
+-
+ #declare source and include files
+ add_subdirectory(inc)
+ add_subdirectory(src)
+@@ -139,9 +135,10 @@ if (LOTTIE_TEST)
+ endif()
+ 
+ SET(PREFIX ${CMAKE_INSTALL_PREFIX})
+-SET(EXEC_DIR ${PREFIX})
+-SET(LIBDIR ${LIB_INSTALL_DIR})
+-SET(INCDIR ${PREFIX}/include)
++SET(EXEC_DIR bin)
++SET(LIBDIR lib)
++SET(INCDIR include)
++SET(LIB_INSTALL_DIR lib)
+ 
+ CONFIGURE_FILE(${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc)
+ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+@@ -156,8 +153,8 @@ install(FILES
+ 
+ #install lib
+ install( TARGETS rlottie EXPORT rlottie-targets
+-         LIBRARY     DESTINATION    ${LIB_INSTALL_DIR}
+-         ARCHIVE     DESTINATION    ${LIB_INSTALL_DIR}
++         LIBRARY     DESTINATION    lib
++         ARCHIVE     DESTINATION    lib
+          INCLUDES    DESTINATION    include
+        )
+ 
+@@ -166,7 +163,7 @@ install( TARGETS rlottie EXPORT rlottie-targets
+ install( EXPORT rlottie-targets
+          FILE          rlottieTargets.cmake
+          NAMESPACE     rlottie::
+-         DESTINATION   ${LIB_INSTALL_DIR}/cmake/rlottie
++         DESTINATION   share/rlottie
+        )
+ 
+ 
+@@ -180,14 +177,14 @@ write_basic_package_version_file(
+ 
+ configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/rlottieConfig.cmake.in
+     ${CMAKE_CURRENT_BINARY_DIR}/rlottieConfig.cmake
+-    INSTALL_DESTINATION ${LIB_INSTALL_DIR}/cmake/rlottie
++    INSTALL_DESTINATION share/rlottie
+ )
+ 
+ #Install the config, configversion and custom find modules
+ install(FILES
+     ${CMAKE_CURRENT_BINARY_DIR}/rlottieConfig.cmake
+     ${CMAKE_CURRENT_BINARY_DIR}/rlottieConfigVersion.cmake
+-    DESTINATION ${LIB_INSTALL_DIR}/cmake/rlottie
++    DESTINATION share/rlottie
+ )
+ 
+ 

--- a/ports/rlottie/patches/02_add_limits.patch
+++ b/ports/rlottie/patches/02_add_limits.patch
@@ -1,0 +1,12 @@
+diff --git a/src/vector/vrle.cpp b/src/vector/vrle.cpp
+index c7a520f..379f8ed 100644
+--- a/src/vector/vrle.cpp
++++ b/src/vector/vrle.cpp
+@@ -27,6 +27,7 @@
+ #include <array>
+ #include <cstdlib>
+ #include <cstring>
++#include <limits>
+ #include <vector>
+ #include "vdebug.h"
+ #include "vglobal.h"

--- a/ports/rlottie/patches/03_fix_arm_neon.patch
+++ b/ports/rlottie/patches/03_fix_arm_neon.patch
@@ -1,0 +1,39 @@
+diff --git a/src/vector/vdrawhelper_neon.cpp b/src/vector/vdrawhelper_neon.cpp
+index 681eabb..1c1eed6 100644
+--- a/src/vector/vdrawhelper_neon.cpp
++++ b/src/vector/vdrawhelper_neon.cpp
+@@ -2,28 +2,20 @@
+ 
+ #include "vdrawhelper.h"
+ 
+-extern "C" void pixman_composite_src_n_8888_asm_neon(int32_t w, int32_t h,
+-                                                     uint32_t *dst,
+-                                                     int32_t   dst_stride,
+-                                                     uint32_t  src);
+-
+-extern "C" void pixman_composite_over_n_8888_asm_neon(int32_t w, int32_t h,
+-                                                      uint32_t *dst,
+-                                                      int32_t   dst_stride,
+-                                                      uint32_t  src);
+-
+ void memfill32(uint32_t *dest, uint32_t value, int length)
+ {
+-    pixman_composite_src_n_8888_asm_neon(length, 1, dest, length, value);
++    memset(dest, value, length);
+ }
+ 
+ static void color_SourceOver(uint32_t *dest, int length,
+                                       uint32_t color,
+-                                     uint32_t const_alpha)
++                                     uint32_t alpha)
+ {
+-    if (const_alpha != 255) color = BYTE_MUL(color, const_alpha);
++    int ialpha, i;
+ 
+-    pixman_composite_over_n_8888_asm_neon(length, 1, dest, length, color);
++    if (alpha != 255) color = BYTE_MUL(color, alpha);
++    ialpha = 255 - vAlpha(color);
++    for (i = 0; i < length; ++i) dest[i] = color + BYTE_MUL(dest[i], ialpha);
+ }
+ 
+ void RenderFuncTable::neon()

--- a/ports/rlottie/portfile.cmake
+++ b/ports/rlottie/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Samsung/rlottie
+    REF v0.2
+    SHA512 1f645ae998ddbe83e4911addf28ec24ae3ff33f6439a9fb6c1e56986b46ac17dba155773ab02a59712e781febb31709a99075a3fbcda6136a0cb43dbd7c753de
+    HEAD_REF master
+    PATCHES
+        "patches/01_fix_install.patch"
+        "patches/02_add_limits.patch"
+        "patches/03_fix_arm_neon.patch"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(LOTTIE_MODULE OFF)
+elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(LOTTIE_MODULE ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLOTTIE_MODULE=${LOTTIE_MODULE}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/rlottie/vcpkg.json
+++ b/ports/rlottie/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "name": "rlottie",
+  "version": "0.2",
+  "maintainers": [
+    "Subhransu Mohanty <sub.mohanty@samsung.com>",
+    "Hermet Park <hermetpark@gmail.com>",
+    "Youngbok Shin <youngb.shin@samsung.com>",
+    "Jaeun Choi <jaeun12.choi@samsung.com>",
+    "Bryce Harrington <bryce@bryceharrington.org>",
+    "Junsu Choi <jsuya.choi@samsung.com>",
+    "Yuangu <lifulinghan@aol.com>",
+    "Mihai Serban <mihai.serban@gmail.com>",
+    "Shinwoo Kim <cinoo.kim@samsung.com>",
+    "Vincent Torri <vincent.torri@gmail.com>",
+    "Nicholas Guriev <guriev-ns@ya.ru>",
+    "John Preston <johnprestonmail@gmail.com>"
+  ],
+  "description": "rlottie is a platform independent standalone c++ library for rendering vector based animations and art in realtime.",
+  "homepage": "https://github.com/Samsung/rlottie",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7256,6 +7256,10 @@
       "baseline": "1.10.0",
       "port-version": 0
     },
+    "rlottie": {
+      "baseline": "0.2",
+      "port-version": 0
+    },
     "rmlui": {
       "baseline": "5.1",
       "port-version": 0

--- a/versions/r-/rlottie.json
+++ b/versions/r-/rlottie.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "af69e12bfbb08ee322c676d9bafdc3b663583da4",
+      "version": "0.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
