### PR TITLE
[libpqxx] Update to 7.8.1

### DIFF
--- a/ports/libpqxx/fix_build_with_vs2017.patch
+++ b/ports/libpqxx/fix_build_with_vs2017.patch
@@ -27,48 +27,48 @@ index abc1a39..cba0242 100644
  #if defined(PQXX_HAVE_LIKELY)
  #  define PQXX_LIKELY [[likely]]
 diff --git a/include/pqxx/stream_from.hxx b/include/pqxx/stream_from.hxx
-index ff4a93d..5b300d6 100644
+index 1e8a272..299248c 100644
 --- a/include/pqxx/stream_from.hxx
 +++ b/include/pqxx/stream_from.hxx
-@@ -153,7 +153,7 @@ public:
+@@ -160,7 +160,7 @@ public:
    /** @deprecated Use factories @ref table or @ref raw_table instead.
     */
    template<typename Iter>
--  [[deprecated("Use table() or raw_table() factory instead.")]] stream_from(
-+  PQXX_DEPRECATED("Use table() or raw_table() factory instead.") stream_from(
+-  [[deprecated("Use transaction_base::stream instead.")]] stream_from(
++  PQXX_DEPRECATED("Use transaction_base::stream instead.") stream_from(
      transaction_base &, from_table_t, std::string_view table,
      Iter columns_begin, Iter columns_end);
  
-@@ -161,13 +161,13 @@ public:
+@@ -168,13 +168,13 @@ public:
    /** @deprecated Use factory function @ref query instead.
     */
    template<typename Columns>
--  [[deprecated("Use table() or raw_table() factory instead.")]] stream_from(
-+  PQXX_DEPRECATED("Use table() or raw_table() factory instead.") stream_from(
+-  [[deprecated("Use transaction_base::stream() instead.")]] stream_from(
++  PQXX_DEPRECATED("Use transaction_base::stream() instead.") stream_from(
      transaction_base &tx, from_table_t, std::string_view table,
      Columns const &columns);
  
  #include "pqxx/internal/ignore-deprecated-pre.hxx"
    /// @deprecated Use factories @ref table or @ref raw_table instead.
--  [[deprecated("Use the from_table_t overload instead.")]] stream_from(
-+  PQXX_DEPRECATED("Use the from_table_t overload instead.") stream_from(
+-  [[deprecated("Use transaction_base::stream instead.")]] stream_from(
++  PQXX_DEPRECATED("Use transaction_base::stream instead.") stream_from(
      transaction_base &tx, std::string_view table) :
            stream_from{tx, from_table, table}
    {}
-@@ -175,14 +175,14 @@ public:
+@@ -182,14 +182,14 @@ public:
  
    /// @deprecated Use factories @ref table or @ref raw_table instead.
    template<typename Columns>
--  [[deprecated("Use the from_table_t overload instead.")]] stream_from(
-+  PQXX_DEPRECATED("Use the from_table_t overload instead.") stream_from(
+-  [[deprecated("Use transaction_base::stream instead.")]] stream_from(
++  PQXX_DEPRECATED("Use transaction_base::stream instead.") stream_from(
      transaction_base &tx, std::string_view table, Columns const &columns) :
            stream_from{tx, from_table, table, columns}
    {}
  
    /// @deprecated Use factories @ref table or @ref raw_table instead.
    template<typename Iter>
--  [[deprecated("Use the from_table_t overload instead.")]] stream_from(
-+  PQXX_DEPRECATED("Use the from_table_t overload instead.") stream_from(
+-  [[deprecated("Use transaction_base::stream instead.")]] stream_from(
++  PQXX_DEPRECATED("Use transaction_base::stream instead.") stream_from(
      transaction_base &, std::string_view table, Iter columns_begin,
      Iter columns_end);
  

--- a/ports/libpqxx/portfile.cmake
+++ b/ports/libpqxx/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jtv/libpqxx
-    REF 17e5a6c8ac3abc05329891aaa378bd6004b9c8ee # 7.7.4
-    SHA512 51dc5525e801696b7716e4a4a7d8d794baa5bf7372da62a30e4b602bfb09ff53a4355bfc5e39945636cff018095d2917c9a79181bb3f824091b7780863b0073c
+    REF "${VERSION}"
+    SHA512 ce37fdfce2671d97e422ae3339fb5650065111b0635a7293200c56a8755a7dc7de80806816863c606c46b6049e4cb490d24dfb97446ea0014b55907554862fed
     HEAD_REF master
     PATCHES
         fix_build_with_vs2017.patch
@@ -23,6 +23,6 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libpqxx)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/libpqxx/vcpkg.json
+++ b/ports/libpqxx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libpqxx",
-  "version": "7.7.4",
+  "version": "7.8.1",
   "description": "The official C++ client API for PostgreSQL",
   "homepage": "https://www.postgresql.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4557,7 +4557,7 @@
       "port-version": 2
     },
     "libpqxx": {
-      "baseline": "7.7.4",
+      "baseline": "7.8.1",
       "port-version": 0
     },
     "libprotobuf-mutator": {

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8083e94ed4ded4546cbad5263a7efb4b9b154b73",
+      "version": "7.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7ddefb009a457fb899a8661e46ba79544da6b2df",
       "version": "7.7.4",
       "port-version": 0


### PR DESCRIPTION
Fixes #34211, update `libpqxx` to 7.8.1.

No feature needs to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
