### PR TITLE
[wg21-linear-algebra] update to 0.7.3

### DIFF
--- a/ports/wg21-linear-algebra/portfile.cmake
+++ b/ports/wg21-linear-algebra/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BobSteagall/wg21
     REF "v${VERSION}"
-    SHA512 c249344d035d09760a9e5ea059ed6db5a1cb42b918735672bd7aa6dbda08f947855582f76ad61d33f59a847d8befe5caed57d25da2bcfc9fa8e6cef50a4c24e2
+    SHA512 ab1db0cff476d2f63a5d1fcc1d3b40acbceeacae61a99d7ad0b8d8abe21413da97b71c088a331b70c0d0c3dc4615953485c68af46698ec7f0013e14bea5f9452
 )
 
 vcpkg_cmake_configure(

--- a/ports/wg21-linear-algebra/vcpkg.json
+++ b/ports/wg21-linear-algebra/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wg21-linear-algebra",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A linear algebra proposal for the C++ standard library",
   "license": "NCSA",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8801,7 +8801,7 @@
       "port-version": 3
     },
     "wg21-linear-algebra": {
-      "baseline": "0.7.2",
+      "baseline": "0.7.3",
       "port-version": 0
     },
     "wg21-sg14": {

--- a/versions/w-/wg21-linear-algebra.json
+++ b/versions/w-/wg21-linear-algebra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85073707ba15d2e60bdcf7e7f0c513d6bebe6332",
+      "version": "0.7.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "d3968b4096fba4dbd1189fb9b7b1d33ba562fdc7",
       "version": "0.7.2",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

