### PR TITLE
[liblzma] update to version 5.4.4

### DIFF
--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tukaani-project/xz
     REF "v${VERSION}"
-    SHA512 67292be900a713035d2a3dab4c3b6697cf0db37a78faaa5e0d3f5a96909ef9645c15a6030af94fb7f4224c3ad8eacd1a653ba67dfdeb6372165c1c36e0cf16b7
+    SHA512 c28461123562564e030f3f733f078bc4c840e87598d9f4b718d4bca639120d8133f969c45d7bdc62f33f081d789ec0f14a1791fb7da18515682bfe3c0c7362e0
     HEAD_REF master
     PATCHES
         fix_config_include.patch

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "liblzma",
-  "version": "5.4.3",
-  "port-version": 1,
+  "version": "5.4.4",
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4365,8 +4365,8 @@
       "port-version": 2
     },
     "liblzma": {
-      "baseline": "5.4.3",
-      "port-version": 1
+      "baseline": "5.4.4",
+      "port-version": 0
     },
     "libmad": {
       "baseline": "0.15.1",

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f285b7c4ffa2cc065c7c6fec4b61006f7fa2714e",
+      "version": "5.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f97f6a0904a3add9c3273f8ab1993902d75d5ef",
       "version": "5.4.3",
       "port-version": 1


### PR DESCRIPTION
Fixes #34305.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

