### PR TITLE
[libgnutls] update to 3.8.1

### DIFF
--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
     FILENAME "gnutls-${VERSION}.tar.xz"
-    SHA512 4199bcf7c9e3aab2f52266aadceefc563dfe2d938d0ea1f3ec3be95d66f4a8c8e5494d3a800c03dd02ad386dec1738bd63e1fe0d8b394a2ccfc7d6c6a0cc9359
+    SHA512 22e78db86b835843df897d14ad633d8a553c0f9b1389daa0c2f864869c6b9ca889028d434f9552237dc4f1b37c978fbe0cce166e3768e5d4e8850ff69a6fc872
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${tarball}"

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgnutls",
-  "version": "3.7.8",
+  "version": "3.8.1",
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols.",
   "homepage": "https://www.gnutls.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4189,7 +4189,7 @@
       "port-version": 0
     },
     "libgnutls": {
-      "baseline": "3.7.8",
+      "baseline": "3.8.1",
       "port-version": 0
     },
     "libgo": {

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7818d88f0b76ec5775b8bc6269ebf22d9aea466d",
+      "version": "3.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "93d9f1a3a919257ac3d518297d3ef4d34b5f5e3e",
       "version": "3.7.8",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

