### PR TITLE
[libplctag] Add new port

### DIFF
--- a/ports/libplctag/cmake.patch
+++ b/ports/libplctag/cmake.patch
@@ -1,0 +1,124 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d64d1a..e1599b2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -390,45 +390,64 @@ FOREACH( lib_src ${libplctag_SRCS} )
+     set_source_files_properties(${lib_src} PROPERTIES COMPILE_FLAGS "${C99_FLAGS} ${BASE_C_FLAGS} ${C11_CHECK}")
+ ENDFOREACH()
+ 
++if(LIBPLCTAG_BUILD_SHARED)
+ # shared library
+ add_library(plctag_dyn SHARED ${libplctag_SRCS} )
+ 
+ # set various properties on them
+ set_target_properties(plctag_dyn PROPERTIES SOVERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}" OUTPUT_NAME "plctag")
++    set(tool_lib "plctag_dyn")
++    if(WIN32)
++        target_compile_definitions(plctag_dyn PUBLIC -DLIBPLCTAGDLL_EXPORTS=1)
++    endif()
+ 
+ if(BASE_LINK_FLAGS)
+     set_target_properties(plctag_dyn PROPERTIES LINK_FLAGS "${BASE_LINK_FLAGS}")
+ endif()
++endif()
+ 
+-if(UNIX)
++if(UNIX AND LIBPLCTAG_BUILD_STATIC)
+ 	# static library
+ 	add_library(plctag_static STATIC ${libplctag_SRCS} )
+     set_target_properties(plctag_static PROPERTIES LINK_FLAGS "${BASE_LINK_FLAGS}")
+ 	set_target_properties(plctag_static PROPERTIES VERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}" OUTPUT_NAME "plctag")
+-
+-	set(tool_lib "plctag_dyn")
+-elseif(WIN32)
++elseif(WIN32 AND LIBPLCTAG_BUILD_STATIC)
+     # static library
+ 	add_library(plctag_static STATIC ${libplctag_SRCS} )
+ 	set_target_properties(plctag_static PROPERTIES LINK_FLAGS "${BASE_LINK_FLAGS}")
+-	set_target_properties(plctag_static PROPERTIES VERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}" OUTPUT_NAME "plctag_static")
+-
+-    target_compile_definitions(plctag_dyn PUBLIC -DLIBPLCTAGDLL_EXPORTS=1)
+-	set(tool_lib "plctag_dyn")
++	set_target_properties(plctag_static PROPERTIES VERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}" OUTPUT_NAME "plctag")
++        set_target_properties(plctag_static PROPERTIES COMPILE_DEFINITIONS LIBPLCTAG_STATIC)
+ endif()
+ 
+ # make sure we link with the threading library.
+ if (UNIX)
+     if(CMAKE_THREAD_LIBS_INIT)
++      if(LIBPLCTAG_BUILD_SHARED)
+       target_link_libraries(plctag_dyn "${CMAKE_THREAD_LIBS_INIT}")
++      endif()
++      if(LIBPLCTAG_BUILD_STATIC)
+       target_link_libraries(plctag_static "${CMAKE_THREAD_LIBS_INIT}")
++      endif()
+     endif()
+ endif()
+ 
++# Ensure PkgConfig file adds correct LDFLAGS
++if (NOT MSVC)
++    set(PTHREAD_LDFLAGS "-pthread")
++endif()
++# WIN32 builds need to link the WINSOCK library
++if (WIN32)
++    set(WINSOCK_LDFLAGS "-lws2_32")
++endif()
++
+ # Windows needs to link the library to the WINSOCK library
+ if (WIN32)
++    if(LIBPLCTAG_BUILD_SHARED)
+     target_link_libraries(plctag_dyn ws2_32)
++    endif()
++    if(LIBPLCTAG_BUILD_STATIC)
+     target_link_libraries(plctag_static ws2_32)
++    endif()
+ endif()
+ 
+ # add the examples and tests
+@@ -537,9 +556,6 @@ elseif (BUILD_EXAMPLES)
+         set_target_properties(simple_cpp PROPERTIES LINK_FLAGS "${BASE_LINK_FLAGS}")
+     endif()
+ 
+-    # Generate files from templates
+-    CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/libplctag.pc.in" "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libplctag.pc" @ONLY)
+-
+     # build the GitHub Actions config file
+     CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/.github/workflows/ci.yml.in" "${CMAKE_CURRENT_SOURCE_DIR}/.github/workflows/ci.yml" @ONLY)
+ 
+@@ -609,21 +625,32 @@ endif(ANDROID_BUILD)
+ 
+ # for installation
+ if(UNIX)
++    if(LIBPLCTAG_BUILD_SHARED)
+ 	install(TARGETS plctag_dyn DESTINATION lib${LIB_SUFFIX})
++    endif()
++    if(LIBPLCTAG_BUILD_STATIC)
+ 	install(TARGETS plctag_static DESTINATION lib${LIB_SUFFIX})
++    endif()
+ elseif(WIN32)
+-	install(TARGETS plctag_dyn DESTINATION lib${LIB_SUFFIX})
++    if(LIBPLCTAG_BUILD_SHARED)
++	install(TARGETS plctag_dyn)
++    endif()
++    if(LIBPLCTAG_BUILD_STATIC)
+ 	install(TARGETS plctag_static DESTINATION lib${LIB_SUFFIX})
++    endif()
+ endif()
+ 
+-if(ANDROID_BUILD)
++if(ANDROID_BUILD AND 0)
+     message("Skipping package config and header file copy for Android build.")
+ else()
++    # Generate files from templates
++    CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/libplctag.pc.in" "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libplctag.pc" @ONLY)
++
+     install(FILES "${lib_SRC_PATH}/libplctag.h" DESTINATION include)
+     if(EXISTS "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libplctag.pc")
+         install(FILES "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libplctag.pc" DESTINATION "lib${LIB_SUFFIX}/pkgconfig")
+     endif()
+-endif(ANDROID_BUILD)
++endif(ANDROID_BUILD AND 0)
+ 
+ macro(print_all_variables)
+     message(STATUS "print_all_variables------------------------------------------{")
+

