### PR TITLE
[ecos] update to 2.0.10

### DIFF
--- a/ports/ecos/portfile.cmake
+++ b/ports/ecos/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO embotech/ecos
-    REF v2.0.8
-    SHA512 c1adb188d6b2c400f817de15272472adfd013e2a174f49ec0bb2f7f889f26ba2b7ea165d9bedac3031bd2da7a770f2a285ad825d5b22ccc6cf43c756a20f844f
+    REF "v${VERSION}"
+    SHA512 b79434c194b5681f323b275eff0126f56beba792d270bd1773307cdf33297bee550b13bd2f96f5923dc4b8e200216d897ea01978f65da69dd81f1a669f8fd6e2
     HEAD_REF develop
 )
 

--- a/ports/ecos/vcpkg.json
+++ b/ports/ecos/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ecos",
-  "version": "2.0.8",
-  "port-version": 3,
+  "version": "2.0.10",
   "description": "A lightweight conic solver for second-order cone programming.",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2309,8 +2309,8 @@
       "port-version": 0
     },
     "ecos": {
-      "baseline": "2.0.8",
-      "port-version": 3
+      "baseline": "2.0.10",
+      "port-version": 0
     },
     "ecsutil": {
       "baseline": "1.0.7.15",

--- a/versions/e-/ecos.json
+++ b/versions/e-/ecos.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27839500a8e0bfa142a3486e32410ea3c5c1de42",
+      "version": "2.0.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "78694a162b97c80fc2b0017c3dc13c9c7e79f9c2",
       "version": "2.0.8",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

