### PR TITLE
[libxpm] update to 3.5.16

### DIFF
--- a/ports/libxpm/portfile.cmake
+++ b/ports/libxpm/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libxpm
     REF "libXpm-${VERSION}"
-    SHA512 1ae8c48b0d928265cfc6baac1286f241f20e70c88d6f9b6881ccccd7f2e290ca0afaf0f3a051ad5526449dec93c6cc41c48bb6e488e29e2baec87238f17f6bcf
+    SHA512 006d5fb2fd951b8857b8d409d65ebe4f819dc51df3bbe933ef9b879a9dc832b0828481c7c0cac453a82a1e81f39990fc49819314a443a1082bdaea6044bb3013
     PATCHES
         remove_strings_h.patch
         fix-dependency-gettext.patch

--- a/ports/libxpm/portfile.cmake
+++ b/ports/libxpm/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libxpm
-    REF libXpm-3.5.14
+    REF "libXpm-${VERSION}"
     SHA512 1ae8c48b0d928265cfc6baac1286f241f20e70c88d6f9b6881ccccd7f2e290ca0afaf0f3a051ad5526449dec93c6cc41c48bb6e488e29e2baec87238f17f6bcf
     PATCHES
         remove_strings_h.patch

--- a/ports/libxpm/vcpkg.json
+++ b/ports/libxpm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxpm",
-  "version": "3.5.14",
+  "version": "3.5.16",
   "description": "XPM format pixmap library",
   "homepage": "https://github.com/freedesktop/libXpm",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4965,7 +4965,7 @@
       "port-version": 1
     },
     "libxpm": {
-      "baseline": "3.5.14",
+      "baseline": "3.5.16",
       "port-version": 0
     },
     "libxpresent": {

--- a/versions/l-/libxpm.json
+++ b/versions/l-/libxpm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08b786672b77cbb1707fbde4ad2c5902df4cbfe4",
+      "version": "3.5.16",
+      "port-version": 0
+    },
+    {
       "git-tree": "6fb796fec0f4bcbf52d4da236bce4e3394c619e9",
       "version": "3.5.14",
       "port-version": 0

--- a/versions/l-/libxpm.json
+++ b/versions/l-/libxpm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "08b786672b77cbb1707fbde4ad2c5902df4cbfe4",
+      "git-tree": "ab78e7ef1aa0fd25dfc94278d05e4c1f983aa71a",
       "version": "3.5.16",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
