### PR TITLE
[kf5texteditor] Create a new port with v5.98.0

### DIFF
--- a/ports/kf5parts/portfile.cmake
+++ b/ports/kf5parts/portfile.cmake
@@ -9,11 +9,21 @@ vcpkg_from_github(
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
 
+# See ECM/kde-modules/KDEInstallDirs5.cmake
+# Relocate .desktop files for next ports
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND KDE_OPTIONS
+        -DKDE_INSTALL_KSERVICES5DIR="share/kservices5"
+        -DKDE_INSTALL_KSERVICETYPES5DIR="share/kservicetypes5"
+    )
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
         ${FEATURE_OPTIONS}
+        ${KDE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5parts/vcpkg.json
+++ b/ports/kf5parts/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5parts",
   "version": "5.98.0",
+  "port-version": 1,
   "description": "Plugin framework for user interface component",
   "homepage": "https://api.kde.org/frameworks/kparts/html/index.html",
   "license": "LGPL-2.0-or-later",

--- a/ports/kf5service/portfile.cmake
+++ b/ports/kf5service/portfile.cmake
@@ -34,11 +34,21 @@ vcpkg_add_to_path(PREPEND "${BISON_DIR}")
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
 
+# See ECM/kde-modules/KDEInstallDirs5.cmake
+# Relocate .desktop files for next ports
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND KDE_OPTIONS
+        -DKDE_INSTALL_KSERVICES5DIR="share/kservices5"
+        -DKDE_INSTALL_KSERVICETYPES5DIR="share/kservicetypes5"
+    )
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_KF5DocTools=ON
+        ${KDE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5service/vcpkg.json
+++ b/ports/kf5service/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5service",
   "version": "5.98.0",
+  "port-version": 1,
   "description": "Plugin framework for desktop services",
   "homepage": "https://api.kde.org/frameworks/kservice/html/index.html",
   "dependencies": [

--- a/ports/kf5texteditor/portfile.cmake
+++ b/ports/kf5texteditor/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/ktexteditor
+    REF v5.98.0
+    SHA512 0
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DKDE_INSTALL_QTPLUGINDIR=plugins
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME KF5TextEditor CONFIG_PATH lib/cmake/KF5TextEditor)
+vcpkg_copy_pdbs()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})
+

--- a/ports/kf5texteditor/portfile.cmake
+++ b/ports/kf5texteditor/portfile.cmake
@@ -2,20 +2,26 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/ktexteditor
     REF v5.98.0
-    SHA512 0
+    SHA512 06aad3993cd2133b99ef9e8b510c8b89a844ce778a71351797122c6b05e31e6277d238a8563653a42aafe773457ec89842bbd6184277d471069969c177304696
     HEAD_REF master
 )
 
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
 
+# A trick for `kcoreaddons_desktop_to_json` (see KF5CoreAddonsMacros.cmake) to generate katepart.desktop
+# The copied *.desktop files should be removed after vcpkg_cmake_install
+file(COPY "${CURRENT_INSTALLED_DIR}/share/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share")
+file(COPY "${CURRENT_INSTALLED_DIR}/share/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/share")
+file(GLOB TEMP_DESKTOP_FILES "${CURRENT_PACKAGES_DIR}/share/kservicetypes5/*")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
-        -DKDE_INSTALL_QTPLUGINDIR=plugins
+        -DENABLE_KAUTH_DEFAULT=OFF
+        -DKDE_INSTALL_PLUGINDIR=plugins
 )
-
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME KF5TextEditor CONFIG_PATH lib/cmake/KF5TextEditor)
 vcpkg_copy_pdbs()
@@ -24,9 +30,11 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    ${TEMP_DESKTOP_FILES}
+)
 
 file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
 vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})
-

--- a/ports/kf5texteditor/portfile.cmake
+++ b/ports/kf5texteditor/portfile.cmake
@@ -23,9 +23,31 @@ else()
     file(GLOB TEMP_DESKTOP_FILES_REL "${CURRENT_PACKAGES_DIR}/share/kservicetypes5/*")
 endif()
 
