### PR TITLE
[plplot] Fix download errors

### DIFF
--- a/ports/plplot/portfile.cmake
+++ b/ports/plplot/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO plplot/plplot
-    REF "${VERSION} Source"
+    REF "${VERSION}%20Source"
     FILENAME "plplot-${VERSION}.tar.gz"
     SHA512 54533245569b724a7ef90392cc6e9ae65873e6cbab923df0f841c8b43def5e4307690894c7681802209bd3c8df97f54285310a706428f79b3340cce3207087c8
     PATCHES

--- a/ports/plplot/vcpkg.json
+++ b/ports/plplot/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "plplot",
   "version-semver": "5.15.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "PLplot is a cross-platform software package for creating scientific plots whose (UTF-8) plot symbols and text are limited in practice only by what Unicode-aware system fonts are installed on a user's computer.",
   "homepage": "http://plplot.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6506,7 +6506,7 @@
     },
     "plplot": {
       "baseline": "5.15.0",
-      "port-version": 1
+      "port-version": 2
     },
     "plustache": {
       "baseline": "0.4.0",

--- a/versions/p-/plplot.json
+++ b/versions/p-/plplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "650f7b8973b4a28f84fc0e8ab1711e468417f564",
+      "version-semver": "5.15.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "3fb1fa2f2f5f9c3ea3543f5ba3074138be2d2320",
       "version-semver": "5.15.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/34357
```
error: https://sourceforge.net/projects/plplot/files/plplot/5.15.0 Source/plplot-5.15.0.tar.gz/download?use_mirror=tenet: curl failed to download with exit code 3
curl: (3) URL rejected: Malformed input to a URL function
```

Fix download `url` error.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Compile test pass with following triplets:
```
x64-osx
```