### PR TITLE
[gtest] update to 1.14.0

### DIFF
--- a/ports/gtest/001-fix-UWP-death-test.patch
+++ b/ports/gtest/001-fix-UWP-death-test.patch
@@ -2,12 +2,12 @@ diff --git a/googletest/src/gtest.cc b/googletest/src/gtest.cc
 index a64e887c..45ff24c3 100644
 --- a/googletest/src/gtest.cc
 +++ b/googletest/src/gtest.cc
-@@ -5409,7 +5409,7 @@ int UnitTest::Run() {
+@@ -5434,7 +5434,7 @@ int UnitTest::Run() {
    // used for the duration of the program.
    impl()->set_catch_exceptions(GTEST_FLAG_GET(catch_exceptions));
  
--#if GTEST_OS_WINDOWS
-+#if GTEST_OS_WINDOWS && GTEST_HAS_DEATH_TEST
+-#ifdef GTEST_OS_WINDOWS
++#if defined(GTEST_OS_WINDOWS) && defined(GTEST_HAS_DEATH_TEST)
    // Either the user wants Google Test to catch exceptions thrown by the
    // tests or this is executing in the context of death test child
    // process. In either case the user does not want to see pop-up dialogs

--- a/ports/gtest/fix-main-lib-path.patch
+++ b/ports/gtest/fix-main-lib-path.patch
@@ -2,7 +2,7 @@ diff --git a/googlemock/CMakeLists.txt b/googlemock/CMakeLists.txt
 index e7df8ec..1ecd596 100644
 --- a/googlemock/CMakeLists.txt
 +++ b/googlemock/CMakeLists.txt
-@@ -120,7 +120,8 @@ endif()
+@@ -112,7 +112,8 @@ endif()
  ########################################################################
  #
  # Install rules
@@ -16,7 +16,7 @@ diff --git a/googletest/CMakeLists.txt b/googletest/CMakeLists.txt
 index abdd98b..7d1c01d 100644
 --- a/googletest/CMakeLists.txt
 +++ b/googletest/CMakeLists.txt
-@@ -148,7 +148,8 @@ target_link_libraries(gtest_main PUBLIC gtest)
+@@ -155,7 +155,8 @@ target_link_libraries(gtest_main PUBLIC gtest)
  ########################################################################
  #
  # Install rules
@@ -30,16 +30,17 @@ diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_u
 index 8d8d60a..b08ce28 100644
 --- a/googletest/cmake/internal_utils.cmake
 +++ b/googletest/cmake/internal_utils.cmake
-@@ -315,11 +315,15 @@ function(install_project)
-     install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
+@@ -300,12 +300,16 @@ function(install_project)
+       COMPONENT "${PROJECT_NAME}"
        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
      # Install the project targets.
 +    set (LIB_INSTALL_DST ${CMAKE_INSTALL_LIBDIR})
 +    if (${ARGN} MATCHES "_main")
 +      set (LIB_INSTALL_DST ${CMAKE_INSTALL_LIBDIR}/manual-link)
-+    endif()    
++    endif()
      install(TARGETS ${ARGN}
        EXPORT ${targets_export_name}
+       COMPONENT "${PROJECT_NAME}"
        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 -      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 -      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
@@ -48,10 +49,10 @@ index 8d8d60a..b08ce28 100644
      if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
        # Install PDBs
        foreach(t ${ARGN})
-@@ -328,7 +332,7 @@ function(install_project)
-         get_target_property(t_pdb_output_directory ${t} PDB_OUTPUT_DIRECTORY)
+@@ -315,7 +319,7 @@ function(install_project)
          install(FILES
            "${t_pdb_output_directory}/\${CMAKE_INSTALL_CONFIG_NAME}/$<$<CONFIG:Debug>:${t_pdb_name_debug}>$<$<NOT:$<CONFIG:Debug>>:${t_pdb_name}>.pdb"
+           COMPONENT "${PROJECT_NAME}"
 -          DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +          DESTINATION ${LIB_INSTALL_DST}
            OPTIONAL)

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
-    REF v1.13.0
-    SHA512 70c0cfb1b4147bdecb467ecb22ae5b5529eec0abc085763213a796b7cdbd81d1761d12b342060539b936fa54f345d33f060601544874d6213fdde79111fa813e
+    REF "v${VERSION}"
+    SHA512 765c326ccc1b87a01027385e69238266e356361cd4ee3e18e3c9d137a5d11fa5d657c164d02dd1be8fe693c8e10f2b580588dbfa57d27f070e2750f50d3e662c
     HEAD_REF main
     PATCHES
         001-fix-UWP-death-test.patch

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtest",
-  "version-semver": "1.13.0",
+  "version-semver": "1.14.0",
   "description": "GoogleTest and GoogleMock testing frameworks",
   "homepage": "https://github.com/google/googletest",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3061,7 +3061,7 @@
       "port-version": 11
     },
     "gtest": {
-      "baseline": "1.13.0",
+      "baseline": "1.14.0",
       "port-version": 0
     },
     "gtk": {

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6dde67781b31b556e0868cc9f45f3eec59dc2a8",
+      "version-semver": "1.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f70f42192aacc5f8242c14d959d02a802f7559c",
       "version-semver": "1.13.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.