### PR TITLE
[sml2] add new port

### DIFF
--- a/ports/bext-sml2/portfile.cmake
+++ b/ports/bext-sml2/portfile.cmake
@@ -1,0 +1,15 @@
+# Header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO boost-ext/sml2
+    REF 6989e01776ab0d51a7b9463c307855d4a274888f
+    SHA512 215e404769b80da01735d4038ec8fd63804ef3dfb6b65fcbce38b9e90491d4758c28338a1d259776b2258e35f14a4fb27330fa730800cf7289d147cf5e580d4e
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/sml2"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/include/boost"
+)
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/bext-sml2/vcpkg.json
+++ b/ports/bext-sml2/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "bext-sml2",
+  "version-date": "2023-09-20",
+  "description": "Your scalable C++20 one header only State Machine Library with no dependencies",
+  "homepage": "https://github.com/boost-ext/sml2",
+  "license": "BSL-1.0"
+}

--- a/versions/b-/bext-sml2.json
+++ b/versions/b-/bext-sml2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b61fcb31fd93d5b99b7f039aa2c1bab7b5eec83a",
+      "version-date": "2023-09-20",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -556,6 +556,10 @@
       "baseline": "1.1.5",
       "port-version": 0
     },
+    "bext-sml2": {
+      "baseline": "2023-09-20",
+      "port-version": 0
+    },
     "bext-ut": {
       "baseline": "1.1.9",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- find_path(BEXT_SML2_INCLUDE_DIRS "boost/sml2")
     target_include_directories(main PRIVATE ${BEXT_SML2_INCLUDE_DIRS})
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
