### PR TITLE
[vsgxchange] Update to v1.0.5

### DIFF
--- a/ports/vsgxchange/portfile.cmake
+++ b/ports/vsgxchange/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vsg-dev/vsgXchange
     REF "v${VERSION}"
-    SHA512 488bdc9fdbd61cc083675b2970cea9ab307827aa80f05220a21d6f831d308e1bb8e65c288f96e37561903759212b9f5f1269eb4fcf898b8c91b1e50733c71c40
+    SHA512 b2f8c0382dee8d91a31852c29fecd946deb8c3d45dc9a80eb1fb0d7efce8ecefb099bfd2dba4b3171ddd9e7099da41dbf0b72e11ec53bf982aaf9d04afad5104
     HEAD_REF master
     PATCHES require-features.patch
 )
@@ -10,10 +10,10 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         assimp   VSGXCHANGE_WITH_ASSIMP
-	curl     VSGXCHANGE_WITH_CURL
-	freetype VSGXCHANGE_WITH_FREETYPE
-	gdal     VSGXCHANGE_WITH_GDAL
-	openexr  VSGXCHANGE_WITH_OPENEXR
+        curl     VSGXCHANGE_WITH_CURL
+        freetype VSGXCHANGE_WITH_FREETYPE
+        gdal     VSGXCHANGE_WITH_GDAL
+        openexr  VSGXCHANGE_WITH_OPENEXR
 )
 
 vcpkg_cmake_configure(

--- a/ports/vsgxchange/vcpkg.json
+++ b/ports/vsgxchange/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vsgxchange",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Utility library for converting 3rd party images, models and fonts formats to/from VulkanSceneGraph.",
   "homepage": "https://github.com/vsg-dev/vsgXchange",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8669,7 +8669,7 @@
       "port-version": 0
     },
     "vsgxchange": {
-      "baseline": "1.0.4",
+      "baseline": "1.0.5",
       "port-version": 0
     },
     "vtk": {

--- a/versions/v-/vsgxchange.json
+++ b/versions/v-/vsgxchange.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a026d7763afb5ffa6081e9baf6de63a8d500790",
+      "version": "1.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "4019eb900d9064c6cb03767678bf82dd9860033e",
       "version": "1.0.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
