### PR TITLE
[cairo] no uwp

### DIFF
--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "cairo",
   "version": "1.17.8",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1-only OR MPL-1.1",
-  "supports": "!xbox",
+  "supports": "!xbox & !uwp",
   "dependencies": [
     "dirent",
     "expat",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1390,7 +1390,7 @@
     },
     "cairo": {
       "baseline": "1.17.8",
-      "port-version": 3
+      "port-version": 4
     },
     "cairomm": {
       "baseline": "1.17.1",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "127eefeeba4725293adb6ea574b7bad98c845298",
+      "version": "1.17.8",
+      "port-version": 4
+    },
+    {
       "git-tree": "e8fda1b05b3f6a99f08c23f8ad94ed43d4a69875",
       "version": "1.17.8",
       "port-version": 3


### PR DESCRIPTION
Fails with 
```
..\src\1.17.8-13a78b6e7b.clean\meson.build:503:2: ERROR: C shared or static library 'gdi32' not found
```
