### PR TITLE
[soci] Fix usage

### DIFF
--- a/ports/soci/portfile.cmake
+++ b/ports/soci/portfile.cmake
@@ -55,12 +55,20 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+file(READ "${CURRENT_PORT_DIR}/usage" usage)
 set(backends ${FEATURES})
 list(REMOVE_ITEM backends core boost)
 if(backends STREQUAL "")
-    message(STATUS "Attention:\n\nThis soci build doesn't include any backends.\n")
-    set(backends "none")
+    string(APPEND usage "
+This soci build doesn't include any backend and may not be useful.
+")
 endif()
-configure_file("${CURRENT_PORT_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
+foreach(backend IN LISTS backends)
+    string(APPEND usage "
+    # Using the ${backend} backend directly
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SOCI::soci_${backend}>,SOCI::soci_${backend},SOCI::soci_${backend}_static>)
+")
+endforeach()
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" "${usage}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE_1_0.txt")

--- a/ports/soci/usage
+++ b/ports/soci/usage
@@ -1,5 +1,5 @@
 soci provides CMake targets:
 
-    find_package(soci CONFIG REQUIRED)
+    find_package(SOCI CONFIG REQUIRED)
     # Using core (loading backends at runtime)
     target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SOCI::soci_core>,SOCI::soci_core,SOCI::soci_core_static>)

--- a/ports/soci/usage
+++ b/ports/soci/usage
@@ -1,7 +1,5 @@
 soci provides CMake targets:
 
     find_package(soci CONFIG REQUIRED)
+    # Using core (loading backends at runtime)
     target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SOCI::soci_core>,SOCI::soci_core,SOCI::soci_core_static>)
-
-    # Linking specific backends (enabled: @backends@)
-    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SOCI::soci_<BACKEND>,SOCI::soci_<BACKEND>,SOCI::soci_<BACKEND>_static>)

--- a/ports/soci/vcpkg.json
+++ b/ports/soci/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "soci",
   "version": "4.0.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "SOCI - The C++ Database Access Library",
   "homepage": "https://soci.sourceforge.net/",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7818,7 +7818,7 @@
     },
     "soci": {
       "baseline": "4.0.3",
-      "port-version": 2
+      "port-version": 3
     },
     "socket-io-client": {
       "baseline": "2023-02-14",

--- a/versions/s-/soci.json
+++ b/versions/s-/soci.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9811b837f5656b6238b497a0fa2ba162243ee1a2",
+      "version": "4.0.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "63f4471adc41e108aed34cd585a06e354f1b4762",
       "version": "4.0.3",
       "port-version": 2

--- a/versions/s-/soci.json
+++ b/versions/s-/soci.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9811b837f5656b6238b497a0fa2ba162243ee1a2",
+      "git-tree": "24c340284022dab38da690548caa65c4f003bb7c",
       "version": "4.0.3",
       "port-version": 3
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/pull/34327#issuecomment-1758967261.

CC @baziorek 

Now (Edit: SOCI!)
~~~
soci provides CMake targets:

    find_package(SOCI CONFIG REQUIRED)
    # Using core (loading backends at runtime)
    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SOCI::soci_core>,SOCI::soci_core,SOCI::soci_core_static>)

This static build doesn't include any soci backend and may not be useful.
~~~

or e.g.

~~~
soci provides CMake targets:

    find_package(SOCI CONFIG REQUIRED)
    # Using core (loading backends at runtime)
    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SOCI::soci_core>,SOCI::soci_core,SOCI::soci_core_static>)

    # Using the mysql backend directly
    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SOCI::soci_mysql>,SOCI::soci_mysql,SOCI::soci_mysql_static>)

    # Using the sqlite3 backend directly
    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SOCI::soci_sqlite3>,SOCI::soci_sqlite3,SOCI::soci_sqlite3_static>)
~~~