### PR TITLE
[upb] tools no uwp

### DIFF
--- a/ports/upb/0001-make-cmakelists-py.patch
+++ b/ports/upb/0001-make-cmakelists-py.patch
@@ -1,16 +1,15 @@
 diff --git a/cmake/make_cmakelists.py b/cmake/make_cmakelists.py
-index d64c14f..e5f76b2 100644
+index d64c14f6..ad3597c3 100755
 --- a/cmake/make_cmakelists.py
 +++ b/cmake/make_cmakelists.py
-@@ -315,11 +315,135 @@ class Converter(object):
-     elseif(UNIX)
+@@ -316,10 +316,136 @@ class Converter(object):
        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id")
      endif()
-+    
+ 
 +    if (MSVC)
 +      add_compile_options(/wd4146 /wd4703 -D_CRT_SECURE_NO_WARNINGS)
 +    endif()
- 
++
      enable_testing()
  
 +    set(CMAKE_CXX_STANDARD 11)
@@ -49,6 +48,7 @@ index d64c14f..e5f76b2 100644
 +        absl::flat_hash_map
 +        absl::strings
 +        protobuf::libprotobuf
++        protobuf::libprotoc
 +      )
 +
 +      add_executable(protoc-gen-upb
@@ -64,6 +64,7 @@ index d64c14f..e5f76b2 100644
 +        absl::flat_hash_set
 +        absl::strings
 +        protobuf::libprotobuf
++        protobuf::libprotoc
 +      )
 +
 +      set(PROTOC_PROGRAM "\$<TARGET_FILE:protobuf::protoc>")

--- a/ports/upb/0001-make-cmakelists-py.patch
+++ b/ports/upb/0001-make-cmakelists-py.patch
@@ -1,15 +1,16 @@
 diff --git a/cmake/make_cmakelists.py b/cmake/make_cmakelists.py
-index d64c14f6..ad3597c3 100755
+index d64c14f..e5f76b2 100644
 --- a/cmake/make_cmakelists.py
 +++ b/cmake/make_cmakelists.py
-@@ -316,10 +316,136 @@ class Converter(object):
+@@ -315,11 +315,135 @@ class Converter(object):
+     elseif(UNIX)
        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id")
      endif()
- 
++    
 +    if (MSVC)
 +      add_compile_options(/wd4146 /wd4703 -D_CRT_SECURE_NO_WARNINGS)
 +    endif()
-+
+ 
      enable_testing()
  
 +    set(CMAKE_CXX_STANDARD 11)
@@ -48,7 +49,6 @@ index d64c14f6..ad3597c3 100755
 +        absl::flat_hash_map
 +        absl::strings
 +        protobuf::libprotobuf
-+        protobuf::libprotoc
 +      )
 +
 +      add_executable(protoc-gen-upb
@@ -64,7 +64,6 @@ index d64c14f6..ad3597c3 100755
 +        absl::flat_hash_set
 +        absl::strings
 +        protobuf::libprotobuf
-+        protobuf::libprotoc
 +      )
 +
 +      set(PROTOC_PROGRAM "\$<TARGET_FILE:protobuf::protoc>")

--- a/ports/upb/vcpkg.json
+++ b/ports/upb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "upb",
   "version-date": "2022-06-21",
+  "port-version": 1,
   "description": "μpb (often written 'upb') is a small protobuf implementation written in C.",
   "homepage": "https://github.com/protocolbuffers/upb/",
   "license": "BSD-2-Clause",
@@ -27,7 +28,8 @@
       "dependencies": [
         "abseil",
         "protobuf"
-      ]
+      ],
+      "supports": "!uwp"
     }
   }
 }

