### PR TITLE
[devil] does not support uwp

### DIFF
--- a/ports/devil/vcpkg.json
+++ b/ports/devil/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "devil",
   "version": "1.8.0",
-  "port-version": 10,
+  "port-version": 11,
   "description": "A full featured cross-platform image library",
   "homepage": "https://github.com/DentonW/DevIL",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2110,7 +2110,7 @@
     },
     "devil": {
       "baseline": "1.8.0",
-      "port-version": 10
+      "port-version": 11
     },
     "dimcli": {
       "baseline": "7.1.0",

--- a/versions/d-/devil.json
+++ b/versions/d-/devil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03010167ad1849c5f1a8e5bc044115b3c84478a3",
+      "version": "1.8.0",
+      "port-version": 11
+    },
+    {
       "git-tree": "ed3ecd6484dfd9737eee0c415817fdddffcc03e2",
       "version": "1.8.0",
       "port-version": 10


### PR DESCRIPTION
You get errors like
```
C:\v\vcpkg4\buildtrees\devil\src\v1.8.0-13a02e996b.clean\DevIL\include\IL/ilut.h(212): error C2143: syntax error: missing ';' before '__cdecl'
C:\v\vcpkg4\buildtrees\devil\src\v1.8.0-13a02e996b.clean\DevIL\include\IL/ilut.h(212): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\v\vcpkg4\buildtrees\devil\src\v1.8.0-13a02e996b.clean\DevIL\include\IL/ilut.h(212): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\v\vcpkg4\buildtrees\devil\src\v1.8.0-13a02e996b.clean\DevIL\include\IL/ilut.h(213): error C2143: syntax error: missing ';' before '__cdecl'
C:\v\vcpkg4\buildtrees\devil\src\v1.8.0-13a02e996b.clean\DevIL\include\IL/ilut.h(213): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\v\vcpkg4\buildtrees\devil\src\v1.8.0-13a02e996b.clean\DevIL\include\IL/ilut.h(213): error C2086: 'int GLuint': redefinition
```