### PR TITLE
[vcpkg_from_gitlab]: Support nested subgroups

### DIFF
--- a/scripts/cmake/vcpkg_from_gitlab.cmake
+++ b/scripts/cmake/vcpkg_from_gitlab.cmake
@@ -52,20 +52,15 @@ function(vcpkg_from_gitlab)
         message(FATAL_ERROR "At least one of REF or HEAD_REF must be specified.")
     endif()
 
-    if(arg_REPO MATCHES [[^([^/]*)/([^/]*)$]]) # 2 elements
-        set(org_name "${CMAKE_MATCH_1}")
-        set(repo_name "${CMAKE_MATCH_2}")
-        set(gitlab_link "${arg_GITLAB_URL}/${org_name}/${repo_name}")
-    elseif(arg_REPO MATCHES [[^([^/]*)/([^/]*)/([^/]*)$]]) # 3 elements
-        set(org_name "${CMAKE_MATCH_1}")
-        set(group_name "${CMAKE_MATCH_2}")
-        set(repo_name "${CMAKE_MATCH_3}")
-        set(gitlab_link "${arg_GITLAB_URL}/${org_name}/${group_name}/${repo_name}")
-    else()
+    if (NOT arg_REPO MATCHES [[^([^/;]+/)+([^/;]+)$]])
         message(FATAL_ERROR "REPO (${arg_REPO}) is not a valid repo name. It must be:
     - an organization name followed by a repository name separated by a single slash, or
-    - an organization name, group name, and repository name separated by slashes.")
+    - an organization name, group name, subgroup names and repository name separated by slashes.")
     endif()
+    set(gitlab_link "${arg_GITLAB_URL}/${arg_REPO}")
+    string(REPLACE "/" "-" downloaded_file_name_base "${arg_REPO}")
+    string(REPLACE "/" ";" repo_parts "${arg_REPO}")
+    list(GET repo_parts -1 repo_name)
 
     set(redownload_param "")
     set(working_directory_param "")
@@ -88,9 +83,9 @@ function(vcpkg_from_gitlab)
     # we assume that no one will name a ref "foo_-bar"
     string(REPLACE "/" "_-" sanitized_ref "${ref_to_use}")
     if(DEFINED arg_FILE_DISAMBIGUATOR AND NOT VCPKG_USE_HEAD_VERSION)
-        set(downloaded_file_name "${org_name}-${repo_name}-${sanitized_ref}-${arg_FILE_DISAMBIGUATOR}.tar.gz")
+        set(downloaded_file_name "${downloaded_file_name_base}-${sanitized_ref}-${arg_FILE_DISAMBIGUATOR}.tar.gz")
     else()
-        set(downloaded_file_name "${org_name}-${repo_name}-${sanitized_ref}.tar.gz")
+        set(downloaded_file_name "${downloaded_file_name_base}-${sanitized_ref}.tar.gz")
     endif()
 
 


### PR DESCRIPTION
Don't enforce a hardcoded nesting limit as these limits are enforced by GitLab itself and may change in the future. Furthermore I believe that users can be trusted to successfully copy'n'paste the path portion of an URL. Therefore we just require that the assumptions of our implementation hold, i.e. that we can convert the repo path to a CMake list by replacing `/` with `;` and that there is a repository name.

Resolves #33735 