### PR TITLE
[mpfr] update to 4.2.1

### DIFF
--- a/ports/mpfr/portfile.cmake
+++ b/ports/mpfr/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_download_distfile(ARCHIVE
     URLS "http://www.mpfr.org/mpfr-${VERSION}/mpfr-${VERSION}.tar.xz" "https://ftp.gnu.org/gnu/mpfr/mpfr-${VERSION}.tar.xz"
     FILENAME "mpfr-${VERSION}.tar.xz"
-    SHA512 58e843125884ca58837ae5159cd4092af09e8f21931a2efd19c15de057c9d1dc0753ae95c592e2ce59a727fbc491af776db8b00a055320413cdcf2033b90505c
+    SHA512 bc68c0d755d5446403644833ecbb07e37360beca45f474297b5d5c40926df1efc3e2067eecffdf253f946288bcca39ca89b0613f545d46a9e767d1d4cf358475
 )
 
 vcpkg_extract_source_archive(

--- a/ports/mpfr/vcpkg.json
+++ b/ports/mpfr/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mpfr",
-  "version": "4.2.0",
-  "port-version": 1,
+  "version": "4.2.1",
   "description": "The MPFR library is a C library for multiple-precision floating-point computations with correct rounding",
   "homepage": "https://www.mpfr.org",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5549,8 +5549,8 @@
       "port-version": 3
     },
     "mpfr": {
-      "baseline": "4.2.0",
-      "port-version": 1
+      "baseline": "4.2.1",
+      "port-version": 0
     },
     "mpg123": {
       "baseline": "1.31.3",

--- a/versions/m-/mpfr.json
+++ b/versions/m-/mpfr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d612486f81111c3f56a2ac56727dde81fda96f8e",
+      "version": "4.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a2163475ac427c02bc7a7c24142b45662d5993cc",
       "version": "4.2.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

