### PR TITLE
[mpir] Build include files even when building static

### DIFF
--- a/ports/mpir/fix-static-include-files.patch
+++ b/ports/mpir/fix-static-include-files.patch
@@ -16,10 +16,10 @@ index de1ed08..e4ecceb 100644
  echo copying outputs from %tgt_dir% to %bin_dir%
  if not exist %bin_dir% md %bin_dir%
 diff --git a/build.vc15/lib_mpir_cxx/lib_mpir_cxx.vcxproj b/build.vc15/lib_mpir_cxx/lib_mpir_cxx.vcxproj
-index 3a23f01..499fe1f 100644
+index 3a23f01..1f44b22 100644
 --- a/build.vc15/lib_mpir_cxx/lib_mpir_cxx.vcxproj
 +++ b/build.vc15/lib_mpir_cxx/lib_mpir_cxx.vcxproj
-@@ -70,10 +70,17 @@
+@@ -70,6 +70,11 @@
      <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">mpirxx</TargetName>
    </PropertyGroup>
    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -31,13 +31,7 @@ index 3a23f01..499fe1f 100644
      <ClCompile>
        <AdditionalIncludeDirectories>..\..\</AdditionalIncludeDirectories>
        <PreprocessorDefinitions>NDEBUG;WIN32;_LIB;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-     </ClCompile>
-+    <Link>
-+    </Link>
- 
-     <PostBuildEvent>
-       <Command>cd ..\..\build.vc
-@@ -82,10 +89,17 @@ postbuild "$(TargetPath)" 15
+@@ -82,6 +87,11 @@ postbuild "$(TargetPath)" 15
      </PostBuildEvent>
    </ItemDefinitionGroup>
    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -49,13 +43,7 @@ index 3a23f01..499fe1f 100644
      <ClCompile>
        <AdditionalIncludeDirectories>..\..\</AdditionalIncludeDirectories>
        <PreprocessorDefinitions>_DEBUG;WIN32;_LIB;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-     </ClCompile>
-+    <Link>
-+    </Link>
- 
-     <PostBuildEvent>
-       <Command>cd ..\..\build.vc
-@@ -94,10 +108,17 @@ postbuild "$(TargetPath)" 15
+@@ -94,6 +104,11 @@ postbuild "$(TargetPath)" 15
      </PostBuildEvent>
    </ItemDefinitionGroup>
    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -67,13 +55,7 @@ index 3a23f01..499fe1f 100644
      <ClCompile>
        <AdditionalIncludeDirectories>..\..\</AdditionalIncludeDirectories>
        <PreprocessorDefinitions>NDEBUG;WIN32;_LIB;HAVE_CONFIG_H;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-     </ClCompile>
-+    <Link>
-+    </Link>
- 
-     <PostBuildEvent>
-       <Command>cd ..\..\build.vc
-@@ -106,10 +127,17 @@ postbuild "$(TargetPath)" 15
+@@ -106,6 +121,11 @@ postbuild "$(TargetPath)" 15
      </PostBuildEvent>
    </ItemDefinitionGroup>
    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -85,9 +67,3 @@ index 3a23f01..499fe1f 100644
      <ClCompile>
        <AdditionalIncludeDirectories>..\..\</AdditionalIncludeDirectories>
        <PreprocessorDefinitions>_DEBUG;WIN32;_LIB;HAVE_CONFIG_H;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-     </ClCompile>
-+    <Link>
-+    </Link>
- 
-     <PostBuildEvent>
-       <Command>cd ..\..\build.vc

