### PR TITLE
[hffix] update to 1.3.0

### DIFF
--- a/ports/hffix/portfile.cmake
+++ b/ports/hffix/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jamesdbrock/hffix
-    REF v1.2.1
-    SHA512 81947d5b2fbc2818b6ae7274febece8a813a67afc4a605bd92a1d7cb5df4e19e5df73a1a597c27898134fab1a0cc7c672d2dcba7688bab24184469b0760be06f
+    REF "v${VERSION}"
+    SHA512 a04a22360074f383997756d36ddf520a565e5d200e32e8439ef92f33bcb30ab29e962fc4d85142c1da323ddf9fef2d8b6a023dcbeedf1a5c269889adfcd70fb8
     HEAD_REF master
 )
 

--- a/ports/hffix/vcpkg.json
+++ b/ports/hffix/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hffix",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Financial Information Exchange Protocol C++ Library",
   "homepage": "https://jamesdbrock.github.io/hffix",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3209,7 +3209,7 @@
       "port-version": 0
     },
     "hffix": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "hfsm2": {

--- a/versions/h-/hffix.json
+++ b/versions/h-/hffix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3aab9fe5c85f6055d5df986ca8c6a8e67cd7014c",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae376d1e63858194fc64a2c32221d273d0e2d953",
       "version": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

