### PR TITLE
[libpq] update to 16.0

### DIFF
--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.postgresql.org/pub/source/v${VERSION}/postgresql-${VERSION}.tar.bz2"
     FILENAME "postgresql-${VERSION}.tar.bz2"
-    SHA512 cac97edeb40df1e8f2162f401b465751132929d7249495ef001e950645a2db46343bd732e7bd6504a7f795e25aea66724f2f4ab0065e3d9331b36db4b3a3bec6
+    SHA512 c66b72d2d9bc503b9ad19c67384517ae921c494b2916f32157c2528dcbb38aefeb4a8cd5003fd40ba8a19612ea64511d534ff5d99e7a1b266024232f983bcf39
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libpq/unix/fix-configure.patch
+++ b/ports/libpq/unix/fix-configure.patch
@@ -1,10 +1,10 @@
 diff --git a/configure.ac b/configure.ac
-index 9a73f50..a35395e 100644
+index 7f97248..48ff1a1 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -19,7 +19,8 @@ m4_pattern_forbid(^PGAC_)dnl to catch undefined macros
  
- AC_INIT([PostgreSQL], [15.3], [pgsql-bugs@lists.postgresql.org], [], [https://www.postgresql.org/])
+ AC_INIT([PostgreSQL], [16.0], [pgsql-bugs@lists.postgresql.org], [], [https://www.postgresql.org/])
  
 -m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.69], [], [m4_fatal([Autoconf version 2.69 is required.
 +cross_compiling=yes # Avoid conftest loading shared objects
@@ -12,7 +12,7 @@ index 9a73f50..a35395e 100644
  Untested combinations of 'autoconf' and PostgreSQL versions are not
  recommended.  You can remove the check from 'configure.ac' but it is then
  your responsibility whether the result works or not.])])
-@@ -1274,7 +1275,8 @@ if test "$enable_thread_safety" = yes; then
+@@ -1311,7 +1312,8 @@ if test "$enable_thread_safety" = yes; then
  fi
  
  if test "$with_readline" = yes; then
@@ -22,7 +22,7 @@ index 9a73f50..a35395e 100644
    if test x"$pgac_cv_check_readline" = x"no"; then
      AC_MSG_ERROR([readline library not found
  If you have readline already installed, see config.log for details on the
-@@ -1284,7 +1286,7 @@ Use --without-readline to disable readline support.])
+@@ -1321,7 +1323,7 @@ Use --without-readline to disable readline support.])
  fi
  
  if test "$with_zlib" = yes; then
