### PR TITLE
[atk/gdk-pixbuf/gtk/gtk3/harfbuzz/pango] Fix dependency gobject-instrospection of feature instrospection

### DIFF
--- a/ports/atk/portfile.cmake
+++ b/ports/atk/portfile.cmake
@@ -10,9 +10,6 @@ vcpkg_from_gitlab(
 )
 
 if("introspection" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        message(FATAL_ERROR "Feature introspection currently only supports dynamic build.")
-    endif()
     list(APPEND OPTIONS_DEBUG -Dintrospection=false)
     list(APPEND OPTIONS_RELEASE -Dintrospection=true)
 else()

--- a/ports/atk/vcpkg.json
+++ b/ports/atk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "atk",
   "version": "2.38.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "GNOME Accessibility Toolkit",
   "homepage": "https://developer.gnome.org/atk/",
   "license": "LGPL-2.0-or-later",
@@ -30,14 +30,7 @@
     "introspection": {
       "description": "build with introspection",
       "dependencies": [
-        {
-          "name": "gobject-introspection",
-          "host": true
-        },
-        {
-          "name": "gobject-introspection",
-          "platform": "windows & x86"
-        }
+        "gobject-introspection"
       ]
     }
   }

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -13,9 +13,6 @@ vcpkg_from_gitlab(
 )
 
 if("introspection" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        message(FATAL_ERROR "Feature introspection currently only supports dynamic build.")
-    endif()
     list(APPEND OPTIONS_DEBUG -Dintrospection=disabled)
     list(APPEND OPTIONS_RELEASE -Dintrospection=enabled)
 else()

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.10",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",
@@ -28,14 +28,7 @@
     "introspection": {
       "description": "build with introspection",
       "dependencies": [
-        {
-          "name": "gobject-introspection",
-          "host": true
-        },
-        {
-          "name": "gobject-introspection",
-          "platform": "windows & x86"
-        }
+        "gobject-introspection"
       ]
     }
   }

--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -33,9 +33,6 @@ list(APPEND OPTIONS -Dwin32-backend=${win32}) #Enable the Windows gdk backend (o
 list(APPEND OPTIONS -Dmacos-backend=${osx}) #Enable the macOS gdk backend (only when building on macOS)
 
 if("introspection" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        message(FATAL_ERROR "Feature introspection currently only supports dynamic build.")
-    endif()
     list(APPEND OPTIONS_DEBUG -Dintrospection=disabled)
     list(APPEND OPTIONS_RELEASE -Dintrospection=enabled)
 else()

--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gtk",
   "version": "4.10.5",
+  "port-version": 1,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": "LGPL-2.0-only",
@@ -72,14 +73,6 @@
           "features": [
             "introspection"
           ]
-        },
-        {
-          "name": "gobject-introspection",
-          "host": true
-        },
-        {
-          "name": "gobject-introspection",
-          "platform": "windows & x86"
         },
         {
           "name": "graphene",

--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gtk3",
   "version": "3.24.38",
+  "port-version": 1,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,
@@ -77,14 +78,6 @@
           "features": [
             "introspection"
           ]
-        },
-        {
-          "name": "gobject-introspection",
-          "host": true
-        },
-        {
-          "name": "gobject-introspection",
-          "platform": "windows & x86"
         },
         {
           "name": "pango",

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -35,9 +35,6 @@ list(APPEND FEATURE_OPTIONS -Dfreetype=enabled) #Enable freetype interop helpers
 #endif()
 
 if("introspection" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        message(FATAL_ERROR "Feature introspection currently only supports dynamic build.")
-    endif()
     list(APPEND OPTIONS_DEBUG -Dgobject=enabled -Dintrospection=disabled)
     list(APPEND OPTIONS_RELEASE -Dgobject=enabled -Dintrospection=enabled)
 else()

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "harfbuzz",
   "version": "8.2.0",
+  "port-version": 1,
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",
@@ -50,14 +51,7 @@
       "description": "build with introspection",
       "dependencies": [
         "glib",
-        {
-          "name": "gobject-introspection",
-          "host": true
-        },
-        {
-          "name": "gobject-introspection",
-          "platform": "windows & x86"
-        }
+        "gobject-introspection"
       ]
     }
   }

