### PR TITLE
[libxml2] Fix post-build errors

### DIFF
--- a/ports/libxml2/fix_cmakelist.patch
+++ b/ports/libxml2/fix_cmakelist.patch
@@ -102,7 +102,7 @@ index 9701bdc..39e96ee 100644
 +set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
  configure_file(xml2-config.in xml2-config @ONLY)
  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/xml2-config DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT development)
- 
+
 diff --git a/libxml-2.0.pc.in b/libxml-2.0.pc.in
 index 88e3963b..0d1706c9 100644
 --- a/libxml-2.0.pc.in
@@ -117,4 +117,3 @@ index 88e3963b..0d1706c9 100644
 +Libs: -L${libdir} -l@XML_LIB_NAME@
 +Libs.private: @THREAD_LIBS@ @ICONV_LIBS@ @LIBM@ @WINSOCK_LIBS@ @LIBS@
  Cflags: @XML_INCLUDEDIR@ @XML_CFLAGS@
- 

--- a/ports/libxml2/fix_cmakelist.patch
+++ b/ports/libxml2/fix_cmakelist.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 834b35d3..685a4403 100644
+index 9701bdc..39e96ee 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -393,15 +393,15 @@ endif()
@@ -56,7 +56,7 @@ index 834b35d3..685a4403 100644
  endif()
  
  install(FILES ${LIBXML2_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libxml2/libxml COMPONENT development)
-@@ -584,30 +570,30 @@ install(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT documentati
+@@ -574,30 +560,30 @@ endif()
  
  configure_package_config_file(
  	libxml2-config.cmake.cmake.in libxml2-config.cmake
@@ -92,6 +92,17 @@ index 834b35d3..685a4403 100644
  	NAMESPACE LibXml2::
  	FILE libxml2-export.cmake
  	COMPONENT development
+@@ -635,9 +621,7 @@ set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ configure_file(libxml-2.0.pc.in libxml-2.0.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxml-2.0.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT development)
+ 
+-if(WIN32)
+-	set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
+-endif()
++set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
+ configure_file(xml2-config.in xml2-config @ONLY)
+ install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/xml2-config DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT development)
+ 
 diff --git a/libxml-2.0.pc.in b/libxml-2.0.pc.in
 index 88e3963b..0d1706c9 100644
 --- a/libxml-2.0.pc.in
@@ -106,3 +117,4 @@ index 88e3963b..0d1706c9 100644
 +Libs: -L${libdir} -l@XML_LIB_NAME@
 +Libs.private: @THREAD_LIBS@ @ICONV_LIBS@ @LIBM@ @WINSOCK_LIBS@ @LIBS@
  Cflags: @XML_INCLUDEDIR@ @XML_CFLAGS@
+ 

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -86,4 +86,4 @@ file(COPY
     "${CMAKE_CURRENT_LIST_DIR}/usage"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
-file(INSTALL "${SOURCE_PATH}/Copyright" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/Copyright")

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libxml2",
   "version": "2.11.5",
+  "port-version": 1,
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4910,7 +4910,7 @@
     },
     "libxml2": {
       "baseline": "2.11.5",
-      "port-version": 0
+      "port-version": 1
     },
     "libxmlmm": {
       "baseline": "0.6.0",

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28d5a3edcedcaa06a625fadaacb2f2cdcefb40fe",
+      "version": "2.11.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "a8c20b561ed09ee9bd274071751dafbf8c0825ed",
       "version": "2.11.5",
       "port-version": 0

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28d5a3edcedcaa06a625fadaacb2f2cdcefb40fe",
+      "git-tree": "5ce0144d5c48f5140af55d0fbb58396b955d87a3",
       "version": "2.11.5",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #33744, resolved post-build errors for some community triplets.
```
-- Performing post-build validation
warning: There should be no absolute paths, such as the following, in an installed package:
    /home/adrian/Work/doctotext/vcpkg/packages/libxml2_x64-linux-dynamic
    /home/adrian/Work/doctotext/vcpkg/installed
    /home/adrian/Work/doctotext/vcpkg/buildtrees/libxml2
    /home/adrian/Work/doctotext/vcpkg/downloads
Absolute paths were found in the following files:
    /home/adrian/Work/doctotext/vcpkg/packages/libxml2_x64-linux-dynamic/bin/xml2-config
    /home/adrian/Work/doctotext/vcpkg/packages/libxml2_x64-linux-dynamic/debug/bin/xml2-config
error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: /home/adrian/Work/doctotext/vcpkg/ports/libxml2/portfile.cmake
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
