### PR TITLE
[sqlitecpp] update to 3.3.1

### DIFF
--- a/ports/sqlitecpp/portfile.cmake
+++ b/ports/sqlitecpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO "SRombauts/SQLiteCpp"
     REF ${VERSION}
     HEAD_REF master
-    SHA512 9702b17c55b1b3bc46a72d5c204b560249e9c1f02647c864fd4ca54011e4b0238638800ee870baa5106512a9568338d3faa9c9f9799d42fbd558d10376e3b73a
+    SHA512 08a42ef2495b65e8565569842b40882aff91a3bf1887f09b5b2f2950ae4e16ef927809e7ff9870ffcf143bc187bb3eea5c3f2e4881943144e8cb6e1605ba71ce
     PATCHES
         fix_dependency.patch
         add_runtime_destination.patch

--- a/ports/sqlitecpp/vcpkg.json
+++ b/ports/sqlitecpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlitecpp",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "SQLiteC++ (SQLiteCpp) is a smart and easy to use C++ SQLite3 wrapper.",
   "homepage": "https://github.com/SRombauts/SQLiteCpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7917,7 +7917,7 @@
       "port-version": 0
     },
     "sqlitecpp": {
-      "baseline": "3.3.0",
+      "baseline": "3.3.1",
       "port-version": 0
     },
     "sqlpp11": {

--- a/versions/s-/sqlitecpp.json
+++ b/versions/s-/sqlitecpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82921718a535a8c074d454e2b3a650467b866877",
+      "version": "3.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b239a7578034b934210ab61e462b789feffe2136",
       "version": "3.3.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #33808 

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->



- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.