--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -15,9 +15,6 @@ vcpkg_from_gitlab(
 vcpkg_replace_string("${SOURCE_PATH}/meson.build" "-Werror=array-bounds" "")
 
 if("introspection" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        message(FATAL_ERROR "Feature introspection currently only supports dynamic build.")
-    endif()
     list(APPEND OPTIONS_DEBUG -Dintrospection=disabled)
     list(APPEND OPTIONS_RELEASE -Dintrospection=enabled)
 else()

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pango",
   "version": "1.50.14",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "license": "LGPL-2.0-or-later",
@@ -39,14 +39,6 @@
     "introspection": {
       "description": "build with introspection",
       "dependencies": [
-        {
-          "name": "gobject-introspection",
-          "host": true
-        },
-        {
-          "name": "gobject-introspection",
-          "platform": "windows & x86"
-        },
         {
           "name": "harfbuzz",
           "features": [

--- a/versions/a-/atk.json
+++ b/versions/a-/atk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c97f8dd9d133fb3e75abf33040b3ec61e032734d",
+      "version": "2.38.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "d21ac2c541d67128cafda7c4b190e217cb943174",
       "version": "2.38.0",
       "port-version": 7

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -290,7 +290,7 @@
     },
     "atk": {
       "baseline": "2.38.0",
-      "port-version": 7
+      "port-version": 8
     },
     "atkmm": {
       "baseline": "2.36.1",
@@ -2810,7 +2810,7 @@
     },
     "gdk-pixbuf": {
       "baseline": "2.42.10",
-      "port-version": 1
+      "port-version": 2
     },
     "gemmlowp": {
       "baseline": "2021-09-28",
@@ -3070,11 +3070,11 @@
     },
     "gtk": {
       "baseline": "4.10.5",
-      "port-version": 0
+      "port-version": 1
     },
     "gtk3": {
       "baseline": "3.24.38",
-      "port-version": 0
+      "port-version": 1
     },
     "gtkmm": {
       "baseline": "4.10.0",
@@ -3154,7 +3154,7 @@
     },
     "harfbuzz": {
       "baseline": "8.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "hash-library": {
       "baseline": "8",
@@ -6258,7 +6258,7 @@
     },
     "pango": {
       "baseline": "1.50.14",
-      "port-version": 3
+      "port-version": 4
     },
     "pangolin": {
       "baseline": "0.8",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3dc0bb4b0113c8043f2ed716694303d1bdc08d88",
+      "version": "2.42.10",
+      "port-version": 2
+    },
+    {
       "git-tree": "ca75f73ba67cdacfd245b67e6dca8c45fb97ee93",
       "version": "2.42.10",
       "port-version": 1

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "814624705f6cc11a3468d9c3418bc20521b6b207",
+      "version": "4.10.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "1d2910bafafe5342d557621dfb784fab156ae169",
       "version": "4.10.5",
       "port-version": 0

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1362bb3978886e043fd12c089f2c1337a4f1adf8",
+      "version": "3.24.38",
+      "port-version": 1
+    },
+    {
       "git-tree": "63636acf7b77eead112fc9faa84680d1df97acd3",
       "version": "3.24.38",
       "port-version": 0

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "053b71e591f5599aa5e887fbf6531c7baa58b23d",
+      "version": "8.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d804324af44593c0877fdf035cda178123d9c87f",
       "version": "8.2.0",
       "port-version": 0

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2a88ce998fab5ed3f3a2edf817f32734c78187b",
+      "version": "1.50.14",
+      "port-version": 4
+    },
+    {
       "git-tree": "4c3bbb58011a3e259be06531c08854dfd7bbabee",
       "version": "1.50.14",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #33751, the supports of `gobject-instrospection` is `!static & (native | (windows & x86))`, and its dependency has 
```
    {
      "name": "gobject-introspection",
      "host": true
    }
```
So change the dependency of feature `instrospection` to `gobject-instrospection`.

Fix the build error: 
```
Run-time dependency gobject-introspection-1.0 found: NO (tried pkgconfig and cmake)

..\src\2.38.0-91fb0d495c.clean\atk\meson.build:139:2: ERROR: Dependency "gobject-introspection-1.0" not found, tried pkgconfig and cmake
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
