### PR TITLE
[eventpp] update to 0.1.3

### DIFF
--- a/ports/eventpp/portfile.cmake
+++ b/ports/eventpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wqking/eventpp
-    REF v0.1.2
-    SHA512 01fd536024dfef8c4025fc184f6b6326a901849dbf73d81430d7cfadeff25c9c140ab6a28b0143a4090703668c1d9e743a54e874c0321c3453cf40aeb4583db3
+    REF "v${VERSION}"
+    SHA512 b39994e9bd581d6bb61b634c434c46075e41ec2217e1174578fefd206a927bd725744ae0724d319cde8f2b2a43d2e030a04c271197500d94c6b1afd849f779fd
     HEAD_REF master
 )
 
@@ -19,4 +19,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/license" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license")

--- a/ports/eventpp/vcpkg.json
+++ b/ports/eventpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "eventpp",
-  "version-semver": "0.1.2",
+  "version-semver": "0.1.3",
   "description": "C++ library for event dispatcher and callback list",
   "homepage": "https://github.com/wqking/eventpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2405,7 +2405,7 @@
       "port-version": 0
     },
     "eventpp": {
-      "baseline": "0.1.2",
+      "baseline": "0.1.3",
       "port-version": 0
     },
     "evpp": {

--- a/versions/e-/eventpp.json
+++ b/versions/e-/eventpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13f41aca93677fedad3baaf9ed698546434ae379",
+      "version-semver": "0.1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f11cacc8b5a6f9f2951992d29cee39e52ef601f",
       "version-semver": "0.1.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/33909
No feature needs to test.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