+find_program(MSGMERGE NAMES msgmerge
+    PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext"
+          "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin"
+    REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH
+)
+message(STATUS "Using msgmerge: ${MSGMERGE}")
+
+find_program(MSGFMT NAMES msgfmt
+    PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext"
+          "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin"
+    REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH
+)
+message(STATUS "Using msgfmt: ${MSGFMT}")
+
+if(VCPKG_CROSSCOMPILING)
+    list(APPEND HOST_TOOL_OPTIONS
+        -DGETTEXT_MSGMERGE_EXECUTABLE:FILEPATH="${MSGMERGE}"
+        -DGETTEXT_MSGFMT_EXECUTABLE:FILEPATH="${MSGFMT}"
+    )
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${HOST_TOOL_OPTIONS}
         -DBUILD_TESTING=OFF
         -DENABLE_KAUTH_DEFAULT=OFF
         -DKDE_INSTALL_PLUGINDIR=plugins

--- a/ports/kf5texteditor/portfile.cmake
+++ b/ports/kf5texteditor/portfile.cmake
@@ -11,9 +11,17 @@ file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: fa
 
 # A trick for `kcoreaddons_desktop_to_json` (see KF5CoreAddonsMacros.cmake) to generate katepart.desktop
 # The copied *.desktop files should be removed after vcpkg_cmake_install
-file(COPY "${CURRENT_INSTALLED_DIR}/share/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share")
-file(COPY "${CURRENT_INSTALLED_DIR}/share/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/share")
-file(GLOB TEMP_DESKTOP_FILES "${CURRENT_PACKAGES_DIR}/share/kservicetypes5/*")
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(COPY "${CURRENT_INSTALLED_DIR}/bin/data/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/data")
+    file(GLOB TEMP_DESKTOP_FILES_DBG "${CURRENT_PACKAGES_DIR}/debug/bin/data/kservicetypes5/*")
+    file(COPY "${CURRENT_INSTALLED_DIR}/bin/data/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/bin/data")
+    file(GLOB TEMP_DESKTOP_FILES_REL "${CURRENT_PACKAGES_DIR}/bin/data/kservicetypes5/*")
+else()
+    file(COPY "${CURRENT_INSTALLED_DIR}/share/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share")
+    file(GLOB TEMP_DESKTOP_FILES_DBG "${CURRENT_PACKAGES_DIR}/debug/share/kservicetypes5/*")
+    file(COPY "${CURRENT_INSTALLED_DIR}/share/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/share")
+    file(GLOB TEMP_DESKTOP_FILES_REL "${CURRENT_PACKAGES_DIR}/share/kservicetypes5/*")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -33,7 +41,7 @@ endif()
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
-    ${TEMP_DESKTOP_FILES}
+    ${TEMP_DESKTOP_FILES_DBG} ${TEMP_DESKTOP_FILES_REL}
 )
 
 file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")

--- a/ports/kf5texteditor/portfile.cmake
+++ b/ports/kf5texteditor/portfile.cmake
@@ -12,10 +12,15 @@ file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: fa
 # A trick for `kcoreaddons_desktop_to_json` (see KF5CoreAddonsMacros.cmake) to generate katepart.desktop
 # The copied *.desktop files should be removed after vcpkg_cmake_install
 if(VCPKG_TARGET_IS_WINDOWS)
