### PR TITLE
[blosc] update to 1.21.5

### DIFF
--- a/ports/blosc/portfile.cmake
+++ b/ports/blosc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Blosc/c-blosc
     REF "v${VERSION}"
-    SHA512 e9542aa2d1ebae9f6dcc12916d7ac3b920d771281ab96e2b2d59c2951e5f51d02d2684859b8823643d43d320613fb9dd8a3ea411ade34e66e323fcefa8165a91
+    SHA512 01e6d80e1114d76c4bd1b413778c293d0455879ec38e1e1ec46e8e7eaf2997b47cc2de35bc52cdc4c2c70341b6f87d70626a9a9c24ffc8b7b170d760efa60c07
     HEAD_REF master
     PATCHES
       0001-fix-CMake-config.patch
@@ -45,6 +45,6 @@ find_dependency(Threads)]]
 # cleanup
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 # Handle copyright
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/BLOSC.txt")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/blosc/vcpkg.json
+++ b/ports/blosc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "blosc",
-  "version": "1.21.3",
+  "version": "1.21.5",
   "description": "A blocking, shuffling and loss-less compression library that can be faster than `memcpy()`",
   "homepage": "https://github.com/Blosc/c-blosc",
   "license": "BSD-3-Clause",

--- a/versions/b-/blosc.json
+++ b/versions/b-/blosc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c0e6152db6058a53ff21fc8037e5c9e685a0fe8",
+      "version": "1.21.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "08be7493a8b0644853e545f50d243680b1d13fd9",
       "version": "1.21.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -641,7 +641,7 @@
       "port-version": 5
     },
     "blosc": {
-      "baseline": "1.21.3",
+      "baseline": "1.21.5",
       "port-version": 0
     },
     "blpapi": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

