### PR TITLE
[mpg123] Add patch for wasm triplet, fix checktypesize

### DIFF
--- a/ports/mpg123/fix-checktypesize.patch
+++ b/ports/mpg123/fix-checktypesize.patch
@@ -1,0 +1,14 @@
+diff --git a/ports/cmake/src/CMakeLists.txt b/ports/cmake/src/CMakeLists.txt
+index 79e1f9b..e057567 100644
+--- a/ports/cmake/src/CMakeLists.txt
++++ b/ports/cmake/src/CMakeLists.txt
+@@ -5,6 +5,7 @@ include(CheckFunctionExists)
+ include(CheckIncludeFile)
+ include(CheckIncludeFiles)
+ include(CheckSymbolExists)
++include(CheckTypeSize)
+ include(CMakeDependentOption)
+ include(TestBigEndian)
+ 
+ 
+ 

--- a/ports/mpg123/fix-checktypesize.patch
+++ b/ports/mpg123/fix-checktypesize.patch
@@ -11,4 +11,4 @@ index 79e1f9b..e057567 100644
  include(TestBigEndian)
  
  
- 
+

--- a/ports/mpg123/portfile.cmake
+++ b/ports/mpg123/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_sourceforge(
     FILENAME "mpg123-${VERSION}.tar.bz2"
     SHA512 5dd550e06f5d0d432cac1b7e546215e56378b44588c1a98031498473211e08bc4228de45be41f7ba764f7f6c0eb752a6501235bcc3712c9a8d8852ae3c607d98
     PATCHES
+        fix-checktypesize.patch
         fix-modulejack.patch
         fix-m1-build.patch
 )

--- a/ports/mpg123/vcpkg.json
+++ b/ports/mpg123/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpg123",
   "version": "1.31.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "mpg123 is a real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3 (MPEG 1.0 layer 3 also known as MP3).",
   "homepage": "https://sourceforge.net/projects/mpg123/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5518,7 +5518,7 @@
     },
     "mpg123": {
       "baseline": "1.31.3",
-      "port-version": 1
+      "port-version": 2
     },
     "mpi": {
       "baseline": "1",

--- a/versions/m-/mpg123.json
+++ b/versions/m-/mpg123.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9061ff9d5ec4d54567ef17f37c7ed38f0139e04f",
+      "version": "1.31.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "73f380749ae40814a07c7a0952e94db2970a9b85",
       "version": "1.31.3",
       "port-version": 1

--- a/versions/m-/mpg123.json
+++ b/versions/m-/mpg123.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9061ff9d5ec4d54567ef17f37c7ed38f0139e04f",
+      "git-tree": "58fbb0bf0ec6307689125ef1ba71112b670a42a9",
       "version": "1.31.3",
       "port-version": 2
     },


### PR DESCRIPTION
Seems that something about the wasm env ended up triggering an error when the CMakelists.txt calls `check_type_size` due to CheckTypeSize not being included, Working on submitting a report to the maintainers.

I attempted to update to 1.32.0 that just released a few hours ago, but it seems there's just issues with that release, I think they accidentally dropped a couple folders when they archived the release, as the install fails even on x64-windows for the same reason (can't install the manual due to the file/folder not existing) I'll report that as well after reporting the `check_type_size` fix.
 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.