### PR TITLE
[discount] update to 3.0.0a

### DIFF
--- a/ports/discount/disable-deprecated-warnings.patch
+++ b/ports/discount/disable-deprecated-warnings.patch
@@ -1,11 +1,11 @@
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 11fa675..34cc9ed 100644
+index ae859a3..77a936a 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
-@@ -20,6 +20,11 @@ set(${PROJECT_NAME}_INSTALL_SAMPLES OFF CACHE BOOL
- set(${PROJECT_NAME}_ONLY_LIBRARY OFF CACHE BOOL
-     "Set to ON to only build markdown library (default is OFF)")
-
+@@ -23,6 +23,11 @@ set(${PROJECT_NAME}_ONLY_LIBRARY OFF CACHE BOOL
+ set(${PROJECT_NAME}_CXX_BINDING OFF CACHE BOOL
+     "Set to ON to install header files with c++ wrappers (default is OFF)")
+ 
 +# MSVC deprecated warnings (C4996,strdup, ...)
 +if(MSVC)
 +    add_definitions(-D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS)

--- a/ports/discount/portfile.cmake
+++ b/ports/discount/portfile.cmake
@@ -4,11 +4,10 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Orc/discount
-    REF v2.2.6
-    SHA512 4c5956dea78aacd3a105ddac13f1671d811a5b2b04990cdf8485c36190c8872c4b1b9432a7236f669c34b07564ecd0096632dced54d67de9eaf4f23641417ecc
+    REF "v${VERSION}"
+    SHA512 d86bfc6d3e11131622046418a1f54bd9dfa5f1233e510189cd2c89dc857da31e88ffbe6670cc506ca8b9763e8fb74ed215f1018f83e25767c77acb8a7c296b8a
     HEAD_REF master
     PATCHES
-      cmake.patch
       generate-blocktags-command.patch
       disable-deprecated-warnings.patch
 )

--- a/ports/discount/portfile.cmake
+++ b/ports/discount/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/discount)
+vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/discount/vcpkg.json
+++ b/ports/discount/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "discount",
-  "version": "2.2.6",
-  "port-version": 3,
+  "version-string": "3.0.0a",
   "description": "DISCOUNT is a implementation of John Gruber & Aaron Swartz's Markdown markup language.",
   "homepage": "https://github.com/Orc/discount",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2161,8 +2161,8 @@
       "port-version": 0
     },
     "discount": {
-      "baseline": "2.2.6",
-      "port-version": 3
+      "baseline": "3.0.0a",
+      "port-version": 0
     },
     "discreture": {
       "baseline": "2020-01-29",

--- a/versions/d-/discount.json
+++ b/versions/d-/discount.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b8f98c49b478b28c8445069fa08738e46b8771f",
+      "version-string": "3.0.0a",
+      "port-version": 0
+    },
+    {
       "git-tree": "4cd434c2eb8785c098c1bedc33764a78291fbf2b",
       "version": "2.2.6",
       "port-version": 3

--- a/versions/d-/discount.json
+++ b/versions/d-/discount.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4b8f98c49b478b28c8445069fa08738e46b8771f",
+      "git-tree": "0964d0b7e61494ef8a5c81def6fe5070b3d60d4f",
       "version-string": "3.0.0a",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

