### PR TITLE
 [linalg] Bump to 2.2

### DIFF
--- a/ports/linalg/portfile.cmake
+++ b/ports/linalg/portfile.cmake
@@ -1,11 +1,13 @@
 #header-only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sgorsten/linalg
-    REF v2.1
-    SHA512 48d8248ea1bca3d4fe35d038690f496cd0c8c9469d76eca684668ce6fef5df0eb9556f9b49e4da90e2c2e8ef475791877aa815c3f9437c097fbfc303134d02d7
+    REF "v${VERSION}"
+    SHA512 736f6ff83fcc4a772ef5ab8e574b0e56aca9fcf2318d92f56f94684ffbd7283540b6496381d52834545b4902147bc67a3afa21ab877bc44bba84471c2eff6862
     HEAD_REF master
 )
 
-configure_file(${SOURCE_PATH}/UNLICENSE ${CURRENT_PACKAGES_DIR}/share/linalg/copyright COPYONLY)
-configure_file(${SOURCE_PATH}/linalg.h ${CURRENT_PACKAGES_DIR}/include/linalg.h COPYONLY)
+file(INSTALL "${SOURCE_PATH}/linalg.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/UNLICENSE")

--- a/ports/linalg/vcpkg.json
+++ b/ports/linalg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "linalg",
-  "version": "2.1",
-  "port-version": 2,
-  "description": "linalg.h is a single header public domain linear algebra library for C++11"
+  "version": "2.2",
+  "description": "linalg.h is a single header public domain linear algebra library for C++11",
+  "homepage": "https://github.com/sgorsten/linalg",
+  "license": "Unlicense"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5061,8 +5061,8 @@
       "port-version": 2
     },
     "linalg": {
-      "baseline": "2.1",
-      "port-version": 2
+      "baseline": "2.2",
+      "port-version": 0
     },
     "linenoise-ng": {
       "baseline": "4754bee2d8eb3",

--- a/versions/l-/linalg.json
+++ b/versions/l-/linalg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8287026554baea7ac2fbbf2ec7c54d3ebe181b7",
+      "version": "2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "dec66a04dc695329609da7aad70ecfde3e36aa4b",
       "version": "2.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
