### PR TITLE
[libwebp] Update to 1.3.2

### DIFF
--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libwebp
     REF "v${VERSION}"
-    SHA512 9131c256f78fa09c3fc569b0b3657f62b06466cfa7b88b81cbae68f0a37f7a36ac6b0fe257b150406e15d623eda288c46ee97ee023aebe7dec25ca0a6d4ba85c
+    SHA512 2faa1bee1b73ded2b1460fc50a5973a37eefdc7b88d6a013491ba1c921d61413a653d44a953e8f6a3161ca6183f57ca9fe3be0f0a72b480895a299429a500dcf
     HEAD_REF master
     PATCHES
         0002-cmake-config.patch

--- a/ports/libwebp/vcpkg.json
+++ b/ports/libwebp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libwebp",
-  "version": "1.3.1",
-  "port-version": 2,
+  "version": "1.3.2",
   "description": "WebP codec: library to encode and decode images in WebP format",
   "homepage": "https://github.com/webmproject/libwebp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4829,8 +4829,8 @@
       "port-version": 1
     },
     "libwebp": {
-      "baseline": "1.3.1",
-      "port-version": 2
+      "baseline": "1.3.2",
+      "port-version": 0
     },
     "libwebsockets": {
       "baseline": "4.3.2",

--- a/versions/l-/libwebp.json
+++ b/versions/l-/libwebp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0b981028589375097039d5e39e7d87659cdfa824",
+      "version": "1.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ce9a702064516d77e0b1239edc29efd603ee323e",
       "version": "1.3.1",
       "port-version": 2


### PR DESCRIPTION
Updates libwebp to 1.3.2

* [x]  Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
* [x]  SHA512s are updated for each updated download
* [x]  The "supports" clause reflects platforms that may be fixed by this new version
* [x]  Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
* [x]  Any patches that are no longer applied are deleted from the port's directory.
* [x]  The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
* [x]  Only one version is added to each modified port's versions file.