### PR TITLE
[font-util] update to 1.4.1

### DIFF
--- a/ports/font-util/portfile.cmake
+++ b/ports/font-util/portfile.cmake
@@ -9,8 +9,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO font/util
-    REF  d45011b8324fecebb4fc79e57491d341dd96e325 #1.3.2
-    SHA512 d783cbb5b8b0975891a247f98b78c2afadfd33e1d26ee8bcf7ab7ccc11615b0150d07345c719182b0929afc3c54dc3288a01a789b5374e18aff883ac23d15b04
+    REF "font-util-${VERSION}"
+    SHA512 93285c2e8c5c01f069a7621dba0bbb1175c0ebbea27d521395b40f036443c162fc1948c4d3cb34fe6c509d1818d95ed7e6d38919e3f7857dfa53e388aadb9128
     HEAD_REF master
     PATCHES build.patch
 ) 

--- a/ports/font-util/vcpkg.json
+++ b/ports/font-util/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "font-util",
-  "version": "1.3.2",
-  "port-version": 1,
+  "version": "1.4.1",
   "description": "X.Org font package creation/installation utilities",
   "homepage": "https://gitlab.freedesktop.org/xorg/font/util",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2641,8 +2641,8 @@
       "port-version": 0
     },
     "font-util": {
-      "baseline": "1.3.2",
-      "port-version": 1
+      "baseline": "1.4.1",
+      "port-version": 0
     },
     "fontconfig": {
       "baseline": "2.14.2",

--- a/versions/f-/font-util.json
+++ b/versions/f-/font-util.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13ebd42f06ed8e809382f48f36c729219e1182eb",
+      "version": "1.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "67faf30776c5600c8cfe00f9def5143b5e36eb08",
       "version": "1.3.2",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

