### PR TITLE
[libmad] Detect the FPM flag according to the CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/ports/libmad/CMakeLists.txt
+++ b/ports/libmad/CMakeLists.txt
@@ -41,9 +41,37 @@ add_library(
 )
 
 target_compile_definitions(mad
-    PRIVATE _LIB _MBCS ASO_ZEROCHECK HAVE_CONFIG_H FPM_DEFAULT
+    PRIVATE _LIB _MBCS ASO_ZEROCHECK HAVE_CONFIG_H
     PRIVATE _CRT_SECURE_NO_WARNINGS
 )
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(^i.86$)")
+    target_compile_definitions(mad
+        PRIVATE FPM_INTEL
+    )
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|^(aarch64|arm64)")
+    target_compile_definitions(mad
+        PRIVATE FPM_64BIT
+    )
+# This fails with "error: invalid instruction" on armv7-a 
+#elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+#    target_compile_definitions(mad
+#        PRIVATE FPM_ARM
+#    )
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^mips")
+    target_compile_definitions(mad
+        PRIVATE FPM_MIPS
+    )
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)")
+    target_compile_definitions(mad
+        PRIVATE FPM_PPC
+    )
+else()
+    target_compile_definitions(mad
+        PRIVATE FPM_DEFAULT
+    )
+    message(WARNING "CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR} unknown. Fall back to FPM_DEFAULT, loosing significant accuracy")
+endif()
 
 install(
     TARGETS mad

--- a/ports/libmad/vcpkg.json
+++ b/ports/libmad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmad",
   "version": "0.15.1",
-  "port-version": 12,
+  "port-version": 13,
   "description": "high-quality MPEG audio decoder",
   "homepage": "http://www.mars.org/home/rob/proj/mpeg/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4310,7 +4310,7 @@
     },
     "libmad": {
       "baseline": "0.15.1",
-      "port-version": 12
+      "port-version": 13
     },
     "libmagic": {
       "baseline": "5.40",

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88e56333079029031e808b84c95ded6dd33a2bbd",
+      "version": "0.15.1",
+      "port-version": 13
+    },
+    {
       "git-tree": "eaed142825775ca972204c5c2d7720043eef3c2b",
       "version": "0.15.1",
       "port-version": 12


### PR DESCRIPTION
This avoids to use the 32 bit default math with significant lower accuracy.

Thia has been detected by undesired noise at the beginning of a track compared with a libmad Debian build here: 
https://github.com/mixxxdj/mixxx/pull/11887

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.