### PR TITLE
[pbc] fix error path

### DIFF
--- a/ports/pbc/portfile.cmake
+++ b/ports/pbc/portfile.cmake
@@ -47,17 +47,17 @@ else()
         PATCHES windows.patch
     )
 
-    find_path(MPIR_INCLUDE_DIR "gmp.h" HINTS ${CURRENT_INSTALLED_DIR} PATH_SUFFIXES include)
+    find_path(MPIR_INCLUDE_DIR "gmp.h" HINTS "${CURRENT_INSTALLED_DIR}" PATH_SUFFIXES include)
     if(NOT MPIR_INCLUDE_DIR)
         message(FATAL_ERROR "GMP includes not found")
     endif()
 
-    find_library(MPIR_LIBRARIES_REL NAMES "mpir.lib" HINTS ${CURRENT_INSTALLED_DIR} PATH_SUFFIXES lib)
+    find_library(MPIR_LIBRARIES_REL NAMES "mpir.lib" HINTS "${CURRENT_INSTALLED_DIR}" PATH_SUFFIXES lib)
     if(NOT MPIR_LIBRARIES_REL)
         message(FATAL_ERROR "mpir library not found")
     endif()
 
-    find_library(MPIR_LIBRARIES_DBG NAMES "mpir.lib" HINTS ${CURRENT_INSTALLED_DIR} PATH_SUFFIXES debug/lib)
+    find_library(MPIR_LIBRARIES_DBG NAMES "mpir.lib" HINTS "${CURRENT_INSTALLED_DIR}" PATH_SUFFIXES debug/lib)
     if(NOT MPIR_LIBRARIES_DBG)
         message(FATAL_ERROR "mpir debug library not found")
     endif()
@@ -77,22 +77,22 @@ else()
     endif()
 
     # PBC expects mpir directory in build root
-    get_filename_component(SOURCE_PATH_PARENT ${SOURCE_PATH} DIRECTORY)
-    file(REMOVE_RECURSE ${SOURCE_PATH_PARENT}/mpir)
-    file(MAKE_DIRECTORY ${SOURCE_PATH_PARENT}/mpir)
+    get_filename_component(SOURCE_PATH_PARENT "${SOURCE_PATH}" DIRECTORY)
+    file(REMOVE_RECURSE "${SOURCE_PATH_PARENT}/mpir")
+    file(MAKE_DIRECTORY "${SOURCE_PATH_PARENT}/mpir")
     file(GLOB FILES ${MPIR_INCLUDE_DIR}/gmp*.h)
     file(COPY ${FILES} ${MPIR_LIBRARIES_REL} DESTINATION "${SOURCE_PATH_PARENT}/mpir/${LibrarySuffix}/${Platform}/Release")
     file(COPY ${FILES} ${MPIR_LIBRARIES_DBG} DESTINATION "${SOURCE_PATH_PARENT}/mpir/${LibrarySuffix}/${Platform}/Debug")
 
-    get_filename_component(SOURCE_PATH_SUFFIX ${SOURCE_PATH} NAME)
-    vcpkg_msbuild_install(SOURCE_PATH ${SOURCE_PATH_PARENT}
-        PROJECT_SUBPATH ${SOURCE_PATH_SUFFIX}/pbcwin/projects/pbclib.vcxproj
+    get_filename_component(SOURCE_PATH_SUFFIX "${SOURCE_PATH}" NAME)
+    vcpkg_msbuild_install(SOURCE_PATH "${SOURCE_PATH_PARENT}"
+        PROJECT_SUBPATH "${SOURCE_PATH_SUFFIX}/pbcwin/projects/pbclib.vcxproj"
         RELEASE_CONFIGURATION "Release${ConfigurationSuffix}"
         DEBUG_CONFIGURATION "Debug${ConfigurationSuffix}"
         OPTIONS /p:SolutionDir=../
     )
 
-    vcpkg_install_copyright(FILE_LIST " ${SOURCE_PATH}/COPYING")
+    vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
     file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
     # clean up mpir stuff
     file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/mpir.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/mpir.lib")

--- a/ports/pbc/vcpkg.json
+++ b/ports/pbc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pbc",
   "version": "0.5.14",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Pairing-Based Crypto library provides low-level routines for pairing-based cryptosystems.",
   "homepage": "https://crypto.stanford.edu/pbc",
   "license": "LGPL-3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6286,7 +6286,7 @@
     },
     "pbc": {
       "baseline": "0.5.14",
-      "port-version": 8
+      "port-version": 9
     },
     "pcapplusplus": {
       "baseline": "22.11",

--- a/versions/p-/pbc.json
+++ b/versions/p-/pbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6789ed942578afe4baac765d5e7549d421c25c76",
+      "version": "0.5.14",
+      "port-version": 9
+    },
+    {
       "git-tree": "096b1e1d4077f9fbe44e8b0a6fa306e83270c632",
       "version": "0.5.14",
       "port-version": 8


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33762
Error:
```
  file INSTALL cannot find "C:/Utils/vcpkg/
  C:/Utils/vcpkg/buildtrees/pbc/src/e816cf9d08-73bced3986.clean/COPYING":
  File exists.
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
