### PR TITLE
[aws-c-cal] fix linux build

### DIFF
--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,12 +1,17 @@
 {
   "name": "aws-c-cal",
   "version": "0.6.2",
+  "port-version": 1,
   "description": "C99 wrapper for cryptography primitives.",
   "homepage": "https://github.com/awslabs/aws-c-cal",
   "license": "Apache-2.0",
   "supports": "!(windows & arm) & !uwp",
   "dependencies": [
     "aws-c-common",
+    {
+      "name": "openssl",
+      "platform": "!windows & !osx"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/a-/aws-c-cal.json
+++ b/versions/a-/aws-c-cal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df757b731aa4c59ac71c43d02fe87edaff5680b3",
+      "version": "0.6.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "5633a1e4fad4542c5e3a665a09bf77d276031429",
       "version": "0.6.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -350,7 +350,7 @@
     },
     "aws-c-cal": {
       "baseline": "0.6.2",
-      "port-version": 0
+      "port-version": 1
     },
     "aws-c-common": {
       "baseline": "0.9.3",


### PR DESCRIPTION
Otherwise fails with
```
CMake Error at /home/vcpkg/vcpkg/downloads/tools/cmake-3.27.1-linux/cmake-3.27.1-linux-x86_64/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find crypto (missing: crypto_LIBRARY crypto_INCLUDE_DIR)
```