### PR TITLE
[assimp] Fix configure warning when using minizip from assimp library

### DIFF
--- a/ports/assimp/build_fixes.patch
+++ b/ports/assimp/build_fixes.patch
@@ -268,7 +268,8 @@ index 5339454..45e07c0 100644
 -  hunter_add_package(minizip)
 +IF(1)
 +  #hunter_add_package(minizip)
-   find_package(minizip CONFIG REQUIRED)
+-  find_package(minizip CONFIG REQUIRED)
++  find_package(unofficial-minizip CONFIG REQUIRED)
  ELSE()
    SET( unzip_SRCS
 @@ -969,9 +969,9 @@ ENDIF()
@@ -383,7 +384,8 @@ index 5339454..45e07c0 100644
 +      ${OPENDDL_PARSER_LIBRARIES}
 -      #poly2tri::poly2tri
 +      poly2tri::poly2tri
-       minizip::minizip
+-      minizip::minizip
++      unofficial::minizip::minizip
 -      ZLIB::zlib
 -      RapidJSON::rapidjson
 +      ZLIB::ZLIB

--- a/ports/assimp/vcpkg.json
+++ b/ports/assimp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "assimp",
   "version": "5.3.1",
+  "port-version": 1,
   "description": "The Open Asset import library",
   "homepage": "https://github.com/assimp/assimp",
   "license": "BSD-3-Clause",

--- a/versions/a-/assimp.json
+++ b/versions/a-/assimp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "572034c626843af86fe62b64905fd4e79f19535f",
+      "version": "5.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "f9934603cb6f42343b122951f22b5af3c1967cde",
       "version": "5.3.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -266,7 +266,7 @@
     },
     "assimp": {
       "baseline": "5.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "async-mqtt": {
       "baseline": "2.0.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
