### PR TITLE
[apr-util] update to 1.6.3

### DIFF
--- a/ports/apr-util/portfile.cmake
+++ b/ports/apr-util/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://archive.apache.org/dist/apr/apr-util-1.6.1.tar.bz2"
-    FILENAME "apr-util-1.6.1.tar.bz2"
-    SHA512 40eff8a37c0634f7fdddd6ca5e596b38de15fd10767a34c30bbe49c632816e8f3e1e230678034f578dd5816a94f246fb5dfdf48d644829af13bf28de3225205d
+  URLS "https://archive.apache.org/dist/apr/apr-util-${VERSION}.tar.bz2"
+    FILENAME "apr-util-${VERSION}.tar.bz2"
+    SHA512 8050a481eeda7532ef3751dbd8a5aa6c48354d52904a856ef9709484f4b0cc2e022661c49ddf55ec58253db22708ee0607dfa7705d9270e8fee117ae4f06a0fe
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/apr-util/use-vcpkg-expat.patch
+++ b/ports/apr-util/use-vcpkg-expat.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9ae90b1..71a50b0 100644
+index fcbfc58..7781131 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -21,16 +21,14 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
  
  FIND_PACKAGE(OpenSSL)
  
--FIND_PACKAGE(expat)
+-FIND_PACKAGE(EXPAT)
 -
  OPTION(APU_HAVE_CRYPTO      "Crypto support"                            OFF)
  OPTION(APU_HAVE_ODBC        "Build ODBC DBD driver"                     ON)
@@ -48,55 +48,45 @@ index 9ae90b1..71a50b0 100644
  SET(install_targets ${install_targets} libaprutil-1)
  SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/libaprutil-1.pdb)
  TARGET_LINK_LIBRARIES(libaprutil-1 ${APR_LIBRARIES} ${XMLLIB_LIBRARIES})
--SET_TARGET_PROPERTIES(libaprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_EXPORT;APR_DECLARE_EXPORT;XML_STATIC;WINNT")
-+SET_TARGET_PROPERTIES(libaprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_EXPORT;APR_DECLARE_IMPORT;XML_STATIC;WINNT")
+ SET_TARGET_PROPERTIES(libaprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_EXPORT;APR_DECLARE_IMPORT;XML_STATIC;WINNT")
  
 +else(BUILD_SHARED_LIBS)
  ADD_LIBRARY(aprutil-1 STATIC ${APR_SOURCES} ${APR_PUBLIC_HEADERS_GENERATED})
  SET(install_targets ${install_targets} aprutil-1)
  TARGET_LINK_LIBRARIES(aprutil-1 ${APR_LIBRARIES} ${XMLLIB_LIBRARIES})
  SET_TARGET_PROPERTIES(aprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_STATIC;APR_DECLARE_STATIC;APU_DSO_MODULE_BUILD;XML_STATIC")
-+endif(BUILD_SHARED_LIBS)
++endif()
  
 +if(BUILD_SHARED_LIBS)
  IF(APU_HAVE_CRYPTO)
    IF(NOT OPENSSL_FOUND)
      MESSAGE(FATAL_ERROR "Only OpenSSL-based crypto is currently implemented in the cmake build")
-@@ -249,7 +251,7 @@ IF(APU_HAVE_CRYPTO)
-   SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/apr_crypto_openssl-1.pdb)
-   SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES INCLUDE_DIRECTORIES "${APR_INCLUDE_DIRECTORIES};${OPENSSL_INCLUDE_DIR}")
-   SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES COMPILE_DEFINITIONS "WINNT")
--  SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_EXPORT=1 -DAPU_DECLARE_EXPORT=1 -DDLL_NAME=apr_crypto_openssl")
-+  SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_IMPORT -DAPU_DECLARE_IMPORT -DDLL_NAME=apr_crypto_openssl")
-   TARGET_LINK_LIBRARIES(apr_crypto_openssl-1 libaprutil-1 ${APR_LIBRARIES} ${OPENSSL_LIBRARIES})
- ENDIF()
- 
-@@ -260,8 +262,8 @@ IF(APU_HAVE_ODBC)
-   SET(dbd_drivers ${dbd_drivers} odbc)
-   TARGET_LINK_LIBRARIES(apr_dbd_odbc-1 libaprutil-1 ${APR_LIBRARIES} odbc32 odbccp32)
-   SET_PROPERTY(TARGET apr_dbd_odbc-1 APPEND PROPERTY LINK_FLAGS /export:apr_dbd_odbc_driver)
--  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_DEFINITIONS "APU_HAVE_ODBC;HAVE_SQL_H;APU_DECLARE_EXPORT;APR_DECLARE_EXPORT;APU_DSO_MODULE_BUILD;WINNT")
--  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_EXPORT=1 -DAPU_DECLARE_EXPORT=1 -DDLL_NAME=apr_dbd_odbc")
-+  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_DEFINITIONS "APU_HAVE_ODBC;HAVE_SQL_H;APU_DECLARE_IMPORT;APR_DECLARE_IMPORT;APU_DSO_MODULE_BUILD;WINNT")
-+  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_IMPORT  -DAPU_DECLARE_IMPORT -DDLL_NAME=apr_dbd_odbc")
+@@ -265,7 +267,7 @@ IF(APU_HAVE_ODBC)
  ENDIF()
  
  IF(APR_HAS_LDAP)
