### PR TITLE
[async-mqtt ] Update port to 2.0.0.

### DIFF
--- a/ports/async-mqtt/portfile.cmake
+++ b/ports/async-mqtt/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO redboltz/async_mqtt
     REF "${VERSION}"
-    SHA512 1040b0cc23c385db713ccc6fe54a0caf0597d497bb2d1ec817d2b86fc77f14f6a82e287ef305e416bd454ab2be2ed01d8d7ceb859461f52c1b13fbb55e45bd34
+    SHA512 0bcb0bc3a08329a11ebe3efee4f919efc7bb8192373efd924f29f63c3bc7ca3ddd2c6e669f5800baf2fb3c5d67ae423e89cc802275d088848da83b2f343f7318
     HEAD_REF main
 )
 

--- a/ports/async-mqtt/vcpkg.json
+++ b/ports/async-mqtt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "async-mqtt",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "Header-only Asynchronous MQTT communication library for C++17 based on Boost.Asio.",
   "homepage": "https://github.com/redboltz/async_mqtt",
   "license": "BSL-1.0",

--- a/versions/a-/async-mqtt.json
+++ b/versions/a-/async-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1785cef2cfd89416b423c3a67c5ef0ef29c76100",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f7194dfdf664f2037e9917fd58220d421dc9de76",
       "version": "1.0.9",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -269,7 +269,7 @@
       "port-version": 0
     },
     "async-mqtt": {
-      "baseline": "1.0.9",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "asynch": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
