### PR TITLE
[hwloc] update to 2.9.3

### DIFF
--- a/ports/hwloc/portfile.cmake
+++ b/ports/hwloc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-mpi/hwloc
-    REF 42bebfa5e4b96c99c2482645c8eb86d4755ef23b
-    SHA512 87aff1e0eb7389a8d433f2936b6e23e8c37381d46fb7e60a205a97bc0f86f3c8926e3a6da6e54d4aeb89ef19abbe73a9d392f8c7871108b2a9fbf0b011de9f2c
+    REF "hwloc-${VERSION}"
+    SHA512 958f385d846ed1b6ab60725b7966374213eff3e304a77c5bc8a26f1900c04eb082119d5147f98b2c7f931f566e2d1b05a2a4e89bda220f45258e497b68735929
     PATCHES
         fix_shared_win_build.patch
         stdout_fileno.patch

--- a/ports/hwloc/vcpkg.json
+++ b/ports/hwloc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hwloc",
-  "version": "2.9.0",
+  "version": "2.9.3",
   "maintainers": "bgoglin<Brice.Goglin@inria.fr>",
   "description": [
     "Portable Hardware Locality (hwloc)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3265,7 +3265,7 @@
       "port-version": 4
     },
     "hwloc": {
-      "baseline": "2.9.0",
+      "baseline": "2.9.3",
       "port-version": 0
     },
     "hyperscan": {

--- a/versions/h-/hwloc.json
+++ b/versions/h-/hwloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c536aed23026d6f8a30f1815e47f30652112c22",
+      "version": "2.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a5178039005718c78a3a9a0386fb4e6113797576",
       "version": "2.9.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

