### PR TITLE
[mp-units] update to v2.0.0

### DIFF
--- a/ports/mp-units/config.patch
+++ b/ports/mp-units/config.patch
@@ -1,11 +1,11 @@
 diff --git a/src/mp-unitsConfig.cmake b/src/mp-unitsConfig.cmake
-index 668fd97d..0eebeded 100644
+index 10f82a82..ea637abd 100644
 --- a/src/mp-unitsConfig.cmake
 +++ b/src/mp-unitsConfig.cmake
 @@ -42,10 +42,10 @@ endfunction()
  include(CMakeFindDependencyMacro)
  
- if(UNITS_USE_LIBFMT)
+ if(MP_UNITS_USE_LIBFMT)
 -    find_dependency(fmt)
 +    find_dependency(fmt CONFIG)
  endif()

--- a/ports/mp-units/portfile.cmake
+++ b/ports/mp-units/portfile.cmake
@@ -19,7 +19,7 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/src"
     OPTIONS
-      -DUNITS_USE_LIBFMT=${USE_LIBFMT}
+      -DMP_UNITS_USE_LIBFMT=${USE_LIBFMT}
 )
 
 vcpkg_cmake_install()

--- a/ports/mp-units/portfile.cmake
+++ b/ports/mp-units/portfile.cmake
@@ -1,8 +1,12 @@
+if(VCPKG_TARGET_IS_LINUX)
+    message("Note: `mp-units` requires Clang16+ or GCC11+")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mpusz/units
     REF "v${VERSION}"
-    SHA512 6369c886629955c6457911b98a702c29bacce58e9049e1da700055a3f8b1981cce4f545c1d09550ec1c57f8805f7fc1f0198118950a14b2a7b797dd437ed72df
+    SHA512 994922a391ed5c1d0e023545beeb0bbeb8ec067be408f715d553e509d9106cdb5b27cfbaa69f0ca1a27cdf9532edacaff7d2cabaafd54b1713f9c8add93bc389
     PATCHES
       config.patch
 )

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mp-units",
-  "version": "0.8.0",
+  "version": "2.0.0",
   "description": "mp-units - A Units Library for C++",
   "homepage": "https://github.com/mpusz/units",
   "license": "MIT",
@@ -25,17 +25,10 @@
         {
           "name": "mp-units",
           "features": [
-            "install-range-v3",
             "use-libfmt"
           ],
           "platform": "osx"
         }
-      ]
-    },
-    "install-range-v3": {
-      "description": "Provide range-v3 for compilers not supporting std::ranges",
-      "dependencies": [
-        "range-v3"
       ]
     },
     "use-libfmt": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5533,7 +5533,7 @@
       "port-version": 0
     },
     "mp-units": {
-      "baseline": "0.8.0",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "mp3lame": {

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f3a9510faa1227a5060a1b71e8b57024155023e",
+      "git-tree": "20c8d575daac74f89db17c42e3aec02c88075962",
       "version": "2.0.0",
       "port-version": 0
     },

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "20c8d575daac74f89db17c42e3aec02c88075962",
+      "git-tree": "f410b971351069e2e9f1b140104a8e836b76c1b8",
       "version": "2.0.0",
       "port-version": 0
     },

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f3a9510faa1227a5060a1b71e8b57024155023e",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f26957340de86e12abc971d4db95b5a2a2cd7d37",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
