### PR TITLE
[cppzmq] Update to 4.10.0

### DIFF
--- a/ports/cppzmq/portfile.cmake
+++ b/ports/cppzmq/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeromq/cppzmq
-    REF v4.9.0
-    SHA512 a9d1c25084b5b84dfa20a005299213c3bb610e46ac7433236fd8d3c60c7e71153c738da4645343080c0d1cad9008aca1a3091d4247c7a2f08c506ed3054d55a7
+    REF "v${VERSION}"
+    SHA512 4a4f3c2a270b9b21591b08a81f2ab6a72693af213c115f2c0aa5b737fd0363d09dba92437f48268ff982e6c27d6830f79244599bd9198e3402c6cca566cea27a
     HEAD_REF master
 )
 
@@ -25,4 +25,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/share/${PORT}/libzmq-pkg-config")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cppzmq/vcpkg.json
+++ b/ports/cppzmq/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cppzmq",
-  "version": "4.9.0",
-  "port-version": 1,
+  "version": "4.10.0",
   "description": "Header-only C++ binding for ZeroMQ",
   "homepage": "https://github.com/zeromq/cppzmq",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1873,8 +1873,8 @@
       "port-version": 1
     },
     "cppzmq": {
-      "baseline": "4.9.0",
-      "port-version": 1
+      "baseline": "4.10.0",
+      "port-version": 0
     },
     "cpr": {
       "baseline": "1.10.2+3",

--- a/versions/c-/cppzmq.json
+++ b/versions/c-/cppzmq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e7a8ca62f55304268afb4ddd9220cc39d6b4831",
+      "version": "4.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f50d93799a1982bbbdd22e88c7a784f9a7e38368",
       "version": "4.9.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

No feature needs to be tested, the usage test passed on `x64-windows` (header files found):
```
cppzmq provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(cppzmq CONFIG REQUIRED)
  target_link_libraries(main PRIVATE cppzmq cppzmq-static)
```