### PR TITLE
[harfbuzz] Fix build error

### DIFF
--- a/ports/harfbuzz/fix-win32-build.patch
+++ b/ports/harfbuzz/fix-win32-build.patch
@@ -1,0 +1,12 @@
+diff --git a/src/meson.build b/src/meson.build
+index 4d63ecf..266c213 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -561,6 +561,7 @@ version = '0.@0@.0'.format(hb_version_int)
+ 
+ extra_hb_cpp_args = []
+ if cpp.get_argument_syntax() == 'msvc'
++  extra_hb_cpp_args += ['/bigobj']
+   if get_option('default_library') != 'static'
+     extra_hb_cpp_args += '-DHB_DLL_EXPORT'
+   endif

--- a/ports/harfbuzz/fix-win32-build.patch
+++ b/ports/harfbuzz/fix-win32-build.patch
@@ -1,12 +1,26 @@
 diff --git a/src/meson.build b/src/meson.build
-index 4d63ecf..266c213 100644
+index 87e8962..bdfa797 100644
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -561,6 +561,7 @@ version = '0.@0@.0'.format(hb_version_int)
+@@ -387,6 +387,11 @@ hb_subset_sources = files(
+   'hb-subset.hh',
+ )
  
- extra_hb_cpp_args = []
- if cpp.get_argument_syntax() == 'msvc'
++extra_hb_cpp_args = []
++if cpp.get_argument_syntax() == 'msvc'
 +  extra_hb_cpp_args += ['/bigobj']
++endif
++
+ hb_subset_headers = files(
+   'hb-subset.h',
+   'hb-subset-repacker.h'
+@@ -559,8 +564,7 @@ defs_list = [harfbuzz_def]
+ 
+ version = '0.@0@.0'.format(hb_version_int)
+ 
+-extra_hb_cpp_args = []
+-if cpp.get_define('_MSC_FULL_VER') != ''
++if cpp.get_argument_syntax() == 'msvc'
    if get_option('default_library') != 'static'
      extra_hb_cpp_args += '-DHB_DLL_EXPORT'
    endif

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF ${VERSION}
     SHA512 23d6abbd270885d7ae1ebb3c981f0c331a48d891e23caffe9e254f5e7e205bb0348add7b371526166a49b336f8076f92c11ef76ca81f48a6fd9f58812ec96d79
     HEAD_REF master
+    PATCHES
+        fix-win32-build.patch
 )
 
 if("icu" IN_LIST FEATURES)

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "harfbuzz",
   "version": "8.2.1",
+  "port-version": 1,
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3186,7 +3186,7 @@
     },
     "harfbuzz": {
       "baseline": "8.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b5c3272f29b8d4a9d24e475c13982825cec6377a",
+      "version": "8.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6894af0b171aea403718ebb131b454a60b0c961a",
       "version": "8.2.1",
       "port-version": 0

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b5c3272f29b8d4a9d24e475c13982825cec6377a",
+      "git-tree": "1f39a3081e7055cbf5e8cc27b5f91fef2a274415",
       "version": "8.2.1",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/34037 https://github.com/microsoft/vcpkg/issues/34295
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Recovery patch [fix-win32-build.patch](https://github.com/microsoft/vcpkg/pull/26229/files#diff-fa8cf40d76a5a329bcdc7b7f709ab434d95395bf6f00365ca9f344d9ab7f0baa)
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
