### PR TITLE
[czmq] code clean up

### DIFF
--- a/ports/czmq/portfile.cmake
+++ b/ports/czmq/portfile.cmake
@@ -63,10 +63,8 @@ file(COPY
 )
 
 if ("tool" IN_LIST FEATURES)
-    vcpkg_copy_tools(TOOL_NAMES zmakecert)
+    vcpkg_copy_tools(TOOL_NAMES zmakecert AUTO_CLEAN)
 endif()
-
-vcpkg_clean_executables_in_bin(FILE_NAMES zmakecert)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
@@ -84,4 +82,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/czmq/portfile.cmake
+++ b/ports/czmq/portfile.cmake
@@ -62,9 +62,7 @@ file(COPY
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
 
-if ("tool" IN_LIST FEATURES)
-    vcpkg_copy_tools(TOOL_NAMES zmakecert AUTO_CLEAN)
-endif()
+vcpkg_copy_tools(TOOL_NAMES zmakecert AUTO_CLEAN)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/czmq/vcpkg.json
+++ b/ports/czmq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "czmq",
   "version-semver": "4.2.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "High-level C binding for ZeroMQ",
   "homepage": "https://github.com/zeromq/czmq",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2018,7 +2018,7 @@
     },
     "czmq": {
       "baseline": "4.2.1",
-      "port-version": 2
+      "port-version": 3
     },
     "d3d12-memory-allocator": {
       "baseline": "2021-05-05",

--- a/versions/c-/czmq.json
+++ b/versions/c-/czmq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "edba2a9c366af24d918391dd2cbb0005dfdb66c6",
+      "version-semver": "4.2.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "5bebd4e3a17c277fc4813a24cbdde5d2a06ccc01",
       "version-semver": "4.2.1",
       "port-version": 2

--- a/versions/c-/czmq.json
+++ b/versions/c-/czmq.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "edba2a9c366af24d918391dd2cbb0005dfdb66c6",
+      "git-tree": "ec9f27596e7ff9e8b8aa401f27525075abec28ea",
       "version-semver": "4.2.1",
       "port-version": 3
     },


### PR DESCRIPTION
Add parameter AUTO_CLEAN to `vcpkg_copy_tools `and delete redundant function `vcpkg_clean_executables_in_bin`


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Tesed feature tool in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static