### PR TITLE
[graphviz] update to 9.0.0

### DIFF
--- a/ports/graphviz/cpp-error.patch
+++ b/ports/graphviz/cpp-error.patch
@@ -1,0 +1,12 @@
+diff --git a/cmd/gvedit/mainwindow.cpp b/cmd/gvedit/mainwindow.cpp
+--- a/cmd/gvedit/mainwindow.cpp
++++ b/cmd/gvedit/mainwindow.cpp
+@@ -595,7 +595,7 @@ void CMainWindow::readSettings()
+     // first try new settings
+     {
+       QSettings settings("Graphviz", "gvedit");
+-      if (settings.contains("pos") and settings.contains("size")) {
++      if (settings.contains("pos") && settings.contains("size")) {
+         QPoint pos = settings.value("pos", QPoint(200, 200)).toPoint();
+         QSize size = settings.value("size", QSize(400, 400)).toSize();
+         move(pos);

--- a/ports/graphviz/fix-dependencies.patch
+++ b/ports/graphviz/fix-dependencies.patch
@@ -1,20 +1,16 @@
 diff --git a/cmake/FindCAIRO.cmake b/cmake/FindCAIRO.cmake
-index a92916e..799fa68 100644
 --- a/cmake/FindCAIRO.cmake
 +++ b/cmake/FindCAIRO.cmake
-@@ -1,6 +1,6 @@
+@@ -1,4 +1,4 @@
  include(FindPackageHandleStandardArgs)
  
 -if(WIN32)
 +if(0)
-   find_path(CAIRO_INCLUDE_DIR cairo/cairo.h)
- 
-   find_library(CAIRO_LIBRARY NAMES cairo)
+   find_path(
 diff --git a/cmake/FindGD.cmake b/cmake/FindGD.cmake
-index d7e0cc9..2322fcd 100644
 --- a/cmake/FindGD.cmake
 +++ b/cmake/FindGD.cmake
-@@ -1,3 +1,11 @@
+@@ -1,3 +1,10 @@
 +find_package(PkgConfig)
 +pkg_check_modules(GD gdlib IMPORTED_TARGET)
 +set(GD_LIBRARIES PkgConfig::GD)
@@ -22,23 +18,24 @@ index d7e0cc9..2322fcd 100644
 +  set(HAVE_GD_${item} 1)
 +endforeach()
 +return()
-+
  find_path(GD_INCLUDE_DIR gd.h)
  find_library(GD_LIBRARY NAMES gd libgd)
  find_program(GD_RUNTIME_LIBRARY libgd.dll)
 diff --git a/cmake/FindLTDL.cmake b/cmake/FindLTDL.cmake
-index a1ee8c2..08b7f50 100644
 --- a/cmake/FindLTDL.cmake
 +++ b/cmake/FindLTDL.cmake
-@@ -16,3 +16,6 @@ mark_as_advanced(LTDL_INCLUDE_DIR LTDL_LIBRARY)
+@@ -15,6 +15,9 @@ endif()
+ mark_as_advanced(LTDL_INCLUDE_DIR LTDL_LIBRARY)
  
  set(LTDL_INCLUDE_DIRS ${LTDL_INCLUDE_DIR})
- set(LTDL_LIBRARIES ${LTDL_LIBRARY})
+-if(NOT WIN32 OR MINGW)
++if(1)
+   set(LTDL_LIBRARIES ${LTDL_LIBRARY})
+ endif()
 +if(CMAKE_DL_LIBS AND NOT BUILD_SHARED_LIBS)
 +  set(LTDL_LIBRARIES "${LTDL_LIBRARIES};${CMAKE_DL_LIBS}")
 +endif()
 diff --git a/cmake/FindPANGOCAIRO.cmake b/cmake/FindPANGOCAIRO.cmake
-index b92e5be..225589e 100644
 --- a/cmake/FindPANGOCAIRO.cmake
 +++ b/cmake/FindPANGOCAIRO.cmake
 @@ -1,6 +1,6 @@
@@ -59,3 +56,39 @@ index b92e5be..225589e 100644
  
    find_package_handle_standard_args(PANGOCAIRO DEFAULT_MSG
      PANGOCAIRO_INCLUDE_DIRS
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -114,7 +114,6 @@ endif()
+ 
+ find_package(GD)
+ find_package(GS)
+-find_package(GTS)
+ 
+ if(enable_ltdl)
+   find_package(LTDL)
+@@ -126,9 +125,10 @@ endif()
+ find_package(PANGOCAIRO)
+ find_package(PkgConfig)
+ if(PkgConfig_FOUND)
++  pkg_check_modules(GTS gts REQUIRED)
+   pkg_check_modules(POPPLER poppler-glib)
+-  pkg_check_modules(RSVG librsvg-2.0)
+-  pkg_check_modules(WEBP libwebp)
++  pkg_check_modules(librsvg REQUIRED IMPORTED_TARGET librsvg)
++  # pkg_check_modules(WEBP libwebp)
+ else()
+   set(POPPLER_FOUND 0)
+   set(RSVG_FOUND 0)
+diff --git a/cmd/dot/CMakeLists.txt b/cmd/dot/CMakeLists.txt
+--- a/cmd/dot/CMakeLists.txt
++++ b/cmd/dot/CMakeLists.txt
+@@ -88,7 +88,7 @@ endif()
+ if(PANGOCAIRO_FOUND)
+   target_link_libraries(dot_builtins PRIVATE gvplugin_pango)
+   if(PkgConfig_FOUND)
+-    pkg_check_modules(WEBP libwebp)
++    # pkg_check_modules(WEBP libwebp)
+     if(WEBP_FOUND)
+       target_link_libraries(dot_builtins PRIVATE gvplugin_webp)
+     endif()

--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -5,13 +5,14 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO graphviz/graphviz
     REF "${VERSION}"
-    SHA512 5872db8aefb9bebf6fea91dbe96759c42fa82dbe811238c7d6de8db5a0c6af77749083af60fc21f8e42c4fc159a2cbfefcc304967edda3d2832ef396c457530a
+    SHA512 1edcf6aa232d38d1861a344c1a4a88aac51fd4656d667783ca1608ac694025199595a72a293c4eee2f7c7326ce54f22b787a5b7f4c44946f2de6096bd8f0e79d
     HEAD_REF main
     PATCHES
         fix-dependencies.patch
         no-absolute-paths.patch
         select-plugins.patch
         static-linkage.patch
+        cpp-error.patch
 )
 
 if(VCPKG_TARGET_IS_OSX)
@@ -63,6 +64,7 @@ vcpkg_cmake_configure(
         -DCMAKE_REQUIRE_FIND_PACKAGE_GD=ON
         -DCMAKE_REQUIRE_FIND_PACKAGE_LTDL=ON
         -DCMAKE_REQUIRE_FIND_PACKAGE_PANGOCAIRO=ON
+        -Dwith_gvedit=OFF
         ${OPTIONS}
     MAYBE_UNUSED_VARIABLES
         install_win_dependency_dlls
@@ -84,7 +86,41 @@ foreach(script_or_link IN ITEMS "dot2gxl${VCPKG_TARGET_EXECUTABLE_SUFFIX}" gvmap
     endif()
 endforeach()
 vcpkg_copy_tools(
-    TOOL_NAMES acyclic bcomps ccomps circo diffimg dijkstra dot edgepaint fdp gc gml2gv graphml2gv gv2gml gvcolor gvgen gvmap gvpack gvpr gxl2gv mm2gv neato nop osage patchwork sccmap sfdp tred twopi unflatten
+    TOOL_NAMES
+        acyclic
+        bcomps
+        ccomps
+        circo
+        diffimg
+        dijkstra
+        dot
+        edgepaint
+        fdp
+        gc
+        gml2gv
+        graphml2gv
+        gv2gml
+        gvcolor
+        gvgen
+        gvmap
+        gvpack
+        gvpr
+        gxl2gv
+        mm2gv
+        neato
+        nop
+        osage
+        patchwork
+        sccmap
+        sfdp
+        tred
+        twopi
+        unflatten
+        cluster
+        dot_builtins
+        gv2gxl
+        gxl2dot
+        prune
     AUTO_CLEAN
 )
 

--- a/ports/graphviz/vcpkg.json
+++ b/ports/graphviz/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "graphviz",
-  "version-semver": "7.0.0",
-  "port-version": 2,
+  "version-semver": "9.0.0",
   "description": "Graph Visualization Tools",
   "homepage": "https://graphviz.org/",
   "license": "EPL-1.0",
@@ -12,6 +11,7 @@
       "default-features": false
     },
     "getopt",
+    "gts",
     {
       "name": "libgd",
       "default-features": false,
@@ -23,6 +23,7 @@
         "tiff"
       ]
     },
+    "librsvg",
     "pango",
     {
       "name": "pkgconf",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3029,8 +3029,8 @@
       "port-version": 4
     },
     "graphviz": {
-      "baseline": "7.0.0",
-      "port-version": 2
+      "baseline": "9.0.0",
+      "port-version": 0
     },
     "greatest": {
       "baseline": "1.5.0",

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a1450baf722dffefe9e4e4c4b5939ed1933ba269",
+      "version-semver": "9.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "793ff2f4883ca15332814044876e57a9b0921c43",
       "version-semver": "7.0.0",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
