### PR TITLE
[glaze] update to 1.4.1

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 277ad9fa36d0cb381a366e481e0c388961bfdb0d230f0bb0185e3515b0aa55667e0fc65e3f6f6321218b897691afc20fd4997266127d054141579d67b8a0d107
+    SHA512 191200d799ad484aae9e4774d420782e6e6f68770cda4c3c9518f78befb5ddf1cc9611b8efb757a44b3217a6e7c41530af3bb2098252b309c46db96557b555f8
 )
 
 vcpkg_cmake_configure(
@@ -20,4 +20,4 @@ vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "1.3.5",
+  "version": "1.4.1",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2889,7 +2889,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "1.3.5",
+      "baseline": "1.4.1",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88849c5a68d5bb707658928cb55d9b3fd24c6617",
+      "version": "1.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2ab2277d5f2a066a86c9c67d394b8449d3257c66",
       "version": "1.3.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.