### PR TITLE
[civetweb] update to 1.16

### DIFF
--- a/ports/civetweb/fix-fseeko.patch
+++ b/ports/civetweb/fix-fseeko.patch
@@ -1,0 +1,16 @@
+diff --git a/src/civetweb.c b/src/civetweb.c
+index 9e321ed..c6e9894 100644
+--- a/src/civetweb.c
++++ b/src/civetweb.c
+@@ -652,7 +652,10 @@ typedef const char *SOCK_OPT_TYPE;
+ #define close(x) (_close(x))
+ #define dlsym(x, y) (GetProcAddress((HINSTANCE)(x), (y)))
+ #define RTLD_LAZY (0)
+-#define fseeko(x, y, z) ((_lseeki64(_fileno(x), (y), (z)) == -1) ? -1 : 0)
++#if defined(__ANDROID_API__) && __ANDROID_API__ < 24
++    // Cf. https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md#32_bit-and
++    #define fseeko(x, y, z) fseek
++#endif
+ #define fdopen(x, y) (_fdopen((x), (y)))
+ #define write(x, y, z) (_write((x), (y), (unsigned)z))
+ #define read(x, y, z) (_read((x), (y), (unsigned)z))

--- a/ports/civetweb/fix-fseeko.patch
+++ b/ports/civetweb/fix-fseeko.patch
@@ -1,16 +1,17 @@
 diff --git a/src/civetweb.c b/src/civetweb.c
-index 9e321ed..c6e9894 100644
+index 9e321ed..0f11407 100644
 --- a/src/civetweb.c
 +++ b/src/civetweb.c
-@@ -652,7 +652,10 @@ typedef const char *SOCK_OPT_TYPE;
- #define close(x) (_close(x))
- #define dlsym(x, y) (GetProcAddress((HINSTANCE)(x), (y)))
- #define RTLD_LAZY (0)
--#define fseeko(x, y, z) ((_lseeki64(_fileno(x), (y), (z)) == -1) ? -1 : 0)
+@@ -892,6 +892,12 @@ typedef unsigned short int in_port_t;
+ #if defined(USE_X_DOM_SOCKET)
+ #include <sys/un.h>
+ #endif
++
 +#if defined(__ANDROID_API__) && __ANDROID_API__ < 24
 +    // Cf. https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md#32_bit-and
 +    #define fseeko fseek
 +#endif
- #define fdopen(x, y) (_fdopen((x), (y)))
- #define write(x, y, z) (_write((x), (y), (unsigned)z))
- #define read(x, y, z) (_read((x), (y), (unsigned)z))
++
+ #endif
+ 
+ #define vsnprintf_impl vsnprintf

--- a/ports/civetweb/fix-fseeko.patch
+++ b/ports/civetweb/fix-fseeko.patch
@@ -9,7 +9,7 @@ index 9e321ed..c6e9894 100644
 -#define fseeko(x, y, z) ((_lseeki64(_fileno(x), (y), (z)) == -1) ? -1 : 0)
 +#if defined(__ANDROID_API__) && __ANDROID_API__ < 24
 +    // Cf. https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md#32_bit-and
-+    #define fseeko(x, y, z) fseek
++    #define fseeko fseek
 +#endif
  #define fdopen(x, y) (_fdopen((x), (y)))
  #define write(x, y, z) (_write((x), (y), (unsigned)z))

--- a/ports/civetweb/portfile.cmake
+++ b/ports/civetweb/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO civetweb/civetweb
-    REF eefb26f82b233268fc98577d265352720d477ba4 # v1.15
-    SHA512 5ce962e31b3c07b7110cbc645458dba9c0e26e693fbe3b4a7ffe8a28563827049a22fc5596a911fbcea4d88a9adbef3f82000ff61027ff4387f40e4a4045c26d
+    REF "v${VERSION}"
+    SHA512 a0b943dfc76d7fd47f5a7d2c834fd38ddd4cf01a11730cf2f7cfaf32fea9698f59672f3a0f86ac80e0abc315d94d2367a500d37013f305c87d45e84cf39ca816
     HEAD_REF master
     PATCHES
         disable_warnings.patch # cl will simply ignore the other invalid options. 

--- a/ports/civetweb/portfile.cmake
+++ b/ports/civetweb/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         disable_warnings.patch # cl will simply ignore the other invalid options. 
+        fix-fseeko.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/civetweb/portfile.cmake
+++ b/ports/civetweb/portfile.cmake
@@ -39,6 +39,11 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/civetweb)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/civetweb.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/civetweb.pc")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/civetweb-cpp.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/civetweb-cpp.pc")
+vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/civetweb/vcpkg.json
+++ b/ports/civetweb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "civetweb",
-  "version": "1.15",
-  "port-version": 4,
+  "version": "1.16",
   "description": "Easy to use, powerful, C/C++ embeddable web server.",
   "homepage": "https://github.com/civetweb/civetweb",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1557,8 +1557,8 @@
       "port-version": 3
     },
     "civetweb": {
-      "baseline": "1.15",
-      "port-version": 4
+      "baseline": "1.16",
+      "port-version": 0
     },
     "cjson": {
       "baseline": "1.7.16",

--- a/versions/c-/civetweb.json
+++ b/versions/c-/civetweb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "09b961ba0bc6d7bd02818b00cfec4087dee07603",
+      "git-tree": "b66e2f8163fb7d87bcd7c7a392636a4e1ffc4e63",
       "version": "1.16",
       "port-version": 0
     },

--- a/versions/c-/civetweb.json
+++ b/versions/c-/civetweb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ca87a5a63b216403480b7e4b3f8352b54c091c6f",
+      "git-tree": "09b961ba0bc6d7bd02818b00cfec4087dee07603",
       "version": "1.16",
       "port-version": 0
     },

--- a/versions/c-/civetweb.json
+++ b/versions/c-/civetweb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b66e2f8163fb7d87bcd7c7a392636a4e1ffc4e63",
+      "git-tree": "46ba5309a5759827c0d729344e8f17cc5f3132b9",
       "version": "1.16",
       "port-version": 0
     },

--- a/versions/c-/civetweb.json
+++ b/versions/c-/civetweb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca87a5a63b216403480b7e4b3f8352b54c091c6f",
+      "version": "1.16",
+      "port-version": 0
+    },
+    {
       "git-tree": "10dad0fc40c4cb9fe210cabab019806d2b32230d",
       "version": "1.15",
       "port-version": 4


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

