### PR TITLE
[fplus] update to 0.2.20-p0

### DIFF
--- a/ports/fplus/portfile.cmake
+++ b/ports/fplus/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/FunctionalPlus
-    REF v0.2.18-p0
-    SHA512 119aaef75020ef06818bf5d33db8bce272e89d69699df9be636bc6fdf06b584e1842440896a431ea2a75b88ce01472f3a9886b8dd781f5e5533315e9ad6860ac
+    REF "v${VERSION}"
+    SHA512 
     HEAD_REF master
 )
 

--- a/ports/fplus/portfile.cmake
+++ b/ports/fplus/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/FunctionalPlus
     REF "v${VERSION}"
-    SHA512 
+    SHA512 0e3478400c1acc2fc34642784f8bb3eb0f79bc4c157a38fb39c9f05d8e4c47cc6c9da765f76350fd593517c3a2db2515161f6f3d6ff770f2ace2da2a99bb493d
     HEAD_REF master
 )
 

--- a/ports/fplus/vcpkg.json
+++ b/ports/fplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fplus",
-  "version": "0.2.18-p0",
+  "version": "0.2.20-p0",
   "description": "Functional Programming Library for C++. Write concise and readable C++ code",
   "homepage": "https://github.com/Dobiasd/FunctionalPlus",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2669,7 +2669,7 @@
       "port-version": 2
     },
     "fplus": {
-      "baseline": "0.2.18-p0",
+      "baseline": "0.2.20-p0",
       "port-version": 0
     },
     "freealut": {

--- a/versions/f-/fplus.json
+++ b/versions/f-/fplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32f77339885e4a1a1b398c0be917880b991c95dc",
+      "version": "0.2.20-p0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e982e423baaf3d7728a2122368494d1c57c8e55e",
       "version": "0.2.18-p0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
