### PR TITLE
[gstreamer] Change HEAD_REF from master to main

### DIFF
--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -5,12 +5,12 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/
+    GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gstreamer/gstreamer
-    REF ${VERSION}
+    REF "${VERSION}"
     SHA512 0d69896d0a83452320df0d0f56c710df1365a259cd3f48dc7cd4df18d45b27caea7174aafa15ae5eb8637ccdef192c1047185b369b7232db4eaacbc57ffaaa22
-    HEAD_REF master
+    HEAD_REF main
     PATCHES
         fix-clang-cl.patch
         fix-clang-cl-gstreamer.patch

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.22.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3074,7 +3074,7 @@
     },
     "gstreamer": {
       "baseline": "1.22.5",
-      "port-version": 1
+      "port-version": 2
     },
     "gtest": {
       "baseline": "1.14.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "921fefd3f9b9ce85c031881f5861074957d1a7f1",
+      "version": "1.22.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "7f37f12f5a39fa6eea841721c51bb591039c3251",
       "version": "1.22.5",
       "port-version": 1


### PR DESCRIPTION
Fixes #30734.

Change `HEAD_REF` from `master` to `main`, consistent with the upstream.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
