### PR TITLE
[onnxruntime-gpu]Update version to 1.15.1

### DIFF
--- a/ports/onnxruntime-gpu/portfile.cmake
+++ b/ports/onnxruntime-gpu/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-win-x64-gpu-${VERSION}.zip"
     FILENAME "onnxruntime-win-x64-gpu-${VERSION}.zip"
-    SHA512 f927302daa7b778eaf15693e446303060c0a38dfd18b8026c28ac65f545dd463ee7cd3f0aa6bfe59301c5c85ccf4512584ed968ac42ce8d78c12a79d8af2de1e
+    SHA512 6e95199e8cfdee7c056811c2c27f45f7b45bd00b48424d331d8685993102d1b59e14fc3c86e7307b780531ac3e5dcbe760c93018d1b1f106bb36fe32dc44974c
 )
 
 vcpkg_extract_source_archive(
@@ -17,7 +17,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH REPO_PATH
     REPO microsoft/onnxruntime
     REF v${VERSION}
-    SHA512 d8f7ea161e850a738b9a22187662218871f88ad711282c58631196a74f4a4567184047bab0001b973f841a3b63c7dc7e350f92306cc5fa9a7adc4db2ce09766f
+    SHA512 c9ad2ab1102bb97bdd88aa8e06432fff2960fb21172891eee9631ff7cbbdf3366cd7cf5c0baa494eb883135eab47273ed3128851ff4d9adfa004a479e941b6b5
 )
 
 file(COPY

--- a/ports/onnxruntime-gpu/vcpkg.json
+++ b/ports/onnxruntime-gpu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "onnxruntime-gpu",
-  "version": "1.14.1",
-  "port-version": 1,
+  "version": "1.15.1",
+  "port-version": 0,
   "description": "onnxruntime (GPU)",
   "homepage": "https://github.com/microsoft/onnxruntime",
   "license": "MIT",

--- a/ports/onnxruntime-gpu/vcpkg.json
+++ b/ports/onnxruntime-gpu/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "onnxruntime-gpu",
   "version": "1.15.1",
-  "port-version": 0,
   "description": "onnxruntime (GPU)",
   "homepage": "https://github.com/microsoft/onnxruntime",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5977,8 +5977,8 @@
       "port-version": 0
     },
     "onnxruntime-gpu": {
-      "baseline": "1.14.1",
-      "port-version": 1
+      "baseline": "1.15.1",
+      "port-version": 0
     },
     "oof": {
       "baseline": "2021-11-23",

--- a/versions/o-/onnxruntime-gpu.json
+++ b/versions/o-/onnxruntime-gpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cc823e72cab7f23d5cfeeeef64e180f4c3288911",
+      "git-tree": "3836c30f0e39aa6c9f9a9dbfa8f146e3ae5e97cf",
       "version": "1.15.1",
       "port-version": 0
     },

--- a/versions/o-/onnxruntime-gpu.json
+++ b/versions/o-/onnxruntime-gpu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc823e72cab7f23d5cfeeeef64e180f4c3288911",
+      "version": "1.15.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7b91d7cf9e629be0d5581c85e8520a1850d0bf2a",
       "version": "1.14.1",
       "port-version": 1


### PR DESCRIPTION
Note: Update `onnxruntime-gpu version` to 1.15.1
No feature need to test.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
~~- [ ] The "supports" clause reflects platforms that may be fixed by this new version~~
~~- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
~~- [ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
