### PR TITLE
[pcl] fix feature apps

### DIFF
--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -117,5 +117,11 @@ if(BUILD_tools OR BUILD_apps OR BUILD_examples)
     vcpkg_copy_tools(TOOL_NAMES ${tool_names} AUTO_CLEAN)
 endif()
 
+# pcl_apps.dll is only build for release but not used at all since BUILD_apps_3d_rec_framework is OFF.
+# Because it is not copied to the tool folder and there is no debug variant, we get an post build check error.
+# Since the lib is not needed. Delete it:
+file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/pcl_apps.dll" "${CURRENT_PACKAGES_DIR}/bin/pcl_apps.pdb"
+            "${CURRENT_PACKAGES_DIR}/lib/pcl_apps.lib" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/pcl_apps.pc")
+
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/pcl/vcpkg.json
+++ b/ports/pcl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pcl",
   "version": "1.13.1",
+  "port-version": 1,
   "description": "Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.",
   "homepage": "https://github.com/PointCloudLibrary/pcl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6290,7 +6290,7 @@
     },
     "pcl": {
       "baseline": "1.13.1",
-      "port-version": 0
+      "port-version": 1
     },
     "pcre": {
       "baseline": "8.45",

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f4bb7a9a1e628b9444dad7f5a36a2163df572ac",
+      "version": "1.13.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "83f84dc2de83d25e4eb58d69fcf09086ee8b65b5",
       "version": "1.13.1",
       "port-version": 0


### PR DESCRIPTION
Fixes:
```
-- Performing post-build validation
warning: Mismatching number of debug and release binaries.
Found 20 debug binaries:

    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_commond.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_featuresd.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_filtersd.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_iod.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_io_plyd.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_kdtreed.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_keypointsd.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_mld.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_octreed.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_outofcored.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_peopled.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_recognitiond.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_registrationd.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_sample_consensusd.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_searchd.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_segmentationd.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_stereod.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_surfaced.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_trackingd.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\lib\pcl_visualizationd.lib

Found 21 release binaries:

    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_apps.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_common.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_features.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_filters.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_io.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_io_ply.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_kdtree.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_keypoints.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_ml.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_octree.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_outofcore.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_people.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_recognition.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_registration.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_sample_consensus.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_search.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_segmentation.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_stereo.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_surface.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_tracking.lib
    C:\v\vcpkg2\packages\pcl_x64-windows\lib\pcl_visualization.lib

warning: Mismatching number of debug and release binaries.
Found 20 debug binaries:

    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_commond.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_featuresd.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_filtersd.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_iod.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_io_plyd.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_kdtreed.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_keypointsd.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_mld.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_octreed.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_outofcored.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_peopled.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_recognitiond.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_registrationd.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_sample_consensusd.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_searchd.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_segmentationd.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_stereod.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_surfaced.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_trackingd.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\debug\bin\pcl_visualizationd.dll

Found 21 release binaries:

    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_apps.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_common.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_features.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_filters.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_io.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_io_ply.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_kdtree.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_keypoints.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_ml.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_octree.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_outofcore.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_people.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_recognition.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_registration.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_sample_consensus.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_search.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_segmentation.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_stereo.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_surface.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_tracking.dll
    C:\v\vcpkg2\packages\pcl_x64-windows\bin\pcl_visualization.dll

error: Found 2 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: C:\v\vcpkg2\ports\pcl\portfile.cmake
```