### PR TITLE
[caf] update to 0.19.3

### DIFF
--- a/ports/caf/fix_cxx17.patch
+++ b/ports/caf/fix_cxx17.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ed753b9..7b6c8d6 100644
+index ed753b9..5dc80c2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -131,7 +131,7 @@ endif()
@@ -11,12 +11,37 @@ index ed753b9..7b6c8d6 100644
      set(snippet "#include <format>
                   #include <iostream>
                   int main() { std::cout << std::format(\"{}\", \"ok\"); }")
-@@ -373,7 +373,7 @@ endfunction()
+@@ -177,7 +177,6 @@ endif()
+ 
+ # -- create the libcaf_test target ahead of time for caf_core ------------------
+ 
+-add_library(libcaf_test)
+ 
+ # -- add uninstall target if it does not exist yet -----------------------------
+ 
+@@ -289,8 +288,6 @@ function(caf_add_component name)
+       string(REPLACE "/" "-" test_name "${test_path}/${test_name}-test")
+       add_executable("${test_name}" ${source_file}
+                      $<TARGET_OBJECTS:${obj_lib_target}>)
+-      target_link_libraries(${test_name} PRIVATE libcaf_test
+-                            ${CAF_ADD_COMPONENT_DEPENDENCIES})
+       target_include_directories(${test_name} PRIVATE
+                                  "${CMAKE_CURRENT_SOURCE_DIR}"
+                                  "${CMAKE_CURRENT_BINARY_DIR}")
+@@ -314,8 +311,6 @@ function(caf_add_component name)
+     add_executable(${tst_bin_target}
+                    ${CAF_ADD_COMPONENT_LEGACY_TEST_SOURCES}
+                    $<TARGET_OBJECTS:${obj_lib_target}>)
+-    target_link_libraries(${tst_bin_target} PRIVATE libcaf_test
+-                          ${CAF_ADD_COMPONENT_DEPENDENCIES})
+     target_include_directories(${tst_bin_target} PRIVATE
+                                "${CMAKE_CURRENT_SOURCE_DIR}/tests/legacy")
+     if(CAF_ADD_COMPONENT_LEGACY_TEST_SUITES)
+@@ -373,7 +368,6 @@ endfunction()
  
  add_subdirectory(libcaf_core)
  
 -add_subdirectory(libcaf_test)
-+#add_subdirectory(libcaf_test)
  
  if(CAF_ENABLE_NET_MODULE)
    add_subdirectory(libcaf_net)

--- a/ports/caf/fix_cxx17.patch
+++ b/ports/caf/fix_cxx17.patch
@@ -1,8 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ed753b9..7509855 100644
 --- a/CMakeLists.txt
-+++ a/CMakeLists.txt
-@@ -115,3 +115,4 @@
-+target_compile_features(caf_internal INTERFACE cxx_std_17)
- # TODO: simply set CXX_STANDARD when switching to CMake ≥ 3.9.6
--if(NOT CMAKE_CROSSCOMPILING)
-+if(0)
-   try_compile(caf_has_cxx_17
++++ b/CMakeLists.txt
+@@ -131,7 +131,7 @@ endif()
+ 
+ if(NOT DEFINED CAF_USE_STD_FORMAT)
+   set(CAF_USE_STD_FORMAT OFF CACHE BOOL "Enable std::format support" FORCE)
+-  if(NOT CMAKE_CROSSCOMPILING)
++  if(0)
+     set(snippet "#include <format>
+                  #include <iostream>
+                  int main() { std::cout << std::format(\"{}\", \"ok\"); }")

--- a/ports/caf/fix_cxx17.patch
+++ b/ports/caf/fix_cxx17.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ed753b9..7509855 100644
+index ed753b9..7b6c8d6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -131,7 +131,7 @@ endif()
@@ -11,3 +11,12 @@ index ed753b9..7509855 100644
      set(snippet "#include <format>
                   #include <iostream>
                   int main() { std::cout << std::format(\"{}\", \"ok\"); }")
+@@ -373,7 +373,7 @@ endfunction()
+ 
+ add_subdirectory(libcaf_core)
+ 
+-add_subdirectory(libcaf_test)
++#add_subdirectory(libcaf_test)
+ 
+ if(CAF_ENABLE_NET_MODULE)
+   add_subdirectory(libcaf_net)

--- a/ports/caf/portfile.cmake
+++ b/ports/caf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO actor-framework/actor-framework
-    REF bac5b8b24a62ff2a818de1b08f6f31f897e42222 # 0.19.1
-    SHA512 c61f3cce4d4707f19db8c1b1a8b2c4655335a7a29c77a0c9692775c9fcdc90d6dce75d3122804c31cf66c47f37d3a3674ad18df67d1204c7f52eb4740ff766af
+    REF "${VERSION}"
+    SHA512 97766b5b0a4db96b03be77c1ffd2198cc5536c09e2a06bb6fcff023ee78692f2c23ad213dc9698d6abfe950c61c4a2565bbfdfe871652cef816829e83d16ceab
     HEAD_REF master
     PATCHES
         fix_dependency.patch

--- a/ports/caf/vcpkg.json
+++ b/ports/caf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "caf",
-  "version": "0.19.1",
+  "version": "0.19.3",
   "description": "an open source implementation of the actor model for C++ featuring lightweight & fast actor implementations, pattern matching for messages, network transparent messaging, and more.",
   "homepage": "https://github.com/actor-framework/actor-framework",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1381,7 +1381,7 @@
       "port-version": 0
     },
     "caf": {
-      "baseline": "0.19.1",
+      "baseline": "0.19.3",
       "port-version": 0
     },
     "caffe2": {

--- a/versions/c-/caf.json
+++ b/versions/c-/caf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9bd9083fe1e383a6fe768777b3c0c5ac825cb5ef",
+      "git-tree": "ccf2775e7f20d9cfccc3f3df52e419567c69ca1b",
       "version": "0.19.3",
       "port-version": 0
     },

--- a/versions/c-/caf.json
+++ b/versions/c-/caf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ccf2775e7f20d9cfccc3f3df52e419567c69ca1b",
+      "git-tree": "2b744b08352077e2bf620c383d9924f4a008cbca",
       "version": "0.19.3",
       "port-version": 0
     },

--- a/versions/c-/caf.json
+++ b/versions/c-/caf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9bd9083fe1e383a6fe768777b3c0c5ac825cb5ef",
+      "version": "0.19.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "0561defb72007b054cede4fed6ef5950f8c2e2bc",
       "version": "0.19.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

