### PR TITLE
[capstone] update to 5.0.1

### DIFF
--- a/ports/capstone/portfile.cmake
+++ b/ports/capstone/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "capstone-engine/capstone"
-    REF 000561b4f74dc15bda9af9544fe714efda7a6e13 # 5.0.0-rc2
-    SHA512 66b09a7d2fda297836bbedaeece71dcfe39bdbd633d9b6ecb68ee2e5aa094b697226136ab172cdc4550e8b2ef1448d001c8ee4e0d456c6d277afe0b3d1aab5a1
+    REF "${VERSION}"
+    SHA512 350aba77ce2d96b5c25764913591ba80e4497177ae0a8b2c820c6755ee8310848fbfc54e7ccac27fafc2dbc6778118ad92c53d1b5cb601d4fa146dec7d7e11e5
     HEAD_REF next
     PATCHES
         001-silence-windows-crt-secure-warnings.patch

--- a/ports/capstone/vcpkg.json
+++ b/ports/capstone/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "capstone",
-  "version": "5.0.0-rc2",
-  "port-version": 2,
+  "version": "5.0.1",
   "description": "Multi-architecture disassembly framework",
   "homepage": "https://github.com/capstone-engine/capstone",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1409,8 +1409,8 @@
       "port-version": 0
     },
     "capstone": {
-      "baseline": "5.0.0-rc2",
-      "port-version": 2
+      "baseline": "5.0.1",
+      "port-version": 0
     },
     "cargs": {
       "baseline": "1.0.3",

--- a/versions/c-/capstone.json
+++ b/versions/c-/capstone.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c89ad8669fdc6aa946d13cfe053a64fa50f75a7",
+      "version": "5.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3c9184889dd21d609401fe4ea34fa5320a9443a2",
       "version": "5.0.0-rc2",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

