### PR TITLE
[qt5-imageformats] clarify whether CVE-2023-4863 needs to be patched

### DIFF
--- a/ports/qt5-imageformats/portfile.cmake
+++ b/ports/qt5-imageformats/portfile.cmake
@@ -46,4 +46,16 @@ else()
     list(APPEND CORE_OPTIONS -no-webp)
 endif()
 
-qt_submodule_installation(BUILD_OPTIONS ${CORE_OPTIONS} BUILD_OPTIONS_RELEASE ${OPT_REL} BUILD_OPTIONS_DEBUG ${OPT_DBG})
+qt_submodule_installation(
+    BUILD_OPTIONS ${CORE_OPTIONS} 
+    BUILD_OPTIONS_RELEASE ${OPT_REL} 
+    BUILD_OPTIONS_DEBUG ${OPT_DBG} 
+    OUT_SOURCE_PATH SOURCE_PATH
+)
+
+# Remove vendored dependencies to ensure they are not picked up by the build
+foreach(DEPENDENCY libtiff libwebp)
+    if(EXISTS ${SOURCE_PATH}/src/3rdparty/${DEPENDENCY})
+        file(REMOVE_RECURSE ${SOURCE_PATH}/src/3rdparty/${DEPENDENCY})
+    endif()
+endforeach()

--- a/ports/qt5-imageformats/vcpkg.json
+++ b/ports/qt5-imageformats/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-imageformats",
   "version": "5.15.10",
+  "port-version": 1,
   "description": "Qt5 Image Formats Module - Plugins for additional image formats: TIFF, MNG, TGA, WBMP",
   "license": null,
   "dependencies": [

--- a/ports/qt5-imageformats/vulnerabilities.md
+++ b/ports/qt5-imageformats/vulnerabilities.md
@@ -1,0 +1,17 @@
+# Vulnerabilities 
+
+This documents lists the known vulnerabilities for the port `qt5-imageformats` and any countermeasures that were taken. 
+
+Please assume that the port is affected by all known vulnerabilities of `qt5-imageformats` that are not listed herein.
+
+## CVE-2023-4863
+
+This port is unaffected by CVE-2023-4863, provided that is is compiled with the current version of `libwebp` from `vcpkg`.
+
+According to [a security advisory from Qt](https://www.qt.io/blog/two-qt-security-advisorys-gdi-font-engine-webp-image-format), `qt5-imageformats` is affected by CVE-2023-4863 through its dependency on `libwebp`. The advisory states the following.
+
+> Solution: As a workaround, update the WebP library manually to 1.3.2 and rebuild the imageformat plugin. Alternatively, apply the corresponding patch or update to Qt 5.15.16, Qt 6.2.10, Qt 6.5.3, Qt 6.6.0
+
+The version of `libwebp` that ships with `vcpkg` is at least 1.3.2 and, hence, unaffected. 
+
+An affected copy of `libwebp` that ships with `qt5-imageformats` is removed before the build. Hence, there is no need to apply the patch provided by Qt.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6782,7 +6782,7 @@
     },
     "qt5-imageformats": {
       "baseline": "5.15.10",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-location": {
       "baseline": "5.15.10",

--- a/versions/q-/qt5-imageformats.json
+++ b/versions/q-/qt5-imageformats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68f6942871e888a643c83b2ce76b5819a1afd1c3",
+      "version": "5.15.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "39d5acff58afd279f8249487ea29263910b24220",
       "version": "5.15.10",
       "port-version": 0


### PR DESCRIPTION
Fixes #34233

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This pull request implements the proposed sultuion for issue #34233:
* It removes the vendored copies of `libtiff` and `libwebp` to make sure that they are not used for the build. This mitigates the risk of using a version of `libwebp` that is affected by CVE-2023-4863. 
* It adds a `vulnerabilities.md` that clarifies that the port `qt5-imageformats` is not affected by CVE-2023-4863 provided that the current version of `libwebp` from `vcpkg` is used.

Suggestions for improvements are welcome. So are other ideas of how to make it transparent which vulnerabilities affect and do not affect the ports provided by vcpkg.