### PR TITLE
[paraview] Always use the release exe

### DIFF
--- a/ports/paraview/portfile.cmake
+++ b/ports/paraview/portfile.cmake
@@ -197,6 +197,14 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
+file(GLOB FILES "${CURRENT_PACKAGES_DIR}/share/${PORT}/*.cmake")
+
+foreach(FILE ${FILES})
+    file(READ "${FILE}" file_contents)
+    STRING(REPLACE "pv5.11d.exe" "pv5.11.exe" file_contents "${file_contents}")
+    file(WRITE "${FILE}" "${file_contents}")
+endforeach()   
+ 
 # The plugins also work without these files
 file(REMOVE "${CURRENT_PACKAGES_DIR}/Applications/paraview.app/Contents/Resources/paraview.conf")
 file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/Applications/paraview.app/Contents/Resources/paraview.conf")

--- a/ports/paraview/portfile.cmake
+++ b/ports/paraview/portfile.cmake
@@ -197,13 +197,10 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(GLOB FILES "${CURRENT_PACKAGES_DIR}/share/${PORT}/*.cmake")
-
-foreach(FILE ${FILES})
-    file(READ "${FILE}" file_contents)
-    STRING(REPLACE "pv5.11d.exe" "pv5.11.exe" file_contents "${file_contents}")
-    file(WRITE "${FILE}" "${file_contents}")
-endforeach()   
+file(GLOB cmake_files "${CURRENT_PACKAGES_DIR}/share/${PORT}/*.cmake")
+foreach(file IN LISTS cmake_files)
+    vcpkg_replace_string("${file}" "pv5.11d.exe" "pv5.11.exe")
+endforeach() 
  
 # The plugins also work without these files
 file(REMOVE "${CURRENT_PACKAGES_DIR}/Applications/paraview.app/Contents/Resources/paraview.conf")

--- a/ports/paraview/vcpkg.json
+++ b/ports/paraview/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "paraview",
   "version": "5.11.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "VTK-based Data Analysis and Visualization Application",
   "homepage": "https://www.paraview.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6258,7 +6258,7 @@
     },
     "paraview": {
       "baseline": "5.11.0",
-      "port-version": 3
+      "port-version": 4
     },
     "parmetis": {
       "baseline": "2022-07-27",

--- a/versions/p-/paraview.json
+++ b/versions/p-/paraview.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f9b120802ef7b14447d29739db0769b8a57ac9ad",
+      "git-tree": "2aa3d8185a319a76c7961608ecce8b2f03c08cd7",
       "version": "5.11.0",
       "port-version": 4
     },

--- a/versions/p-/paraview.json
+++ b/versions/p-/paraview.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f9b120802ef7b14447d29739db0769b8a57ac9ad",
+      "version": "5.11.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "ef783841125e47d511ecc6d0108e7b1ecaef1469",
       "version": "5.11.0",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/33489
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
