### PR TITLE
[Brotli] Fix emscripten

### DIFF
--- a/ports/brotli/emscripten.patch
+++ b/ports/brotli/emscripten.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0589fc1..9b32b60 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -153,10 +153,8 @@ foreach(lib ${BROTLI_LIBRARIES_CORE})
+   set_property(TARGET ${lib} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${BROTLI_INCLUDE_DIRS}>" $<INSTALL_INTERFACE:include>)
+ endforeach()
+ 
+-if(NOT BROTLI_EMSCRIPTEN)
+ target_link_libraries(brotlidec brotlicommon)
+ target_link_libraries(brotlienc brotlicommon)
+-endif()
+ 
+ # For projects stuck on older versions of CMake, this will set the
+ # BROTLI_INCLUDE_DIRS and BROTLI_LIBRARIES variables so they still

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -8,14 +8,13 @@ vcpkg_from_github(
         install.patch
         fix-arm-uwp.patch
         pkgconfig.patch
+        emscripten.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBROTLI_DISABLE_TESTS=ON
-        # Required for wasm32-emscripten triplet to avoid "install" being turned off
-        -DBROTLI_EMSCRIPTEN=OFF
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
@@ -23,7 +22,14 @@ vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/unofficial-brotli PACKAGE_NAME unofficial-brotli)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/tools")
-vcpkg_copy_tools(TOOL_NAMES "brotli" SEARCH_DIR "${CURRENT_PACKAGES_DIR}/tools/brotli")
+
+# Under emscripten the brotli executable tool is produced with .js extension but vcpkg_copy_tools
+# has no special behaviour in this case and searches for the tool name with no extension
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+	set(TOOL_SUFFIX ".js" )
+endif()
+
+vcpkg_copy_tools(TOOL_NAMES "brotli${TOOL_SUFFIX}" SEARCH_DIR "${CURRENT_PACKAGES_DIR}/tools/brotli")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/brotli/vcpkg.json
+++ b/ports/brotli/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "brotli",
   "version": "1.1.0",
+  "port-version": 1,
   "description": "a generic-purpose lossless compression algorithm that compresses data using a combination of a modern variant of the LZ77 algorithm, Huffman coding and 2nd order context modeling.",
   "homepage": "https://github.com/google/brotli",
   "license": "MIT",

--- a/versions/b-/brotli.json
+++ b/versions/b-/brotli.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e5b5ae1ad26c80535c893cc0307121f0398549e",
+      "version": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4156ea7744047f9ace2769b857d97d11154de28f",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1298,7 +1298,7 @@
     },
     "brotli": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "brpc": {
       "baseline": "1.5.0",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes issue reported in https://github.com/microsoft/vcpkg/pull/33665#issuecomment-1739094306
Related to: WerWolv/ImHex#1299
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
