### PR TITLE
[kf5solid] Fix baseline regression, cleanup

### DIFF
--- a/ports/kf5solid/002_fix_imobile.patch
+++ b/ports/kf5solid/002_fix_imobile.patch
@@ -2,29 +2,17 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 60172b0d..1dfe6e8a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -55,18 +55,33 @@ set_package_properties(BISON PROPERTIES
+@@ -55,18 +55,26 @@ set_package_properties(BISON PROPERTIES
      PURPOSE "Required for the Predicate parser"
  )
  
 -find_package(IMobileDevice)
--set_package_properties(IMobileDevice PROPERTIES
-+find_package(unofficial-libimobiledevice CONFIG)
-+set_package_properties(unofficial-libimobiledevice PROPERTIES
++find_package(IMobileDevice NAMES unofficial-libimobiledevice)
+ set_package_properties(IMobileDevice PROPERTIES
                         TYPE OPTIONAL
                         PURPOSE "Needed to build the iOS device support backend"
                        )
- 
--find_package(PList)
--set_package_properties(PList PROPERTIES
-+find_package(unofficial-libplist CONFIG)
-+set_package_properties(unofficial-libplist PROPERTIES
-                        TYPE OPTIONAL
-                        PURPOSE "Needed to build the iOS device support backend"
-                       )
- 
-+set(HAVE_IMOBILE OFF)
-+if(TARGET unofficial::libimobiledevice::libimobiledevice AND TARGET unofficial::libplist::libplist)
-+    set(HAVE_IMOBILE ON)
++if(TARGET unofficial::libimobiledevice::libimobiledevice)
 +    set(IMobileDevice_VERSION "1.3.0")
 +    set(_imobile_version "0x00000")
 +    if (IMobileDevice_VERSION VERSION_GREATER_EQUAL 1.3.0)
@@ -36,19 +24,13 @@ index 60172b0d..1dfe6e8a 100644
 +        INTERFACE_COMPILE_DEFINITIONS "IMOBILEDEVICE_API=${_imobile_version}"
 +    )
 +endif()
-+
- # Used by the UDisks backend on Linux
- find_package(LibMount)
- set_package_properties(LibMount PROPERTIES
-@@ -138,7 +153,7 @@ elseif (NOT ANDROID)
-     endif()
- endif()
  
--if(IMobileDevice_FOUND AND PList_FOUND)
-+if(HAVE_IMOBILE)
-     add_device_backend(imobile)
- endif()
- 
+-find_package(PList)
++find_package(PList NAMES unofficial-libplist CONFIG)
+ set_package_properties(PList PROPERTIES
+                        TYPE OPTIONAL
+                        PURPOSE "Needed to build the iOS device support backend"
+                       )
 diff --git a/KF5SolidConfig.cmake.in b/KF5SolidConfig.cmake.in
 index 6fc15eeb..a6250ce6 100644
 --- a/KF5SolidConfig.cmake.in
@@ -57,7 +39,7 @@ index 6fc15eeb..a6250ce6 100644
          find_dependency(LibMount)
      endif()
  
-+    if (@HAVE_IMOBILE@)
++    if ("@IMobileDevice_FOUND@" AND "@PList_FOUND@")
 +        find_dependency(unofficial-libimobiledevice)
 +        find_dependency(unofficial-libplist)
 +    endif()

--- a/ports/kf5solid/002_fix_imobile.patch
+++ b/ports/kf5solid/002_fix_imobile.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 60172b0d..1dfe6e8a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -55,18 +55,26 @@ set_package_properties(BISON PROPERTIES
+@@ -55,13 +55,25 @@ set_package_properties(BISON PROPERTIES
      PURPOSE "Required for the Predicate parser"
  )
  
@@ -30,7 +30,6 @@ index 60172b0d..1dfe6e8a 100644
  set_package_properties(PList PROPERTIES
                         TYPE OPTIONAL
                         PURPOSE "Needed to build the iOS device support backend"
-                       )
 diff --git a/KF5SolidConfig.cmake.in b/KF5SolidConfig.cmake.in
 index 6fc15eeb..a6250ce6 100644
 --- a/KF5SolidConfig.cmake.in

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -46,6 +46,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBUILD_TESTING=OFF
         -DKDE_INSTALL_QMLDIR=qml
 )

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -8,12 +8,14 @@ vcpkg_from_github(
         001_fix_libmount.patch
         002_fix_imobile.patch
 )
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
 
 if(VCPKG_TARGET_IS_OSX)
     # On Darwin platform, the bundled version of 'bison' may be too old (< 3.0).
     vcpkg_find_acquire_program(BISON)
     execute_process(
-        COMMAND ${BISON} --version
+        COMMAND "${BISON}" --version
         OUTPUT_VARIABLE BISON_OUTPUT
     )
     string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" BISON_VERSION "${BISON_OUTPUT}")
@@ -28,19 +30,16 @@ endif()
 vcpkg_find_acquire_program(BISON)
 vcpkg_find_acquire_program(FLEX)
 
-get_filename_component(FLEX_DIR "${FLEX}" DIRECTORY )
-get_filename_component(BISON_DIR "${BISON}" DIRECTORY )
+get_filename_component(FLEX_DIR "${FLEX}" DIRECTORY)
+get_filename_component(BISON_DIR "${BISON}" DIRECTORY)
 
 vcpkg_add_to_path(PREPEND "${FLEX_DIR}")
 vcpkg_add_to_path(PREPEND "${BISON_DIR}")
 
-# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
-file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
-
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-  INVERTED_FEATURES
-    "libmount" CMAKE_DISABLE_FIND_PACKAGE_LibMount
-    "imobile" CMAKE_DISABLE_FIND_PACKAGE_unofficial-libimobiledevice
+    INVERTED_FEATURES
+        libmount    CMAKE_DISABLE_FIND_PACKAGE_LibMount
+        imobile     CMAKE_DISABLE_FIND_PACKAGE_unofficial-libimobiledevice
 )
 
 vcpkg_cmake_configure(
@@ -52,7 +51,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME KF5Solid CONFIG_PATH lib/cmake/KF5Solid)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF5Solid)
 vcpkg_copy_pdbs()
 
 vcpkg_copy_tools(
@@ -60,13 +59,8 @@ vcpkg_copy_tools(
     AUTO_CLEAN
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
 vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})
-

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -66,6 +66,10 @@ vcpkg_copy_tools(
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    # Until https://github.com/microsoft/vcpkg/pull/34091
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
 
 file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
 vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -37,9 +37,14 @@ vcpkg_add_to_path(PREPEND "${FLEX_DIR}")
 vcpkg_add_to_path(PREPEND "${BISON_DIR}")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        libmount    CMAKE_REQUIRE_FIND_PACKAGE_LibMount
+        imobile     CMAKE_REQUIRE_FIND_PACKAGE_IMobileDevice
+        imobile     CMAKE_REQUIRE_FIND_PACKAGE_PList
     INVERTED_FEATURES
         libmount    CMAKE_DISABLE_FIND_PACKAGE_LibMount
-        imobile     CMAKE_DISABLE_FIND_PACKAGE_unofficial-libimobiledevice
+        imobile     CMAKE_DISABLE_FIND_PACKAGE_IMobileDevice
+        imobile     CMAKE_DISABLE_FIND_PACKAGE_PList
 )
 
 vcpkg_cmake_configure(

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -18,7 +18,10 @@
     }
   ],
   "default-features": [
-    "platform-default-features"
+    {
+      "name": "libmount",
+      "platform": "linux"
+    }
   ],
   "features": {
     "imobile": {
@@ -33,18 +36,6 @@
       "supports": "linux",
       "dependencies": [
         "libmount"
-      ]
-    },
-    "platform-default-features": {
-      "description": "Enable platform-dependent default features",
-      "dependencies": [
-        {
-          "name": "kf5solid",
-          "features": [
-            "libmount"
-          ],
-          "platform": "linux"
-        }
       ]
     }
   }

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5solid",
   "version": "5.98.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Desktop hardware abstraction",
   "homepage": "https://api.kde.org/frameworks/solid/html/index.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3758,7 +3758,7 @@
     },
     "kf5solid": {
       "baseline": "5.98.0",
-      "port-version": 2
+      "port-version": 3
     },
     "kf5sonnet": {
       "baseline": "5.98.0",

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8d3c67ac0516cb82d8b7840b9b2d3ac328be7365",
+      "git-tree": "9ecd28d7a0b0b93fe9ba9026ceccc2b5e75d91a4",
       "version": "5.98.0",
       "port-version": 3
     },

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "16702722273745de70ceb5d8f8f3c4148d0fab19",
+      "git-tree": "8d3c67ac0516cb82d8b7840b9b2d3ac328be7365",
       "version": "5.98.0",
       "port-version": 3
     },

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9ecd28d7a0b0b93fe9ba9026ceccc2b5e75d91a4",
+      "git-tree": "8c660cbdee5e0b076d034c774bdd4ac2e92d18eb",
       "version": "5.98.0",
       "port-version": 3
     },

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "16702722273745de70ceb5d8f8f3c4148d0fab19",
+      "version": "5.98.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "3a95b547baf6f1c849928b20dfc319a2374f975f",
       "version": "5.98.0",
       "port-version": 2


### PR DESCRIPTION
Amends #33888.

The portfile didn't pass FEATURE_OPTIONS to the CMake build, allowing to find optional dependencies when they weren't selected. This breaks later builds from cached artifact as in vcpkg CI https://dev.azure.com/vcpkg/public/_build/results?buildId=94631.
