### PR TITLE
[ctre] update to 3.8

### DIFF
--- a/ports/ctre/portfile.cmake
+++ b/ports/ctre/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hanickadot/compile-time-regular-expressions
     REF "v${VERSION}"
-    SHA512 1ffb56ca88db5c8b0e5a5e1bf25f4eb9d59b43a31f9a38970bb2beaa22390e86a5beaf350b20e336759d7af99509c4c120b4638969719b931e316e01976c24dc
+    SHA512 bc0382156059999a5d55cd68dcfa35974c5dab56a10e970ce4eefe455fa3e53276bc87c7e7698de4b8a6a4d984f5883926668847816a1a594b94cac9d42ac4b8
     HEAD_REF main
 )
 

--- a/ports/ctre/vcpkg.json
+++ b/ports/ctre/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ctre",
-  "version-semver": "3.7.2",
+  "version": "3.8",
   "description": "A Compile time PCRE (almost) compatible regular expression matcher",
   "homepage": "https://github.com/hanickadot/compile-time-regular-expressions",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1965,7 +1965,7 @@
       "port-version": 2
     },
     "ctre": {
-      "baseline": "3.7.2",
+      "baseline": "3.8",
       "port-version": 0
     },
     "cub": {

--- a/versions/c-/ctre.json
+++ b/versions/c-/ctre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70b866377c945c0c024c7379e0f06b00b898fcfb",
+      "version": "3.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "f1277ac9132e7a6c91bdfd6cc355eccedbb28732",
       "version-semver": "3.7.2",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.