### PR TITLE
[d3d12-memory-allocator] Fix header file paths

### DIFF
--- a/ports/d3d12-memory-allocator/CMakeLists.txt
+++ b/ports/d3d12-memory-allocator/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(${PROJECT_NAME} STATIC
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "src/D3D12MemAlloc.h")
-#target_include_directories(${PROJECT_NAME} PRIVATE "src/")
+target_include_directories(${PROJECT_NAME} INTERFACE PUBLIC $<INSTALL_INTERFACE:include>)
 
 install(
     TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-config

--- a/ports/d3d12-memory-allocator/portfile.cmake
+++ b/ports/d3d12-memory-allocator/portfile.cmake
@@ -8,10 +8,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
 vcpkg_cmake_install()
@@ -19,4 +19,4 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH cmake/)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/d3d12-memory-allocator/vcpkg.json
+++ b/ports/d3d12-memory-allocator/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "d3d12-memory-allocator",
   "version-date": "2021-05-05",
+  "port-version": 1,
   "description": "Easy to integrate D3d12 memory allocation library from GPUOpen",
   "homepage": "https://gpuopen.com/gaming-product/d3d12-memory-allocator/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2022,7 +2022,7 @@
     },
     "d3d12-memory-allocator": {
       "baseline": "2021-05-05",
-      "port-version": 0
+      "port-version": 1
     },
     "d3dx12": {
       "baseline": "may2021",

--- a/versions/d-/d3d12-memory-allocator.json
+++ b/versions/d-/d3d12-memory-allocator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ada5dd1ad2d93ae0c4d56924dfaea88f8fc0e55",
+      "version-date": "2021-05-05",
+      "port-version": 1
+    },
+    {
       "git-tree": "988836f8b901c1a30f4b667ac37f81f1ef3bcdd8",
       "version-date": "2021-05-05",
       "port-version": 0


### PR DESCRIPTION
Fixes #34007.

Fix errors caused by header file paths:
```
C:\Users\monica\source\repos\CMakeUsage\CMakeUsage\CMakeUsage.cpp(2,10): fatal error C1083: Cannot open include file: 'D3D12MemAlloc.h': No such file or directory 
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
