### PR TITLE
[zeroc-ice] Fixes include files missing IceUtil

### DIFF
--- a/ports/zeroc-ice/portfile.cmake
+++ b/ports/zeroc-ice/portfile.cmake
@@ -40,6 +40,7 @@ endfunction()
 vcpkg_list(SET ICE_INCLUDE_SUB_DIRECTORIES
   "Glacier2"
   "Ice"
+  "IceUtil"
   "IceBT"
   "IceBox"
   "IceBT"

--- a/ports/zeroc-ice/vcpkg.json
+++ b/ports/zeroc-ice/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zeroc-ice",
   "version": "3.7.9",
-  "port-version": 3,
+  "port-version": 4,
   "maintainers": "Benjamin Oldenburg <benjamin.oldenburg@ordis.co.th>",
   "description": "Comprehensive RPC framework with support for C++, CSharp, Java, JavaScript, Python and more.",
   "homepage": "https://github.com/zeroc-ice/ice",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9062,7 +9062,7 @@
     },
     "zeroc-ice": {
       "baseline": "3.7.9",
-      "port-version": 3
+      "port-version": 4
     },
     "zeromq": {
       "baseline": "2023-06-20",

--- a/versions/z-/zeroc-ice.json
+++ b/versions/z-/zeroc-ice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9048b568a7f81f0a8788c6dd8b0215cb1cd300eb",
+      "version": "3.7.9",
+      "port-version": 4
+    },
+    {
       "git-tree": "45f338a327c4b8ea7eb16fc81e650cd0f999449c",
       "version": "3.7.9",
       "port-version": 3


### PR DESCRIPTION
As of version 3.6 IceUtil and Ice were merged, and as of 3.7 the IceUtil library was completely removed. IceUtil is directly compiled into the Ice library, the header files still exist though, and therefore need to be copied with every Ice core build.

https://doc.zeroc.com/ice/3.7/release-notes/upgrading-your-application-from-ice-3-6#id-.UpgradingyourApplicationfromIce3.6v3.7-IceUtilLibraryRemoved

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
