### PR TITLE
[libusbmuxd] Add tools feature

### DIFF
--- a/ports/libusbmuxd/005_fix_tools_msvc.patch
+++ b/ports/libusbmuxd/005_fix_tools_msvc.patch
@@ -1,0 +1,42 @@
+diff --git a/tools/inetcat.c b/tools/inetcat.c
+index f70215b..748db15 100644
+--- a/tools/inetcat.c
++++ b/tools/inetcat.c
+@@ -33,7 +33,9 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <stddef.h>
++#ifndef _MSC_VER
+ #include <unistd.h>
++#endif
+ #include <errno.h>
+ #include <getopt.h>
+ #ifdef WIN32
+@@ -50,6 +52,13 @@
+ #include "usbmuxd.h"
+ #include <libimobiledevice-glue/socket.h>
+ 
++#ifdef _MSC_VER
++#include <BaseTsd.h>
++typedef SSIZE_T ssize_t;
++#define STDIN_FILENO  _fileno(stdin)
++#define STDOUT_FILENO _fileno(stdout)
++#endif
++
+ static int debug_level = 0;
+ 
+ static size_t read_data_socket(int fd, uint8_t* buf, size_t bufsize)
+diff --git a/tools/iproxy.c b/tools/iproxy.c
+index d5f66b6..6510cb8 100644
+--- a/tools/iproxy.c
++++ b/tools/iproxy.c
+@@ -34,7 +34,9 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <stddef.h>
++#ifndef _MSC_VER
+ #include <unistd.h>
++#endif
+ #include <errno.h>
+ #include <getopt.h>
+ #ifdef WIN32

--- a/ports/libusbmuxd/CMakeLists.txt
+++ b/ports/libusbmuxd/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(libusbmuxd C)
 
+option(BUILD_TOOLS "Build tools." OFF)
+
 include(GNUInstallDirs)
 
 file(GLOB_RECURSE LIBUSBMUXD_HEADER include/*.h)
@@ -25,6 +27,7 @@ endif()
 
 if(WIN32)
     list(APPEND DEFINITIONS -D_CRT_SECURE_NO_WARNINGS)
+    list(APPEND DEFINITIONS -DWIN32_LEAN_AND_MEAN)
     list(APPEND DEFINITIONS -DWIN32)
 endif()
 
@@ -32,11 +35,9 @@ find_package(unofficial-libplist CONFIG REQUIRED)
 find_package(unofficial-libimobiledevice-glue CONFIG REQUIRED)
 
 add_library(libusbmuxd ${LIBUSBMUXD_SOURCE})
-target_include_directories(libusbmuxd
-    PRIVATE
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-    PUBLIC
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+target_include_directories(libusbmuxd PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 target_compile_definitions(libusbmuxd PRIVATE ${DEFINITIONS})
 target_link_libraries(libusbmuxd
@@ -82,3 +83,35 @@ install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/libusbmuxd-2.0.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
+
+if(BUILD_TOOLS)
+    if(WIN32)
+        find_package(unofficial-getopt-win32 REQUIRED)
+    endif()
+
+    function(add_tool name source)
+        add_executable("${name}" "${source}")
+        target_compile_definitions("${name}" PRIVATE
+            -DPACKAGE_VERSION="2.0.2"
+            -DPACKAGE_URL="https://github.com/libimobiledevice/libusbmuxd"
+            -DPACKAGE_BUGREPORT="https://github.com/libimobiledevice/libusbmuxd/issues"
+        )
+        target_link_libraries("${name}" PRIVATE libusbmuxd unofficial::libimobiledevice-glue::libimobiledevice-glue)
+        if(WIN32)
+            target_compile_definitions("${name}" PRIVATE
+                -D_CRT_SECURE_NO_WARNINGS
+                -DWIN32_LEAN_AND_MEAN
+                -DWIN32
+            )
+            target_link_libraries("${name}" PRIVATE unofficial::getopt-win32::getopt Ws2_32)
+        endif()
+    endfunction(add_tool)
+
+    add_tool(inetcat "tools/inetcat.c")
+    add_tool(iproxy "tools/iproxy.c")
+
+    install(
+        TARGETS inetcat iproxy
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    )
+endif()

--- a/ports/libusbmuxd/portfile.cmake
+++ b/ports/libusbmuxd/portfile.cmake
@@ -9,18 +9,29 @@ vcpkg_from_github(
         002_fix_struct_pack.patch
         003_fix_msvc.patch
         004_fix_api.patch
+        005_fix_tools_msvc.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/exports.def" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 vcpkg_fixup_pkgconfig()
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES inetcat iproxy AUTO_CLEAN)
+endif()
 
 file(READ "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-${PORT}-config.cmake" cmake_config)
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-${PORT}-config.cmake"

--- a/ports/libusbmuxd/vcpkg.json
+++ b/ports/libusbmuxd/vcpkg.json
@@ -18,9 +18,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "tools"
-  ],
   "features": {
     "tools": {
       "description": "build command line tool",

--- a/ports/libusbmuxd/vcpkg.json
+++ b/ports/libusbmuxd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libusbmuxd",
   "version-date": "2023-06-21",
+  "port-version": 1,
   "description": "A client library to multiplex connections from and to iOS devices",
   "homepage": "https://libimobiledevice.org/",
   "license": "LGPL-2.1-or-later",
@@ -16,5 +17,17 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "tools"
+  ],
+  "features": {
+    "tools": {
+      "description": "build command line tool",
+      "supports": "!android & !ios & !xbox",
+      "dependencies": [
+        "getopt"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4790,7 +4790,7 @@
     },
     "libusbmuxd": {
       "baseline": "2023-06-21",
-      "port-version": 0
+      "port-version": 1
     },
     "libuuid": {
       "baseline": "1.0.3",

--- a/versions/l-/libusbmuxd.json
+++ b/versions/l-/libusbmuxd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "956fa0cebe739a612d015c79b3f6dfa5d76fee4c",
+      "version-date": "2023-06-21",
+      "port-version": 1
+    },
+    {
       "git-tree": "7a9145917e1df41e8820d26c2e167f3839d7a947",
       "version-date": "2023-06-21",
       "port-version": 0

--- a/versions/l-/libusbmuxd.json
+++ b/versions/l-/libusbmuxd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "956fa0cebe739a612d015c79b3f6dfa5d76fee4c",
+      "git-tree": "ba5bfe9a2e679d22d3b3b520e432c493df3919e9",
       "version-date": "2023-06-21",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

See also #33246 