### PR TITLE
[vsg] Update to v1.0.9

### DIFF
--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vsg-dev/VulkanSceneGraph
     REF "v${VERSION}"
-    SHA512 e88b2e665dbd2ea13e5b104c4bad1f30b32c64c0b97c085576916410e9abe246d61958e44cf46ec87ce2fcbe9399569817a44787697811aeb95081bab7d4f5bc
+    SHA512 79ea02c5816c6b99ce847938d9004e0078cb685523c720d4abce5136b91bf4d17fff52893eba972ce9ac3d6db7fe92581039cba6ef72fb9e44ff37f9d9b314f3
     HEAD_REF master
 	PATCHES devendor-glslang.patch
 )

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vsg",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A modern, cross platform, high performance scene graph library built upon Vulkan.",
   "homepage": "http://www.vulkanscenegraph.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8665,7 +8665,7 @@
       "port-version": 2
     },
     "vsg": {
-      "baseline": "1.0.8",
+      "baseline": "1.0.9",
       "port-version": 0
     },
     "vsgxchange": {

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e541c0ad81c0926c15e5f362dcdac38f99dbed19",
+      "version": "1.0.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "6c882aab471b516ea2137b20450773b5ae7c57c3",
       "version": "1.0.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
