### PR TITLE
[qtwayland] Not supported on macos

### DIFF
--- a/ports/qtwayland/vcpkg.json
+++ b/ports/qtwayland/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "qtwayland",
   "version": "6.5.2",
+  "port-version": 1,
   "description": "A toolbox for making Qt based Wayland compositors",
   "homepage": "https://www.qt.io/",
   "license": null,
-  "supports": "!windows",
+  "supports": "!windows & !osx",
   "dependencies": [
     {
       "name": "qtbase",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1019,9 +1019,6 @@ qt5-canvas3d:x64-windows=skip
 qt5-canvas3d:x64-windows-static=skip
 qt5-canvas3d:x64-windows-static-md=skip
 qt5-canvas3d:x86-windows=skip
-# Missing system libraries
-qtwayland:x64-osx=fail
-qtwayland:arm64-osx=fail
 # Missing prerequisites for CI success
 # Fail due to outdated protoc headers.
 # D:\buildtrees\qt5-webengine\x64-windows-dbg\src\core\debug\gen\net/third_party/quiche/src/quic/core/proto/cached_network_parameters.pb.h(17):

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7026,7 +7026,7 @@
     },
     "qtwayland": {
       "baseline": "6.5.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtwebchannel": {
       "baseline": "6.5.2",

--- a/versions/q-/qtwayland.json
+++ b/versions/q-/qtwayland.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0cc80bd40dca1f18abd2db5d1f1f039c95b160b3",
+      "version": "6.5.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "6a7bfa9db606a9849407ef81e575c95a76bb404b",
       "version": "6.5.2",
       "port-version": 0


### PR DESCRIPTION
```
Installing 1581/2016 qtwayland:x64-osx...
Building qtwayland:x64-osx...
CMake Warning at ports/qtwayland/portfile.cmake:4 (message):
  qtwayland requires libwayland-dev from your system package manager.  You
  can install it with

  sudo apt install libwayland-dev

  on Ubuntu systems.
Call Stack (most recent call first):
  scripts/ports.cmake:147 (include)

-- Downloading https://download.qt.io/archive/qt/6.5/6.5.2/submodules/qtwayland-everywhere-src-6.5.2.tar.xz -> qtwayland-everywhere-src-6.5.2.tar.xz...
-- Extracting source /Users/vagrant/Data/downloads/qtwayland-everywhere-src-6.5.2.tar.xz
-- Using source at /Users/vagrant/Data/buildtrees/qtwayland/src/here-src-6-199f26667d.clean
-- Found external ninja('1.11.1').
-- Configuring x64-osx
-- Building x64-osx-dbg
-- Building x64-osx-rel
-- Performing post-build validation
warning: The folder /include is empty or not present. This indicates the library was not correctly installed.
warning: There should be no empty directories in /Users/vagrant/Data/packages/qtwayland_x64-osx. The following empty directories were found:

    /Users/vagrant/Data/packages/qtwayland_x64-osx/debug

warning: If a directory should be populated but is not, this might indicate an error in the portfile.
If the directories are not needed and their creation cannot be disabled, use something like this in the portfile to remove them:
    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

error: Found 2 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: /Users/vagrant/Data/work/2/s/ports/qtwayland/portfile.cmake
error: building qtwayland:x64-osx failed with: POST_BUILD_CHECKS_FAILED
Elapsed time to handle qtwayland:x64-osx: 13 s
```
