### PR TITLE
[inginition-common3] update to 3.16.0

### DIFF
--- a/ports/ignition-common3/portfile.cmake
+++ b/ports/ignition-common3/portfile.cmake
@@ -1,8 +1,16 @@
-ignition_modular_library(NAME common
-                         VERSION "3.14.1"
-                         SHA512 5f83685b67cb0b8e295136f74a681e2ca5f00a730b0a221f0c00cab5f9049c84692185fb5924ab29cd07cbdf85450e81dfcdc984fc8af4ed4cc549b2fe2f9a6e
-                         OPTIONS -DUSE_EXTERNAL_TINYXML2=ON
-                         PATCHES fix-dependencies.patch)
+set(PACKAGE_NAME common)
+
+ignition_modular_library(
+   NAME ${PACKAGE_NAME}
+   REF ${PORT}_${VERSION}
+   VERSION ${VERSION}
+   SHA512 022f5f68cdc134fa84dc22b49dc43e5c62d6e987e7fd63630586716e43fb2aad57ab4fb470ea1c3884c79b910d403a94a4d47ac24ffbb6f3b89b36c5b0e708f8
+   OPTIONS 
+      -DUSE_EXTERNAL_TINYXML2=ON
+   PATCHES
+      fix-dependencies.patch
+)
+
 
 # Remove non-relocatable helper scripts (see https://github.com/ignitionrobotics/ign-common/issues/82)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin/ign_remotery_vis" "${CURRENT_PACKAGES_DIR}/debug/bin/ign_remotery_vis")

--- a/ports/ignition-common3/vcpkg.json
+++ b/ports/ignition-common3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ignition-common3",
-  "version": "3.14.1",
+  "version": "3.16.0",
   "description": "Common libraries for robotics applications",
   "homepage": "https://ignitionrobotics.org/libs/common",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3301,7 +3301,7 @@
       "port-version": 3
     },
     "ignition-common3": {
-      "baseline": "3.14.1",
+      "baseline": "3.16.0",
       "port-version": 0
     },
     "ignition-fuel-tools1": {

--- a/versions/i-/ignition-common3.json
+++ b/versions/i-/ignition-common3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae2e9feb5941cbe46f6aeaa757078c0074ed33fe",
+      "version": "3.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f63b7872dccdd6f71e0a075ea4bbf677c679a9d8",
       "version": "3.14.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


