### PR TITLE
[vcpkg docs] Add Arch Linux developer tools instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ $ sudo yum install devtoolset-7
 $ scl enable devtoolset-7 bash
 ```
 
+- Arch Linux based distributions:
+
+```sh
+$ sudo pacman -Syu base-devel curl zip unzip tar cmake ninja
+```
+
 For any other distributions, make sure you're installing g++ 6 or above.
 If you want to add instructions for your specific distro,
 [please open a PR][contributing:submit-pr]!

--- a/README_es.md
+++ b/README_es.md
@@ -4,6 +4,7 @@
 [English](README.md)
 [한국어](README_ko_KR.md)
 [Français](README_fr.md)
+[Tiếng Việt](README_vn.md)
 
 Vcpkg ayuda a manejar bibliotecas de C y C++ en Windows, Linux y MacOS.
 Esta herramienta y ecosistema se encuentran en constante evolución ¡Siempre apreciamos contribuciones nuevas!
@@ -195,6 +196,12 @@ $ sudo apt-get install build-essential tar curl zip unzip
 $ sudo yum install centos-release-scl
 $ sudo yum install devtoolset-7
 $ scl enable devtoolset-7 bash
+```
+
+- Distribuciones basadas en Arch Linux
+
+```sh
+$ sudo pacman -Syu base-devel curl zip unzip tar cmake ninja
 ```
 
 Para cualquier otra distribución, asegúrese que dispone de g++ 6 o superior.


### PR DESCRIPTION
this PR adds the developer tools install instructions for Arch Linux based distributions.

additionally adds the missing Vietnamese link for the Spanish readme.