### PR TITLE
[llhttp] update to 9.1.2

### DIFF
--- a/ports/llhttp/fix-usage.patch
+++ b/ports/llhttp/fix-usage.patch
@@ -1,15 +1,15 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 65484a7..a6c02c2 100644
+index bdef288..72555c6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -75,6 +75,10 @@ function(config_library target)
-         FILE llhttp-config.cmake
-         NAMESPACE llhttp::
-         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp)
+@@ -77,6 +77,10 @@ function(config_library target)
+     NAMESPACE llhttp::
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp
+   )
 +  target_include_directories(${target}
-+    PRIVATE include ${CMAKE_CURRENT_BINARY_DIR}
-+    INTERFACE $<INSTALL_INTERFACE:include>
-+)
++     PRIVATE include ${CMAKE_CURRENT_BINARY_DIR}
++     INTERFACE $<INSTALL_INTERFACE:include>
++  )
  endfunction(config_library target)
  
  if(BUILD_SHARED_LIBS)

--- a/ports/llhttp/fix-usage.patch
+++ b/ports/llhttp/fix-usage.patch
@@ -7,8 +7,8 @@ index bdef288..72555c6 100644
      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp
    )
 +  target_include_directories(${target}
-+     PRIVATE include ${CMAKE_CURRENT_BINARY_DIR}
-+     INTERFACE $<INSTALL_INTERFACE:include>
++    PRIVATE include ${CMAKE_CURRENT_BINARY_DIR}
++    INTERFACE $<INSTALL_INTERFACE:include>
 +  )
  endfunction(config_library target)
  

--- a/ports/llhttp/portfile.cmake
+++ b/ports/llhttp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nodejs/llhttp
-    REF refs/tags/release/v8.1.0
-    SHA512 3b79555f734a6a200a790f04f10be6d3ce5bd999c027a43c0900bb408e7d64be38fe4bbe9f15e57e389f07ba26b8089fc6ba5eef3b497742484f0719e92e9722
+    REF refs/tags/release/v${VERSION}
+    SHA512 d3e2c45f631e8bbc5b4b72f931a1af3e7b4f9d2851856a3c797577a3c261c7da15606efe41ff6b4f26713274f44eb3086019711461cb6bbe04e561b20af40a6f
     PATCHES
         fix-usage.patch
 )

--- a/ports/llhttp/vcpkg.json
+++ b/ports/llhttp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "llhttp",
-  "version": "8.1.0",
-  "port-version": 2,
+  "version": "9.1.2",
   "description": "Port of http_parser to llparse.",
   "homepage": "https://github.com/nodejs/llhttp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5077,8 +5077,8 @@
       "port-version": 0
     },
     "llhttp": {
-      "baseline": "8.1.0",
-      "port-version": 2
+      "baseline": "9.1.2",
+      "port-version": 0
     },
     "llvm": {
       "baseline": "15.0.7",

--- a/versions/l-/llhttp.json
+++ b/versions/l-/llhttp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6522364abf3f0f64ba9b3fd48b6ce367dc3ccb8e",
+      "version": "9.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "02d4bf2e1a15712c39a825aa81791f032b06fd10",
       "version": "8.1.0",
       "port-version": 2

--- a/versions/l-/llhttp.json
+++ b/versions/l-/llhttp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6522364abf3f0f64ba9b3fd48b6ce367dc3ccb8e",
+      "git-tree": "3a46d3c8233039a700b07997705cc2a49d832e15",
       "version": "9.1.2",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #33927 

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


