### PR TITLE
[mpg123] Fix pc file for Windows, update deps

### DIFF
--- a/ports/mpg123/portfile.cmake
+++ b/ports/mpg123/portfile.cmake
@@ -15,11 +15,17 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     yasm_tool_helper(APPEND_TO_PATH)
 endif()
 
+vcpkg_list(SET options)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_list(APPEND options "-DLIBMPG123_LIBS=-lshlwapi")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/ports/cmake"
     OPTIONS
         -DUSE_MODULES=OFF
         -DBUILD_PROGRAMS=OFF
+        ${options}
     MAYBE_UNUSED_VARIABLES
         BUILD_PROGRAMS
 )

--- a/ports/mpg123/portfile.cmake
+++ b/ports/mpg123/portfile.cmake
@@ -11,7 +11,6 @@ vcpkg_from_sourceforge(
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-    include("${CURRENT_INSTALLED_DIR}/share/yasm-tool-helper/yasm-tool-helper.cmake")
     yasm_tool_helper(APPEND_TO_PATH)
 endif()
 

--- a/ports/mpg123/vcpkg.json
+++ b/ports/mpg123/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpg123",
   "version": "1.31.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "mpg123 is a real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3 (MPEG 1.0 layer 3 also known as MP3).",
   "homepage": "https://sourceforge.net/projects/mpg123/",
   "license": "LGPL-2.1-or-later",

--- a/ports/mpg123/vcpkg.json
+++ b/ports/mpg123/vcpkg.json
@@ -16,8 +16,12 @@
       "host": true
     },
     {
-      "name": "yasm-tool-helper",
-      "platform": "windows"
+      "name": "yasm",
+      "host": true,
+      "features": [
+        "tools"
+      ],
+      "platform": "windows & !mingw"
     }
   ]
 }

--- a/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
@@ -97,14 +97,6 @@
       "name": "ffmpeg",
       "default-features": false,
       "features": [
-        "x265"
-      ],
-      "platform": "!uwp & !(arm & windows)"
-    },
-    {
-      "name": "ffmpeg",
-      "default-features": false,
-      "features": [
         "aom"
       ],
       "platform": "!(windows & arm & !uwp)"
@@ -116,6 +108,14 @@
         "dav1d"
       ],
       "platform": "!(uwp | arm | x86 | osx)"
+    },
+    {
+      "name": "ffmpeg",
+      "default-features": false,
+      "features": [
+        "x265"
+      ],
+      "platform": "!uwp & !(arm & windows)"
     },
     {
       "name": "ffmpeg",

--- a/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
@@ -23,6 +23,7 @@
         "mp3lame",
         "nonfree",
         "openjpeg",
+        "openmpt",
         "openssl",
         "opus",
         "postproc",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5586,7 +5586,7 @@
     },
     "mpg123": {
       "baseline": "1.31.3",
-      "port-version": 2
+      "port-version": 3
     },
     "mpi": {
       "baseline": "1",

--- a/versions/m-/mpg123.json
+++ b/versions/m-/mpg123.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e990602e7caa6965db94c4ef01e3f1b44fb4f67",
+      "version": "1.31.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "58fbb0bf0ec6307689125ef1ba71112b670a42a9",
       "version": "1.31.3",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/30030 which actually is `mpg123` not exporting a `shlwapi` linking requirement.
Adds CI test of `ffmpeg[openmpt]`.