### PR TITLE
[clipper2] Provide CLIPPER2_UTILS target

### DIFF
--- a/ports/clipper2/portfile.cmake
+++ b/ports/clipper2/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DCLIPPER2_EXAMPLES=OFF
         -DCLIPPER2_TESTS=OFF
-        -DCLIPPER2_UTILS=OFF
+        -DCLIPPER2_UTILS=ON
 )
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()

--- a/ports/clipper2/vcpkg.json
+++ b/ports/clipper2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "clipper2",
   "version": "1.2.2",
+  "port-version": 1,
   "description": "Polygon Clipping and Offsetting",
   "homepage": "http://www.angusj.com/clipper2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1610,7 +1610,7 @@
     },
     "clipper2": {
       "baseline": "1.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "clockutils": {
       "baseline": "1.1.1",

--- a/versions/c-/clipper2.json
+++ b/versions/c-/clipper2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a78eeaf159608c707e8191ce0ae9aed946c2e45",
+      "version": "1.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "59bb15f5ddaeb1198a06437295f808d03669373f",
       "version": "1.2.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #33578

Set `CLIPPER2 _UTILS` to ON for the supplied CLIPPER2 _UTILS target

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

