### PR TITLE
[pmdk] Fix linux compilation

### DIFF
--- a/ports/pmdk/vcpkg.json
+++ b/ports/pmdk/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "pmdk",
   "version": "1.12.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Persistent Memory Development Kit",
   "homepage": "https://github.com/pmem/pmdk",
   "license": "BSD-3-Clause",
-  "supports": "!(arm | x86)",
+  "supports": "!(linux |arm | x86)",
   "dependencies": [
     "getopt",
     {

--- a/ports/pmdk/vcpkg.json
+++ b/ports/pmdk/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "Persistent Memory Development Kit",
   "homepage": "https://github.com/pmem/pmdk",
   "license": "BSD-3-Clause",
-  "supports": "!(linux |arm | x86)",
+  "supports": "!(linux | arm | x86)",
   "dependencies": [
     "getopt",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6458,7 +6458,7 @@
     },
     "pmdk": {
       "baseline": "1.12.0",
-      "port-version": 1
+      "port-version": 2
     },
     "pngpp": {
       "baseline": "0.2.10",

--- a/versions/p-/pmdk.json
+++ b/versions/p-/pmdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b208389a2bc32898f0f4d13c5f222015ce9bd072",
+      "version": "1.12.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5dc7f0e5a4d6348ac49617010105730775580f78",
       "version": "1.12.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #15896
Pmdk compilation methods are compiled through sln files, so linux is not supported 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