--- a/ports/upb/vcpkg.json
+++ b/ports/upb/vcpkg.json
@@ -25,11 +25,11 @@
   "features": {
     "codegen": {
       "description": "Build code generator machinery",
+      "supports": "!uwp",
       "dependencies": [
         "abseil",
         "protobuf"
-      ],
-      "supports": "!uwp"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8458,7 +8458,7 @@
     },
     "upb": {
       "baseline": "2022-06-21",
-      "port-version": 0
+      "port-version": 1
     },
     "urdfdom": {
       "baseline": "3.1.1",

--- a/versions/u-/upb.json
+++ b/versions/u-/upb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7b5472d2c1c279cbe76384cdfffd09a7739ea6a9",
+      "git-tree": "1d7a6a503d8e111f919697470e47030cba1172b3",
       "version-date": "2022-06-21",
       "port-version": 1
     },

--- a/versions/u-/upb.json
+++ b/versions/u-/upb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b5472d2c1c279cbe76384cdfffd09a7739ea6a9",
+      "version-date": "2022-06-21",
+      "port-version": 1
+    },
+    {
       "git-tree": "4a5b5306d38f1a58f65c98c236b84ca297501ab1",
       "version-date": "2022-06-21",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/33775
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Note: 
`protoc` does not support `uwp`.

Same error and explanation:
https://github.com/microsoft/vcpkg/issues/33622#issuecomment-1711233787
```
protoc-gen-upbdefs.cc.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: __cdecl google::protobuf::compiler::CodeGenerator::CodeGenerator(void)" (__imp_??0CodeGenerator@compiler@protobuf@google@@QEAA@XZ) referenced in function "public: __cdecl upbc::`anonymous namespace'::Generator::Generator(void)" (??0Generator@?A0x1ec6339d@upbc@@QEAA@XZ)
protoc-gen-upbdefs.cc.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: virtual __cdecl google::protobuf::compiler::CodeGenerator::~CodeGenerator(void)" (__imp_??1CodeGenerator@compiler@protobuf@google@@UEAA@XZ) referenced in function "private: virtual __cdecl upbc::`anonymous namespace'::Generator::~Generator(void)" (??1Generator@?A0x1ec6339d@upbc@@EEAA@XZ)
protoc-gen-upbdefs.cc.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) void __cdecl google::protobuf::compiler::ParseGeneratorParameter(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::vector<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >,class std::allocator<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > > > *)" (__imp_?ParseGeneratorParameter@compiler@protobuf@google@@YAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEAV?$vector@U?$pair@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V12@@std@@V?$allocator@U?$pair@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V12@@std@@@2@@5@@Z) referenced in function "private: virtual bool __cdecl upbc::`anonymous namespace'::Generator::Generate(class google::protobuf::FileDescriptor const *,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class google::protobuf::compiler::GeneratorContext *,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)const " (?Generate@Generator@?A0x1ec6339d@upbc@@EEBA_NPEBVFileDescriptor@protobuf@google@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEAVGeneratorContext@compiler@56@PEAV78@@Z)
protoc-gen-upbdefs.cc.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) int __cdecl google::protobuf::compiler::PluginMain(int,char * * const,class google::protobuf::compiler::CodeGenerator const *)" (__imp_?PluginMain@compiler@protobuf@google@@YAHHQEAPEADPEBVCodeGenerator@123@@Z) referenced in function main
protoc-gen-upbdefs.cc.obj : error LNK2001: unresolved external symbol "public: virtual bool __cdecl google::protobuf::compiler::CodeGenerator::HasGenerateAll(void)const " (?HasGenerateAll@CodeGenerator@compiler@protobuf@google@@UEBA_NXZ)
protoc-gen-upbdefs.cc.obj : error LNK2001: unresolved external symbol "public: virtual bool __cdecl google::protobuf::compiler::CodeGenerator::GenerateAll(class std::vector<class google::protobuf::FileDescriptor const *,class std::allocator<class google::protobuf::FileDescriptor const *> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class google::protobuf::compiler::GeneratorContext *,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)const " (?GenerateAll@CodeGenerator@compiler@protobuf@google@@UEBA_NAEBV?$vector@PEBVFileDescriptor@protobuf@google@@V?$allocator@PEBVFileDescriptor@protobuf@google@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@6@PEAVGeneratorContext@234@PEAV76@@Z)
```
<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
