### PR TITLE
[harfbuzz] update to 8.2.0

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
     REF ${VERSION}
-    SHA512 044f8ce9d195f83eb90412e76e9f381559ed6565f956a3cdf1da26b0540df85d1dc51b4a6bcca2f8fcb48a4a1f2e5535ef6d786dfaf63d68ce5fe70ea6f2f2f9
+    SHA512 6e6c56196157e1ccddbfb4717b15fb15821e43f0ebaf7de1d5c0d41ff5d2a58f9ada56bac0472e1a8f4abe8e9cf325fcda33b0b287ed7c1a41c0fc8854f8d36e
     HEAD_REF master
 )
 

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3149,7 +3149,7 @@
       "port-version": 1
     },
     "harfbuzz": {
-      "baseline": "8.1.1",
+      "baseline": "8.2.0",
       "port-version": 0
     },
     "hash-library": {

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d804324af44593c0877fdf035cda178123d9c87f",
+      "version": "8.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "458a6aee4457133d8ea6b97f1a18724fead35551",
       "version": "8.1.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #33701.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.