### PR TITLE
[ismrmrd] Removed unused dependencies

### DIFF
--- a/ports/ismrmrd/vcpkg.json
+++ b/ports/ismrmrd/vcpkg.json
@@ -6,8 +6,6 @@
   "license": "BSD-3-Clause",
   "supports": "!(x86 | arm | wasm32)",
   "dependencies": [
-    "boost",
-    "fftw3",
     "hdf5",
     "pugixml",
     {

--- a/ports/ismrmrd/vcpkg.json
+++ b/ports/ismrmrd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ismrmrd",
   "version": "1.13.2",
+  "port-version": 1,
   "description": "ISMRM Raw Data Format",
   "homepage": "https://github.com/ismrmrd/ismrmrd",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3490,7 +3490,7 @@
     },
     "ismrmrd": {
       "baseline": "1.13.2",
-      "port-version": 0
+      "port-version": 1
     },
     "itk": {
       "baseline": "5.2.1",

--- a/versions/i-/ismrmrd.json
+++ b/versions/i-/ismrmrd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b378ab76b7b723dd6b9091f897c87b5a99fc11b7",
+      "version": "1.13.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "f8f4bb483f585631015c8991706874b535628dec",
       "version": "1.13.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
