### PR TITLE
[libopenmpt] use libc++ in Apple platform build

### DIFF
--- a/ports/libopenmpt/CMakeLists.txt
+++ b/ports/libopenmpt/CMakeLists.txt
@@ -4,8 +4,10 @@ project(libopenmpt)
 if(MSVC)
   add_compile_options(
     /W3 /wd4005 /wd4267 /wd4244 /wd4996 /wd4100 /wd4018
-    -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE
-    -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS
+  )
+  add_compile_definitions(
+    _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE
+    _CRT_SECURE_NO_DEPRECATE _CRT_NONSTDC_NO_WARNINGS
   )
 endif()
 
@@ -47,16 +49,16 @@ add_library(libopenmpt ${SOURCES})
 set_target_properties(libopenmpt PROPERTIES OUTPUT_NAME openmpt)
 
 target_compile_definitions(libopenmpt PRIVATE
-  -DMPT_WITH_MPG123 -DMPT_WITH_OGG
-  -DMPT_WITH_VORBIS -DMPT_WITH_VORBISFILE
-  -DMPT_WITH_ZLIB -DMPT_BUILD_VCPKG
-  -DLIBOPENMPT_BUILD
+  MPT_WITH_MPG123 MPT_WITH_OGG
+  MPT_WITH_VORBIS MPT_WITH_VORBISFILE
+  MPT_WITH_ZLIB MPT_BUILD_VCPKG
+  LIBOPENMPT_BUILD
 )
 
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(
     libopenmpt
-    PRIVATE -DLIBOPENMPT_BUILD_DLL
+    PRIVATE LIBOPENMPT_BUILD_DLL
   )
 endif()
 
@@ -74,6 +76,9 @@ target_link_libraries(
     Vorbis::vorbis
     ZLIB::ZLIB
 )
+if(APPLE)
+  target_link_libraries(libopenmpt PRIVATE c++)
+endif()
 
 set(LIBOPENMPT_REQUIRES_PRIVATE "zlib vorbis vorbisfile libmpg123")
 set(LIBOPENMPT_LIBS_PRIVATE "")

--- a/ports/libopenmpt/vcpkg.json
+++ b/ports/libopenmpt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libopenmpt",
   "version": "0.6.7",
+  "port-version": 1,
   "description": "a cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream.",
   "homepage": "https://openmpt.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4474,7 +4474,7 @@
     },
     "libopenmpt": {
       "baseline": "0.6.7",
-      "port-version": 0
+      "port-version": 1
     },
     "libopensp": {
       "baseline": "1.5.2",

--- a/versions/l-/libopenmpt.json
+++ b/versions/l-/libopenmpt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40069a56f10fe9eec54ceddd206f41a811a775ae",
+      "version": "0.6.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "5d66142c7858d9ac23b31a1ab5d596e2370ef7c2",
       "version": "0.6.7",
       "port-version": 0


### PR DESCRIPTION
### Changes

fix #31109

* requires #34152

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
