### PR TITLE
[cubeb] no docs

### DIFF
--- a/ports/cubeb/portfile.cmake
+++ b/ports/cubeb/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_cmake_configure(
         -DUSE_SANITIZERS=OFF
         -DBUILD_TESTS=OFF
         -DBUILD_TOOLS=OFF
+        -DDOXYGEN_EXECUTABLE= # Prevents the generation of documentation
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/cubeb)

--- a/ports/cubeb/vcpkg.json
+++ b/ports/cubeb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cubeb",
   "version-date": "2023-09-26",
+  "port-version": 1,
   "description": "Cross platform audio library",
   "homepage": "https://github.com/mozilla/cubeb",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1974,7 +1974,7 @@
     },
     "cubeb": {
       "baseline": "2023-09-26",
-      "port-version": 0
+      "port-version": 1
     },
     "cuda": {
       "baseline": "10.1",

--- a/versions/c-/cubeb.json
+++ b/versions/c-/cubeb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9eac0d45fa24887b010ffdd09284d936950d6b0e",
+      "version-date": "2023-09-26",
+      "port-version": 1
+    },
+    {
       "git-tree": "734318573d1aab99ec902221d209cd01940b37e7",
       "version-date": "2023-09-26",
       "port-version": 0


### PR DESCRIPTION
No docs should be generated. Otherwise fails with:
```
-- Performing post-build validation
warning: /debug/share should not exist. Please reorganize any important files, then use
file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: /Users/leanderSchulten/git_projekte/vcpkg/ports/cubeb/portfile.cmake
error: building cubeb:arm64-osx failed with: POST_BUILD_CHECKS_FAILED
```