### PR TITLE
[Thorvg] Update Thorvg port to v0.11.0

### DIFF
--- a/ports/thorvg/install-tools.patch
+++ b/ports/thorvg/install-tools.patch
@@ -1,18 +1,17 @@
-diff --git a/src/bin/svg2png/meson.build b/src/bin/svg2png/meson.build
-index c9fe63b6..92bfdda4 100644
---- a/src/bin/svg2png/meson.build
-+++ b/src/bin/svg2png/meson.build
+diff --git a/src/tools/svg2png/meson.build b/src/tools/svg2png/meson.build
+index c9fe63b6..010c6ac4 100644
+--- a/src/tools/svg2png/meson.build
++++ b/src/tools/svg2png/meson.build
 @@ -5,4 +5,4 @@ executable('svg2png',
             include_directories : headers,
             cpp_args : compiler_flags,
             install : true,
 -           link_with : thorvg_lib)
 +           link_with : thorvg_lib , install_dir : get_option('bindir'))
-\ No newline at end of file
-diff --git a/src/bin/svg2tvg/meson.build b/src/bin/svg2tvg/meson.build
+diff --git a/src/tools/svg2tvg/meson.build b/src/tools/svg2tvg/meson.build
 index 158376b5..8d960aec 100644
---- a/src/bin/svg2tvg/meson.build
-+++ b/src/bin/svg2tvg/meson.build
+--- a/src/tools/svg2tvg/meson.build
++++ b/src/tools/svg2tvg/meson.build
 @@ -5,4 +5,4 @@ executable('svg2tvg',
             include_directories : headers,
             cpp_args : compiler_flags,

--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -45,9 +45,9 @@ vcpkg_fixup_pkgconfig()
 
 if ("tools" IN_LIST FEATURES)
     if(VCPKG_TARGET_IS_WINDOWS)
-        vcpkg_copy_tools(TOOL_NAMES svg2tvg svg2png AUTO_CLEAN)
         message(FATAL_ERROR "This feature doesn't support Windows platform")
     endif()
+    vcpkg_copy_tools(TOOL_NAMES svg2tvg svg2png AUTO_CLEAN)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -16,9 +16,6 @@ else()
 endif()
 
 if ("tools" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_WINDOWS)
-        message(FATAL_ERROR "This feature doesn't support Windows platform")
-    endif()
     list(APPEND BUILD_OPTIONS -Dtools=all)
 endif()
 
@@ -44,9 +41,6 @@ vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
 
 if ("tools" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_WINDOWS)
-        message(FATAL_ERROR "This feature doesn't support Windows platform")
-    endif()
     vcpkg_copy_tools(TOOL_NAMES svg2tvg svg2png AUTO_CLEAN)
 endif()
 

--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO thorvg/thorvg
-    REF v0.10.1
-    SHA512 8a105f4d854829995799016bb2837ec3c80da1cca0bc1833069a04928d6104677568d1e80fac02a4aa86d1b79b837586366fa28e2d21d43211f31bbb0e79399c
+    REF v0.11.0
+    SHA512 abca41b95152d30fc20fd51383447958347e19b123c798b321bcc3ab6850c4f70edd1cd89dc60fdce866afa3f8ffe50a913cdfb4ffbf2d3c1384937cf80183d8
     HEAD_REF master
     PATCHES
         install-tools.patch
@@ -16,6 +16,9 @@ else()
 endif()
 
 if ("tools" IN_LIST FEATURES)
+    if(VCPKG_TARGET_IS_WINDOWS)
+        message(FATAL_ERROR "This feature doesn't support Windows platform")
+    endif()
     list(APPEND BUILD_OPTIONS -Dtools=all)
 endif()
 

--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -44,7 +44,10 @@ vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
 
 if ("tools" IN_LIST FEATURES)
-    vcpkg_copy_tools(TOOL_NAMES svg2tvg svg2png AUTO_CLEAN)
+    if(VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_copy_tools(TOOL_NAMES svg2tvg svg2png AUTO_CLEAN)
+        message(FATAL_ERROR "This feature doesn't support Windows platform")
+    endif()
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -13,7 +13,8 @@
   ],
   "features": {
     "tools": {
-      "description": "Build tools"
+      "description": "Build tools",
+      "supports": "!windows"
     }
   }
 }

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "thorvg",
-  "version": "0.10.1",
-  "port-version": 1,
+  "version": "0.11.0",
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",
@@ -14,8 +13,7 @@
   ],
   "features": {
     "tools": {
-      "description": "Build tools",
-      "supports": "!windows"
+      "description": "Build tools"
     }
   }
 }

--- a/ports/thorvg/windows-build-option.patch
+++ b/ports/thorvg/windows-build-option.patch
@@ -1,5 +1,5 @@
 diff --git a/meson.build b/meson.build
-index dff33edb..f8339a3a 100644
+index 65e6ab51..87e2ed38 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1,6 +1,6 @@
@@ -7,6 +7,6 @@ index dff33edb..f8339a3a 100644
          'cpp',
 -        default_options : ['buildtype=debugoptimized', 'b_sanitize=none', 'werror=false', 'optimization=s', 'cpp_std=c++14', 'strip=true'],
 +        default_options : ['buildtype=debugoptimized', 'b_sanitize=none', 'werror=false', 'optimization=s', 'cpp_std=c++14'],
-         version : '0.10.1',
+         version : '0.11.0',
          license : 'MIT')
  

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8185,8 +8185,8 @@
       "port-version": 0
     },
     "thorvg": {
-      "baseline": "0.10.1",
-      "port-version": 1
+      "baseline": "0.11.0",
+      "port-version": 0
     },
     "threadpool": {
       "baseline": "0.2.5",

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bdebe7c734f8c6131f13639c667464acdfb67bd9",
+      "git-tree": "2e02db3046c69a5da788c15218353904e5bc607d",
       "version": "0.11.0",
       "port-version": 0
     },

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bdebe7c734f8c6131f13639c667464acdfb67bd9",
+      "version": "0.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "11178391a67b24a7bbbe7950359aaad9e51cfce6",
       "version": "0.10.1",
       "port-version": 1

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bfc4b021e89fb6c273545e51f14a3ec7a60e1ba2",
+      "git-tree": "cbb26c5be253aeb4d6694bf7ab34a3ec08586309",
       "version": "0.11.0",
       "port-version": 0
     },

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cbb26c5be253aeb4d6694bf7ab34a3ec08586309",
+      "git-tree": "f54024173375727d79da6658e23e99337a55a8a6",
       "version": "0.11.0",
       "port-version": 0
     },

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2e02db3046c69a5da788c15218353904e5bc607d",
+      "git-tree": "bfc4b021e89fb6c273545e51f14a3ec7a60e1ba2",
       "version": "0.11.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
