### PR TITLE
[highfive] update to 2.7.1

### DIFF
--- a/ports/highfive/portfile.cmake
+++ b/ports/highfive/portfile.cmake
@@ -1,19 +1,12 @@
-# Must be removed on next release
-vcpkg_download_distfile(CATCH2_PATCH
-    URLS https://github.com/BlueBrain/HighFive/commit/be9285ee4661ff4154830989899a2a050d6fbc64.patch?full_index=1
-    FILENAME ${PORT}-669-be9285ee.diff
-    SHA512 d4b085557fdcfaed195efaa25e02358714e6ccb00cc532594592183e934d99e3b80883991fcac1d073fbedb5773d76a5e9a58da4328b71215dd30b259df1eba3
-)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BlueBrain/HighFive
-    REF v2.6.2
-    SHA512 80deb3d7f0b2e8e8c660ee37b189d1a4993e23b5ada30c72f3ef4fef80020f8564c8a5a507a34f891cec6c5db0d75d7c7de89040defaf91a3b1cec2018d1bf9e
+    REF "v${VERSION}"
+    SHA512 4fbbd3898791a67e44329a5d0e20e16454b9393510236563b12fe4346cd4f2785d43d915ea05239ac1568d00651e41d85d93590f01454ffc1b82e7bba28e780a
     HEAD_REF master
     PATCHES
         fix-error-C1128.patch
-        ${CATCH2_PATCH}
 )
 
 vcpkg_check_features(

--- a/ports/highfive/vcpkg.json
+++ b/ports/highfive/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "highfive",
-  "version": "2.6.2",
-  "port-version": 2,
+  "version": "2.7.1",
   "description": "HighFive is a modern header-only C++/C++11 friendly interface for libhdf5",
   "homepage": "https://github.com/BlueBrain/HighFive",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3221,8 +3221,8 @@
       "port-version": 0
     },
     "highfive": {
-      "baseline": "2.6.2",
-      "port-version": 2
+      "baseline": "2.7.1",
+      "port-version": 0
     },
     "highs": {
       "baseline": "1.5.1",

--- a/versions/h-/highfive.json
+++ b/versions/h-/highfive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de97a368e21a37ade6556f064c16409a0a3132dd",
+      "version": "2.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6139bdb8e7791f8cc8cf5a355dad303f277e2c6e",
       "version": "2.6.2",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

