### PR TITLE
[directxtk] fix wrong dep on arm

### DIFF
--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directxtk",
   "version-date": "2023-09-01",
+  "port-version": 1,
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",
@@ -34,10 +35,7 @@
     "xaudio2redist": {
       "description": "Build with XAudio2Redist support for Windows 7 SP1 or later",
       "dependencies": [
-        {
-          "name": "xaudio2redist",
-          "platform": "!uwp & !arm"
-        }
+        "xaudio2redist"
       ]
     }
   }

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directxtk12",
   "version-date": "2023-09-01",
+  "port-version": 1,
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",
@@ -47,10 +48,7 @@
     "xaudio2redist": {
       "description": "Build with XAudio2Redist",
       "dependencies": [
-        {
-          "name": "xaudio2redist",
-          "platform": "!uwp & !arm & !xbox"
-        }
+        "xaudio2redist"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2142,11 +2142,11 @@
     },
     "directxtk": {
       "baseline": "2023-09-01",
-      "port-version": 0
+      "port-version": 1
     },
     "directxtk12": {
       "baseline": "2023-09-01",
-      "port-version": 0
+      "port-version": 1
     },
     "dirent": {
       "baseline": "1.23.2",

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67b1d9a329c9e9d8d067359c18bb997148f4e84e",
+      "version-date": "2023-09-01",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf6287265ca9c166405069e8ed3d54e79388cf14",
       "version-date": "2023-09-01",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "981fd27befe2b9d8afaab87f1b66c1f8c6f31c18",
+      "version-date": "2023-09-01",
+      "port-version": 1
+    },
+    {
       "git-tree": "5e74058955f67b88369b4cc3f600dc6a65be1035",
       "version-date": "2023-09-01",
       "port-version": 0


### PR DESCRIPTION
The dep also exists on arm, otherwise you get:
```
CMake Error at C:/v/vcpkg4/scripts/buildsystems/vcpkg.cmake:859 (_find_package):
  Could not find a package configuration file provided by "xaudio2redist"
  with any of the following names:

    xaudio2redistConfig.cmake
    xaudio2redist-config.cmake
```