### PR TITLE
[ezc3d] update to 1.5.0

### DIFF
--- a/ports/ezc3d/portfile.cmake
+++ b/ports/ezc3d/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pyomeca/ezc3d
-    REF Release_1.4.7
-    SHA512 ba234be76b5d95b9527952c7e1bf67d9725fc280bf991f45e7cbd68f1aeeab7e963c8c4d928e720d02ebc02ec2b0e41f1c28036cd728ccb4c5a77c6fa81a74ad
+    REF "Release_${VERSION}"
+    SHA512 19f2602be04ea4b0d65d7c26cc6b5c687f65ef5bceae104d7bcddec1e8db05cc65db2cb37ac8133b7bbda99cd097ead08fd7dcdaf470f710f5cc68cd73edb150
     HEAD_REF dev
 )
 

--- a/ports/ezc3d/portfile.cmake
+++ b/ports/ezc3d/portfile.cmake
@@ -16,11 +16,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_cmake_config_fixup(CONFIG_PATH "CMake")
-else()
-    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ezc3d")
-endif()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ezc3d")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/ezc3d/vcpkg.json
+++ b/ports/ezc3d/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ezc3d",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "description": "C3D reader/writer",
   "homepage": "https://github.com/pyomeca/ezc3d",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2429,7 +2429,7 @@
       "port-version": 2
     },
     "ezc3d": {
-      "baseline": "1.4.7",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "ezfoundation": {

--- a/versions/e-/ezc3d.json
+++ b/versions/e-/ezc3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9ed0a0b3b06199ef4e4d9809c5764d239904145",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "21ec5f8371f785c406c466171aadff744e2b34e2",
       "version": "1.4.7",
       "port-version": 0

--- a/versions/e-/ezc3d.json
+++ b/versions/e-/ezc3d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e9ed0a0b3b06199ef4e4d9809c5764d239904145",
+      "git-tree": "f41d466838bd526b6e8717bf3c962b29a7bb47c5",
       "version": "1.5.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

