### PR TITLE
[ktx] fix ktx[tools]:x64-uwp build

### DIFF
--- a/ports/ktx/0005-Fix-tools-argparser.patch
+++ b/ports/ktx/0005-Fix-tools-argparser.patch
@@ -1,0 +1,24 @@
+ utils/argparser.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/utils/argparser.h b/utils/argparser.h
+index 4ed86d7187..de5e248b30 100644
+--- a/utils/argparser.h
++++ b/utils/argparser.h
+@@ -13,13 +13,13 @@
+ #include <sstream>
+ #include <string>
+ #include <vector>
+-#if defined(_WIN32)
++#if 0
+   #include <tchar.h>
+ #else
+   #define _TCHAR char
+   #define _T(x) x
+ #endif
+-#if defined(_UNICODE)
++#if 0
+   #define _tstring std::wstring
+ #else
+   #define _tstring std::string
+  

--- a/ports/ktx/0006-Fix-tools-stdafx.patch
+++ b/ports/ktx/0006-Fix-tools-stdafx.patch
@@ -11,9 +11,9 @@ index 30d7ff4675..155ccdb773 100644
  #include <stdio.h>
 -#ifdef _WIN32
 +
-+#ifdef UNICODE
-+#undef UNICODE
-+#endif
++
++
++
 +
 +#if WIN32
 +  #include <io.h>

--- a/ports/ktx/0006-Fix-tools-stdafx.patch
+++ b/ports/ktx/0006-Fix-tools-stdafx.patch
@@ -1,0 +1,48 @@
+ utils/stdafx.h | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/utils/stdafx.h b/utils/stdafx.h
+index 30d7ff4675..155ccdb773 100644
+--- a/utils/stdafx.h
++++ b/utils/stdafx.h
+@@ -8,14 +8,28 @@
+ #define _CRT_SECURE_NO_WARNINGS // For _WIN32. Must be before <stdio.h>.
+ #include <assert.h>
+ #include <stdio.h>
+-#ifdef _WIN32
++
++#ifdef UNICODE
++#undef UNICODE
++#endif
++
++#if WIN32
++  #include <io.h>
++  #if _MSC_VER < 1900
++    #define snprintf _snprintf
++  #endif
++#endif
++
++#if 0
+   #include <io.h>
+   #include <tchar.h>
+   #if _MSC_VER < 1900
+     #define snprintf _snprintf
+   #endif
+ #else
+-  #include <unistd.h>
++  #ifndef WIN32
++    #include <unistd.h>
++  #endif
+ 
+   #define _setmode(x, y) 0
+   #define _tmain main
+@@ -35,6 +49,8 @@
+   #define _trename rename
+   #define _tunlink unlink
+   #define _T(x) x
++  #define _tfopen_s fopen_s
++  #define _tmktemp_s _mktemp_s
+ #endif
+ #include <fcntl.h>
+ #include <errno.h>
+  

--- a/ports/ktx/0007-Fix-tools-ktxsc.patch
+++ b/ports/ktx/0007-Fix-tools-ktxsc.patch
@@ -1,0 +1,17 @@
+ tools/ktxsc/ktxsc.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/ktxsc/ktxsc.cpp b/tools/ktxsc/ktxsc.cpp
+index 3c306f020d..4c2b599d6b 100644
+--- a/tools/ktxsc/ktxsc.cpp
++++ b/tools/ktxsc/ktxsc.cpp
+@@ -308,7 +308,7 @@ ktxSupercompressor::main(int argc, _TCHAR* argv[])
+                     assert(tmpfile.size() > 0 && infile.length());
+ #if defined(_WIN32)
+                     // Windows' rename() fails if the destination file exists!
+-                    if (!MoveFileEx(tmpfile.c_str(), infile.c_str(),
++                    if (!MoveFileExA(tmpfile.c_str(), infile.c_str(),
+                                     MOVEFILE_REPLACE_EXISTING))
+ #else
+                     if (_trename(tmpfile.c_str(), infile.c_str()))
+  

--- a/ports/ktx/portfile.cmake
+++ b/ports/ktx/portfile.cmake
@@ -9,6 +9,9 @@ vcpkg_from_github(
         0002-Fix-versioning.patch
         0003-mkversion.patch
         0004-quirks.patch
+        0005-Fix-tools-argparser.patch
+        0006-Fix-tools-stdafx.patch
+        0007-Fix-tools-ktxsc.patch
 )
 file(REMOVE "${SOURCE_PATH}/other_include/zstd_errors.h")
 

--- a/ports/ktx/vcpkg.json
+++ b/ports/ktx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ktx",
   "version-semver": "4.1.0",
+  "port-version": 1,
   "description": [
     "The Khronos KTX library and tools.",
     "Functions for writing and reading KTX files, and instantiating OpenGL®, OpenGL ES™️ and Vulkan® textures from them."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3802,7 +3802,7 @@
     },
     "ktx": {
       "baseline": "4.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kubazip": {
       "baseline": "0.2.4",

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "74b3fa8f53d6a1d173c09c2f87f865125717d894",
+      "git-tree": "e020c33f3e353560571e01aaadbb7a198f09c687",
       "version-semver": "4.1.0",
       "port-version": 1
     },

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e020c33f3e353560571e01aaadbb7a198f09c687",
+      "git-tree": "b9e27068604e8f9d2ba438371b8b0207e0896bb2",
       "version-semver": "4.1.0",
       "port-version": 1
     },

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -3,6 +3,11 @@
     {
       "git-tree": "74b3fa8f53d6a1d173c09c2f87f865125717d894",
       "version-semver": "4.1.0",
+      "port-version": 1
+    },
+    {
+      "git-tree": "74b3fa8f53d6a1d173c09c2f87f865125717d894",
+      "version-semver": "4.1.0",
       "port-version": 0
     },
     {


### PR DESCRIPTION
closes https://github.com/microsoft/vcpkg/issues/33687

code changes in `utils` only affect tools so it's safe for current lib users

didn't test with non-uwp triplets, but i guess tools could be broken not only for UWP