### PR TITLE
[double-conversion] update to 3.3.0

### DIFF
--- a/ports/double-conversion/portfile.cmake
+++ b/ports/double-conversion/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/double-conversion
-    REF af09fd65fcf24eee95dc62813ba9123414635428 #v3.2.1
-    SHA512 721d736a2d065b8ff6058345afe6990ab568174e202361abc7ce36c16931c05128df4fd5034f98f114a7b01972eda3b98bfc209ef45394d0b5d4bbce8140b28a
+    REF "v${VERSION}"
+    SHA512 51e84eb7a5c407f7bc8f8b8ca19932ece5c9d8ac18aedff7b7620fc67369d9b2aa8c5a6b133e7f8633d7cc5e3788bad6e60b0e48ac08d0a4bc5e4abe7cee1334
     HEAD_REF master
 )
 

--- a/ports/double-conversion/vcpkg.json
+++ b/ports/double-conversion/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "double-conversion",
-  "version": "3.2.1",
-  "port-version": 1,
+  "version": "3.3.0",
   "description": "Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles.",
   "homepage": "https://github.com/google/double-conversion",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2193,8 +2193,8 @@
       "port-version": 0
     },
     "double-conversion": {
-      "baseline": "3.2.1",
-      "port-version": 1
+      "baseline": "3.3.0",
+      "port-version": 0
     },
     "dp-thread-pool": {
       "baseline": "0.6.2",

--- a/versions/d-/double-conversion.json
+++ b/versions/d-/double-conversion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63037e8b38231f15de1dddb0593eebfb0bf32496",
+      "version": "3.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c3184965fe6c2b602348a73c58752c2ef72bf9d",
       "version": "3.2.1",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
