### PR TITLE
[usearch] Add new port

### DIFF
--- a/ports/usearch/portfile.cmake
+++ b/ports/usearch/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO unum-cloud/usearch
+    REF "v${VERSION}"
+    SHA512 b18006b248ea76b1a8c27c9c1285954f9101305cb5228d3565c854bd1aaf92e430556a5dbeb3f43a6a307914dd60b277a3ed342b953101e502871de294962bd4
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DUSEARCH_INSTALL=ON
+        -DUSEARCH_BUILD_TEST=OFF
+        -DUSEARCH_BUILD_BENCHMARK=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/usearch)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/usearch/vcpkg.json
+++ b/ports/usearch/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "usearch",
+  "version": "2.3.2",
+  "description": "Fastest Search & Clustering engine × for Vectors & Strings",
+  "homepage": "https://github.com/unum-cloud/usearch",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8468,6 +8468,10 @@
       "baseline": "23.5",
       "port-version": 3
     },
+    "usearch": {
+      "baseline": "2.3.2",
+      "port-version": 0
+    },
     "usockets": {
       "baseline": "0.8.6",
       "port-version": 1

--- a/versions/u-/usearch.json
+++ b/versions/u-/usearch.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5ed129aec7ee2dec29767918714015211a556038",
+      "version": "2.3.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #33479

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.