### PR TITLE
[gtk3] fix module directory search

### DIFF
--- a/ports/gtk3/fix-modules-dir.patch
+++ b/ports/gtk3/fix-modules-dir.patch
@@ -1,0 +1,52 @@
+diff --git a/gtk/gtkmodules.c b/gtk/gtkmodules.c
+index 704e412..6700da9 100644
+--- a/gtk/gtkmodules.c
++++ b/gtk/gtkmodules.c
+@@ -66,6 +66,14 @@ get_module_path (void)
+ 
+   if (exe_prefix)
+     default_dir = g_build_filename (exe_prefix, "lib", "gtk-3.0", NULL);
++  else if (g_file_test (GTK_PLUGIN_DIR, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR))
++    default_dir = g_build_filename (GTK_PLUGIN_DIR, NULL);
++  else if (sizeof(void *) == 8 && g_file_test ("/usr/lib64/gtk-3.0", G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR))
++    default_dir = g_build_filename ("/usr/lib64/gtk-3.0", NULL);
++  else if (sizeof(void *) == 4 && g_file_test ("/usr/lib32/gtk-3.0", G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR))
++    default_dir = g_build_filename ("/usr/lib32/gtk-3.0", NULL);
++  else if (g_file_test ("/usr/lib/gtk-3.0", G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR))
++    default_dir = g_build_filename ("/usr/lib/gtk-3.0", NULL);
+   else
+     default_dir = g_build_filename (_gtk_get_libdir (), "gtk-3.0", NULL);
+ 
+diff --git a/gtk/meson.build b/gtk/meson.build
+index 967bffd..e8adfad 100644
+--- a/gtk/meson.build
++++ b/gtk/meson.build
+@@ -13,6 +13,7 @@ gtk_cargs = [
+   '-DGTK_LOCALEDIR="@0@"'.format(gtk_localedir),
+   '-DGTK_DATADIR="@0@"'.format(gtk_datadir),
+   '-DGTK_SYSCONFDIR="@0@"'.format(gtk_sysconfdir),
++  '-DGTK_PLUGIN_DIR="@0@"'.format(gtk_plugin_dir),
+ ]
+ 
+ # List of sources to build the library from
+diff --git a/meson.build b/meson.build
+index 5ab26a7..873e879 100644
+--- a/meson.build
++++ b/meson.build
+@@ -176,6 +176,7 @@ gtk_libdir = join_paths(gtk_prefix, get_option('libdir'))
+ gtk_datadir = join_paths(gtk_prefix, get_option('datadir'))
+ gtk_localedir = join_paths(gtk_prefix, get_option('localedir'))
+ gtk_sysconfdir = join_paths(gtk_prefix, get_option('sysconfdir'))
++gtk_plugin_dir = get_option('gtk_plugin_dir')
+ gtk_applicationsdir = join_paths(gtk_datadir, 'applications')
+ gtk_schemasdir = join_paths(gtk_datadir, 'glib-2.0/schemas')
+ gtk_appdatadir = join_paths(gtk_datadir, 'metainfo')
+diff --git a/meson_options.txt b/meson_options.txt
+index 94099aa..ee7fa59 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -47,3 +47,4 @@ option('installed_tests', type: 'boolean', value: 'false',
+ # input modules
+ option('builtin_immodules', type: 'string',
+        value: '', description: 'Build specified immodules into GTK so/DLL (comma-separated list), "all", "none" or "backend"')
++option('gtk_plugin_dir', type: 'string', value: '', description: '')

--- a/ports/gtk3/portfile.cmake
+++ b/ports/gtk3/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_gitlab(
     PATCHES
         0001-build.patch
         cairo-cpp-linkage.patch
+        fix-modules-dir.patch
 )
 
 vcpkg_find_acquire_program(PKGCONFIG)
@@ -42,6 +43,20 @@ else()
     list(APPEND OPTIONS -Dintrospection=false)
 endif()
 
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(GTK_PLUGIN_DIR "/usr/lib/x86_64-linux-gnu/gtk-3.0")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(GTK_PLUGIN_DIR "/usr/lib/aarch64-linux-gnu/gtk-3.0")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    set(GTK_PLUGIN_DIR "/usr/lib/arm-linux-gnueabihf/gtk-3.0")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "s390x")
+    set(GTK_PLUGIN_DIR "/usr/lib/s390x-linux-gnu/gtk-3.0")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "ppc64le")
+    set(GTK_PLUGIN_DIR "/usr/lib/powerpc64le-linux-gnu/gtk-3.0")
+else()
+    set(GTK_PLUGIN_DIR "/usr/lib/gtk-3.0")
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -52,6 +67,7 @@ vcpkg_configure_meson(
         -Dtests=false
         -Dgtk_doc=false
         -Dman=false
+        -Dgtk_plugin_dir=${GTK_PLUGIN_DIR}
         -Dxinerama=no               # Enable support for the X11 Xinerama extension
         -Dcloudproviders=false      # Enable the cloudproviders support
         -Dprofiler=false            # include tracing support for sysprof

--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk3",
   "version": "3.24.38",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3082,7 +3082,7 @@
     },
     "gtk3": {
       "baseline": "3.24.38",
-      "port-version": 1
+      "port-version": 2
     },
     "gtkmm": {
       "baseline": "4.10.0",

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d898cf957ca09e93e6fad45535c7ecc2d4747190",
+      "version": "3.24.38",
+      "port-version": 2
+    },
+    {
       "git-tree": "1362bb3978886e043fd12c089f2c1337a4f1adf8",
       "version": "3.24.38",
       "port-version": 1


### PR DESCRIPTION
Fixes the paths searched for the GTK modules by prioritizing the modules that are in /usr/lib* (where the user's plugins will be in). 