### PR TITLE
[cppmicroservices] update to 3.7.6

### DIFF
--- a/ports/cppmicroservices/fix-thirdparty.patch
+++ b/ports/cppmicroservices/fix-thirdparty.patch
@@ -12,7 +12,7 @@ index 2bec34f..5740b6e 100644
  #-----------------------------------------------------------------------------
  
 diff --git a/tools/rc/CMakeLists.txt b/tools/rc/CMakeLists.txt
-index 5c49432..c04247a 100755
+index 5c49432..1f5e98c 100755
 --- a/tools/rc/CMakeLists.txt
 +++ b/tools/rc/CMakeLists.txt
 @@ -19,9 +19,8 @@ set_property(TARGET ${US_RCC_EXECUTABLE_TARGET} PROPERTY OUTPUT_NAME ${US_RCC_EX
@@ -22,13 +22,13 @@ index 5c49432..c04247a 100755
 -
 -target_link_libraries(${US_RCC_EXECUTABLE_TARGET} nowide::nowide)
 -target_include_directories(${US_RCC_EXECUTABLE_TARGET} PRIVATE ${CppMicroServices_SOURCE_DIR}/third_party/boost/nowide/include)
-+    find_package(Boost REQUIRED nowide)
-+    target_link_libraries(${US_RCC_EXECUTABLE_TARGET} PRIVATE Boost::boost Boost::nowide)
++find_package(Boost REQUIRED nowide)
++target_link_libraries(${US_RCC_EXECUTABLE_TARGET} Boost::boost Boost::nowide)
  
  set_property(TARGET ${US_RCC_EXECUTABLE_TARGET} APPEND PROPERTY
               COMPILE_DEFINITIONS "MINIZ_NO_ARCHIVE_READING_API;MINIZ_NO_ZLIB_COMPATIBLE_NAMES")
 diff --git a/tools/rc/ResourceCompiler.cpp b/tools/rc/ResourceCompiler.cpp
-index 622ef9c..d50971d 100755
+index 622ef9c..e4547d5 100755
 --- a/tools/rc/ResourceCompiler.cpp
 +++ b/tools/rc/ResourceCompiler.cpp
 @@ -35,12 +35,12 @@

--- a/ports/cppmicroservices/fix-thirdparty.patch
+++ b/ports/cppmicroservices/fix-thirdparty.patch
@@ -1,0 +1,70 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2bec34f..5740b6e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -649,7 +649,7 @@ endif()
+ #-----------------------------------------------------------------------------
+ add_subdirectory(third_party/absl)
+ set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
+-add_subdirectory(third_party/boost/nowide)
++#add_subdirectory(third_party/boost/nowide)
+ set(BUILD_SHARED_LIBS ${_us_build_shared} CACHE BOOL "Build shared libraries" FORCE)
+ #-----------------------------------------------------------------------------
+ 
+diff --git a/tools/rc/CMakeLists.txt b/tools/rc/CMakeLists.txt
+index 5c49432..c04247a 100755
+--- a/tools/rc/CMakeLists.txt
++++ b/tools/rc/CMakeLists.txt
+@@ -19,9 +19,8 @@ set_property(TARGET ${US_RCC_EXECUTABLE_TARGET} PROPERTY OUTPUT_NAME ${US_RCC_EX
+ if(WIN32)
+     target_link_libraries(${US_RCC_EXECUTABLE_TARGET} Shlwapi)
+ endif()
+-
+-target_link_libraries(${US_RCC_EXECUTABLE_TARGET} nowide::nowide)
+-target_include_directories(${US_RCC_EXECUTABLE_TARGET} PRIVATE ${CppMicroServices_SOURCE_DIR}/third_party/boost/nowide/include)
++    find_package(Boost REQUIRED nowide)
++    target_link_libraries(${US_RCC_EXECUTABLE_TARGET} PRIVATE Boost::boost Boost::nowide)
+ 
+ set_property(TARGET ${US_RCC_EXECUTABLE_TARGET} APPEND PROPERTY
+              COMPILE_DEFINITIONS "MINIZ_NO_ARCHIVE_READING_API;MINIZ_NO_ZLIB_COMPATIBLE_NAMES")
+diff --git a/tools/rc/ResourceCompiler.cpp b/tools/rc/ResourceCompiler.cpp
+index 622ef9c..d50971d 100755
+--- a/tools/rc/ResourceCompiler.cpp
++++ b/tools/rc/ResourceCompiler.cpp
+@@ -35,12 +35,12 @@
+ #include <utility>
+ #include <vector>
+ 
+-#include <nowide/args.hpp>
+-#include <nowide/fstream.hpp>
++#include <boost/nowide/args.hpp>
++#include <boost/nowide/fstream.hpp>
+ 
+ #include "optionparser.h"
+ #include "json/json.h"
+-
++namespace nowide = boost::nowide;
+ // ---------------------------------------------------------------------------------
+ // --------------------------    PLATFORM SPECIFIC CODE    -------------------------
+ // ---------------------------------------------------------------------------------
+diff --git a/util/src/FileSystem.cpp b/util/src/FileSystem.cpp
+index 868f9b7..c0442a4 100644
+--- a/util/src/FileSystem.cpp
++++ b/util/src/FileSystem.cpp
+@@ -28,6 +28,7 @@
+ #include <stdexcept>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ #ifdef US_PLATFORM_POSIX
+ #    include <cerrno>
+@@ -124,7 +125,7 @@ namespace cppmicroservices
+         std::string
+         GetExecutablePath()
+         {
+-            uint32_t bufsize = MAXPATHLEN;
++            std::uint32_t bufsize = MAXPATHLEN;
+ #ifdef US_PLATFORM_WINDOWS
+             std::vector<wchar_t> wbuf(bufsize + 1, '\0');
+             if (GetModuleFileNameW(nullptr, wbuf.data(), bufsize) == 0 || GetLastError() == ERROR_INSUFFICIENT_BUFFER)

--- a/ports/cppmicroservices/portfile.cmake
+++ b/ports/cppmicroservices/portfile.cmake
@@ -1,13 +1,12 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CppMicroServices/CppMicroservices
-    REF v3.6.0
-    SHA512 C1407E1D3C2FD31675C32D8C00F7D005C09B03A835D5B09411B0043DDEAF5E3A1A0C7A5FA34FA04D5A643169D222D0E8D3A3C31CDA69FB64CDF1A8CCA276BE18
+    REF "v${VERSION}"
+    SHA512 4743846a8ba45e6bd320c93bb3bd443b5dac16ea0bbf55bda6212e9200a40ee29031fd74c6141de4c6b5ef9ad3e70789d13fda25b40638547782d386a12dd7e2
     HEAD_REF development
     PATCHES
         werror.patch
-        fix-dependency-gtest.patch
-        fix-warning-c4834.patch
+        fix-thirdparty.patch
 )
 
 vcpkg_cmake_configure(
@@ -16,6 +15,7 @@ vcpkg_cmake_configure(
         -DTOOLS_INSTALL_DIR:STRING=tools/cppmicroservices
         -DAUXILIARY_INSTALL_DIR:STRING=share/cppmicroservices
         -DUS_USE_SYSTEM_GTEST=TRUE
+        -DUS_BUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/cppmicroservices/vcpkg.json
+++ b/ports/cppmicroservices/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "cppmicroservices",
-  "version": "3.6.0",
-  "port-version": 1,
+  "version": "3.7.6",
   "description": "An OSGi-like C++ dynamic module system and service registry",
   "homepage": "https://github.com/CppMicroServices/CppMicroServices",
   "dependencies": [
+    "boost-nowide",
     "gtest",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1845,8 +1845,8 @@
       "port-version": 0
     },
     "cppmicroservices": {
-      "baseline": "3.6.0",
-      "port-version": 1
+      "baseline": "3.7.6",
+      "port-version": 0
     },
     "cpprestsdk": {
       "baseline": "2.10.18",

--- a/versions/c-/cppmicroservices.json
+++ b/versions/c-/cppmicroservices.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "634211a7cccaea975986f1ef75521786fe8c0181",
+      "git-tree": "7e50ec77ce6ec215a5f78ef9b42374015f350934",
       "version": "3.7.6",
       "port-version": 0
     },

--- a/versions/c-/cppmicroservices.json
+++ b/versions/c-/cppmicroservices.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "634211a7cccaea975986f1ef75521786fe8c0181",
+      "version": "3.7.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d97b6213a9f6a77e8f1062229ead80ffd4703a7",
       "version": "3.6.0",
       "port-version": 1


### PR DESCRIPTION


- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

