### PR TITLE
[libharu] update to 2.4.4

### DIFF
--- a/ports/libharu/portfile.cmake
+++ b/ports/libharu/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libharu/libharu
     REF v${VERSION}
-    SHA512 4b01dd0d23bdcaec6f69fe5f059902e7f49eafdf19d53d4cce8b4d52a54b2057b764de29390f4da9e75aeb32cb6af8606b23478b04edf9f7dcb1e4b769c5fff2
+    SHA512 422210b09f89643cb25808559aeea109db5cce8a71c779d51f87222cdd50434f4f0f92322ebe429fca8f85ad73592bcabb14c3e36cd0bea19b6ec4c729220522
     HEAD_REF master
     PATCHES
         fix-include-path.patch

--- a/ports/libharu/vcpkg.json
+++ b/ports/libharu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libharu",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "libharu - free PDF library",
   "homepage": "https://github.com/libharu/libharu",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4237,7 +4237,7 @@
       "port-version": 2
     },
     "libharu": {
-      "baseline": "2.4.3",
+      "baseline": "2.4.4",
       "port-version": 0
     },
     "libhdfs3": {

--- a/versions/l-/libharu.json
+++ b/versions/l-/libharu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0acfe5296a4986caf51cea318361967f5d57e3ee",
+      "version": "2.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "0418db9cf0a5dac68fd54f5a6dfc384bbece1406",
       "version": "2.4.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