--- a/ports/libplctag/cmake.patch
+++ b/ports/libplctag/cmake.patch
@@ -2,11 +2,11 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 4d64d1a..e1599b2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -390,45 +390,64 @@ FOREACH( lib_src ${libplctag_SRCS} )
+@@ -390,45 +390,62 @@ FOREACH( lib_src ${libplctag_SRCS} )
      set_source_files_properties(${lib_src} PROPERTIES COMPILE_FLAGS "${C99_FLAGS} ${BASE_C_FLAGS} ${C11_CHECK}")
  ENDFOREACH()
  
-+if(LIBPLCTAG_BUILD_SHARED)
++if(BUILD_SHARED_LIBS)
  # shared library
  add_library(plctag_dyn SHARED ${libplctag_SRCS} )
  
@@ -23,7 +23,7 @@ index 4d64d1a..e1599b2 100644
 +endif()
  
 -if(UNIX)
-+if(UNIX AND LIBPLCTAG_BUILD_STATIC)
++if(UNIX AND NOT BUILD_SHARED_LIBS)
  	# static library
  	add_library(plctag_static STATIC ${libplctag_SRCS} )
      set_target_properties(plctag_static PROPERTIES LINK_FLAGS "${BASE_LINK_FLAGS}")
@@ -31,7 +31,7 @@ index 4d64d1a..e1599b2 100644
 -
 -	set(tool_lib "plctag_dyn")
 -elseif(WIN32)
-+elseif(WIN32 AND LIBPLCTAG_BUILD_STATIC)
++elseif(WIN32 AND NOT BUILD_SHARED_LIBS)
      # static library
  	add_library(plctag_static STATIC ${libplctag_SRCS} )
  	set_target_properties(plctag_static PROPERTIES LINK_FLAGS "${BASE_LINK_FLAGS}")
@@ -46,10 +46,9 @@ index 4d64d1a..e1599b2 100644
  # make sure we link with the threading library.
  if (UNIX)
      if(CMAKE_THREAD_LIBS_INIT)
-+      if(LIBPLCTAG_BUILD_SHARED)
++      if(BUILD_SHARED_LIBS)
        target_link_libraries(plctag_dyn "${CMAKE_THREAD_LIBS_INIT}")
-+      endif()
-+      if(LIBPLCTAG_BUILD_STATIC)
++      else()
        target_link_libraries(plctag_static "${CMAKE_THREAD_LIBS_INIT}")
 +      endif()
      endif()
