### PR TITLE
[strong-type] Update to v12

### DIFF
--- a/ports/strong-type/portfile.cmake
+++ b/ports/strong-type/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO "rollbear/strong_type"
-    REF "v8"
-    SHA512 "d9bd43c090aac6d36183f70f6cc066484357e997b1b2081114ecb459f80cd990ad31c9141948bf2a9d12ac504da77331a470f2f0eaadc57fbfc9bec6c4de6464"
+    REF "v${VERSION}"
+    SHA512 "ad8302b3c22404f4a12ae49fd1099ad89d1a66f6354b5e751149ce9f739466a279493931b338f9e933817782d58c795cb43afb47af7f9a214212bf85ba7c6235"
 )
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
@@ -9,4 +9,4 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME "strong_type" CONFIG_PATH "lib/cmake/strong_type")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/strong-type/vcpkg.json
+++ b/ports/strong-type/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "strong-type",
-  "version": "8",
+  "version": "12",
   "description": "An additive strong typedef library for C++14/17/20",
   "homepage": "https://github.com/rollbear/strong_type",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7981,7 +7981,7 @@
       "port-version": 1
     },
     "strong-type": {
-      "baseline": "8",
+      "baseline": "12",
       "port-version": 0
     },
     "stronk": {

--- a/versions/s-/strong-type.json
+++ b/versions/s-/strong-type.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "946a58c83d58700039546b6f177b1a1c97ba9487",
+      "version": "12",
+      "port-version": 0
+    },
+    {
       "git-tree": "017b73a108f38fb46a32be946809985a6b1ab96c",
       "version": "8",
       "port-version": 0


### PR DESCRIPTION
Fixes #33580, update `strong-type` to v12.

No feature needs to be tested, the usage test passed on `x64-windows` (header files found):
```
strong-type provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(strong_type CONFIG REQUIRED)
    target_link_libraries(main PRIVATE strong_type::strong_type)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
