### PR TITLE
[zeroc-ice] Added icelocatordiscovery feature

### DIFF
--- a/ports/zeroc-ice/portfile.cmake
+++ b/ports/zeroc-ice/portfile.cmake
@@ -135,6 +135,12 @@ if("icediscovery" IN_LIST FEATURES)
     vcpkg_list(APPEND ICE_OPTIONAL_COMPONENTS_MAKE "IceDiscovery")
 endif()
 
+# IceLocatorDiscovery
+if("icelocatordiscovery" IN_LIST FEATURES)
+    vcpkg_list(APPEND ICE_OPTIONAL_COMPONENTS_MSBUILD "/t:C++11\\icelocatordiscovery++11")
+    vcpkg_list(APPEND ICE_OPTIONAL_COMPONENTS_MAKE "IceLocatorDiscovery")
+endif()
+
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     # Clean up for the first round (important for install --editable)
     vcpkg_execute_build_process(

--- a/ports/zeroc-ice/vcpkg.json
+++ b/ports/zeroc-ice/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zeroc-ice",
   "version": "3.7.9",
-  "port-version": 2,
+  "port-version": 3,
   "maintainers": "Benjamin Oldenburg <benjamin.oldenburg@ordis.co.th>",
   "description": "Comprehensive RPC framework with support for C++, CSharp, Java, JavaScript, Python and more.",
   "homepage": "https://github.com/zeroc-ice/ice",
@@ -102,6 +102,20 @@
             "iceboxlib",
             "icegridlib",
             "icessl"
+          ]
+        }
+      ]
+    },
+    "icelocatordiscovery": {
+      "description": "IceLocatorDiscovery",
+      "dependencies": [
+        {
+          "name": "zeroc-ice",
+          "features": [
+            "glacier2lib",
+            "iceboxlib",
+            "icessl",
+            "icestormlib"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9050,7 +9050,7 @@
     },
     "zeroc-ice": {
       "baseline": "3.7.9",
-      "port-version": 2
+      "port-version": 3
     },
     "zeromq": {
       "baseline": "2023-06-20",

--- a/versions/z-/zeroc-ice.json
+++ b/versions/z-/zeroc-ice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45f338a327c4b8ea7eb16fc81e650cd0f999449c",
+      "version": "3.7.9",
+      "port-version": 3
+    },
+    {
       "git-tree": "dc07eee81cdf5c66efc83d606c635e722ef23d39",
       "version": "3.7.9",
       "port-version": 2


### PR DESCRIPTION
Added IceLocatorDiscovery library for C++11 bindings(as zeroc-ice currently only provides the C++11 bindings)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I hope this time the hash and version updating worked correctly :D