### PR TITLE
[talib] New port

### DIFF
--- a/ports/talib/portfile.cmake
+++ b/ports/talib/portfile.cmake
@@ -1,0 +1,79 @@
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "ta-lib/ta-lib"
+    REF "${VERSION}"
+    FILENAME "ta-lib-${VERSION}-msvc.zip"
+    SHA512 5f211327b6a1d4f00d0a2b9e276adadd118d7aa29fc87c6771d550fda124a863b4a20e3803f325f7c903c82ea12bfb23121a5f0566eeaa434e0f107a6eedb737
+)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+    set(LFLAG "d")
+else()
+    set(LFLAG "m")
+endif()
+
+# Debug build
+vcpkg_execute_build_process(
+    COMMAND nmake -f Makefile
+    WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}d/win32/msvc"
+    LOGNAME build-${TARGET_TRIPLET}-dbg
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}d.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+    RENAME ta_abstract.lib
+)
+file(
+    INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}d.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+    RENAME ta_libc.lib
+)
+file(
+    INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}d.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+    RENAME ta_func.lib
+)
+file(
+    INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}d.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+    RENAME ta_common.lib
+)
+
+# Release build
+vcpkg_execute_build_process(
+    COMMAND nmake -f Makefile
+    WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}r/win32/msvc"
+    LOGNAME build-${TARGET_TRIPLET}-rel
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}r.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+    RENAME ta_abstract.lib
+)
+file(
+    INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}r.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+    RENAME ta_libc.lib
+)
+file(
+    INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}r.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+    RENAME ta_func.lib
+)
+file(
+    INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}r.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+    RENAME ta_common.lib
+)
+
+# Include files
+file(
+    INSTALL "${SOURCE_PATH}/c/include"
+    DESTINATION ${CURRENT_PACKAGES_DIR}
+)
+
+# License file
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.TXT") 

--- a/ports/talib/portfile.cmake
+++ b/ports/talib/portfile.cmake
@@ -14,32 +14,34 @@ else()
 endif()
 
 # Debug build
-vcpkg_execute_build_process(
-    COMMAND nmake -f Makefile
-    WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}d/win32/msvc"
-    LOGNAME build-${TARGET_TRIPLET}-dbg
-)
+if (NOT VCPKG_BUILD_TYPE)
+    vcpkg_execute_build_process(
+        COMMAND nmake -f Makefile
+        WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}d/win32/msvc"
+        LOGNAME build-${TARGET_TRIPLET}-dbg
+    )
 
-file(
-    INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}d.lib"
-    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
-    RENAME ta_abstract.lib
-)
-file(
-    INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}d.lib"
-    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
-    RENAME ta_libc.lib
-)
-file(
-    INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}d.lib"
-    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
-    RENAME ta_func.lib
-)
-file(
-    INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}d.lib"
-    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
-    RENAME ta_common.lib
-)
+    file(
+        INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}d.lib"
+        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+        RENAME ta_abstract.lib
+    )
+    file(
+        INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}d.lib"
+        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+        RENAME ta_libc.lib
+    )
+    file(
+        INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}d.lib"
+        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+        RENAME ta_func.lib
+    )
+    file(
+        INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}d.lib"
+        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+        RENAME ta_common.lib
+    )
+endif()
 
 # Release build
 vcpkg_execute_build_process(
@@ -76,4 +78,4 @@ file(
 )
 
 # License file
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.TXT") 
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.TXT")

--- a/ports/talib/vcpkg.json
+++ b/ports/talib/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "talib",
+  "version-semver": "0.4.0",
+  "description": "TA-Lib - Technical Analysis Library",
+  "homepage": "https://ta-lib.github.io/",
+  "license": "BSD-2-Clause",
+  "supports": "windows & !uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8112,6 +8112,10 @@
       "baseline": "1.13.1",
       "port-version": 1
     },
+    "talib": {
+      "baseline": "0.4.0",
+      "port-version": 0
+    },
     "taocpp-json": {
       "baseline": "2020-09-14",
       "port-version": 3

--- a/versions/t-/talib.json
+++ b/versions/t-/talib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "67b2163aed9009bece38ee884ebc9c433a28851b",
+      "git-tree": "639b6ba11c1768faf5ab92f42d4cdf0a1bba2270",
       "version-semver": "0.4.0",
       "port-version": 0
     }

--- a/versions/t-/talib.json
+++ b/versions/t-/talib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "67b2163aed9009bece38ee884ebc9c433a28851b",
+      "version-semver": "0.4.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR resumes work on https://github.com/microsoft/vcpkg/issues/29328

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.
