### PR TITLE
[libvpx] Update to 1.13.1

### DIFF
--- a/ports/libvpx/0003-add-uwp-v142-and-v143-support.patch
+++ b/ports/libvpx/0003-add-uwp-v142-and-v143-support.patch
@@ -85,21 +85,19 @@ index 58bb66b..b4cad6c 100644
                  fi
              fi
 diff --git a/configure b/configure
-index beea650..91ae3c8 100644
+index ae289f7..78f5fc1 100644
 --- a/configure
 +++ b/configure
-@@ -102,16 +102,24 @@ all_platforms="${all_platforms} arm64-darwin-gcc"
- all_platforms="${all_platforms} arm64-darwin20-gcc"
+@@ -103,6 +103,8 @@ all_platforms="${all_platforms} arm64-darwin20-gcc"
  all_platforms="${all_platforms} arm64-darwin21-gcc"
+ all_platforms="${all_platforms} arm64-darwin22-gcc"
  all_platforms="${all_platforms} arm64-linux-gcc"
 +all_platforms="${all_platforms} arm64-uwp-vs16"
 +all_platforms="${all_platforms} arm64-uwp-vs17"
  all_platforms="${all_platforms} arm64-win64-gcc"
  all_platforms="${all_platforms} arm64-win64-vs15"
-+all_platforms="${all_platforms} arm64-win64-vs16"
-+all_platforms="${all_platforms} arm64-win64-vs17"
- all_platforms="${all_platforms} armv7-android-gcc"   #neon Cortex-A8
- all_platforms="${all_platforms} armv7-darwin-gcc"    #neon Cortex-A8
+ all_platforms="${all_platforms} arm64-win64-vs16"
+@@ -112,6 +114,8 @@ all_platforms="${all_platforms} armv7-darwin-gcc"    #neon Cortex-A8
  all_platforms="${all_platforms} armv7-linux-rvct"    #neon Cortex-A8
  all_platforms="${all_platforms} armv7-linux-gcc"     #neon Cortex-A8
  all_platforms="${all_platforms} armv7-none-rvct"     #neon Cortex-A8
@@ -108,12 +106,7 @@ index beea650..91ae3c8 100644
  all_platforms="${all_platforms} armv7-win32-gcc"
  all_platforms="${all_platforms} armv7-win32-vs14"
  all_platforms="${all_platforms} armv7-win32-vs15"
-+all_platforms="${all_platforms} armv7-win32-vs16"
-+all_platforms="${all_platforms} armv7-win32-vs17"
- all_platforms="${all_platforms} armv7s-darwin-gcc"
- all_platforms="${all_platforms} armv8-linux-gcc"
- all_platforms="${all_platforms} loongarch32-linux-gcc"
-@@ -138,6 +146,8 @@ all_platforms="${all_platforms} x86-linux-gcc"
+@@ -143,6 +147,8 @@ all_platforms="${all_platforms} x86-linux-gcc"
  all_platforms="${all_platforms} x86-linux-icc"
  all_platforms="${all_platforms} x86-os2-gcc"
  all_platforms="${all_platforms} x86-solaris-gcc"
@@ -122,7 +115,7 @@ index beea650..91ae3c8 100644
  all_platforms="${all_platforms} x86-win32-gcc"
  all_platforms="${all_platforms} x86-win32-vs14"
  all_platforms="${all_platforms} x86-win32-vs15"
-@@ -161,6 +171,8 @@ all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
+@@ -167,6 +173,8 @@ all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
  all_platforms="${all_platforms} x86_64-linux-gcc"
  all_platforms="${all_platforms} x86_64-linux-icc"
  all_platforms="${all_platforms} x86_64-solaris-gcc"
@@ -131,7 +124,7 @@ index beea650..91ae3c8 100644
  all_platforms="${all_platforms} x86_64-win64-gcc"
  all_platforms="${all_platforms} x86_64-win64-vs14"
  all_platforms="${all_platforms} x86_64-win64-vs15"
