### PR TITLE
[behaviortree-cpp] Update version to 4.3.7

### DIFF
--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -1,12 +1,9 @@
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/BehaviorTree/BehaviorTree.CPP/archive/${VERSION}.tar.gz"
-    FILENAME "BehaviorTree.CPP.${VERSION}.tar.gz"
-    SHA512 4505c4c8798ccbbc02f58320810eb86e791fb6ef57d8c85882e62bd2b509b41e0549dc311ed61926a873b5b956eda979efda488f01d00746e1e8db559f60253c
-)
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO BehaviorTree/BehaviorTree.CPP
+    REF ${VERSION}
+    SHA512 f2ee647c734e39e50f92405c5dc9fd2876602ff074a86416959fbf6548e37130d35f312cafb084ca4a40da7ee81386502a75ad839ce99a2859c30ff187820fdf
+    HEAD_REF master
     PATCHES
         fix-x86_build.patch
 )

--- a/ports/behaviortree-cpp/vcpkg.json
+++ b/ports/behaviortree-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "behaviortree-cpp",
-  "version": "4.1.1",
+  "version": "4.3.7",
   "description": "Behavior Trees Library in C++.",
   "homepage": "https://www.behaviortree.dev",
   "supports": "!uwp",

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4cacd1d5f1a465b3ca9d23ebb0b9b4626a26db63",
+      "version": "4.3.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "66a97129b31a5e70e45a40c767ea96b1e0477a93",
       "version": "4.1.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -533,7 +533,7 @@
       "port-version": 2
     },
     "behaviortree-cpp": {
-      "baseline": "4.1.1",
+      "baseline": "4.3.7",
       "port-version": 0
     },
     "benchmark": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
For https://github.com/BehaviorTree/BehaviorTree.CPP/pull/421
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
