### PR TITLE
[alsa] update to 1.2.10

### DIFF
--- a/ports/alsa/portfile.cmake
+++ b/ports/alsa/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alsa-project/alsa-lib
     REF "v${VERSION}"
-    SHA512 34ebeb64fd43432df779bfd6de08fb26cfd59d75586100cab7308d1ecf60d722cf137f1209426a288bdbaa27c31e963ce09690272b8d85653989a935a6fc50af
+    SHA512 923cd9f19afa77cf46bb15b4fefdaa2db75054052af0f11b6d18e1703a0d3d05fecca235606ea06bca380a4306c134f88b71be73839eca3f4ce077dbdcb13c6a
     HEAD_REF master
     PATCHES
         "fix-plugin-dir.patch"

--- a/ports/alsa/vcpkg.json
+++ b/ports/alsa/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "alsa",
-  "version": "1.2.8",
-  "port-version": 1,
+  "version": "1.2.10",
   "description": "The Advanced Linux Sound Architecture (ALSA) - library",
   "homepage": "https://www.alsa-project.org/",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/alsa.json
+++ b/versions/a-/alsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3fa8b1fd27e767f429d0736b6636df796e2c335",
+      "version": "1.2.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "18d67806b319dea0e3c2e9c921a1864901af1d22",
       "version": "1.2.8",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -93,8 +93,8 @@
       "port-version": 1
     },
     "alsa": {
-      "baseline": "1.2.8",
-      "port-version": 1
+      "baseline": "1.2.10",
+      "port-version": 0
     },
     "amd-adl-sdk": {
       "baseline": "17.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