-@@ -485,11 +497,10 @@ process_targets() {
+@@ -491,11 +499,10 @@ process_targets() {
      ! enabled multithread && DIST_DIR="${DIST_DIR}-nomt"
      ! enabled install_docs && DIST_DIR="${DIST_DIR}-nodocs"
      DIST_DIR="${DIST_DIR}-${tgt_isa}-${tgt_os}"
@@ -147,7 +140,7 @@ index beea650..91ae3c8 100644
      if [ -f "${source_path}/build/make/version.sh" ]; then
          ver=`"$source_path/build/make/version.sh" --bare "$source_path"`
          DIST_DIR="${DIST_DIR}-${ver}"
-@@ -578,6 +589,10 @@ process_detect() {
+@@ -584,6 +591,10 @@ process_detect() {
  
              # Specialize windows and POSIX environments.
              case $toolchain in

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -1,12 +1,10 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(LIBVPX_VERSION 1.12.0)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libvpx
-    REF v${LIBVPX_VERSION}
-    SHA512 dc059bc3102b75524ae29989372334b3e0f2acf1520e5a4daa4073831bb55949d82897c498fb9d2d38b59f1a66bb0ad24407d0d086b1e3a8394a4933f04f2ed0
+    REF "v${VERSION}"
+    SHA512 49706838563c92fab7334376848d0f374efcbc1729ef511e967c908fd2ecd40e8d197f1d85da6553b3a7026bdbc17e5a76595319858af26ce58cb9a4c3854897
     HEAD_REF master
     PATCHES
         0002-Fix-nasm-debug-format-flag.patch
@@ -108,11 +106,11 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     )
 
     if (VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
-        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nopost-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${LIBVPX_VERSION}/include/vpx")
+        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nopost-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${VERSION}/include/vpx")
     elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
-        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nopost-nomt-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${LIBVPX_VERSION}/include/vpx")
+        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nopost-nomt-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${VERSION}/include/vpx")
     else()
-        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${LIBVPX_VERSION}/include/vpx")
+        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${VERSION}/include/vpx")
     endif()
     file(
         INSTALL
@@ -162,13 +160,13 @@ else()
         message(FATAL_ERROR "libvpx does not support architecture ${VCPKG_TARGET_ARCHITECTURE}")
     endif()
 
-	if(VCPKG_TARGET_IS_MINGW)
-		if(LIBVPX_TARGET_ARCH STREQUAL "x86")
-			set(LIBVPX_TARGET "x86-win32-gcc")
-		else()
-			set(LIBVPX_TARGET "x86_64-win64-gcc")
-		endif()
-	elseif(VCPKG_TARGET_IS_LINUX)
+    if(VCPKG_TARGET_IS_MINGW)
+        if(LIBVPX_TARGET_ARCH STREQUAL "x86")
+            set(LIBVPX_TARGET "x86-win32-gcc")
+        else()
+            set(LIBVPX_TARGET "x86_64-win64-gcc")
+        endif()
+    elseif(VCPKG_TARGET_IS_LINUX)
         set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-linux-gcc")
     elseif(VCPKG_TARGET_IS_OSX)
         if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
@@ -265,4 +263,4 @@ endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/unofficial-libvpx-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/unofficial-libvpx/unofficial-libvpx-config.cmake" @ONLY)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libvpx",
-  "version": "1.12.0",
-  "port-version": 2,
+  "version": "1.13.1",
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4865,8 +4865,8 @@
       "port-version": 2
     },
     "libvpx": {
-      "baseline": "1.12.0",
-      "port-version": 2
+      "baseline": "1.13.1",
+      "port-version": 0
     },
     "libwandio": {
       "baseline": "4.2.1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e6a50c06aabc83cfda54af613175cf4fdc8137a",
+      "version": "1.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "255c8c5ca6526bd7a0ac6f3a6a7838c77ee97e5e",
       "version": "1.12.0",
       "port-version": 2


### PR DESCRIPTION
Fixes #34237, update `libvpx` to 1.13.1.

All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```

The usage test passed on `x64-windows` (header files found):
```
libvpx provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(unofficial-libvpx CONFIG REQUIRED)
  target_link_libraries(main PRIVATE unofficial::libvpx::libvpx)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