-@@ -271,11 +273,12 @@ IF(APR_HAS_LDAP)
+-  ADD_LIBRARY(apr_ldap-1 SHARED ldap/apr_ldap_init.c ldap/apr_ldap_option.c 
++  ADD_LIBRARY(apr_ldap-1 SHARED ldap/apr_ldap_init.c ldap/apr_ldap_option.c
+               ldap/apr_ldap_rebind.c libaprutil.rc)
+   SET(install_targets ${install_targets} apr_ldap-1)
    SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/apr_ldap-1.pdb)
-   TARGET_LINK_LIBRARIES(apr_ldap-1 libaprutil-1 ${APR_LIBRARIES} ${LDAP_LIBRARIES})
-   SET_TARGET_PROPERTIES(apr_ldap-1 PROPERTIES COMPILE_DEFINITIONS "WINNT")
--  SET_TARGET_PROPERTIES(apr_ldap-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_EXPORT=1 -DAPU_DECLARE_EXPORT=1 -DDLL_NAME=apr_ldap")
-+  SET_TARGET_PROPERTIES(apr_ldap-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_IMPORT -DAPU_DECLARE_IMPORT -DDLL_NAME=apr_ldap")
-   SET(apr_ldap_libraries apr_ldap-1)
+@@ -276,6 +278,7 @@ IF(APR_HAS_LDAP)
  ELSE()
    SET(apr_ldap_libraries)
  ENDIF()
-+endif(BUILD_SHARED_LIBS)
++endif()
  
  IF(APR_BUILD_TESTAPR)
    ENABLE_TESTING()
-@@ -289,7 +292,7 @@ IF(APR_BUILD_TESTAPR)
+@@ -283,13 +286,13 @@ IF(APR_BUILD_TESTAPR)
+   ADD_CUSTOM_TARGET(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose)
+ 
+   # copy data files to build directory so that we can run programs from there
+-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory 
++  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory
+                   ${PROJECT_BINARY_DIR}/data)
+-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
++  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy_if_different
                    ${PROJECT_SOURCE_DIR}/test/data/billion-laughs.xml
                    ${PROJECT_BINARY_DIR}/data/billion-laughs.xml)
  

--- a/ports/apr-util/vcpkg.json
+++ b/ports/apr-util/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "apr-util",
-  "version": "1.6.1",
-  "port-version": 10,
+  "version": "1.6.3",
   "description": "Apache Portable Runtime (APR) project  mission is to create and maintain software libraries that provide a predictable and consistent interface to underlying platform-specific implementation",
   "homepage": "https://apr.apache.org/",
   "license": "Apache-2.0",

--- a/versions/a-/apr-util.json
+++ b/versions/a-/apr-util.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4e5d849625c94b913aee1f51ffd2efb84e38e1af",
+      "git-tree": "c6555c2af4f36e5aeb1eabc818738e4ffbba77d8",
       "version": "1.6.3",
       "port-version": 0
     },

--- a/versions/a-/apr-util.json
+++ b/versions/a-/apr-util.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e5d849625c94b913aee1f51ffd2efb84e38e1af",
+      "version": "1.6.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "41451c5e1e1fa8344f6c2d1baf6c0f14b656c433",
       "version": "1.6.1",
       "port-version": 10

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -165,8 +165,8 @@
       "port-version": 0
     },
     "apr-util": {
-      "baseline": "1.6.1",
-      "port-version": 10
+      "baseline": "1.6.3",
+      "port-version": 0
     },
     "apsi": {
       "baseline": "0.9.0",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
