### PR TITLE
Version database consistency fixes

### DIFF
--- a/ports/kinectsdk1/vcpkg.json
+++ b/ports/kinectsdk1/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kinectsdk1",
   "version": "1.8",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Kinect for Windows SDK for Kinect v1 sensor.",
   "license": null,
   "supports": "!arm & windows & !uwp & !xbox",
@@ -9,7 +9,7 @@
     {
       "name": "vcpkg-tool-lessmsi",
       "host": true,
-      "version>=": "1.10#1"
+      "version>=": "1.10.0#1"
     }
   ]
 }

--- a/ports/kinectsdk2/vcpkg.json
+++ b/ports/kinectsdk2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kinectsdk2",
   "version": "2.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Kinect for Windows SDK for Kinect v2 sensor.",
   "license": null,
   "supports": "!arm & windows & !uwp & !xbox",
@@ -9,7 +9,7 @@
     {
       "name": "vcpkg-tool-lessmsi",
       "host": true,
-      "version>=": "1.10#1"
+      "version>=": "1.10.0#1"
     }
   ]
 }

--- a/ports/matroska/vcpkg.json
+++ b/ports/matroska/vcpkg.json
@@ -1,13 +1,13 @@
 {
   "name": "matroska",
   "version": "1.7.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "a C++ library to parse Matroska files (.mkv and .mka)",
   "homepage": "https://github.com/Matroska-Org/libmatroska",
   "dependencies": [
     {
       "name": "ebml",
-      "version>=": "1.4.3"
+      "version>=": "1.4.4"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
   "version": "2023.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [
@@ -95,12 +95,12 @@
         },
         {
           "name": "protobuf",
-          "version>=": "3.20.3"
+          "version>=": "3.21.2"
         },
         {
           "name": "protobuf",
           "host": true,
-          "version>=": "3.20.3"
+          "version>=": "3.21.2"
         }
       ]
     },
@@ -109,12 +109,12 @@
       "dependencies": [
         {
           "name": "protobuf",
-          "version>=": "3.20.3"
+          "version>=": "3.21.2"
         },
         {
           "name": "protobuf",
           "host": true,
-          "version>=": "3.20.3"
+          "version>=": "3.21.2"
         }
       ]
     },
@@ -126,12 +126,12 @@
       "dependencies": [
         {
           "name": "protobuf",
-          "version>=": "3.20.3"
+          "version>=": "3.21.2"
         },
         {
           "name": "protobuf",
           "host": true,
-          "version>=": "3.20.3"
+          "version>=": "3.21.2"
         },
         "snappy"
       ]

--- a/ports/qtvirtualkeyboard/portfile.cmake
+++ b/ports/qtvirtualkeyboard/portfile.cmake
@@ -8,11 +8,13 @@ if("hunspell" IN_LIST FEATURES)
 else()
     list(APPEND FEATURE_OPTIONS -DINPUT_vkb_hunspell=no)
 endif()
-if("t9write" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -DINPUT_vkb_handwriting=t9write)
-else()
-    list(APPEND FEATURE_OPTIONS -DINPUT_vkb_handwriting=no)
-endif()
+
+#
+# To use t9write, overlay this port with the following line changed to:
+# list(APPEND FEATURE_OPTIONS -DINPUT_vkb_handwriting=t9write)
+# and add t9write as a dependency.
+#
+list(APPEND FEATURE_OPTIONS -DINPUT_vkb_handwriting=no)
 
 qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
                      CONFIGURE_OPTIONS ${FEATURE_OPTIONS}

--- a/ports/qtvirtualkeyboard/vcpkg.json
+++ b/ports/qtvirtualkeyboard/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "qtvirtualkeyboard",
   "version": "6.5.2",
