### PR TITLE
[igraph] update to 0.10.7

### DIFF
--- a/ports/igraph/portfile.cmake
+++ b/ports/igraph/portfile.cmake
@@ -4,9 +4,9 @@
 #  - The release tarball contains pre-generated parser sources, which eliminates the dependency on bison/flex.
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/igraph/igraph/releases/download/0.10.6/igraph-0.10.6.tar.gz"
-    FILENAME "igraph-0.10.6.tar.gz"
-    SHA512 e01d8bf2335b95a94a0abf095d2f43bc4397f028406389c4a0bddc038b117d7c5b6f02032d77c11c44ae51dbae10b92c677555d879dec6f028a5d8cb97c37029
+    URLS "https://github.com/igraph/igraph/releases/download/0.10.7/igraph-0.10.7.tar.gz"
+    FILENAME "igraph-0.10.7.tar.gz"
+    SHA512 72187052de16c791176dce797addaa54c18f14f47b44983374e3d8bb94a664dc70d773fb9296aa4fb1c68dbf5fb3d61803f1c4b167388d9217ce80f38a90f522
 )
 
 vcpkg_extract_source_archive(

--- a/ports/igraph/vcpkg.json
+++ b/ports/igraph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "igraph",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "igraph is a C library for network analysis and graph theory, with an emphasis on efficiency portability and ease of use.",
   "homepage": "https://igraph.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3353,7 +3353,7 @@
       "port-version": 0
     },
     "igraph": {
-      "baseline": "0.10.6",
+      "baseline": "0.10.7",
       "port-version": 0
     },
     "iir1": {

--- a/versions/i-/igraph.json
+++ b/versions/i-/igraph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ebbf67005ba6625597ef12c78cccf2d67854701d",
+      "version": "0.10.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "9af4a5b0f4764e59cb3c107a55646b9c26555aaf",
       "version": "0.10.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version 
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory. _Nothing to delete_
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

