### PR TITLE
[osg] Fix build error for release-only triplets

### DIFF
--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -136,10 +136,12 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-osg)
 
 # Add debug folder prefix for plugin targets. vcpkg_cmake_config_fixup only handles this for targets in bin/ and lib/.
 set(osg_plugins_debug_targets "${CURRENT_PACKAGES_DIR}/share/unofficial-osg/osg-plugins-debug.cmake")
-file(READ "${osg_plugins_debug_targets}" contents)
-string(REPLACE "${CURRENT_INSTALLED_DIR}" "\${_IMPORT_PREFIX}" contents "${contents}")
-string(REPLACE "\${_IMPORT_PREFIX}/plugins" "\${_IMPORT_PREFIX}/debug/plugins" contents "${contents}")
-file(WRITE "${osg_plugins_debug_targets}" "${contents}")
+if(EXISTS "${osg_plugins_debug_targets}")
+    file(READ "${osg_plugins_debug_targets}" contents)
+    string(REPLACE "${CURRENT_INSTALLED_DIR}" "\${_IMPORT_PREFIX}" contents "${contents}")
+    string(REPLACE "\${_IMPORT_PREFIX}/plugins" "\${_IMPORT_PREFIX}/debug/plugins" contents "${contents}")
+    file(WRITE "${osg_plugins_debug_targets}" "${contents}")
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(APPEND "${CURRENT_PACKAGES_DIR}/include/osg/Config" "#ifndef OSG_LIBRARY_STATIC\n#define OSG_LIBRARY_STATIC 1\n#endif\n")

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osg",
   "version": "3.6.5",
-  "port-version": 21,
+  "port-version": 22,
   "description": "The OpenSceneGraph is an open source high performance 3D graphics toolkit.",
   "homepage": "https://www.openscenegraph.com/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6206,7 +6206,7 @@
     },
     "osg": {
       "baseline": "3.6.5",
-      "port-version": 21
+      "port-version": 22
     },
     "osg-qt": {
       "baseline": "Qt5",

--- a/versions/o-/osg.json
+++ b/versions/o-/osg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27f28ccf9745bc2ca1757d5fa32b92373c176e2a",
+      "version": "3.6.5",
+      "port-version": 22
+    },
+    {
       "git-tree": "6e9d4d04aae606c5ac02c497b17774d37e74de7a",
       "version": "3.6.5",
       "port-version": 21


### PR DESCRIPTION
This fixes a regression mentioned in https://github.com/microsoft/vcpkg/pull/33782#issuecomment-1726425508 which affects triplets that only build release targets.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
