### PR TITLE
[sqlite3] update to 3.43.1

### DIFF
--- a/ports/sqlite3/add-config-include.patch
+++ b/ports/sqlite3/add-config-include.patch
@@ -1,17 +1,17 @@
 diff --git a/sqlite3.c b/sqlite3.c
-index 310583f..61f7d9e 100644
+index 1884b08..0d191be 100644
 --- a/sqlite3.c
 +++ b/sqlite3.c
 @@ -20,6 +20,7 @@
  ** The content in this amalgamation comes from Fossil check-in
- ** f80b798b3f4b81a7bb4233c58294edd0f11.
+ ** d3a40c05c49e1a49264912b1a05bc2143ac.
  */
 +#include "sqlite3-vcpkg-config.h"
  #define SQLITE_CORE 1
  #define SQLITE_AMALGAMATION 1
  #ifndef SQLITE_PRIVATE
 diff --git a/sqlite3.h b/sqlite3.h
-index ec451a5..9c01424 100644
+index b9d0692..698c410 100644
 --- a/sqlite3.h
 +++ b/sqlite3.h
 @@ -32,6 +32,7 @@

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -4,7 +4,7 @@ string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2023/sqlite-amalgamation-${SQLITE_VERSION}.zip"
     FILENAME "sqlite-amalgamation-${SQLITE_VERSION}.zip"
-    SHA512 241b22899c9090d94677328335588ba964a5bc3bfb278b8dcc97d6062cdfab6460b5b03dc166124f6119f5f8ece62ef9d06298de06eb5b36ed3ea49fd6ddc394
+    SHA512 f17810f3b68b7f77a174503a863385a17bac0e9c819b9813cb75597cbd229ae8ad0b545410fc320669f377e79ab8412bbff8863f197d0f804c3a05b573df57e9
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.43.0",
+  "version": "3.43.1",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7937,7 +7937,7 @@
       "port-version": 0
     },
     "sqlite3": {
-      "baseline": "3.43.0",
+      "baseline": "3.43.1",
       "port-version": 0
     },
     "sqlitecpp": {

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6497ccc9668ca1e0b17a080b01e8585b33660336",
+      "version": "3.43.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4f7a1dcf86377b6045fbf05eb0ec1baff1d2ceb6",
       "version": "3.43.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

