### PR TITLE
[pkgconf] update to 2.0.3

### DIFF
--- a/ports/pkgconf/portfile.cmake
+++ b/ports/pkgconf/portfile.cmake
@@ -1,15 +1,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pkgconf/pkgconf
-    REF cef30268e1a3f79efd607c26abcf556aa314c9c4 
-    SHA512 ea03b81d01521201bdc471a39cdc8b13f9452f7cc78706d5c57056595f3e4e8a3562c022ebb72ce6444f2c7a8dfc778114814ef5064eaef770a70cc294c7f7ee
+    REF "pkgconf-${VERSION}"
+    SHA512 182a186c0cb8fa0abd7b23809eef5956f7c0b924076bad0d61c0221536497ee339b16ec69dae432b3e8ed6e016da6f2b1905fb377856939cbcd15c7ac4612762
     HEAD_REF master
 )
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     NO_PKG_CONFIG
-    OPTIONS -Dtests=false
+    OPTIONS -Dtests=disabled
 )
 
 set(systemsuffix "")

--- a/ports/pkgconf/vcpkg.json
+++ b/ports/pkgconf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pkgconf",
-  "version": "1.8.0",
-  "port-version": 5,
+  "version": "2.0.3",
   "description": "pkgconf is a program which helps to configure compiler and linker flags for development libraries. It is similar to pkg-config from freedesktop.org.",
   "homepage": "https://github.com/pkgconf/pkgconf",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6405,8 +6405,8 @@
       "port-version": 2
     },
     "pkgconf": {
-      "baseline": "1.8.0",
-      "port-version": 5
+      "baseline": "2.0.3",
+      "port-version": 0
     },
     "plasma-wayland-protocols": {
       "baseline": "1.8.0",

--- a/versions/p-/pkgconf.json
+++ b/versions/p-/pkgconf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da24d77d71fbf9cb314f7a91087ea8f0fa4941ca",
+      "version": "2.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "8848e56b32837456dfb872f6ca3cc9953558d453",
       "version": "1.8.0",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.