### PR TITLE
[opentelemetry-cpp] Fix warning and miss include files

### DIFF
--- a/ports/opentelemetry-cpp/add-missing-include-file.patch
+++ b/ports/opentelemetry-cpp/add-missing-include-file.patch
@@ -1,0 +1,22 @@
+diff --git a/exporters/jaeger/src/TUDPTransport.cc b/exporters/jaeger/src/TUDPTransport.cc
+index e411127..0ff5296 100644
+--- a/exporters/jaeger/src/TUDPTransport.cc
++++ b/exporters/jaeger/src/TUDPTransport.cc
+@@ -2,7 +2,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ #include <sstream>  // std::stringstream
+-
++#include <unistd.h>
+ #include "TUDPTransport.h"
+ #include "opentelemetry/sdk_config.h"
+ 
+@@ -48,7 +48,7 @@ void TUDPTransport::open()
+   hints.ai_socktype = SOCK_DGRAM;
+   hints.ai_flags    = AI_PASSIVE | AI_ADDRCONFIG;
+ 
+-  sprintf(port, "%d", port_);
++  snprintf(port, sizeof(port), "%d", port_);
+ 
+   error = getaddrinfo(host_.c_str(), port, &hints, &server_addr_info_);
+ 

--- a/ports/opentelemetry-cpp/add-missing-include-file.patch
+++ b/ports/opentelemetry-cpp/add-missing-include-file.patch
@@ -1,17 +1,19 @@
 diff --git a/exporters/jaeger/src/TUDPTransport.cc b/exporters/jaeger/src/TUDPTransport.cc
-index e411127..0ff5296 100644
+index e411127..a5e08fa 100644
 --- a/exporters/jaeger/src/TUDPTransport.cc
 +++ b/exporters/jaeger/src/TUDPTransport.cc
-@@ -2,7 +2,7 @@
+@@ -2,7 +2,9 @@
  // SPDX-License-Identifier: Apache-2.0
  
  #include <sstream>  // std::stringstream
 -
++#ifndef _MSC_VER
 +#include <unistd.h>
++#endif
  #include "TUDPTransport.h"
  #include "opentelemetry/sdk_config.h"
  
-@@ -48,7 +48,7 @@ void TUDPTransport::open()
+@@ -48,7 +50,7 @@ void TUDPTransport::open()
    hints.ai_socktype = SOCK_DGRAM;
    hints.ai_flags    = AI_PASSIVE | AI_ADDRCONFIG;
  

--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
         add-missing-dependencies.patch
         # Missing find_dependency for Abseil
         add-missing-find-dependency.patch
+        add-missing-include-file.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.9.1",
+  "port-version": 1,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6142,7 +6142,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "opentelemetry-fluentd": {
       "baseline": "2.0.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "757cf2a1abda3e6890de80f9675445ce4d494167",
+      "version-semver": "1.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "47c5c172ee9a7c663746a3c1cbabb359a1cbaf56",
       "version-semver": "1.9.1",
       "port-version": 0

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "757cf2a1abda3e6890de80f9675445ce4d494167",
+      "git-tree": "3ad2a8625bd852a203f6156970c0eada6f90c192",
       "version-semver": "1.9.1",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/33800

Note: Replace old function `sprintf` to prevent buffer overflow.
```
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/opentelemetry-cpp/src/v1.9.1-711a32e9e2.clean/exporters/jaeger/src/TUDPTransport.cc:51:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  sprintf(port, "%d", port_);
  ^
```
Add the missing header file to ensure that the `THRIFT_CLOSESOCKET` macro defined in `PlatformSocket.h` maps to the `close` function.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
