### PR TITLE
[yyjson] fix feature writer

### DIFF
--- a/ports/yyjson/vcpkg.json
+++ b/ports/yyjson/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "yyjson",
   "version": "0.6.0",
+  "port-version": 1,
   "description": "A high performance JSON library written in ANSI C",
   "homepage": "https://github.com/ibireme/yyjson",
   "license": "MIT",
@@ -31,7 +32,16 @@
       "description": "Build with JSON reader"
     },
     "writer": {
-      "description": "Build with JSON writer"
+      "description": "Build with JSON writer",
+      "dependencies": [
+        {
+          "name": "yyjson",
+          "default-features": false,
+          "features": [
+            "reader"
+          ]
+        }
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9046,7 +9046,7 @@
     },
     "yyjson": {
       "baseline": "0.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "z3": {
       "baseline": "4.12.2",

--- a/versions/y-/yyjson.json
+++ b/versions/y-/yyjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "658e0c2de9549d6330f76f33992a45e110bfcb74",
+      "version": "0.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "959e0191dd4850c8915d57c1ffeccfaf983e0616",
       "version": "0.6.0",
       "port-version": 0


### PR DESCRIPTION
Otherwise you get the error
```
[1/3] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DYYJSON_DISABLE_FAST_FP_CONV -DYYJSON_DISABLE_NON_STANDARD -DYYJSON_DISABLE_READER -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/yyjson/src/0.6.0-13b03ca572.clean/src -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -MD -MT CMakeFiles/yyjson.dir/src/yyjson.c.o -MF CMakeFiles/yyjson.dir/src/yyjson.c.o.d -o CMakeFiles/yyjson.dir/src/yyjson.c.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/yyjson/src/0.6.0-13b03ca572.clean/src/yyjson.c
FAILED: CMakeFiles/yyjson.dir/src/yyjson.c.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DYYJSON_DISABLE_FAST_FP_CONV -DYYJSON_DISABLE_NON_STANDARD -DYYJSON_DISABLE_READER -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/yyjson/src/0.6.0-13b03ca572.clean/src -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -MD -MT CMakeFiles/yyjson.dir/src/yyjson.c.o -MF CMakeFiles/yyjson.dir/src/yyjson.c.o.d -o CMakeFiles/yyjson.dir/src/yyjson.c.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/yyjson/src/0.6.0-13b03ca572.clean/src/yyjson.c
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/yyjson/src/0.6.0-13b03ca572.clean/src/yyjson.c:6458:19: error: call to undeclared function 'digi_is_digit'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (unlikely(!digi_is_digit(*cur))) {
                  ^
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/yyjson/src/0.6.0-13b03ca572.clean/src/yyjson.c:6480:17: error: call to undeclared function 'digi_is_fp'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            if (digi_is_fp((u8)buf[i])) fp = true;
                ^
2 errors generated.
ninja: build stopped: subcommand failed.
```
The function `digi_is_digit` is only defined if the "reader" feature is enabled 