### PR TITLE
[bde-tools] Add script port bde-tools

### DIFF
--- a/ports/bde-tools/portfile.cmake
+++ b/ports/bde-tools/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bloomberg/bde-tools 
+    REF "${VERSION}"
+    HEAD_REF main
+    SHA512 e59560810acfe562d85a13585d908decce17ec76c89bd61f43dac56cddfdf6c56269566da75730f8eda14b5fc046d2ebce959b24110a428e8eac0e358d2597c2
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+# Necessary since bde-tools only provides CMake modules and scripts
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/bde-tools/vcpkg.json
+++ b/ports/bde-tools/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "bde-tools",
+  "version": "3.123.0.0",
+  "description": "A CMake package supporting the BDE build system",
+  "homepage": "https://github.com/bloomberg/bde-tools",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/b-/bde-tools.json
+++ b/versions/b-/bde-tools.json
@@ -1,0 +1,10 @@
+{
+    "versions": [
+      {
+        "git-tree": "cf37f7a2074d6d7814850d9832660f2f93639edf",
+        "version": "3.123.0.0",
+        "port-version": 0
+      }
+  ]
+  }
+  

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -524,6 +524,10 @@
       "baseline": "3.117.0.0",
       "port-version": 0
     },
+    "bde-tools": {
+      "baseline": "3.123.0.0",
+      "port-version": 0
+    },
     "bdwgc": {
       "baseline": "8.2.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Adding this to help support ports like bde and future ports like bloomberg/blazingmq. I think I did this correctly, but given that this is a port with just CMake modules and scripts I might have missed something. Thanks!