### PR TITLE
[sfml] fix osx build

### DIFF
--- a/ports/sfml/fix-osx.patch
+++ b/ports/sfml/fix-osx.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/Macros.cmake b/cmake/Macros.cmake
+index e0118eb..76a4dcc 100644
+--- a/cmake/Macros.cmake
++++ b/cmake/Macros.cmake
+@@ -24,8 +24,6 @@ function(sfml_set_stdlib target)
+         if (${CMAKE_GENERATOR} MATCHES "Xcode")
+             sfml_set_xcode_property(${target} CLANG_CXX_LIBRARY "libc++")
+         else()
+-            target_compile_options(${target} PRIVATE "-stdlib=libc++")
+-            target_link_libraries(${target} PRIVATE "-stdlib=libc++")
+         endif()
+     endif()
+ endfunction()

--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     SHA512 aac734e8b0e16936c0238ec792c922923545ec6cf06576bc70004fa1920cd05b4c5e56fbc8a77b650bbe6e202adc39df1d30509dbce95778d04338917a38a87a
     PATCHES
         fix-dependencies.patch
+        fix-osx.patch
 )
 
 # The embedded FindFreetype doesn't properly handle debug libraries

--- a/ports/sfml/vcpkg.json
+++ b/ports/sfml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sfml",
   "version": "2.6.0",
-  "port-version": 18,
+  "port-version": 19,
   "description": "Simple and fast multimedia library",
   "homepage": "https://github.com/SFML/SFML",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7610,7 +7610,7 @@
     },
     "sfml": {
       "baseline": "2.6.0",
-      "port-version": 18
+      "port-version": 19
     },
     "sfsexp": {
       "baseline": "1.3.1",

--- a/versions/s-/sfml.json
+++ b/versions/s-/sfml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29d5488afb2bc4a0ea9a986412d569ba9575809b",
+      "version": "2.6.0",
+      "port-version": 19
+    },
+    {
       "git-tree": "7712e31893217c566173961ad3681c19856e69e6",
       "version": "2.6.0",
       "port-version": 18


### PR DESCRIPTION

Fixes
```
[37/124] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DSFML_STATIC -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/src -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/extlibs/headers/vulkan -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/extlibs/headers/glad/include -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -fvisibility=hidden -stdlib=libc++  -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wcast-align -Wunused -Woverloaded-virtual -Wconversion -Wsign-conversion -Wdouble-promotion -Wformat=2 -Wnull-dereference -Wold-style-cast -Wpedantic -Werror -Wno-unknown-warning-option -MD -MT src/SFML/Window/CMakeFiles/sfml-window.dir/OSX/SFApplicationDelegate.m.o -MF src/SFML/Window/CMakeFiles/sfml-window.dir/OSX/SFApplicationDelegate.m.o.d -o src/SFML/Window/CMakeFiles/sfml-window.dir/OSX/SFApplicationDelegate.m.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/src/SFML/Window/OSX/SFApplicationDelegate.m
FAILED: src/SFML/Window/CMakeFiles/sfml-window.dir/OSX/SFApplicationDelegate.m.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DSFML_STATIC -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/include -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/src -I/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/extlibs/headers/vulkan -isystem /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/extlibs/headers/glad/include -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -fvisibility=hidden -stdlib=libc++  -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wcast-align -Wunused -Woverloaded-virtual -Wconversion -Wsign-conversion -Wdouble-promotion -Wformat=2 -Wnull-dereference -Wold-style-cast -Wpedantic -Werror -Wno-unknown-warning-option -MD -MT src/SFML/Window/CMakeFiles/sfml-window.dir/OSX/SFApplicationDelegate.m.o -MF src/SFML/Window/CMakeFiles/sfml-window.dir/OSX/SFApplicationDelegate.m.o.d -o src/SFML/Window/CMakeFiles/sfml-window.dir/OSX/SFApplicationDelegate.m.o -c /Users/leanderSchulten/git_projekte/vcpkg/buildtrees/sfml/src/2.6.0-2d6a42d05d.clean/src/SFML/Window/OSX/SFApplicationDelegate.m
clang: error: argument unused during compilation: '-stdlib=libc++' [-Werror,-Wunused-command-line-argument]
```