### PR TITLE
[launch-darkly-server] Port Launch Darkly Server is supported on ARM

### DIFF
--- a/ports/launch-darkly-server/portfile.cmake
+++ b/ports/launch-darkly-server/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         findPCRE.patch
         FixStrictPrototypes.patch # required with clang-15
+        removeWarningAsError.patch
 )
 
 

--- a/ports/launch-darkly-server/removeWarningAsError.patch
+++ b/ports/launch-darkly-server/removeWarningAsError.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9acff7d..12904e6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -184,7 +184,6 @@ else()
+                 -pedantic
+                 -Wall
+                 -Wextra
+-                -Werror
+                 -Wstrict-prototypes
+                 -Wmissing-prototypes
+                 -Wmissing-declarations
+diff --git a/c-sdk-common/CMakeLists.txt b/c-sdk-common/CMakeLists.txt
+index 15340f7..091e46d 100644
+--- a/c-sdk-common/CMakeLists.txt
++++ b/c-sdk-common/CMakeLists.txt
+@@ -87,7 +87,6 @@ else()
+                 -pedantic
+                 -Wall
+                 -Wextra
+-                -Werror
+                 -Wstrict-prototypes
+                 -Wmissing-prototypes
+                 -Wmissing-declarations
+@@ -123,7 +122,6 @@ else()
+         PRIVATE -fno-omit-frame-pointer
+                 -Wall
+                 -Wextra
+-                -Werror
+                 -Wstrict-prototypes
+                 -Wmissing-prototypes
+                 -Wmissing-declarations

--- a/ports/launch-darkly-server/vcpkg.json
+++ b/ports/launch-darkly-server/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "launch-darkly-server",
   "version": "2.8.6",
+  "port-version": 1,
   "description": "LaunchDarkly server-side SDK for C/C++",
   "homepage": "https://github.com/launchdarkly/c-server-sdk",
   "license": "Apache-2.0",
-  "supports": "!uwp & !arm",
+  "supports": "!uwp",
   "dependencies": [
     "curl",
     "pcre",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -537,7 +537,6 @@ kfr:x64-uwp=fail
 lastools:arm-neon-android=fail
 lastools:arm64-android=fail
 lastools:x64-android=fail
-launch-darkly-server:arm-neon-android=fail
 lcm:x64-windows-static=fail
 lcm:x64-windows-static-md=fail
 lcm:arm-neon-android=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -537,6 +537,7 @@ kfr:x64-uwp=fail
 lastools:arm-neon-android=fail
 lastools:arm64-android=fail
 lastools:x64-android=fail
+launch-darkly-server:arm-neon-android=fail
 lcm:x64-windows-static=fail
 lcm:x64-windows-static-md=fail
 lcm:arm-neon-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3878,7 +3878,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.8.6",
-      "port-version": 0
+      "port-version": 1
     },
     "lazy-importer": {
       "baseline": "2023-08-03",

--- a/versions/l-/launch-darkly-server.json
+++ b/versions/l-/launch-darkly-server.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c287ef5e0bcb576385b2288bd0672b1baef81605",
+      "version": "2.8.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "1d45ebf10971a96ca975c36630545acfbc37b64b",
       "version": "2.8.6",
       "port-version": 0

--- a/versions/l-/launch-darkly-server.json
+++ b/versions/l-/launch-darkly-server.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c287ef5e0bcb576385b2288bd0672b1baef81605",
+      "git-tree": "d2e41e5748cc5b77167205b83be64003e979e637",
       "version": "2.8.6",
       "port-version": 1
     },


### PR DESCRIPTION
I tested building on aarch64 with Ubuntu 22.04.3 LTS.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
