### PR TITLE
[nanodbc] fix build

### DIFF
--- a/ports/nanodbc/no-werror.patch
+++ b/ports/nanodbc/no-werror.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1ce7232..57836fe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,7 +35,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
+ message(STATUS "nanodbc compile: C++${CMAKE_CXX_STANDARD}")
+ 
+ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+   include(CheckCXXCompilerFlag)
+ 
+   if (NANODBC_ENABLE_COVERAGE)

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         rename-version.patch
         add-missing-include.patch
         find-unixodbc.patch
+        no-werror.patch
 )
 file(RENAME "${SOURCE_PATH}/VERSION" "${SOURCE_PATH}/VERSION.txt")
 

--- a/ports/nanodbc/vcpkg.json
+++ b/ports/nanodbc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nanodbc",
   "version": "2.13.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "A small C++ wrapper for the native C ODBC API.",
   "homepage": "https://github.com/nanodbc/nanodbc",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5670,7 +5670,7 @@
     },
     "nanodbc": {
       "baseline": "2.13.0",
-      "port-version": 6
+      "port-version": 7
     },
     "nanoflann": {
       "baseline": "1.5.0",

--- a/versions/n-/nanodbc.json
+++ b/versions/n-/nanodbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b57473b86bc71733209e195206d253f1dd3658b2",
+      "version": "2.13.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "7de6296fc337f181517f8ed4c2e6ed35d749e414",
       "version": "2.13.0",
       "port-version": 6


### PR DESCRIPTION
Failed with
```
[1/3] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/nanodbc/src/3d2fc404eb-e944ce5342.clean -isystem /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/include -fPIC -Wall -Werror -stdlib=libc++ -Wno-unused-command-line-argument -g -std=c++14 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -mmacosx-version-min=13.6 -MD -MT CMakeFiles/nanodbc.dir/nanodbc/nanodbc.cpp.o -MF CMakeFiles/nanodbc.dir/nanodbc/nanodbc.cpp.o.d -o CMakeFiles/nanodbc.dir/nanodbc/nanodbc.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/nanodbc/src/3d2fc404eb-e944ce5342.clean/nanodbc/nanodbc.cpp
FAILED: CMakeFiles/nanodbc.dir/nanodbc/nanodbc.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/nanodbc/src/3d2fc404eb-e944ce5342.clean -isystem /Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/include -fPIC -Wall -Werror -stdlib=libc++ -Wno-unused-command-line-argument -g -std=c++14 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -mmacosx-version-min=13.6 -MD -MT CMakeFiles/nanodbc.dir/nanodbc/nanodbc.cpp.o -MF CMakeFiles/nanodbc.dir/nanodbc/nanodbc.cpp.o.d -o CMakeFiles/nanodbc.dir/nanodbc/nanodbc.cpp.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/nanodbc/src/3d2fc404eb-e944ce5342.clean/nanodbc/nanodbc.cpp
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/nanodbc/src/3d2fc404eb-e944ce5342.clean/nanodbc/nanodbc.cpp:263:25: error: 'char_traits<unsigned char>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it. [-Werror,-Wdeprecated-declarations]
    auto const n = std::char_traits<NANODBC_SQLCHAR>::length(array);
                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/__string/char_traits.h:79:8: note: 'char_traits<unsigned char>' has been explicitly marked deprecated here
struct _LIBCPP_DEPRECATED_("char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it.")
       ^
```