### PR TITLE
[gstreamer] update to 1.22.5

### DIFF
--- a/ports/gstreamer/fix-clang-cl-bad.patch
+++ b/ports/gstreamer/fix-clang-cl-bad.patch
@@ -1,8 +1,8 @@
 diff --git a/subprojects/gst-plugins-bad/ext/dts/meson.build b/subprojects/gst-plugins-bad/ext/dts/meson.build
-index 8ab3fc917..c19aa2264 100644
+index c4868a4..6b34cb7 100644
 --- a/subprojects/gst-plugins-bad/ext/dts/meson.build
 +++ b/subprojects/gst-plugins-bad/ext/dts/meson.build
-@@ -15,7 +15,7 @@ if not dca_dep.found()
+@@ -20,7 +20,7 @@ if not dca_dep.found()
  endif
  
  no_warn_c_args = []
@@ -12,10 +12,10 @@ index 8ab3fc917..c19aa2264 100644
    # can point to a non-existing location (/usr/include/dca)
    no_warn_c_args = ['-Wno-missing-include-dirs']
 diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
-index 4a844ef75..cd97e8f7a 100644
+index 160080a..6acf110 100644
 --- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
 +++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
-@@ -174,7 +174,7 @@ endif
+@@ -158,7 +158,7 @@ endif
  
  # MinGW 32bits compiler seems to be complaining about redundant-decls
  # when ComPtr is in use. Let's just disable the warning
@@ -25,12 +25,13 @@ index 4a844ef75..cd97e8f7a 100644
      '-Wno-redundant-decls',
    ])
 diff --git a/subprojects/gst-plugins-bad/meson.build b/subprojects/gst-plugins-bad/meson.build
-index 7cab556e0..35531110b 100644
+index 84eeb17..1743f41 100644
 --- a/subprojects/gst-plugins-bad/meson.build
 +++ b/subprojects/gst-plugins-bad/meson.build
-@@ -45,7 +45,7 @@ endif
- 
+@@ -54,7 +54,7 @@ endif
+
  cdata = configuration_data()
+ cdata.set('ENABLE_NLS', 1)
  
 -if cc.get_id() == 'msvc'
 +if cc.get_argument_syntax() == 'msvc'
@@ -38,7 +39,7 @@ index 7cab556e0..35531110b 100644
        # Ignore several spurious warnings for things gstreamer does very commonly
        # If a warning is completely useless and spammy, use '/wdXXXX' to suppress it
 diff --git a/subprojects/gst-plugins-bad/sys/asio/meson.build b/subprojects/gst-plugins-bad/sys/asio/meson.build
-index 3006d26ce..1afbd0022 100644
+index c61ad4e..b30793c 100644
 --- a/subprojects/gst-plugins-bad/sys/asio/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/asio/meson.build
 @@ -15,7 +15,7 @@ endif
@@ -51,10 +52,10 @@ index 3006d26ce..1afbd0022 100644
      error('asio plugin can only be built with MSVC')
    else
 diff --git a/subprojects/gst-plugins-bad/sys/d3d11/meson.build b/subprojects/gst-plugins-bad/sys/d3d11/meson.build
-index 43f213d9c..9c9e9b535 100644
+index 1368b79..8dd3b30 100644
 --- a/subprojects/gst-plugins-bad/sys/d3d11/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/d3d11/meson.build
-@@ -102,7 +102,7 @@ endif
+@@ -96,7 +96,7 @@ endif
  
  # MinGW 32bits compiler seems to be complaining about redundant-decls
  # when ComPtr is in use. Let's just disable the warning
@@ -77,10 +78,10 @@ index d869e79a4..c7b37a7c6 100644
      comutil_dep = cxx.find_library('comsuppw', required : get_option('decklink'))
      if comutil_dep.found()
 diff --git a/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build b/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build
-index 828954909..af570f9ff 100644
+index 6b9a059..40713ce 100644
 --- a/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build
-@@ -48,7 +48,7 @@ if host_system != 'windows' or mf_option.disabled()
+@@ -54,7 +54,7 @@ if host_system != 'windows' or mf_option.disabled()
    subdir_done()
  endif
  
@@ -90,10 +91,10 @@ index 828954909..af570f9ff 100644
      error('mediafoundation plugin can only be built with MSVC')
    endif
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/meson.build b/subprojects/gst-plugins-bad/sys/msdk/meson.build
-index a77160049..7c834d8ed 100644
+index 659b96c..92e6bc4 100644
 --- a/subprojects/gst-plugins-bad/sys/msdk/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/msdk/meson.build
