### PR TITLE
[ntf-core] Fix builiding on x86_64 Linux

### DIFF
--- a/ports/ntf-core/dont-use-lib64.patch
+++ b/ports/ntf-core/dont-use-lib64.patch
@@ -1,0 +1,17 @@
+diff --git a/repository.cmake b/repository.cmake
+index 9b6c699..ed2ce32 100644
+--- a/repository.cmake
++++ b/repository.cmake
+@@ -1737,11 +1737,7 @@ function (ntf_group_end)
+ 
+     ntf_ufid_string_has(UFID ${build_ufid} FLAG "64" OUTPUT is_64_bit)
+ 
+-    if (${is_64_bit} AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+-        set(lib_name "lib64" CACHE INTERNAL "")
+-    else()
+-        set(lib_name "lib" CACHE INTERNAL "")
+-    endif()
++    set(lib_name "lib" CACHE INTERNAL "")
+ 
+     # Set the relative path to the library directory under the prefix. For
+     # example: lib64

--- a/ports/ntf-core/portfile.cmake
+++ b/ports/ntf-core/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 57662d2dd105b2781e580623c26cd7bde84fce8374bbd70c18595a5f6934869b7a570f0d3c2e17e115f6c7eb1067541f8d19523639815b285324061f807d3179
     HEAD_REF main
+    PATCHES dont-use-lib64.patch
 )
 
 # ntf-core requires debugger information to for dev tooling purposes, so we just fake it
@@ -40,7 +41,24 @@ endfunction()
 
 fix_install_dir("lib" "opt_exc_mt")
 fix_install_dir("debug/lib" "dbg_exc_mt")
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake")
+
+# The ntf-core build installs CMake configs for both targets into share/ntf-core, which
+# find_package will not be able to find on its own. We use vcpkg_cmake_config_fixup to install
+# CMake configs into share/nts, and then move the ntc CMake configs into share/ntc with this
+# function.
+function(ntf_core_fixup_ntc_config)
+    set(nts_share "${CURRENT_PACKAGES_DIR}/share/nts")
+    set(ntc_share "${CURRENT_PACKAGES_DIR}/share/ntc")
+    file(GLOB ntc_configs "${nts_share}/ntc*.cmake")
+    file(MAKE_DIRECTORY "${ntc_share}")
+    foreach(ntc_config IN LISTS ntc_configs)
+        file(RELATIVE_PATH ntc_config_rel "${nts_share}" "${ntc_config}")
+        file(RENAME "${ntc_config}" "${ntc_share}/${ntc_config_rel}")
+    endforeach()
+endfunction()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake" PACKAGE_NAME nts)
+ntf_core_fixup_ntc_config()
 
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ntf-core/usage
+++ b/ports/ntf-core/usage
@@ -1,9 +1,9 @@
 The package ntf-core provides the CMake targets:
 
     # Blocking and non-blocking sockets for network programming
-    find_package(nts REQUIRED)
+    find_package(nts CONFIG REQUIRED)
     target_link_libraries(main PRIVATE nts)
 
     # Asynchronous sockets, timers, event loops, and thread pools for network programming
-    find_package(ntc REQUIRED)
+    find_package(ntc CONFIG REQUIRED)
     target_link_libraries(main PRIVATE ntc)

--- a/ports/ntf-core/vcpkg.json
+++ b/ports/ntf-core/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ntf-core",
   "version": "2.1.0",
+  "port-version": 1,
   "description": "The Network Transport Framework: Core Libraries",
   "license": "Apache-2.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5810,7 +5810,7 @@
     },
     "ntf-core": {
       "baseline": "2.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nu-book-zxing-cpp": {
       "baseline": "2.1.0",

--- a/versions/n-/ntf-core.json
+++ b/versions/n-/ntf-core.json
@@ -2,6 +2,11 @@
     "versions": [
         {
             "version": "2.1.0",
+            "port-version": 1,
+            "git-tree": "1e517e2393650769e701f62317e905a3f1776367"   
+        },
+        {
+            "version": "2.1.0",
             "port-version": 0,
             "git-tree": "eabeb2b30205bef45e72e4a069f21d71797f3f5d"   
         }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result. 
- [x] Only one version is added to each modified port's versions file.

Attempting to run `vcpkg x-add-version --all` caused the following:

```
error: can't load port microsoft-signalr
error: while loading /Users/tfoxhall/repos/vcpkg/ports/microsoft-signalr/vcpkg.json:
$.default-features[0]: mismatched type: expected an identifierinternal error: /tmp/vcpkg-20230411-5267-16p751l/vcpkg-tool-2023-04-07/src/vcpkg/commands.add-version.cpp(412): vcpkg has crashed; no additional details are available.
```

I can open this as a separate issue if this is a real problem.