### PR TITLE
[simsimd] Add new port

### DIFF
--- a/ports/simsimd/portfile.cmake
+++ b/ports/simsimd/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ashvardanian/SimSIMD
+    REF "v${VERSION}"
+    SHA512 44a3f971bebbb4f4575dc50dc50795762fd5555f4811fc86a8699fe97dff556b4391128abb4f21b3b94210f9f6f20da854d9471d5443f4ad700a9e21ea905041
+    HEAD_REF main
+)
+
+file(INSTALL "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/simsimd/vcpkg.json
+++ b/ports/simsimd/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "simsimd",
+  "version": "1.4.0",
+  "description": "Fastest similarity-measures and distance functions on the Wild West – vectors, strings, short molecules, and even DNA sequences. All with a pinch of SIMD for both x86 and ARM.",
+  "homepage": "https://github.com/ashvardanian/SimSIMD",
+  "license": "Apache-2.0"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7672,6 +7672,10 @@
       "baseline": "4.19",
       "port-version": 0
     },
+    "simsimd": {
+      "baseline": "1.4.0",
+      "port-version": 0
+    },
     "sjpeg": {
       "baseline": "2021-10-31",
       "port-version": 0

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3d7b5f4bfb287e7ac7f0a9ad241a566f53f959d4",
+      "version": "1.4.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #33553

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
