### PR TITLE
[meshoptimizer] gltfpack no uwp

### DIFF
--- a/ports/meshoptimizer/vcpkg.json
+++ b/ports/meshoptimizer/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "meshoptimizer",
   "version": "0.19",
+  "port-version": 1,
   "description": "Mesh optimization library that makes meshes smaller and faster to render",
   "homepage": "https://github.com/zeux/meshoptimizer",
   "license": "MIT",
@@ -16,7 +17,8 @@
   ],
   "features": {
     "gltfpack": {
-      "description": "Build gltfpack tool"
+      "description": "Build gltfpack tool",
+      "supports": "!uwp"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5330,7 +5330,7 @@
     },
     "meshoptimizer": {
       "baseline": "0.19",
-      "port-version": 0
+      "port-version": 1
     },
     "metis": {
       "baseline": "2022-07-27",

--- a/versions/m-/meshoptimizer.json
+++ b/versions/m-/meshoptimizer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4443e075e83187322a4323485d302fb52746a9e4",
+      "version": "0.19",
+      "port-version": 1
+    },
+    {
       "git-tree": "c13ff2acc01518548a4d669e3d2976235c55780f",
       "version": "0.19",
       "port-version": 0


### PR DESCRIPTION
Fails with 
```
C:\v\vcpkg4\buildtrees\meshoptimizer\src\v0.19-d9d6fb38cc.clean\gltf\fileio.cpp(20): error C3861: '_getpid': identifier not found
```
And 
https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/getpid?view=msvc-170
