### PR TITLE
[ankurvdev-embedresource] adding new port

### DIFF
--- a/ports/ankurvdev-embedresource/portfile.cmake
+++ b/ports/ankurvdev-embedresource/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ankurvdev/embedresource
+    REF "v${VERSION}"
+    SHA512 96d2208fd5d654dad5662968296fa363cea0a935fec8474b780717c9303d2dd763833370bcdf02d6d63e264368b0955fa1f13c6e55685280df5fdaf9e72b8c9f
+    HEAD_REF main)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+vcpkg_copy_tools(TOOL_NAMES embedresource AUTO_CLEAN)
+
+file(READ "${CURRENT_PACKAGES_DIR}/share/embedresource/EmbedResourceConfig.cmake" config_contents)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/embedresource/EmbedResourceConfig.cmake"
+"find_program(
+    EMBEDRESOURCE_EXECUTABLE embedresource
+    PATHS
+        \"\${CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/tools/${PORT}\"
+    NO_DEFAULT_PATH
+    REQUIRED)
+${config_contents}"
+)

--- a/ports/ankurvdev-embedresource/vcpkg.json
+++ b/ports/ankurvdev-embedresource/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "ankurvdev-embedresource",
+  "version": "0.0.10",
+  "description": "Cross Platform Resource Embedding",
+  "homepage": "https://github.com/ankurvdev/embedresource",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "ankurvdev-embedresource",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/scripts/test_ports/vcpkg-ci-ankurvdev-embedresource/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-ankurvdev-embedresource/portfile.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-ankurvdev-embedresource/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-ankurvdev-embedresource/project/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(embedresource-test VERSION 0.0.1)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(EmbedResource REQUIRED)
+
+file(SIZE "${CMAKE_CURRENT_LIST_DIR}/main.cpp" MAIN_CPP_FILE_SIZE)
+file(SIZE "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" CMAKELISTS_TXT_FILE_SIZE)
+
+add_resource_library(sample_test_resources OBJECT RESOURCE_COLLECTION_NAME testdata1 RESOURCES main.cpp GENERATOR_COMMAND echo "CMakeLists.txt" GENERATOR_DEPEND CMakeLists.txt)
+add_resource_library(testdata3 OBJECT RESOURCES main.cpp)
+
+macro(setup_target target)
+    target_add_resource(${target} RESOURCE_COLLECTION_NAME testdata2 RESOURCES main.cpp)
+    get_target_property(type ${target} TYPE)
+    if ("${type}" STREQUAL "STATIC_LIBRARY")
+        target_link_libraries(${target} PRIVATE $<BUILD_INTERFACE:sample_test_resources> $<BUILD_INTERFACE:testdata3>)
+    else()
+        target_link_libraries(${target} PRIVATE sample_test_resources testdata3)
+    endif()
+
+    target_compile_definitions(${target} PRIVATE MAIN_CPP_FILE_SIZE=${MAIN_CPP_FILE_SIZE})
+    target_compile_definitions(${target} PRIVATE CMAKELISTS_TXT_FILE_SIZE=${CMAKELISTS_TXT_FILE_SIZE})
+endmacro()
+
+add_executable(sample_test_exe main.cpp)
+setup_target(sample_test_exe)
+
+add_library(sample_test_shlib SHARED main.cpp)
+target_compile_features(sample_test_shlib PRIVATE cxx_std_20)
+setup_target(sample_test_shlib)
+
+add_library(sample_test_lib STATIC main.cpp)
+setup_target(sample_test_lib)
+
+install(TARGETS sample_test_shlib EXPORT sample_test_shlib)
+install(EXPORT sample_test_shlib  FILE sampleTargets.cmake DESTINATION cmake)
+
+install(TARGETS sample_test_lib EXPORT sample_test_lib)
+install(EXPORT sample_test_lib  FILE sampleTargets.cmake DESTINATION cmake)
+
+enable_testing()
+add_test(NAME sample_test_exe COMMAND sample_test_exe)

--- a/scripts/test_ports/vcpkg-ci-ankurvdev-embedresource/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-ankurvdev-embedresource/project/main.cpp
@@ -1,0 +1,58 @@
+#include <EmbeddedResource.h>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string_view>
+
+DECLARE_RESOURCE_COLLECTION(testdata1);
+DECLARE_RESOURCE_COLLECTION(testdata2);
+DECLARE_RESOURCE_COLLECTION(testdata3);
+DECLARE_RESOURCE(testdata3, main_cpp);
+
+void verify_resource(ResourceLoader const& r)
+{
+    if (r.name() == L"main.cpp")
+    {
+#ifdef __cpp_lib_span
+        if (r.template data<uint8_t>().size() != MAIN_CPP_FILE_SIZE) { throw std::runtime_error("r.data.len() != MAIN_CPP_FILE_SIZE"); }
+#endif
+#ifdef __cpp_lib_string_view
+        if (r.string().size() != MAIN_CPP_FILE_SIZE) { throw std::runtime_error("r.string().size() != MAIN_CPP_FILE_SIZE"); }
+#endif
+    }
+    else if (r.name() == L"CMakeLists.txt")
+    {
+#ifdef __cpp_lib_span
+        if (r.template data<uint8_t>().size() != CMAKELISTS_TXT_FILE_SIZE)
+        {
+            throw std::runtime_error("r.data.len() != CMAKELISTS_TXT_FILE_SIZE");
+        }
+#endif
+#ifdef __cpp_lib_string_view
+        if (r.string().size() != CMAKELISTS_TXT_FILE_SIZE) { throw std::runtime_error("r.string().size() != CMAKELISTS_TXT_FILE_SIZE"); }
+#endif
+    }
+    else { throw std::runtime_error("Unknown resource name"); }
+}
+
+int main(int argc, char* argv[])
+try
+{
+    std::string_view res = LOAD_RESOURCE(testdata3, main_cpp).data;
+    if (res.size() != MAIN_CPP_FILE_SIZE) { throw std::runtime_error("r.data.len() != MAIN_CPP_FILE_SIZE"); }
+
+    auto resourceCollection1 = LOAD_RESOURCE_COLLECTION(testdata1);
+    for (auto const r : resourceCollection1) { verify_resource(r); }
+
+    auto resourceCollection2 = LOAD_RESOURCE_COLLECTION(testdata2);
+    for (auto const r : resourceCollection2) { verify_resource(r); }
+
+    auto resourceCollection3 = LOAD_RESOURCE_COLLECTION(testdata3);
+    for (auto const r : resourceCollection2) { verify_resource(r); }
+
+    return 0;
+} catch (const std::exception& ex)
+{
+    std::cerr << "Failed: " << ex.what() << std::endl;
+    return -1;
+}

--- a/scripts/test_ports/vcpkg-ci-ankurvdev-embedresource/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-ankurvdev-embedresource/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "vcpkg-ci-ankurvdev-embedresource",
+  "version-string": "ci",
+  "description": "Validates ankurvdev-embedresource",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "ankurvdev-embedresource"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/ankurvdev-embedresource.json
+++ b/versions/a-/ankurvdev-embedresource.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b200fce22ffffeb4174ca68fcca609a9c4857c38",
+      "version": "0.0.10",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -132,6 +132,10 @@
       "baseline": "chromium_5414",
       "port-version": 7
     },
+    "ankurvdev-embedresource": {
+      "baseline": "0.0.10",
+      "port-version": 0
+    },
     "annoy": {
       "baseline": "1.17.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
