### PR TITLE
[dcmtk] Fix build error when install feature tiff and tools at the same

### DIFF
--- a/ports/dcmtk/fix-tool-with-tiff.patch
+++ b/ports/dcmtk/fix-tool-with-tiff.patch
@@ -1,0 +1,28 @@
+diff --git a/CMake/3rdparty.cmake b/CMake/3rdparty.cmake
+index 2c974e8..4818672 100644
+--- a/CMake/3rdparty.cmake
++++ b/CMake/3rdparty.cmake
+@@ -34,7 +34,7 @@ if(DCMTK_USE_FIND_PACKAGE)
+         message(STATUS "Info: DCMTK TIFF support will be enabled")
+         include_directories(${TIFF_INCLUDE_DIR} ${JPEG_INCLUDE_DIR})
+       endif()
+-      set(LIBTIFF_LIBS ${TIFF_LIBRARY} ${TIFF_EXTRA_LIBS_STATIC} ${JPEG_LIBRARY})
++      set(LIBTIFF_LIBS ${TIFF_LIBRARY} ${TIFF_EXTRA_LIBS_STATIC})
+     endif()
+   endif()
+ 
+diff --git a/CMake/dcmtkPrepare.cmake b/CMake/dcmtkPrepare.cmake
+index 5162a44..bb17714 100644
+--- a/CMake/dcmtkPrepare.cmake
++++ b/CMake/dcmtkPrepare.cmake
+@@ -135,7 +135,9 @@ else()
+     set(OPENJPEG_EXTRA_LIBS_STATIC)
+     set(OPENSSL_EXTRA_LIBS_STATIC)
+     set(SNDFILE_EXTRA_LIBS_STATIC)
+-    set(TIFF_EXTRA_LIBS_STATIC)
++    get_static_library("STATIC_LZMA" "liblzma.a")
++    get_static_library("STATIC_ZLIB" "libz.a")
++    set(TIFF_EXTRA_LIBS_STATIC "STATIC_LZMA" "STATIC_ZLIB")
+     set(WRAP_EXTRA_LIBS_STATIC)
+ endif()
+ 

--- a/ports/dcmtk/fix-tool-with-tiff.patch
+++ b/ports/dcmtk/fix-tool-with-tiff.patch
@@ -22,7 +22,7 @@ index 5162a44..bb17714 100644
 -    set(TIFF_EXTRA_LIBS_STATIC)
 +    get_static_library("STATIC_LZMA" "liblzma.a")
 +    get_static_library("STATIC_ZLIB" "libz.a")
