### PR TITLE
[clblast] update to 1.6.1

### DIFF
--- a/ports/clblast/portfile.cmake
+++ b/ports/clblast/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CNugteren/CLBlast
-    REF 1.5.2
-    SHA512 6693704321bb7623a632ebfc71dcf07bbe4ba6c6f03a2ecf52bc10b401ae546bf82cdd3f6cc28aa9ea10f40dc7b2e86a6530f32cfbd522e24d4cf6a75c8c1100
+    REF "${VERSION}"
+    SHA512 3114b2499f13a8b12dc5dfaf3633d4a25c953da63bea3c2f09a99699ee49239c28a1db0033619ef74234af56068f94413aae8c721d1af6114b862670a32cdb8d
     HEAD_REF master
     PATCHES
         fix_install_path.patch
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/CLBLast)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/CLBlast)
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 

--- a/ports/clblast/vcpkg.json
+++ b/ports/clblast/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "clblast",
-  "version": "1.5.2",
-  "port-version": 3,
+  "version": "1.6.1",
   "description": "A modern, lightweight, performant and tunable OpenCL BLAS library written in C++11.",
   "homepage": "https://github.com/CNugteren/CLBlast",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1581,8 +1581,8 @@
       "port-version": 7
     },
     "clblast": {
-      "baseline": "1.5.2",
-      "port-version": 3
+      "baseline": "1.6.1",
+      "port-version": 0
     },
     "clfft": {
       "baseline": "2.12.2",

--- a/versions/c-/clblast.json
+++ b/versions/c-/clblast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f514afe9163a9445befe8ddc91f8cd8f0105c9d",
+      "version": "1.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "5d3c066f06df46440c055d265aa2dee1c21a9971",
       "version": "1.5.2",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

