### PR TITLE
[argtable3] update to 3.2.2.f25c624

### DIFF
--- a/ports/argtable3/portfile.cmake
+++ b/ports/argtable3/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO argtable/argtable3
-    REF 7704006f3cbb556e11da80a5b97469075a32892e # 3.2.1 + minor patches including ARGTABLE3_ENABLE_EXAMPLES support
-    SHA512 c51aa0a33a247c3801e36ca5d9523acefa31f21a34c1e86965a39290c1b437785e4d7e0ae80a65d811803b8fcbbc3a96ba3d6aefaea9bda15abc0f38bd1f45cc
+    REF "v${VERSION}"
+    SHA512 623197142fd1749b2fd5bc3e51758ae49c58ec8699b6afa5ecb2d0199d98f9c05366f92c5169c8039b5c417f4774fb4a09c879a7b04ddbed9d5e43585692ed7f
     HEAD_REF master
     PATCHES Fix-dependence-getopt.patch
 )

--- a/ports/argtable3/vcpkg.json
+++ b/ports/argtable3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "argtable3",
-  "version": "3.2.1",
-  "port-version": 3,
+  "version-string": "3.2.2.f25c624",
   "description": "A single-file, ANSI C, command-line parsing library that parses GNU-style command-line options",
   "homepage": "https://www.argtable.org/",
   "license": "BSD-2-Clause-NetBSD AND TCL",

--- a/versions/a-/argtable3.json
+++ b/versions/a-/argtable3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "949eef38520716ab831bb7f008cce93b28af8f54",
+      "version-string": "3.2.2.f25c624",
+      "port-version": 0
+    },
+    {
       "git-tree": "b84ef22a845ccccda6197d1865ddd1d8df9098c1",
       "version": "3.2.1",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -209,8 +209,8 @@
       "port-version": 10
     },
     "argtable3": {
-      "baseline": "3.2.1",
-      "port-version": 3
+      "baseline": "3.2.2.f25c624",
+      "port-version": 0
     },
     "argumentum": {
       "baseline": "0.3.2",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

