### PR TITLE
[vlpp] tools on osx

### DIFF
--- a/ports/vlpp/vcpkg.json
+++ b/ports/vlpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vlpp",
   "version": "1.1.0.0",
+  "port-version": 1,
   "maintainers": "vczh",
   "description": "Common C++ construction, including string operation / generic container / linq / General-LR parser generator / multithreading / reflection for C++ / etc",
   "homepage": "https://github.com/vczh-libraries/Release",
@@ -68,7 +69,8 @@
       "description": "Enable Reflection"
     },
     "tools": {
-      "description": "Build tools"
+      "description": "Build tools",
+      "supports": "!osx"
     },
     "workflowcompiler": {
       "description": "Enable VlppWorkflow Compiler",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8670,7 +8670,7 @@
     },
     "vlpp": {
       "baseline": "1.1.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "volk": {
       "baseline": "1.3.250",

--- a/versions/v-/vlpp.json
+++ b/versions/v-/vlpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "654b1fb66c8a083d723a6a655acf5eb706fe97f2",
+      "version": "1.1.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8df8b965877d7d55e02b0563e1874d6c4fbbd9f2",
       "version": "1.1.0.0",
       "port-version": 0


### PR DESCRIPTION
It fails with
```
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/vlpp/src/f3d81afcb5-8ec733c9b4.clean/Import/gacgen/Import/VlppOS.Linux.cpp:51:17: error: use of undeclared identifier 'PATH_MAX'
                                char buffer[PATH_MAX] = { 0 };
                                            ^
```
There are only the files `VlppOS.Linux.cpp` and `VlppOS.Windows.cpp`