### PR TITLE
[murmur3] New port

### DIFF
--- a/ports/murmur3/CMakeLists.txt
+++ b/ports/murmur3/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
-project(murmur3 VERSION 2015.05.02 LANGUAGES C)
+project(murmur3 LANGUAGES C)
+set(PROJECT_VERSION "${VERSION}")
 
 set(Header_Files "${PROJECT_NAME}.h")
 set(Source_Files "${PROJECT_NAME}.c")

--- a/ports/murmur3/CMakeLists.txt
+++ b/ports/murmur3/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.19)
+project(murmur3 LANGUAGES C)
+
+set(Header_Files "${PROJECT_NAME}.h")
+set(Source_Files "${PROJECT_NAME}.c")
+
+add_library("${PROJECT_NAME}" "${Header_Files}" "${Source_Files}")
+
+include(GNUInstallDirs)
+target_include_directories(
+  "${PROJECT_NAME}"
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+target_compile_features("${PROJECT_NAME}" PRIVATE c_std_90)
+set_target_properties("${PROJECT_NAME}" PROPERTIES C_VISIBILITY_PRESET hidden
+                      PUBLIC_HEADER "${Header_Files}")
+
+install(
+  TARGETS                   "${PROJECT_NAME}"
+  EXPORT                    "unofficial-${PROJECT_NAME}Config"
+  RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+include(CMakePackageConfigHelpers)
+set(VERSION_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}ConfigVersion.cmake")
+write_basic_package_version_file(
+  "${VERSION_FILE_PATH}"
+  VERSION       "${PROJECT_VERSION}"
+  COMPATIBILITY SameMajorVersion
+)
+install(FILES "${VERSION_FILE_PATH}" DESTINATION "share/unofficial-${PROJECT_NAME}")
+
+install(FILES ${Header_Files} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+install(
+  EXPORT      "unofficial-${PROJECT_NAME}Config"
+  FILE        "unofficial-${PROJECT_NAME}Config.cmake"
+  NAMESPACE   "unofficial::${PROJECT_NAME}::"
+  DESTINATION "share/unofficial-${PROJECT_NAME}")
+
+export(PACKAGE "${PROJECT_NAME}")

--- a/ports/murmur3/CMakeLists.txt
+++ b/ports/murmur3/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
-project(murmur3 LANGUAGES C)
+project(murmur3 VERSION 1430524800 LANGUAGES C)
 
 set(Header_Files "${PROJECT_NAME}.h")
 set(Source_Files "${PROJECT_NAME}.c")

--- a/ports/murmur3/CMakeLists.txt
+++ b/ports/murmur3/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
-project(murmur3 VERSION 1430524800 LANGUAGES C)
+project(murmur3 VERSION 2015.05.02 LANGUAGES C)
 
 set(Header_Files "${PROJECT_NAME}.h")
 set(Source_Files "${PROJECT_NAME}.c")

--- a/ports/murmur3/portfile.cmake
+++ b/ports/murmur3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO            PeterScott/${PORT}
+    REPO            PeterScott/murmur3
     REF             dae94be0c0f54a399d23ea6cbe54bca5a4e93ce4
     SHA512          1bc01eefc04f06704800a7448231db9f82fc809079bd3f43ef24d7dd3d8deaec2143f252a8e556dafe366401f898b676922b0c93ac181aaf38ae69ad638adbba
     HEAD_REF        master
@@ -19,11 +19,7 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "CC0-1.0")
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" [=[
-${PORT} provides CMake targets:
-    find_package(unofficial-${PORT} CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE unofficial::${PORT}::${PORT})
-]=])
-
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
                     "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/murmur3/portfile.cmake
+++ b/ports/murmur3/portfile.cmake
@@ -13,6 +13,8 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DVERSION=${VERSION}"
 )
 
 vcpkg_cmake_install()

--- a/ports/murmur3/portfile.cmake
+++ b/ports/murmur3/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            PeterScott/${PORT}
+    REF             dae94be0c0f54a399d23ea6cbe54bca5a4e93ce4
+    SHA512          1bc01eefc04f06704800a7448231db9f82fc809079bd3f43ef24d7dd3d8deaec2143f252a8e556dafe366401f898b676922b0c93ac181aaf38ae69ad638adbba
+    HEAD_REF        master
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
+     DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
+
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "CC0-1.0")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" [=[
+${PORT} provides CMake targets:
+    find_package(unofficial-${PORT} CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::${PORT}::${PORT})
+]=])
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/murmur3/portfile.cmake
+++ b/ports/murmur3/portfile.cmake
@@ -19,7 +19,8 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "CC0-1.0")
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
                     "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/murmur3/usage
+++ b/ports/murmur3/usage
@@ -1,0 +1,3 @@
+murmur3 provides CMake targets:
+    find_package(unofficial-murmur3 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::murmur3::murmur3)

--- a/ports/murmur3/vcpkg.json
+++ b/ports/murmur3/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "murmur3",
+  "version-date": "2015-05-02",
+  "description": "Murmur3 hash in C",
+  "homepage": "https://github.com/PeterScott/murmur3",
+  "license": "CC0-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5656,6 +5656,10 @@
       "baseline": "2.3.4",
       "port-version": 0
     },
+    "murmur3": {
+      "baseline": "2015-05-02",
+      "port-version": 0
+    },
     "murmurhash": {
       "baseline": "2016-01-09",
       "port-version": 7

--- a/versions/m-/murmur3.json
+++ b/versions/m-/murmur3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f5d312dcf0dd9300043d9d6f3911cb86c225e0dc",
+      "git-tree": "2f774b401cfb3d3ba3931a9c6d854f6981787c8c",
       "version-date": "2015-05-02",
       "port-version": 0
     }

--- a/versions/m-/murmur3.json
+++ b/versions/m-/murmur3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0366e11399ebd483ed2cb65b98d2785f6a084c7e",
+      "git-tree": "4a1af63837424ece7a5f1377e214e6737be8d7e0",
       "version-date": "2015-05-02",
       "port-version": 0
     }

--- a/versions/m-/murmur3.json
+++ b/versions/m-/murmur3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f774b401cfb3d3ba3931a9c6d854f6981787c8c",
+      "git-tree": "5f4ab89578aaab8f3e4edf66398db2a693753abb",
       "version-date": "2015-05-02",
       "port-version": 0
     }

--- a/versions/m-/murmur3.json
+++ b/versions/m-/murmur3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a1af63837424ece7a5f1377e214e6737be8d7e0",
+      "git-tree": "f5d312dcf0dd9300043d9d6f3911cb86c225e0dc",
       "version-date": "2015-05-02",
       "port-version": 0
     }

--- a/versions/m-/murmur3.json
+++ b/versions/m-/murmur3.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0366e11399ebd483ed2cb65b98d2785f6a084c7e",
+      "version-date": "2015-05-02",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
-->
