### PR TITLE
[imgui-node-editor] New port

### DIFF
--- a/ports/imgui-node-editor/CMakeLists.txt
+++ b/ports/imgui-node-editor/CMakeLists.txt
@@ -48,7 +48,7 @@ if (NOT IMGUI_NODE_EDITOR_SKIP_HEADERS)
             imgui_node_editor.h
             imgui_node_editor_internal.h
             imgui_node_editor_internal.inl
-        DESTINATION include
+        DESTINATION include/${PROJECT_NAME}
     )
 endif()
 

--- a/ports/imgui-node-editor/CMakeLists.txt
+++ b/ports/imgui-node-editor/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.8)
+project(imgui-node-editor)
+
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(imgui CONFIG REQUIRED)
+get_target_property(IMGUI_INCLUDE_DIRS imgui::imgui
+    INTERFACE_INCLUDE_DIRECTORIES
+)
+
+add_library(${PROJECT_NAME} "")
+
+target_include_directories(
+	${PROJECT_NAME}
+	PUBLIC
+	   	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<INSTALL_INTERFACE:include>
+	PRIVATE
+		${IMGUI_INCLUDE_DIRS}
+)
+
+target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
+        crude_json.cpp
+        imgui_canvas.cpp
+        imgui_node_editor.cpp
+        imgui_node_editor_api.cpp
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT unofficial-${PROJECT_NAME}-target
+    ARCHIVE DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+if (NOT IMGUI_NODE_EDITOR_SKIP_HEADERS)
+    install(
+        FILES
+            crude_json.h
+            imgui_bezier_math.h
+            imgui_bezier_math.inl
+            imgui_canvas.h
+            imgui_extra_math.h
+            imgui_extra_math.inl
+            imgui_node_editor.h
+            imgui_node_editor_internal.h
+            imgui_node_editor_internal.inl
+        DESTINATION include
+    )
+endif()
+
+install(
+    EXPORT unofficial-${PROJECT_NAME}-target
+    NAMESPACE unofficial::${PROJECT_NAME}::
+    FILE unofficial-${PROJECT_NAME}-config.cmake
+    DESTINATION share/unofficial-${PROJECT_NAME}
+)

--- a/ports/imgui-node-editor/CMakeLists.txt
+++ b/ports/imgui-node-editor/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(imgui-node-editor)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(imgui CONFIG REQUIRED)
 get_target_property(IMGUI_INCLUDE_DIRS imgui::imgui

--- a/ports/imgui-node-editor/portfile.cmake
+++ b/ports/imgui-node-editor/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO thedmd/imgui-node-editor
+    REF v${VERSION}
+    SHA512 7dbc34a7af1554a7e683e0b55d18fc08cf5832bf5d6a57a30820e7ef98a6fbb5a65a7287f6250d3b6f47b89ac0499f51fbe19d9c11850e26f74e3b0e806abb1b
+    HEAD_REF master
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS_DEBUG
+        -DIMGUI_NODE_EDITOR_SKIP_HEADERS=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH share/unofficial-${PORT})
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/imgui-node-editor/vcpkg.json
+++ b/ports/imgui-node-editor/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "imgui-node-editor",
+  "version": "0.9.2",
+  "description": "Node Editor built using Dear ImGui",
+  "homepage": "https://github.com/thedmd/imgui-node-editor",
+  "license": "MIT",
+  "dependencies": [
+    "imgui",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3384,6 +3384,10 @@
       "baseline": "1.89.7",
       "port-version": 1
     },
+    "imgui-node-editor": {
+      "baseline": "0.9.2",
+      "port-version": 0
+    },
     "imgui-sfml": {
       "baseline": "2.5",
       "port-version": 4

--- a/versions/i-/imgui-node-editor.json
+++ b/versions/i-/imgui-node-editor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "df65fa32113e1783bf13baca1ea86edc526e7683",
+      "git-tree": "26e2cf3260ea1e08e61912431635f49d24b6ea87",
       "version": "0.9.2",
       "port-version": 0
     }

--- a/versions/i-/imgui-node-editor.json
+++ b/versions/i-/imgui-node-editor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4064aa26024862b7a5fdad86c151e852c7c34617",
+      "git-tree": "df65fa32113e1783bf13baca1ea86edc526e7683",
       "version": "0.9.2",
       "port-version": 0
     }

--- a/versions/i-/imgui-node-editor.json
+++ b/versions/i-/imgui-node-editor.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4064aa26024862b7a5fdad86c151e852c7c34617",
+      "version": "0.9.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add new port imgui-node-editor : https://github.com/thedmd/imgui-node-editor

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
