### PR TITLE
[dirent] update to 1.24

### DIFF
--- a/ports/dirent/portfile.cmake
+++ b/ports/dirent/portfile.cmake
@@ -6,8 +6,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tronkko/dirent
-    REF 1.23.2
-    SHA512 e7a991445ee9ca8f1118753df559d28beb283b3c0d25edcfb23dd5322f2bdfeadffe802d0c908bb6d4dfc17bf5ec38bdecfa717319fb4e26682bee0ba0d14c5c
+    REF "${VERSION}"
+    SHA512 bdfc5cd41034719a7bcb3b04ad1c821b73e8ab37768b831362bdd36dceb2bab832ecb56ed6e99db145d38b15e295c0971496320b0482cb339dc973a9870bb72d
     HEAD_REF master
 )
 file(INSTALL ${SOURCE_PATH}/include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include)

--- a/ports/dirent/vcpkg.json
+++ b/ports/dirent/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dirent",
-  "version": "1.23.2",
-  "port-version": 3,
+  "version": "1.24",
   "description": "Dirent is a C/C++ programming interface that allows programmers to retrieve information about files and directories under Linux/UNIX. This project provides Linux compatible Dirent interface for Microsoft Windows.",
   "homepage": "https://github.com/tronkko/dirent",
   "license": "MIT"

--- a/ports/libmagic/0003-Fix-WIN32-macro-checks.patch
+++ b/ports/libmagic/0003-Fix-WIN32-macro-checks.patch
@@ -1,29 +1,12 @@
-diff --git a/src/cdf.h b/src/cdf.h
-index 0505666..5de662a 100644
---- a/src/cdf.h
-+++ b/src/cdf.h
-@@ -35,7 +35,7 @@
- #ifndef _H_CDF_
- #define _H_CDF_
- 
--#ifdef WIN32
-+#ifdef _WIN32
- #include <winsock2.h>
- #define timespec timeval
- #define tv_nsec tv_usec
-diff --git a/src/compress.c b/src/compress.c
-index 9f65e4f..3b4c0e8 100644
---- a/src/compress.c
-+++ b/src/compress.c
-@@ -51,7 +51,7 @@ FILE_RCSID("@(#)$File: compress.c,v 1.129 2020/12/08 21:26:00 christos Exp $")
- #ifndef HAVE_SIG_T
- typedef void (*sig_t)(int);
- #endif /* HAVE_SIG_T */
--#if !defined(__MINGW32__) && !defined(WIN32) && !defined(__MINGW64__)
-+#if !defined(__MINGW32__) && !defined(_WIN32) && !defined(__MINGW64__)
- #include <sys/ioctl.h>
- #endif
- #ifdef HAVE_SYS_WAIT_H
+From 2fffeb273ea46c1e91536f3d660982de785c8d49 Mon Sep 17 00:00:00 2001
+From: Long Nguyen <nguyen.long.908132@gmail.com>
+Date: Sat, 8 May 2021 20:52:59 +0700
+Subject: [PATCH 03/14] Fix WIN32 macro checks
+
+---
+ src/file.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/src/file.h b/src/file.h
 index 299ac0c..2c365a6 100644
 --- a/src/file.h
@@ -55,114 +38,6 @@ index 299ac0c..2c365a6 100644
  #define public  __attribute__ ((__visibility__("default")))
  #ifndef protected
  #define protected __attribute__ ((__visibility__("hidden")))
