### PR TITLE
[icu] fix x64-osx-dynamic rpath workaround

### DIFF
--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "icu",
   "version": "73.1",
+  "port-version": 1,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3258,7 +3258,7 @@
     },
     "icu": {
       "baseline": "73.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ideviceinstaller": {
       "baseline": "1.1.2.23",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35b9625ece1b019beb6a0ec4ee05fa5e1b1f5fca",
+      "version": "73.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "acc3cf9137af5fc8fdd3e8607377026cf88f144d",
       "version": "73.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/33440

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I'm not too sure whether this is the correct way, but it does fix the problem for me inside a github action, and it seems for @phoenixwxy it works on his local machine.

Edit: I'm too stupid to add files to commits :D