### PR TITLE
[raylib] Enable raylib on ARM

### DIFF
--- a/ports/raylib/vcpkg.json
+++ b/ports/raylib/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "raylib",
   "version-semver": "4.5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A simple and easy-to-use library to enjoy videogames programming",
   "homepage": "https://github.com/raysan5/raylib",
   "license": "Zlib",
-  "supports": "!(uwp)",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "glfw3",

--- a/ports/raylib/vcpkg.json
+++ b/ports/raylib/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "A simple and easy-to-use library to enjoy videogames programming",
   "homepage": "https://github.com/raysan5/raylib",
   "license": "Zlib",
-  "supports": "!(arm | uwp)",
+  "supports": "!(uwp)",
   "dependencies": [
     {
       "name": "glfw3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7190,7 +7190,7 @@
     },
     "raylib": {
       "baseline": "4.5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "rbdl": {
       "baseline": "3.2.0",

--- a/versions/r-/raylib.json
+++ b/versions/r-/raylib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9169c9a95d90ee917a73c48e0bd616fbf74af998",
+      "git-tree": "8481bb808a6e0cdd0862e22df7b59cc0e13542cc",
       "version-semver": "4.5.0",
       "port-version": 2
     },

--- a/versions/r-/raylib.json
+++ b/versions/r-/raylib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9169c9a95d90ee917a73c48e0bd616fbf74af998",
+      "version-semver": "4.5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "1ae048ec33152df88804d243fd6e89691d5712d2",
       "version-semver": "4.5.0",
       "port-version": 1


### PR DESCRIPTION
Raylib has been working on ARM for a while now. I've tested it on my own M1 Mac, and the raylib project has been successfully used on raspberry pi's and android. This PR simply removes the restriction for using raylib from vcpkg on ARM platforms.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