-    file(COPY "${CURRENT_INSTALLED_DIR}/bin/data/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/data")
-    file(GLOB TEMP_DESKTOP_FILES_DBG "${CURRENT_PACKAGES_DIR}/debug/bin/data/kservicetypes5/*")
-    file(COPY "${CURRENT_INSTALLED_DIR}/bin/data/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/bin/data")
-    file(GLOB TEMP_DESKTOP_FILES_REL "${CURRENT_PACKAGES_DIR}/bin/data/kservicetypes5/*")
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        set(DATAROOT "bin/data") # maybe ADD_BIN_TO_PATH can work in this case...
+    elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        set(DATAROOT "share")
+    endif()
+    file(COPY "${CURRENT_INSTALLED_DIR}/${DATAROOT}/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/data")
+    file(GLOB TEMP_DESKTOP_FILES_DBG "${CURRENT_PACKAGES_DIR}/debug/${DATAROOT}/kservicetypes5/*")
+    file(COPY "${CURRENT_INSTALLED_DIR}/${DATAROOT}/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/bin/data")
+    file(GLOB TEMP_DESKTOP_FILES_REL "${CURRENT_PACKAGES_DIR}/${DATAROOT}/kservicetypes5/*")
 else()
     file(COPY "${CURRENT_INSTALLED_DIR}/share/kservicetypes5" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share")
     file(GLOB TEMP_DESKTOP_FILES_DBG "${CURRENT_PACKAGES_DIR}/debug/share/kservicetypes5/*")

--- a/ports/kf5texteditor/portfile.cmake
+++ b/ports/kf5texteditor/portfile.cmake
@@ -23,34 +23,13 @@ else()
     file(GLOB TEMP_DESKTOP_FILES_REL "${CURRENT_PACKAGES_DIR}/share/kservicetypes5/*")
 endif()
 
-find_program(MSGMERGE NAMES msgmerge
-    PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext"
-          "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin"
-    REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH
-)
-message(STATUS "Using msgmerge: ${MSGMERGE}")
-
-find_program(MSGFMT NAMES msgfmt
-    PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext"
-          "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin"
-    REQUIRED NO_DEFAULT_PATH NO_CMAKE_PATH
-)
-message(STATUS "Using msgfmt: ${MSGFMT}")
-
-if(VCPKG_CROSSCOMPILING)
-    list(APPEND HOST_TOOL_OPTIONS
-        -DGETTEXT_MSGMERGE_EXECUTABLE:FILEPATH="${MSGMERGE}"
-        -DGETTEXT_MSGFMT_EXECUTABLE:FILEPATH="${MSGFMT}"
-    )
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        ${HOST_TOOL_OPTIONS}
         -DBUILD_TESTING=OFF
         -DENABLE_KAUTH_DEFAULT=OFF
         -DKDE_INSTALL_PLUGINDIR=plugins
+        -DVCPKG_HOST_TRIPLET=${VCPKG_HOST_TRIPLET}
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME KF5TextEditor CONFIG_PATH lib/cmake/KF5TextEditor)

