### PR TITLE
[opencv4] Fix cuDNN feature for CUDA 12.2

### DIFF
--- a/ports/opencv4/0020-fix-compat-cuda12.2.patch
+++ b/ports/opencv4/0020-fix-compat-cuda12.2.patch
@@ -1,0 +1,32 @@
+commit ab8cb6f8a9034da2a289b84685c6d959266029be
+Author: cudawarped <12133430+cudawarped@users.noreply.github.com>
+Date:   Tue Aug 1 13:02:42 2023 +0300
+
+    cuda: fix for compatibility with CUDA Toolkit >= 12.2.0
+
+diff --git a/modules/dnn/src/cuda4dnn/primitives/normalize_bbox.hpp b/modules/dnn/src/cuda4dnn/primitives/normalize_bbox.hpp
+index f067dddaa7..91ff33f817 100644
+--- a/modules/dnn/src/cuda4dnn/primitives/normalize_bbox.hpp
++++ b/modules/dnn/src/cuda4dnn/primitives/normalize_bbox.hpp
+@@ -111,7 +111,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
+              * or there might be several weights
+              * or we don't have to scale
+              */
+-            if (weight != 1.0)
++            if (weight != static_cast<T>(1.0f))
+             {
+                 kernels::scale1_with_bias1<T>(stream, output, input, weight, 1.0);
+             }
+diff --git a/modules/dnn/src/cuda4dnn/primitives/region.hpp b/modules/dnn/src/cuda4dnn/primitives/region.hpp
+index d22d44214e..3af05155fe 100644
+--- a/modules/dnn/src/cuda4dnn/primitives/region.hpp
++++ b/modules/dnn/src/cuda4dnn/primitives/region.hpp
+@@ -121,7 +121,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
+                 new_coords
+             );
+ 
+-            if (nms_iou_threshold > 0) {
++            if (nms_iou_threshold > static_cast<T>(0.0f)) {
+                 auto output_mat = output_wrapper->getMutableHostMat();
+                 CV_Assert(output_mat.type() == CV_32F);
+                 for (int i = 0; i < input.get_axis_size(0); i++) {

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_from_github(
       0015-fix-freetype.patch
       0017-fix-flatbuffers.patch
       0019-missing-include.patch
+      0020-fix-compat-cuda12.2.patch
       "${ARM64_WINDOWS_FIX}"
 )
 # Disallow accidental build of vendored copies

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6082,7 +6082,7 @@
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 6
+      "port-version": 7
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef78c1958b122045e9d1e353150049431b3162fa",
+      "version": "4.8.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "6a1280a0a3854032ba4ae9172b509ce46f81795f",
       "version": "4.8.0",
       "port-version": 6


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #33874.

Adds fix from https://github.com/opencv/opencv/pull/24104 as a patch to the `opencv4` v4.8.0 port, to allow installing with `dnn-cuda` feature and CUDA 12.2.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
