### PR TITLE
[harfbuzz] update to 8.2.1

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
     REF ${VERSION}
-    SHA512 6e6c56196157e1ccddbfb4717b15fb15821e43f0ebaf7de1d5c0d41ff5d2a58f9ada56bac0472e1a8f4abe8e9cf325fcda33b0b287ed7c1a41c0fc8854f8d36e
+    SHA512 23d6abbd270885d7ae1ebb3c981f0c331a48d891e23caffe9e254f5e7e205bb0348add7b371526166a49b336f8076f92c11ef76ca81f48a6fd9f58812ec96d79
     HEAD_REF master
 )
 

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "8.2.0",
-  "port-version": 1,
+  "version": "8.2.1",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3153,8 +3153,8 @@
       "port-version": 1
     },
     "harfbuzz": {
-      "baseline": "8.2.0",
-      "port-version": 1
+      "baseline": "8.2.1",
+      "port-version": 0
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6894af0b171aea403718ebb131b454a60b0c961a",
+      "version": "8.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "053b71e591f5599aa5e887fbf6531c7baa58b23d",
       "version": "8.2.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #33896.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
