### PR TITLE
[libfreenect2] Update to 0.2.1

### DIFF
--- a/ports/libfreenect2/portfile.cmake
+++ b/ports/libfreenect2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenKinect/libfreenect2
-    REF v0.2.0
-    SHA512 3525e3f21462cecd3b198f64545786ffddc2cafdfd8146e5a46f0300b83f29f1ad0739618a07ab195c276149d7e2e909f7662e2d379a2880593cac75942b0666
+    REF "v${VERSION}"
+    SHA512 0fcee5471deb013d2b57581ef8d8838f652dfed2f457c4240d5b754674e949c59337a167ac74ad04b25ace69af470a7e014e0474a688d930a3323946feadee67
     HEAD_REF master
     PATCHES
         fix-dependency-libusb.patch
@@ -37,6 +37,6 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/GPL2" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/GPL2")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/libfreenect2/vcpkg.json
+++ b/ports/libfreenect2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libfreenect2",
-  "version": "0.2.0",
-  "port-version": 10,
+  "version": "0.2.1",
   "description": "Open source drivers for the Kinect for Windows v2 device",
   "homepage": "https://github.com/OpenKinect/libfreenect2",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4169,8 +4169,8 @@
       "port-version": 1
     },
     "libfreenect2": {
-      "baseline": "0.2.0",
-      "port-version": 10
+      "baseline": "0.2.1",
+      "port-version": 0
     },
     "libfs": {
       "baseline": "1.0.8",

--- a/versions/l-/libfreenect2.json
+++ b/versions/l-/libfreenect2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bfa5e96443079122b324178a6ed421423067039a",
+      "version": "0.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "68766f591851bf3b1bf97eff04a69dcd894d712a",
       "version": "0.2.0",
       "port-version": 10


### PR DESCRIPTION
Fixes #28280

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

All features passed with following triplets:
- x86-windows
- x64-windows