### PR TITLE
[fameta-counter]  New port

### DIFF
--- a/ports/fameta-counter/portfile.cmake
+++ b/ports/fameta-counter/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO falemagn/fameta-counter
+    REF 35f4421524b61eaa658c23e9c3667dc914df72fa
+    SHA512 624baa2646a4141a1b326910f567d8a4799b72ee4cf569497940a877be2f035a19cf9a709f3bb64be7055175bd72c698d3f82df5bd47996eacbe6bbc2f4a42cd
+    HEAD_REF master
+)
+
+file(COPY ${SOURCE_PATH}/include/fameta/counter.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/fameta-counter)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fameta-counter/portfile.cmake
+++ b/ports/fameta-counter/portfile.cmake
@@ -6,6 +6,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/include/fameta/counter.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/fameta-counter)
+file(COPY "${SOURCE_PATH}/include/fameta/counter.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/fameta-counter")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fameta-counter/vcpkg.json
+++ b/ports/fameta-counter/vcpkg.json
@@ -1,0 +1,7 @@
+{
+    "name": "fameta-counter",
+    "version-date": "2021-02-13",
+    "description": "Compile time counter that works with all major modern compilers, compatible with C++11 and above.",
+    "homepage": "https://github.com/falemagn/fameta-counter",
+    "license": "Unlicense"
+}

--- a/ports/fameta-counter/vcpkg.json
+++ b/ports/fameta-counter/vcpkg.json
@@ -1,7 +1,7 @@
 {
-    "name": "fameta-counter",
-    "version-date": "2021-02-13",
-    "description": "Compile time counter that works with all major modern compilers, compatible with C++11 and above.",
-    "homepage": "https://github.com/falemagn/fameta-counter",
-    "license": "Unlicense"
+  "name": "fameta-counter",
+  "version-date": "2021-02-13",
+  "description": "Compile time counter that works with all major modern compilers, compatible with C++11 and above.",
+  "homepage": "https://github.com/falemagn/fameta-counter",
+  "license": "Unlicense"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2452,6 +2452,10 @@
       "baseline": "2.3.0",
       "port-version": 0
     },
+    "fameta-counter": {
+      "baseline": "2021-02-13",
+      "port-version": 0
+    },
     "fann": {
       "baseline": "2.2.0",
       "port-version": 3

--- a/versions/f-/fameta-counter.json
+++ b/versions/f-/fameta-counter.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "efc3b07777b78eb8cbd32d8159998e074924e718",
+      "git-tree": "e830075f562957049cad7d3d3526e4707884ff0a",
       "version-date": "2021-02-13",
       "port-version": 0
     }

--- a/versions/f-/fameta-counter.json
+++ b/versions/f-/fameta-counter.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "efc3b07777b78eb8cbd32d8159998e074924e718",
+      "version-date": "2021-02-13",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
