### PR TITLE
[minizip] Fix build with android NDK r26

### DIFF
--- a/ports/minizip/CMakeLists.txt
+++ b/ports/minizip/CMakeLists.txt
@@ -41,10 +41,6 @@ else()
   message(STATUS "Building without bzip2 support")
 endif()
 
-if(ANDROID)
-  target_compile_definitions(minizip PRIVATE IOAPI_NO_64)
-endif()
-
 if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
   target_compile_definitions(minizip PRIVATE -DIOWIN32_USING_WINRT_API)
 endif()

--- a/ports/minizip/android-fileapi.patch
+++ b/ports/minizip/android-fileapi.patch
@@ -1,0 +1,17 @@
+diff --git a/contrib/minizip/ioapi.h b/contrib/minizip/ioapi.h
+index c588a18..b5395e2 100644
+--- a/contrib/minizip/ioapi.h
++++ b/contrib/minizip/ioapi.h
+@@ -21,6 +21,12 @@
+ #ifndef _ZLIBIOAPI64_H
+ #define _ZLIBIOAPI64_H
+ 
++#if defined(__ANDROID_API__) && __ANDROID_API__ < 24
++    // Cf. https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md#32_bit-and
++    // stdio functions for off_t are incomplete.
++    #define USE_FILE32API
++#endif
++
+ #if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))
+ 
+   // Linux needs this to support file operation on files larger then 4+GB

--- a/ports/minizip/portfile.cmake
+++ b/ports/minizip/portfile.cmake
@@ -12,13 +12,12 @@ vcpkg_from_github(
         android-fileapi.patch
 )
 
-vcpkg_cmake_get_vars(cmake_vars_file)
-include("${cmake_vars_file}")
-
 # Maintainer switch: Temporarily set this to 1 to re-generate the lists
 # of exported symbols. This is needed when the version is bumped.
 set(GENERATE_SYMBOLS 0)
 if(GENERATE_SYMBOLS)
+    vcpkg_cmake_get_vars(cmake_vars_file)
+    include("${cmake_vars_file}")
     if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
         vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
     else()

--- a/ports/minizip/portfile.cmake
+++ b/ports/minizip/portfile.cmake
@@ -2,13 +2,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO madler/zlib
-    REF v${VERSION}
+    REF "v${VERSION}"
     SHA512 78eecf335b14af1f7188c039a4d5297b74464d61156e4f12a485c74beec7d62c4159584ad482a07ec57ae2616d58873e45b09cb8ea822bb5b17e43d163df84e9
     HEAD_REF master
     PATCHES
         0001-remove-ifndef-NOUNCRYPT.patch
         0002-add-declaration-for-mkdir.patch
         pkgconfig.patch
+        android-fileapi.patch
 )
 
 vcpkg_cmake_get_vars(cmake_vars_file)

--- a/ports/minizip/vcpkg.json
+++ b/ports/minizip/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "minizip",
   "version": "1.3",
+  "port-version": 1,
   "description": "Minizip zip file manipulation library",
   "homepage": "https://github.com/madler/zlib",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5454,7 +5454,7 @@
     },
     "minizip": {
       "baseline": "1.3",
-      "port-version": 0
+      "port-version": 1
     },
     "minizip-ng": {
       "baseline": "4.0.0",

--- a/versions/m-/minizip.json
+++ b/versions/m-/minizip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "91fe1aaa8a5d696bda657a3d2b687fecfa92a7c3",
+      "version": "1.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "2295a5b26e2cbbbf59706f08dc1c5717da951bd1",
       "version": "1.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #33889. Tested with: 
arm-neon-android vs. arm64-android, 
API level 24 vs. vcpkg default (21), 
NDK r15 vs NDK r26.

AFAIU no 64 bit offsets can be used on 32 bit Android before API level 24, 
cf. https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md#32_bit-and
