### PR TITLE
[minizip-ng] fix pkgconfig file

### DIFF
--- a/ports/minizip-ng/fix-pkgconfig.patch
+++ b/ports/minizip-ng/fix-pkgconfig.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5ca7729e..9af0a7ad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -128,6 +128,7 @@ set(MINIZIP_HDR
+     mz_zip_rw.h)
+ 
+ set(PC_PRIVATE_LIBS)
++set(PC_PRIVATE_DEPS)
+ 
+ # Check for system includes
+ check_include_file(stdint.h   HAVE_STDINT_H)
+@@ -184,7 +185,7 @@ if(MZ_ZLIB)
+         list(APPEND MINIZIP_LIB ${ZLIBNG_LIBRARIES})
+         list(APPEND MINIZIP_LBD ${ZLIBNG_LIBRARY_DIRS})
+ 
+-        set(PC_PRIVATE_LIBS " -lz-ng")
++        set(PC_PRIVATE_DEPS "zlib-ng")
+         set(ZLIB_COMPAT OFF)
+     elseif(ZLIB_FOUND AND NOT MZ_FORCE_FETCH_LIBS)
+         message(STATUS "Using ZLIB ${ZLIB_VERSION}")
+@@ -193,7 +194,7 @@ if(MZ_ZLIB)
+         list(APPEND MINIZIP_LIB ${ZLIB_LIBRARIES})
+         list(APPEND MINIZIP_LBD ${ZLIB_LIBRARY_DIRS})
+ 
+-        set(PC_PRIVATE_LIBS " -lz")
++        set(PC_PRIVATE_DEPS "zlib")
+         set(ZLIB_COMPAT ON)
+     elseif(MZ_FETCH_LIBS)
+         clone_repo(zlib https://github.com/madler/zlib)
+diff --git a/minizip.pc.cmakein b/minizip.pc.cmakein
+index d8a0dd72..7aecd852 100644
+--- a/minizip.pc.cmakein
++++ b/minizip.pc.cmakein
+@@ -8,7 +8,7 @@ Name: @MINIZIP_TARGET@
+ Description: Zip manipulation library
+ Version: @VERSION@
+ 
+-Requires: zlib
++Requires.private: @PC_PRIVATE_DEPS@
+ Libs: -L${libdir} -L${sharedlibdir} -l@MINIZIP_TARGET@
+ Libs.private:@PC_PRIVATE_LIBS@
+ Cflags: -I${includedir}

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix_find_zstd.patch
+        fix-pkgconfig.patch
 )
 
 vcpkg_check_features(

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "minizip-ng",
   "version": "4.0.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5402,7 +5402,7 @@
     },
     "minizip-ng": {
       "baseline": "4.0.0",
-      "port-version": 3
+      "port-version": 4
     },
     "mio": {
       "baseline": "2023-03-03",

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb59eb8b735f74193a79326e33fb6f9abc66846a",
+      "version": "4.0.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "1483ef1293bbd3eea5edd9b5051bb4457eebfa2e",
       "version": "4.0.0",
       "port-version": 3


### PR DESCRIPTION
Otherwise you get
```
CMake Error at scripts/cmake/vcpkg_fixup_pkgconfig.cmake:141 (message):
  C:/v/downloads/tools/msys2/6f3fa1a12ef85a6f/mingw32/bin/pkg-config.exe
  --exists minizip-ng failed with error code: 1

      ENV{PKG_CONFIG_PATH}: "C:/v/vcpkg2/packages/minizip-ng_x64-windows/lib/pkgconfig;C:/v/vcpkg2/packages/minizip-ng_x64-windows/share/pkgconfig;C:/v/vcpkg2/vcpkg_installed/x64-windows/lib/pkgconfig;C:/v/vcpkg2/vcpkg_installed/x64-windows/share/pkgconfig"
      output: Package zlib was not found in the pkg-config search path.

  Perhaps you should add the directory containing `zlib.pc'

  to the PKG_CONFIG_PATH environment variable

  Package 'zlib', required by 'minizip-ng', not found
```