### PR TITLE
[opentelemetry-proto] New port

### DIFF
--- a/ports/opentelemetry-proto/CMakeLists.txt
+++ b/ports/opentelemetry-proto/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(OtlpProtoLib CXX)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/Modules/")
+
+find_package(abseil REQUIRED)
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+
+find_program(PROTOBUF_PROTOC_EXECUTABLE NAMES protoc)
+find_program(GRPC_CPP_PLUGIN NAMES grpc_cpp_plugin)
+
+set(OTLP_COMMON_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/common/v1/common.proto")
+set(OTLP_RESOURCE_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/resource/v1/resource.proto")
+set(OTLP_METRICS_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/metrics/v1/metrics.proto")
+set(OTLP_METRICS_SERVICE_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/collector/metrics/v1/metrics_service.proto")
+
+set(SOURCES
+    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc"
+    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc"
+    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/common/v1/common.grpc.pb.cc"
+    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/common/v1/common.pb.cc"
+    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/resource/v1/resource.grpc.pb.cc"
+    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/resource/v1/resource.pb.cc"
+    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/metrics/v1/metrics.grpc.pb.cc"
+    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/metrics/v1/metrics.pb.cc"
+)
+
+if(NOT EXISTS ${OTLP_PROTO_OUT_DIR})
+    message(STATUS "Creating proto out folder: ${OTLP_PROTO_OUT_DIR}")
+    file(MAKE_DIRECTORY ${OTLP_PROTO_OUT_DIR})
+else()
+    message(STATUS "Proto out folder is found: ${OTLP_PROTO_OUT_DIR}")
+endif()
+
+add_custom_command(
+    OUTPUT ${SOURCES} #_fake.h
+    COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --version
+    COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+    ARGS
+        --grpc_out "${OTLP_PROTO_OUT_DIR}"
+        --cpp_out "${OTLP_PROTO_OUT_DIR}"
+        -I "${OTLP_PROTO_BUILD_ROOT}"
+        --plugin=protoc-gen-grpc="${GRPC_CPP_PLUGIN}"
+        "${OTLP_COMMON_PROTO}" "${OTLP_METRICS_PROTO}" "${OTLP_RESOURCE_PROTO}" "${OTLP_METRICS_SERVICE_PROTO}"
+    DEPENDS "${OTLP_COMMON_PROTO}" "${OTLP_METRICS_PROTO}" "${OTLP_RESOURCE_PROTO}" "${OTLP_METRICS_SERVICE_PROTO}"
+    COMMENT "Compiling open-telemetry proto files"
+)
+
+add_library(${PROJECT_NAME} ${SOURCES})
+
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    protobuf::libprotobuf
+    gRPC::grpc++
+    absl::synchronization
+)

--- a/ports/opentelemetry-proto/CMakeLists.txt
+++ b/ports/opentelemetry-proto/CMakeLists.txt
@@ -59,12 +59,12 @@ set(TRACE_SERVICE_PB_H_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
 )
 if(WITH_OTLP_GRPC)
-  set(TRACE_SERVICE_GRPC_PB_CPP_FILE
-      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.cc"
-  )
-  set(TRACE_SERVICE_GRPC_PB_H_FILE
-      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h"
-  )
+    set(TRACE_SERVICE_GRPC_PB_CPP_FILE
+        "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.cc"
+    )
+    set(TRACE_SERVICE_GRPC_PB_H_FILE
+        "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h"
+    )
 endif()
 set(LOGS_SERVICE_PB_CPP_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.pb.cc"
@@ -73,12 +73,12 @@ set(LOGS_SERVICE_PB_H_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.pb.h"
 )
 if(WITH_OTLP_GRPC)
-  set(LOGS_SERVICE_GRPC_PB_CPP_FILE
-      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.cc"
-  )
-  set(LOGS_SERVICE_GRPC_PB_H_FILE
-      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.h"
-  )
+    set(LOGS_SERVICE_GRPC_PB_CPP_FILE
+        "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.cc"
+    )
+    set(LOGS_SERVICE_GRPC_PB_H_FILE
+        "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.h"
+    )
 endif()
 set(METRICS_SERVICE_PB_CPP_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc"
@@ -87,29 +87,29 @@ set(METRICS_SERVICE_PB_H_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
 )
 if(WITH_OTLP_GRPC)
-  set(METRICS_SERVICE_GRPC_PB_CPP_FILE
-      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc"
-  )
-  set(METRICS_SERVICE_GRPC_PB_H_FILE
-      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h"
-  )
+    set(METRICS_SERVICE_GRPC_PB_CPP_FILE
+        "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc"
+    )
+    set(METRICS_SERVICE_GRPC_PB_H_FILE
+        "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h"
+    )
 endif()
 
 foreach(IMPORT_DIR ${PROTOBUF_IMPORT_DIRS})
-  list(APPEND PROTOBUF_INCLUDE_FLAGS "-I${IMPORT_DIR}")
+    list(APPEND PROTOBUF_INCLUDE_FLAGS "-I${IMPORT_DIR}")
 endforeach()
 
 if(WITH_OTLP_GRPC)
-  if(CMAKE_CROSSCOMPILING)
-    find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
-  else()
-    if(TARGET gRPC::grpc_cpp_plugin)
-      project_build_tools_get_imported_location(gRPC_CPP_PLUGIN_EXECUTABLE
-                                                gRPC::grpc_cpp_plugin)
+    if(CMAKE_CROSSCOMPILING)
+        find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
     else()
-      find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+        if(TARGET gRPC::grpc_cpp_plugin)
+            project_build_tools_get_imported_location(gRPC_CPP_PLUGIN_EXECUTABLE
+                                                    gRPC::grpc_cpp_plugin)
+        else()
+            find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+        endif()
     endif()
-  endif()
   message(STATUS "gRPC_CPP_PLUGIN_EXECUTABLE=${gRPC_CPP_PLUGIN_EXECUTABLE}")
 endif()
 
@@ -119,9 +119,9 @@ set(PROTOBUF_COMMON_FLAGS "--proto_path=${CMAKE_CURRENT_SOURCE_DIR}"
 # --experimental_allow_proto3_optional is available from 3.13 and be stable and
 # enabled by default from 3.16
 if(Protobuf_VERSION AND Protobuf_VERSION VERSION_LESS "3.16")
-  list(APPEND PROTOBUF_COMMON_FLAGS "--experimental_allow_proto3_optional")
+    list(APPEND PROTOBUF_COMMON_FLAGS "--experimental_allow_proto3_optional")
 elseif(PROTOBUF_VERSION AND PROTOBUF_VERSION VERSION_LESS "3.16")
-  list(APPEND PROTOBUF_COMMON_FLAGS "--experimental_allow_proto3_optional")
+    list(APPEND PROTOBUF_COMMON_FLAGS "--experimental_allow_proto3_optional")
 endif()
 
 set(PROTOBUF_GENERATED_FILES
@@ -148,14 +148,14 @@ if(WITH_OTLP_GRPC)
          --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}")
   
     list(
-      APPEND
-      PROTOBUF_GENERATED_FILES
-      ${TRACE_SERVICE_GRPC_PB_H_FILE}
-      ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
-      ${LOGS_SERVICE_GRPC_PB_H_FILE}
-      ${LOGS_SERVICE_GRPC_PB_CPP_FILE}
-      ${METRICS_SERVICE_GRPC_PB_H_FILE}
-      ${METRICS_SERVICE_GRPC_PB_CPP_FILE})
+        APPEND
+        PROTOBUF_GENERATED_FILES
+        ${TRACE_SERVICE_GRPC_PB_H_FILE}
+        ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
+        ${LOGS_SERVICE_GRPC_PB_H_FILE}
+        ${LOGS_SERVICE_GRPC_PB_CPP_FILE}
+        ${METRICS_SERVICE_GRPC_PB_H_FILE}
+        ${METRICS_SERVICE_GRPC_PB_CPP_FILE})
 endif()
 
 set(PROTOBUF_RUN_PROTOC_COMMAND "\"${PROTOBUF_PROTOC_EXECUTABLE}\"")
@@ -176,37 +176,37 @@ foreach(
 endforeach()
 
 add_custom_command(
-  OUTPUT ${PROTOBUF_GENERATED_FILES}
-  COMMAND
-    ${PROTOBUF_PROTOC_EXECUTABLE} ${PROTOBUF_COMMON_FLAGS}
-    ${PROTOBUF_INCLUDE_FLAGS} ${COMMON_PROTO} ${RESOURCE_PROTO} ${TRACE_PROTO}
-    ${LOGS_PROTO} ${METRICS_PROTO} ${TRACE_SERVICE_PROTO} ${LOGS_SERVICE_PROTO}
-    ${METRICS_SERVICE_PROTO}
-  COMMENT "[Run]: ${PROTOBUF_RUN_PROTOC_COMMAND}")
+    OUTPUT ${PROTOBUF_GENERATED_FILES}
+    COMMAND
+        ${PROTOBUF_PROTOC_EXECUTABLE} ${PROTOBUF_COMMON_FLAGS}
+        ${PROTOBUF_INCLUDE_FLAGS} ${COMMON_PROTO} ${RESOURCE_PROTO} ${TRACE_PROTO}
+        ${LOGS_PROTO} ${METRICS_PROTO} ${TRACE_SERVICE_PROTO} ${LOGS_SERVICE_PROTO}
+        ${METRICS_SERVICE_PROTO}
+    COMMENT "[Run]: ${PROTOBUF_RUN_PROTOC_COMMAND}")
 
 include_directories("${GENERATED_PROTOBUF_PATH}")
 
 unset(OTELCPP_PROTO_TARGET_OPTIONS)
 if(CMAKE_SYSTEM_NAME MATCHES "Windows|MinGW|WindowsStore")
-  list(APPEND OTELCPP_PROTO_TARGET_OPTIONS STATIC)
+    list(APPEND OTELCPP_PROTO_TARGET_OPTIONS STATIC)
 elseif(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
-  list(APPEND OTELCPP_PROTO_TARGET_OPTIONS SHARED)
+    list(APPEND OTELCPP_PROTO_TARGET_OPTIONS SHARED)
 else()
-  list(APPEND OTELCPP_PROTO_TARGET_OPTIONS STATIC)
+    list(APPEND OTELCPP_PROTO_TARGET_OPTIONS STATIC)
 endif()
 
 set(OPENTELEMETRY_PROTO_TARGETS opentelemetry_proto)
 add_library(
-  opentelemetry_proto
-  ${OTELCPP_PROTO_TARGET_OPTIONS}
-  ${COMMON_PB_CPP_FILE}
-  ${RESOURCE_PB_CPP_FILE}
-  ${TRACE_PB_CPP_FILE}
-  ${LOGS_PB_CPP_FILE}
-  ${METRICS_PB_CPP_FILE}
-  ${TRACE_SERVICE_PB_CPP_FILE}
-  ${LOGS_SERVICE_PB_CPP_FILE}
-  ${METRICS_SERVICE_PB_CPP_FILE})
+    opentelemetry_proto
+    ${OTELCPP_PROTO_TARGET_OPTIONS}
+    ${COMMON_PB_CPP_FILE}
+    ${RESOURCE_PB_CPP_FILE}
+    ${TRACE_PB_CPP_FILE}
+    ${LOGS_PB_CPP_FILE}
+    ${METRICS_PB_CPP_FILE}
+    ${TRACE_SERVICE_PB_CPP_FILE}
+    ${LOGS_SERVICE_PB_CPP_FILE}
+    ${METRICS_SERVICE_PB_CPP_FILE})
 
 if(WITH_ABSEIL)
     find_package(absl REQUIRED)
@@ -214,30 +214,30 @@ if(WITH_ABSEIL)
 endif()
 
 if(WITH_OTLP_GRPC)
-  add_library(
-    opentelemetry_proto_grpc
-    ${OTELCPP_PROTO_TARGET_OPTIONS} ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
-    ${LOGS_SERVICE_GRPC_PB_CPP_FILE} ${METRICS_SERVICE_GRPC_PB_CPP_FILE})
+    add_library(
+        opentelemetry_proto_grpc
+        ${OTELCPP_PROTO_TARGET_OPTIONS} ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
+        ${LOGS_SERVICE_GRPC_PB_CPP_FILE} ${METRICS_SERVICE_GRPC_PB_CPP_FILE})
 
-  list(APPEND OPENTELEMETRY_PROTO_TARGETS opentelemetry_proto_grpc)
-  target_link_libraries(opentelemetry_proto_grpc
-    PUBLIC opentelemetry_proto)
-
-  get_target_property(grpc_lib_type gRPC::grpc++ TYPE)
-  if (grpc_lib_type STREQUAL "SHARED_LIBRARY")
+    list(APPEND OPENTELEMETRY_PROTO_TARGETS opentelemetry_proto_grpc)
     target_link_libraries(opentelemetry_proto_grpc
-      PUBLIC gRPC::grpc++)
-  endif()
-  set_target_properties(opentelemetry_proto_grpc PROPERTIES EXPORT_NAME
+        PUBLIC opentelemetry_proto)
+
+    get_target_property(grpc_lib_type gRPC::grpc++ TYPE)
+    if (grpc_lib_type STREQUAL "SHARED_LIBRARY")
+        target_link_libraries(opentelemetry_proto_grpc
+        PUBLIC gRPC::grpc++)
+    endif()
+    set_target_properties(opentelemetry_proto_grpc PROPERTIES EXPORT_NAME
                                                             proto_grpc)
-  patch_protobuf_targets(opentelemetry_proto_grpc)
-  get_target_property(GRPC_INCLUDE_DIRECTORY gRPC::grpc++
-                      INTERFACE_INCLUDE_DIRECTORIES)
-  if(GRPC_INCLUDE_DIRECTORY)
-    target_include_directories(
-      opentelemetry_proto_grpc
-      PUBLIC "$<BUILD_INTERFACE:${GRPC_INCLUDE_DIRECTORY}>")
-  endif()
+    patch_protobuf_targets(opentelemetry_proto_grpc)
+    get_target_property(GRPC_INCLUDE_DIRECTORY gRPC::grpc++
+                        INTERFACE_INCLUDE_DIRECTORIES)
+    if(GRPC_INCLUDE_DIRECTORY)
+        target_include_directories(
+            opentelemetry_proto_grpc
+            PUBLIC "$<BUILD_INTERFACE:${GRPC_INCLUDE_DIRECTORY}>")
+    endif()
 endif()
 
 set_target_properties(opentelemetry_proto PROPERTIES EXPORT_NAME proto)
@@ -257,25 +257,25 @@ install(
     PATTERN "*.h")
 
 if(TARGET protobuf::libprotobuf)
-  target_link_libraries(opentelemetry_proto PUBLIC protobuf::libprotobuf)
+    target_link_libraries(opentelemetry_proto PUBLIC protobuf::libprotobuf)
 else() # cmake 3.8 or lower
-  target_include_directories(opentelemetry_proto
-                             PUBLIC ${Protobuf_INCLUDE_DIRS})
-  target_link_libraries(opentelemetry_proto PUBLIC ${Protobuf_LIBRARIES})
+    target_include_directories(opentelemetry_proto
+                               PUBLIC ${Protobuf_INCLUDE_DIRS})
+    target_link_libraries(opentelemetry_proto PUBLIC ${Protobuf_LIBRARIES})
 endif()
 
 if(WITH_OTLP_GRPC)
-  if(WITH_ABSEIL)
-    find_package(absl CONFIG)
-    if(TARGET absl::synchronization)
-      target_link_libraries(opentelemetry_proto_grpc
-                            PRIVATE absl::synchronization)
+    if(WITH_ABSEIL)
+        find_package(absl CONFIG)
+        if(TARGET absl::synchronization)
+            target_link_libraries(opentelemetry_proto_grpc
+                                  PRIVATE absl::synchronization)
+        endif()
     endif()
-  endif()
 endif()
 
 if(BUILD_SHARED_LIBS)
-  foreach(proto_target ${OPENTELEMETRY_PROTO_TARGETS})
-    set_property(TARGET ${proto_target} PROPERTY POSITION_INDEPENDENT_CODE ON)
-  endforeach()
+    foreach(proto_target ${OPENTELEMETRY_PROTO_TARGETS})
+        set_property(TARGET ${proto_target} PROPERTY POSITION_INDEPENDENT_CODE ON)
+    endforeach()
 endif()

--- a/ports/opentelemetry-proto/CMakeLists.txt
+++ b/ports/opentelemetry-proto/CMakeLists.txt
@@ -1,58 +1,281 @@
-cmake_minimum_required(VERSION 3.5)
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.1)
 
 project(OtlpProtoLib CXX)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/Modules/")
+include("${CMAKE_CURRENT_SOURCE_DIR}/tools.cmake")
 
-find_package(abseil REQUIRED)
 find_package(Protobuf REQUIRED)
-find_package(gRPC REQUIRED)
-
-find_program(PROTOBUF_PROTOC_EXECUTABLE NAMES protoc)
-find_program(GRPC_CPP_PLUGIN NAMES grpc_cpp_plugin)
-
-set(OTLP_COMMON_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/common/v1/common.proto")
-set(OTLP_RESOURCE_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/resource/v1/resource.proto")
-set(OTLP_METRICS_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/metrics/v1/metrics.proto")
-set(OTLP_METRICS_SERVICE_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/collector/metrics/v1/metrics_service.proto")
-
-set(SOURCES
-    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc"
-    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc"
-    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/common/v1/common.grpc.pb.cc"
-    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/common/v1/common.pb.cc"
-    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/resource/v1/resource.grpc.pb.cc"
-    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/resource/v1/resource.pb.cc"
-    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/metrics/v1/metrics.grpc.pb.cc"
-    "${OTLP_PROTO_OUT_DIR}/opentelemetry/proto/metrics/v1/metrics.pb.cc"
-)
-
-if(NOT EXISTS ${OTLP_PROTO_OUT_DIR})
-    message(STATUS "Creating proto out folder: ${OTLP_PROTO_OUT_DIR}")
-    file(MAKE_DIRECTORY ${OTLP_PROTO_OUT_DIR})
-else()
-    message(STATUS "Proto out folder is found: ${OTLP_PROTO_OUT_DIR}")
+if(WITH_OTLP_GRPC)
+    find_package(gRPC REQUIRED)
 endif()
 
+set(COMMON_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/common/v1/common.proto")
+set(RESOURCE_PROTO
+    "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/resource/v1/resource.proto")
+set(TRACE_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/trace/v1/trace.proto")
+set(LOGS_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/logs/v1/logs.proto")
+set(METRICS_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/metrics/v1/metrics.proto")
+set(TRACE_SERVICE_PROTO
+    "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/collector/trace/v1/trace_service.proto")
+set(LOGS_SERVICE_PROTO
+    "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/collector/logs/v1/logs_service.proto")
+set(METRICS_SERVICE_PROTO
+    "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry/proto/collector/metrics/v1/metrics_service.proto"
+)
+
+set(GENERATED_PROTOBUF_PATH
+    "${CMAKE_BINARY_DIR}/generated/third_party/opentelemetry-proto")
+
+file(MAKE_DIRECTORY "${GENERATED_PROTOBUF_PATH}")
+
+set(COMMON_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/common/v1/common.pb.cc")
+set(COMMON_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/common/v1/common.pb.h")
+set(RESOURCE_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/resource/v1/resource.pb.cc")
+set(RESOURCE_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/resource/v1/resource.pb.h")
+set(TRACE_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/trace/v1/trace.pb.cc")
+set(TRACE_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/trace/v1/trace.pb.h")
+set(LOGS_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/logs/v1/logs.pb.cc")
+set(LOGS_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/logs/v1/logs.pb.h")
+set(METRICS_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/metrics/v1/metrics.pb.cc")
+set(METRICS_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/metrics/v1/metrics.pb.h")
+
+set(TRACE_SERVICE_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.pb.cc"
+)
+set(TRACE_SERVICE_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
+)
+if(WITH_OTLP_GRPC)
+  set(TRACE_SERVICE_GRPC_PB_CPP_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.cc"
+  )
+  set(TRACE_SERVICE_GRPC_PB_H_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h"
+  )
+endif()
+set(LOGS_SERVICE_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.pb.cc"
+)
+set(LOGS_SERVICE_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.pb.h"
+)
+if(WITH_OTLP_GRPC)
+  set(LOGS_SERVICE_GRPC_PB_CPP_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.cc"
+  )
+  set(LOGS_SERVICE_GRPC_PB_H_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.h"
+  )
+endif()
+set(METRICS_SERVICE_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc"
+)
+set(METRICS_SERVICE_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
+)
+if(WITH_OTLP_GRPC)
+  set(METRICS_SERVICE_GRPC_PB_CPP_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc"
+  )
+  set(METRICS_SERVICE_GRPC_PB_H_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h"
+  )
+endif()
+
+foreach(IMPORT_DIR ${PROTOBUF_IMPORT_DIRS})
+  list(APPEND PROTOBUF_INCLUDE_FLAGS "-I${IMPORT_DIR}")
+endforeach()
+
+if(WITH_OTLP_GRPC)
+  if(CMAKE_CROSSCOMPILING)
+    find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+  else()
+    if(TARGET gRPC::grpc_cpp_plugin)
+      project_build_tools_get_imported_location(gRPC_CPP_PLUGIN_EXECUTABLE
+                                                gRPC::grpc_cpp_plugin)
+    else()
+      find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+    endif()
+  endif()
+  message(STATUS "gRPC_CPP_PLUGIN_EXECUTABLE=${gRPC_CPP_PLUGIN_EXECUTABLE}")
+endif()
+
+set(PROTOBUF_COMMON_FLAGS "--proto_path=${CMAKE_CURRENT_SOURCE_DIR}"
+                          "--cpp_out=${GENERATED_PROTOBUF_PATH}")
+
+# --experimental_allow_proto3_optional is available from 3.13 and be stable and
+# enabled by default from 3.16
+if(Protobuf_VERSION AND Protobuf_VERSION VERSION_LESS "3.16")
+  list(APPEND PROTOBUF_COMMON_FLAGS "--experimental_allow_proto3_optional")
+elseif(PROTOBUF_VERSION AND PROTOBUF_VERSION VERSION_LESS "3.16")
+  list(APPEND PROTOBUF_COMMON_FLAGS "--experimental_allow_proto3_optional")
+endif()
+
+set(PROTOBUF_GENERATED_FILES
+    ${COMMON_PB_H_FILE}
+    ${COMMON_PB_CPP_FILE}
+    ${RESOURCE_PB_H_FILE}
+    ${RESOURCE_PB_CPP_FILE}
+    ${TRACE_PB_H_FILE}
+    ${TRACE_PB_CPP_FILE}
+    ${LOGS_PB_H_FILE}
+    ${LOGS_PB_CPP_FILE}
+    ${METRICS_PB_H_FILE}
+    ${METRICS_PB_CPP_FILE}
+    ${TRACE_SERVICE_PB_H_FILE}
+    ${TRACE_SERVICE_PB_CPP_FILE}
+    ${LOGS_SERVICE_PB_H_FILE}
+    ${LOGS_SERVICE_PB_CPP_FILE}
+    ${METRICS_SERVICE_PB_H_FILE}
+    ${METRICS_SERVICE_PB_CPP_FILE})
+
+if(WITH_OTLP_GRPC)
+    list(APPEND PROTOBUF_COMMON_FLAGS
+         "--grpc_out=generate_mock_code=true:${GENERATED_PROTOBUF_PATH}"
+         --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}")
+  
+    list(
+      APPEND
+      PROTOBUF_GENERATED_FILES
+      ${TRACE_SERVICE_GRPC_PB_H_FILE}
+      ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
+      ${LOGS_SERVICE_GRPC_PB_H_FILE}
+      ${LOGS_SERVICE_GRPC_PB_CPP_FILE}
+      ${METRICS_SERVICE_GRPC_PB_H_FILE}
+      ${METRICS_SERVICE_GRPC_PB_CPP_FILE})
+endif()
+
+set(PROTOBUF_RUN_PROTOC_COMMAND "\"${PROTOBUF_PROTOC_EXECUTABLE}\"")
+foreach(
+    PROTOBUF_RUN_PROTOC_ARG
+    ${PROTOBUF_COMMON_FLAGS}
+    ${PROTOBUF_INCLUDE_FLAGS}
+    ${COMMON_PROTO}
+    ${RESOURCE_PROTO}
+    ${TRACE_PROTO}
+    ${LOGS_PROTO}
+    ${METRICS_PROTO}
+    ${TRACE_SERVICE_PROTO}
+    ${LOGS_SERVICE_PROTO}
+    ${METRICS_SERVICE_PROTO})
+    set(PROTOBUF_RUN_PROTOC_COMMAND
+        "${PROTOBUF_RUN_PROTOC_COMMAND} \"${PROTOBUF_RUN_PROTOC_ARG}\"")
+endforeach()
+
 add_custom_command(
-    OUTPUT ${SOURCES} #_fake.h
-    COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --version
-    COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
-    ARGS
-        --grpc_out "${OTLP_PROTO_OUT_DIR}"
-        --cpp_out "${OTLP_PROTO_OUT_DIR}"
-        -I "${OTLP_PROTO_BUILD_ROOT}"
-        --plugin=protoc-gen-grpc="${GRPC_CPP_PLUGIN}"
-        "${OTLP_COMMON_PROTO}" "${OTLP_METRICS_PROTO}" "${OTLP_RESOURCE_PROTO}" "${OTLP_METRICS_SERVICE_PROTO}"
-    DEPENDS "${OTLP_COMMON_PROTO}" "${OTLP_METRICS_PROTO}" "${OTLP_RESOURCE_PROTO}" "${OTLP_METRICS_SERVICE_PROTO}"
-    COMMENT "Compiling open-telemetry proto files"
-)
+  OUTPUT ${PROTOBUF_GENERATED_FILES}
+  COMMAND
+    ${PROTOBUF_PROTOC_EXECUTABLE} ${PROTOBUF_COMMON_FLAGS}
+    ${PROTOBUF_INCLUDE_FLAGS} ${COMMON_PROTO} ${RESOURCE_PROTO} ${TRACE_PROTO}
+    ${LOGS_PROTO} ${METRICS_PROTO} ${TRACE_SERVICE_PROTO} ${LOGS_SERVICE_PROTO}
+    ${METRICS_SERVICE_PROTO}
+  COMMENT "[Run]: ${PROTOBUF_RUN_PROTOC_COMMAND}")
 
-add_library(${PROJECT_NAME} ${SOURCES})
+include_directories("${GENERATED_PROTOBUF_PATH}")
 
-target_link_libraries(${PROJECT_NAME}
-    PRIVATE
-    protobuf::libprotobuf
-    gRPC::grpc++
-    absl::synchronization
-)
+unset(OTELCPP_PROTO_TARGET_OPTIONS)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows|MinGW|WindowsStore")
+  list(APPEND OTELCPP_PROTO_TARGET_OPTIONS STATIC)
+elseif(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
+  list(APPEND OTELCPP_PROTO_TARGET_OPTIONS SHARED)
+else()
+  list(APPEND OTELCPP_PROTO_TARGET_OPTIONS STATIC)
+endif()
+
+set(OPENTELEMETRY_PROTO_TARGETS opentelemetry_proto)
+add_library(
+  opentelemetry_proto
+  ${OTELCPP_PROTO_TARGET_OPTIONS}
+  ${COMMON_PB_CPP_FILE}
+  ${RESOURCE_PB_CPP_FILE}
+  ${TRACE_PB_CPP_FILE}
+  ${LOGS_PB_CPP_FILE}
+  ${METRICS_PB_CPP_FILE}
+  ${TRACE_SERVICE_PB_CPP_FILE}
+  ${LOGS_SERVICE_PB_CPP_FILE}
+  ${METRICS_SERVICE_PB_CPP_FILE})
+
+if(WITH_ABSEIL)
+    find_package(absl REQUIRED)
+    target_link_libraries(opentelemetry_proto PUBLIC absl::bad_variant_access)
+endif()
+
+if(WITH_OTLP_GRPC)
+  add_library(
+    opentelemetry_proto_grpc
+    ${OTELCPP_PROTO_TARGET_OPTIONS} ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
+    ${LOGS_SERVICE_GRPC_PB_CPP_FILE} ${METRICS_SERVICE_GRPC_PB_CPP_FILE})
+
+  list(APPEND OPENTELEMETRY_PROTO_TARGETS opentelemetry_proto_grpc)
+  target_link_libraries(opentelemetry_proto_grpc
+    PUBLIC opentelemetry_proto)
+
+  get_target_property(grpc_lib_type gRPC::grpc++ TYPE)
+  if (grpc_lib_type STREQUAL "SHARED_LIBRARY")
+    target_link_libraries(opentelemetry_proto_grpc
+      PUBLIC gRPC::grpc++)
+  endif()
+  set_target_properties(opentelemetry_proto_grpc PROPERTIES EXPORT_NAME
+                                                            proto_grpc)
+  patch_protobuf_targets(opentelemetry_proto_grpc)
+  get_target_property(GRPC_INCLUDE_DIRECTORY gRPC::grpc++
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  if(GRPC_INCLUDE_DIRECTORY)
+    target_include_directories(
+      opentelemetry_proto_grpc
+      PUBLIC "$<BUILD_INTERFACE:${GRPC_INCLUDE_DIRECTORY}>")
+  endif()
+endif()
+
+set_target_properties(opentelemetry_proto PROPERTIES EXPORT_NAME proto)
+patch_protobuf_targets(opentelemetry_proto)
+
+install(
+    TARGETS ${OPENTELEMETRY_PROTO_TARGETS}
+    EXPORT "${PROJECT_NAME}-target"
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(
+    DIRECTORY ${GENERATED_PROTOBUF_PATH}/opentelemetry
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.h")
+
+if(TARGET protobuf::libprotobuf)
+  target_link_libraries(opentelemetry_proto PUBLIC protobuf::libprotobuf)
+else() # cmake 3.8 or lower
+  target_include_directories(opentelemetry_proto
+                             PUBLIC ${Protobuf_INCLUDE_DIRS})
+  target_link_libraries(opentelemetry_proto PUBLIC ${Protobuf_LIBRARIES})
+endif()
+
+if(WITH_OTLP_GRPC)
+  if(WITH_ABSEIL)
+    find_package(absl CONFIG)
+    if(TARGET absl::synchronization)
+      target_link_libraries(opentelemetry_proto_grpc
+                            PRIVATE absl::synchronization)
+    endif()
+  endif()
+endif()
+
+if(BUILD_SHARED_LIBS)
+  foreach(proto_target ${OPENTELEMETRY_PROTO_TARGETS})
+    set_property(TARGET ${proto_target} PROPERTY POSITION_INDEPENDENT_CODE ON)
+  endforeach()
+endif()

--- a/ports/opentelemetry-proto/CMakeLists.txt
+++ b/ports/opentelemetry-proto/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.1)
 
-project(OtlpProtoLib CXX)
+project(opentelemetry_proto CXX)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/tools.cmake")
 

--- a/ports/opentelemetry-proto/portfile.cmake
+++ b/ports/opentelemetry-proto/portfile.cmake
@@ -1,0 +1,21 @@
+set(VERSION "0.14.0")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO open-telemetry/opentelemetry-PROTO
+    REF "v${VERSION}"
+    SHA512 0ea22ccc4f13530754e722bc56f1a7f2bcba176da8c414bedbdc0ac281b18c1fb0ed2c74473bd7d1d6c7f59017fc64435c1c23a2428b6fdab6a44d98a157fff4
+    HEAD_REF main
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        -DWITH_OTLP_GRPC=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/opentelemetry-proto/portfile.cmake
+++ b/ports/opentelemetry-proto/portfile.cmake
@@ -1,5 +1,3 @@
-set(VERSION "0.14.0")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-telemetry/opentelemetry-PROTO
@@ -9,13 +7,23 @@ vcpkg_from_github(
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/tools.cmake" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        otlp-grpc WITH_OTLP_GRPC
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS 
-        -DWITH_OTLP_GRPC=ON
+    OPTIONS
+        -DWITH_ABSEIL=ON
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
+
+# Remove the duplicated header files in the debug directory
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/opentelemetry-proto/tools.cmake
+++ b/ports/opentelemetry-proto/tools.cmake
@@ -1,0 +1,119 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+macro(check_append_cxx_compiler_flag OUTPUT_VAR)
+  foreach(CHECK_FLAG ${ARGN})
+    check_cxx_compiler_flag(${CHECK_FLAG}
+                            "check_cxx_compiler_flag_${CHECK_FLAG}")
+    if(check_cxx_compiler_flag_${CHECK_FLAG})
+      list(APPEND ${OUTPUT_VAR} ${CHECK_FLAG})
+    endif()
+  endforeach()
+endmacro()
+
+if(NOT PATCH_PROTOBUF_SOURCES_OPTIONS_SET)
+  if(MSVC)
+    unset(PATCH_PROTOBUF_SOURCES_OPTIONS CACHE)
+    set(PATCH_PROTOBUF_SOURCES_OPTIONS /wd4244 /wd4251 /wd4267 /wd4309 /wd4668 /wd4946 /wd6001 /wd6244 /wd6246)
+
+    if(MSVC_VERSION GREATER_EQUAL 1922)
+      # see
+      # https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=vs-2019#improvements_162
+      # for detail
+      list(APPEND PATCH_PROTOBUF_SOURCES_OPTIONS /wd5054)
+    endif()
+
+    if(MSVC_VERSION GREATER_EQUAL 1925)
+      list(APPEND PATCH_PROTOBUF_SOURCES_OPTIONS /wd4996)
+    endif()
+
+    if(MSVC_VERSION LESS 1910)
+      list(APPEND PATCH_PROTOBUF_SOURCES_OPTIONS /wd4800)
+    endif()
+  else()
+    unset(PATCH_PROTOBUF_SOURCES_OPTIONS CACHE)
+    include(CheckCXXCompilerFlag)
+    check_append_cxx_compiler_flag(
+      PATCH_PROTOBUF_SOURCES_OPTIONS -Wno-type-limits
+      -Wno-deprecated-declarations -Wno-unused-parameter)
+  endif()
+  set(PATCH_PROTOBUF_SOURCES_OPTIONS_SET TRUE)
+  if(PATCH_PROTOBUF_SOURCES_OPTIONS)
+    set(PATCH_PROTOBUF_SOURCES_OPTIONS
+        ${PATCH_PROTOBUF_SOURCES_OPTIONS}
+        CACHE INTERNAL
+              "Options to disable warning of generated protobuf sources" FORCE)
+  endif()
+endif()
+
+function(patch_protobuf_sources)
+  if(PATCH_PROTOBUF_SOURCES_OPTIONS)
+    foreach(PROTO_SRC ${ARGN})
+      unset(PROTO_SRC_OPTIONS)
+      get_source_file_property(PROTO_SRC_OPTIONS ${PROTO_SRC} COMPILE_OPTIONS)
+      if(PROTO_SRC_OPTIONS)
+        list(APPEND PROTO_SRC_OPTIONS ${PATCH_PROTOBUF_SOURCES_OPTIONS})
+      else()
+        set(PROTO_SRC_OPTIONS ${PATCH_PROTOBUF_SOURCES_OPTIONS})
+      endif()
+
+      set_source_files_properties(
+        ${PROTO_SRC} PROPERTIES COMPILE_OPTIONS "${PROTO_SRC_OPTIONS}")
+    endforeach()
+    unset(PROTO_SRC)
+    unset(PROTO_SRC_OPTIONS)
+  endif()
+endfunction()
+
+function(patch_protobuf_targets)
+  if(PATCH_PROTOBUF_SOURCES_OPTIONS)
+    foreach(PROTO_TARGET ${ARGN})
+      unset(PROTO_TARGET_OPTIONS)
+      get_target_property(PROTO_TARGET_OPTIONS ${PROTO_TARGET} COMPILE_OPTIONS)
+      if(PROTO_TARGET_OPTIONS)
+        list(APPEND PROTO_TARGET_OPTIONS ${PATCH_PROTOBUF_SOURCES_OPTIONS})
+      else()
+        set(PROTO_TARGET_OPTIONS ${PATCH_PROTOBUF_SOURCES_OPTIONS})
+      endif()
+
+      set_target_properties(
+        ${PROTO_TARGET} PROPERTIES COMPILE_OPTIONS "${PROTO_TARGET_OPTIONS}")
+    endforeach()
+    unset(PROTO_TARGET)
+    unset(PROTO_TARGET_OPTIONS)
+  endif()
+endfunction()
+
+function(project_build_tools_get_imported_location OUTPUT_VAR_NAME TARGET_NAME)
+  if(CMAKE_BUILD_TYPE)
+    string(TOUPPER "IMPORTED_LOCATION_${CMAKE_BUILD_TYPE}"
+                   TRY_SPECIFY_IMPORTED_LOCATION)
+    get_target_property(${OUTPUT_VAR_NAME} ${TARGET_NAME}
+                        ${TRY_SPECIFY_IMPORTED_LOCATION})
+  endif()
+  if(NOT ${OUTPUT_VAR_NAME})
+    get_target_property(${OUTPUT_VAR_NAME} ${TARGET_NAME} IMPORTED_LOCATION)
+  endif()
+  if(NOT ${OUTPUT_VAR_NAME})
+    get_target_property(
+      project_build_tools_get_imported_location_IMPORTED_CONFIGURATIONS
+      ${TARGET_NAME} IMPORTED_CONFIGURATIONS)
+    foreach(
+      project_build_tools_get_imported_location_IMPORTED_CONFIGURATION IN
+      LISTS project_build_tools_get_imported_location_IMPORTED_CONFIGURATIONS)
+      get_target_property(
+        ${OUTPUT_VAR_NAME}
+        ${TARGET_NAME}
+        "IMPORTED_LOCATION_${project_build_tools_get_imported_location_IMPORTED_CONFIGURATION}"
+      )
+      if(${OUTPUT_VAR_NAME})
+        break()
+      endif()
+    endforeach()
+  endif()
+  if(${OUTPUT_VAR_NAME})
+    set(${OUTPUT_VAR_NAME}
+        ${${OUTPUT_VAR_NAME}}
+        PARENT_SCOPE)
+  endif()
+endfunction()

--- a/ports/opentelemetry-proto/vcpkg.json
+++ b/ports/opentelemetry-proto/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "opentelemetry-proto",
+  "version-semver": "0.14.0",
+  "port-version": 1,
+  "description": [
+    "OpenTelemetry protocol (OTLP) specification and Protobuf definitions",
+    "The OpenTelemetry Protocol (OTLP) specification describes the encoding, transport, and delivery mechanism of telemetry data between telemetry sources, intermediate nodes such as collectors and telemetry backends."
+  ],
+  "homepage": "https://github.com/open-telemetry/opentelemetry-proto",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "abseil",
+    "protobuf",
+    "grpc"
+  ]
+}

--- a/ports/opentelemetry-proto/vcpkg.json
+++ b/ports/opentelemetry-proto/vcpkg.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/open-telemetry/opentelemetry-proto",
   "license": "Apache-2.0",
   "dependencies": [
+    "abseil",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -18,8 +19,14 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "abseil",
-    "protobuf",
-    "grpc"
-  ]
+    "protobuf"
+  ],
+  "features": {
+    "otlp-grpc": {
+      "description": "Whether to include OTLP gRPC.",
+      "dependencies": [
+        "grpc"
+      ]
+    }
+  }
 }

--- a/ports/opentelemetry-proto/vcpkg.json
+++ b/ports/opentelemetry-proto/vcpkg.json
@@ -11,6 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": [
     "abseil",
+    "protobuf",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -18,8 +19,7 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    "protobuf"
+    }
   ],
   "features": {
     "otlp-grpc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6180,6 +6180,10 @@
       "baseline": "2.0.0",
       "port-version": 0
     },
+    "opentelemetry-proto": {
+      "baseline": "0.14.0",
+      "port-version": 1
+    },
     "opentracing": {
       "baseline": "1.6.0",
       "port-version": 4

--- a/versions/o-/opentelemetry-proto.json
+++ b/versions/o-/opentelemetry-proto.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "44078a96f2602a2981559919cf75709ac614bf8f",
+      "version-semver": "0.14.0",
+      "port-version": 1
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] <del> The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. </del>
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

