### PR TITLE
[yomm2] Fix DLL install for `x64-windows`

### DIFF
--- a/ports/yomm2/fix_install.patch
+++ b/ports/yomm2/fix_install.patch
@@ -35,3 +35,13 @@ index 7e8a282..f550c2d 100644
      $<INSTALL_INTERFACE:include>
 -    $<INSTALL_INTERFACE:Boost::yomm2>
    )
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -36,5 +36,6 @@
+ install(TARGETS yomm2
+   EXPORT YOMM2Targets
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib
++  RUNTIME DESTINATION bin
+ )

--- a/ports/yomm2/portfile.cmake
+++ b/ports/yomm2/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512  35d869f79b278ae219d61e0ae3b01902c5df5457d2ced7bfd109cf0e75f3f7835ce3d4751c34838d134531f6483dc89b7d67d5ecab6e8af42b4b735284573db4
     HEAD_REF master
-    PATCHES "fix_find_boost.patch"
+    PATCHES "fix_install.patch"
 )
 
 set(YOMM2_SHARED OFF)

--- a/ports/yomm2/vcpkg.json
+++ b/ports/yomm2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "yomm2",
   "version": "1.4.0",
+  "port-version": 1,
   "description": "YOMM2 is an implementation of open multi-methods.",
   "homepage": "https://github.com/jll63/yomm2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9110,7 +9110,7 @@
     },
     "yomm2": {
       "baseline": "1.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "yyjson": {
       "baseline": "0.6.0",

--- a/versions/y-/yomm2.json
+++ b/versions/y-/yomm2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7fb081bdba7637ab5c5bc26d1dfb2a80a1fd1303",
+      "version": "1.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "eb04c5f671a8ba74f8f98bb4c1b53716336ce441",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
Fix missing DLL not being installed on `x64-windows` reported by https://github.com/microsoft/vcpkg/pull/33509#discussion_r1326764929

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
