### PR TITLE
[osg] Fix debug targets for plugins in unofficial-osg

### DIFF
--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -134,6 +134,13 @@ vcpkg_copy_pdbs()
 configure_file("${CMAKE_CURRENT_LIST_DIR}/unofficial-osg-config.cmake" "${CURRENT_PACKAGES_DIR}/share/unofficial-osg/unofficial-osg-config.cmake" @ONLY)
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-osg)
 
+# Add debug folder prefix for plugin targets. vcpkg_cmake_config_fixup only handles this for targets in bin/ and lib/.
+set(osg_plugins_debug_targets "${CURRENT_PACKAGES_DIR}/share/unofficial-osg/osg-plugins-debug.cmake")
+file(READ "${osg_plugins_debug_targets}" contents)
+string(REPLACE "${CURRENT_INSTALLED_DIR}" "\${_IMPORT_PREFIX}" contents "${contents}")
+string(REPLACE "\${_IMPORT_PREFIX}/plugins" "\${_IMPORT_PREFIX}/debug/plugins" contents "${contents}")
+file(WRITE "${osg_plugins_debug_targets}" "${contents}")
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(APPEND "${CURRENT_PACKAGES_DIR}/include/osg/Config" "#ifndef OSG_LIBRARY_STATIC\n#define OSG_LIBRARY_STATIC 1\n#endif\n")
 endif()

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osg",
   "version": "3.6.5",
-  "port-version": 20,
+  "port-version": 21,
   "description": "The OpenSceneGraph is an open source high performance 3D graphics toolkit.",
   "homepage": "https://www.openscenegraph.com/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6206,7 +6206,7 @@
     },
     "osg": {
       "baseline": "3.6.5",
-      "port-version": 20
+      "port-version": 21
     },
     "osg-qt": {
       "baseline": "Qt5",

--- a/versions/o-/osg.json
+++ b/versions/o-/osg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e9d4d04aae606c5ac02c497b17774d37e74de7a",
+      "version": "3.6.5",
+      "port-version": 21
+    },
+    {
       "git-tree": "87727f247e97af37e53f77acadff05d6d06559d0",
       "version": "3.6.5",
       "port-version": 20


### PR DESCRIPTION
This fixes the imported locations for the OSG plugin targets in `unofficial-osg`. Since these plugins are installed to the `plugins/` folder, instead of `bin/` or `lib/`, `vcpkg_cmake_config_fixup` will not add the debug folder prefix to the imported locations. This causes an error when running `find_package(unofficial-osg COMPONENTS plugins)`.

To fix this issue, the relevant bit of `vcpkg_cmake_config_fixup` is copied into the portfile and modified to apply specifically to the plugin targets file. It's not exactly the cleanest method, but I don't think there's another way to do it that doesn't require manually patching paths outside of `vcpkg_cmake_config_fixup`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
