### PR TITLE
[avro-cpp] update to 1.11.3

### DIFF
--- a/ports/avro-cpp/portfile.cmake
+++ b/ports/avro-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/avro
-    REF e44b680621328c4e6524bd2983af1ce11afeebed
-    SHA512 932f642f272997b5c0be467d3a3ccc354c6edf425c36b33aa7e61984f67312c712bb1d74cb1a5fd8066169104851e73830f0ed3fdb450e005a5c5bef33c34f20
+    REF "release-${VERSION}"
+    SHA512 728609f562460e1115366663ede2c5d4acbdd6950c1ee3e434ffc65d28b72e3a43c3ebce93d0a8459f0c4f6c492ebb9444e2127a0385f38eb7cdf74b28f0c3ed
     HEAD_REF master
     PATCHES
         fix-cmake.patch

--- a/ports/avro-cpp/vcpkg.json
+++ b/ports/avro-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "avro-cpp",
-  "version-date": "2022-11-07",
-  "port-version": 1,
+  "version": "1.11.3",
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5b130595cfdd2c5fcecf41bcbbed730aab60285",
+      "version": "1.11.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "0f04b2076c299b830bfdd3a698db754f4f8cf269",
       "version-date": "2022-11-07",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -341,8 +341,8 @@
       "port-version": 3
     },
     "avro-cpp": {
-      "baseline": "2022-11-07",
-      "port-version": 1
+      "baseline": "1.11.3",
+      "port-version": 0
     },
     "aws-c-auth": {
       "baseline": "0.7.4",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

