### PR TITLE
[gstreamer] disable "nvcodec" of "plugins-bad"

### DIFF
--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -248,7 +248,7 @@ vcpkg_configure_meson(
         -Dgst-plugins-bad:msdk=disabled
         -Dgst-plugins-bad:musepack=disabled
         -Dgst-plugins-bad:neon=disabled
-        -Dgst-plugins-bad:nvcodec=enabled
+        -Dgst-plugins-bad:nvcodec=disabled
         -Dgst-plugins-bad:onnx=disabled # libonnxruntime not found
         -Dgst-plugins-bad:openaptx=disabled
         -Dgst-plugins-bad:opencv=disabled # opencv not found

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.22.5",
+  "port-version": 1,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3062,7 +3062,7 @@
     },
     "gstreamer": {
       "baseline": "1.22.5",
-      "port-version": 0
+      "port-version": 1
     },
     "gtest": {
       "baseline": "1.14.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f37f12f5a39fa6eea841721c51bb591039c3251",
+      "version": "1.22.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "76183f0a0e77acbf09ac1ae73b1b2a27f986fcf6",
       "version": "1.22.5",
       "port-version": 0


### PR DESCRIPTION
### Changes

Resolve #34109

`nvcodec` is enabled since https://github.com/microsoft/vcpkg/pull/30689
Disable it to fix build error...

I found the error while trying to add `libonnxruntime` support for the port.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
