### PR TITLE
[kealib] update to 1.5.2

### DIFF
--- a/ports/kealib/hdf5_include.patch
+++ b/ports/kealib/hdf5_include.patch
@@ -1,5 +1,5 @@
 diff --git a/include/libkea/KEAAttributeTable.h b/include/libkea/KEAAttributeTable.h
-index 95a5d7f..fbfebc1 100644
+index 3991ffb..ddc314f 100644
 --- a/include/libkea/KEAAttributeTable.h
 +++ b/include/libkea/KEAAttributeTable.h
 @@ -37,7 +37,7 @@
@@ -12,7 +12,7 @@ index 95a5d7f..fbfebc1 100644
  #include "libkea/KEACommon.h"
  #include "libkea/KEAException.h"
 diff --git a/include/libkea/KEAAttributeTableFile.h b/include/libkea/KEAAttributeTableFile.h
-index 9987a7c..39dbb21 100644
+index 902f485..245e068 100644
 --- a/include/libkea/KEAAttributeTableFile.h
 +++ b/include/libkea/KEAAttributeTableFile.h
 @@ -35,7 +35,7 @@
@@ -25,7 +25,7 @@ index 9987a7c..39dbb21 100644
  #include "libkea/KEACommon.h"
  #include "libkea/KEAException.h"
 diff --git a/include/libkea/KEAAttributeTableInMem.h b/include/libkea/KEAAttributeTableInMem.h
-index b4f7fad..6a8a8b7 100644
+index 7df369a..28018cc 100644
 --- a/include/libkea/KEAAttributeTableInMem.h
 +++ b/include/libkea/KEAAttributeTableInMem.h
 @@ -35,7 +35,7 @@
@@ -38,7 +38,7 @@ index b4f7fad..6a8a8b7 100644
  #include "libkea/KEACommon.h"
  #include "libkea/KEAException.h"
 diff --git a/include/libkea/KEACommon.h b/include/libkea/KEACommon.h
-index 3175c93..67b02a2 100644
+index cb8a577..a6fbfca 100644
 --- a/include/libkea/KEACommon.h
 +++ b/include/libkea/KEACommon.h
 @@ -38,7 +38,7 @@
@@ -48,10 +48,10 @@ index 3175c93..67b02a2 100644
 -#include "H5Cpp.h"
 +#include <H5Cpp.h>
  
- // MSVC 2008 uses different names....
- #ifdef _MSC_VER
+ #include <stdint.h>
+ 
 diff --git a/include/libkea/KEAImageIO.h b/include/libkea/KEAImageIO.h
-index d510cae..4c2aa97 100644
+index 87a2d07..c59a7f0 100644
 --- a/include/libkea/KEAImageIO.h
 +++ b/include/libkea/KEAImageIO.h
 @@ -35,7 +35,7 @@

--- a/ports/kealib/portfile.cmake
+++ b/ports/kealib/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ubarsc/kealib
-    REF  4984102cf5867105a28ae754689566217309d120 #1.4.14
-    SHA512 06628996757bc9cffc5af0f03468ec32246980b6f72f7f1c88a489a8a2aed70924115df0726fcbb9851e44030c6a44ee0f3137660de43af421dec1eab81cc147
+    REF "kealib-${VERSION}"
+    SHA512 82399f1332ff2aeb6342732e9e5c897c813109fd18e77cfc8d866f06adf4faa7f080f1f3c0a3b777fb3a679912dacf4851b7ad09a338d6087dd1d26eb2d1689f
     HEAD_REF master
     PATCHES hdf5_include.patch
 )
@@ -20,6 +20,8 @@ vcpkg_copy_pdbs()
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
 endif()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libkea)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/kealib/vcpkg.json
+++ b/ports/kealib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "kealib",
-  "version": "1.4.14",
-  "port-version": 1,
+  "version": "1.5.2",
   "description": "KEALib provides an implementation of the GDAL data model using HDF5.",
   "homepage": "https://github.com/ubarsc/kealib",
   "dependencies": [
@@ -13,6 +12,10 @@
     },
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3633,8 +3633,8 @@
       "port-version": 0
     },
     "kealib": {
-      "baseline": "1.4.14",
-      "port-version": 1
+      "baseline": "1.5.2",
+      "port-version": 0
     },
     "kenlm": {
       "baseline": "20230531",

--- a/versions/k-/kealib.json
+++ b/versions/k-/kealib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e23b8bf23a4254e1028ca0c93f722a2691012852",
+      "version": "1.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d6136ef42467c0204cd6a082a272c16ab955caa3",
       "version": "1.4.14",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

