### PR TITLE
[blend2d] Fix core build

### DIFF
--- a/ports/blend2d/portfile.cmake
+++ b/ports/blend2d/portfile.cmake
@@ -10,7 +10,6 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BLEND2D_STATIC)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
   INVERTED_FEATURES
-    futex      BLEND2D_NO_FUTEX
     jit        BLEND2D_NO_JIT
     logging    BLEND2D_NO_JIT_LOGGING
     tls        BLEND2D_NO_TLS
@@ -36,6 +35,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DBLEND2D_STATIC=${BLEND2D_STATIC}"
+        "-DBLEND2D_NO_FUTEX=OFF"
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/blend2d/vcpkg.json
+++ b/ports/blend2d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "blend2d",
   "version-date": "2023-06-16",
+  "port-version": 1,
   "description": "Beta 2D Vector Graphics Powered by a JIT Compiler",
   "homepage": "https://github.com/blend2d/blend2d",
   "documentation": "https://blend2d.com/doc/index.html",
@@ -17,24 +18,17 @@
     }
   ],
   "default-features": [
-    "futex",
     "jit",
     "logging",
     "tls"
   ],
   "features": {
-    "futex": {
-      "description": "Default feature. Enables use of futex."
-    },
     "jit": {
       "description": "Default feature. Enables jit pipeline compilation.",
       "dependencies": [
         {
           "name": "blend2d",
           "default-features": false,
-          "features": [
-            "futex"
-          ],
           "platform": "windows"
         }
       ]
@@ -57,9 +51,6 @@
         {
           "name": "blend2d",
           "default-features": false,
-          "features": [
-            "futex"
-          ],
           "platform": "windows"
         }
       ]

--- a/versions/b-/blend2d.json
+++ b/versions/b-/blend2d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5440e80d03f5d70356c3295281949898811ff97",
+      "version-date": "2023-06-16",
+      "port-version": 1
+    },
+    {
       "git-tree": "7e16be134e98cabefdf318161ef7f74d83b0512d",
       "version-date": "2023-06-16",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -626,7 +626,7 @@
     },
     "blend2d": {
       "baseline": "2023-06-16",
-      "port-version": 0
+      "port-version": 1
     },
     "blingfire": {
       "baseline": "0.1.8.1",


### PR DESCRIPTION
Fixes #33467, fix `blend2d[core]` build.

Integrate `futex` into `blend2d`'s `core` instead of `default-features`, missing it in `core` will cause the following error:
```
G:\vcpkg\buildtrees\blend2d\src\ce84a75da8-8739d68a35.clean\src\blend2d\threading\futex.cpp(34): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
G:\vcpkg\buildtrees\blend2d\src\ce84a75da8-8739d68a35.clean\src\blend2d\threading\futex.cpp(34): error C2146: syntax error: missing ';' before identifier 'futexWinAPI'
G:\vcpkg\buildtrees\blend2d\src\ce84a75da8-8739d68a35.clean\src\blend2d\threading\futex.cpp(42): error C2039: 'futexWinAPI': is not a member of 'BLFutex'
G:\vcpkg\buildtrees\blend2d\src\ce84a75da8-8739d68a35.clean\src\blend2d\threading\futex.cpp(34): note: see declaration of 'BLFutex'
G:\vcpkg\buildtrees\blend2d\src\ce84a75da8-8739d68a35.clean\src\blend2d\threading\futex.cpp(42): error C2065: 'futexWinAPI': undeclared identifier
G:\vcpkg\buildtrees\blend2d\src\ce84a75da8-8739d68a35.clean\src\blend2d\threading\futex.cpp(42): error C2039: 'FutexWinAPI': is not a member of 'BLFutex'
G:\vcpkg\buildtrees\blend2d\src\ce84a75da8-8739d68a35.clean\src\blend2d\threading\futex.cpp(34): note: see declaration of 'BLFutex'
...
```

All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```

The usage test passed on `x64-windows` (header files found):
```
blend2d provides CMake targets:

    find_package(blend2d CONFIG REQUIRED)
    target_link_libraries(main PRIVATE blend2d::blend2d)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

