### PR TITLE
[libsvm] tools no uwp

### DIFF
--- a/ports/libsvm/vcpkg.json
+++ b/ports/libsvm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libsvm",
   "version": "3.25",
+  "port-version": 1,
   "description": "A library for Support Vector Machines.",
   "homepage": "https://www.csie.ntu.edu.tw/~cjlin/libsvm/",
   "dependencies": [
@@ -15,7 +16,8 @@
   ],
   "features": {
     "tools": {
-      "description": "build libsvm CLI tools."
+      "description": "build libsvm CLI tools.",
+      "supports": "!uwp"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4682,7 +4682,7 @@
     },
     "libsvm": {
       "baseline": "3.25",
-      "port-version": 0
+      "port-version": 1
     },
     "libtar": {
       "baseline": "1.2.20",

--- a/versions/l-/libsvm.json
+++ b/versions/l-/libsvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ee5de615b1449a216f61cb83ec2704e93a34495",
+      "version": "3.25",
+      "port-version": 1
+    },
+    {
       "git-tree": "a5bcb4cdaf7906a6e12948dcb5b170f79fba900e",
       "version": "3.25",
       "port-version": 0


### PR DESCRIPTION
```
C:\v\vcpkg3\buildtrees\libsvm\src\v325-1a4171a877.clean\svm-toy\windows\svm-toy.cpp(63): error C2065: 'wndclass': undeclared identifier
```
wndclass is not supported on uwp 