### PR TITLE
[netcdf-c] Fix dependency import/export

### DIFF
--- a/ports/netcdf-c/fix-dependency-libzip.patch
+++ b/ports/netcdf-c/fix-dependency-libzip.patch
@@ -23,10 +23,10 @@ index b3be259..72b4b25 100644
 --- a/netCDFConfig.cmake.in
 +++ b/netCDFConfig.cmake.in
 @@ -15,6 +15,9 @@ set(netCDF_LIBRARIES netCDF::netcdf)
- include(CMakeFindDependencyMacro)
- find_dependency(HDF5 CONFIG)
- find_dependency(CURL CONFIG)
-+if(@ENABLE_NCZARR_ZIP@)
+ if("@FOUND_CURL@")
+   find_dependency(CURL CONFIG)
+ endif()
++if("@ENABLE_NCZARR_ZIP@")
 +    find_dependency(libzip CONFIG)
 +endif()
  include("${CMAKE_CURRENT_LIST_DIR}/netCDFTargets.cmake")

--- a/ports/netcdf-c/fix-dependency-libzip.patch
+++ b/ports/netcdf-c/fix-dependency-libzip.patch
@@ -1,28 +1,38 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b93a141..c3763a7 100644
+index 1113c7b..69f465e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -957,7 +957,14 @@ OPTION(ENABLE_DAP_REMOTE_TESTS "Enable DAP remote tests." ON)
+@@ -960,7 +960,12 @@ OPTION(ENABLE_DAP_REMOTE_TESTS "Enable DAP remote tests." ON)
  SET(REMOTETESTSERVERS "remotetest.unidata.ucar.edu" CACHE STRING "test servers to use for remote test")
  
  # See if we have libzip
 -FIND_PACKAGE(Zip)
 +if(ENABLE_NCZARR_ZIP)
-+  find_package(libzip CONFIG REQUIRED)
-+  set(Zip_LIBRARIES zip)
-+  set(Zip_FOUND TRUE)
++  find_package(Zip NAMES libzip REQUIRED)
++  set(Zip_LIBRARIES libzip::zip)
 +else()
 +  set(Zip_LIBRARIES "")
-+  set(Zip_FOUND FALSE)
 +endif()
  
  # Define a test flag for have curl library
  IF(Zip_FOUND)
+diff --git a/libnczarr/CMakeLists.txt b/libnczarr/CMakeLists.txt
+index 86e093b..c0efe1b 100644
+--- a/libnczarr/CMakeLists.txt
++++ b/libnczarr/CMakeLists.txt
+@@ -57,6 +57,7 @@ ENDIF()
+ # the netCDF library.
+ 
+ add_library(nczarr OBJECT ${libnczarr_SOURCES})
++target_link_libraries(nczarr PRIVATE ${Zip_LIBRARIES})
+ 
+ IF(MPI_C_INCLUDE_PATH)
+     target_include_directories(nczarr PUBLIC ${MPI_C_INCLUDE_PATH})
 diff --git a/netCDFConfig.cmake.in b/netCDFConfig.cmake.in
-index b3be259..72b4b25 100644
+index 715e33e..0167326 100644
 --- a/netCDFConfig.cmake.in
 +++ b/netCDFConfig.cmake.in
-@@ -15,6 +15,9 @@ set(netCDF_LIBRARIES netCDF::netcdf)
+@@ -19,6 +19,9 @@ endif()
  if("@FOUND_CURL@")
    find_dependency(CURL CONFIG)
  endif()
@@ -32,62 +42,3 @@ index b3be259..72b4b25 100644
  include("${CMAKE_CURRENT_LIST_DIR}/netCDFTargets.cmake")
  
  # Compiling Options
