### PR TITLE
[libplist] Add tools feature

### DIFF
--- a/ports/libplist/004_fix_tools_msvc.patch
+++ b/ports/libplist/004_fix_tools_msvc.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/plistutil.c b/tools/plistutil.c
-index 8121a7d..e59faf9 100644
+index 8121a7d..98b440e 100644
 --- a/tools/plistutil.c
 +++ b/tools/plistutil.c
 @@ -32,10 +32,13 @@
@@ -12,7 +12,7 @@ index 8121a7d..e59faf9 100644
  
  #ifdef _MSC_VER
  #pragma warning(disable:4996)
-+#define STDIN_FILENO 0
++#define STDIN_FILENO _fileno(stdin)
  #endif
  
  typedef struct _options

--- a/ports/libplist/004_fix_tools_msvc.patch
+++ b/ports/libplist/004_fix_tools_msvc.patch
@@ -1,0 +1,18 @@
+diff --git a/tools/plistutil.c b/tools/plistutil.c
+index 8121a7d..e59faf9 100644
+--- a/tools/plistutil.c
++++ b/tools/plistutil.c
+@@ -32,10 +32,13 @@
+ #include <string.h>
+ #include <sys/stat.h>
+ #include <errno.h>
++#ifndef _MSC_VER
+ #include <unistd.h>
++#endif
+ 
+ #ifdef _MSC_VER
+ #pragma warning(disable:4996)
++#define STDIN_FILENO 0
+ #endif
+ 
+ typedef struct _options

--- a/ports/libplist/CMakeLists.txt
+++ b/ports/libplist/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(libplist C CXX)
 
+option(BUILD_TOOLS "Build tools." OFF)
+
 include(GNUInstallDirs)
 
 file(GLOB_RECURSE LIBCNARY_SOURCE libcnary/node.c libcnary/node_list.c)
@@ -26,13 +28,11 @@ if(WIN32)
 endif()
 
 add_library(libplist ${LIBPLIST_SOURCE} ${LIBCNARY_SOURCE})
-target_include_directories(libplist
-    PRIVATE
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/libcnary/include>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>"
-    PUBLIC
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+target_include_directories(libplist PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/libcnary/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 target_compile_definitions(libplist PRIVATE ${DEFINITIONS})
 set_target_properties(libplist PROPERTIES OUTPUT_NAME plist-2.0)
@@ -41,13 +41,11 @@ if(UNIX AND NOT APPLE)
 endif()
 
 add_library(libplist++ STATIC ${LIBPLISTPP_SOURCE} ${LIBCNARY_SOURCE})
-target_include_directories(libplist++
-    PRIVATE
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/libcnary/include>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>"
-    PUBLIC
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+target_include_directories(libplist++ PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/libcnary/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 target_compile_definitions(libplist++ PRIVATE ${DEFINITIONS})
 target_link_libraries(libplist++ PUBLIC libplist)
@@ -85,3 +83,21 @@ foreach(PLIST_PKGCONFIG libplist-2.0.pc libplist++-2.0.pc)
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
     )
 endforeach()
+
+if(BUILD_TOOLS)
+    add_executable(plistutil "tools/plistutil.c")
+    target_compile_definitions(plistutil PRIVATE
+        -DPACKAGE_VERSION="2.3.0"
+        -DPACKAGE_URL="https://github.com/libimobiledevice/libplist"
+        -DPACKAGE_BUGREPORT="https://github.com/libimobiledevice/libplist/issues"
+    )
+    if(NOT BUILD_SHARED_LIBS)
+        target_compile_definitions(plistutil PRIVATE -DLIBPLIST_STATIC)
+    endif()
+    target_link_libraries(plistutil PRIVATE libplist)
+
+    install(
+        TARGETS plistutil
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    )
+endif()

--- a/ports/libplist/portfile.cmake
+++ b/ports/libplist/portfile.cmake
@@ -8,17 +8,28 @@ vcpkg_from_github(
         001_fix_static_build.patch
         002_fix_api.patch
         003_fix_msvc.patch
+        004_fix_tools_msvc.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 vcpkg_fixup_pkgconfig()
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES plistutil AUTO_CLEAN)
+endif()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/plist/plist.h"

--- a/ports/libplist/vcpkg.json
+++ b/ports/libplist/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libplist",
   "version-date": "2023-06-15",
+  "port-version": 1,
   "description": "A library to handle Apple Property List format in binary or XML",
   "homepage": "https://libimobiledevice.org/",
   "license": "LGPL-2.1-or-later",
@@ -13,5 +14,14 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "tools"
+  ],
+  "features": {
+    "tools": {
+      "description": "build command line tool",
+      "supports": "!android & !ios & !xbox"
+    }
+  }
 }

--- a/ports/libplist/vcpkg.json
+++ b/ports/libplist/vcpkg.json
@@ -15,9 +15,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "tools"
-  ],
   "features": {
     "tools": {
       "description": "build command line tool",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4498,7 +4498,7 @@
     },
     "libplist": {
       "baseline": "2023-06-15",
-      "port-version": 0
+      "port-version": 1
     },
     "libpmemobj-cpp": {
       "baseline": "1.13.0",

--- a/versions/l-/libplist.json
+++ b/versions/l-/libplist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1c8568d50b90f364d75b83af64916db9507cf76b",
+      "git-tree": "c0550bd82aaa3f3ae23f9b481285c6cb9f92b44c",
       "version-date": "2023-06-15",
       "port-version": 1
     },

--- a/versions/l-/libplist.json
+++ b/versions/l-/libplist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e6521580f66333046f509589eb29b5c7403f29d8",
+      "git-tree": "1c8568d50b90f364d75b83af64916db9507cf76b",
       "version-date": "2023-06-15",
       "port-version": 1
     },

--- a/versions/l-/libplist.json
+++ b/versions/l-/libplist.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6521580f66333046f509589eb29b5c7403f29d8",
+      "version-date": "2023-06-15",
+      "port-version": 1
+    },
+    {
       "git-tree": "8a79aaf94792ae73eea5094eebac773fe6705b54",
       "version-date": "2023-06-15",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

See also #33246