-diff --git a/src/fmtcheck.c b/src/fmtcheck.c
-index fcad436..ae9d631 100644
---- a/src/fmtcheck.c
-+++ b/src/fmtcheck.c
-@@ -91,7 +91,7 @@ get_next_format_from_precision(const char **pf)
- 		f++;
- 		longdouble = 1;
- 		break;
--#ifdef WIN32
-+#ifdef _WIN32
- 	case 'I':
- 		f++;
- 		if (!*f) RETURN(pf,f,FMTCHECK_UNKNOWN);
-diff --git a/src/fsmagic.c b/src/fsmagic.c
-index 5204f20..60736fd 100644
---- a/src/fsmagic.c
-+++ b/src/fsmagic.c
-@@ -56,7 +56,7 @@ FILE_RCSID("@(#)$File: fsmagic.c,v 1.81 2019/07/16 13:30:32 christos Exp $")
- /* Might be defined in sys/types.h.  */
- # define HAVE_MAJOR
- #endif
--#ifdef WIN32
-+#ifdef _WIN32
- # define WIN32_LEAN_AND_MEAN
- # include <windows.h>
- #endif
-@@ -129,7 +129,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, struct stat *sb)
- #endif
- 	ret = stat(fn, sb);	/* don't merge into if; see "ret =" above */
- 
--#ifdef WIN32
-+#ifdef _WIN32
- 	{
- 		HANDLE hFile = CreateFile((LPCSTR)fn, 0, FILE_SHARE_DELETE |
- 		    FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0,
-diff --git a/src/magic.c b/src/magic.c
-index 81a0840..bf0c9ba 100644
---- a/src/magic.c
-+++ b/src/magic.c
-@@ -25,7 +25,7 @@
-  * SUCH DAMAGE.
-  */
- 
--#ifdef WIN32
-+#ifdef _WIN32
- #include <windows.h>
- #include <shlwapi.h>
- #endif
-@@ -81,7 +81,7 @@ private const char *file_or_fd(struct magic_set *, const char *, int);
- #define	STDIN_FILENO	0
- #endif
- 
--#ifdef WIN32
-+#ifdef _WIN32
- /* HINSTANCE of this shared library. Needed for get_default_magic() */
- static HINSTANCE _w32_dll_instance = NULL;
- 
-@@ -176,7 +176,7 @@ get_default_magic(void)
- 	static char *default_magic;
- 	char *home, *hmagicpath;
- 
--#ifndef WIN32
-+#ifndef _WIN32
- 	struct stat st;
- 
- 	if (default_magic) {
-@@ -430,7 +430,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
- 		goto done;
- 	}
- 
--#ifdef WIN32
-+#ifdef _WIN32
- 	/* Place stdin in binary mode, so EOF (Ctrl+Z) doesn't stop early. */
- 	if (fd == STDIN_FILENO)
- 		_setmode(STDIN_FILENO, O_BINARY);
-@@ -442,7 +442,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
- 			okstat = stat(inname, &sb) == 0;
- 			if (okstat && S_ISFIFO(sb.st_mode))
- 				ispipe = 1;
--#ifdef WIN32
-+#ifdef _WIN32
- 			/*
- 			 * Can't stat, can't open.  It may have been opened in
- 			 * fsmagic, so if the user doesn't have read permission,
-@@ -498,7 +498,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
- 	} else if (fd != -1) {
- 		/* Windows refuses to read from a big console buffer. */
- 		size_t howmany =
--#if defined(WIN32)
-+#if defined(_WIN32)
- 		    _isatty(fd) ? 8 * 1024 :
- #endif
- 		    ms->bytes_max;
-diff --git a/src/vasprintf.c b/src/vasprintf.c
-index 9b2cecb..3788fa5 100644
---- a/src/vasprintf.c
-+++ b/src/vasprintf.c
-@@ -632,11 +632,11 @@ int vasprintf(char **ptr, const char *format_string, va_list vargs)
- # ifdef __va_copy
-   __va_copy (s.vargs, vargs);
- # else
--#  ifdef WIN32
-+#  ifdef _WIN32
-   s.vargs = vargs;
- #  else
-   memcpy (&s.vargs, &vargs, sizeof (s.va_args));
--#  endif /* WIN32 */
-+#  endif /* _WIN32 */
- # endif /* __va_copy */
- #endif /* va_copy */
-   s.maxlen = (size_t)INT_MAX;
+-- 
+2.29.2.windows.2
+

--- a/ports/libmagic/0003-Fix-WIN32-macro-checks.patch
+++ b/ports/libmagic/0003-Fix-WIN32-macro-checks.patch
@@ -25,11 +25,11 @@ index 9f65e4f..3b4c0e8 100644
  #endif
  #ifdef HAVE_SYS_WAIT_H
 diff --git a/src/file.h b/src/file.h
-index c548e97..f02a7b1 100644
+index 299ac0c..2c365a6 100644
 --- a/src/file.h
 +++ b/src/file.h
 @@ -82,7 +82,7 @@
- #include <regex.h>
+ #include <tre/regex.h>
  #include <time.h>
  #include <sys/types.h>
 -#ifndef WIN32

--- a/ports/libmagic/0003-Fix-WIN32-macro-checks.patch
+++ b/ports/libmagic/0003-Fix-WIN32-macro-checks.patch
@@ -1,18 +1,35 @@
-From 2fffeb273ea46c1e91536f3d660982de785c8d49 Mon Sep 17 00:00:00 2001
-From: Long Nguyen <nguyen.long.908132@gmail.com>
-Date: Sat, 8 May 2021 20:52:59 +0700
-Subject: [PATCH 03/14] Fix WIN32 macro checks
-
----
- src/file.h | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
-
+diff --git a/src/cdf.h b/src/cdf.h
+index 0505666..5de662a 100644
+--- a/src/cdf.h
++++ b/src/cdf.h
+@@ -35,7 +35,7 @@
+ #ifndef _H_CDF_
+ #define _H_CDF_
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #include <winsock2.h>
+ #define timespec timeval
+ #define tv_nsec tv_usec
+diff --git a/src/compress.c b/src/compress.c
+index 9f65e4f..3b4c0e8 100644
+--- a/src/compress.c
++++ b/src/compress.c
+@@ -51,7 +51,7 @@ FILE_RCSID("@(#)$File: compress.c,v 1.129 2020/12/08 21:26:00 christos Exp $")
+ #ifndef HAVE_SIG_T
+ typedef void (*sig_t)(int);
+ #endif /* HAVE_SIG_T */
+-#if !defined(__MINGW32__) && !defined(WIN32) && !defined(__MINGW64__)
++#if !defined(__MINGW32__) && !defined(_WIN32) && !defined(__MINGW64__)
+ #include <sys/ioctl.h>
+ #endif
+ #ifdef HAVE_SYS_WAIT_H
 diff --git a/src/file.h b/src/file.h
-index 299ac0c..2c365a6 100644
+index c548e97..f02a7b1 100644
 --- a/src/file.h
 +++ b/src/file.h
 @@ -82,7 +82,7 @@
- #include <tre/regex.h>
+ #include <regex.h>
  #include <time.h>
  #include <sys/types.h>
 -#ifndef WIN32
@@ -38,6 +55,114 @@ index 299ac0c..2c365a6 100644
  #define public  __attribute__ ((__visibility__("default")))
  #ifndef protected
  #define protected __attribute__ ((__visibility__("hidden")))
--- 
-2.29.2.windows.2
-
+diff --git a/src/fmtcheck.c b/src/fmtcheck.c
+index fcad436..ae9d631 100644
+--- a/src/fmtcheck.c
++++ b/src/fmtcheck.c
+@@ -91,7 +91,7 @@ get_next_format_from_precision(const char **pf)
+ 		f++;
+ 		longdouble = 1;
+ 		break;
+-#ifdef WIN32
++#ifdef _WIN32
+ 	case 'I':
+ 		f++;
+ 		if (!*f) RETURN(pf,f,FMTCHECK_UNKNOWN);
+diff --git a/src/fsmagic.c b/src/fsmagic.c
+index 5204f20..60736fd 100644
+--- a/src/fsmagic.c
++++ b/src/fsmagic.c
+@@ -56,7 +56,7 @@ FILE_RCSID("@(#)$File: fsmagic.c,v 1.81 2019/07/16 13:30:32 christos Exp $")
+ /* Might be defined in sys/types.h.  */
+ # define HAVE_MAJOR
+ #endif
+-#ifdef WIN32
++#ifdef _WIN32
+ # define WIN32_LEAN_AND_MEAN
+ # include <windows.h>
+ #endif
+@@ -129,7 +129,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, struct stat *sb)
+ #endif
+ 	ret = stat(fn, sb);	/* don't merge into if; see "ret =" above */
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ 	{
+ 		HANDLE hFile = CreateFile((LPCSTR)fn, 0, FILE_SHARE_DELETE |
+ 		    FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0,
+diff --git a/src/magic.c b/src/magic.c
+index 81a0840..bf0c9ba 100644
+--- a/src/magic.c
++++ b/src/magic.c
+@@ -25,7 +25,7 @@
+  * SUCH DAMAGE.
+  */
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #include <windows.h>
+ #include <shlwapi.h>
+ #endif
+@@ -81,7 +81,7 @@ private const char *file_or_fd(struct magic_set *, const char *, int);
+ #define	STDIN_FILENO	0
+ #endif
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ /* HINSTANCE of this shared library. Needed for get_default_magic() */
+ static HINSTANCE _w32_dll_instance = NULL;
+ 
+@@ -176,7 +176,7 @@ get_default_magic(void)
+ 	static char *default_magic;
+ 	char *home, *hmagicpath;
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ 	struct stat st;
+ 
+ 	if (default_magic) {
+@@ -430,7 +430,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
+ 		goto done;
+ 	}
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ 	/* Place stdin in binary mode, so EOF (Ctrl+Z) doesn't stop early. */
+ 	if (fd == STDIN_FILENO)
+ 		_setmode(STDIN_FILENO, O_BINARY);
+@@ -442,7 +442,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
+ 			okstat = stat(inname, &sb) == 0;
+ 			if (okstat && S_ISFIFO(sb.st_mode))
+ 				ispipe = 1;
+-#ifdef WIN32
++#ifdef _WIN32
+ 			/*
+ 			 * Can't stat, can't open.  It may have been opened in
+ 			 * fsmagic, so if the user doesn't have read permission,
+@@ -498,7 +498,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
+ 	} else if (fd != -1) {
+ 		/* Windows refuses to read from a big console buffer. */
+ 		size_t howmany =
+-#if defined(WIN32)
++#if defined(_WIN32)
+ 		    _isatty(fd) ? 8 * 1024 :
+ #endif
+ 		    ms->bytes_max;
+diff --git a/src/vasprintf.c b/src/vasprintf.c
+index 9b2cecb..3788fa5 100644
+--- a/src/vasprintf.c
++++ b/src/vasprintf.c
+@@ -632,11 +632,11 @@ int vasprintf(char **ptr, const char *format_string, va_list vargs)
+ # ifdef __va_copy
+   __va_copy (s.vargs, vargs);
+ # else
+-#  ifdef WIN32
++#  ifdef _WIN32
+   s.vargs = vargs;
+ #  else
+   memcpy (&s.vargs, &vargs, sizeof (s.va_args));
+-#  endif /* WIN32 */
++#  endif /* _WIN32 */
+ # endif /* __va_copy */
+ #endif /* va_copy */
+   s.maxlen = (size_t)INT_MAX;

--- a/ports/libmagic/0016-Fix-file_famagic-function.patch
+++ b/ports/libmagic/0016-Fix-file_famagic-function.patch
@@ -1,0 +1,177 @@
+diff --git a/src/compress.c b/src/compress.c
+index f89b956..4ab64f3 100644
+--- a/src/compress.c
++++ b/src/compress.c
+@@ -51,7 +51,7 @@ FILE_RCSID("@(#)$File: compress.c,v 1.129 2020/12/08 21:26:00 christos Exp $")
+ #ifndef HAVE_SIG_T
+ typedef void (*sig_t)(int);
+ #endif /* HAVE_SIG_T */
+-#if !defined(__MINGW32__) && !defined(WIN32) && !defined(__MINGW64__)
++#if !defined(__MINGW32__) && !defined(_WIN32) && !defined(__MINGW64__)
+ #include <sys/ioctl.h>
+ #endif
+ #ifdef HAVE_SYS_WAIT_H
+@@ -380,7 +380,7 @@ protected ssize_t
+ sread(int fd, void *buf, size_t n, int canbepipe __attribute__((__unused__)))
+ {
+ 	ssize_t rv;
+-#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(WIN32)
++#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(_WIN32)
+ 	int t = 0;
+ #endif
+ 	size_t rn = n;
+@@ -388,7 +388,7 @@ sread(int fd, void *buf, size_t n, int canbepipe __attribute__((__unused__)))
+ 	if (fd == STDIN_FILENO)
+ 		goto nocheck;
+ 
+-#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(WIN32)
++#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(_WIN32)
+ 	if (canbepipe && (ioctl(fd, FIONREAD, &t) == -1 || t == 0)) {
+ #ifdef FD_ZERO
+ 		ssize_t cnt;
+diff --git a/src/fmtcheck.c b/src/fmtcheck.c
+index fcad436..ae9d631 100644
+--- a/src/fmtcheck.c
++++ b/src/fmtcheck.c
+@@ -91,7 +91,7 @@ get_next_format_from_precision(const char **pf)
+ 		f++;
+ 		longdouble = 1;
+ 		break;
+-#ifdef WIN32
++#ifdef _WIN32
+ 	case 'I':
+ 		f++;
+ 		if (!*f) RETURN(pf,f,FMTCHECK_UNKNOWN);
+diff --git a/src/fsmagic.c b/src/fsmagic.c
+index 7244841..33ad47e 100644
+--- a/src/fsmagic.c
++++ b/src/fsmagic.c
+@@ -56,7 +56,7 @@ FILE_RCSID("@(#)$File: fsmagic.c,v 1.81 2019/07/16 13:30:32 christos Exp $")
+ /* Might be defined in sys/types.h.  */
+ # define HAVE_MAJOR
+ #endif
+-#ifdef WIN32
++#ifdef _WIN32
+ # define WIN32_LEAN_AND_MEAN
+ # include <windows.h>
+ #endif
+@@ -66,7 +66,7 @@ FILE_RCSID("@(#)$File: fsmagic.c,v 1.81 2019/07/16 13:30:32 christos Exp $")
+ # define minor(dev)  ((dev) & 0xff)
+ #endif
+ #undef HAVE_MAJOR
+-#if S_IFLNK != 0
++#if S_IFLNK != 0 && ! defined(_WIN32)
+ private int
+ bad_link(struct magic_set *ms, int err, char *buf)
+ {
+@@ -108,7 +108,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, struct stat *sb)
+ 	int ret, did = 0;
+ 	int mime = ms->flags & MAGIC_MIME;
+ 	int silent = ms->flags & (MAGIC_APPLE|MAGIC_EXTENSION);
+-#if S_IFLNK != 0
++#if S_IFLNK != 0 && ! defined(_WIN32)
+ 	char buf[BUFSIZ+4];
+ 	ssize_t nch;
+ 	struct stat tstatbuf;
+@@ -122,14 +122,14 @@ file_fsmagic(struct magic_set *ms, const char *fn, struct stat *sb)
+ 	 * Fstat is cheaper but fails for files you don't have read perms on.
+ 	 * On 4.2BSD and similar systems, use lstat() to identify symlinks.
+ 	 */
+-#if S_IFLNK != 0
++#if S_IFLNK != 0 && ! defined(_WIN32)
+ 	if ((ms->flags & MAGIC_SYMLINK) == 0)
+ 		ret = lstat(fn, sb);
+ 	else
+ #endif
+ 	ret = stat(fn, sb);	/* don't merge into if; see "ret =" above */
+ 
+-#ifdef WIN32
++#ifdef _WIN32 && ! defined(_WIN32)
+ 	{
+ 		HANDLE hFile = CreateFile((LPCSTR)fn, 0, FILE_SHARE_DELETE |
+ 		    FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0,
+@@ -290,7 +290,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, struct stat *sb)
+ 			return -1;
+ 		break;
+ #endif
+-#if S_IFLNK != 0
++#if S_IFLNK != 0 && ! defined(_WIN32)
+ 	case S_IFLNK:
+ 		if ((nch = readlink(fn, buf, BUFSIZ-1)) <= 0) {
+ 			if (ms->flags & MAGIC_ERROR) {
+diff --git a/src/magic.c b/src/magic.c
+index 382bd96..d4fa91a 100644
+--- a/src/magic.c
++++ b/src/magic.c
+@@ -25,7 +25,7 @@
+  * SUCH DAMAGE.
+  */
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #include <windows.h>
+ #include <shlwapi.h>
+ #endif
+@@ -83,7 +83,7 @@ private const char *file_or_fd(struct magic_set *, const char *, int);
+ #define	STDIN_FILENO	0
+ #endif
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ /* HINSTANCE of this shared library. Needed for get_default_magic() */
+ static HINSTANCE _w32_dll_instance = NULL;
+ 
+@@ -178,7 +178,7 @@ get_default_magic(void)
+ 	static char *default_magic;
+ 	char *home, *hmagicpath;
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ 	struct stat st;
+ 
+ 	if (default_magic) {
+@@ -432,7 +432,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
+ 		goto done;
+ 	}
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ 	/* Place stdin in binary mode, so EOF (Ctrl+Z) doesn't stop early. */
+ 	if (fd == STDIN_FILENO)
+ 		_setmode(STDIN_FILENO, O_BINARY);
+@@ -444,7 +444,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
+ 			okstat = stat(inname, &sb) == 0;
+ 			if (okstat && S_ISFIFO(sb.st_mode))
+ 				ispipe = 1;
+-#ifdef WIN32
++#ifdef _WIN32
+ 			/*
+ 			 * Can't stat, can't open.  It may have been opened in
+ 			 * fsmagic, so if the user doesn't have read permission,
+@@ -500,7 +500,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
+ 	} else if (fd != -1) {
+ 		/* Windows refuses to read from a big console buffer. */
+ 		size_t howmany =
+-#if defined(WIN32)
++#if defined(_WIN32)
+ 		    _isatty(fd) ? 8 * 1024 :
+ #endif
+ 		    ms->bytes_max;
+diff --git a/src/vasprintf.c b/src/vasprintf.c
+index 9b2cecb..3788fa5 100644
+--- a/src/vasprintf.c
++++ b/src/vasprintf.c
+@@ -632,11 +632,11 @@ int vasprintf(char **ptr, const char *format_string, va_list vargs)
+ # ifdef __va_copy
+   __va_copy (s.vargs, vargs);
+ # else
+-#  ifdef WIN32
++#  ifdef _WIN32
+   s.vargs = vargs;
+ #  else
+   memcpy (&s.vargs, &vargs, sizeof (s.va_args));
+-#  endif /* WIN32 */
++#  endif /* _WIN32 */
+ # endif /* __va_copy */
+ #endif /* va_copy */
+   s.maxlen = (size_t)INT_MAX;

--- a/ports/libmagic/0016-Fix-file_famagic-function.patch
+++ b/ports/libmagic/0016-Fix-file_famagic-function.patch
@@ -1,60 +1,7 @@
-diff --git a/src/compress.c b/src/compress.c
-index f89b956..4ab64f3 100644
---- a/src/compress.c
-+++ b/src/compress.c
-@@ -51,7 +51,7 @@ FILE_RCSID("@(#)$File: compress.c,v 1.129 2020/12/08 21:26:00 christos Exp $")
- #ifndef HAVE_SIG_T
- typedef void (*sig_t)(int);
- #endif /* HAVE_SIG_T */
--#if !defined(__MINGW32__) && !defined(WIN32) && !defined(__MINGW64__)
-+#if !defined(__MINGW32__) && !defined(_WIN32) && !defined(__MINGW64__)
- #include <sys/ioctl.h>
- #endif
- #ifdef HAVE_SYS_WAIT_H
-@@ -380,7 +380,7 @@ protected ssize_t
- sread(int fd, void *buf, size_t n, int canbepipe __attribute__((__unused__)))
- {
- 	ssize_t rv;
--#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(WIN32)
-+#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(_WIN32)
- 	int t = 0;
- #endif
- 	size_t rn = n;
-@@ -388,7 +388,7 @@ sread(int fd, void *buf, size_t n, int canbepipe __attribute__((__unused__)))
- 	if (fd == STDIN_FILENO)
- 		goto nocheck;
- 
--#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(WIN32)
-+#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(_WIN32)
- 	if (canbepipe && (ioctl(fd, FIONREAD, &t) == -1 || t == 0)) {
- #ifdef FD_ZERO
- 		ssize_t cnt;
-diff --git a/src/fmtcheck.c b/src/fmtcheck.c
-index fcad436..ae9d631 100644
---- a/src/fmtcheck.c
-+++ b/src/fmtcheck.c
-@@ -91,7 +91,7 @@ get_next_format_from_precision(const char **pf)
- 		f++;
- 		longdouble = 1;
- 		break;
--#ifdef WIN32
-+#ifdef _WIN32
- 	case 'I':
- 		f++;
- 		if (!*f) RETURN(pf,f,FMTCHECK_UNKNOWN);
 diff --git a/src/fsmagic.c b/src/fsmagic.c
-index 7244841..33ad47e 100644
+index 7244841..2c553c1 100644
 --- a/src/fsmagic.c
 +++ b/src/fsmagic.c
-@@ -56,7 +56,7 @@ FILE_RCSID("@(#)$File: fsmagic.c,v 1.81 2019/07/16 13:30:32 christos Exp $")
- /* Might be defined in sys/types.h.  */
- # define HAVE_MAJOR
- #endif
--#ifdef WIN32
-+#ifdef _WIN32
- # define WIN32_LEAN_AND_MEAN
- # include <windows.h>
- #endif
 @@ -66,7 +66,7 @@ FILE_RCSID("@(#)$File: fsmagic.c,v 1.81 2019/07/16 13:30:32 christos Exp $")
  # define minor(dev)  ((dev) & 0xff)
  #endif
@@ -73,7 +20,7 @@ index 7244841..33ad47e 100644
  	char buf[BUFSIZ+4];
  	ssize_t nch;
  	struct stat tstatbuf;
-@@ -122,14 +122,14 @@ file_fsmagic(struct magic_set *ms, const char *fn, struct stat *sb)
+@@ -122,7 +122,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, struct stat *sb)
  	 * Fstat is cheaper but fails for files you don't have read perms on.
  	 * On 4.2BSD and similar systems, use lstat() to identify symlinks.
  	 */
@@ -82,14 +29,6 @@ index 7244841..33ad47e 100644
  	if ((ms->flags & MAGIC_SYMLINK) == 0)
  		ret = lstat(fn, sb);
  	else
- #endif
- 	ret = stat(fn, sb);	/* don't merge into if; see "ret =" above */
- 
--#ifdef WIN32
-+#ifdef _WIN32
- 	{
- 		HANDLE hFile = CreateFile((LPCSTR)fn, 0, FILE_SHARE_DELETE |
- 		    FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0,
 @@ -290,7 +290,7 @@ file_fsmagic(struct magic_set *ms, const char *fn, struct stat *sb)
  			return -1;
  		break;
@@ -99,79 +38,3 @@ index 7244841..33ad47e 100644
  	case S_IFLNK:
  		if ((nch = readlink(fn, buf, BUFSIZ-1)) <= 0) {
  			if (ms->flags & MAGIC_ERROR) {
-diff --git a/src/magic.c b/src/magic.c
-index 382bd96..d4fa91a 100644
---- a/src/magic.c
-+++ b/src/magic.c
-@@ -25,7 +25,7 @@
-  * SUCH DAMAGE.
-  */
- 
--#ifdef WIN32
-+#ifdef _WIN32
- #include <windows.h>
- #include <shlwapi.h>
- #endif
-@@ -83,7 +83,7 @@ private const char *file_or_fd(struct magic_set *, const char *, int);
- #define	STDIN_FILENO	0
- #endif
- 
--#ifdef WIN32
-+#ifdef _WIN32
- /* HINSTANCE of this shared library. Needed for get_default_magic() */
- static HINSTANCE _w32_dll_instance = NULL;
- 
-@@ -178,7 +178,7 @@ get_default_magic(void)
- 	static char *default_magic;
- 	char *home, *hmagicpath;
- 
--#ifndef WIN32
-+#ifndef _WIN32
- 	struct stat st;
- 
- 	if (default_magic) {
-@@ -432,7 +432,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
- 		goto done;
- 	}
- 
--#ifdef WIN32
-+#ifdef _WIN32
- 	/* Place stdin in binary mode, so EOF (Ctrl+Z) doesn't stop early. */
- 	if (fd == STDIN_FILENO)
- 		_setmode(STDIN_FILENO, O_BINARY);
-@@ -444,7 +444,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
- 			okstat = stat(inname, &sb) == 0;
- 			if (okstat && S_ISFIFO(sb.st_mode))
- 				ispipe = 1;
--#ifdef WIN32
-+#ifdef _WIN32
- 			/*
- 			 * Can't stat, can't open.  It may have been opened in
- 			 * fsmagic, so if the user doesn't have read permission,
-@@ -500,7 +500,7 @@ file_or_fd(struct magic_set *ms, const char *inname, int fd)
- 	} else if (fd != -1) {
- 		/* Windows refuses to read from a big console buffer. */
- 		size_t howmany =
--#if defined(WIN32)
-+#if defined(_WIN32)
- 		    _isatty(fd) ? 8 * 1024 :
- #endif
- 		    ms->bytes_max;
-diff --git a/src/vasprintf.c b/src/vasprintf.c
-index 9b2cecb..3788fa5 100644
---- a/src/vasprintf.c
-+++ b/src/vasprintf.c
-@@ -632,11 +632,11 @@ int vasprintf(char **ptr, const char *format_string, va_list vargs)
- # ifdef __va_copy
-   __va_copy (s.vargs, vargs);
- # else
--#  ifdef WIN32
-+#  ifdef _WIN32
-   s.vargs = vargs;
- #  else
-   memcpy (&s.vargs, &vargs, sizeof (s.va_args));
--#  endif /* WIN32 */
-+#  endif /* _WIN32 */
- # endif /* __va_copy */
- #endif /* va_copy */
-   s.maxlen = (size_t)INT_MAX;

--- a/ports/libmagic/0016-Fix-file_famagic-function.patch
+++ b/ports/libmagic/0016-Fix-file_famagic-function.patch
@@ -86,7 +86,7 @@ index 7244841..33ad47e 100644
  	ret = stat(fn, sb);	/* don't merge into if; see "ret =" above */
  
 -#ifdef WIN32
-+#ifdef _WIN32 && ! defined(_WIN32)
++#ifdef _WIN32
  	{
  		HANDLE hFile = CreateFile((LPCSTR)fn, 0, FILE_SHARE_DELETE |
  		    FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0,

--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -15,6 +15,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         "0013-Check-for-backslash-in-argv-0-on-Windows.patch"
         "0014-Define-POSIX-macros-if-missing.patch"
         "0015-MSYS2-Remove-ioctl-call.patch"
+        "0016-Fix-file_famagic-function.patch"
     )
 endif()
 

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmagic",
   "version": "5.40",
-  "port-version": 2,
+  "port-version": 3,
   "description": "This library can be used to classify files according to magic number tests.",
   "homepage": "https://github.com/file/file",
   "dependencies": [

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmagic",
   "version": "5.40",
-  "port-version": 3,
+  "port-version": 2,
   "description": "This library can be used to classify files according to magic number tests.",
   "homepage": "https://github.com/file/file",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4354,7 +4354,7 @@
     },
     "libmagic": {
       "baseline": "5.40",
-      "port-version": 2
+      "port-version": 3
     },
     "libmariadb": {
       "baseline": "3.3.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2145,8 +2145,8 @@
       "port-version": 1
     },
     "dirent": {
-      "baseline": "1.23.2",
-      "port-version": 3
+      "baseline": "1.24",
+      "port-version": 0
     },
     "discord-game-sdk": {
       "baseline": "3.2.1",

--- a/versions/d-/dirent.json
+++ b/versions/d-/dirent.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bcace8750d2b6080c63877eed432f8b862501012",
+      "version": "1.24",
+      "port-version": 0
+    },
+    {
       "git-tree": "6df6238f6f97735c39e2e9b19d90f3895c4a636b",
       "version": "1.23.2",
       "port-version": 3

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3537aadd75d5c7ab29eecee4ae683acc2fdb3653",
+      "git-tree": "dd152683ef2811c65f61f1785dbf5804235143b0",
       "version": "5.40",
       "port-version": 3
     },

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e42c9d7665ed22a7e11f9fa5ca2f1bdcd212816c",
+      "git-tree": "89e91d9261aed73e5118bae232f45521a9ae0172",
       "version": "5.40",
       "port-version": 3
     },

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e42c9d7665ed22a7e11f9fa5ca2f1bdcd212816c",
+      "version": "5.40",
+      "port-version": 3
+    },
+    {
       "git-tree": "d70a57e09ed4060b2ade1cb1f80bcbdbd8a7a1ec",
       "version": "5.40",
       "port-version": 2

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89e91d9261aed73e5118bae232f45521a9ae0172",
+      "git-tree": "3537aadd75d5c7ab29eecee4ae683acc2fdb3653",
       "version": "5.40",
       "port-version": 3
     },

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dd152683ef2811c65f61f1785dbf5804235143b0",
+      "git-tree": "2bb05dd744d7eb83ad0a8d887ef589aaea37f6b3",
       "version": "5.40",
       "port-version": 3
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
