### PR TITLE
[sdl2-mixer-ext] uwp

### DIFF
--- a/ports/sdl2-mixer-ext/vcpkg.json
+++ b/ports/sdl2-mixer-ext/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2-mixer-ext",
   "version-date": "2023-05-04",
+  "port-version": 1,
   "description": "An audio mixer library based on the SDL library, a fork of SDL_mixer",
   "homepage": "https://wohlsoft.github.io/SDL-Mixer-X",
   "license": "Zlib OR LGPL-2.1-or-later OR GPL-2.0-or-later OR GPL-3.0-or-later",
@@ -100,7 +101,7 @@
     },
     "nativemidi": {
       "description": "Use Native MIDI Player to play MIDI audio format.",
-      "supports": "windows | osx"
+      "supports": "(windows & !uwp) | osx"
     },
     "opusfile": {
       "description": "Use opusfile to play Opus audio format.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7614,7 +7614,7 @@
     },
     "sdl2-mixer-ext": {
       "baseline": "2023-05-04",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-net": {
       "baseline": "2.2.0",

--- a/versions/s-/sdl2-mixer-ext.json
+++ b/versions/s-/sdl2-mixer-ext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "72599d1d3f046b10ba695a83a5de68a98bf86ec8",
+      "version-date": "2023-05-04",
+      "port-version": 1
+    },
+    {
       "git-tree": "04312072ef4ea392cb39c240e579f06b4d62b955",
       "version-date": "2023-05-04",
       "port-version": 0


### PR DESCRIPTION
Uses `HMIDIOUT` which does not exists on uwp 