### PR TITLE
[autodock-vina] update to boost 83

### DIFF
--- a/ports/autodock-vina/portfile.cmake
+++ b/ports/autodock-vina/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF v${VERSION}
     SHA512 d36908e5833d22bcbc4dae353ef32b905d6eb46511302f7583a291398bfadff5e75fc99ce7b380860578b2257e5c32434cc75b1ca51fafb4b5f12d9477a878e9
     HEAD_REF develop
+	PATCHES progress_display.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/autodock-vina/progress_display.patch
+++ b/ports/autodock-vina/progress_display.patch
@@ -1,0 +1,32 @@
+diff --git a/src/lib/parallel_progress.h b/src/lib/parallel_progress.h
+index 958b170..2af270a 100755
+--- a/src/lib/parallel_progress.h
++++ b/src/lib/parallel_progress.h
+@@ -23,7 +23,8 @@
+ #ifndef VINA_PARALLEL_PROGRESS_H
+ #define VINA_PARALLEL_PROGRESS_H
+ 
+-#include <boost/progress.hpp>
++#include <boost/version.hpp>
++#include <boost/timer/progress_display.hpp>
+ #include <boost/thread/mutex.hpp>
+ 
+ #include <functional>
+@@ -34,7 +35,7 @@ struct parallel_progress : public incrementable {
+ 	parallel_progress(std::function<void(double)>* c = NULL) : p(NULL), callback(c) {}
+ 	void init(unsigned long n) {
+         count = n;
+-        p = new boost::progress_display(count);
++        p = new boost::timer::progress_display(count);
+     }
+ 	void operator++() {
+ 		if(p) {
+@@ -47,7 +48,7 @@ struct parallel_progress : public incrementable {
+ 	virtual ~parallel_progress() { delete p; }
+ private:
+ 	boost::mutex self;
+-	boost::progress_display* p;
++	boost::timer::progress_display* p;
+     std::function<void(double)>* callback;
+     unsigned long count;
+ };

--- a/ports/autodock-vina/vcpkg.json
+++ b/ports/autodock-vina/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "autodock-vina",
   "version-semver": "1.2.5",
+  "port-version": 1,
   "description": "AutoDock Vina is one of the fastest and most widely used open-source docking engines.",
   "homepage": "http://vina.scripps.edu/",
   "dependencies": [

--- a/versions/a-/autodock-vina.json
+++ b/versions/a-/autodock-vina.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "edc6bd3e6443724f7ae0c56dfc816c6eb9bc1501",
+      "git-tree": "c7584343e0f45b6dd29dd37fb727ca4e5abbf55d",
       "version-semver": "1.2.5",
       "port-version": 1
     },

--- a/versions/a-/autodock-vina.json
+++ b/versions/a-/autodock-vina.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "edc6bd3e6443724f7ae0c56dfc816c6eb9bc1501",
+      "version-semver": "1.2.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "fbbf68e11b2e95110b26735162c7c07b4db2d670",
       "version-semver": "1.2.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -326,7 +326,7 @@
     },
     "autodock-vina": {
       "baseline": "1.2.5",
-      "port-version": 0
+      "port-version": 1
     },
     "avcpp": {
       "baseline": "2.1.0",


### PR DESCRIPTION
Fix autodock-vina when we update to boost 1.83.
boost/process.hpp is deprecated and now it's obligatory to use <boost/timer/progress_display.hpp>
Also we have to use boost::timer namespate instead of only boost namespace.
This should fix one automatic ci-fail detected in pull request #33597 ([boost] update to v1.83.0)

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