-  "description": "SCXML (state machine notation) compiler and related tools",
+  "port-version": 1,
+  "description": "The Qt Virtual Keyboard project provides an input framework and reference keyboard frontend for Qt 6 on Linux Desktop/X11, Windows Desktop, and Boot2Qt targets.",
   "homepage": "https://www.qt.io/",
   "license": null,
   "dependencies": [
@@ -33,12 +34,6 @@
       "description": "Use hunspell",
       "dependencies": [
         "hunspell"
-      ]
-    },
-    "t9write": {
-      "description": "T9Write handwriting (commercial SDK requires port overlay)",
-      "dependencies": [
-        "t9write"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3802,11 +3802,11 @@
     },
     "kinectsdk1": {
       "baseline": "1.8",
-      "port-version": 7
+      "port-version": 8
     },
     "kinectsdk2": {
       "baseline": "2.0",
-      "port-version": 6
+      "port-version": 7
     },
     "kissfft": {
       "baseline": "131.1.0",
@@ -5318,7 +5318,7 @@
     },
     "matroska": {
       "baseline": "1.7.1",
-      "port-version": 1
+      "port-version": 2
     },
     "mbedtls": {
       "baseline": "2.28.1",
@@ -6198,7 +6198,7 @@
     },
     "openvino": {
       "baseline": "2023.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "openvpn3": {
       "baseline": "3.7.0",
@@ -7066,7 +7066,7 @@
     },
     "qtvirtualkeyboard": {
       "baseline": "6.5.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtwayland": {
       "baseline": "6.5.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -796,10 +796,6 @@
       "baseline": "1.83.0",
       "port-version": 0
     },
-    "boost-di": {
-      "baseline": "1.2.0",
-      "port-version": 0
-    },
     "boost-dll": {
       "baseline": "1.83.0",
       "port-version": 0
@@ -1488,10 +1484,6 @@
       "baseline": "3.2.19",
       "port-version": 7
     },
-    "cgl": {
-      "baseline": "0.60.3",
-      "port-version": 0
-    },
     "cglm": {
       "baseline": "0.8.8",
       "port-version": 0
@@ -1618,10 +1610,6 @@
     },
     "clockutils": {
       "baseline": "1.1.1",
-      "port-version": 1
-    },
-    "clp": {
-      "baseline": "1.17.6",
       "port-version": 1
     },
     "clrng": {
@@ -2658,10 +2646,6 @@
     },
     "foonathan-memory": {
       "baseline": "0.7.3",
-      "port-version": 0
-    },
-    "forest": {
-      "baseline": "12.1.0",
       "port-version": 0
     },
     "forge": {
@@ -6056,10 +6040,6 @@
       "baseline": "2.2.1",
       "port-version": 1
     },
-    "opencolorio-tools": {
-      "baseline": "1.1.1",
-      "port-version": 0
-    },
     "opencsg": {
       "baseline": "1.4.2",
       "port-version": 4
@@ -6250,10 +6230,6 @@
     },
     "osgearth": {
       "baseline": "3.4",
-      "port-version": 1
-    },
-    "osi": {
-      "baseline": "0.108.6",
       "port-version": 1
     },
     "osmanip": {
@@ -6902,10 +6878,6 @@
     },
     "qt5compat": {
       "baseline": "6.5.2",
-      "port-version": 0
-    },
-    "qt6betablock": {
-      "baseline": "6.2.0-beta",
       "port-version": 0
     },
     "qtactiveqt": {
@@ -7919,10 +7891,6 @@
     "spirv-tools": {
       "baseline": "2022.4",
       "port-version": 1
-    },
-    "spix": {
-      "baseline": "0.5",
-      "port-version": 0
     },
     "spout2": {
       "baseline": "2.007.010",

--- a/versions/k-/kinectsdk1.json
+++ b/versions/k-/kinectsdk1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13e4fb052326c67afb016cb1e4ad9de60dd15fe5",
+      "version": "1.8",
+      "port-version": 8
+    },
+    {
       "git-tree": "95650640a3c97fff440182fb35e878cc0b3111de",
       "version": "1.8",
       "port-version": 7

--- a/versions/k-/kinectsdk2.json
+++ b/versions/k-/kinectsdk2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d794c2a74ee00c3ed932903f7d0587024fab247e",
+      "version": "2.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "e703f6797d85c9d99a150e4325c67bf7f3a7ea3f",
       "version": "2.0",
       "port-version": 6

--- a/versions/m-/matroska.json
+++ b/versions/m-/matroska.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d414c27a074d4262517bf3fe72571e8f16ccab0",
+      "version": "1.7.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "12137590eb6e5ec4e644e61b664d83a4ed6c8022",
       "version": "1.7.1",
       "port-version": 1

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "142339d6db532cdecd3d59ccdb43411769bed1ca",
+      "version": "2023.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b038a324f094f69ef18efe7cd9b4c3e7c71d7c9b",
       "version": "2023.1.0",
       "port-version": 1

--- a/versions/q-/qtvirtualkeyboard.json
+++ b/versions/q-/qtvirtualkeyboard.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8b5060f737cdf43c76dee17eb62ec5992d5ed6c3",
+      "version": "6.5.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "56528dbb98540dc6267def8ffa5ea971982870bb",
       "version": "6.5.2",
       "port-version": 0


### PR DESCRIPTION
In working on teaching `x-ci-validate-versions` to check that version constraints exist in the version database I found these existing consistency problems:

```console
C:\Dev\vcpkg\ports\kinectsdk1\vcpkg.json: error: the "version>=" constraint to vcpkg-tool-lessmsi names version 1.10#1 which does not exist in the version database. All versions must exist in the version database to be interpreted by vcpkg. Consider removing the version constraint or choosing a value declared in C:\Dev\vcpkg\versions\v-\vcpkg-tool-lessmsi.json.
C:\Dev\vcpkg\ports\kinectsdk2\vcpkg.json: error: the "version>=" constraint to vcpkg-tool-lessmsi names version 1.10#1 which does not exist in the version database. All versions must exist in the version database to be interpreted by vcpkg. Consider removing the version constraint or choosing a value declared in C:\Dev\vcpkg\versions\v-\vcpkg-tool-lessmsi.json.
C:\Dev\vcpkg\ports\matroska\vcpkg.json: error: the "version>=" constraint to ebml names version 1.4.3 which does not exist in the version database. All versions must exist in the version database to be interpreted by vcpkg. Consider removing the version constraint or choosing a value declared in C:\Dev\vcpkg\versions\e-\ebml.json.
C:\Dev\vcpkg\ports\openvino\vcpkg.json: error: the "version>=" constraint to protobuf names version 3.20.3 which does not exist in the version database. All versions must exist in the version database to be interpreted by vcpkg. Consider removing the version constraint or choosing a value declared in C:\Dev\vcpkg\versions\p-\protobuf.json.
note: the dependency is in the feature named onnx.
C:\Dev\vcpkg\ports\openvino\vcpkg.json: error: the "version>=" constraint to protobuf names version 3.20.3 which does not exist in the version database. All versions must exist in the version database to be interpreted by vcpkg. Consider removing the version constraint or choosing a value declared in C:\Dev\vcpkg\versions\p-\protobuf.json.
note: the dependency is in the feature named onnx.
C:\Dev\vcpkg\ports\openvino\vcpkg.json: error: the "version>=" constraint to protobuf names version 3.20.3 which does not exist in the version database. All versions must exist in the version database to be interpreted by vcpkg. Consider removing the version constraint or choosing a value declared in C:\Dev\vcpkg\versions\p-\protobuf.json.
note: the dependency is in the feature named paddle.
C:\Dev\vcpkg\ports\openvino\vcpkg.json: error: the "version>=" constraint to protobuf names version 3.20.3 which does not exist in the version database. All versions must exist in the version database to be interpreted by vcpkg. Consider removing the version constraint or choosing a value declared in C:\Dev\vcpkg\versions\p-\protobuf.json.
note: the dependency is in the feature named paddle.
C:\Dev\vcpkg\ports\openvino\vcpkg.json: error: the "version>=" constraint to protobuf names version 3.20.3 which does not exist in the version database. All versions must exist in the version database to be interpreted by vcpkg. Consider removing the version constraint or choosing a value declared in C:\Dev\vcpkg\versions\p-\protobuf.json.
note: the dependency is in the feature named tensorflow.
C:\Dev\vcpkg\ports\openvino\vcpkg.json: error: the "version>=" constraint to protobuf names version 3.20.3 which does not exist in the version database. All versions must exist in the version database to be interpreted by vcpkg. Consider removing the version constraint or choosing a value declared in C:\Dev\vcpkg\versions\p-\protobuf.json.
note: the dependency is in the feature named tensorflow.
C:\Dev\vcpkg\ports\qtvirtualkeyboard\vcpkg.json: error: the dependency t9write does not exist in the version database; does that port exist?
note: the dependency is in the feature named t9write.
```

Separately, as part of working on `z-changelog` I found ports that are in `baseline.json` that do not exist.