### PR TITLE
[duktape] Update to 2.7.0 and don't require python2 to build.

### DIFF
--- a/ports/duktape/CMakeLists.txt
+++ b/ports/duktape/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 
 
 set(duktape_MAJOR_VERSION 2)
-set(duktape_MINOR_VERSION 4)
+set(duktape_MINOR_VERSION 7)
 set(duktape_PATCH_VERSION 0)
 set(duktape_VERSION ${duktape_MAJOR_VERSION}.${duktape_MINOR_VERSION}.${duktape_PATCH_VERSION})
 

--- a/ports/duktape/portfile.cmake
+++ b/ports/duktape/portfile.cmake
@@ -1,52 +1,18 @@
-if(VCPKG_TARGET_IS_LINUX)
-    message("${PORT} currently requires the following tools from the system package manager:\n    python-yaml\n\nThis can be installed on Ubuntu systems via apt-get install python-yaml PYTHON2-yaml (depending on your current python default interpreter)")
-endif()
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz
+    FILENAME duktape-2.7.0.tar.xz
+    SHA512 8ff5465c9c335ea08ebb0d4a06569c991b9dc4661b63e10da6b123b882e7375e82291d6b883c2644902d68071a29ccc880dae8229447cebe710c910b54496c1d
+)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO svaarala/duktape
-    REF 6001888049cb42656f8649db020e804bcdeca6a7 # v2.5.0
-    SHA512 ffbc7f1b16b7469ddfc0af0054a7891ffda128cc099e693773c6b4597ee6a96f8a08d354f7a7cf3a1f16369bef7b7a94c2670a617ec0355cc3614f56e1668dc4
-    HEAD_REF master
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/duktapeConfig.cmake.in" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
-if (VCPKG_TARGET_IS_WINDOWS)
-    set(EXECUTABLE_SUFFIX ".exe")
-    set(PYTHON_OPTION "")
-else()
-    set(EXECUTABLE_SUFFIX "")
-    set(PYTHON_OPTION "--user")
-endif()
-
-vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR "${PYTHON2}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON2_DIR}")
-
-if(NOT EXISTS "${PYTHON2_DIR}/easy_install${EXECUTABLE_SUFFIX}")
-    if(NOT EXISTS "${PYTHON2_DIR}/Scripts/pip${EXECUTABLE_SUFFIX}")
-        vcpkg_from_github(
-            OUT_SOURCE_PATH PYFILE_PATH
-            REPO pypa/get-pip
-            REF 309a56c5fd94bd1134053a541cb4657a4e47e09d #2019-08-25
-            SHA512 bb4b0745998a3205cd0f0963c04fb45f4614ba3b6fcbe97efe8f8614192f244b7ae62705483a5305943d6c8fedeca53b2e9905aed918d2c6106f8a9680184c7a
-            HEAD_REF master
-        )
-        execute_process(COMMAND ${PYTHON2_DIR}/python${EXECUTABLE_SUFFIX} ${PYFILE_PATH}/get-pip.py ${PYTHON_OPTION})
-    endif()
-    execute_process(COMMAND ${PYTHON2_DIR}/Scripts/pip${EXECUTABLE_SUFFIX} install pyyaml ${PYTHON_OPTION})
-else()
-    execute_process(COMMAND ${PYTHON2_DIR}/easy_install${EXECUTABLE_SUFFIX} pyyaml)
-endif()
-
-vcpkg_execute_required_process(
-    COMMAND ${PYTHON2} tools/configure.py --source-directory src-input --output-directory src --config-metadata config -DDUK_USE_FASTINT
-    WORKING_DIRECTORY ${SOURCE_PATH}
-    LOGNAME pre-configure
-)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
   set(DUK_CONFIG_H_PATH "${SOURCE_PATH}/src/duk_config.h")

--- a/ports/duktape/vcpkg.json
+++ b/ports/duktape/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "duktape",
-  "version": "2.5.0",
-  "port-version": 4,
+  "version": "2.7.0",
   "description": "Embeddable Javascript engine with a focus on portability and compact footprint.",
   "homepage": "https://github.com/svaarala/duktape",
   "dependencies": [

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -302,15 +302,6 @@ drogon:arm-neon-android=fail
 drogon:arm64-android=fail
 drogon:x64-android=fail
 
-# requires python@2 from brew, but that no longer exists
-# python2 EOL yay!
-duktape:arm-neon-android=fail
-duktape:arm64-android=fail
-duktape:x64-android=fail
-duktape:x64-osx=skip
-duktape:arm64-osx=skip
-duktape:x64-linux=fail
-
 eathread:x64-android=fail
 elfio:arm-neon-android=fail
 elfio:arm64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2249,8 +2249,8 @@
       "port-version": 0
     },
     "duktape": {
-      "baseline": "2.5.0",
-      "port-version": 4
+      "baseline": "2.7.0",
+      "port-version": 0
     },
     "dumb": {
       "baseline": "2.0.3",

--- a/versions/d-/duktape.json
+++ b/versions/d-/duktape.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dddb2510d64d70d7c0cb632039123a1721857e72",
+      "version": "2.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d5a2a59ce6d8477151b1bd30ad12e5a65ce86331",
       "version": "2.5.0",
       "port-version": 4


### PR DESCRIPTION
Instead use a release tarball which includes all codegened stuff.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