@@ -66,10 +65,9 @@ index 4d64d1a..e1599b2 100644
 +
  # Windows needs to link the library to the WINSOCK library
  if (WIN32)
-+    if(LIBPLCTAG_BUILD_SHARED)
++    if(BUILD_SHARED_LIBS)
      target_link_libraries(plctag_dyn ws2_32)
-+    endif()
-+    if(LIBPLCTAG_BUILD_STATIC)
++    else()
      target_link_libraries(plctag_static ws2_32)
 +    endif()
  endif()
@@ -85,22 +83,20 @@ index 4d64d1a..e1599b2 100644
      # build the GitHub Actions config file
      CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/.github/workflows/ci.yml.in" "${CMAKE_CURRENT_SOURCE_DIR}/.github/workflows/ci.yml" @ONLY)
  
-@@ -609,21 +625,32 @@ endif(ANDROID_BUILD)
+@@ -609,21 +625,30 @@ endif(ANDROID_BUILD)
  
  # for installation
  if(UNIX)
-+    if(LIBPLCTAG_BUILD_SHARED)
++    if(BUILD_SHARED_LIBS)
  	install(TARGETS plctag_dyn DESTINATION lib${LIB_SUFFIX})
-+    endif()
-+    if(LIBPLCTAG_BUILD_STATIC)
++    else()
  	install(TARGETS plctag_static DESTINATION lib${LIB_SUFFIX})
 +    endif()
  elseif(WIN32)
 -	install(TARGETS plctag_dyn DESTINATION lib${LIB_SUFFIX})
-+    if(LIBPLCTAG_BUILD_SHARED)
++    if(BUILD_SHARED_LIBS)
 +	install(TARGETS plctag_dyn)
-+    endif()
-+    if(LIBPLCTAG_BUILD_STATIC)
++    else()
  	install(TARGETS plctag_static DESTINATION lib${LIB_SUFFIX})
 +    endif()
  endif()

