### PR TITLE
[libdeflate] update to v1.19

### DIFF
--- a/ports/libdeflate/portfile.cmake
+++ b/ports/libdeflate/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ebiggers/libdeflate
     REF "v${VERSION}"
-    SHA512 8a60fa5850f323389370f931579f85a094a35b3db334f2a2afa61bee39ecebc797e93c6fe5deb4178e19d83a1427533975dba6c05ce0b1db88b43c9268d09124
+    SHA512 fe57542a0d28ad61d70bef9b544bb6805f9f30930b16432712b3b1caab041f1f4e64315a4306a0635b96c2632239c5af0e45a3915581d0b89975729fc2e95613
     HEAD_REF master
     PATCHES
         remove_wrong_c_flags_modification.diff

--- a/ports/libdeflate/vcpkg.json
+++ b/ports/libdeflate/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdeflate",
-  "version": "1.18",
+  "version": "1.19",
   "description": "libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.",
   "homepage": "https://github.com/ebiggers/libdeflate",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4037,7 +4037,7 @@
       "port-version": 2
     },
     "libdeflate": {
-      "baseline": "1.18",
+      "baseline": "1.19",
       "port-version": 0
     },
     "libdisasm": {

--- a/versions/l-/libdeflate.json
+++ b/versions/l-/libdeflate.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60231c270c3eca938a64b43dfb0b66846787a464",
+      "version": "1.19",
+      "port-version": 0
+    },
+    {
       "git-tree": "6a0df33e92ed3be5674c6c0a4fd63faff93dea9d",
       "version": "1.18",
       "port-version": 0


### PR DESCRIPTION
Fixes #33822

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


All feature tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static
