### PR TITLE
[prism] New port

### DIFF
--- a/ports/prism/portfile.cmake
+++ b/ports/prism/portfile.cmake
@@ -1,0 +1,38 @@
+#vcpkg_from_git(
+#    OUT_SOURCE_PATH SOURCE_PATH
+#    URL https://github.com/nocanstillbb/prism.git
+#    REF 59fc49ca76338364c6351475a4ad5d80578f625
+#)
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO nocanstillbb/prism
+    REF b9a1ce36948a02058be3bd57d64953bc6cfabf3e
+  SHA512 12b26fa97cfbf0227a7dc057f100ff79df23880d1522aeed02e939fb6c9afccb092a264d78c08702dfb7cc30701d4ea48d9bdea29168be5751c8965e2011fb0d
+  HEAD_REF master
+)
+
+
+#https://learn.microsoft.com/en-us/vcpkg/examples/packaging-github-repos
+vcpkg_cmake_configure( SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+
+#vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+#vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright)
+file(
+  INSTALL "${SOURCE_PATH}/usage"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+#execute_process(COMMAND ${CMAKE_COMMAND} -E echo "
+#----------
+##----------" )
+

--- a/ports/prism/vcpkg.json
+++ b/ports/prism/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "prism",
+  "version": "1.0.0",
+  "description": "a static reflect library of c++",
+  "homepage": "https://github.com/nocanstillbb/prism",
+  "supports": "(windows & !arm & !uwp) | osx | (linux & !arm)",
+  "dependencies": [
+    "catch2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6592,6 +6592,10 @@
       "baseline": "1.7.0",
       "port-version": 2
     },
+    "prism": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "proj": {
       "baseline": "9.3.0",
       "port-version": 1

--- a/versions/p-/prism.json
+++ b/versions/p-/prism.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ade379d7873fdf426e0c1eaad34f305dc5b61b54",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

