### PR TITLE
[murmurhash] Add support for arm

### DIFF
--- a/ports/murmurhash/vcpkg.json
+++ b/ports/murmurhash/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "murmurhash",
   "version-date": "2016-01-09",
-  "port-version": 6,
+  "port-version": 7,
   "description": "MurmurHash a family of hash functions.",
   "homepage": "https://github.com/aappleby/smhasher",
   "supports": "!uwp",

--- a/ports/murmurhash/vcpkg.json
+++ b/ports/murmurhash/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 6,
   "description": "MurmurHash a family of hash functions.",
   "homepage": "https://github.com/aappleby/smhasher",
-  "supports": "!uwp & !arm",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5638,7 +5638,7 @@
     },
     "murmurhash": {
       "baseline": "2016-01-09",
-      "port-version": 6
+      "port-version": 7
     },
     "mvfst": {
       "baseline": "2023-05-18",

--- a/versions/m-/murmurhash.json
+++ b/versions/m-/murmurhash.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "45bd675545871cedcdf81382a4a126c1bd35af51",
+      "git-tree": "53f2656ff91aeec6d11585b61c650390b23e6340",
       "version-date": "2016-01-09",
       "port-version": 7
     },

--- a/versions/m-/murmurhash.json
+++ b/versions/m-/murmurhash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45bd675545871cedcdf81382a4a126c1bd35af51",
+      "version-date": "2016-01-09",
+      "port-version": 7
+    },
+    {
       "git-tree": "e5ec901e9cab9845f18d18276ddea5e4ad5d4538",
       "version-date": "2016-01-09",
       "port-version": 6


### PR DESCRIPTION
Fixes #34056 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] <del> SHA512s are updated for each updated download </del>
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. 
- [x] Any patches that are no longer applied are deleted from the port's directory. 
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
