### PR TITLE
[easyloggingpp] update to 9.97.1

### DIFF
--- a/ports/easyloggingpp/0001_add_cmake_options.patch
+++ b/ports/easyloggingpp/0001_add_cmake_options.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 538cc8a..9221dab 100644
+index 8604a54..e08df91 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -25,6 +25,10 @@ option(test "Build all tests" OFF)
@@ -29,6 +29,6 @@ index 538cc8a..9221dab 100644
 +                add_definitions(-DELPP_FORCE_USE_STD_THREAD)
 +        endif()
 +
-         require_cpp11()
+         require_cpp14()
          add_library(easyloggingpp STATIC src/easylogging++.cc)
          set_property(TARGET easyloggingpp PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/ports/easyloggingpp/0002_fix_build_uwp.patch
+++ b/ports/easyloggingpp/0002_fix_build_uwp.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9221dab..b18e0f5 100644
+index e08df91..7c02adf 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -28,6 +28,7 @@ option(lib_utc_datetime "Build library with UTC date/time logging" OFF)
@@ -7,16 +7,16 @@ index 9221dab..b18e0f5 100644
  option(thread_safe "Build easyloggingpp thread safe (define ELPP_THREAD_SAFE)" OFF)
  option(use_std_threads "Use standard library thread synchronization (define ELPP_FORCE_USE_STD_THREAD)" OFF)
 +option(is_uwp "The compilation platform is uwp." OFF)
-
+ 
  set(ELPP_MAJOR_VERSION "9")
  set(ELPP_MINOR_VERSION "96")
 @@ -76,6 +77,9 @@ if (build_static_lib)
-         require_cpp11()
+         require_cpp14()
          add_library(easyloggingpp STATIC src/easylogging++.cc)
          set_property(TARGET easyloggingpp PROPERTY POSITION_INDEPENDENT_CODE ON)
 +        if(is_uwp)
 +            target_compile_definitions(easyloggingpp PUBLIC WIN32_LEAN_AND_MEAN ELPP_WINSOCK2)
 +        endif()
-
+ 
          install(TARGETS
              easyloggingpp

--- a/ports/easyloggingpp/portfile.cmake
+++ b/ports/easyloggingpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO abumq/easyloggingpp
     REF "v${VERSION}"
-    SHA512 e45789edaf7a43ad6a73861840d24ccce9b9d6bba1aaacf93c6ac26ff7449957251d2ca322c9da85130b893332dd305b13a2499eaffc65ecfaaafa3e11f8d63d
+    SHA512 3df813f7f9796c81c974ba794624db2602253e14b938370deb4c851fe8725f5c7ebf71d7ae0277fcb770b043ccf8f04bbf8e770d14565f4cb704328973473387
     HEAD_REF master
     PATCHES
         0001_add_cmake_options.patch

--- a/ports/easyloggingpp/vcpkg.json
+++ b/ports/easyloggingpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "easyloggingpp",
-  "version": "9.97.0",
-  "port-version": 4,
+  "version": "9.97.1",
   "description": "Easylogging++ is a single header efficient logging library for C++ applications.",
   "homepage": "https://github.com/abumq/easyloggingpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2289,8 +2289,8 @@
       "port-version": 7
     },
     "easyloggingpp": {
-      "baseline": "9.97.0",
-      "port-version": 4
+      "baseline": "9.97.1",
+      "port-version": 0
     },
     "eathread": {
       "baseline": "1.32.09",

--- a/versions/e-/easyloggingpp.json
+++ b/versions/e-/easyloggingpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "38a4e115b196ff65465edaf05ce8a89a2640128a",
+      "version": "9.97.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "89605d63db69f67c4dfaf9a5b2cc33650967e065",
       "version": "9.97.0",
       "port-version": 4


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

