### PR TITLE
[ffmpeg] enable a feature to support libpng

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -346,6 +346,10 @@ else()
     set(OPTIONS "${OPTIONS} --disable-lzma")
 endif()
 
+if("libpng" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-decoder=png --enable-encoder=png")
+endif()
+
 if("mp3lame" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --enable-libmp3lame")
 else()

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "5.1.2",
-  "port-version": 7,
+  "port-version": 8,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -42,6 +42,7 @@
             "bzip2",
             "freetype",
             "iconv",
+            "libpng",
             "lzma",
             "mp3lame",
             "openjpeg",
@@ -441,6 +442,19 @@
       "description": "iLBC de/encoding via libilbc",
       "dependencies": [
         "libilbc"
+      ]
+    },
+    "libpng": {
+      "description": "PNG de/encoding via libpng",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "zlib"
+          ]
+        },
+        "libpng"
       ]
     },
     "lzma": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2522,7 +2522,7 @@
     },
     "ffmpeg": {
       "baseline": "5.1.2",
-      "port-version": 7
+      "port-version": 8
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ee8d10aa504c74cfef80d47e1901afa3289a544",
+      "version": "5.1.2",
+      "port-version": 8
+    },
+    {
       "git-tree": "1fcd248f6f655e6aecb94976680b1c537da6d918",
       "version": "5.1.2",
       "port-version": 7


### PR DESCRIPTION
updates ffmpeg port to enable the optional libpng feature for libpng based encoders/decoders

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
