### PR TITLE
[cmark] update to 0.30.3

### DIFF
--- a/ports/cmark/portfile.cmake
+++ b/ports/cmark/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO commonmark/cmark
-    REF 977b128291c0cf6c5053cdcf2ac72e627f09c105    #0.30.1
-    SHA512 ff8139fbb45549d6bea70e11c35ae1d8cf6108d0141688cc2b878afa6247147e0c15ac885e6ed8fa2263534dc79e88e398b30d3d3ae800f13dcdd878114adac8
+    REF "${VERSION}"
+    SHA512 27383bfef95ae1390c26aff0dd2cbca33704e7d20116bf29da4695d2c9a4146b86daba0da1e91bdb9eab95671702f885e832b3d31d51601731f1dc630df5237b
     HEAD_REF master
     PATCHES
         add-feature-tools.patch

--- a/ports/cmark/vcpkg.json
+++ b/ports/cmark/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cmark",
-  "version-semver": "0.30.1",
-  "port-version": 1,
+  "version-semver": "0.30.3",
   "description": "CommonMark parsing and rendering library",
   "homepage": "https://github.com/commonmark/cmark",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1629,8 +1629,8 @@
       "port-version": 0
     },
     "cmark": {
-      "baseline": "0.30.1",
-      "port-version": 1
+      "baseline": "0.30.3",
+      "port-version": 0
     },
     "cmcstl2": {
       "baseline": "2019-07-20",

--- a/versions/c-/cmark.json
+++ b/versions/c-/cmark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46de0e92eb13e52bb044f1d925a477483fe23c80",
+      "version-semver": "0.30.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "4225c9caf09938ef676f688bf246026bc26fef3f",
       "version-semver": "0.30.1",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

