### PR TITLE
[libremidi] Disable optional dependencies.

### DIFF
--- a/ports/libremidi/portfile.cmake
+++ b/ports/libremidi/portfile.cmake
@@ -9,10 +9,12 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLIBREMIDI_NO_BOOST=ON
+        -DLIBREMIDI_NO_JACK=ON
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libremidi PACKAGE_NAME libremidi)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
-

--- a/ports/libremidi/portfile.cmake
+++ b/ports/libremidi/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DLIBREMIDI_NO_ALSA=ON
         -DLIBREMIDI_NO_BOOST=ON
         -DLIBREMIDI_NO_JACK=ON
 )

--- a/ports/libremidi/vcpkg.json
+++ b/ports/libremidi/vcpkg.json
@@ -7,10 +7,6 @@
   "license": "BSD-2-Clause",
   "dependencies": [
     {
-      "name": "alsa",
-      "platform": "linux"
-    },
-    {
       "name": "vcpkg-cmake",
       "host": true
     },

--- a/ports/libremidi/vcpkg.json
+++ b/ports/libremidi/vcpkg.json
@@ -1,10 +1,15 @@
 {
   "name": "libremidi",
   "version": "4.1.0",
+  "port-version": 1,
   "description": "A modern C++ MIDI real-time & file I/O library",
   "homepage": "https://github.com/jcelerier/libremidi",
   "license": "BSD-2-Clause",
   "dependencies": [
+    {
+      "name": "alsa",
+      "platform": "linux"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4590,7 +4590,7 @@
     },
     "libremidi": {
       "baseline": "4.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libressl": {
       "baseline": "3.6.2",

--- a/versions/l-/libremidi.json
+++ b/versions/l-/libremidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9085f5a8c99d7a22274eb8c7f7a32ecda12095c",
+      "version": "4.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4c1473e864943f0e6189d315c1eb09a77ce3a3f0",
       "version": "4.1.0",
       "port-version": 0

--- a/versions/l-/libremidi.json
+++ b/versions/l-/libremidi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a9085f5a8c99d7a22274eb8c7f7a32ecda12095c",
+      "git-tree": "0a6cac97560ba37eae699bdb65f6561a8415d362",
       "version": "4.1.0",
       "port-version": 1
     },


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/33848 the build passed because jack2 was not installed first, but it fails in our full builds.

Resolves https://dev.azure.com/vcpkg/public/_build/results?buildId=94820

```
REGRESSION: libremidi:arm-neon-android failed with BUILD_FAILED. If expected, add libremidi:arm-neon-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: libremidi:arm64-android failed with BUILD_FAILED. If expected, add libremidi:arm64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: libremidi:arm64-windows failed with BUILD_FAILED. If expected, add libremidi:arm64-windows=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt.
REGRESSION: libremidi:x64-android failed with BUILD_FAILED. If expected, add libremidi:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
REGRESSION: libremidi:x64-windows failed with BUILD_FAILED. If expected, add libremidi:x64-windows=fail to C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt.
REGRESSION: libremidi:x64-windows-static failed with BUILD_FAILED. If expected, add libremidi:x64-windows-static=fail to C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt.
REGRESSION: libremidi:x64-windows-static-md failed with BUILD_FAILED. If expected, add libremidi:x64-windows-static-md=fail to C:\a\2\s\scripts\azure-pipelines/../ci.baseline.txt.
```