--- a/ports/libplctag/fix_static.patch
+++ b/ports/libplctag/fix_static.patch
@@ -1,0 +1,25 @@
+diff --git a/src/lib/libplctag.h b/src/lib/libplctag.h
+index a06144d..6c60a08 100644
+--- a/src/lib/libplctag.h
++++ b/src/lib/libplctag.h
+@@ -40,14 +40,17 @@ extern "C" {
+ #endif
+ 
+ 
+-#if  defined(_WIN32) || defined(WIN32) || defined(WIN64) || defined(_WIN64)
++#if  (defined(_WIN32) || defined(WIN32) || defined(WIN64) || defined(_WIN64)) && \
++     defined(_MSC_VER)
+     #ifdef __cplusplus
+         #define C_FUNC extern "C"
+     #else
+         #define C_FUNC
+     #endif
+ 
+-    #ifdef LIBPLCTAGDLL_EXPORTS
++    #ifdef LIBPLCTAG_STATIC
++        #define LIB_EXPORT extern
++    #elif defined(LIBPLCTAGDLL_EXPORTS)
+         #define LIB_EXPORT __declspec(dllexport)
+     #else
+         #define LIB_EXPORT __declspec(dllimport)
+

--- a/ports/libplctag/pkgconfig.patch
+++ b/ports/libplctag/pkgconfig.patch
@@ -7,8 +7,7 @@ index 0ea8ff6..3fca384 100644
  Version: @VERSION@
  
 -Libs: -L${libdir} -lplctag -pthread
--Cflags: -I${includedir}
 +Libs: -L${libdir} -lplctag @PTHREAD_LDFLAGS@ @WINSOCK_LDFLAGS@
-+Cflags: -I${includedir} @STATIC_CFLAGS@
+ Cflags: -I${includedir}
 +Cflags.private: -DLIBPLCTAG_STATIC
 

--- a/ports/libplctag/pkgconfig.patch
+++ b/ports/libplctag/pkgconfig.patch
@@ -1,0 +1,14 @@
+diff --git a/libplctag.pc.in b/libplctag.pc.in
+index 0ea8ff6..3fca384 100644
+--- a/libplctag.pc.in
++++ b/libplctag.pc.in
+@@ -7,5 +7,6 @@ Name: libplctag
+ Description: Portable and simple API for accessing Allen-Bradley PLC data over Ethernet
+ Version: @VERSION@
+ 
+-Libs: -L${libdir} -lplctag -pthread
+-Cflags: -I${includedir}
++Libs: -L${libdir} -lplctag @PTHREAD_LDFLAGS@ @WINSOCK_LDFLAGS@
++Cflags: -I${includedir} @STATIC_CFLAGS@
++Cflags.private: -DLIBPLCTAG_STATIC
+

--- a/ports/libplctag/portfile.cmake
+++ b/ports/libplctag/portfile.cmake
@@ -1,0 +1,48 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO libplctag/libplctag
+  REF "v${VERSION}"
+  SHA512 f540780642112483bd199995b327342bd2df2ec4a4d44c2356886ab94879aeb2da3e420760da2f00b5aee0d1278fc582f73cba8227b276787d21b18fa12a3add
+  HEAD_REF release
+  PATCHES
+	cmake.patch
+	sanitizer.patch
+	pkgconfig.patch
+	fix_static.patch
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+	set(LIBPLCTAG_BUILD_STATIC 1)
+else()
+	set(LIBPLCTAG_BUILD_SHARED 1)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
+        -DUSE_SANITIZERS=OFF
+	-DLIBPLCTAG_BUILD_STATIC=${LIBPLCTAG_BUILD_STATIC}
+	-DLIBPLCTAG_BUILD_SHARED=${LIBPLCTAG_BUILD_SHARED}
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+# Handle copyright
+file(READ "${SOURCE_PATH}/LICENSE-1.MPL" mpl)
+file(READ "${SOURCE_PATH}/LICENSE-2.LGPL" lgpl)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright"
+"${PORT} is released under a dual MPL / LGPL license.
+
+---
+
+${mpl}
+
+---
+
+${lgpl}
+")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/libplctag/portfile.cmake
+++ b/ports/libplctag/portfile.cmake
@@ -11,20 +11,12 @@ vcpkg_from_github(
 	fix_static.patch
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-	set(LIBPLCTAG_BUILD_STATIC 1)
-else()
-	set(LIBPLCTAG_BUILD_SHARED 1)
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DUSE_SANITIZERS=OFF
-	-DLIBPLCTAG_BUILD_STATIC=${LIBPLCTAG_BUILD_STATIC}
-	-DLIBPLCTAG_BUILD_SHARED=${LIBPLCTAG_BUILD_SHARED}
 )
 
 vcpkg_cmake_install()

--- a/ports/libplctag/portfile.cmake
+++ b/ports/libplctag/portfile.cmake
@@ -19,6 +19,7 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DUSE_SANITIZERS=OFF

--- a/ports/libplctag/portfile.cmake
+++ b/ports/libplctag/portfile.cmake
@@ -32,18 +32,6 @@ vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 # Handle copyright
-file(READ "${SOURCE_PATH}/LICENSE-1.MPL" mpl)
-file(READ "${SOURCE_PATH}/LICENSE-2.LGPL" lgpl)
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright"
-"${PORT} is released under a dual MPL / LGPL license.
-
----
-
-${mpl}
-
----
-
-${lgpl}
-")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-1.MPL" "${SOURCE_PATH}/LICENSE-2.LGPL" COMMENT "LIBPLCTAG is released under a dual MPL / LGPL license")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/libplctag/sanitizer.patch
+++ b/ports/libplctag/sanitizer.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d64d1af..5574f6bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -143,6 +143,8 @@ endif()
+ # build examples flag
+ set(BUILD_EXAMPLES 1 CACHE BOOL "Build examples or not")
+ 
++set(USE_SANITIZERS 1 CACHE BOOL "Build with google sanitizers or not")
++
+ # set flags for MacOSX
+ if (APPLE)
+     set(CMAKE_MACOSX_RPATH ON)
+@@ -258,11 +260,17 @@ elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+         SET(STR_OP_OVERFLOW_OFF "")
+     endif()
+ 
+-    set(BASE_RELEASE_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Wextra -Wconversion -fms-extensions -fno-strict-aliasing -fvisibility=hidden ${STR_OP_OVERFLOW_OFF} -D__USE_POSIX=1 -D_POSIX_C_SOURCE=200809L")
+-    set(BASE_DEBUG_FLAGS "${CMAKE_C_FLAGS} -g -Wall -pedantic -Wextra -Wconversion -fms-extensions -fno-strict-aliasing -fvisibility=hidden -fsanitize=address -fsanitize=leak -fsanitize=undefined ${STR_OP_OVERFLOW_ON} -D__USE_POSIX=1 -D_POSIX_C_SOURCE=200809L")
+-	set(C99_FLAGS "-std=c99" )
+-    set(BASE_RELEASE_LINK_FLAGS "")
+-    set(BASE_DEBUG_LINK_FLAGS "-fsanitize=address -fsanitize=leak -fsanitize=undefined")
++    SET(BASE_RELEASE_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Wextra -Wconversion -fms-extensions -fno-strict-aliasing -fvisibility=hidden ${STR_OP_OVERFLOW_OFF} -D__USE_POSIX=1 -D_POSIX_C_SOURCE=200809L")
++    SET(BASE_DEBUG_FLAGS "${CMAKE_C_FLAGS} -g -Wall -pedantic -Wextra -Wconversion -fms-extensions -fno-strict-aliasing -fvisibility=hidden ${STR_OP_OVERFLOW_ON} -D__USE_POSIX=1 -D_POSIX_C_SOURCE=200809L")
++	SET(C99_FLAGS "-std=c99" )
++    SET(BASE_RELEASE_LINK_FLAGS "")
++    SET(BASE_DEBUG_LINK_FLAGS "")
++
++    if(USE_SANITIZERS)
++        SET(SANITIZERS_FLAGS " -fsanitize=address -fsanitize=leak -fsanitize=undefined")
++        STRING(APPEND BASE_DEBUG_FLAGS ${SANITIZERS_FLAGS})
++        STRING(APPEND BASE_DEBUG_LINK_FLAGS ${SANITIZERS_FLAGS})
++    endif()
+ 
+     # check to see if we are building 32-bit or 64-bit
+     if(BUILD_32_BIT)

--- a/ports/libplctag/usage
+++ b/ports/libplctag/usage
@@ -1,0 +1,5 @@
+The package libplctag can be imported via CMake FindPkgConfig module:
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(libplctag REQUIRED IMPORTED_TARGET libplctag)
+    target_link_libraries(main PRIVATE PkgConfig::libplctag)

--- a/ports/libplctag/vcpkg.json
+++ b/ports/libplctag/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libplctag",
+  "version": "2.5.5",
+  "description": "C library for PLC communication",
+  "license": "MPL-2.0 OR LGPL-2.0-or-later",
+  "supports": "!uwp",
+  "dependencies": [
+    "pthreads",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libplctag/vcpkg.json
+++ b/ports/libplctag/vcpkg.json
@@ -5,7 +5,10 @@
   "license": "MPL-2.0 OR LGPL-2.0-or-later",
   "supports": "!uwp",
   "dependencies": [
-    "pthreads",
+    {
+      "name": "pthreads",
+      "platform": "!windows"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4488,6 +4488,10 @@
       "baseline": "8.13.17",
       "port-version": 0
     },
+    "libplctag": {
+      "baseline": "2.5.5",
+      "port-version": 0
+    },
     "libplist": {
       "baseline": "1.3.6",
       "port-version": 2

--- a/versions/l-/libplctag.json
+++ b/versions/l-/libplctag.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "134a66f07865aad41f69158806d4463bae268f96",
+      "version": "2.5.5",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libplctag.json
+++ b/versions/l-/libplctag.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "24278dd0844def4a509536dcbb17055d69a71def",
+      "git-tree": "a1625c578a5023010fcd58fd86dcf7fc3c78bde5",
       "version": "2.5.5",
       "port-version": 0
     }

--- a/versions/l-/libplctag.json
+++ b/versions/l-/libplctag.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "134a66f07865aad41f69158806d4463bae268f96",
+      "git-tree": "20ff23ab2bd3df9c6861d78d94b149043c190866",
       "version": "2.5.5",
       "port-version": 0
     }

--- a/versions/l-/libplctag.json
+++ b/versions/l-/libplctag.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "20ff23ab2bd3df9c6861d78d94b149043c190866",
+      "git-tree": "da137539561fa6ec1b0f6fa6d4aec698e684fa06",
       "version": "2.5.5",
       "port-version": 0
     }

--- a/versions/l-/libplctag.json
+++ b/versions/l-/libplctag.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "da137539561fa6ec1b0f6fa6d4aec698e684fa06",
+      "git-tree": "24278dd0844def4a509536dcbb17055d69a71def",
       "version": "2.5.5",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.