### PR TITLE
Delete broken version database entries.

### DIFF
--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -16,11 +16,6 @@
       "port-version": 1
     },
     {
-      "git-tree": "2209360b556a40cf034551f6f9063456eac63986",
-      "version": "20230125.3",
-      "port-version": 2
-    },
-    {
       "git-tree": "6a337fa251c0ac4489d9c0ea1e2f1c9a7d019eb5",
       "version": "20230125.3",
       "port-version": 0
@@ -89,11 +84,6 @@
       "git-tree": "0d4dfbea87f5b8903a5db5ed3ed6851b6e6a3a79",
       "version-string": "2020-03-03",
       "port-version": 8
-    },
-    {
-      "git-tree": "28fa609b06eec70bb06e61891e94b94f35f7d06e",
-      "version-string": "2020-03-03",
-      "port-version": 7
     },
     {
       "git-tree": "606b9214364983e5df021d0556dbec5e44f4b0a8",

--- a/versions/a-/async-mqtt.json
+++ b/versions/a-/async-mqtt.json
@@ -11,11 +11,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "61071a18dc0dc629c374fa016b81473e04a28ff1",
-      "version": "1.0.8",
-      "port-version": 0
-    },
-    {
       "git-tree": "e68200b49b2f55aaf0e4a597af4dcd6d3f91d478",
       "version": "1.0.7",
       "port-version": 0

--- a/versions/b-/blend2d.json
+++ b/versions/b-/blend2d.json
@@ -66,16 +66,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "ffce764b880d8cc24e3b00328aa3861f15bae91d",
-      "version-string": "beta_2020-07-31",
-      "port-version": 0
-    },
-    {
-      "git-tree": "03a43f03eb0cab95aac27a77b71273fc4aa2e94d",
-      "version-string": "beta_2020-07-09",
-      "port-version": 0
-    },
-    {
       "git-tree": "4b67e6ac18485e7209ec86219d16ce3659446e8a",
       "version-string": "beta_2020-06-01",
       "port-version": 0

--- a/versions/e-/elfio.json
+++ b/versions/e-/elfio.json
@@ -17,7 +17,7 @@
     },
     {
       "git-tree": "19659f0b36d05c1643f7ecb4b553341a942b1fd5",
-      "version": "3.8",
+      "version-string": "3.8",
       "port-version": 0
     }
   ]

--- a/versions/f-/flashlight-text.json
+++ b/versions/f-/flashlight-text.json
@@ -4,11 +4,6 @@
       "git-tree": "fdf18ae36763962256b235eec31becbe02f2534d",
       "version": "0.0.4",
       "port-version": 0
-    },
-    {
-      "git-tree": "6386901fa48bce946fdc5775a1c1b784e0a97175",
-      "version": "0.0.3",
-      "port-version": 0
     }
   ]
 }

