### PR TITLE
[ogre-next] fix ogre-next dependencies

### DIFF
--- a/ports/ogre-next/fix-dependencies.patch
+++ b/ports/ogre-next/fix-dependencies.patch
@@ -1,0 +1,68 @@
+diff --git a/CMake/Dependencies.cmake b/CMake/Dependencies.cmake
+--- a/CMake/Dependencies.cmake
++++ b/CMake/Dependencies.cmake
+@@ -73,23 +73,26 @@
+ # Core dependencies
+ #######################################################################
+ 
+ # Find zlib
+-find_package(ZLIB)
++find_package(ZLIB REQUIRED)
+ macro_log_feature(ZLIB_FOUND "zlib" "Simple data compression library" "http://www.zlib.net" FALSE "" "")
+ 
+ if (ZLIB_FOUND)
+   # Find zziplib
+-  find_package(ZZip)
++  find_package(ZZip NAMES unofficial-zziplib CONFIG REQUIRED)
++  set(ZZip_LIBRARIES unofficial::zziplib::libzzip)
+   macro_log_feature(ZZip_FOUND "zziplib" "Extract data from zip archives" "http://zziplib.sourceforge.net" FALSE "" "")
+ endif ()
+ 
+ # Find FreeImage
+-find_package(FreeImage)
++find_package(FreeImage NAMES freeimage REQUIRED)
++set(FreeImage_LIBRARIES freeimage::FreeImage)
+ macro_log_feature(FreeImage_FOUND "freeimage" "Support for commonly used graphics image formats" "http://freeimage.sourceforge.net" FALSE "" "")
+ 
+ # Find FreeType
+-find_package(Freetype)
++find_package(FREETYPE NAMES freetype REQUIRED)
++set(FREETYPE_LIBRARIES freetype)
+ macro_log_feature(FREETYPE_FOUND "freetype" "Portable font engine" "http://www.freetype.org" FALSE "" "")
+ 
+ find_package(Vulkan)
+ macro_log_feature(Vulkan_FOUND "vulkan-sdk" "Vulkan SDK" "https://vulkan.lunarg.com/" FALSE "" "")
+diff --git a/CMake/CMakeLists.txt b/CMake/CMakeLists.txt
+--- a/CMake/CMakeLists.txt
++++ b/CMake/CMakeLists.txt
+@@ -43,14 +43,10 @@
+ endif ()
+ 
+ set(STATIC_INST_FILES
+   Packages/FindDirectX.cmake
+-  Packages/FindFreeImage.cmake
+-  Packages/FindFreetype.cmake
+   Packages/FindOpenGLES.cmake
+   Packages/FindOpenGLES2.cmake
+-  Packages/FindZLIB.cmake
+-  Packages/FindZZip.cmake
+   Packages/FindSoftimage.cmake
+ )
+ if (WIN32)
+   set(INST_FILES ${INST_FILES}
+diff --git a/CMake/Packages/FindZLIB.cmake b/CMake/Packages/FindZLIB_NOTUSE.cmake
+similarity index 100%
+rename from CMake/Packages/FindZLIB.cmake
+rename to CMake/Packages/FindZLIB_NOTUSE.cmake
+diff --git a/CMake/Packages/FindZZip.cmake b/CMake/Packages/FindZZip_NOTUSE.cmake
+similarity index 100%
+rename from CMake/Packages/FindZZip.cmake
+rename to CMake/Packages/FindZZip_NOTUSE.cmake
+diff --git a/CMake/Packages/FindFreeImage.cmake b/CMake/Packages/FindFreeImage_NOTUSE.cmake
+similarity index 100%
+rename from CMake/Packages/FindFreeImage.cmake
+rename to CMake/Packages/FindFreeImage_NOTUSE.cmake
+diff --git a/CMake/Packages/FindFreetype.cmake b/CMake/Packages/FindFreetype_NOTUSE.cmake
+similarity index 100%
+rename from CMake/Packages/FindFreetype.cmake
+rename to CMake/Packages/FindFreetype_NOTUSE.cmake

--- a/ports/ogre-next/portfile.cmake
+++ b/ports/ogre-next/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
         fix_find_package_sdl2.patch
         avoid-name-clashes.patch
         fix-error-c2039.patch
+        fix-dependencies.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/CMake/Packages/FindOpenEXR.cmake")

--- a/ports/ogre-next/toolchain_fixes.patch
+++ b/ports/ogre-next/toolchain_fixes.patch
@@ -19,19 +19,6 @@ index f3a62f2..b53df6f 100644
  endif()
  
  set(INST_FILES
-diff --git a/CMake/Packages/FindFreeImage.cmake b/CMake/Packages/FindFreeImage.cmake
-index 7c89ec5..d8314f0 100644
---- a/CMake/Packages/FindFreeImage.cmake
-+++ b/CMake/Packages/FindFreeImage.cmake
-@@ -43,7 +43,7 @@ find_path(FreeImage_INCLUDE_DIR NAMES FreeImage.h HINTS ${FreeImage_INC_SEARCH_P
- find_library(FreeImage_LIBRARY_REL NAMES ${FreeImage_LIBRARY_NAMES} HINTS ${FreeImage_LIB_SEARCH_PATH} ${FreeImage_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" Release RelWithDebInfo MinSizeRel)
- find_library(FreeImage_LIBRARY_DBG NAMES ${FreeImage_LIBRARY_NAMES_DBG} HINTS ${FreeImage_LIB_SEARCH_PATH} ${FreeImage_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" Debug)
- 
--make_library_set(FreeImage_LIBRARY)
-+make_library_set(FreeImage)
- 
- findpkg_finish(FreeImage)
- 
 diff --git a/CMake/Packages/FindGLSLOptimizer.cmake b/CMake/Packages/FindGLSLOptimizer.cmake
 index dd4b179..6f158fc 100644
 --- a/CMake/Packages/FindGLSLOptimizer.cmake
@@ -149,25 +136,6 @@ index 4200aa0..35e4ea3 100644
 -make_library_set(TBB_MALLOC_PROXY_LIBRARY)
 +make_library_set(TBB_MALLOC_PROXY)
  findpkg_finish(TBB_MALLOC_PROXY)
-diff --git a/CMake/Packages/FindZZip.cmake b/CMake/Packages/FindZZip.cmake
-index c112071..214d9e5 100644
---- a/CMake/Packages/FindZZip.cmake
-+++ b/CMake/Packages/FindZZip.cmake
-@@ -39,12 +39,12 @@ use_pkgconfig(ZZip_PKGC zziplib)
- 
- findpkg_framework(ZZip)
- 
--find_path(ZZip_INCLUDE_DIR NAMES zzip/zzip.h HINTS ${ZZip_INC_SEARCH_PATH} ${ZZip_PKGC_INCLUDE_DIRS})
-+find_path(ZZip_INCLUDE_DIRS NAMES zzip/zzip.h HINTS ${ZZip_INC_SEARCH_PATH} ${ZZip_PKGC_INCLUDE_DIRS})
- 
- find_library(ZZip_LIBRARY_REL NAMES ${ZZip_LIBRARY_NAMES} HINTS ${ZZip_LIB_SEARCH_PATH} ${ZZip_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" Release RelWithDebInfo MinSizeRel)
- find_library(ZZip_LIBRARY_DBG NAMES ${ZZip_LIBRARY_NAMES_DBG} HINTS ${ZZip_LIB_SEARCH_PATH} ${ZZip_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" Debug)
- 
--make_library_set(ZZip_LIBRARY)
-+make_library_set(ZZip)
- 
- findpkg_finish(ZZip)
- 
 diff --git a/CMake/Utils/FindPkgMacros.cmake b/CMake/Utils/FindPkgMacros.cmake
 index 53111e0..8dffbbc 100644
 --- a/CMake/Utils/FindPkgMacros.cmake

--- a/ports/ogre-next/vcpkg.json
+++ b/ports/ogre-next/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ogre-next",
   "version": "2.3.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Ogre 2.1 & 2.2 - scene-oriented, flexible 3D engine written in C++",
   "homepage": "https://github.com/OGRECave/ogre-next",
   "license": "MIT",
@@ -11,6 +11,7 @@
     "freeimage",
     "freetype",
     "openvr",
+    "pkgconf",
     "poco",
     "rapidjson",
     "sdl2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6018,7 +6018,7 @@
     },
     "ogre-next": {
       "baseline": "2.3.1",
-      "port-version": 2
+      "port-version": 3
     },
     "ois": {
       "baseline": "1.5.1",

--- a/versions/o-/ogre-next.json
+++ b/versions/o-/ogre-next.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c93cd3ebf7b2a50082e97f5f7a6f4ed1cf1f5c94",
+      "version": "2.3.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "0089cd2cc3d48d19a5b465f43454dfb0124f9723",
       "version": "2.3.1",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->


Taken from here:
https://github.com/microsoft/vcpkg/pull/27115