### PR TITLE
[mdns] Update to 1.4.3

### DIFF
--- a/ports/mdns/portfile.cmake
+++ b/ports/mdns/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mjansson/mdns
-    REF 1.4.2
-    SHA512 fa3fcf130721ee6f7012225c1e7952bd41703c2488b1d0ffe2b8c73ed06744d1cd9f03b6ab19aa0b8074fbfaafe46f8e102d6a648756725a60dc076e896cfbf6
+    REF "${VERSION}"
+    SHA512 0bbfeefdd3f324a8e5aa85227bfa45c2b5cd88c12a9f77df2a1c48cb2661ba8b283dd53541e39d20ed2705646dc8d8724a0287c58f9efa91d2b1b796a0ca9a7a
     HEAD_REF master
 )
 
@@ -17,4 +17,4 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mdns/vcpkg.json
+++ b/ports/mdns/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mdns",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Public domain mDNS/DNS-SD library in C",
   "homepage": "https://github.com/mjansson/mdns",
   "license": "Unlicense",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5353,7 +5353,7 @@
       "port-version": 3
     },
     "mdns": {
-      "baseline": "1.4.2",
+      "baseline": "1.4.3",
       "port-version": 0
     },
     "mdnsresponder": {

--- a/versions/m-/mdns.json
+++ b/versions/m-/mdns.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67bfd722fb49f35c6a08ca9c1e4e1dea2a53d5df",
+      "version": "1.4.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "56cbde1a40c13e9584e62d15f69c2579f6bcd476",
       "version": "1.4.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #34359, update `mdns` to 1.4.3.

No feature needs to be tested, the usage test passed on `x64-windows` (header files found):
```
mdns is header-only and can be used from CMake via:

    find_path(MDNS_INCLUDE_DIRS "mdns.h")
    target_include_directories(main PRIVATE ${MDNS_INCLUDE_DIRS})
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
