### PR TITLE
[effolkronium-random] update to 1.5.0

### DIFF
--- a/ports/effolkronium-random/portfile.cmake
+++ b/ports/effolkronium-random/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO effolkronium/random
-    REF v1.4.1
-    SHA512 215fd34ea3a99c955a1fcd70d6c317e3829b3c562c737d22be1371213b3e14346b2f61fc76afbbcc55e26b4fdf630fa428b8bc34104170cbfc4afebcf24d160b
+    REF "v${VERSION}"
+    SHA512 778667d3b3a4bd51b67ef7d1842652dcf6d7df210345f667d0474cdfe48bb75fa2c891f8843f3fc4946fb2ef71da652c296eaaa03718ed889dee4926d743b7dd
     HEAD_REF master
 )
 

--- a/ports/effolkronium-random/vcpkg.json
+++ b/ports/effolkronium-random/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "effolkronium-random",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Random with a modern C++ API",
   "homepage": "https://github.com/effolkronium/random",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2329,7 +2329,7 @@
       "port-version": 3
     },
     "effolkronium-random": {
-      "baseline": "1.4.1",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "efsw": {

--- a/versions/e-/effolkronium-random.json
+++ b/versions/e-/effolkronium-random.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92d5b3e1b94743447e68f6c774bbbc56b3556461",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2ffd6600668e6304e7e60f9ef447855efc89a0a0",
       "version": "1.4.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

