### PR TITLE
[mfx-dispatch] Fix pkgconfig lib syntax

### DIFF
--- a/ports/mfx-dispatch/fix-pkgconf.patch
+++ b/ports/mfx-dispatch/fix-pkgconf.patch
@@ -33,7 +33,7 @@ index fabb541..5d248fe 100644
  Requires.private:
  Conflicts:
 -Libs: -L${libdir} -lsupc++ ${libdir}/libmfx.lib
-+Libs: -L${libdir} ${libdir}/libmfx.lib
++Libs: -L${libdir} -llibmfx
  Libs.private:
 -Cflags: -I${includedir} -I@INTELMEDIASDK_PATH@
 +Cflags: -I${includedir}

--- a/ports/mfx-dispatch/vcpkg.json
+++ b/ports/mfx-dispatch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mfx-dispatch",
   "version": "1.35.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Open source Intel media sdk dispatcher",
   "homepage": "https://github.com/lu-zero/mfx_dispatch",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5382,7 +5382,7 @@
     },
     "mfx-dispatch": {
       "baseline": "1.35.1",
-      "port-version": 2
+      "port-version": 3
     },
     "mgnlibs": {
       "baseline": "2019-09-29",

--- a/versions/m-/mfx-dispatch.json
+++ b/versions/m-/mfx-dispatch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4372c27465a70b6b113adc8fb69ea86da3c21a3f",
+      "version": "1.35.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "07eb6cc5ee276c7e965868d1cb6de113d41e0e41",
       "version": "1.35.1",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

Fixes building `ffmpeg[qsv]` on Windows.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

---

Currently trying to make use of ffmpeg via CMake returns this result:
```
[cmake] CMake Error at .build/vcpkg_installed/x86-windows-static/share/ffmpeg/FindFFMPEG.cmake:70 (find_library):
[cmake]   Could not find
[cmake]   FFMPEG_DEPENDENCY_c:/vcpkg/packages/ffmpeg_x86-windows-static/debug/lib/libmfx_DEBUG
[cmake]   using the following names:
[cmake]   c:/vcpkg/packages/ffmpeg_x86-windows-static/debug/lib/libmfx
[cmake] Call Stack (most recent call first):
[cmake]   .build/vcpkg_installed/x86-windows-static/share/ffmpeg/FindFFMPEG.cmake:145 (append_dependencies)
[cmake]   .build/vcpkg_installed/x86-windows-static/share/ffmpeg/vcpkg-cmake-wrapper.cmake:6 (_find_package)
[cmake]   C:/vcpkg/scripts/buildsystems/vcpkg.cmake:813 (include)
[cmake]   CMakeLists.txt:69 (find_package)
```

Reason for this is because inside the `FindFFMPEG.cmake` we can see that `libmfx` is addressed via a path instead of just being the library name:
```cmake
append_dependencies(FFMPEG_DEPS_LIBRARY_RELEASE NAMES "psapi;uuid;oleaut32;shlwapi;gdi32;vfw32;secur32;ws2_32;vpx;dav1d;opus;speex;theoraenc;theoradec;vorbisenc;vorbis;ogg;libx264;x265-static;mfuuid;strmiids;c:/vcpkg/packages/ffmpeg_x86-windows-static/lib/libmfx;opencl;advapi32;ole32;cfgmgr32;user32;bcrypt")
append_dependencies(FFMPEG_DEPS_LIBRARY_DEBUG   NAMES "psapi;uuid;oleaut32;shlwapi;gdi32;vfw32;secur32;ws2_32;vpx;dav1d;opus;speex;theoraenc;theoradec;vorbisenc;vorbis;ogg;libx264;x265-static;mfuuid;strmiids;c:/vcpkg/packages/ffmpeg_x86-windows-static/debug/lib/libmfx;opencl;advapi32;ole32;cfgmgr32;user32;bcrypt" DEBUG)
```

This patch fixes the behavior by fixing the notation in the `pkgconfig` file of `mfx-dispatch`.
