### PR TITLE
[alembic] update to 1.8.6

### DIFF
--- a/ports/alembic/portfile.cmake
+++ b/ports/alembic/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alembic/alembic
     REF "${VERSION}"
-    SHA512 89a480970eb09893112bf650011ede852205d1fa3718680a3983392bbcf3eb3f22f4ec01f42d12bfcaf655ce43d7d6f583b764ec03f4c5a84023359502b3636e
+    SHA512 6371b830242be90d4ea833248df5fd42d9e713e305d15eb1383d04410319acdae5743d48d65e8f75f1cedce777d2af7d969cde095f678b17322c19f1c69f477b
     HEAD_REF master
     PATCHES
         fix-runtime-destination.patch

--- a/ports/alembic/vcpkg.json
+++ b/ports/alembic/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "alembic",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Alembic is an open framework for storing and sharing scene data that includes a C++ library, a file format, and client plugins and applications.",
   "homepage": "https://alembic.io/",
   "supports": "!(windows & x86) & !uwp",

--- a/versions/a-/alembic.json
+++ b/versions/a-/alembic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca5f035424c794b8cde9d41c7103b612e912a275",
+      "version": "1.8.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "5cb4b9d32a6098f48e3d0a75ddd7eaae7a7df085",
       "version": "1.8.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -73,7 +73,7 @@
       "port-version": 7
     },
     "alembic": {
-      "baseline": "1.8.5",
+      "baseline": "1.8.6",
       "port-version": 0
     },
     "aliyun-oss-c-sdk": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
