### PR TITLE
[vcpkg baseline][anari] passing remove from fail

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -46,7 +46,6 @@ allegro5:arm-neon-android=fail
 allegro5:arm64-android=fail
 allegro5:x64-android=fail
 ampl-asl:x64-android=fail
-anari:arm64-windows=fail
 apr:arm-neon-android=fail
 apr:arm64-android=fail
 apr:x64-android=fail


### PR DESCRIPTION
Fixed [CI pipeline](https://dev.azure.com/vcpkg/public/_build/results?buildId=93804&view=results) issue:
```
REGRESSIONS: PASSING, REMOVE FROM FAIL LIST: anari:arm64-windows (C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt).
```

Added `anari` to `ci.baseline.txt` by #33213, which has been fixed by #33616, so remove this record.