### PR TITLE
[rtmidi] Fix include path

### DIFF
--- a/ports/rtmidi/fix-cmake-install.patch
+++ b/ports/rtmidi/fix-cmake-install.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e6af930..f3eadf2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -191,7 +191,7 @@ set_target_properties(rtmidi PROPERTIES
+ target_include_directories(rtmidi PRIVATE ${INCDIRS}
+                                   PUBLIC
+                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-                                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++                                    $<INSTALL_INTERFACE:include>)
+ 
+ # Set compile-time definitions
+ target_compile_definitions(rtmidi PRIVATE ${API_DEFS})

--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -8,7 +8,9 @@ vcpkg_from_github(
     REF 84a99422a3faf1ab417fe71c0903a48debb9376a # 5.0.0
     SHA512 388e280b7966281e22b0048d6fb2541921df1113d84e49bbc444fff591d2025588edd8d61dbe5ff017afd76c26fd05edc8f9f15d0cce16315ccc15e6aac1d57f
     HEAD_REF master
-    PATCHES fix-cmake-usage.patch # Remove this patch in the next update
+    PATCHES
+        fix-cmake-usage.patch # Remove this patch in the next update
+        fix-cmake-install.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-cmake-usage.patch # Remove this patch in the next update
-        fix-cmake-install.patch
+        fix-cmake-install.patch # Remove this patch in the next update
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/rtmidi/vcpkg.json
+++ b/ports/rtmidi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rtmidi",
   "version": "5.0.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)",
   "homepage": "https://github.com/thestk/rtmidi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7394,7 +7394,7 @@
     },
     "rtmidi": {
       "baseline": "5.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "rttr": {
       "baseline": "0.9.6+20210811",

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "276ed292eddb040a29a99be2eedaa5df030f555f",
+      "git-tree": "83f2bd1bc41359997ee59a894bbfe5aab7e5a5df",
       "version": "5.0.0",
       "port-version": 3
     },

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "276ed292eddb040a29a99be2eedaa5df030f555f",
+      "version": "5.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "70873823ce910dcf80078a94f12191371523d84c",
       "version": "5.0.0",
       "port-version": 2


### PR DESCRIPTION
Fixes #33969 
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