--- a/ports/mpir/fix-static-include-files.patch
+++ b/ports/mpir/fix-static-include-files.patch
@@ -1,0 +1,93 @@
+diff --git a/build.vc/postbuild.bat b/build.vc/postbuild.bat
+index de1ed08..e4ecceb 100644
+--- a/build.vc/postbuild.bat
++++ b/build.vc/postbuild.bat
+@@ -37,12 +37,10 @@ set bin_dir="..\%extn%\%plat%\%conf%\"
+ set hdr_dir="..\%extn%\%plat%\%conf%\"
+ 
+ rem output parametrers for the MPIR tests
+-if /i "%filename%" EQU "mpirxx" goto skip 
+ echo (set ldir=%loc%)   > output_params.bat
+ echo (set libr=%extn%) >> output_params.bat
+ echo (set plat=%plat%) >> output_params.bat
+ echo (set conf=%conf%) >> output_params.bat
+-:skip
+ 
+ echo copying outputs from %tgt_dir% to %bin_dir%
+ if not exist %bin_dir% md %bin_dir%
+diff --git a/build.vc15/lib_mpir_cxx/lib_mpir_cxx.vcxproj b/build.vc15/lib_mpir_cxx/lib_mpir_cxx.vcxproj
+index 3a23f01..499fe1f 100644
+--- a/build.vc15/lib_mpir_cxx/lib_mpir_cxx.vcxproj
++++ b/build.vc15/lib_mpir_cxx/lib_mpir_cxx.vcxproj
+@@ -70,10 +70,17 @@
+     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">mpirxx</TargetName>
+   </PropertyGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
++    <PreBuildEvent>
++      <Command>cd ..\..\build.vc
++prebuild gc Win32 15
++      </Command>
++    </PreBuildEvent>
+     <ClCompile>
+       <AdditionalIncludeDirectories>..\..\</AdditionalIncludeDirectories>
+       <PreprocessorDefinitions>NDEBUG;WIN32;_LIB;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+     </ClCompile>
++    <Link>
++    </Link>
+ 
+     <PostBuildEvent>
+       <Command>cd ..\..\build.vc
+@@ -82,10 +89,17 @@ postbuild "$(TargetPath)" 15
+     </PostBuildEvent>
+   </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
++    <PreBuildEvent>
++      <Command>cd ..\..\build.vc
++prebuild gc Win32 15
++      </Command>
++    </PreBuildEvent>
+     <ClCompile>
+       <AdditionalIncludeDirectories>..\..\</AdditionalIncludeDirectories>
+       <PreprocessorDefinitions>_DEBUG;WIN32;_LIB;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+     </ClCompile>
++    <Link>
++    </Link>
+ 
+     <PostBuildEvent>
+       <Command>cd ..\..\build.vc
+@@ -94,10 +108,17 @@ postbuild "$(TargetPath)" 15
+     </PostBuildEvent>
+   </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
++    <PreBuildEvent>
++      <Command>cd ..\..\build.vc
++prebuild gc Win32 15
++      </Command>
++    </PreBuildEvent>
+     <ClCompile>
+       <AdditionalIncludeDirectories>..\..\</AdditionalIncludeDirectories>
+       <PreprocessorDefinitions>NDEBUG;WIN32;_LIB;HAVE_CONFIG_H;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+     </ClCompile>
++    <Link>
++    </Link>
+ 
+     <PostBuildEvent>
+       <Command>cd ..\..\build.vc
+@@ -106,10 +127,17 @@ postbuild "$(TargetPath)" 15
+     </PostBuildEvent>
+   </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
++    <PreBuildEvent>
++      <Command>cd ..\..\build.vc
++prebuild gc Win32 15
++      </Command>
++    </PreBuildEvent>
+     <ClCompile>
+       <AdditionalIncludeDirectories>..\..\</AdditionalIncludeDirectories>
+       <PreprocessorDefinitions>_DEBUG;WIN32;_LIB;HAVE_CONFIG_H;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+     </ClCompile>
++    <Link>
++    </Link>
+ 
+     <PostBuildEvent>
+       <Command>cd ..\..\build.vc

--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     SHA512 f46e45bdba27c9f89953ba23186b694486fd3010bd370ea2de71a4649a2816e716a6520c9baa96936f1884437ef03f92b21c0b1fb5b757beba5a05fed30b2bfc
     HEAD_REF master
     PATCHES enable-runtimelibrary-toggle.patch
+            fix-static-include-files.patch
 )
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)

--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -8,8 +8,9 @@ vcpkg_from_github(
     REF cdd444aedfcbb190f00328526ef278428702d56e # 3.0.0
     SHA512 f46e45bdba27c9f89953ba23186b694486fd3010bd370ea2de71a4649a2816e716a6520c9baa96936f1884437ef03f92b21c0b1fb5b757beba5a05fed30b2bfc
     HEAD_REF master
-    PATCHES enable-runtimelibrary-toggle.patch
-            fix-static-include-files.patch
+    PATCHES 
+        enable-runtimelibrary-toggle.patch
+        fix-static-include-files.patch
 )
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)

--- a/ports/mpir/vcpkg.json
+++ b/ports/mpir/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpir",
   "version-date": "2022-03-02",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Multiple Precision Integers and Rationals",
   "homepage": "https://github.com/wbhart/mpir",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5506,7 +5506,7 @@
     },
     "mpir": {
       "baseline": "2022-03-02",
-      "port-version": 2
+      "port-version": 3
     },
     "mpmcqueue": {
       "baseline": "2021-12-01",

--- a/versions/m-/mpir.json
+++ b/versions/m-/mpir.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a81427e8201ddbceb242091faf87c7271fe928f7",
+      "git-tree": "66630c57080280e1089146536f7d5d21c7504600",
       "version-date": "2022-03-02",
       "port-version": 3
     },

--- a/versions/m-/mpir.json
+++ b/versions/m-/mpir.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a81427e8201ddbceb242091faf87c7271fe928f7",
+      "version-date": "2022-03-02",
+      "port-version": 3
+    },
+    {
       "git-tree": "de9b5962358546e5cc0d7ac9b6dd9bfba95e1763",
       "version-date": "2022-03-02",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/33463
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
