### PR TITLE
[sparsehash-c11] New port

### DIFF
--- a/ports/sparsehash-c11/portfile.cmake
+++ b/ports/sparsehash-c11/portfile.cmake
@@ -1,0 +1,17 @@
+if(EXISTS ${CURRENT_INSTALLED_DIR}/share/sparsehash/copyright)
+    message(FATAL_ERROR "'${PORT}' conflicts with 'sparsehash'. Please remove sparsehash:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
+endif()
+
+# header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO sparsehash/sparsehash-c11
+    REF "v${VERSION}"
+    SHA512 e70f61236f2070da9e5c6a3c3559dee77eb571d996849a5b80fd1c55f7b0b2cae04b59242c103534b897bfe6b542117c252c10ac0a202b5f991ca65e7bad6536
+    HEAD_REF master
+)
+
+file(COPY "${SOURCE_PATH}/sparsehash" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/README" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sparsehash-c11/vcpkg.json
+++ b/ports/sparsehash-c11/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "sparsehash-c11",
+  "version": "2.11.1",
+  "description": "Experimental C++11 version of sparsehash",
+  "homepage": "https://github.com/sparsehash/sparsehash-c11",
+  "license": "BSD-3-Clause"
+}

--- a/ports/sparsehash/portfile.cmake
+++ b/ports/sparsehash/portfile.cmake
@@ -1,3 +1,7 @@
+if(EXISTS ${CURRENT_INSTALLED_DIR}/share/sparsehash-c11/copyright)
+    message(FATAL_ERROR "'${PORT}' conflicts with 'sparsehash-c11'. Please remove sparsehash-c11:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sparsehash/sparsehash

--- a/ports/sparsehash/vcpkg.json
+++ b/ports/sparsehash/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sparsehash",
   "version": "2.0.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The sparsehash package consists of two hashtable implementations: sparse, which is designed to be very space efficient, and dense, which is designed to be very time efficient.",
   "homepage": "https://github.com/sparsehash/sparsehash"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7802,7 +7802,11 @@
     },
     "sparsehash": {
       "baseline": "2.0.4",
-      "port-version": 2
+      "port-version": 3
+    },
+    "sparsehash-c11": {
+      "baseline": "2.11.1",
+      "port-version": 0
     },
     "sparsepp": {
       "baseline": "1.22",

--- a/versions/s-/sparsehash-c11.json
+++ b/versions/s-/sparsehash-c11.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0d10d7d6466d7521a3aaddc593b70608cbfbdc4c",
+      "version": "2.11.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/sparsehash.json
+++ b/versions/s-/sparsehash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e5345f008266b99008d0ccd6754603944f3590b",
+      "version": "2.0.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "c835b4a393784616327a8e5532769096fc443375",
       "version": "2.0.4",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.