### PR TITLE
[readline-unix] No empty tools dir; patch crash

### DIFF
--- a/ports/readline-unix/8.2p1.diff
+++ b/ports/readline-unix/8.2p1.diff
@@ -1,0 +1,24 @@
+diff --git a/nls.c b/nls.c
+index 5c6a13b..8c027d6 100644
+--- a/nls.c
++++ b/nls.c
+@@ -141,6 +141,10 @@ _rl_init_locale (void)
+   if (lspec == 0)
+     lspec = "";
+   ret = setlocale (LC_CTYPE, lspec);	/* ok, since it does not change locale */
++  if (ret == 0 || *ret == 0)
++    ret = setlocale (LC_CTYPE, (char *)NULL);
++  if (ret == 0 || *ret == 0)
++    ret = RL_DEFAULT_LOCALE;
+ #else
+   ret = (lspec == 0 || *lspec == 0) ? RL_DEFAULT_LOCALE : lspec;
+ #endif
+diff --git a/patchlevel b/patchlevel
+index d8c9df7..fdf4740 100644
+--- a/patchlevel
++++ b/patchlevel
+@@ -1,3 +1,3 @@
+ # Do not edit -- exists only for use by patch
+ 
+-0
++1

--- a/ports/readline-unix/portfile.cmake
+++ b/ports/readline-unix/portfile.cmake
@@ -1,4 +1,3 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 set(filename readline-${VERSION}.tar.gz)
 vcpkg_download_distfile(
     ARCHIVE
@@ -9,7 +8,11 @@ vcpkg_download_distfile(
     SHA512 0a451d459146bfdeecc9cdd94bda6a6416d3e93abd80885a40b334312f16eb890f8618a27ca26868cebbddf1224983e631b1cbc002c1a4d1cd0d65fba9fea49a
 )
 
-vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        8.2p1.diff
+)
 
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/readline-unix/portfile.cmake
+++ b/ports/readline-unix/portfile.cmake
@@ -21,7 +21,10 @@ vcpkg_configure_make(
 
 vcpkg_install_make()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/tools"
+)
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/readline-unix/vcpkg.json
+++ b/ports/readline-unix/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "readline-unix",
   "version": "8.2",
+  "port-version": 1,
   "description": "The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in.",
   "homepage": "https://tiswww.case.edu/php/chet/readline/rltop.html",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7186,7 +7186,7 @@
     },
     "readline-unix": {
       "baseline": "8.2",
-      "port-version": 0
+      "port-version": 1
     },
     "readline-win32": {
       "baseline": "5.0",

--- a/versions/r-/readline-unix.json
+++ b/versions/r-/readline-unix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ebb801609be21f9a93e7e6d4db1e594d9767d475",
+      "version": "8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "19fcd2b764ea6d261dfbd80961833e807cf93ea0",
       "version": "8.2",
       "port-version": 0

--- a/versions/r-/readline-unix.json
+++ b/versions/r-/readline-unix.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ebb801609be21f9a93e7e6d4db1e594d9767d475",
+      "git-tree": "4ad0f063e0bf86f7bfbf455e7a1f7f16883528f0",
       "version": "8.2",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes post-build check error for x64-linux-dynamic.