### PR TITLE
[sigmatch] add new port

### DIFF
--- a/ports/sigmatch/portfile.cmake
+++ b/ports/sigmatch/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SpriteOvO/sigmatch
+    REF v0.2.0
+    SHA512 a2ae12bf2da4de4b4b65f443febca8bec5ded2cdcbfe5c166538869431558241883576fed04fc373b60fe5b5709c96a56110181d3b1c07dbb42ecfdddae74c06
+    HEAD_REF main
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSIGMATCH_BUILD_TESTS=OFF
+)
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sigmatch)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/sigmatch/vcpkg.json
+++ b/ports/sigmatch/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "sigmatch",
+  "version": "0.2.0",
+  "description": "Modern C++ 20 signature match / search library",
+  "homepage": "https://github.com/SpriteOvO/sigmatch",
+  "license": "Apache-2.0",
+  "supports": "windows & !uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7628,6 +7628,10 @@
       "baseline": "2.5.1",
       "port-version": 0
     },
+    "sigmatch": {
+      "baseline": "0.2.0",
+      "port-version": 0
+    },
     "signalrclient": {
       "baseline": "1.0.0-beta1-9",
       "port-version": 5

--- a/versions/s-/sigmatch.json
+++ b/versions/s-/sigmatch.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "83b6f5b1da02efa0313fdf8caa5ee44f41047143",
+      "version": "0.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
