### PR TITLE
[qtkeychain] update to 0.14.1

### DIFF
--- a/ports/qtkeychain-qt6/portfile.cmake
+++ b/ports/qtkeychain-qt6/portfile.cmake
@@ -3,9 +3,8 @@ message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliat
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
-    # 0.13.2 plus three commits, for a CMake export target fix
-    REF cd4d73299b144d11c310f6ca9a6ab1ef50c45431
-    SHA512 a1af668bec23df5d696ad49129ec2aa6d332f043b43bb9875c2b025007452571bfd9431fd37c72189e957329491c04703e8c6d1104c7a117ebf28cb91249b639
+    REF "${VERSION}"
+    SHA512 bf84b19090e667a2946297e63d9813574193d80e4eecbde2fdfca317a66da3f029b3abef326f4ffb32de032a48004f9cf1bc818468af612723d762652dc25eb6
     HEAD_REF master
 )
 

--- a/ports/qtkeychain-qt6/vcpkg.json
+++ b/ports/qtkeychain-qt6/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qtkeychain-qt6",
-  "version": "0.13.2",
-  "port-version": 1,
+  "version": "0.14.1",
   "description": "(Unaffiliated with Qt) Platform-independent Qt6 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",

--- a/ports/qtkeychain/portfile.cmake
+++ b/ports/qtkeychain/portfile.cmake
@@ -3,9 +3,8 @@ message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliat
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
-    # 0.13.2 plus three commits, for a CMake export target fix
-    REF cd4d73299b144d11c310f6ca9a6ab1ef50c45431
-    SHA512 a1af668bec23df5d696ad49129ec2aa6d332f043b43bb9875c2b025007452571bfd9431fd37c72189e957329491c04703e8c6d1104c7a117ebf28cb91249b639
+    REF "${VERSION}"
+    SHA512 bf84b19090e667a2946297e63d9813574193d80e4eecbde2fdfca317a66da3f029b3abef326f4ffb32de032a48004f9cf1bc818468af612723d762652dc25eb6
     HEAD_REF master
 )
 

--- a/ports/qtkeychain/vcpkg.json
+++ b/ports/qtkeychain/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qtkeychain",
-  "version": "0.13.2",
-  "port-version": 4,
+  "version": "0.14.1",
   "description": "(Unaffiliated with Qt) Platform-independent Qt5 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6921,12 +6921,12 @@
       "port-version": 0
     },
     "qtkeychain": {
-      "baseline": "0.13.2",
-      "port-version": 4
+      "baseline": "0.14.1",
+      "port-version": 0
     },
     "qtkeychain-qt6": {
-      "baseline": "0.13.2",
-      "port-version": 1
+      "baseline": "0.14.1",
+      "port-version": 0
     },
     "qtlanguageserver": {
       "baseline": "6.5.2",

--- a/versions/q-/qtkeychain-qt6.json
+++ b/versions/q-/qtkeychain-qt6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dcb9fb0fa722410c03a4d6fbfdb3608af68de9d5",
+      "version": "0.14.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3733fba48696a40e64b18c2d52d4adc04e6eb22d",
       "version": "0.13.2",
       "port-version": 1

--- a/versions/q-/qtkeychain.json
+++ b/versions/q-/qtkeychain.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a1cf630fddc142e2a81d7f198eb8c93b40c64a34",
+      "version": "0.14.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "516e24d31a7d28d7b5df372f99cf2780a3a7edbc",
       "version": "0.13.2",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.