### PR TITLE
ci.baseline.txt fixes from 2023-09-30

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -59,7 +59,6 @@ arrayfire:x64-osx=fail
 allegro5:arm64-windows=fail
 # Cross compiling CI machine cannot run gen_test_char to generate apr_escape_test_char.h
 apr:arm64-windows=fail
-assimp:arm-neon-android=fail
 avro-c:arm-neon-android=fail
 avro-c:arm64-android=fail
 avro-c:x64-android=fail
@@ -201,9 +200,6 @@ lapack-reference:x64-uwp=skip
 clblas:arm-neon-android=fail
 clblas:arm64-android=fail
 clblas:x64-android=fail
-clblast:arm-neon-android=fail
-clblast:arm64-android=fail
-clblast:x64-android=fail
 clockutils:arm-neon-android=fail
 clockutils:arm64-android=fail
 clockutils:x64-android=fail
@@ -869,6 +865,7 @@ ompl:x64-osx=fail
 ompl:arm64-osx=fail
 ompl:x64-linux=fail
 # opencc/deps/rapidjson-1.1.0/rapidjson.h: Unknown machine endianess detected
+omplapp:arm-neon-android=fail
 omplapp:arm64-android=fail
 omplapp:x64-android=fail
 onednn:x64-android=fail
@@ -923,10 +920,6 @@ openscap:x64-windows-static=fail
 opensubdiv:x64-android=fail
 # osx needs bison 3.4 installed
 openturns:x64-osx=fail
-# https://github.com/AcademySoftwareFoundation/openvdb/issues/1362
-# openvdb\openvdb\libopenvdb.lib : fatal error LNK1248: image size (109A36020) exceeds maximum allowable size (FFFFFFFF)
-openvdb:x64-windows-static=fail
-openvdb:x64-windows-static-md=fail
 openvpn3:x64-osx=fail
 openvpn3:arm64-osx=fail
 openvr:x64-windows-static=fail


### PR DESCRIPTION
From https://dev.azure.com/vcpkg/public/_build/results?buildId=94820


REGRESSION: caffe2:arm64-windows is marked as fail but one dependency is not supported for arm64-windows.  
REGRESSION: gtk:x64-windows-static is marked as fail but one dependency is not supported for x64-windows-static.  
Fixed by https://github.com/microsoft/vcpkg/pull/33999

REGRESSION: omplapp:arm-neon-android failed with BUILD_FAILED. If expected, add omplapp:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.  
Previously blocked by:
PASSING, REMOVE FROM FAIL LIST: assimp:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).


PASSING, REMOVE FROM FAIL LIST: clblast:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).  
PASSING, REMOVE FROM FAIL LIST: clblast:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).  
PASSING, REMOVE FROM FAIL LIST: clblast:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).  
PASSING, REMOVE FROM FAIL LIST: openvdb:x64-windows-static (C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt).  
PASSING, REMOVE FROM FAIL LIST: openvdb:x64-windows-static-md (C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt).
