### PR TITLE
[ismrmrd] update to 1.13.7

### DIFF
--- a/ports/ismrmrd/portfile.cmake
+++ b/ports/ismrmrd/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ismrmrd/ismrmrd
-    REF v1.13.2
-    SHA512 8bfdceedefa7dae6cc047e9498f30d3e763f5ab8aa3726f0dc0b2ac086c00a0fddee9c6feadcf4b41c55c692230e8db596cdfc8d79af29c704b79bbad270187b
+    REF "v${VERSION}"
+    SHA512 cbd34cfbcc16e898f44c00888bc605d01e6a915b6c02454630a61c92b6179d727affb1ffeebc7d14da5aac189f929f5d36a6fd7ab68a73cb963ee4a233fba056
     HEAD_REF master
     PATCHES
         ${WIN32_INCLUDE_STDDEF_PATCH}

--- a/ports/ismrmrd/vcpkg.json
+++ b/ports/ismrmrd/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ismrmrd",
-  "version": "1.13.2",
-  "port-version": 1,
+  "version": "1.13.7",
   "description": "ISMRM Raw Data Format",
   "homepage": "https://github.com/ismrmrd/ismrmrd",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3493,8 +3493,8 @@
       "port-version": 0
     },
     "ismrmrd": {
-      "baseline": "1.13.2",
-      "port-version": 1
+      "baseline": "1.13.7",
+      "port-version": 0
     },
     "itk": {
       "baseline": "5.2.1",

--- a/versions/i-/ismrmrd.json
+++ b/versions/i-/ismrmrd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d06eae0d931f4c173562d89e9b4239f844910ab",
+      "version": "1.13.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "b378ab76b7b723dd6b9091f897c87b5a99fc11b7",
       "version": "1.13.2",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

