### PR TITLE
[glib] Update version to 2.76.5

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -2,7 +2,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIB_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIB_ARCHIVE
     URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${VERSION}.tar.xz"
     FILENAME "glib-${VERSION}.tar.xz"
-    SHA512 291b8913918d411b679442b888f56893a857a77decfe428086c8bd1da1949498938ddb0bf254ed99d192e4a09b5e8cee1905fd6932ee642463fb229cac7c226e
+    SHA512 190a98e9a0ebb802a31b511e95725ed1fec9d750aed6bd87f14f3047d1f1d79458be3fa954fd6eb9af9f481a8deeaae73c95c990f5aa002a4b1166372ed4c4f1
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glib",
-  "version": "2.76.3",
-  "port-version": 3,
+  "version": "2.76.5",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2913,8 +2913,8 @@
       "port-version": 2
     },
     "glib": {
-      "baseline": "2.76.3",
-      "port-version": 3
+      "baseline": "2.76.5",
+      "port-version": 0
     },
     "glibmm": {
       "baseline": "2.76.0",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ae4475a91c8ec7f156e5904da9f0c3f02224cdc",
+      "version": "2.76.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "ac7af1a224e7dfe9c18e629bf8de7798a0cda932",
       "version": "2.76.3",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/33501
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
All features have been tested successfully on `x64-linux`.
<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] ~~Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)~~
- [x] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
