### PR TITLE
[gmmlib] update to 22.3.12

### DIFF
--- a/ports/gmmlib/portfile.cmake
+++ b/ports/gmmlib/portfile.cmake
@@ -7,8 +7,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/gmmlib
-    REF intel-gmmlib-21.3.2
-    SHA512 155f7077f3135ff812b9fe759e56fecd595f1c5dde9a377df31a9acedcfeea9d93751badba68077c00929a21cb87e1bd69b8fe3961ac61765fabbc5d6d89e6be
+    REF "intel-gmmlib-${VERSION}"
+    SHA512 afe64aaaddac9b72ff12aa41faeb668141999e1b9c644fa21ced8fd851cf698ec57bac1080c87c0fae5c464b47ea5b94e6290c0e4c0c24ec010071f535c60e42
     HEAD_REF master
 )
 

--- a/ports/gmmlib/vcpkg.json
+++ b/ports/gmmlib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gmmlib",
-  "version": "21.3.2",
-  "port-version": 1,
+  "version": "22.3.12",
   "description": "Intel(R) Graphics Memory Management Library",
   "homepage": "https://github.com/intel/gmmlib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2957,8 +2957,8 @@
       "port-version": 6
     },
     "gmmlib": {
-      "baseline": "21.3.2",
-      "port-version": 1
+      "baseline": "22.3.12",
+      "port-version": 0
     },
     "gmp": {
       "baseline": "6.2.1",

--- a/versions/g-/gmmlib.json
+++ b/versions/g-/gmmlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04bd253bdd2f2e7e02b69feb0d72854fd663d3fb",
+      "version": "22.3.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "d7dbf37aa324f038b12f99d697da82299d3ec9a0",
       "version": "21.3.2",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

