### PR TITLE
[bde] Bump BDE port to 3.123.0 and fixup subpackages config

### DIFF
--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -11,8 +11,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH TOOLS_PATH
     REPO "bloomberg/bde-tools"
     REF "${BDE_TOOLS_VERSION}"
-    SHA512 3c39da8d1ea40459e36e11ada93cc2821ae1b16a831f93cccab463996394a400cc08bb1654642eae1aa5187f139d7fb80c4729e464051eee182133eb8a74158d
-    HEAD_REF main
+    SHA512 e59560810acfe562d85a13585d908decce17ec76c89bd61f43dac56cddfdf6c56269566da75730f8eda14b5fc046d2ebce959b24110a428e8eac0e358d2597c2
+    HEAD_REF 3.123.0.0
 )
 
 message(STATUS "Configure bde-tools-v${BDE_TOOLS_VERSION}")
@@ -24,8 +24,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "bloomberg/bde"
     REF "${VERSION}"
-    SHA512 810b4a06a08739dcd990751dd543aa7dc58355f9d64a7c96ef0cf45c81501946434db42ad5bcf5d16110d5a463586b587ce09a446136e824298f39a8a871b490
-    HEAD_REF main
+    SHA512 f1c3c5ddec7ff1d301ca6f8ab00e6be42ab6a5fa3c889639e7797df74f68425d57d8b71978098331c9247820c7c831edeaf4427ae64c890d81f704343b1bb112
+    HEAD_REF 3.123.0.0
 )
 
 vcpkg_cmake_configure(
@@ -49,12 +49,16 @@ vcpkg_cmake_build()
 # Install release
 vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/)
+list(APPEND SUBPACKAGES "ryu" "inteldfp" "pcre2" "s_baltst" "bsl" "bdl" "bal")
+include(GNUInstallDirs) # needed for CMAKE_INSTALL_LIBDIR
+foreach(subpackage IN LISTS SUBPACKAGES)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME ${subpackage} CONFIG_PATH /${CMAKE_INSTALL_LIBDIR}/cmake/${subpackage} DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endforeach()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake" "${CURRENT_PACKAGES_DIR}/debug/${CMAKE_INSTALL_LIBDIR}/cmake")
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE
      DESTINATION ${CURRENT_PACKAGES_DIR}/share/bde
      RENAME copyright
 )
-
 vcpkg_fixup_pkgconfig()

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bde",
-  "version": "3.117.0.0",
+  "version": "3.123.0.0",
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
   "supports": "!windows & !arm & !android & !osx",
   "dependencies": [

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "71df70f3716434e8069b394593ba8859b6556959",
+      "version": "3.123.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a8fc4329574711907399309f06012a486d373c64",
       "version": "3.117.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -521,7 +521,7 @@
       "port-version": 0
     },
     "bde": {
-      "baseline": "3.117.0.0",
+      "baseline": "3.123.0.0",
       "port-version": 0
     },
     "bdwgc": {


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->


- Building with the current portfile lead to cmake not being able to find the `*Config.cmake` files for the BDE subpackages (`bal`, `bsl`, `bdl`). This is because the port name `${PORT}` does not match what we `find_package` and using `vcpkg_cmake_config_fixup()` with multiple `*-config.cmake` files did not work. 

- The change is to bump bde to version `3.123.0` and in the portfile, fixup the config for every subpackage that we want the consumers of BDE to `find_package` / have a `find_dependency` on, i.e we can directly do `find_package(bal REQUIRED)`. 

- Similar problem was discussed in https://github.com/microsoft/vcpkg/discussions/20511