### PR TITLE
[makeid] update to 1.0.3

### DIFF
--- a/ports/makeid/portfile.cmake
+++ b/ports/makeid/portfile.cmake
@@ -1,10 +1,10 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.humus.name/3D/MakeID.h"
     FILENAME "MakeID.h-${VERSION}"
-    SHA512 9b7cb5c1b71904f37f65fcac3d18194154029fbe04d89099d879ce8eb03e796662c78653322317ed72988d3695414aaa6e6c24cfff999bea5009ec47119c57a7
+    SHA512 fd4222d2cc0b0e16b0cfbac048cb64ac59d53ede10ab7f88f710e4b866cb67ffb0ec139821c181f1804a813cc9ab20cf33282c8b73e9ef0fdba414be474c2b64
 )
 
-file(COPY "${ARCHIVE}" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${ARCHIVE}" DESTINATION "${CURRENT_PACKAGES_DIR}/include" RENAME "MakeID.h")
 
 set(license_text 
 "Public Domain

--- a/ports/makeid/vcpkg.json
+++ b/ports/makeid/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "makeid",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MakeID is a cross platform C++ library for IDs allocation/deallocation",
   "homepage": "http://www.humus.name/index.php?page=3D",
   "license": null

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5185,7 +5185,7 @@
       "port-version": 2
     },
     "makeid": {
-      "baseline": "1.0.2",
+      "baseline": "1.0.3",
       "port-version": 0
     },
     "manif": {

--- a/versions/m-/makeid.json
+++ b/versions/m-/makeid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1e67fd4892325f13527874899102c734da3333d",
+      "version": "1.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "08114cbf3e65a21af7fa59508fc838fb4cac067c",
       "version": "1.0.2",
       "port-version": 0


### PR DESCRIPTION
unfortunately no versioned URLs for this library yet

also fixes the filename. I guess it's ok when port updates