### PR TITLE
[openblas] update to 0.3.24

### DIFF
--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -68,7 +68,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/OpenBLAS)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/OpenBLAS)
 
 if (EXISTS "${CURRENT_PACKAGES_DIR}/bin/getarch${VCPKG_HOST_EXECUTABLE_SUFFIX}")
     vcpkg_copy_tools(TOOL_NAMES getarch AUTO_CLEAN)

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xianyi/OpenBLAS
-    REF v{VERSION}
-    SHA512 d79ae7ba4f9146f0bcacdef9b9cf4cd287e5eb2e3891f7deb4b3992b742a557ca094ac2f258420a16cfe6bbda7ca82addf415aecd7ced425a02374847c0b6013
+    REF v${VERSION}
+    SHA512 fe66e3a258ca1720764ed243f6d61017d6ef14bd33b76f20b19b34754096ec2be9fbeb1a78743f38ee71381746d6af9a1c16a8f3982e423afec422fcb50852d0
     HEAD_REF develop
     PATCHES
         uwp.patch

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xianyi/OpenBLAS
-    REF v${VERSION}
+    REF "v${VERSION}"
     SHA512 fe66e3a258ca1720764ed243f6d61017d6ef14bd33b76f20b19b34754096ec2be9fbeb1a78743f38ee71381746d6af9a1c16a8f3982e423afec422fcb50852d0
     HEAD_REF develop
     PATCHES

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xianyi/OpenBLAS
-    REF 394a9fbafe9010b76a2615c562204277a956eb52 # v0.3.23
+    REF v{VERSION}
     SHA512 d79ae7ba4f9146f0bcacdef9b9cf4cd287e5eb2e3891f7deb4b3992b742a557ca094ac2f258420a16cfe6bbda7ca82addf415aecd7ced425a02374847c0b6013
     HEAD_REF develop
     PATCHES

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openblas",
-  "version": "0.3.23",
-  "port-version": 1,
+  "version": "0.3.24",
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/xianyi/OpenBLAS",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6037,8 +6037,8 @@
       "port-version": 0
     },
     "openblas": {
-      "baseline": "0.3.23",
-      "port-version": 1
+      "baseline": "0.3.24",
+      "port-version": 0
     },
     "opencascade": {
       "baseline": "7.7.2",

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "488e2ec60894835ebacaa8b2399ce3591b1313cf",
+      "git-tree": "c876665c0fa5b8d427ee9cadd4185a1a08d008da",
       "version": "0.3.24",
       "port-version": 0
     },

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "488e2ec60894835ebacaa8b2399ce3591b1313cf",
+      "version": "0.3.24",
+      "port-version": 0
+    },
+    {
       "git-tree": "d701021ccf4a0729f77788b2d90da377bfdd1486",
       "version": "0.3.23",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.