### PR TITLE
[cppdap] new port

### DIFF
--- a/ports/cppdap/baseline.json
+++ b/ports/cppdap/baseline.json
@@ -1,0 +1,4 @@
+"cppdap": {
+  "baseline": "1.58.0-a",
+  "port-version": 0
+  }

--- a/ports/cppdap/baseline.json
+++ b/ports/cppdap/baseline.json
@@ -1,4 +1,0 @@
-"cppdap": {
-  "baseline": "1.58.0-a",
-  "port-version": 0
-  }

--- a/ports/cppdap/portfile.cmake
+++ b/ports/cppdap/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  google/cppdap
@@ -16,8 +14,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/cppdap")
 
-vcpkg_cmake_config_fixup(
-    CONFIG_PATH "lib/cmake/cppdap")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cppdap/portfile.cmake
+++ b/ports/cppdap/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO  google/cppdap
+    REF "dap-${VERSION}"
+    SHA512 36f31cf7b90190820f5a5b7df679a3ca1a4f51b58a7a4c46f85c7b55b0ad9dbeba3436992b5eb8a3fd4499fc38bbf2b16f834f5f1989717f151abf13c262c747
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCPPDAP_USE_EXTERNAL_NLOHMANN_JSON_PACKAGE=ON
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH "lib/cmake/cppdap")

--- a/ports/cppdap/vcpkg.json
+++ b/ports/cppdap/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "cppdap",
+  "version": "1.58.0-a",
+  "description": "A C++11 library (\"SDK\") implementation of the Debug Adapter Protocol, providing an API for implementing a DAP client or server.",
+  "homepage": "https://github.com/google/cppdap",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/cppdap/vcpkg.json
+++ b/ports/cppdap/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppdap",
-  "version": "1.58.0-a",
+  "version-semver": "1.58.0-a",
   "description": "A C++11 library (\"SDK\") implementation of the Debug Adapter Protocol, providing an API for implementing a DAP client or server.",
   "homepage": "https://github.com/google/cppdap",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1820,6 +1820,10 @@
       "baseline": "2022-10-25",
       "port-version": 0
     },
+    "cppdap": {
+      "baseline": "1.58.0-a",
+      "port-version": 0
+    },
     "cppfs": {
       "baseline": "1.3.0",
       "port-version": 3

--- a/versions/c-/cppdap.json
+++ b/versions/c-/cppdap.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "7ad344c8fa0afe57844181a9a2e068ed1fd5b145",
-      "version": "1.58.0-a",
+      "git-tree": "ab1e5e1b50226ecd6d45d53b357dac35051a8a47",
+      "version-semver": "1.58.0-a",
       "port-version": 0
     }
   ]

--- a/versions/c-/cppdap.json
+++ b/versions/c-/cppdap.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7ad344c8fa0afe57844181a9a2e068ed1fd5b145",
+      "version": "1.58.0-a",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
