### PR TITLE
[bfgroup-lyra] Bump to 1.6.1

### DIFF
--- a/ports/bfgroup-lyra/portfile.cmake
+++ b/ports/bfgroup-lyra/portfile.cmake
@@ -1,21 +1,24 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bfgroup/Lyra
-    REF 1.6
-    SHA512 e357fd0e925b67a51ad7232035ac66842676837baebf7a69eb416807b11400c283d098a22bf3ae27ce904700c5b849953ede1873d6535a8b34c4704ebcb09748
-    HEAD_REF master
+    REF "${VERSION}"
+    SHA512 643c25fbe996af2e888eacb99a715e3d420dbfc21d48756703cf301ab6ba0d1f8eea1cd0764bd5c173d2ddcef7c799448d8c3a77676024205163305e1363d461
+    HEAD_REF release
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
+
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME lyra
     CONFIG_PATH share/lyra/cmake
 )
 
-# Library is header-only, so no debug content.
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/bfgroup-lyra/usage
+++ b/ports/bfgroup-lyra/usage
@@ -1,0 +1,4 @@
+bfgroup-lyra provides CMake targets:
+
+    find_package(lyra CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE bfg::lyra)

--- a/ports/bfgroup-lyra/vcpkg.json
+++ b/ports/bfgroup-lyra/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bfgroup-lyra",
-  "version": "1.6",
+  "version": "1.6.1",
   "description": "A simple to use, composable, command line parser for C++ 11 and beyond",
   "homepage": "https://bfgroup.github.io/Lyra/",
   "license": "BSL-1.0",

--- a/versions/b-/bfgroup-lyra.json
+++ b/versions/b-/bfgroup-lyra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b58cd66176db34198f2a59a06f87afe194db2a45",
+      "version": "1.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "bbd3e635da6198f0f2458ec62ff937287c5c5b45",
       "version": "1.6",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -577,7 +577,7 @@
       "port-version": 0
     },
     "bfgroup-lyra": {
-      "baseline": "1.6",
+      "baseline": "1.6.1",
       "port-version": 0
     },
     "bgfx": {


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

