### PR TITLE
[jbig2dec] update to 0.20

### DIFF
--- a/ports/jbig2dec/portfile.cmake
+++ b/ports/jbig2dec/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ArtifexSoftware/jbig2dec
-    REF 1c336b8ab44524dc56ea837e2211ff4207704cdd # 0.19
-    SHA512 e189a80cc8da18813cf6c8edc6f1a799793adcba7ea6f302a8cced349bffac68869af338d9723ee1efdc07115ae554cd5757bfda7d7ac41324fde1f9c3a8343c
+    REF "${VERSION}"
+    SHA512 8b8a28b93b23e4284ca229e6c8935fd161ce5c597f7470a46ec06a3241d0ac23cf921aecdd4e0c1bd3c904591409054236f2ce25b6d8ae40db742559c7f4dbe9
     HEAD_REF master
 )
 

--- a/ports/jbig2dec/vcpkg.json
+++ b/ports/jbig2dec/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "jbig2dec",
-  "version": "0.19",
-  "port-version": 3,
+  "version": "0.20",
   "description": "a decoder library and example utility implementing the JBIG2 bi-level image compression spec. Also known as ITU T.88 and ISO IEC 14492, and included by reference in Adobe's PDF version 1.4 and later.",
   "homepage": "https://github.com/ArtifexSoftware/jbig2dec",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3525,8 +3525,8 @@
       "port-version": 2
     },
     "jbig2dec": {
-      "baseline": "0.19",
-      "port-version": 3
+      "baseline": "0.20",
+      "port-version": 0
     },
     "jbigkit": {
       "baseline": "2.1",

--- a/versions/j-/jbig2dec.json
+++ b/versions/j-/jbig2dec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d34cf9e520c5866b3facce621e46e438eb1b31c5",
+      "version": "0.20",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff97df9b9703a6314f50e608b155efb780d6deb7",
       "version": "0.19",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

