### PR TITLE
[hikogui] update to version 0.8.1

### DIFF
--- a/ports/hikogui/portfile.cmake
+++ b/ports/hikogui/portfile.cmake
@@ -1,25 +1,22 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hikogui/hikogui
-    REF v0.7.0
-    SHA512 64555c67e5a44f336a3528d3a894d43e2751a1f4e4e4d9f6618c085ef0be4a502610a36625d95f79298080cb483f7361a758f7c43b4784999b0b5d839baacb28
+    REF v0.8.1
+    SHA512 1a711aeb83d4d84e89ba4895aea321b1e5120fc20e8124237ee575b14955edcfa991965cb80628e7c485a44ba13245ba76781582339f62939a8180a629de996a
     HEAD_REF main
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
-        -DHI_BUILD_TESTS=OFF
-        -DHI_BUILD_EXAMPLES=OFF
+        -DBUILD_TESTING=OFF
+        -DBUILD_EXAMPLES=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup()
-vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(NO_PREFIX_CORRECTION)
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE_1_0.txt")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/hikogui/vcpkg.json
+++ b/ports/hikogui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hikogui",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "maintainers": "@takev",
   "description": "A portable, low latency, retained-mode GUI framework written in C++.",
   "homepage": "https://github.com/hikogui/hikogui",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3213,7 +3213,7 @@
       "port-version": 0
     },
     "hikogui": {
-      "baseline": "0.7.0",
+      "baseline": "0.8.1",
       "port-version": 0
     },
     "hiredis": {

--- a/versions/h-/hikogui.json
+++ b/versions/h-/hikogui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92a9a5aedbc104981ec2fe41b097e8f2c65896f7",
+      "version": "0.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3ed99f330c9de6be97e6e2e25c3ff55080fbbcd5",
       "version": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
This pull requests updates the hikogui port from 0.7.0 to 0.8.1.

HikoGUI is now a header-only library, but it does include a full set of CMake import scripts.
The changes in the portfile.cmake reflects the changes to the new build system.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


