### PR TITLE
[skia] disable the dev test

### DIFF
--- a/ports/skia/disable-dev-test.patch
+++ b/ports/skia/disable-dev-test.patch
@@ -1,0 +1,13 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 3691123..8682b8e 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -97,7 +97,7 @@ config("skia_private") {
+   if (is_skia_dev_build && !is_wasm) {
+     defines += [
+       "SK_ALLOW_STATIC_GLOBAL_INITIALIZERS=1",
+-      "GR_TEST_UTILS=1",
++      "GR_TEST_UTILS=0",
+     ]
+     if (skia_enable_graphite) {
+       defines += [ "GRAPHITE_TEST_UTILS=1" ]

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -114,7 +114,7 @@ elseif(VCPKG_TARGET_IS_EMSCRIPTEN)
 elseif(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     string(APPEND OPTIONS " target_os=\"win\"")
     if(VCPKG_TARGET_IS_UWP)
-        string(APPEND OPTIONS " skia_enable_winuwp=true skia_enable_fontmgr_win=false skia_use_xps=false ")
+        string(APPEND OPTIONS " skia_enable_winuwp=true skia_enable_fontmgr_win=false skia_use_xps=false")
     endif()
 endif()
 

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -114,7 +114,7 @@ elseif(VCPKG_TARGET_IS_EMSCRIPTEN)
 elseif(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     string(APPEND OPTIONS " target_os=\"win\"")
     if(VCPKG_TARGET_IS_UWP)
-        string(APPEND OPTIONS " skia_enable_winuwp=true skia_enable_fontmgr_win=false skia_use_xps=false is_skia_dev_build=false")
+        string(APPEND OPTIONS " skia_enable_winuwp=true skia_enable_fontmgr_win=false skia_use_xps=false ")
     endif()
 endif()
 
@@ -277,7 +277,7 @@ endif()
 
 vcpkg_gn_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS "${OPTIONS} skia_use_lua=false skia_enable_tools=false skia_enable_spirv_validation=false"
+    OPTIONS "${OPTIONS} skia_use_lua=false skia_enable_tools=false skia_enable_spirv_validation=false is_skia_dev_build=false"
     OPTIONS_DEBUG "${OPTIONS_DBG}"
     OPTIONS_RELEASE "${OPTIONS_REL}"
 )

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -114,7 +114,7 @@ elseif(VCPKG_TARGET_IS_EMSCRIPTEN)
 elseif(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     string(APPEND OPTIONS " target_os=\"win\"")
     if(VCPKG_TARGET_IS_UWP)
-        string(APPEND OPTIONS " skia_enable_winuwp=true skia_enable_fontmgr_win=false skia_use_xps=false")
+        string(APPEND OPTIONS " skia_enable_winuwp=true skia_enable_fontmgr_win=false skia_use_xps=false is_skia_dev_build=false")
     endif()
 endif()
 

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_git(
         disable-msvc-env-setup.patch
         uwp.patch
         core-opengl32.patch
+        disable-dev-test.patch
 )
 
 # these following aren't available in vcpkg
@@ -277,7 +278,7 @@ endif()
 
 vcpkg_gn_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS "${OPTIONS} skia_use_lua=false skia_enable_tools=false skia_enable_spirv_validation=false is_skia_dev_build=false"
+    OPTIONS "${OPTIONS} skia_use_lua=false skia_enable_tools=false skia_enable_spirv_validation=false"
     OPTIONS_DEBUG "${OPTIONS_DBG}"
     OPTIONS_RELEASE "${OPTIONS_REL}"
 )

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "skia",
   "version": "0.36.0",
-  "port-version": 8,
+  "port-version": 9,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7658,7 +7658,7 @@
     },
     "skia": {
       "baseline": "0.36.0",
-      "port-version": 8
+      "port-version": 9
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81cd717494ff0fae3a302cddfd158dc215f367b5",
+      "version": "0.36.0",
+      "port-version": 9
+    },
+    {
       "git-tree": "59bcc7110298012cf8f0d6e68ec8d04a4cb01e8b",
       "version": "0.36.0",
       "port-version": 8

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "81cd717494ff0fae3a302cddfd158dc215f367b5",
+      "git-tree": "627da65f537b084f39c83f9026c4e9c252fa0340",
       "version": "0.36.0",
       "port-version": 9
     },

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "14d0d96230114d93c65427a9062256e3ae151f88",
+      "git-tree": "9389efe5ea2540ef9a0885b796d13e0d730fb603",
       "version": "0.36.0",
       "port-version": 9
     },

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "627da65f537b084f39c83f9026c4e9c252fa0340",
+      "git-tree": "14d0d96230114d93c65427a9062256e3ae151f88",
       "version": "0.36.0",
       "port-version": 9
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/33472
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Disable macro `is_skia_dev_build` to avoid `GR_TEST_UTILS` being defined.

https://github.com/google/skia/blob/b8108412832504761a799be9a83f56a399d4f16c/BUILD.gn#L112

cc @meinig-arts Please test this. 
<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
