### PR TITLE
[libidn2] Generally disable autopoint

### DIFF
--- a/ports/libidn2/portfile.cmake
+++ b/ports/libidn2/portfile.cmake
@@ -29,9 +29,9 @@ vcpkg_list(SET options)
 if("nls" IN_LIST FEATURES)
     vcpkg_list(APPEND options "--enable-nls")
 else()
-    set(ENV{AUTOPOINT} true) # true, the program
     vcpkg_list(APPEND options "--disable-nls")
 endif()
+set(ENV{AUTOPOINT} true) # true, the program
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_list(APPEND options "CPPFLAGS=\$CPPFLAGS -DIDN2_STATIC")

--- a/ports/libidn2/vcpkg.json
+++ b/ports/libidn2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libidn2",
   "version": "2.3.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.",
   "homepage": "https://www.gnu.org/software/libidn/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4294,7 +4294,7 @@
     },
     "libidn2": {
       "baseline": "2.3.4",
-      "port-version": 2
+      "port-version": 3
     },
     "libigl": {
       "baseline": "2.4.0",

--- a/versions/l-/libidn2.json
+++ b/versions/l-/libidn2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20e169744f242f67bc4b4dc310f5785d55dba58c",
+      "version": "2.3.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "4784d5f7f99d7ea1ebe6f1ef01943e402e7bfddf",
       "version": "2.3.4",
       "port-version": 2


### PR DESCRIPTION
Fixes #31011.

Cf. https://www.gnu.org/software/gnulib/manual/html_node/gettextize-and-autopoint.html
> When you invoke autoreconf after gnulib-tool, make sure to not invoke autopoint a second time, by setting the AUTOPOINT environment variable, like this:
> ~~~
> $ env AUTOPOINT=true autoreconf --install
> ~~~
vcpkg never runs `gnulib-tool`, so vcpkg's invocation of `autoreconf` is always after `gnulib-tool`.