### PR TITLE
[dav1d] Update to 1.3.0

### DIFF
--- a/ports/dav1d/portfile.cmake
+++ b/ports/dav1d/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO videolan/dav1d
     REF "${VERSION}"
-    SHA512 b2f39fdc95c851f136cbe2be40a75770e56ff0109ee55bd084861eb23a8c1dece070dde8a88781c5bb95e241e019e5985d88321560746ecbcb7ab2f22106c0b4
+    SHA512 fce702048b876794d176dffe53d21aaf6a2e9521a306a078debc26a230b5042e7888edd63eb17bd17f06f30ce51901ebf37ea504da25eb911c1b926631cde278
 )
 
 vcpkg_find_acquire_program(NASM)

--- a/ports/dav1d/vcpkg.json
+++ b/ports/dav1d/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dav1d",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "dav1d is a new open-source AV1 decoder developed by the VideoLAN and FFmpeg communities and sponsored by the Alliance for Open Media.",
   "homepage": "https://code.videolan.org/videolan/dav1d",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2061,7 +2061,7 @@
       "port-version": 5
     },
     "dav1d": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "daw-header-libraries": {

--- a/versions/d-/dav1d.json
+++ b/versions/d-/dav1d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99fc7f3cc963cb7a3e567d13f313e5f0dbf46c72",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e819aee6d5e62ecd2981c858897773239e66b496",
       "version": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
