### PR TITLE
[dbus] update to 1.15.8

### DIFF
--- a/ports/dbus/getpeereid.patch
+++ b/ports/dbus/getpeereid.patch
@@ -1,19 +1,20 @@
 diff --git a/cmake/ConfigureChecks.cmake b/cmake/ConfigureChecks.cmake
-index 7bc789f0e..ec476d9ed 100644
---- a/cmake/ConfigureChecks.cmake	
+index b7f3702..e2336ba 100644
+--- a/cmake/ConfigureChecks.cmake
 +++ b/cmake/ConfigureChecks.cmake
-@@ -44,5 +44,6 @@ check_include_file(sys/inotify.h DBUS_BUS_ENABLE_INOTIFY)
- 
+@@ -51,6 +51,7 @@ check_symbol_exists(closefrom    "unistd.h"         HAVE_CLOSEFROM)          #
+ check_symbol_exists(environ      "unistd.h"                  HAVE_DECL_ENVIRON)
+ check_symbol_exists(fstatfs      "sys/vfs.h"                 HAVE_FSTATFS)
  check_symbol_exists(getgrouplist "grp.h"            HAVE_GETGROUPLIST)       #  dbus-sysdeps.c
 +check_symbol_exists(getpeereid   "sys/types.h;unistd.h" HAVE_GETPEEREID)     #  dbus-sysdeps.c,
  check_symbol_exists(getpeerucred "ucred.h"          HAVE_GETPEERUCRED)       #  dbus-sysdeps.c, dbus-sysdeps-win.c
- check_symbol_exists(nanosleep    "time.h"           HAVE_NANOSLEEP)          #  dbus-sysdeps.c
  check_symbol_exists(getpwnam_r   "errno.h;pwd.h"    HAVE_GETPWNAM_R)         #  dbus-sysdeps-util-unix.c
+ check_symbol_exists(getrandom    "sys/random.h"             HAVE_GETRANDOM)
 diff --git a/cmake/config.h.cmake b/cmake/config.h.cmake
-index cbffcfa91..1f055ddb9 100644
---- a/cmake/config.h.cmake	
+index 77fc19c..2f25643 100644
+--- a/cmake/config.h.cmake
 +++ b/cmake/config.h.cmake
-@@ -169,6 +169,9 @@
+@@ -140,6 +140,9 @@
  /* Define to 1 if you have getgrouplist */
  #cmakedefine   HAVE_GETGROUPLIST 1
  

--- a/ports/dbus/portfile.cmake
+++ b/ports/dbus/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dbus/dbus
-    REF ed866a94889e13c83dc873d8b5f86a907f908456 #1.15.2
-    SHA512  eca9bfabfa6e8a3bf82ecc3c36dbd038c2450aded539a6d405a2709e876ccbf5002391802f6d538a5bbc16723f0d51f059f03cb6d226b400bc032b3bbe59cf10
+    REF "dbus-${VERSION}"
+    SHA512 8e476b408514e6540c36beb84e8025827c22cda8958b6eb74d22b99c64765eb3cd5a6502aea546e3e5f0534039857b37edee89c659acef40e7cab0939947d4af
     HEAD_REF master
     PATCHES 
         cmake.dep.patch

--- a/ports/dbus/vcpkg.json
+++ b/ports/dbus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dbus",
-  "version": "1.15.2",
+  "version": "1.15.8",
   "description": "D-Bus specification and reference implementation, including libdbus and dbus-daemon",
   "homepage": "https://gitlab.freedesktop.org/dbus/dbus",
   "license": "AFL-2.1 OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2081,7 +2081,7 @@
       "port-version": 3
     },
     "dbus": {
-      "baseline": "1.15.2",
+      "baseline": "1.15.8",
       "port-version": 0
     },
     "dcmtk": {

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a49c03bc95822c2f376e3f3758ac3087a428ddec",
+      "version": "1.15.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "1805ee4cbe77b30b7e922f8854acbd7bd3733e83",
       "version": "1.15.2",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