-@@ -139,13 +139,13 @@ if have_mfx_ver134
+@@ -176,12 +176,12 @@ if use_onevpl and have_mfx_ver205
  endif
  
  if host_machine.system() == 'windows'
@@ -102,10 +103,9 @@ index a77160049..7c834d8ed 100644
      error('msdk plugin can only be built with MSVC')
    endif
    legacy_stdio_dep = cc.find_library('legacy_stdio_definitions', required: get_option('msdk'))
-   d3d11_dep = cc.find_library('d3d11', required: get_option('msdk'))
-   msdk_deps = declare_dependency(dependencies: [d3d11_dep, legacy_stdio_dep])
--  msdk_deps_found = d3d11_dep.found() and legacy_stdio_dep.found() and cc.get_id() == 'msvc'
+   msdk_deps = declare_dependency(dependencies: [gstd3d11_dep, legacy_stdio_dep])
+-  msdk_deps_found = gstd3d11_dep.found() and legacy_stdio_dep.found() and cc.get_id() == 'msvc'
 +  msdk_deps_found = d3d11_dep.found() and legacy_stdio_dep.found() and cc.get_argument_syntax() == 'msvc'
  else
-   libva_dep = dependency('libva', required: get_option('msdk'))
-   libva_drm_dep = dependency('libva-drm', required: get_option('msdk'))
+   libdl_dep = cc.find_library('dl', required: get_option('msdk'))
+   libgudev_dep = dependency('gudev-1.0', required: get_option('msdk'))

--- a/ports/gstreamer/fix-clang-cl-base.patch
+++ b/ports/gstreamer/fix-clang-cl-base.patch
@@ -1,8 +1,8 @@
 diff --git a/subprojects/gst-plugins-base/meson.build b/subprojects/gst-plugins-base/meson.build
-index 495671ebb..fff3ea518 100644
+index c040bc9..ce9071c 100644
 --- a/subprojects/gst-plugins-base/meson.build
 +++ b/subprojects/gst-plugins-base/meson.build
-@@ -43,7 +43,7 @@ plugins = []
+@@ -51,7 +51,7 @@ gst_libraries = []
  
  cc = meson.get_compiler('c')
  
