### PR TITLE
[libremidi] update to 4.2.3

### DIFF
--- a/ports/libremidi/portfile.cmake
+++ b/ports/libremidi/portfile.cmake
@@ -3,14 +3,21 @@ vcpkg_from_github(
     REPO jcelerier/libremidi
     REF "v${VERSION}"
 
-    SHA512 7b73d5e1a565e9f85ac28fba041c66a151537a9205b4f3605fa70e18d5e651fa0562329853c7e08bf8e620f9d83d08d167b746d30c39bffcd325fbd6338d0538 
+    SHA512 de7092c70af6fc0a23c8e6018fbd9f380632ac9dec8794171726fda9a6e7ba45479a8e8317919ba7a8a0267524bab8d5430782a54bc50a914658cf277e18145b
     HEAD_REF master
 )
+
+vcpkg_list(SET options)
+if(VCPKG_TARGET_IS_LINUX)
+    vcpkg_list(APPEND options -DLIBREMIDI_NO_ALSA=OFF)
+else()
+    vcpkg_list(APPEND options -DLIBREMIDI_NO_ALSA=ON)
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DLIBREMIDI_NO_ALSA=ON
+        ${options}
         -DLIBREMIDI_NO_BOOST=ON
         -DLIBREMIDI_NO_JACK=ON
 )

--- a/ports/libremidi/vcpkg.json
+++ b/ports/libremidi/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "libremidi",
-  "version": "4.1.0",
+  "version": "4.2.3",
   "port-version": 1,
   "description": "A modern C++ MIDI real-time & file I/O library",
   "homepage": "https://github.com/jcelerier/libremidi",
   "license": "BSD-2-Clause",
   "dependencies": [
+    {
+      "name": "alsa",
+      "platform": "linux"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4597,7 +4597,7 @@
       "port-version": 1
     },
     "libremidi": {
-      "baseline": "4.1.0",
+      "baseline": "4.2.3",
       "port-version": 1
     },
     "libressl": {

--- a/versions/l-/libremidi.json
+++ b/versions/l-/libremidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4427d9259242a0dbc53753710b42b6531276f392",
+      "version": "4.2.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "0a6cac97560ba37eae699bdb65f6561a8415d362",
       "version": "4.1.0",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [?] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
