### PR TITLE
[proj] tools fix uwp

### DIFF
--- a/ports/proj/fix-uwp.patch
+++ b/ports/proj/fix-uwp.patch
@@ -1,0 +1,17 @@
+diff --git a/src/apps/CMakeLists.txt b/src/apps/CMakeLists.txt
+index cdd85bd3..5c63cab7 100644
+--- a/src/apps/CMakeLists.txt
++++ b/src/apps/CMakeLists.txt
+@@ -37,10 +37,12 @@ if(NOT MSVC)
+ 
+ else()
+ 
++  if(NOT WINDOWS_STORE)
+     # Linking to setargv.obj enables wildcard globbing for the
+     # command line utilities, when compiling with MSVC
+     # https://docs.microsoft.com/cpp/c-language/expanding-wildcard-arguments
+     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} setargv.obj")
++  endif()
+ 
+ endif()
+ 

--- a/ports/proj/portfile.cmake
+++ b/ports/proj/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix-win-output-name.patch
         fix-proj4-targets-cmake.patch
         remove_toolset_restriction.patch
+        fix-uwp.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/proj/vcpkg.json
+++ b/ports/proj/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "proj",
   "version": "9.3.0",
+  "port-version": 1,
   "description": "PROJ library for cartographic projections",
   "homepage": "https://proj.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6542,7 +6542,7 @@
     },
     "proj": {
       "baseline": "9.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "proj4": {
       "baseline": "8.9.9",

--- a/versions/p-/proj.json
+++ b/versions/p-/proj.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e31164b906c96903b8352e6a9211ae019672ac4",
+      "version": "9.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d3932aae445fce753fd58b103e1dcb0acfff0a39",
       "version": "9.3.0",
       "port-version": 0


### PR DESCRIPTION
Otherwise you get errors like
```
[235/239] cmd.exe /C "cd . && C:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=src\apps\CMakeFiles\invproj.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1437~1.328\bin\Hostx64\x64\link.exe  src\apps\CMakeFiles\invproj.dir\proj.cpp.obj src\apps\CMakeFiles\invproj.dir\emess.cpp.obj src\apps\CMakeFiles\invproj.dir\utils.cpp.obj  /out:bin\invproj.exe /implib:lib\invproj.lib /pdb:bin\invproj.pdb /version:0.0 /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD /APPCONTAINER /MANIFESTUAC:NO  setargv.obj /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF  /subsystem:console -LIBPATH:C:\v\vcpkg3\buildtrees\proj\x64-uwp-rel\lib lib\proj.lib  WindowsApp.lib && cd ."
FAILED: bin/invproj.exe 
cmd.exe /C "cd . && C:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=src\apps\CMakeFiles\invproj.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1437~1.328\bin\Hostx64\x64\link.exe  src\apps\CMakeFiles\invproj.dir\proj.cpp.obj src\apps\CMakeFiles\invproj.dir\emess.cpp.obj src\apps\CMakeFiles\invproj.dir\utils.cpp.obj  /out:bin\invproj.exe /implib:lib\invproj.lib /pdb:bin\invproj.pdb /version:0.0 /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD /APPCONTAINER /MANIFESTUAC:NO  setargv.obj /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF  /subsystem:console -LIBPATH:C:\v\vcpkg3\buildtrees\proj\x64-uwp-rel\lib lib\proj.lib  WindowsApp.lib && cd ."
LINK: command "C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1437~1.328\bin\Hostx64\x64\link.exe src\apps\CMakeFiles\invproj.dir\proj.cpp.obj src\apps\CMakeFiles\invproj.dir\emess.cpp.obj src\apps\CMakeFiles\invproj.dir\utils.cpp.obj /out:bin\invproj.exe /implib:lib\invproj.lib /pdb:bin\invproj.pdb /version:0.0 /MANIFEST:NO /NXCOMPAT /DYNAMICBASE /DEBUG /WINMD /APPCONTAINER /MANIFESTUAC:NO setargv.obj /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF /subsystem:console -LIBPATH:C:\v\vcpkg3\buildtrees\proj\x64-uwp-rel\lib lib\proj.lib WindowsApp.lib" failed (exit code 1181) with the following output:
Microsoft (R) Incremental Linker Version 14.37.32822.0

Copyright (C) Microsoft Corporation.  All rights reserved.



LINK : warning LNK4075: ignoring '/MANIFESTUAC' due to '/MANIFEST:NO' specification

LINK : fatal error LNK1181: cannot open input file 'setargv.obj'
```