### PR TITLE
[civetweb] no windows arm

### DIFF
--- a/ports/civetweb/vcpkg.json
+++ b/ports/civetweb/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "civetweb",
   "version": "1.15",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Easy to use, powerful, C/C++ embeddable web server.",
   "homepage": "https://github.com/civetweb/civetweb",
-  "supports": "!uwp",
+  "supports": "!uwp & !(arm & windows)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -184,9 +184,6 @@ chromium-base:x64-linux=skip
 #  because the first attempt to build it fails, but subsequent attempts succeed
 chromium-base:x64-osx=skip
 
-civetweb:arm64-windows      = skip
-civetweb:arm-uwp            = skip
-civetweb:x64-uwp            = skip
 clamav:arm64-windows=fail
 
 # clapack is replaced by lapack-reference on the platforms lapack-reference supports

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1558,7 +1558,7 @@
     },
     "civetweb": {
       "baseline": "1.15",
-      "port-version": 2
+      "port-version": 3
     },
     "cjson": {
       "baseline": "1.7.15",

--- a/versions/c-/civetweb.json
+++ b/versions/c-/civetweb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3847be52c382b4546939abf4ab3bf422bde1be3",
+      "version": "1.15",
+      "port-version": 3
+    },
+    {
       "git-tree": "f5c4ed510288187d465737a301891b1101d6c373",
       "version": "1.15",
       "port-version": 2


### PR DESCRIPTION
You get
```
CMake Error at cmake/DetermineTargetArchitecture.cmake:27 (message):
  Failed to determine the MSVC target architecture: ARM64
```