### PR TITLE
[antlr4] update to 4.13.1

### DIFF
--- a/ports/antlr4/portfile.cmake
+++ b/ports/antlr4/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO antlr/antlr4
     HEAD_REF dev
     REF "${VERSION}"
-    SHA512 947ecca28712aa4dd98d7b7e0753e91881e55642f7951ca65a576b94db87440767a1b93d08e82db69ad527ee28bf89f0b2f9c0aaa604a999a7e48c163764ee12
+    SHA512 79ac3cdfc8f2368c647d06aec85d87507629a75527205ff2cbf7d9802989b0c6e6a8fac76148ad101f539c9ef922e431e22ba489f899f847ccc3d3d889bb2b70
     PATCHES
         set-export-macro-define-as-private.patch
 )

--- a/ports/antlr4/vcpkg.json
+++ b/ports/antlr4/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "antlr4",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "description": "ANother Tool for Language Recognition",
   "homepage": "https://www.antlr.org",
   "license": "BSD-3-Clause",

--- a/versions/a-/antlr4.json
+++ b/versions/a-/antlr4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8a6e8e88f1e6f604f094ce3a3927a8412eb6011",
+      "version": "4.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1fd51b053d31e5215682e6c2970aca92e24d488b",
       "version": "4.13.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -137,7 +137,7 @@
       "port-version": 0
     },
     "antlr4": {
-      "baseline": "4.13.0",
+      "baseline": "4.13.1",
       "port-version": 0
     },
     "any-lite": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

