### PR TITLE
[openjpeg] jpip does not support uwp

### DIFF
--- a/ports/openjpeg/vcpkg.json
+++ b/ports/openjpeg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openjpeg",
   "version": "2.5.0",
+  "port-version": 1,
   "description": "OpenJPEG is an open-source JPEG 2000 codec written in C language. It has been developed in order to promote the use of JPEG 2000, a still-image compression standard from the Joint Photographic Experts Group (JPEG). Since April 2015, it is officially recognized by ISO/IEC and ITU-T as a JPEG 2000 Reference Software.",
   "homepage": "https://github.com/uclouvain/openjpeg",
   "license": "BSD-2-Clause",
@@ -19,7 +20,8 @@
       "description": "(deprecated)"
     },
     "jpip": {
-      "description": "Build optional component jpip"
+      "description": "Build optional component jpip",
+      "supports": "!uwp"
     },
     "jpwl": {
       "description": "(deprecated)"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6074,7 +6074,7 @@
     },
     "openjpeg": {
       "baseline": "2.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openldap": {
       "baseline": "2.5.13",

--- a/versions/o-/openjpeg.json
+++ b/versions/o-/openjpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "608f895171abcfb72dd690a0f7121d265d0904b5",
+      "version": "2.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3451436f9bb5f5ad8946b45868929488fe2c39dd",
       "version": "2.5.0",
       "port-version": 0


### PR DESCRIPTION
Is uses the win32 api that is desktop app exclusive 