-diff --git a/liblib/CMakeLists.txt b/liblib/CMakeLists.txt
-index 1363d35..31dbbda 100644
---- a/liblib/CMakeLists.txt
-+++ b/liblib/CMakeLists.txt
-@@ -134,6 +134,10 @@ ENDIF()
- 
- TARGET_LINK_LIBRARIES(netcdf ${TLL_LIBS})
- 
-+if(ENABLE_NCZARR_ZIP)
-+  target_link_libraries(netcdf libzip::zip)
-+endif()
-+
- SET(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${TLL_LIBS})
- IF(MSVC)
-   SET_TARGET_PROPERTIES(netcdf PROPERTIES
-diff --git a/libnczarr/CMakeLists.txt b/libnczarr/CMakeLists.txt
-index 86e093b..d7edaf6 100644
---- a/libnczarr/CMakeLists.txt
-+++ b/libnczarr/CMakeLists.txt
-@@ -58,6 +58,10 @@ ENDIF()
- 
- add_library(nczarr OBJECT ${libnczarr_SOURCES})
- 
-+IF(ENABLE_NCZARR_ZIP)
-+    target_link_libraries(nczarr PRIVATE libzip::zip)
-+ENDIF()
-+
- IF(MPI_C_INCLUDE_PATH)
-     target_include_directories(nczarr PUBLIC ${MPI_C_INCLUDE_PATH})
- ENDIF(MPI_C_INCLUDE_PATH)
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6357965..3de76cd 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -2123,6 +2123,10 @@ replace_pkgconfig_module("-lzip"       "libzip")
- replace_pkgconfig_module("-lCURL[^ ]*" "libcurl")
- replace_pkgconfig_module("-lZLIB[^ ]*" "zlib")
- 
-+IF(ENABLE_NCZARR_ZIP)
-+  string(APPEND NC_REQUIRES_PRIVATE " libzip")
-+ENDIF()
-+
- configure_file(
-   ${netCDF_SOURCE_DIR}/netcdf.pc.in
-   ${netCDF_BINARY_DIR}/netcdf.pc @ONLY)
-diff --git a/liblib/CMakeLists.txt b/liblib/CMakeLists.txt
-index 31dbbda..eb497cc 100644
---- a/liblib/CMakeLists.txt
-+++ b/liblib/CMakeLists.txt
-@@ -120,9 +120,6 @@ IF(ENABLE_PNETCDF AND PNETCDF)
-   SET(TLL_LIBS ${TLL_LIBS} ${PNETCDF})
- ENDIF()
- 
--IF(ENABLE_NCZARR_ZIP)
--  SET(TLL_LIBS ${TLL_LIBS} ${Zip_LIBRARIES})
--ENDIF()
- 
- IF(ENABLE_S3_SDK)
-   TARGET_LINK_DIRECTORIES(netcdf PUBLIC ${AWSSDK_LIB_DIR})

--- a/ports/netcdf-c/fix-pkgconfig.patch
+++ b/ports/netcdf-c/fix-pkgconfig.patch
@@ -17,7 +17,7 @@ index 390ac0a..4bcd909 100644
 +replace_pkgconfig_module("-lhdf5_hl"   "hdf5_hl")
 +replace_pkgconfig_module("-lhdf5"      "hdf5")
 +replace_pkgconfig_module("-lmpi"       "ompi-c")
-+replace_pkgconfig_module("-lzip"       "libzip")
++replace_pkgconfig_module("-lzip::zip"  "libzip")
 +replace_pkgconfig_module("-lCURL[^ ]*" "libcurl")
 +replace_pkgconfig_module("-lZLIB[^ ]*" "zlib")
 +

--- a/ports/netcdf-c/portfile.cmake
+++ b/ports/netcdf-c/portfile.cmake
@@ -10,10 +10,10 @@ vcpkg_from_github(
         use_targets.patch
         fix-dependency-libmath.patch
         fix-linkage-error.patch
-        fix-pkgconfig.patch
         fix-manpage-msys.patch
         fix-dependency-libzip.patch
         fix-dependency-mpi.patch
+        fix-pkgconfig.patch
 )
 
 #Remove outdated find modules
@@ -41,6 +41,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 if(NOT ENABLE_DAP AND NOT ENABLE_NCZARR)
     list(APPEND FEATURE_OPTIONS "-DCMAKE_DISABLE_FIND_PACKAGE_CURL=ON")
+else()
+    list(APPEND FEATURE_OPTIONS "-DCMAKE_REQUIRE_FIND_PACKAGE_CURL=ON")
 endif()
 
 if(ENABLE_HDF5)

--- a/ports/netcdf-c/use_targets.patch
+++ b/ports/netcdf-c/use_targets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 507eb4c..1113c7b 100644
+index 507eb4c..1516d0c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -433,7 +433,6 @@ IF(NC_EXTRA_DEPS)
@@ -64,14 +64,12 @@ index 507eb4c..1113c7b 100644
        FIND_LIBRARY(SZIP PATH NAMES szip sz)
        SET(SZIP_LIBRARY ${SZIP})
        IF(NOT SZIP)
-@@ -847,12 +852,14 @@ IF(USE_HDF5)
- ENDIF(USE_HDF5)
+@@ -848,11 +853,14 @@ ENDIF(USE_HDF5)
  
  # See if we have libcurl
--FIND_PACKAGE(CURL)
+ FIND_PACKAGE(CURL)
 -ADD_DEFINITIONS(-DCURL_STATICLIB=1)
--INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
-+FIND_PACKAGE(CURL CONFIG)
+ INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
  
  # Define a test flag for have curl library
 -IF(CURL_LIBRARIES OR CURL_LIBRARY)
@@ -83,7 +81,7 @@ index 507eb4c..1113c7b 100644
    SET(FOUND_CURL TRUE)
  ELSE()
    SET(FOUND_CURL FALSE)
-@@ -2089,10 +2096,9 @@ IF(NC_LIBS)
+@@ -2089,10 +2097,9 @@ IF(NC_LIBS)
    STRING(REPLACE "-lhdf5::hdf5_hl-static" "-lhdf5_hl" NC_LIBS ${NC_LIBS})
  ENDIF()
  

--- a/ports/netcdf-c/use_targets.patch
+++ b/ports/netcdf-c/use_targets.patch
@@ -125,13 +125,17 @@ diff --git a/netCDFConfig.cmake.in b/netCDFConfig.cmake.in
 index 9d68eec..b3be259 100644
 --- a/netCDFConfig.cmake.in
 +++ b/netCDFConfig.cmake.in
-@@ -12,6 +12,9 @@ set_and_check(netCDF_LIB_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
+@@ -12,6 +12,13 @@ set_and_check(netCDF_LIB_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
  set(netCDF_LIBRARIES netCDF::netcdf)
  
  # include target information
 +include(CMakeFindDependencyMacro)
-+find_dependency(HDF5 CONFIG)
-+find_dependency(CURL CONFIG)
++if("@USE_HDF5@")
++  find_dependency(HDF5 CONFIG)
++endif()
++if("@FOUND_CURL@")
++  find_dependency(CURL CONFIG)
++endif()
  include("${CMAKE_CURRENT_LIST_DIR}/netCDFTargets.cmake")
  
  # Compiling Options

--- a/ports/netcdf-c/use_targets.patch
+++ b/ports/netcdf-c/use_targets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 507eb4c..c36908b 100644
+index 507eb4c..1113c7b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -433,7 +433,6 @@ IF(NC_EXTRA_DEPS)
@@ -35,11 +35,10 @@ index 507eb4c..c36908b 100644
      ENDIF(MSVC)
  
      ##
-@@ -726,6 +716,19 @@ IF(USE_HDF5)
-       SET(HDF5_C_LIBRARY hdf5)
+@@ -727,6 +717,19 @@ IF(USE_HDF5)
      ENDIF()
    ENDIF(HDF5_C_LIBRARY AND HDF5_HL_LIBRARY AND HDF5_INCLUDE_DIR)
-+  
+ 
 +  if(TARGET hdf5::hdf5-shared)
 +    set(HDF5_C_LIBRARY hdf5::hdf5-shared)
 +    set(HDF5_C_LIBRARY_hdf5 hdf5::hdf5-shared)
@@ -52,9 +51,10 @@ index 507eb4c..c36908b 100644
 +    ADD_DEFINITIONS(-DH5_BUILT_AS_STATIC_LIB)
 +  endif()
 +  list(APPEND CMAKE_REQUIRED_LIBRARIES ${HDF5_C_LIBRARY})
- 
++
    FIND_PACKAGE(Threads)
  
+   # There is a missing case in the above code so default it
 @@ -745,6 +748,8 @@ IF(USE_HDF5)
    IF(USE_SZIP)
      # If user has specified the `SZIP_LIBRARY`, use it; otherwise try to find...
@@ -64,17 +64,26 @@ index 507eb4c..c36908b 100644
        FIND_LIBRARY(SZIP PATH NAMES szip sz)
        SET(SZIP_LIBRARY ${SZIP})
        IF(NOT SZIP)
-@@ -847,8 +852,7 @@ IF(USE_HDF5)
+@@ -847,12 +852,14 @@ IF(USE_HDF5)
  ENDIF(USE_HDF5)
  
  # See if we have libcurl
 -FIND_PACKAGE(CURL)
 -ADD_DEFINITIONS(-DCURL_STATICLIB=1)
+-INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
 +FIND_PACKAGE(CURL CONFIG)
- INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
  
  # Define a test flag for have curl library
-@@ -2089,10 +2093,9 @@ IF(NC_LIBS)
+-IF(CURL_LIBRARIES OR CURL_LIBRARY)
++IF(CURL_FOUND)
++  SET(CURL_LIBRARY CURL::libcurl)
++  if(CURL_VERSION VERSION_GREATER_EQUAL "7.66")
++    set(HAVE_LIBCURL_766 TRUE CACHE INTERNAL "vcpkg")
++  endif()
+   SET(FOUND_CURL TRUE)
+ ELSE()
+   SET(FOUND_CURL FALSE)
+@@ -2089,10 +2096,9 @@ IF(NC_LIBS)
    STRING(REPLACE "-lhdf5::hdf5_hl-static" "-lhdf5_hl" NC_LIBS ${NC_LIBS})
  ENDIF()
  
@@ -88,7 +97,7 @@ index 507eb4c..c36908b 100644
  SET(LIBS ${NC_LIBS})
  SET(NC_LIBS "-lnetcdf")
 diff --git a/liblib/CMakeLists.txt b/liblib/CMakeLists.txt
-index 5e1692f..9e126ec 100644
+index 5e1692f..882f1dd 100644
 --- a/liblib/CMakeLists.txt
 +++ b/liblib/CMakeLists.txt
 @@ -77,6 +77,12 @@ IF(HAVE_LIBDL)
@@ -104,15 +113,6 @@ index 5e1692f..9e126ec 100644
    IF(NOT MSVC)
      # Some version of cmake define HDF5_hdf5_LIBRARY instead of
      # HDF5_LIBRARY. Same with HDF5_HL_LIBRARIES
-@@ -97,7 +103,7 @@ IF(USE_HDF5)
- ENDIF()
- 
- IF(FOUND_CURL)
--  SET(TLL_LIBS ${TLL_LIBS} ${CURL_LIBRARY})
-+  SET(TLL_LIBS ${TLL_LIBS} CURL::libcurl)
- ENDIF()
- 
- IF(USE_HDF4)
 @@ -118,7 +124,6 @@ IF(ENABLE_S3_SDK)
  ENDIF()
  
@@ -122,7 +122,7 @@ index 5e1692f..9e126ec 100644
  
  TARGET_LINK_LIBRARIES(netcdf ${TLL_LIBS})
 diff --git a/netCDFConfig.cmake.in b/netCDFConfig.cmake.in
-index 9d68eec..b3be259 100644
+index 9d68eec..715e33e 100644
 --- a/netCDFConfig.cmake.in
 +++ b/netCDFConfig.cmake.in
 @@ -12,6 +12,13 @@ set_and_check(netCDF_LIB_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")

--- a/ports/netcdf-c/vcpkg.json
+++ b/ports/netcdf-c/vcpkg.json
@@ -16,9 +16,12 @@
   ],
   "default-features": [
     "dap",
+    {
+      "name": "hdf5",
+      "platform": "!uwp & !(arm64 & windows)"
+    },
     "nczarr",
-    "netcdf-4",
-    "platform-default-features"
+    "netcdf-4"
   ],
   "features": {
     "dap": {
@@ -87,20 +90,6 @@
     },
     "netcdf-4": {
       "description": "Build with netCDF-4 support"
-    },
-    "platform-default-features": {
-      "$comment": "Break vcpkg CI cascade.",
-      "description": "Enable platform-dependent default features",
-      "dependencies": [
-        {
-          "name": "netcdf-c",
-          "default-features": false,
-          "features": [
-            "hdf5"
-          ],
-          "platform": "!uwp & !(arm64 & windows)"
-        }
-      ]
     },
     "tools": {
       "description": "Build utilities"

--- a/ports/netcdf-c/vcpkg.json
+++ b/ports/netcdf-c/vcpkg.json
@@ -57,6 +57,10 @@
       "description": "Build with NCZarr cloud storage access support",
       "dependencies": [
         {
+          "name": "curl",
+          "default-features": false
+        },
+        {
           "name": "netcdf-c",
           "default-features": false,
           "features": [

--- a/ports/netcdf-c/vcpkg.json
+++ b/ports/netcdf-c/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "netcdf-c",
   "version": "4.8.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.",
   "homepage": "https://github.com/Unidata/netcdf-c",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5750,7 +5750,7 @@
     },
     "netcdf-c": {
       "baseline": "4.8.1",
-      "port-version": 3
+      "port-version": 4
     },
     "netcdf-cxx4": {
       "baseline": "4.3.1",

--- a/versions/n-/netcdf-c.json
+++ b/versions/n-/netcdf-c.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a549f14ba295c1d3c50c7c482158a3ca2f49939a",
+      "git-tree": "2e357648a678429756cbe2bd2803702a701b7e9d",
       "version": "4.8.1",
       "port-version": 4
     },

--- a/versions/n-/netcdf-c.json
+++ b/versions/n-/netcdf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a549f14ba295c1d3c50c7c482158a3ca2f49939a",
+      "version": "4.8.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "2d17052df3479de37b4c756f4e90661c9fa85e7d",
       "version": "4.8.1",
       "port-version": 3

--- a/versions/n-/netcdf-c.json
+++ b/versions/n-/netcdf-c.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2e357648a678429756cbe2bd2803702a701b7e9d",
+      "git-tree": "12002458bc69dbcd92c6792a3edd1f5e3931ae95",
       "version": "4.8.1",
       "port-version": 4
     },


### PR DESCRIPTION
Fixes #33753 (hdf5 and curl dependencies in exported config).
Amends #30938 (libzip dependency).
Adds curl dependency to feature nczarr.
Replace `platform-default-features` using `platform` expression in `default-features`.

All features tested on x64-linux with `vcpkg test-features netcdf-c`.