### PR TITLE
[libsocket] New port

### DIFF
--- a/ports/libsocket/0001-fix-static-builds.patch
+++ b/ports/libsocket/0001-fix-static-builds.patch
@@ -1,0 +1,20 @@
+diff --git a/C++/CMakeLists.txt b/C++/CMakeLists.txt
+--- a/C++/CMakeLists.txt
++++ b/C++/CMakeLists.txt
+@@ -38,11 +38,11 @@ INSTALL(TARGETS socket++ DESTINATION ${LIB_DIR})
+ ENDIF()
+ 
+ IF(BUILD_STATIC_LIBS)
+-ADD_LIBRARY(socket++_int STATIC $<TARGET_OBJECTS:socket++_o>)
++ADD_LIBRARY(socket++ STATIC $<TARGET_OBJECTS:socket++_o>)
+ 
+-SET_TARGET_PROPERTIES(socket++_int PROPERTIES OUTPUT_NAME socket++)
++SET_TARGET_PROPERTIES(socket++ PROPERTIES OUTPUT_NAME socket++)
+ 
+-TARGET_LINK_LIBRARIES(socket++_int socket_int)
++TARGET_LINK_LIBRARIES(socket++ socket_int)
+ 
+-INSTALL(TARGETS socket++_int DESTINATION ${LIB_DIR})
++INSTALL(TARGETS socket++ DESTINATION ${LIB_DIR})
+ ENDIF()
+

--- a/ports/libsocket/0002-install-cmake-targets.patch
+++ b/ports/libsocket/0002-install-cmake-targets.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -92,3 +92,14 @@ configure_file(libsocketConfig.cmake.in
+ configure_file(libsocketConfigVersion.cmake.in
+   "${PROJECT_BINARY_DIR}/libsocketConfigVersion.cmake" @ONLY)
+ 
++install(TARGETS socket++ socket_int
++  EXPORT libsocketTargets)
++
++INSTALL(EXPORT libsocketTargets
++  DESTINATION share/libsocket)
++
++install(
++  FILES "${CMAKE_CURRENT_BINARY_DIR}/libsocketConfig.cmake"
++        "${CMAKE_CURRENT_BINARY_DIR}/libsocketConfigVersion.cmake"
++  DESTINATION "share/libsocket")
++
+diff --git a/libsocketConfig.cmake.in b/libsocketConfig.cmake.in
+--- a/libsocketConfig.cmake.in
++++ b/libsocketConfig.cmake.in
+@@ -1,6 +1,6 @@
+-set(libsocket_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
++set(libsocket_INCLUDE_DIRS "@INSTALL_INCLUDE_DIR@")
+ 
+-set(libsocket_BINARY_DIR "@PROJECT_BINARY_DIR@")
++set(libsocket_BINARY_DIR "@INSTALL_BIN_DIR@")
+ 
+ include(${libsocket_BINARY_DIR}/libsocketTargets.cmake)
+ 
+

--- a/ports/libsocket/0002-install-cmake-targets.patch
+++ b/ports/libsocket/0002-install-cmake-targets.patch
@@ -26,6 +26,7 @@ diff --git a/libsocketConfig.cmake.in b/libsocketConfig.cmake.in
 -set(libsocket_BINARY_DIR "@PROJECT_BINARY_DIR@")
 +set(libsocket_BINARY_DIR "@INSTALL_BIN_DIR@")
  
- include(${libsocket_BINARY_DIR}/libsocketTargets.cmake)
+-include(${libsocket_BINARY_DIR}/libsocketTargets.cmake)
++include(share/libsocket/libsocketTargets.cmake)
  
 

--- a/ports/libsocket/portfile.cmake
+++ b/ports/libsocket/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dermesser/libsocket
+    REF fe5f78c997478a1915f44a494a50025bdc792698
+    SHA512 c3563365f00021e9fa18e776765681268f52b9596b200f757661781bfb901360b42ad15beba02e39b0602edeac7904b061e46b6709c2023f9b624ceb81bf70ca
+    HEAD_REF master
+    PATCHES
+        0001-fix-static-builds.patch
+        0002-install-cmake-targets.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LIBSOCKET_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIBSOCKET_BUILD_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_STATIC_LIBS=${LIBSOCKET_BUILD_STATIC}
+        -DBUILD_SHARED_LIBS=${LIBSOCKET_BUILD_SHARED}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libsocket/usage
+++ b/ports/libsocket/usage
@@ -1,0 +1,4 @@
+libsocket provides CMake targets:
+
+    find_package(libsocket CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE socket++)

--- a/ports/libsocket/vcpkg.json
+++ b/ports/libsocket/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libsocket",
+  "version-date": "2023-09-17",
+  "description": "The ultimate socket library for C and C++, supporting TCP, UDP and Unix sockets (DGRAM and STREAM) on Linux, FreeBSD, Solaris.",
+  "homepage": "https://github.com/dermesser/libsocket",
+  "license": "BSD-2-Clause",
+  "supports": "linux | freebsd",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4636,6 +4636,10 @@
       "baseline": "0.8.0",
       "port-version": 2
     },
+    "libsocket": {
+      "baseline": "2023-09-17",
+      "port-version": 0
+    },
     "libsodium": {
       "baseline": "1.0.18",
       "port-version": 9

--- a/versions/l-/libsocket.json
+++ b/versions/l-/libsocket.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ff68add433a764b9f437e9d6be2e1dca39c9e252",
+      "version-date": "2023-09-17",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libsocket.json
+++ b/versions/l-/libsocket.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff68add433a764b9f437e9d6be2e1dca39c9e252",
+      "git-tree": "b0cb23f1d935419811dc3559affb7a82d345ae21",
       "version-date": "2023-09-17",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
