### PR TITLE
[cppmicroservices] Remove /WX option

### DIFF
--- a/ports/cppmicroservices/portfile.cmake
+++ b/ports/cppmicroservices/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         werror.patch
         fix_strnicmp.patch
+        remove-wx.patch
 )
 
 #nowide download
@@ -36,7 +37,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_cmake_config_fixup()
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 # CppMicroServices uses a custom resource compiler to compile resources
 # the zipped resources are then appended to the target which cause the linker to crash

--- a/ports/cppmicroservices/remove-wx.patch
+++ b/ports/cppmicroservices/remove-wx.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2bec34f..801d049 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -511,7 +511,7 @@ if(MSVC)
+     set(US_ENABLE_ASAN OFF)
+   endif()
+ 
+-  set(US_CXX_FLAGS "/MP /WX /D${msvc_version_define} ${US_CXX_FLAGS}")
++  set(US_CXX_FLAGS "/MP /D${msvc_version_define} ${US_CXX_FLAGS}")
+ else()
+ 
+   # If not cross-compiling, turn on Stack Smashing Protection.

--- a/ports/cppmicroservices/vcpkg.json
+++ b/ports/cppmicroservices/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "cppmicroservices",
   "version": "3.7.6",
+  "port-version": 1,
   "description": "An OSGi-like C++ dynamic module system and service registry",
   "homepage": "https://github.com/CppMicroServices/CppMicroServices",
+  "license": "Apache-2.0",
   "dependencies": [
     "gtest",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1850,7 +1850,7 @@
     },
     "cppmicroservices": {
       "baseline": "3.7.6",
-      "port-version": 0
+      "port-version": 1
     },
     "cpprestsdk": {
       "baseline": "2.10.18",

--- a/versions/c-/cppmicroservices.json
+++ b/versions/c-/cppmicroservices.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b438280ccc1012bda6457141a3dea8071711ffb9",
+      "version": "3.7.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "3399e4ad64f4b4c0d32f4b5df723384a1bd98dbe",
       "version": "3.7.6",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Remove /WX option for below error:
```
D:\buildtrees\cppmicroservices\src\v3.7.6-c77d5d1a37.clean\third_party\spdlog\include\spdlog/fmt/bundled/format.h(341): error C2220: the following warning is treated as an error
D:\buildtrees\cppmicroservices\src\v3.7.6-c77d5d1a37.clean\third_party\spdlog\include\spdlog/fmt/bundled/format.h(341): warning C4996: 'stdext::checked_array_iterator<T*>': warning STL4043: stdext::checked_array_iterator, stdext::unchecked_array_iterator, and related factory functions are non-Standard extensions and will be removed in the future. std::span (since C++20) and gsl::span can be used instead. You can define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING or _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
