### PR TITLE
[thrift] Update to v0.19.0

### DIFF
--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -12,8 +12,8 @@ vcpkg_find_acquire_program(BISON)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/thrift
-    REF 2a93df80f27739ccabb5b885cb12a8dc7595ecdf #0.16.0
-    SHA512 aed4f60b8a4eca5b4bce26f6f29d1178684d2b4e6de290ab1e696ac78a9f85d941afe5dca99d1d22d640371ad538b930cf445f9f899a2e322f39b0cceec307a3
+    REF "${VERSION}"
+    SHA512 f9bfaf149dde4da1f5353e540b862c2088465115564d981bf02cd89e8c1f84ca53143ca0091b63d24f8f515425d9163af52ec6122245b59810a2b98292a71650
     HEAD_REF master
     PATCHES
       "correct-paths.patch"
@@ -83,7 +83,7 @@ if(COMPILER)
     vcpkg_copy_tools(TOOL_NAMES thrift AUTO_CLEAN)
 endif()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 if ("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/thrift/vcpkg.json
+++ b/ports/thrift/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "thrift",
-  "version": "0.16.0",
-  "port-version": 1,
+  "version": "0.19.0",
   "description": "Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible.",
   "homepage": "https://github.com/apache/thrift",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8153,8 +8153,8 @@
       "port-version": 3
     },
     "thrift": {
-      "baseline": "0.16.0",
-      "port-version": 1
+      "baseline": "0.19.0",
+      "port-version": 0
     },
     "tidy-html5": {
       "baseline": "5.8.0",

--- a/versions/t-/thrift.json
+++ b/versions/t-/thrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a85bec1a50438e0a5d4edbfb7d507a26ace7f010",
+      "version": "0.19.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fc85618cd8a4849e400d28916b733f2426c9246d",
       "version": "0.16.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #33652, update `thrift` to v0.19.0.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