@@ -11,12 +11,3 @@ index 495671ebb..fff3ea518 100644
    msvc_args = [
        # Ignore several spurious warnings for things gstreamer does very commonly
        # If a warning is completely useless and spammy, use '/wdXXXX' to suppress it
-@@ -75,7 +75,7 @@ endif
- core_conf = configuration_data()
- 
- # Symbol visibility
--if cc.get_id() == 'msvc'
-+if cc.get_argument_syntax() == 'msvc'
-   export_define = '__declspec(dllexport) extern'
- elif cc.has_argument('-fvisibility=hidden')
-   add_project_arguments('-fvisibility=hidden', language: 'c')

--- a/ports/gstreamer/fix-clang-cl-gstreamer.patch
+++ b/ports/gstreamer/fix-clang-cl-gstreamer.patch
@@ -1,5 +1,5 @@
 diff --git a/subprojects/gstreamer/gst/parse/meson.build b/subprojects/gstreamer/gst/parse/meson.build
-index 35ed6f2f4..5e38e49ea 100644
+index b79a07c..891f907 100644
 --- a/subprojects/gstreamer/gst/parse/meson.build
 +++ b/subprojects/gstreamer/gst/parse/meson.build
 @@ -16,7 +16,7 @@ else
@@ -12,10 +12,10 @@ index 35ed6f2f4..5e38e49ea 100644
  else
    flex_cdata.set('FLEX_ARGS', '')
 diff --git a/subprojects/gstreamer/meson.build b/subprojects/gstreamer/meson.build
-index 772809e15..70b1eafc5 100644
+index 941bedc..cd37a40 100644
 --- a/subprojects/gstreamer/meson.build
 +++ b/subprojects/gstreamer/meson.build
-@@ -36,7 +36,7 @@ cc = meson.get_compiler('c')
+@@ -47,7 +47,7 @@ endif
  
  cdata = configuration_data()
  
@@ -24,16 +24,7 @@ index 772809e15..70b1eafc5 100644
    msvc_args = [
        # Ignore several spurious warnings for things gstreamer does very commonly
        # If a warning is completely useless and spammy, use '/wdXXXX' to suppress it
-@@ -61,7 +61,7 @@ endif
- 
- # Symbol visibility
- have_visibility_hidden = false
--if cc.get_id() == 'msvc'
-+if cc.get_argument_syntax() == 'msvc'
-   export_define = '__declspec(dllexport) extern'
- elif cc.has_argument('-fvisibility=hidden')
-   add_project_arguments('-fvisibility=hidden', language: 'c')
-@@ -313,8 +313,10 @@ static __uint128_t v2 = 10;
+@@ -347,8 +347,10 @@ static __uint128_t v2 = 10;
  static __uint128_t u;
  u = v1 / v2;
  }'''
@@ -46,12 +37,3 @@ index 772809e15..70b1eafc5 100644
  endif
  
  # All supported platforms have long long now
-@@ -322,7 +324,7 @@ cdata.set('HAVE_LONG_LONG', 1)
- 
- # We only want to use the __declspec(dllexport/import) dance in GST_EXPORT when
- # building with MSVC
--if cc.get_id() == 'msvc'
-+if cc.get_argument_syntax() == 'msvc'
-   cdata.set('GSTCONFIG_BUILT_WITH_MSVC', 1)
- else
-   cdata.set('GSTCONFIG_BUILT_WITH_MSVC', 0)

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -8,8 +8,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gstreamer/gstreamer
-    REF 1.20.5
-    SHA512 2a996d8ac0f70c34dbbc02c875026df6e89346f0844fbaa25475075bcb6e57c81ceb7d71e729c3259eace851e3d7222cb3fe395e375d93eb45b1262a6ede1fdb
+    REF ${VERSION}
+    SHA512 0d69896d0a83452320df0d0f56c710df1365a259cd3f48dc7cd4df18d45b27caea7174aafa15ae5eb8637ccdef192c1047185b369b7232db4eaacbc57ffaaa22
     HEAD_REF master
     PATCHES
         fix-clang-cl.patch

--- a/ports/gstreamer/srtp_fix.patch
+++ b/ports/gstreamer/srtp_fix.patch
@@ -1,8 +1,8 @@
 diff --git a/subprojects/gst-plugins-bad/ext/srtp/meson.build b/subprojects/gst-plugins-bad/ext/srtp/meson.build
-index 7f947191ae..b4a8e9c2a8 100644
+index 49eed5b..db5aed0 100644
 --- a/subprojects/gst-plugins-bad/ext/srtp/meson.build
 +++ b/subprojects/gst-plugins-bad/ext/srtp/meson.build
-@@ -6,12 +6,14 @@ srtp_sources = [
+@@ -6,13 +6,15 @@ srtp_sources = [
    'gstsrtpenc.c',
  ]
  
@@ -10,6 +10,7 @@ index 7f947191ae..b4a8e9c2a8 100644
 +
  srtp_cargs = []
  if get_option('srtp').disabled()
+   srtp_dep = dependency('', required : false)
    subdir_done()
  endif
  
@@ -18,12 +19,12 @@ index 7f947191ae..b4a8e9c2a8 100644
  if srtp_dep.found()
    srtp_cargs += ['-DHAVE_SRTP2']
  else
-@@ -37,7 +39,7 @@ if srtp_dep.found()
+@@ -38,7 +40,7 @@ if srtp_dep.found()
      include_directories : [configinc],
      dependencies : [gstrtp_dep, gstvideo_dep, srtp_dep],
      install : true,
 -    install_dir : plugins_install_dir,
 +    install_dir : gst_plugins_install_dir,
    )
-   pkgconfig.generate(gstsrtp, install_dir : plugins_pkgconfig_install_dir)
    plugins += [gstsrtp]
+ endif

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gstreamer",
-  "version": "1.20.5",
-  "port-version": 11,
+  "version": "1.22.5",
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -464,6 +464,9 @@ gsoap:x64-windows-static-md = skip
 gstreamer:arm-neon-android=fail
 gstreamer:arm64-android=fail
 gstreamer:x64-android=fail
+# upstream issue https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1629.
+gstreamer:x64-windows-static = skip
+gstreamer:x64-windows-static-md = skip
 gtk:x64-windows-static=fail
 gtk:x64-windows-static-md=fail
 gts:arm-neon-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3057,8 +3057,8 @@
       "port-version": 2
     },
     "gstreamer": {
-      "baseline": "1.20.5",
-      "port-version": 11
+      "baseline": "1.22.5",
+      "port-version": 0
     },
     "gtest": {
       "baseline": "1.13.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76183f0a0e77acbf09ac1ae73b1b2a27f986fcf6",
+      "version": "1.22.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ad3c702668f673319b620729150bce73d2181eb",
       "version": "1.20.5",
       "port-version": 11


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33784
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