@@ -31,7 +31,7 @@ index 9a73f50..a35395e 100644
                 [AC_MSG_ERROR([zlib library not found
  If you have zlib already installed, see config.log for details on the
  failure.  It is possible the compiler isn't looking in the proper directory.
-@@ -1333,6 +1335,9 @@ if test "$with_ssl" = openssl ; then
+@@ -1370,6 +1372,9 @@ if test "$with_ssl" = openssl ; then
    # Minimum required OpenSSL version is 1.0.1
    AC_DEFINE(OPENSSL_API_COMPAT, [0x10001000L],
              [Define to the OpenSSL API version in use. This avoids deprecation warnings from newer OpenSSL versions.])
@@ -41,15 +41,15 @@ index 9a73f50..a35395e 100644
    if test "$PORTNAME" != "win32"; then
       AC_CHECK_LIB(crypto, CRYPTO_new_ex_data, [], [AC_MSG_ERROR([library 'crypto' is required for OpenSSL])])
       AC_CHECK_LIB(ssl,    SSL_new, [], [AC_MSG_ERROR([library 'ssl' is required for OpenSSL])])
-@@ -1340,6 +1345,7 @@ if test "$with_ssl" = openssl ; then
+@@ -1377,6 +1382,7 @@ if test "$with_ssl" = openssl ; then
       AC_SEARCH_LIBS(CRYPTO_new_ex_data, [eay32 crypto], [], [AC_MSG_ERROR([library 'eay32' or 'crypto' is required for OpenSSL])])
       AC_SEARCH_LIBS(SSL_new, [ssleay32 ssl], [], [AC_MSG_ERROR([library 'ssleay32' or 'ssl' is required for OpenSSL])])
    fi
 +  fi
-   # Function introduced in OpenSSL 1.0.2.
-   AC_CHECK_FUNCS([X509_get_signature_nid])
-   # Functions introduced in OpenSSL 1.1.0. We used to check for
-@@ -1363,19 +1369,23 @@ if test "$with_pam" = yes ; then
+   # Functions introduced in OpenSSL 1.0.2. LibreSSL does not have
+   # SSL_CTX_set_cert_cb().
+   AC_CHECK_FUNCS([X509_get_signature_nid SSL_CTX_set_cert_cb])
+@@ -1403,19 +1409,23 @@ if test "$with_pam" = yes ; then
  fi
  
  if test "$with_libxml" = yes ; then

--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libpq",
-  "version": "15.3",
-  "port-version": 2,
+  "version": "16.0",
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "license": "PostgreSQL",

--- a/ports/libpq/windows/msbuild.patch
+++ b/ports/libpq/windows/msbuild.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tools/msvc/Install.pm b/src/tools/msvc/Install.pm
-index 8de79c6..3bc677d 100644
+index 05548d7..097db91 100644
 --- a/src/tools/msvc/Install.pm
 +++ b/src/tools/msvc/Install.pm
 @@ -53,6 +53,11 @@ sub Install
@@ -83,7 +83,7 @@ index 8de79c6..3bc677d 100644
  		  || croak "Could not copy $pf.pdb\n";
  		print ".";
  	}
-@@ -482,7 +506,7 @@ sub CopySubdirFiles
+@@ -453,7 +477,7 @@ sub CopySubdirFiles
  		foreach my $f (split /\s+/, $flist)
  		{
  			lcopy("$subdir/$module/$f.control",
@@ -92,7 +92,7 @@ index 8de79c6..3bc677d 100644
  			  || croak("Could not copy file $f.control in contrib $module");
  			print '.';
  		}
-@@ -500,7 +524,7 @@ sub CopySubdirFiles
+@@ -471,7 +495,7 @@ sub CopySubdirFiles
  		foreach my $f (split /\s+/, $flist)
  		{
  			lcopy("$subdir/$module/$f",
@@ -101,7 +101,7 @@ index 8de79c6..3bc677d 100644
  			  || croak("Could not copy file $f in contrib $module");
  			print '.';
  		}
-@@ -515,7 +539,7 @@ sub CopySubdirFiles
+@@ -486,7 +510,7 @@ sub CopySubdirFiles
  		foreach my $f (split /\s+/, $flist)
  		{
  			lcopy("$subdir/$module/$f",
@@ -110,7 +110,7 @@ index 8de79c6..3bc677d 100644
  			  || croak("Could not copy file $f in $subdir $module");
  			print '.';
  		}
-@@ -578,7 +602,7 @@ sub CopySubdirFiles
+@@ -549,7 +573,7 @@ sub CopySubdirFiles
  		  if ($module eq 'spi');
  		foreach my $f (split /\s+/, $flist)
  		{
@@ -119,7 +119,7 @@ index 8de79c6..3bc677d 100644
  			  || croak("Could not copy file $f in contrib $module");
  			print '.';
  		}
-@@ -708,7 +732,7 @@ sub GenerateNLSFiles
+@@ -675,7 +699,7 @@ sub GenerateNLSFiles
  	my $majorver = shift;
  
  	print "Installing NLS files...";
@@ -128,7 +128,7 @@ index 8de79c6..3bc677d 100644
  	my @flist;
  	File::Find::find(
  		{
-@@ -730,12 +754,12 @@ sub GenerateNLSFiles
+@@ -697,12 +721,12 @@ sub GenerateNLSFiles
  			next unless /([^\/]+)\.po/;
  			$lang = $1;
  
@@ -146,35 +146,36 @@ index 8de79c6..3bc677d 100644
  			system(@args) && croak("Could not run msgfmt on $dir\\$_");
  			print ".";
 diff --git a/src/tools/msvc/MSBuildProject.pm b/src/tools/msvc/MSBuildProject.pm
-index f24d9e5..356cc31 100644
+index 62fec1f..ecb1b86 100644
 --- a/src/tools/msvc/MSBuildProject.pm
 +++ b/src/tools/msvc/MSBuildProject.pm
-@@ -81,13 +81,14 @@ EOF
+@@ -80,14 +80,14 @@ EOF
+ 	print $f <<EOF;
    </PropertyGroup>
  EOF
- 
-+	my $maybe_dll = $self->{solution}->{options}->{VCPKG_CRT_LINKAGE} eq 'dynamic' ? "DLL" : '';
+-
++    my $maybe_dll = $self->{solution}->{options}->{VCPKG_CRT_LINKAGE} eq 'dynamic' ? "DLL" : '';
  	$self->WriteItemDefinitionGroup(
  		$f, 'Debug',
  		{
- 			defs    => "_DEBUG;DEBUG=1",
- 			opt     => 'Disabled',
+ 			defs => "_DEBUG;DEBUG=1",
+ 			opt => 'Disabled',
  			strpool => 'false',
 -			runtime => 'MultiThreadedDebugDLL'
 +			runtime => 'MultiThreadedDebug' . $maybe_dll
  		});
  	$self->WriteItemDefinitionGroup(
  		$f,
-@@ -96,7 +97,7 @@ EOF
- 			defs    => "",
- 			opt     => 'Full',
+@@ -96,7 +96,7 @@ EOF
+ 			defs => "",
+ 			opt => 'Full',
  			strpool => 'true',
 -			runtime => 'MultiThreadedDLL'
 +			runtime => 'MultiThreaded' . $maybe_dll
  		});
  	return;
  }
-@@ -266,6 +267,8 @@ sub WriteConfigurationPropertyGroup
+@@ -266,6 +266,8 @@ sub WriteConfigurationPropertyGroup
  	  ($self->{type} eq "exe")
  	  ? 'Application'
  	  : ($self->{type} eq "dll" ? 'DynamicLibrary' : 'StaticLibrary');
@@ -183,7 +184,7 @@ index f24d9e5..356cc31 100644
  
  	print $f <<EOF;
    <PropertyGroup Condition="'\$(Configuration)|\$(Platform)'=='$cfgname|$self->{platform}'" Label="Configuration">
-@@ -311,7 +314,9 @@ sub WriteItemDefinitionGroup
+@@ -311,7 +313,9 @@ sub WriteItemDefinitionGroup
  	my $libs = $self->GetAdditionalLinkerDependencies($cfgname, ';');
  
  	my $targetmachine =
@@ -191,42 +192,33 @@ index f24d9e5..356cc31 100644
 +	  'Machine' . uc($self->{platform});
 +	$targetmachine =~ s/WIN32/X86/;
 +	my $randomizebase = ($self->{platform} =~ /^ARM/) ? 'true' : 'false';
+ 	my $arch = $self->{platform} eq 'Win32' ? 'x86' : 'x86_64';
  
  	my $includes = join ';', @{ $self->{includes} }, "";
- 
-@@ -347,7 +352,7 @@ sub WriteItemDefinitionGroup
-       <ProgramDatabaseFile>.\\$cfgname\\$self->{name}\\$self->{name}.pdb</ProgramDatabaseFile>
-       <GenerateMapFile>false</GenerateMapFile>
-       <MapFileName>.\\$cfgname\\$self->{name}\\$self->{name}.map</MapFileName>
--      <RandomizedBaseAddress>false</RandomizedBaseAddress>
-+      <RandomizedBaseAddress>$randomizebase</RandomizedBaseAddress>
-       <!-- Permit links to MinGW-built, 32-bit DLLs (default before VS2012). -->
-       <ImageHasSafeExceptionHandlers/>
-       <SubSystem>Console</SubSystem>
 diff --git a/src/tools/msvc/Mkvcbuild.pm b/src/tools/msvc/Mkvcbuild.pm
-index ef0a33c..dd68424 100644
+index 9e05eb9..8ac0a5d 100644
 --- a/src/tools/msvc/Mkvcbuild.pm
 +++ b/src/tools/msvc/Mkvcbuild.pm
-@@ -114,8 +114,10 @@ sub mkvcbuild
+@@ -125,8 +125,10 @@ sub mkvcbuild
  
  	if ($vsVersion >= '9.00')
  	{
-+		if ($solution->{platform} !~ /^ARM/) {
++        if ($solution->{platform} !~ /^ARM/) {
  		push(@pgportfiles, 'pg_crc32c_sse42_choose.c');
  		push(@pgportfiles, 'pg_crc32c_sse42.c');
-+		}
++        }
  		push(@pgportfiles, 'pg_crc32c_sb8.c');
  	}
  	else
-@@ -196,6 +198,7 @@ sub mkvcbuild
+@@ -208,6 +210,7 @@ sub mkvcbuild
  		'syncrep_gram.y');
  	$postgres->AddFiles('src/backend/utils/adt', 'jsonpath_scan.l',
  		'jsonpath_gram.y');
-+	($config->{VCPKG_LIBRARY_LINKAGE} eq 'dynamic') &&
++    ($config->{VCPKG_LIBRARY_LINKAGE} eq 'dynamic') &&
  	$postgres->AddDefine('BUILDING_DLL');
  	$postgres->AddLibrary('secur32.lib');
  	$postgres->AddLibrary('ws2_32.lib');
-@@ -240,12 +243,13 @@ sub mkvcbuild
+@@ -252,12 +255,13 @@ sub mkvcbuild
  		$pltcl->AddIncludeDir($solution->{options}->{tcl} . '/include');
  		$pltcl->AddReference($postgres);
  
@@ -242,17 +234,17 @@ index ef0a33c..dd68424 100644
  				$found = 1;
  				last;
  			}
-@@ -500,8 +504,7 @@ sub mkvcbuild
+@@ -512,8 +516,7 @@ sub mkvcbuild
  		  . "print(str(sys.version_info[0])+str(sys.version_info[1]))";
  		my $prefixcmd =
  		  qq("$solution->{options}->{python}\\python" -c "$pythonprog");
 -		my $pyout = `$prefixcmd`;
 -		die "Could not query for python version!\n" if $?;
-+		my $pyout = "$solution->{options}->{python}\n$solution->{options}->{python_version}";
++        my $pyout = "$solution->{options}->{python}\n$solution->{options}->{python_version}";
  		my ($pyprefix, $pyver) = split(/\r?\n/, $pyout);
  
  		# Sometimes (always?) if python is not present, the execution
-@@ -517,8 +520,8 @@ sub mkvcbuild
+@@ -529,8 +532,8 @@ sub mkvcbuild
  
  		my $plpython = $solution->AddProject('plpython' . $pymajorver,
  			'dll', 'PLs', 'src/pl/plpython');
@@ -264,7 +256,7 @@ index ef0a33c..dd68424 100644
  
  		# Add transform modules dependent on plpython
 diff --git a/src/tools/msvc/Project.pm b/src/tools/msvc/Project.pm
-index 570bab5..2d51abe 100644
+index 0507ad0..48caab9 100644
 --- a/src/tools/msvc/Project.pm
 +++ b/src/tools/msvc/Project.pm
 @@ -167,6 +167,11 @@ sub AddReference
@@ -280,7 +272,7 @@ index 570bab5..2d51abe 100644
  	return;
  }
 diff --git a/src/tools/msvc/Solution.pm b/src/tools/msvc/Solution.pm
-index d30e8fc..231275b 100644
+index b6d31c3..27d89fc 100644
 --- a/src/tools/msvc/Solution.pm
 +++ b/src/tools/msvc/Solution.pm
 @@ -63,6 +63,11 @@ sub DeterminePlatform
@@ -308,22 +300,22 @@ index d30e8fc..231275b 100644
 @@ -148,7 +156,7 @@ sub GetOpenSSLVersion
  sub GenerateFiles
  {
- 	my $self          = shift;
--	my $bits          = $self->{platform} eq 'Win32' ? 32 : 64;
+ 	my $self = shift;
+-	my $bits = $self->{platform} eq 'Win32' ? 32 : 64;
 +	my $bits          = $self->{platform} =~ /64/ ? 64 : 32;
  	my $ac_init_found = 0;
  	my $package_name;
  	my $package_version;
-@@ -502,7 +510,7 @@ sub GenerateFiles
- 		USE_PAM                    => undef,
- 		USE_SLICING_BY_8_CRC32C    => undef,
- 		USE_SSE42_CRC32C           => undef,
+@@ -440,7 +448,7 @@ sub GenerateFiles
+ 		USE_PAM => undef,
+ 		USE_SLICING_BY_8_CRC32C => undef,
+ 		USE_SSE42_CRC32C => undef,
 -		USE_SSE42_CRC32C_WITH_RUNTIME_CHECK => 1,
 +		USE_SSE42_CRC32C_WITH_RUNTIME_CHECK => $self->{platform} =~ /^ARM/ ? undef : 1,
- 		USE_SYSTEMD                         => undef,
- 		USE_SYSV_SEMAPHORES                 => undef,
- 		USE_SYSV_SHARED_MEMORY              => undef,
-@@ -760,14 +768,14 @@ sub GenerateFiles
+ 		USE_SYSTEMD => undef,
+ 		USE_SYSV_SEMAPHORES => undef,
+ 		USE_SYSV_SHARED_MEMORY => undef,
+@@ -725,14 +733,14 @@ sub GenerateFiles
  		  || confess "Could not open pg_config_paths.h";
  		print $o <<EOF;
  #define PGBINDIR "/bin"
@@ -340,7 +332,7 @@ index d30e8fc..231275b 100644
  #define DOCDIR "/doc"
  #define HTMLDIR "/doc"
  #define MANDIR "/man"
-@@ -952,11 +960,15 @@ sub AddProject
+@@ -957,11 +965,15 @@ sub AddProject
  	if ($self->{options}->{zlib})
  	{
  		$proj->AddIncludeDir($self->{options}->{zlib} . '\include');
@@ -357,7 +349,7 @@ index d30e8fc..231275b 100644
  		my ($digit1, $digit2, $digit3) = $self->GetOpenSSLVersion();
  
  		# Starting at version 1.1.0 the OpenSSL installers have
-@@ -1027,7 +1039,7 @@ sub AddProject
+@@ -1032,7 +1044,7 @@ sub AddProject
  	if ($self->{options}->{nls})
  	{
  		$proj->AddIncludeDir($self->{options}->{nls} . '\include');
@@ -366,7 +358,7 @@ index d30e8fc..231275b 100644
  	}
  	if ($self->{options}->{gss})
  	{
-@@ -1060,6 +1072,10 @@ sub AddProject
+@@ -1065,6 +1077,10 @@ sub AddProject
  	if ($self->{options}->{icu})
  	{
  		$proj->AddIncludeDir($self->{options}->{icu} . '\include');
@@ -377,7 +369,7 @@ index d30e8fc..231275b 100644
  		if ($self->{platform} eq 'Win32')
  		{
  			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuin.lib');
-@@ -1077,22 +1093,22 @@ sub AddProject
+@@ -1082,22 +1098,22 @@ sub AddProject
  	{
  		$proj->AddIncludeDir($self->{options}->{xml} . '\include');
  		$proj->AddIncludeDir($self->{options}->{xml} . '\include\libxml2');
@@ -405,24 +397,15 @@ index d30e8fc..231275b 100644
  	if ($self->{options}->{uuid})
  	{
 diff --git a/src/tools/msvc/gendef.pl b/src/tools/msvc/gendef.pl
-index b8c514a..1fb7619 100644
+index cf83d7d..2d9a4ec 100644
 --- a/src/tools/msvc/gendef.pl
 +++ b/src/tools/msvc/gendef.pl
 @@ -122,7 +122,7 @@ sub writedef
  
  		# Strip the leading underscore for win32, but not x64
  		$f =~ s/^_//
--		  unless ($platform eq "x64");
-+		  if ($platform eq "Win32");
+-		  unless ($arch eq "x86_64");
++		  if ($arch eq "Win32");
  
  		# Emit just the name if it's a function symbol, or emit the name
  		# decorated with the DATA option for variables.
-@@ -150,7 +150,7 @@ sub usage
- usage()
-   unless scalar(@ARGV) == 2
-   && ( ($ARGV[0] =~ /\\([^\\]+$)/)
--	&& ($ARGV[1] eq 'Win32' || $ARGV[1] eq 'x64'));
-+	&& ($ARGV[1] ne ''));
- my $defname  = uc $1;
- my $deffile  = "$ARGV[0]/$defname.def";
- my $platform = $ARGV[1];

--- a/ports/libpq/windows/win_bison_flex.patch
+++ b/ports/libpq/windows/win_bison_flex.patch
@@ -1,6 +1,26 @@
+diff --git a/src/tools/msvc/pgbison.pl b/src/tools/msvc/pgbison.pl
+index 25df669..373bedd 100644
+--- a/src/tools/msvc/pgbison.pl
++++ b/src/tools/msvc/pgbison.pl
+@@ -13,7 +13,7 @@ use File::Basename;
+ 
+ do './src/tools/msvc/buildenv.pl' if -e 'src/tools/msvc/buildenv.pl';
+ 
+-my ($bisonver) = `bison -V`;                 # grab first line
++my ($bisonver) = `win_bison -V`;    # grab first line
+ $bisonver = (split(/\s+/, $bisonver))[3];    # grab version number
+ 
+ unless ($bisonver ge '2.3')
+@@ -51,5 +51,5 @@ my $headerflag = ($make =~ /^$basetarg:\s+BISONFLAGS\b.*-d/m ? '-d' : '');
+ 
+ my $nodep = $bisonver ge '3.0' ? "-Wno-deprecated" : "";
+ 
+-system("bison $nodep $headerflag $input -o $output");
++system("win_bison $nodep $headerflag $input -o $output");
+ exit $? >> 8;
 diff --git a/src/tools/msvc/pgflex.pl b/src/tools/msvc/pgflex.pl
-index aceed5ffd..f6ed215e8 100644
---- a/src/tools/msvc/pgflex.pl	
+index c308a08..0807ce7 100644
+--- a/src/tools/msvc/pgflex.pl
 +++ b/src/tools/msvc/pgflex.pl
 @@ -16,7 +16,7 @@ $ENV{CYGWIN} = 'nodosfilewarning';
  
@@ -20,24 +40,3 @@ index aceed5ffd..f6ed215e8 100644
  if ($? == 0)
  {
  
-diff --git a/src/tools/msvc/pgbison.pl b/src/tools/msvc/pgbison.pl
-index 895e398c0..f5b524a5d 100644
---- a/src/tools/msvc/pgbison.pl	
-+++ b/src/tools/msvc/pgbison.pl
-@@ -13,7 +13,7 @@ use File::Basename;
- 
- do './src/tools/msvc/buildenv.pl' if -e 'src/tools/msvc/buildenv.pl';
- 
--my ($bisonver) = `bison -V`;    # grab first line
-+my ($bisonver) = `win_bison -V`;    # grab first line
- $bisonver = (split(/\s+/, $bisonver))[3];    # grab version number
- 
- unless ($bisonver eq '1.875' || $bisonver ge '2.2')
-@@ -51,5 +51,5 @@ close($mf);
- 
- my $nodep = $bisonver ge '3.0' ? "-Wno-deprecated" : "";
- 
--system("bison $nodep $headerflag $input -o $output");
-+system("win_bison $nodep $headerflag $input -o $output");
- exit $? >> 8;
-

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4553,8 +4553,8 @@
       "port-version": 16
     },
     "libpq": {
-      "baseline": "15.3",
-      "port-version": 2
+      "baseline": "16.0",
+      "port-version": 0
     },
     "libpqxx": {
       "baseline": "7.7.4",

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cbd6314cbfd04132985a7a6412184d368c3cd0b6",
+      "version": "16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "859b43f8db33293c411c365d945ecd4ae2cc056b",
       "version": "15.3",
       "port-version": 2


### PR DESCRIPTION
Fixes #34210

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


Feature `zstd,zlib,xslt,xml,tcl,python,openssl,lz4,icu,client,all` are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static


