### PR TITLE
[enkits] New port

### DIFF
--- a/ports/enkits/fix-install.patch
+++ b/ports/enkits/fix-install.patch
@@ -38,13 +38,13 @@ index 7f8572e..8f84548 100644
 -    install(FILES ${ENKITS_HEADERS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/enkiTS")
 +    install(
 +        TARGETS enkiTS
-+        EXPORT enkiTS-config
++        EXPORT unofficial-enkiTS-config
 +        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +    install(FILES ${ENKITS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 +    install(
-+        EXPORT enkiTS-config
-+        NAMESPACE enkiTS::
-+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/enkiTS)
++        EXPORT unofficial-enkiTS-config
++        NAMESPACE unofficial::enkiTS::
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unofficial-enkiTS)
  endif()
  
  if( UNIX )

--- a/ports/enkits/fix-install.patch
+++ b/ports/enkits/fix-install.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7f8572e..8f84548 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0)
+ 
+ project( enkiTS )
+ 
++include(GNUInstallDirs)
++
+ option( ENKITS_BUILD_C_INTERFACE    "Build C interface" ON )
+ option( ENKITS_BUILD_EXAMPLES       "Build example applications" ON )
+ option( ENKITS_BUILD_SHARED         "Build shared library" OFF )
+@@ -9,8 +11,6 @@ option( ENKITS_INSTALL              "Generate installation target" OFF )
+ 
+ set( ENKITS_TASK_PRIORITIES_NUM "3" CACHE STRING "Number of task priorities, 1-5, 0 for defined by defaults in source" ) 
+ 
+-include_directories( "${PROJECT_SOURCE_DIR}/src" )
+-
+ set( ENKITS_HEADERS
+     src/LockLessMultiReadPipe.h
+     src/TaskScheduler.h
+@@ -45,6 +45,9 @@ else()
+     add_library( enkiTS STATIC ${ENKITS_SRC} )
+ endif()
+ 
++target_include_directories( enkiTS PUBLIC
++    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
++           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
+ 
+ if( ENKITS_TASK_PRIORITIES_NUM GREATER "0" )
+     target_compile_definitions( enkiTS PUBLIC "ENKITS_TASK_PRIORITIES_NUM=${ENKITS_TASK_PRIORITIES_NUM}" )    
+@@ -60,8 +63,15 @@ if( UNIX )
+ endif()
+ 
+ if( ENKITS_INSTALL )
+-    install(TARGETS enkiTS DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/enkiTS")
+-    install(FILES ${ENKITS_HEADERS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/enkiTS")
++    install(
++        TARGETS enkiTS
++        EXPORT enkiTS-config
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    install(FILES ${ENKITS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    install(
++        EXPORT enkiTS-config
++        NAMESPACE enkiTS::
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/enkiTS)
+ endif()
+ 
+ if( UNIX )

--- a/ports/enkits/fix-install.patch
+++ b/ports/enkits/fix-install.patch
@@ -40,7 +40,7 @@ index 7f8572e..8f84548 100644
 +        TARGETS enkiTS
 +        EXPORT unofficial-enkiTS-config
 +        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+    install(FILES ${ENKITS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    install(FILES ${ENKITS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/enkiTS)
 +    install(
 +        EXPORT unofficial-enkiTS-config
 +        NAMESPACE unofficial::enkiTS::

--- a/ports/enkits/portfile.cmake
+++ b/ports/enkits/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dougbinks/enkiTS
+    REF v${VERSION}
+    SHA512 72a05058caef8d6a33cd70500aeaf05cc61521721697969d4845279b5a79b63e7a6a3f3971c5eff2776e5575720b58252e9d251ef565c2123275a3e8540948db
+    HEAD_REF master
+    PATCHES fix-install.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DENKITS_BUILD_C_INTERFACE=OFF
+        -DENKITS_BUILD_EXAMPLES=OFF
+        -DENKITS_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")

--- a/ports/enkits/portfile.cmake
+++ b/ports/enkits/portfile.cmake
@@ -19,7 +19,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/unofficial-enkiTS)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/enkits/portfile.cmake
+++ b/ports/enkits/portfile.cmake
@@ -19,7 +19,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/unofficial-enkiTS)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/unofficial-enkiTS  PACKAGE_NAME unofficial-enkiTS)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/enkits/portfile.cmake
+++ b/ports/enkits/portfile.cmake
@@ -24,3 +24,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/unofficial-enkiTS)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/enkits/usage
+++ b/ports/enkits/usage
@@ -1,0 +1,4 @@
+enkits provides CMake targets:
+
+    find_package(unofficial-enkits CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::enkiTS::enkiTS)

--- a/ports/enkits/vcpkg.json
+++ b/ports/enkits/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "A permissively licensed C and C++ Task Scheduler for creating parallel programs. Requires C++11 support.",
   "homepage": "https://github.com/dougbinks/enkiTS",
   "license": "Zlib",
-  "supports": "!android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/enkits/vcpkg.json
+++ b/ports/enkits/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "A permissively licensed C and C++ Task Scheduler for creating parallel programs. Requires C++11 support.",
   "homepage": "https://github.com/dougbinks/enkiTS",
   "license": "Zlib",
+  "supports": "!android",
   "dependencies": [
     "imgui",
     {

--- a/ports/enkits/vcpkg.json
+++ b/ports/enkits/vcpkg.json
@@ -6,7 +6,6 @@
   "license": "Zlib",
   "supports": "!android",
   "dependencies": [
-    "imgui",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/enkits/vcpkg.json
+++ b/ports/enkits/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "enkits",
+  "version": "1.11",
+  "description": "A permissively licensed C and C++ Task Scheduler for creating parallel programs. Requires C++11 support.",
+  "homepage": "https://github.com/dougbinks/enkiTS",
+  "license": "Zlib",
+  "dependencies": [
+    "imgui",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2376,6 +2376,10 @@
       "baseline": "1.3.17",
       "port-version": 2
     },
+    "enkits": {
+      "baseline": "1.11",
+      "port-version": 0
+    },
     "ensmallen": {
       "baseline": "2.19.1",
       "port-version": 0

--- a/versions/e-/enkits.json
+++ b/versions/e-/enkits.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "67bb817982800a07de32f8da873e16f906ea9686",
+      "git-tree": "03d1950373e139622eb8a8d166d2fa291d8fd9a7",
       "version": "1.11",
       "port-version": 0
     }

--- a/versions/e-/enkits.json
+++ b/versions/e-/enkits.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0970bbdf03936528512e6f17895b883287dd4c42",
+      "git-tree": "67bb817982800a07de32f8da873e16f906ea9686",
       "version": "1.11",
       "port-version": 0
     }

--- a/versions/e-/enkits.json
+++ b/versions/e-/enkits.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b54fb3d8ce6f2578d1aec1c9e34088fa9578f55b",
+      "git-tree": "e438bb0ea23cdd956552797001b2ef69bd8e36f1",
       "version": "1.11",
       "port-version": 0
     }

--- a/versions/e-/enkits.json
+++ b/versions/e-/enkits.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "03d1950373e139622eb8a8d166d2fa291d8fd9a7",
+      "git-tree": "c2d12b5724f0576fe6d25f019c9cf2e3d45f56c8",
       "version": "1.11",
       "port-version": 0
     }

--- a/versions/e-/enkits.json
+++ b/versions/e-/enkits.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0970bbdf03936528512e6f17895b883287dd4c42",
+      "version": "1.11",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/e-/enkits.json
+++ b/versions/e-/enkits.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c2d12b5724f0576fe6d25f019c9cf2e3d45f56c8",
+      "git-tree": "b54fb3d8ce6f2578d1aec1c9e34088fa9578f55b",
       "version": "1.11",
       "port-version": 0
     }


### PR DESCRIPTION
Add new port enkits : https://github.com/dougbinks/enkiTS

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.