### PR TITLE
[protobuf-c] update to 1.4.1

### DIFF
--- a/ports/protobuf-c/portfile.cmake
+++ b/ports/protobuf-c/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protobuf-c/protobuf-c
     REF v${VERSION}
-    SHA512 cba4c6116c0f2ebb034236e8455d493bfaa2517733befcd87b6f8d6d3df0c0149b17fcbf59cd1763fa2318119c664d0dae3d2d3a46ebfe2a0fec3ef4719b033b
+    SHA512 57f858118a89befc80e111ad9a57eadbcf2317d60e085b6d99e10f6604ee8c08473fe6ab1fdfb0a3196821a6e68e743943338321d23d15a1229987f140341181
     HEAD_REF master
     PATCHES
         fix-crt-linkage.patch

--- a/ports/protobuf-c/vcpkg.json
+++ b/ports/protobuf-c/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "protobuf-c",
-  "version-semver": "1.4.0",
-  "port-version": 2,
+  "version-semver": "1.4.1",
   "description": "This is protobuf-c, a C implementation of the Google Protocol Buffers data serialization format.",
   "homepage": "https://github.com/protobuf-c/protobuf-c",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6601,8 +6601,8 @@
       "port-version": 0
     },
     "protobuf-c": {
-      "baseline": "1.4.0",
-      "port-version": 2
+      "baseline": "1.4.1",
+      "port-version": 0
     },
     "protopuf": {
       "baseline": "2.2.1",

--- a/versions/p-/protobuf-c.json
+++ b/versions/p-/protobuf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1adcf184e617f9f77bd727e6f5085665e471826",
+      "version-semver": "1.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0ff60f2fb0722cbd851e37aebf489207c3743e18",
       "version-semver": "1.4.0",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

