### PR TITLE
[asiosdk] Fix old hash and usage

### DIFF
--- a/ports/asiosdk/portfile.cmake
+++ b/ports/asiosdk/portfile.cmake
@@ -1,29 +1,32 @@
-set(VERSION 2.3.3)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.steinberg.net/sdk_downloads/asiosdk_2.3.3_2019-06-14.zip"
-    FILENAME "asiosdk_2.3.3_2019-06-14-eac6c1a57829.zip"
-	SHA512 eac6c1a57829b7f722a681c54b2f6469d54695523f08f727d0dd6744dcd7fce4f3249c57689bb15ed7a8bcb912833b226439d800913e122e0ef9ab73672f6542
+    FILENAME "asiosdk_2.3.3_2019-06-14-d74c0bc09162.zip"
+    SHA512 d74c0bc09162640a377aaab2f2ce716f9ee7a6ef8d1aa1aa6bc223a4748c60fa900cc77b1cf6db66f8a4064a074b31a71d75cccc7de3634347865238d9c039af
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    SOURCE_BASE ${VERSION}
+    ARCHIVE "${ARCHIVE}"
+    SOURCE_BASE "${VERSION}"
 )
 
-file(INSTALL ${SOURCE_PATH}/asio/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/asiosdk/asio)
-file(INSTALL ${SOURCE_PATH}/common/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/asiosdk/common)
-file(INSTALL ${SOURCE_PATH}/driver/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/asiosdk/driver)
-file(INSTALL ${SOURCE_PATH}/host/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/asiosdk/host)
-file(INSTALL ${SOURCE_PATH}/readme.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(INSTALL ${SOURCE_PATH}/readme.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(INSTALL ${SOURCE_PATH}/changes.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(INSTALL "${SOURCE_PATH}/Steinberg ASIO Logo Artwork.zip" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(INSTALL "${SOURCE_PATH}/Steinberg ASIO 2.3.3 Licensing Agreement 2.0.1 - 2019.pdf" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(INSTALL "${SOURCE_PATH}/ASIO SDK 2.3.pdf" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(INSTALL "${SOURCE_PATH}/asio/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/asio")
+file(INSTALL "${SOURCE_PATH}/common/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/common")
+file(INSTALL "${SOURCE_PATH}/driver/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/driver")
+file(INSTALL "${SOURCE_PATH}/host/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/host")
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/Findasiosdk.cmake" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/readme.txt")
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(
+    INSTALL
+        "${SOURCE_PATH}/changes.txt"
+        "${SOURCE_PATH}/Steinberg ASIO Logo Artwork.zip"
+        "${SOURCE_PATH}/Steinberg ASIO 2.3.3 Licensing Agreement V2.0.3 - 2023.pdf"
+        "${SOURCE_PATH}/ASIO SDK 2.3.pdf"
+        "${CMAKE_CURRENT_LIST_DIR}/Findasiosdk.cmake"
+        "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
+    DESTINATION
+        "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/asiosdk/usage
+++ b/ports/asiosdk/usage
@@ -1,4 +1,4 @@
 The package asiosdk provides CMake integration:
 
     find_package(asiosdk REQUIRED)
-    target_include_directories(<my_target> PRIVATE ${ASIOSDK_INCLUDE_DIRS})
+    target_include_directories(main PRIVATE ${ASIOSDK_INCLUDE_DIR})

--- a/ports/asiosdk/vcpkg.json
+++ b/ports/asiosdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "asiosdk",
   "version": "2.3.3",
-  "port-version": 6,
+  "port-version": 7,
   "description": "ASIO is a low latency audio API from Steinberg.",
   "homepage": "https://www.steinberg.net/en/company/developers.html",
   "supports": "windows & !(arm | uwp)"

--- a/versions/a-/asiosdk.json
+++ b/versions/a-/asiosdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "798527dff966ba5c7ef8aab89eb941791d682090",
+      "version": "2.3.3",
+      "port-version": 7
+    },
+    {
       "git-tree": "a58f240a86a38690339c96b11db0a62fd2388e4f",
       "version": "2.3.3",
       "port-version": 6

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -254,7 +254,7 @@
     },
     "asiosdk": {
       "baseline": "2.3.3",
-      "port-version": 6
+      "port-version": 7
     },
     "asmjit": {
       "baseline": "2023-03-25",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
The upstream of `asiosdk` updates its source, so fix the old hash and wrong usage.
Usage test pass on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
