### PR TITLE
[ogre-next] fix port

### DIFF
--- a/ports/ogre-next/portfile.cmake
+++ b/ports/ogre-next/portfile.cmake
@@ -10,8 +10,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OGRECave/ogre-next
-    REF e4c5f0f6d36c07af594e3ef143d017bda1581442 #v2.3.1
-    SHA512 263a50b64defa7345a109a068cc17c347a696f83f64abc071256bb46571ed6b2ef94ee3480d90938cdb7f745d36a4c4890d82677d357c62c9a2956eae8d4ac15
+    REF v${VERSION}
+    SHA512 62c721680ed77e74b6e1649ab7324bd49fc3c7c2e60ad76a62ec5f899f327d65a140462d75300eac4f41567a8903a748d07a760dc376eddcadf0aeea5a3ca5a7
     HEAD_REF master
     PATCHES
         toolchain_fixes.patch
@@ -30,6 +30,12 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
 else()
     set(OGRE_STATIC OFF)
 endif()
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        planar-reflections  OGRE_BUILD_COMPONENT_PLANAR_REFLECTIONS
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -89,6 +95,11 @@ if(VCPKG_TARGET_IS_WINDOWS)
         else()
             file(RENAME "${CURRENT_PACKAGES_DIR}/lib/release/OgreMainStatic.lib" "${CURRENT_PACKAGES_DIR}/lib/manual-link/OgreMainStatic.lib")
         endif()
+        file(GLOB LIBS "${CURRENT_PACKAGES_DIR}/lib/release/*")
+        file(GLOB DLLS "${CURRENT_PACKAGES_DIR}/bin/release/*")
+        file(COPY ${LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+        file(COPY ${DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/release/" "${CURRENT_PACKAGES_DIR}/bin/release/")
     endif()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Debug")
         file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link")
@@ -97,6 +108,11 @@ if(VCPKG_TARGET_IS_WINDOWS)
         else()
             file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/debug/OgreMainStatic_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMainStatic_d.lib")
         endif()
+        file(GLOB LIBS "${CURRENT_PACKAGES_DIR}/debug/lib/debug/*")
+        file(GLOB DLLS "${CURRENT_PACKAGES_DIR}/debug/bin/debug/*")
+        file(COPY ${LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+        file(COPY ${DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/debug/" "${CURRENT_PACKAGES_DIR}/debug/bin/debug/")
     endif()
 
     file(GLOB SHARE_FILES "${CURRENT_PACKAGES_DIR}/share/ogre-next/*.cmake")
@@ -112,3 +128,5 @@ vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_fixup_pkgconfig()

--- a/ports/ogre-next/vcpkg.json
+++ b/ports/ogre-next/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ogre-next",
   "version": "2.3.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Ogre 2.1 & 2.2 - scene-oriented, flexible 3D engine written in C++",
   "homepage": "https://github.com/OGRECave/ogre-next",
   "license": "MIT",
@@ -26,5 +26,10 @@
     },
     "zlib",
     "zziplib"
-  ]
+  ],
+  "features": {
+    "planar-reflections": {
+      "description": "Component to use planar reflections, can be used by both HlmsPbs and HlmsUnlit"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5974,7 +5974,7 @@
     },
     "ogre-next": {
       "baseline": "2.3.1",
-      "port-version": 1
+      "port-version": 2
     },
     "ois": {
       "baseline": "1.5.1",

--- a/versions/o-/ogre-next.json
+++ b/versions/o-/ogre-next.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0089cd2cc3d48d19a5b465f43454dfb0124f9723",
+      "version": "2.3.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "6af271c0d09d27f6cea912e0b3f81a310d3992be",
       "version": "2.3.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
fix #34016
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
