### PR TITLE
[octomap] fix c++20 compilation error

### DIFF
--- a/ports/octomap/fix-compilation.patch
+++ b/ports/octomap/fix-compilation.patch
@@ -1,0 +1,22 @@
+diff --git a/octomap/include/octomap/ScanGraph.h b/octomap/include/octomap/ScanGraph.h
+index 07c7436..e54eaf5 100644
+--- a/octomap/include/octomap/ScanGraph.h
++++ b/octomap/include/octomap/ScanGraph.h
+@@ -60,7 +60,7 @@ namespace octomap {
+ 
+     ~ScanNode();
+ 
+-    bool operator == (const ScanNode& other) {
++    bool operator == (const ScanNode& other) const {
+       return (id == other.id);
+     }
+ 
+@@ -87,7 +87,7 @@ namespace octomap {
+       : first(_first), second(_second), constraint(_constraint), weight(1.0) { }
+     ScanEdge() {}
+ 
+-    bool operator == (const ScanEdge& other) {
++    bool operator == (const ScanEdge& other) const {
+       return ( (*first == *(other.first) ) && ( *second == *(other.second) ) );
+     }
+ 

--- a/ports/octomap/portfile.cmake
+++ b/ports/octomap/portfile.cmake
@@ -7,7 +7,8 @@ vcpkg_from_github(
     SHA512 ec321a5355091acbd3d3fda7c858e2078c29195e73461c8a34db2c4614c6b2e38b35a59671f1071f7eb397cac4df78869f14a13af2e68d64e5a2e2d8727846cd
     HEAD_REF master
     PATCHES
-      "001-fix-exported-targets.patch"
+      001-fix-exported-targets.patch
+      fix-compilation.patch
 )
 
 vcpkg_cmake_configure(
@@ -38,7 +39,7 @@ endif()
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/octomap")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/octomap/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/octomap/LICENSE.txt")
 
 vcpkg_copy_pdbs()
 

--- a/ports/octomap/vcpkg.json
+++ b/ports/octomap/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "octomap",
   "version": "1.9.6",
+  "port-version": 1,
   "description": "An Efficient Probabilistic 3D Mapping Framework Based on Octrees",
   "homepage": "https://octomap.github.io/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5922,7 +5922,7 @@
     },
     "octomap": {
       "baseline": "1.9.6",
-      "port-version": 0
+      "port-version": 1
     },
     "ode": {
       "baseline": "0.16.3",

--- a/versions/o-/octomap.json
+++ b/versions/o-/octomap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b778b0aef20fee697a18865995fff021501e8509",
+      "version": "1.9.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "b6146ecee8dcf9ba6573d11f26c1574e89c546d8",
       "version": "1.9.6",
       "port-version": 0


### PR DESCRIPTION
Fixes #31990 

````
current octomap version doesn't compile on latset version of Visual Studio 2017 (15.6).
````
This is fixed in the following (closed) PR:

https://github.com/OctoMap/octomap/pull/398

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
