### PR TITLE
[cpp-httplib] Update to 0.14.0

### DIFF
--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,16 +2,28 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
     REF "v${VERSION}"
-    SHA512 5181f185bc0bb37429847e2656534ff25512458c0219631c982b776c65fd6be73e038f88d47e42b4f614324e51577bc8815e80952c7c7ca6e66eca4a16a9f30d
+    SHA512 fac8fd1730e7f828053c61924d3ff9b660ad3cb385aa7a506c50c1ed1ca9820fb07691e28e03effcc60e391ecb78727108f1fdbe8b428917ab494738bed86d78
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        brotli  HTTPLIB_REQUIRE_BROTLI
+        openssl HTTPLIB_REQUIRE_OPENSSL
+        zlib    HTTPLIB_REQUIRE_ZLIB
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    ${FEATURE_OPTIONS}
+    -DHTTPLIB_USE_OPENSSL_IF_AVAILABLE=OFF
+    -DHTTPLIB_USE_ZLIB_IF_AVAILABLE=OFF
+    -DHTTPLIB_USE_BROTLI_IF_AVAILABLE=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "cpp-httplib",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",
   "dependencies": [
-    "brotli",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -14,5 +13,28 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "brotli"
+  ],
+  "features": {
+    "brotli": {
+      "description": "Enables brotli compression support using brotli",
+      "dependencies": [
+        "brotli"
+      ]
+    },
+    "openssl": {
+      "description": "Enables HTTPS support using OpenSSL",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "zlib": {
+      "description": "Enables gzip compression support using zlib",
+      "dependencies": [
+        "zlib"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1777,7 +1777,7 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.13.3",
+      "baseline": "0.14.0",
       "port-version": 0
     },
     "cpp-ipc": {

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ed5d9de6eeab399563ab93d52f73b7d4691d1cc",
+      "version": "0.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e1a8cffe02efe8a9c92d1aa1e802f12a8d893aa8",
       "version": "0.13.3",
       "port-version": 0


### PR DESCRIPTION
This PR also enables optional features: brotli, zlib and openssl. Before that, all these libraries were silently used by cpp-httplib if found on the system even when not specified in the portfile. To keep the current behavior, 'brotli' dependency is enabled by default.
