### PR TITLE
[libvmdk] Updated to version 20221124

### DIFF
--- a/ports/libvmdk/CMakeLists.txt
+++ b/ports/libvmdk/CMakeLists.txt
@@ -9,7 +9,6 @@ if(MSVC)
     add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE)
 endif()
 
-add_compile_definitions(HAVE_LOCAL_LIBCAES)
 add_compile_definitions(HAVE_LOCAL_LIBCERROR)
 add_compile_definitions(HAVE_LOCAL_LIBCTHREADS)
 add_compile_definitions(HAVE_LOCAL_LIBCDATA)

--- a/ports/libvmdk/portfile.cmake
+++ b/ports/libvmdk/portfile.cmake
@@ -1,8 +1,7 @@
-set(LIB_VERSION 20221124)
-set(LIB_FILENAME libvmdk-alpha-${LIB_VERSION}.tar.gz)
+set(LIB_FILENAME libvmdk-alpha-${VERSION}.tar.gz)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/libyal/libvmdk/releases/download/${LIB_VERSION}/${LIB_FILENAME}"
+    URLS "https://github.com/libyal/libvmdk/releases/download/${VERSION}/${LIB_FILENAME}"
     FILENAME "${LIB_FILENAME}"
     SHA512 7d7ea415d7c2cb1077d591d53ab3c37a7ab6e01dc9525159a70588e6f55e56bbef4d3f49f6e1c01ff0b1ddcede5ec2beb05aca7f12e5212843761e14f6459bcb
 )
@@ -10,7 +9,7 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
-    SOURCE_BASE "${LIB_VERSION}"
+    SOURCE_BASE "${VERSION}"
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/libvmdk/portfile.cmake
+++ b/ports/libvmdk/portfile.cmake
@@ -1,10 +1,10 @@
-set(LIB_VERSION 20200926)
+set(LIB_VERSION 20221124)
 set(LIB_FILENAME libvmdk-alpha-${LIB_VERSION}.tar.gz)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/libyal/libvmdk/releases/download/${LIB_VERSION}/${LIB_FILENAME}"
     FILENAME "${LIB_FILENAME}"
-    SHA512 e70c42580dc58ad0a6459fe461504a8ef128f8d5df9d500f84f316e627232606f22eb4906fc1debc3e75e71daa6a07951af80822695de13d5e466adda4cfd5e0
+    SHA512 7d7ea415d7c2cb1077d591d53ab3c37a7ab6e01dc9525159a70588e6f55e56bbef4d3f49f6e1c01ff0b1ddcede5ec2beb05aca7f12e5212843761e14f6459bcb
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libvmdk/vcpkg.json
+++ b/ports/libvmdk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libvmdk",
-  "version": "20200926",
-  "port-version": 4,
+  "version": "20221124",
   "description": "Library and tools to access the VMware Virtual Disk (VMDK) format",
   "homepage": "https://github.com/libyal/libvmdk",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4845,8 +4845,8 @@
       "port-version": 0
     },
     "libvmdk": {
-      "baseline": "20200926",
-      "port-version": 4
+      "baseline": "20221124",
+      "port-version": 0
     },
     "libvorbis": {
       "baseline": "1.3.7",

--- a/versions/l-/libvmdk.json
+++ b/versions/l-/libvmdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "955a96b53cffdfca512eac9dd261de4cfc9caaab",
+      "version": "20221124",
+      "port-version": 0
+    },
+    {
       "git-tree": "1e57cc839896d460f87ccf1a48562dcb876f7f6b",
       "version": "20200926",
       "port-version": 4

--- a/versions/l-/libvmdk.json
+++ b/versions/l-/libvmdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "955a96b53cffdfca512eac9dd261de4cfc9caaab",
+      "git-tree": "2065c045d5787d9fff6469d31fe6bbe2f925d367",
       "version": "20221124",
       "port-version": 0
     },


### PR DESCRIPTION
Updates libvmdk to latest available version.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

