### PR TITLE
[libirecovery] Add tools feature

### DIFF
--- a/ports/libirecovery/003_fix_msvc.patch
+++ b/ports/libirecovery/003_fix_msvc.patch
@@ -23,17 +23,3 @@ index 45ff6f2..d9ff1e6 100644
  struct irecv_client_private {
  	int debug;
  	int usb_config;
-diff --git a/tools/irecovery.c b/tools/irecovery.c
-index 34e80bf..deffe89 100644
---- a/tools/irecovery.c
-+++ b/tools/irecovery.c
-@@ -27,7 +27,9 @@
- 
- #include <stdio.h>
- #include <stdlib.h>
-+#ifndef _MSC_VER
- #include <unistd.h>
-+#endif
- #include <string.h>
- #include <getopt.h>
- #include <inttypes.h>

--- a/ports/libirecovery/004_fix_tools_msvc.patch
+++ b/ports/libirecovery/004_fix_tools_msvc.patch
@@ -1,0 +1,14 @@
+diff --git a/tools/irecovery.c b/tools/irecovery.c
+index 34e80bf..deffe89 100644
+--- a/tools/irecovery.c
++++ b/tools/irecovery.c
+@@ -27,7 +27,9 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifndef _MSC_VER
+ #include <unistd.h>
++#endif
+ #include <string.h>
+ #include <getopt.h>
+ #include <inttypes.h>

--- a/ports/libirecovery/CMakeLists.txt
+++ b/ports/libirecovery/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(libirecovery C)
 
+option(BUILD_TOOLS "Build tools." OFF)
+
 include(GNUInstallDirs)
 
 file(GLOB_RECURSE LIBIRECOVERY_HEADER include/*.h)
@@ -22,17 +24,16 @@ endif()
 
 if(WIN32)
     list(APPEND DEFINITIONS -D_CRT_SECURE_NO_WARNINGS)
+    list(APPEND DEFINITIONS -DWIN32_LEAN_AND_MEAN)
     list(APPEND DEFINITIONS -DWIN32)
 endif()
 
 find_package(unofficial-libimobiledevice-glue CONFIG REQUIRED)
 
 add_library(libirecovery ${LIBIRECOVERY_SOURCE})
-target_include_directories(libirecovery
-    PRIVATE
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-    PUBLIC
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+target_include_directories(libirecovery PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 target_compile_definitions(libirecovery PRIVATE ${DEFINITIONS})
 target_link_libraries(libirecovery
@@ -85,3 +86,40 @@ install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/libirecovery-1.0.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
+
+if(BUILD_TOOLS)
+    add_executable(irecovery "tools/irecovery.c")
+    target_compile_definitions(irecovery PRIVATE
+        -DPACKAGE_VERSION="1.1.0"
+        -DPACKAGE_URL="https://github.com/libimobiledevice/libirecovery"
+        -DPACKAGE_BUGREPORT="https://github.com/libimobiledevice/libirecovery/issues"
+    )
+    if(NOT BUILD_SHARED_LIBS)
+        target_compile_definitions(irecovery PRIVATE -DIRECV_STATIC)
+    endif()
+    if(WIN32)
+        target_compile_definitions(irecovery PRIVATE
+            -D_CRT_SECURE_NO_WARNINGS
+            -DWIN32_LEAN_AND_MEAN
+            -DWIN32
+        )
+        find_package(unofficial-getopt-win32 REQUIRED)
+        target_link_libraries(irecovery PRIVATE unofficial::getopt-win32::getopt Ws2_32)
+    endif()
+    if(APPLE)
+        target_compile_definitions(irecovery PRIVATE -DHAVE_IOKIT)
+        target_link_libraries(irecovery PRIVATE "-framework IOKit" "-framework CoreFoundation")
+    endif()
+    if(NOT WIN32 AND NOT APPLE)
+        find_package(libusb CONFIG REQUIRED)
+        target_include_directories(irecovery PRIVATE ${LIBUSB_INCLUDE_DIRS})
+        target_link_libraries(irecovery PRIVATE ${LIBUSB_LIBRARIES})
+    endif()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(readline REQUIRED IMPORTED_TARGET readline)
+    target_link_libraries(irecovery PRIVATE libirecovery PkgConfig::readline)
+    install(
+        TARGETS irecovery
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    )
+endif()

--- a/ports/libirecovery/portfile.cmake
+++ b/ports/libirecovery/portfile.cmake
@@ -8,17 +8,33 @@ vcpkg_from_github(
         001_fix_static_build.patch
         002_fix_api.patch
         003_fix_msvc.patch
+        004_fix_tools_msvc.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
+
+if("tools" IN_LIST FEATURES)
+    vcpkg_find_acquire_program(PKGCONFIG)
+    list(APPEND FEATURE_OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 vcpkg_fixup_pkgconfig()
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES irecovery AUTO_CLEAN)
+endif()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libirecovery.h"

--- a/ports/libirecovery/vcpkg.json
+++ b/ports/libirecovery/vcpkg.json
@@ -21,9 +21,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "tools"
-  ],
   "features": {
     "tools": {
       "description": "build command line tool",

--- a/ports/libirecovery/vcpkg.json
+++ b/ports/libirecovery/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libirecovery",
   "version-date": "2023-05-13",
+  "port-version": 1,
   "description": "Library and utility to talk to iBoot/iBSS via USB on Mac OS X, Windows, and Linux",
   "homepage": "https://libimobiledevice.org/",
   "license": "LGPL-2.1-or-later",
@@ -19,5 +20,18 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "tools"
+  ],
+  "features": {
+    "tools": {
+      "description": "build command line tool",
+      "supports": "!android & !ios & !xbox",
+      "dependencies": [
+        "getopt",
+        "readline"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4294,7 +4294,7 @@
     },
     "libirecovery": {
       "baseline": "2023-05-13",
-      "port-version": 0
+      "port-version": 1
     },
     "libjpeg-turbo": {
       "baseline": "3.0.0",

--- a/versions/l-/libirecovery.json
+++ b/versions/l-/libirecovery.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc3482c3dd98b3e0c380e15946fcda722bf63f0e",
+      "git-tree": "72b9637bc62e62eb478d09618545c419bf21ed48",
       "version-date": "2023-05-13",
       "port-version": 1
     },

--- a/versions/l-/libirecovery.json
+++ b/versions/l-/libirecovery.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc3482c3dd98b3e0c380e15946fcda722bf63f0e",
+      "version-date": "2023-05-13",
+      "port-version": 1
+    },
+    {
       "git-tree": "0e9b8ce22a277344a7f29c62f38bf44458a129ba",
       "version-date": "2023-05-13",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

See also #33246
This pr depends on #33892