### PR TITLE
[cfitsio] fix LINK2019 error

### DIFF
--- a/ports/cfitsio/0005-fix-link2019-error.patch
+++ b/ports/cfitsio/0005-fix-link2019-error.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fead70c..f05ae92 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -68,6 +68,7 @@ IF (USE_PTHREADS)
+     FIND_PACKAGE(pthreads REQUIRED)
+     INCLUDE_DIRECTORIES(${PTHREADS_INCLUDE_DIR})
+     ADD_DEFINITIONS(-D_REENTRANT)
++    set(PTHREADS_LIBRARY PThreads4W::PThreads4W)
+ ENDIF()
+ 
+ # Math library (not available in MSVC or MINGW)
+diff --git a/fitsio2.h b/fitsio2.h
+index 1adb17b..19f8511 100644
+--- a/fitsio2.h
++++ b/fitsio2.h
+@@ -26,7 +26,7 @@ extern int Fitsio_Pthread_Status;
+ #define FFUNLOCK1(lockname) (Fitsio_Pthread_Status = pthread_mutex_unlock(&lockname))
+ #define FFLOCK   FFLOCK1(Fitsio_Lock)
+ #define FFUNLOCK FFUNLOCK1(Fitsio_Lock)
+-#define ffstrtok(str, tok, save) strtok_r(str, tok, save)
++#define ffstrtok(str, tok, save) strtok_s(str, tok, save)
+ 
+ #else
+ #define FFLOCK

--- a/ports/cfitsio/portfile.cmake
+++ b/ports/cfitsio/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive(
         0002-export-cmake-targets.patch
         0003-add-Wno-error-implicit-funciton-declaration-to-cmake.patch
         0004-pkg-config.patch
+        0005-fix-link2019-error.patch
 )
 
 vcpkg_check_features(
@@ -69,4 +70,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_
 
 file(INSTALL "${SOURCE_PATH}/FindPthreads.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-cfitsio")
 
-file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")

--- a/ports/cfitsio/vcpkg.json
+++ b/ports/cfitsio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cfitsio",
   "version": "3.49",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Library of C and Fortran subroutines for reading and writing data files in FITS (Flexible Image Transport System) data format",
   "homepage": "https://heasarc.gsfc.nasa.gov/fitsio/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1474,7 +1474,7 @@
     },
     "cfitsio": {
       "baseline": "3.49",
-      "port-version": 3
+      "port-version": 4
     },
     "cgal": {
       "baseline": "5.6",

--- a/versions/c-/cfitsio.json
+++ b/versions/c-/cfitsio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b2df854891a5beda50e8cf8004a7af0766c5c5bc",
+      "version": "3.49",
+      "port-version": 4
+    },
+    {
       "git-tree": "b3f1a4860fc51b43140dc7139dd262f93e4a949d",
       "version": "3.49",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33469
Error:
```
cfileio.c.obj : error LNK2019: unresolved external symbol pthread_mutexattr_init referenced in function fitsio_init_lock
cfileio.c.obj : error LNK2019: unresolved external symbol pthread_mutexattr_settype referenced in function fitsio_init_lock
cfileio.c.obj : error LNK2019: unresolved external symbol pthread_mutex_init referenced in function fitsio_init_lock

iraffits.c.obj : error LNK2019: unresolved external symbol strtok_r referenced in function irafrdimage
```
All feature tested pass in the following triplets:

- x64-windows
- x64-windows-static
- x86-windows

Usage tested pass on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
