### PR TITLE
[openimageio] Add dependency python3 for feature pybind11

### DIFF
--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -23,7 +23,6 @@
     "libjpeg-turbo",
     "libpng",
     "openexr",
-    "python3",
     "robin-map",
     "tiff",
     {
@@ -100,7 +99,8 @@
     "pybind11": {
       "description": "Enable Python bindings support for openimageio",
       "dependencies": [
-        "pybind11"
+        "pybind11",
+        "python3"
       ]
     },
     "tools": {

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openimageio",
   "version": "2.4.14.0",
+  "port-version": 1,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",
@@ -22,6 +23,7 @@
     "libjpeg-turbo",
     "libpng",
     "openexr",
+    "python3",
     "robin-map",
     "tiff",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6058,7 +6058,7 @@
     },
     "openimageio": {
       "baseline": "2.4.14.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openjpeg": {
       "baseline": "2.5.0",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a36fafeaebea4d776ea92dc3ae28a4465dcf188",
+      "version": "2.4.14.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "965f6cf8bde18cb53a219f9b61b5099105b7fd2f",
       "version": "2.4.14.0",
       "port-version": 0

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1a36fafeaebea4d776ea92dc3ae28a4465dcf188",
+      "git-tree": "c74249169c46dbedf60590f672fb709294ffc7c6",
       "version": "2.4.14.0",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
According to the source code, `openimageio[pybind11]` has a strong dependency on `python3,` so add `python3` as a dependency for `openimageio[pybind11]`.

Fix the build error:
```
-- Could NOT find Python (missing: Python_EXECUTABLE Python_LIBRARIES Python_INCLUDE_DIRS Interpreter Development Development.Module Development.Embed) 
-- Python library not found 
--     Try setting Python_ROOT ? 
CMake Error at src/cmake/checked_find_package.cmake:177 (message):
  Python is required, aborting.
Call Stack (most recent call first):
  src/cmake/pythonutils.cmake:35 (checked_find_package)
  src/cmake/externalpackages.cmake:162 (find_python)
  CMakeLists.txt:166 (include)
```

The source codes:
**CMakeLists.txt:166 (include):**
```
# Dependency finding utilities and all dependency-related options
include (externalpackages)
```
**src/cmake/externalpackages.cmake:162 (find_python):**
```
# From pythonutils.cmake
find_python()
```
**src/cmake/pythonutils.cmake:35 (checked_find_package):**
https://github.com/OpenImageIO/oiio/blob/4c36a07d1d9612b7f95b7592af2a90e69cd81464/src/cmake/pythonutils.cmake#L20-L58.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
