### PR TITLE
[ports/keccak-tiny] New port

### DIFF
--- a/ports/keccak-tiny/CMakeLists.txt
+++ b/ports/keccak-tiny/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.19)
+project(keccak-tiny VERSION 2014.09.08 LANGUAGES C)
+
+set(Header_Files "${PROJECT_NAME}.h")
+set(Source_Files "${PROJECT_NAME}-unrolled.c")
+
+add_library("${PROJECT_NAME}" "${Header_Files}" "${Source_Files}")
+
+include(GNUInstallDirs)
+target_include_directories(
+  "${PROJECT_NAME}"
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+target_compile_features("${PROJECT_NAME}" PRIVATE c_std_90)
+set_target_properties("${PROJECT_NAME}" PROPERTIES C_VISIBILITY_PRESET hidden
+                      PUBLIC_HEADER "${Header_Files}")
+
+install(
+  TARGETS                   "${PROJECT_NAME}"
+  EXPORT                    "unofficial-${PROJECT_NAME}Config"
+  RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+include(CMakePackageConfigHelpers)
+set(VERSION_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}ConfigVersion.cmake")
+write_basic_package_version_file(
+  "${VERSION_FILE_PATH}"
+  VERSION       "${PROJECT_VERSION}"
+  COMPATIBILITY SameMajorVersion
+)
+install(FILES "${VERSION_FILE_PATH}" DESTINATION "share/unofficial-${PROJECT_NAME}")
+
+install(FILES ${Header_Files} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+install(
+  EXPORT      "unofficial-${PROJECT_NAME}Config"
+  FILE        "unofficial-${PROJECT_NAME}Config.cmake"
+  NAMESPACE   "unofficial::${PROJECT_NAME}::"
+  DESTINATION "share/unofficial-${PROJECT_NAME}")
+
+export(PACKAGE "${PROJECT_NAME}")

--- a/ports/keccak-tiny/portfile.cmake
+++ b/ports/keccak-tiny/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            coruus/${PORT}
+    REF             64b6647514212b76ae7bca0dea9b7b197d1d8186
+    SHA512          5cf14061efc1b3c934dfb28a08e2a478036109c449aed41d4deb975a9f0748db06f83c1de9e5d991009d04f0220a397f5f66232a4db04bbc0dea0c624522752c
+    HEAD_REF        master
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
+     DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
+
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "CC0-1.0")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" [=[
+${PORT} provides CMake targets:
+    find_package(unofficial-${PORT} CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::${PORT}::${PORT})
+]=])
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/keccak-tiny/portfile.cmake
+++ b/ports/keccak-tiny/portfile.cmake
@@ -19,11 +19,8 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "CC0-1.0")
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" [=[
-${PORT} provides CMake targets:
-    find_package(unofficial-${PORT} CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE unofficial::${PORT}::${PORT})
-]=])
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
                     "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/keccak-tiny/portfile.cmake
+++ b/ports/keccak-tiny/portfile.cmake
@@ -1,4 +1,6 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if(WIN32)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/keccak-tiny/usage
+++ b/ports/keccak-tiny/usage
@@ -1,0 +1,3 @@
+keccak-tiny provides CMake targets:
+    find_package(unofficial-keccak-tiny CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::keccak-tiny::keccak-tiny)

--- a/ports/keccak-tiny/vcpkg.json
+++ b/ports/keccak-tiny/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "keccak-tiny",
+  "version-date": "2014-09-08",
+  "description": "A tiny implementation of SHA-3, SHAKE, Keccak, and sha3sum",
+  "homepage": "https://github.com/coruus/keccak-tiny",
+  "license": "CC0-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3648,6 +3648,10 @@
       "baseline": "1.5.2",
       "port-version": 0
     },
+    "keccak-tiny": {
+      "baseline": "2014-09-08",
+      "port-version": 0
+    },
     "kenlm": {
       "baseline": "20230531",
       "port-version": 0

--- a/versions/k-/keccak-tiny.json
+++ b/versions/k-/keccak-tiny.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4efbabd9eb67655f2e8a9b6fba1037c3c26bfcff",
+      "version-date": "2014-09-08",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/k-/keccak-tiny.json
+++ b/versions/k-/keccak-tiny.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4efbabd9eb67655f2e8a9b6fba1037c3c26bfcff",
+      "git-tree": "94bcb90f91ac7c2ec2a7e4389185e029c9327615",
       "version-date": "2014-09-08",
       "port-version": 0
     }

--- a/versions/k-/keccak-tiny.json
+++ b/versions/k-/keccak-tiny.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "94bcb90f91ac7c2ec2a7e4389185e029c9327615",
+      "git-tree": "068d9cedaf0a577eabe71f008037116929435931",
       "version-date": "2014-09-08",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.