### PR TITLE
[chakracore] enable static crt

### DIFF
--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -15,7 +15,6 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
         set(additional_options NO_TOOLCHAIN_PROPS) # don't know how to fix the linker error about __guard_check_icall_thunk 
     endif()
-    set(CHAKRA_RUNTIME_LIB "static_library") # ChakraCore only supports static CRT linkage
     if(VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
         set(PLATFORM_ARG PLATFORM x86) # it's x86, not Win32 in sln file
     endif()
@@ -25,7 +24,6 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         PROJECT_SUBPATH Build/Chakra.Core.sln
         OPTIONS
             "/p:CustomBeforeMicrosoftCommonTargets=${CMAKE_CURRENT_LIST_DIR}/no-warning-as-error.props"
-            "/p:RuntimeLib=${CHAKRA_RUNTIME_LIB}"
         ${PLATFORM_ARG}
         ${additional_options}
     )

--- a/ports/chakracore/vcpkg.json
+++ b/ports/chakracore/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "chakracore",
   "version-date": "2022-11-09",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Core part of the Chakra Javascript engine",
   "homepage": "https://github.com/Microsoft/ChakraCore",
   "license": "MIT",
-  "supports": "!osx & !uwp & (linux | (!static & !staticcrt))",
+  "supports": "!osx & !uwp & (linux | !static)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1506,7 +1506,7 @@
     },
     "chakracore": {
       "baseline": "2022-11-09",
-      "port-version": 4
+      "port-version": 5
     },
     "charls": {
       "baseline": "2.4.2",

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98c62c0fbb2d410646eec57ce65ec0b91ad19fcf",
+      "version-date": "2022-11-09",
+      "port-version": 5
+    },
+    {
       "git-tree": "cc06634190b18bc8003202b9490c6af7919821a3",
       "version-date": "2022-11-09",
       "port-version": 4


### PR DESCRIPTION
closes #34167

works after fixing my triplet

```cmake
set(VCPKG_TARGET_ARCHITECTURE x64)

set(VCPKG_CRT_LINKAGE static)
set(VCPKG_LIBRARY_LINKAGE static)

if(${PORT} MATCHES "chakracore")
  set(VCPKG_CRT_LINKAGE static) # VCPKG_CRT_LINKAGE should be the same for all ports
  set(VCPKG_LIBRARY_LINKAGE dynamic)
endif()
```

Removing explicit crt option because now MSBuild handles this