### PR TITLE
[breakpad] Fix breakpad use atl not atlmfc

### DIFF
--- a/ports/breakpad/vcpkg.json
+++ b/ports/breakpad/vcpkg.json
@@ -1,14 +1,14 @@
 {
   "name": "breakpad",
   "version-date": "2022-07-12",
-  "port-version": 5,
+  "port-version": 6,
   "description": "a set of client and server components which implement a crash-reporting system.",
   "homepage": "https://github.com/google/breakpad",
   "license": "BSD-3-Clause",
   "supports": "!uwp & (!windows | !arm) & (!windows | !arm64)",
   "dependencies": [
     {
-      "name": "atlmfc",
+      "name": "atl",
       "platform": "windows"
     },
     "libdisasm",

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a244c96e6e67d802de17045cb395c0f11e0b3aa4",
+      "version-date": "2022-07-12",
+      "port-version": 6
+    },
+    {
       "git-tree": "a451811c203f1ec086288b40dd4571d97bb7033e",
       "version-date": "2022-07-12",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1306,7 +1306,7 @@
     },
     "breakpad": {
       "baseline": "2022-07-12",
-      "port-version": 5
+      "port-version": 6
     },
     "brigand": {
       "baseline": "1.3.0",


### PR DESCRIPTION
Just use atl and not atlmfc on breakpad.

- [*] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [*] SHA512s are updated for each updated download
- [*] The "supports" clause reflects platforms that may be fixed by this new version
- [*] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [*] Any patches that are no longer applied are deleted from the port's directory.
- [*] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [*] Only one version is added to each modified port's versions file.