### PR TITLE
[libideviceactivation] Add tools feature

### DIFF
--- a/ports/libideviceactivation/003_fix_tools_msvc.patch
+++ b/ports/libideviceactivation/003_fix_tools_msvc.patch
@@ -1,0 +1,14 @@
+diff --git a/tools/ideviceactivation.c b/tools/ideviceactivation.c
+index 757c54e..e75e9e9 100644
+--- a/tools/ideviceactivation.c
++++ b/tools/ideviceactivation.c
+@@ -28,7 +28,9 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#ifndef _MSC_VER
+ #include <unistd.h>
++#endif
+ #include <ctype.h>
+ #ifndef WIN32
+ #include <signal.h>

--- a/ports/libideviceactivation/CMakeLists.txt
+++ b/ports/libideviceactivation/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(libideviceactivation C)
 
+option(BUILD_TOOLS "Build tools." OFF)
+
 include(GNUInstallDirs)
 
 file(GLOB_RECURSE LIBIDEVICEACTIVATION_HEADER include/*.h)
@@ -18,6 +20,7 @@ endif()
 
 if(WIN32)
     list(APPEND DEFINITIONS -D_CRT_SECURE_NO_WARNINGS)
+    list(APPEND DEFINITIONS -DWIN32_LEAN_AND_MEAN)
     list(APPEND DEFINITIONS -DWIN32)
 endif()
 
@@ -27,11 +30,9 @@ find_package(CURL CONFIG REQUIRED)
 find_package(LibXml2 CONFIG REQUIRED)
 
 add_library(libideviceactivation ${LIBIDEVICEACTIVATION_SOURCE})
-target_include_directories(libideviceactivation
-    PRIVATE
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-    PUBLIC
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+target_include_directories(libideviceactivation PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 target_compile_definitions(libideviceactivation PRIVATE ${DEFINITIONS})
 target_link_libraries(libideviceactivation
@@ -78,3 +79,25 @@ install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/libideviceactivation-1.0.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
+
+if(BUILD_TOOLS)
+    add_executable(ideviceactivation "tools/ideviceactivation.c")
+    target_compile_definitions(ideviceactivation PRIVATE
+        -DPACKAGE_VERSION="1.1.1"
+        -DPACKAGE_URL="https://github.com/libimobiledevice/libideviceactivation"
+        -DPACKAGE_BUGREPORT="https://github.com/libimobiledevice/libideviceactivation/issues"
+    )
+    if(WIN32)
+        target_compile_definitions(ideviceactivation PRIVATE
+            -D_CRT_SECURE_NO_WARNINGS
+            -DWIN32_LEAN_AND_MEAN
+            -DWIN32
+        )
+    endif()
+    target_link_libraries(ideviceactivation PRIVATE libideviceactivation)
+
+    install(
+        TARGETS ideviceactivation
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    )
+endif()

--- a/ports/libideviceactivation/portfile.cmake
+++ b/ports/libideviceactivation/portfile.cmake
@@ -7,18 +7,29 @@ vcpkg_from_github(
     PATCHES
         001_fix_static_build.patch
         002_fix_api.patch
+        003_fix_tools_msvc.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/exports.def" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 vcpkg_fixup_pkgconfig()
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES ideviceactivation AUTO_CLEAN)
+endif()
 
 file(READ "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-${PORT}-config.cmake" cmake_config)
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-${PORT}-config.cmake"

--- a/ports/libideviceactivation/vcpkg.json
+++ b/ports/libideviceactivation/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libideviceactivation",
   "version-date": "2023-05-01",
+  "port-version": 1,
   "description": "A library to handle the activation process of iOS devices",
   "homepage": "https://libimobiledevice.org/",
   "license": "LGPL-2.1-or-later",
@@ -18,5 +19,14 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "tools"
+  ],
+  "features": {
+    "tools": {
+      "description": "build command line tool",
+      "supports": "!android & !ios & !xbox"
+    }
+  }
 }

--- a/ports/libideviceactivation/vcpkg.json
+++ b/ports/libideviceactivation/vcpkg.json
@@ -20,9 +20,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "tools"
-  ],
   "features": {
     "tools": {
       "description": "build command line tool",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4242,7 +4242,7 @@
     },
     "libideviceactivation": {
       "baseline": "2023-05-01",
-      "port-version": 0
+      "port-version": 1
     },
     "libidn2": {
       "baseline": "2.3.4",

--- a/versions/l-/libideviceactivation.json
+++ b/versions/l-/libideviceactivation.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad012d309ba365864f6de2d36909e057515904df",
+      "version-date": "2023-05-01",
+      "port-version": 1
+    },
+    {
       "git-tree": "5f8ea4177ba77bb2eb82284c8ee31504cb7dfbc7",
       "version-date": "2023-05-01",
       "port-version": 0

--- a/versions/l-/libideviceactivation.json
+++ b/versions/l-/libideviceactivation.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad012d309ba365864f6de2d36909e057515904df",
+      "git-tree": "2926e108a78ecdd707c707720093af757292f800",
       "version-date": "2023-05-01",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

See also #33246