### PR TITLE
[freerdp] Update to 2.11.2.

### DIFF
--- a/ports/freerdp/portfile.cmake
+++ b/ports/freerdp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FreeRDP/FreeRDP
     REF "${VERSION}"
-    SHA512 a6c5b395424e730096b992fc2786369a78113819eddb5117bf45e5174286f36a22701c69fdd96b3d03c1aa3c2087bc97e2bfa2a5548236080fdbebcb01ffc4c7
+    SHA512 722d95d7591b5ce6a7e8a3b6ac8999df278dbcfc286a532f56bcbc4a3881e75b02c7e3cd4b296e67bc19d1165020acdcca198bf4bcc92aea5611760037fcc57f
     HEAD_REF master
     PATCHES
         DontInstallSystemRuntimeLibs.patch

--- a/ports/freerdp/vcpkg.json
+++ b/ports/freerdp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "freerdp",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "A free implementation of the Remote Desktop Protocol (RDP)",
   "homepage": "https://github.com/FreeRDP/FreeRDP",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2693,7 +2693,7 @@
       "port-version": 7
     },
     "freerdp": {
-      "baseline": "2.11.1",
+      "baseline": "2.11.2",
       "port-version": 0
     },
     "freetds": {

--- a/versions/f-/freerdp.json
+++ b/versions/f-/freerdp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "90f838d8fb3b7d8d45b9d64f951486cee618ab8e",
+      "version": "2.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "43135a7f0ecf1e2fa292ea7f1fbe69dc0d2ec09d",
       "version": "2.11.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