--- a/versions/l-/libwebp.json
+++ b/versions/l-/libwebp.json
@@ -76,21 +76,6 @@
       "port-version": 1
     },
     {
-      "git-tree": "a05e0de81085231df86f6902aba1e0a364e2ca7b",
-      "version-string": "1.1.0",
-      "port-version": 0
-    },
-    {
-      "git-tree": "5066566c98bc1913b678347c4cbae0a6aff4cf2d",
-      "version-string": "1.0.3-1",
-      "port-version": 0
-    },
-    {
-      "git-tree": "6ff3a23b154fad821db2d8236bf9d0382f0229cf",
-      "version-string": "1.0.3",
-      "port-version": 0
-    },
-    {
       "git-tree": "256b8e8b5d64cb6f66da47f1a361e5538d341023",
       "version-string": "1.0.2-8",
       "port-version": 0

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -11,11 +11,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "9569944b76966b78bec5ef83672899acd7e4febe",
-      "version-semver": "2.1.2",
-      "port-version": 0
-    },
-    {
       "git-tree": "80e8a46f8c1c2cd748834cd225edbe127a489d5a",
       "version-semver": "2.1.1",
       "port-version": 2

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -11,11 +11,6 @@
       "port-version": 1
     },
     {
-      "git-tree": "b5942c0b0a6d9131bc4ad9a1dde662f809a6d965",
-      "version": "2.13.4",
-      "port-version": 0
-    },
-    {
       "git-tree": "63f2d1f0287a6d61b5c85b428920b0fbe102adec",
       "version": "2.12.0",
       "port-version": 1

--- a/versions/r-/robin-map.json
+++ b/versions/r-/robin-map.json
@@ -22,7 +22,7 @@
     },
     {
       "git-tree": "84f1433234bb4813feee71e4042174ec9e8d5a7a",
-      "version-semver": "0.6.3",
+      "version-string": "0.6.3",
       "port-version": 0
     },
     {

--- a/versions/v-/vcpkg-cmake-get-vars.json
+++ b/versions/v-/vcpkg-cmake-get-vars.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "c6eb09f11e34173a4bfc31252d02d6aea6c25d8f",
-      "version-date": "2023-04-13",
-      "port-version": 0
-    },
-    {
       "git-tree": "2e624c2cf12a97a7a802e31ff1d28b9fa6ba9bde",
       "version-date": "2023-03-02",
       "port-version": 0


### PR DESCRIPTION
Under normal circumstances, things can't be removed from the version database, because that breaks outstanding references to those versions. However, these entries can't be parsed in the first place which means nobody can be depending on them being there. (Usually this comes from accidentally merging PRs that add multiple versions, such as https://github.com/microsoft/vcpkg/commit/8184c5e06c6bbf0f9ba67ab9e9b8b5b5202d6c08 https://github.com/microsoft/vcpkg/pull/31859 )

This was detected using new output from https://github.com/microsoft/vcpkg-tool/pull/1210

```
C:\Dev\vcpkg\versions\a-\abseil.json: error: failed to execute: "C:\Program Files\Git\cmd\git.exe" "--git-dir=C:\Dev\vcpkg\.git" "--work-tree=C:\Dev\vcpkg\buildtrees\versioning_\versions\abseil\2209360b556a40cf034551f6f9063456eac63986_83008.tmp" -c core.autocrlf=false read-tree -m -u 2209360b556a40cf034551f6f9063456eac63986 error: git failed with exit code: (128).
fatal: failed to unpack tree object 2209360b556a40cf034551f6f9063456eac63986 note: while checking out port abseil with git tree 2209360b556a40cf034551f6f9063456eac63986 note: while validating version: 20230125.3#2
C:\Dev\vcpkg\versions\a-\abseil.json: C:\Dev\vcpkg\buildtrees\versioning_\versions\abseil\28fa609b06eec70bb06e61891e94b94f35f7d06e\vcpkg.json: error: $.features: mismatched type: expected a set of features note: while validating version: 2020-03-03#7
C:\Dev\vcpkg\versions\a-\async-mqtt.json: error: failed to execute: "C:\Program Files\Git\cmd\git.exe" "--git-dir=C:\Dev\vcpkg\.git" "--work-tree=C:\Dev\vcpkg\buildtrees\versioning_\versions\async-mqtt\61071a18dc0dc629c374fa016b81473e04a28ff1_83008.tmp" -c core.autocrlf=false read-tree -m -u 61071a18dc0dc629c374fa016b81473e04a28ff1 error: git failed with exit code: (128).
fatal: failed to unpack tree object 61071a18dc0dc629c374fa016b81473e04a28ff1 note: while checking out port async-mqtt with git tree 61071a18dc0dc629c374fa016b81473e04a28ff1 note: while validating version: 1.0.8
C:\Dev\vcpkg\versions\b-\blend2d.json: C:\Dev\vcpkg\buildtrees\versioning_\versions\blend2d\ffce764b880d8cc24e3b00328aa3861f15bae91d\vcpkg.json: error: $.features: mismatched type: expected a set of features note: while validating version: beta_2020-07-31
C:\Dev\vcpkg\versions\b-\blend2d.json: C:\Dev\vcpkg\buildtrees\versioning_\versions\blend2d\03a43f03eb0cab95aac27a77b71273fc4aa2e94d\vcpkg.json: error: $.features: mismatched type: expected a set of features note: while validating version: beta_2020-07-09
C:\Dev\vcpkg\versions\e-\elfio.json: error: The version database declares 3.8 as version, but 19659f0b36d05c1643f7ecb4b553341a942b1fd5 declares it as version-string. Versions must be unique, even if they are declared with different schemes. note: run:
vcpkg x-add-version elfio --overwrite-version
to overwrite the scheme declared in the version database with that declared in the port. C:\Dev\vcpkg\versions\f-\flashlight-text.json: error: failed to execute: "C:\Program Files\Git\cmd\git.exe" "--git-dir=C:\Dev\vcpkg\.git" "--work-tree=C:\Dev\vcpkg\buildtrees\versioning_\versions\flashlight-text\6386901fa48bce946fdc5775a1c1b784e0a97175_83008.tmp" -c core.autocrlf=false read-tree -m -u 6386901fa48bce946fdc5775a1c1b784e0a97175 error: git failed with exit code: (128).
fatal: failed to unpack tree object 6386901fa48bce946fdc5775a1c1b784e0a97175 note: while checking out port flashlight-text with git tree 6386901fa48bce946fdc5775a1c1b784e0a97175 note: while validating version: 0.0.3
C:\Dev\vcpkg\versions\l-\libwebp.json: C:\Dev\vcpkg\buildtrees\versioning_\versions\libwebp\a05e0de81085231df86f6902aba1e0a364e2ca7b\CONTROL:1:94: error: invalid character in feature name (must be lowercase, digits, '-', or '*')
  on expression: libwebp[anim, gif2webp, img2webp, info, mux, nearlossless, simd, cwebp, dwebp], libwebp[vwebp_sdl] (!osx), libwebp[extras] (!osx)
                                                                                                              ^
note: while validating version: 1.1.0
C:\Dev\vcpkg\versions\l-\libwebp.json: C:\Dev\vcpkg\buildtrees\versioning_\versions\libwebp\5066566c98bc1913b678347c4cbae0a6aff4cf2d\CONTROL:1:94: error: invalid character in feature name (must be lowercase, digits, '-', or '*')
  on expression: libwebp[anim, gif2webp, img2webp, info, mux, nearlossless, simd, cwebp, dwebp], libwebp[vwebp_sdl] (!osx), libwebp[extras] (!osx)
                                                                                                              ^
note: while validating version: 1.0.3-1
C:\Dev\vcpkg\versions\l-\libwebp.json: C:\Dev\vcpkg\buildtrees\versioning_\versions\libwebp\6ff3a23b154fad821db2d8236bf9d0382f0229cf\CONTROL:1:94: error: invalid character in feature name (must be lowercase, digits, '-', or '*')
  on expression: libwebp[anim, gif2webp, img2webp, info, mux, nearlossless, simd, cwebp, dwebp], libwebp[vwebp_sdl, extras] (!osx)
                                                                                                              ^
note: while validating version: 1.0.3
C:\Dev\vcpkg\versions\o-\opencolorio.json: error: failed to execute: "C:\Program Files\Git\cmd\git.exe" "--git-dir=C:\Dev\vcpkg\.git" "--work-tree=C:\Dev\vcpkg\buildtrees\versioning_\versions\opencolorio\9569944b76966b78bec5ef83672899acd7e4febe_83008.tmp" -c core.autocrlf=false read-tree -m -u 9569944b76966b78bec5ef83672899acd7e4febe error: git failed with exit code: (128).
fatal: failed to unpack tree object 9569944b76966b78bec5ef83672899acd7e4febe note: while checking out port opencolorio with git tree 9569944b76966b78bec5ef83672899acd7e4febe note: while validating version: 2.1.2
C:\Dev\vcpkg\versions\q-\qscintilla.json: error: failed to execute: "C:\Program Files\Git\cmd\git.exe" "--git-dir=C:\Dev\vcpkg\.git" "--work-tree=C:\Dev\vcpkg\buildtrees\versioning_\versions\qscintilla\b5942c0b0a6d9131bc4ad9a1dde662f809a6d965_83008.tmp" -c core.autocrlf=false read-tree -m -u b5942c0b0a6d9131bc4ad9a1dde662f809a6d965 error: git failed with exit code: (128).
fatal: failed to unpack tree object b5942c0b0a6d9131bc4ad9a1dde662f809a6d965 note: while checking out port qscintilla with git tree b5942c0b0a6d9131bc4ad9a1dde662f809a6d965 note: while validating version: 2.13.4
C:\Dev\vcpkg\versions\r-\robin-map.json: error: The version database declares 0.6.3 as version-semver, but 84f1433234bb4813feee71e4042174ec9e8d5a7a declares it as version-string. Versions must be unique, even if they are declared with different schemes. note: run:
vcpkg x-add-version robin-map --overwrite-version
to overwrite the scheme declared in the version database with that declared in the port. C:\Dev\vcpkg\versions\v-\vcpkg-cmake-get-vars.json: error: failed to execute: "C:\Program Files\Git\cmd\git.exe" "--git-dir=C:\Dev\vcpkg\.git" "--work-tree=C:\Dev\vcpkg\buildtrees\versioning_\versions\vcpkg-cmake-get-vars\c6eb09f11e34173a4bfc31252d02d6aea6c25d8f_83008.tmp" -c core.autocrlf=false read-tree -m -u c6eb09f11e34173a4bfc31252d02d6aea6c25d8f error: git failed with exit code: (128).
fatal: failed to unpack tree object c6eb09f11e34173a4bfc31252d02d6aea6c25d8f note: while checking out port vcpkg-cmake-get-vars with git tree c6eb09f11e34173a4bfc31252d02d6aea6c25d8f note: while validating version: 2023-04-13
```