--- a/ports/kf5texteditor/vcpkg.json
+++ b/ports/kf5texteditor/vcpkg.json
@@ -5,7 +5,7 @@
   "homepage": "https://api.kde.org/frameworks/ktexteditor/html/",
   "dependencies": [
     "ecm",
-    "gettext",
+    "gettext-libintl",
     {
       "name": "gettext",
       "host": true,

--- a/ports/kf5texteditor/vcpkg.json
+++ b/ports/kf5texteditor/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "kf5texteditor",
+  "version": "5.98.0",
+  "description": "Full text editor component",
+  "homepage": "https://api.kde.org/frameworks/ktexteditor/html/",
+  "dependencies": [
+    "ecm",
+    {
+      "name": "gettext",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
+    "kf5completion",
+    "kf5config",
+    "kf5configwidgets",
+    "kf5i18n",
+    "kf5sonnet",
+    "kf5widgetsaddons",
+    "qt5-base",
+    "qt5-tools",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/kf5texteditor/vcpkg.json
+++ b/ports/kf5texteditor/vcpkg.json
@@ -5,21 +5,15 @@
   "homepage": "https://api.kde.org/frameworks/ktexteditor/html/",
   "dependencies": [
     "ecm",
-    {
-      "name": "gettext",
-      "host": true,
-      "features": [
-        "tools"
-      ]
-    },
-    "kf5completion",
+    "gettext",
+    "kf5archive",
     "kf5config",
-    "kf5configwidgets",
+    "kf5guiaddons",
     "kf5i18n",
+    "kf5kio",
+    "kf5parts",
     "kf5sonnet",
-    "kf5widgetsaddons",
-    "qt5-base",
-    "qt5-tools",
+    "kf5syntaxhighlighting",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/kf5texteditor/vcpkg.json
+++ b/ports/kf5texteditor/vcpkg.json
@@ -6,6 +6,13 @@
   "dependencies": [
     "ecm",
     "gettext",
+    {
+      "name": "gettext",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
     "kf5archive",
     "kf5config",
     "kf5guiaddons",

--- a/ports/kf5texteditor/vcpkg.json
+++ b/ports/kf5texteditor/vcpkg.json
@@ -5,7 +5,6 @@
   "homepage": "https://api.kde.org/frameworks/ktexteditor/html/",
   "dependencies": [
     "ecm",
-    "gettext-libintl",
     {
       "name": "gettext",
       "host": true,
@@ -13,6 +12,7 @@
         "tools"
       ]
     },
+    "gettext-libintl",
     "kf5archive",
     "kf5config",
     "kf5guiaddons",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3784,6 +3784,10 @@
       "baseline": "5.98.0",
       "port-version": 0
     },
+    "kf5texteditor": {
+      "baseline": "5.98.0",
+      "port-version": 0
+    },
     "kf5textwidgets": {
       "baseline": "5.98.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3762,7 +3762,7 @@
     },
     "kf5parts": {
       "baseline": "5.98.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5plotting": {
       "baseline": "5.98.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3770,7 +3770,7 @@
     },
     "kf5service": {
       "baseline": "5.98.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5solid": {
       "baseline": "5.98.0",

--- a/versions/k-/kf5parts.json
+++ b/versions/k-/kf5parts.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60bbc73ecd2ebcc910f7ea6c1553f79e33ccfb4f",
+      "version": "5.98.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6d66ab25d03620f9df39a90fd00d00b0d6271620",
       "version": "5.98.0",
       "port-version": 0

--- a/versions/k-/kf5service.json
+++ b/versions/k-/kf5service.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f72425338783888d31486fed4fddd847e915f38",
+      "version": "5.98.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "70f03de0d90a7592d61c95a44b83894dfedb1dc2",
       "version": "5.98.0",
       "port-version": 0

--- a/versions/k-/kf5texteditor.json
+++ b/versions/k-/kf5texteditor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d5fc3b8d0746819691f73c177db15e47e12b5312",
+      "git-tree": "ac31ffa46e651d2e4dbac86795aecfc881725df0",
       "version": "5.98.0",
       "port-version": 0
     }

--- a/versions/k-/kf5texteditor.json
+++ b/versions/k-/kf5texteditor.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "85d85b04b3ceae4d29d51d20041ecffbce5f7bfb",
+      "version": "5.98.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/k-/kf5texteditor.json
+++ b/versions/k-/kf5texteditor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "85d85b04b3ceae4d29d51d20041ecffbce5f7bfb",
+      "git-tree": "d5fc3b8d0746819691f73c177db15e47e12b5312",
       "version": "5.98.0",
       "port-version": 0
     }

--- a/versions/k-/kf5texteditor.json
+++ b/versions/k-/kf5texteditor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3671385153c2c67946687f7359c4f1792bbe4205",
+      "git-tree": "65e3187a9352f45ef33cc466b1c809eff7bc2bc4",
       "version": "5.98.0",
       "port-version": 0
     }

--- a/versions/k-/kf5texteditor.json
+++ b/versions/k-/kf5texteditor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ac31ffa46e651d2e4dbac86795aecfc881725df0",
+      "git-tree": "3671385153c2c67946687f7359c4f1792bbe4205",
       "version": "5.98.0",
       "port-version": 0
     }


### PR DESCRIPTION
### Changes

Resolve #33315

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
