### PR TITLE
[libtins] Fix include header file cannot be found

### DIFF
--- a/ports/libtins/fix_include.patch
+++ b/ports/libtins/fix_include.patch
@@ -10,3 +10,13 @@ index 94bc8bf..14a15e9 100644
  
  SET_TARGET_PROPERTIES(tins PROPERTIES OUTPUT_NAME tins)
  SET_TARGET_PROPERTIES(tins PROPERTIES VERSION ${LIBTINS_VERSION} SOVERSION ${LIBTINS_VERSION} )
+diff --git a/libtins.pc.in b/libtins.pc.in
+index e9a5c29..c7e3f6c 100644
+--- a/libtins.pc.in
++++ b/libtins.pc.in
+@@ -7,4 +7,4 @@ Name: libtins
+ Description: C++ packet crafting, sniffing and interpretation library.
+ Version: @pkgconfig_version@
+ Libs: -L${libdir} -ltins
+-Cflags: -I${includedir}/tins
++Cflags: -I${includedir}

--- a/ports/libtins/fix_include.patch
+++ b/ports/libtins/fix_include.patch
@@ -1,0 +1,12 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 94bc8bf..14a15e9 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -211,6 +211,7 @@ ADD_LIBRARY(
+ )
+ 
+ TARGET_LINK_LIBRARIES(tins ${PCAP_LIBRARY} ${OPENSSL_LIBRARIES} ${LIBTINS_OS_LIBS})
++target_include_directories(tins PUBLIC $<INSTALL_INTERFACE:include>)
+ 
+ SET_TARGET_PROPERTIES(tins PROPERTIES OUTPUT_NAME tins)
+ SET_TARGET_PROPERTIES(tins PROPERTIES VERSION ${LIBTINS_VERSION} SOVERSION ${LIBTINS_VERSION} )

--- a/ports/libtins/portfile.cmake
+++ b/ports/libtins/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-source-writes.patch
         find-pcap_static.patch
+        fix_include.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIBTINS_BUILD_SHARED)

--- a/ports/libtins/vcpkg.json
+++ b/ports/libtins/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtins",
   "version": "4.3",
-  "port-version": 6,
+  "port-version": 7,
   "description": "High-level, multiplatform C++ network packet sniffing and crafting library",
   "license": "BSD-2-Clause",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4774,7 +4774,7 @@
     },
     "libtins": {
       "baseline": "4.3",
-      "port-version": 6
+      "port-version": 7
     },
     "libtomcrypt": {
       "baseline": "1.18.2",

--- a/versions/l-/libtins.json
+++ b/versions/l-/libtins.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "82c4af120a9eee2daeb74cbc28687fa0f0202122",
+      "git-tree": "30fbfd14d90e9aedac77f8272135a7e51444b01f",
       "version": "4.3",
       "port-version": 7
     },

--- a/versions/l-/libtins.json
+++ b/versions/l-/libtins.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82c4af120a9eee2daeb74cbc28687fa0f0202122",
+      "version": "4.3",
+      "port-version": 7
+    },
+    {
       "git-tree": "4a1470befea5c6b5c7418f9b85f37d6f8733d7d5",
       "version": "4.3",
       "port-version": 6


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/34440
`fatal error: 'tins/tins.h' file not found`

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```