-+    set(TIFF_EXTRA_LIBS_STATIC "STATIC_LZMA" "STATIC_ZLIB")
++    set(TIFF_EXTRA_LIBS_STATIC "${STATIC_LZMA}" "${STATIC_ZLIB}")
      set(WRAP_EXTRA_LIBS_STATIC)
  endif()
  

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -1,3 +1,7 @@
+if("tools" IN_LIST FEATURES AND "tiff" IN_LIST FEATURES)
+    set(fix-patch "fix-tool-with-tiff.patch")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DCMTK/dcmtk
@@ -8,6 +12,7 @@ vcpkg_from_github(
         dcmtk.patch
         windows-patch.patch
         fix-pc-format.patch
+        ${fix-patch}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -1,5 +1,7 @@
-if("tools" IN_LIST FEATURES AND "tiff" IN_LIST FEATURES)
-    set(fix-patch "fix-tool-with-tiff.patch")
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    if("tools" IN_LIST FEATURES AND "tiff" IN_LIST FEATURES)
+        set(fix-patch "fix-tool-with-tiff.patch")
+    endif()
 endif()
 
 vcpkg_from_github(

--- a/ports/dcmtk/vcpkg.json
+++ b/ports/dcmtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dcmtk",
   "version": "3.6.7",
-  "port-version": 5,
+  "port-version": 6,
   "description": "This DICOM ToolKit (DCMTK) package consists of source code, documentation and installation instructions for a set of software libraries and applications implementing part of the DICOM/MEDICOM Standard.",
   "homepage": "https://github.com/DCMTK/dcmtk",
   "license": "BSD-3-Clause OR BSD-2-Clause OR libtiff OR MIT OR Zlib OR Libpng",
@@ -15,6 +15,16 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
+  ],
+  "default-features": [
+    "iconv",
+    "icu",
+    "openssl",
+    "png",
+    "tiff",
+    "tools",
+    "xml2",
+    "zlib"
   ],
   "features": {
     "iconv": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2090,7 +2090,7 @@
     },
     "dcmtk": {
       "baseline": "3.6.7",
-      "port-version": 5
+      "port-version": 6
     },
     "debug-assert": {
       "baseline": "1.3.3",

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "927cf608e08dff9bf5140fa360082e7ace7b6855",
+      "git-tree": "dff8eead6d5521729f9d15a20060240ecad165b7",
       "version": "3.6.7",
       "port-version": 6
     },

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dff8eead6d5521729f9d15a20060240ecad165b7",
+      "git-tree": "b97239f1e75f9e4baac46cd99f0584c012165847",
       "version": "3.6.7",
       "port-version": 6
     },

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "927cf608e08dff9bf5140fa360082e7ace7b6855",
+      "version": "3.6.7",
+      "port-version": 6
+    },
+    {
       "git-tree": "a66dd62879ace07389aae2f77cc909744f9d7458",
       "version": "3.6.7",
       "port-version": 5


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #33512, fix build error when install feature tiff and tools at the same.

Add link library `libz` and `liblzma` will fix the following error:
```
[411/1275] : && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -fPIC -D_XOPEN_SOURCE_EXTENDED -D_BSD_SOURCE -D_BSD_COMPAT -D_OSF_SOURCE -D_DARWIN_C_SOURCE -O3 -DNDEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  dcmimage/apps/CMakeFiles/dcm2pnm.dir/dcm2pnm.cc.o -o bin/dcm2pnm  lib/libdcmimage.a  lib/libdcmimgle.a  lib/libdcmdata.a  lib/liboflog.a  lib/libofstd.a  -lpthread  /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg_installed/arm64-osx/lib/libtiff.a  /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg_installed/arm64-osx/lib/libjpeg.a && :
FAILED: bin/dcm2pnm 
: && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -fPIC -D_XOPEN_SOURCE_EXTENDED -D_BSD_SOURCE -D_BSD_COMPAT -D_OSF_SOURCE -D_DARWIN_C_SOURCE -O3 -DNDEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  dcmimage/apps/CMakeFiles/dcm2pnm.dir/dcm2pnm.cc.o -o bin/dcm2pnm  lib/libdcmimage.a  lib/libdcmimgle.a  lib/libdcmdata.a  lib/liboflog.a  lib/libofstd.a  -lpthread  /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg_installed/arm64-osx/lib/libtiff.a  /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg_installed/arm64-osx/lib/libjpeg.a && :
Undefined symbols for architecture arm64:
  "_deflate", referenced from:
      _PixarLogPostEncode in libtiff.a(tif_pixarlog.c.o)
      _PixarLogEncode in libtiff.a(tif_pixarlog.c.o)
      _ZIPPostEncode in libtiff.a(tif_zip.c.o)
      _ZIPEncode in libtiff.a(tif_zip.c.o)
  "_deflateEnd", referenced from:
      _PixarLogCleanup in libtiff.a(tif_pixarlog.c.o)
      _ZIPSetupDecode in libtiff.a(tif_zip.c.o)
      _ZIPCleanup in libtiff.a(tif_zip.c.o)
  "_deflateInit_", referenced from:
      _PixarLogSetupEncode in libtiff.a(tif_pixarlog.c.o)
      _ZIPSetupEncode in libtiff.a(tif_zip.c.o)
  "_deflateParams", referenced from:
      _PixarLogVSetField in libtiff.a(tif_pixarlog.c.o)
      _ZIPVSetField in libtiff.a(tif_zip.c.o)
  "_deflateReset", referenced from:
      _PixarLogPreEncode in libtiff.a(tif_pixarlog.c.o)
      _ZIPPreEncode in libtiff.a(tif_zip.c.o)
  "_inflate", referenced from:
      _PixarLogDecode in libtiff.a(tif_pixarlog.c.o)
      _ZIPDecode in libtiff.a(tif_zip.c.o)
  "_inflateEnd", referenced from:
      _PixarLogCleanup in libtiff.a(tif_pixarlog.c.o)
      _ZIPSetupEncode in libtiff.a(tif_zip.c.o)
      _ZIPCleanup in libtiff.a(tif_zip.c.o)
  "_inflateInit_", referenced from:
      _PixarLogSetupDecode in libtiff.a(tif_pixarlog.c.o)
      _ZIPSetupDecode in libtiff.a(tif_zip.c.o)
  "_inflateReset", referenced from:
      _PixarLogPreDecode in libtiff.a(tif_pixarlog.c.o)
      _ZIPPreDecode in libtiff.a(tif_zip.c.o)
  "_lzma_code", referenced from:
      _LZMADecode in libtiff.a(tif_lzma.c.o)
      _LZMAPostEncode in libtiff.a(tif_lzma.c.o)
      _LZMAEncode in libtiff.a(tif_lzma.c.o)
  "_lzma_end", referenced from:
      _LZMASetupDecode in libtiff.a(tif_lzma.c.o)
      _LZMASetupEncode in libtiff.a(tif_lzma.c.o)
      _LZMACleanup in libtiff.a(tif_lzma.c.o)
  "_lzma_lzma_preset", referenced from:
      _TIFFInitLZMA in libtiff.a(tif_lzma.c.o)
      _LZMAVSetField in libtiff.a(tif_lzma.c.o)
  "_lzma_memusage", referenced from:
      _LZMADecode in libtiff.a(tif_lzma.c.o)
  "_lzma_stream_decoder", referenced from:
      _LZMAPreDecode in libtiff.a(tif_lzma.c.o)
      _LZMADecode in libtiff.a(tif_lzma.c.o)
  "_lzma_stream_encoder", referenced from:
      _LZMAVSetField in libtiff.a(tif_lzma.c.o)
      _LZMAPreEncode in libtiff.a(tif_lzma.c.o)
ld: symbol(s) not found for architecture arm64
```
Remove `${JPEG_LIBRARY}` will fix the following error:
```
FAILED: bin/dcmsend
 : && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -fPIC -D_XOPEN_SOURCE_EXTENDED -D_BSD_SOURCE -D_BSD_COMPAT -D_OSF_SOURCE -D_DARW    IN_C_SOURCE -fPIC -O3 -DNDEBUG -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk -Wl,-search_paths_first     -Wl,-headerpad_max_install_names  dcmnet/apps/CMakeFiles/dcmsend.dir/dcmsend.cc.o -o bin/dcmsend  lib/libdcmnet.a  lib/libdcmdata.a  lib/liboflog.a  lib/libofstd.a  lib/libdcm    jpls.a  lib/libdcmjpeg.a  lib/libdcmimage.a  lib/libdcmtkcharls.a  /Users/vcpkg/cheney/vcpkg/installed/x64-osx/lib/libtiff.a  /Users/vcpkg/cheney/vcpkg/installed/x64-osx/lib/li    blzma.a  /Users/vcpkg/cheney/vcpkg/installed/x64-osx/lib/libz.a  /Users/vcpkg/cheney/vcpkg/installed/x64-osx/lib/libjpeg.a  lib/libdcmimgle.a  lib/libdcmdata.a  lib/liboflog.a      lib/libofstd.a  -lpthread  lib/libijg8.a  lib/libijg12.a  lib/libijg16.a && :
 duplicate symbol '_jpeg12_read_scanlines' in:
     /Users/vcpkg/cheney/vcpkg/installed/x64-osx/lib/libjpeg.a(jdapistd.c.o)
     lib/libijg12.a(jdapistd.c.o)
 duplicate symbol '_jpeg12_read_raw_data' in:
     /Users/vcpkg/cheney/vcpkg/installed/x64-osx/lib/libjpeg.a(jdapistd.c.o)
     lib/libijg12.a(jdapistd.c.o)
 duplicate symbol '_jpeg16_read_scanlines' in:
     /Users/vcpkg/cheney/vcpkg/installed/x64-osx/lib/libjpeg.a(jdapistd.c.o)
lib/libijg16.a(jdapistd.c.o)
ld: 3 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
