### PR TITLE
[influxdb-cxx] no uwp

### DIFF
--- a/ports/influxdb-cxx/vcpkg.json
+++ b/ports/influxdb-cxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "influxdb-cxx",
   "version": "0.7.1",
+  "port-version": 1,
   "description": "InfluxDB C++ client library",
   "homepage": "https://github.com/offa/influxdb-cxx",
   "license": "MIT",
@@ -18,6 +19,7 @@
   "features": {
     "boost": {
       "description": "Enables UDP and Unix sockets as Transport Layer",
+      "supports": "!uwp",
       "dependencies": [
         "boost-asio",
         "boost-conversion",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3410,7 +3410,7 @@
     },
     "influxdb-cxx": {
       "baseline": "0.7.1",
-      "port-version": 0
+      "port-version": 1
     },
     "infoware": {
       "baseline": "2023-04-12",

--- a/versions/i-/influxdb-cxx.json
+++ b/versions/i-/influxdb-cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2b48983d5264e3524e619757f16eac814337ecb",
+      "version": "0.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d03720b58912770380a8101fdbb729a57598a904",
       "version": "0.7.1",
       "port-version": 0


### PR DESCRIPTION
```
C:\v\vcpkg3\vcpkg_installed\x64-uwp\include\boost/asio/detail/impl/win_thread.ipp(50): error C2039: 'TerminateThread': is not a member of '`global namespace''
```
