### PR TITLE
[google-cloud-cpp] update to latest release (v2.16.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 225202a8e799f630f0b07c392bf305c28e21b99ef8dc5a670238a6d08e0e2816cd8ca1c43d7b252bcf5d289f875e64c16413085f63663265169807fd59977e43
+    SHA512 a7767e37f0c4997e0d8493ea12e144b22ef529e23da54eb2a2f82848d9535bce23080948be80e5ef6697b55bbfc3ee11225f7ea83fe8fa5f622df7dc45144744
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch
@@ -65,7 +65,7 @@ foreach(feature IN LISTS FEATURES)
 endforeach()
 # These packages are automatically installed depending on what features are
 # enabled.
-foreach(suffix common googleapis grpc_utils rest_internal opentelemetry dialogflow_cx dialogflow_es)
+foreach(suffix common googleapis grpc_utils rest_internal rest_protobuf_internal dialogflow_cx dialogflow_es)
     set(config_path "lib/cmake/google_cloud_cpp_${suffix}")
     if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
         continue()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -319,8 +319,33 @@
         }
       ]
     },
+    "compute": {
+      "description": "Compute Engine C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common",
+            "rest-common"
+          ]
+        }
+      ]
+    },
     "confidentialcomputing": {
       "description": "Confidential Computing API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "config": {
+      "description": "Infrastructure Manager API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -572,20 +597,6 @@
         }
       ]
     },
-    "experimental-opentelemetry": {
-      "description": "OpenTelemetry C++ GCP Exporter Library",
-      "dependencies": [
-        {
-          "name": "google-cloud-cpp",
-          "default-features": false,
-          "features": [
-            "rest-common",
-            "trace"
-          ]
-        },
-        "opentelemetry-cpp"
-      ]
-    },
     "experimental-storage-grpc": {
       "description": "The GCS+gRPC plugin",
       "dependencies": [
@@ -830,6 +841,18 @@
         }
       ]
     },
+    "netapp": {
+      "description": "NetApp API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "networkconnectivity": {
       "description": "Network Connectivity API C++ Client Library",
       "dependencies": [
@@ -876,6 +899,32 @@
             "grpc-common"
           ]
         }
+      ]
+    },
+    "oauth2": {
+      "description": "OAuth2 Access Token Generation Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "rest-common"
+          ]
+        }
+      ]
+    },
+    "opentelemetry": {
+      "description": "OpenTelemetry C++ GCP Exporter Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "rest-common",
+            "trace"
+          ]
+        },
+        "opentelemetry-cpp"
       ]
     },
     "optimization": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2973,7 +2973,7 @@
       "port-version": 5
     },
     "google-cloud-cpp": {
-      "baseline": "2.15.1",
+      "baseline": "2.16.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76121e57d4d9f0ce925973295ee30a574d448e4f",
+      "version": "2.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6b622eca80c311ef081e80432d56f13d9c8f0d72",
       "version": "2.15.1",
       "port-version": 0


### PR DESCRIPTION
Tested on x64:linux with:
```sh
for feature in oauth2 opentelemetry compute config netapp; do
  ./vcpkg remove google-cloud-cpp
  ./vcpkg install "google-cloud-cpp[core,${feature}]" || break
done
```
and
```sh
./vcpkg install google-cloud-cpp[*]
```

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

When I run `./vcpkg x-add-version --all` I see:
```sh
$ ./vcpkg x-add-version --all

error: can't load port tbb
error: while loading /home/dbolduc/code/git/vcpkg/ports/tbb/vcpkg.json:
$.default-features[0]: mismatched type: expected an identifierinternal error: /mnt/vss/_work/1/s/src/vcpkg/commands.add-version.cpp(412): vcpkg has crashed; no additional details are available.
Please open an issue at https://github.com/microsoft/vcpkg/issues/new?template=other-type-of-bug-report.md&labels=category:vcpkg-bug with detailed steps to reproduce the problem.
```

So I ran `./vcpkg x-add-version google-cloud-cpp` instead.