### PR TITLE
[utfcpp] Update to 3.2.4

### DIFF
--- a/ports/utfcpp/portfile.cmake
+++ b/ports/utfcpp/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_minimum_required(VERSION 2022-12-14)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nemtrif/utfcpp
     REF v${VERSION}
-    SHA512 760977df613abfb34fb7864cbbe90e8f2cf1f42b8502427a5e9c2a756ce87655120b7490ebdaa6c926a2cb56caef9ead0e0e10fb7cb732cf99a5b43c0cca411b
+    SHA512 5135b13a03ee814cb35e04459b2d91b8fbe91cd518a604c41062b4ad42b739fce1acf946b01904309e0edffb874f5e81f69d28afdc8b6f759ef2d675ca0c0db0
     HEAD_REF master
 )
 

--- a/ports/utfcpp/vcpkg.json
+++ b/ports/utfcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "utfcpp",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "UTF-8 with C++ in a Portable Way",
   "homepage": "https://github.com/nemtrif/utfcpp",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8505,7 +8505,7 @@
       "port-version": 1
     },
     "utfcpp": {
-      "baseline": "3.2.3",
+      "baseline": "3.2.4",
       "port-version": 0
     },
     "utfz": {

--- a/versions/u-/utfcpp.json
+++ b/versions/u-/utfcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c3de7ba47b92f266d5cce0a4f69925af4abda8f",
+      "version": "3.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "6871a843dce2e99e0973ca0a2a837ea78c3add39",
       "version": "3.2.3",
       "port-version": 0


### PR DESCRIPTION
Updates utfcpp port from 3.2.3 to 3.2.4 : https://github.com/nemtrif/utfcpp/releases/tag/v3.2.4

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
