### PR TITLE
[nifticlib] update to 2022-07-04 to add include path to fix breaks app build

### DIFF
--- a/ports/nifticlib/portfile.cmake
+++ b/ports/nifticlib/portfile.cmake
@@ -1,10 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO    NIFTI-Imaging/nifti_clib 
-    REF 65f801b9c2f1f15f4de4a19d45e6595c25765632
-    SHA512 be03cdc6cf17fd9ff74c5ecc1f6b2132121bb4b7973a731da334af2a8428d1f0dbbf7b94b2511d1ff7e515b8cc4cf3316d62b189566fb6ffc88c6146eebd48ff
+    REPO  NIFTI-Imaging/nifti_clib 
+    REF 5a8016be2161058f116b39ca476734bd81bb83c5
+    SHA512 782cb4e494d73b054f8e3ab5f059b952fa461ceb3a0e12989ef1485675d1009d107c496abe6a495fbc30214d92859faad2c58a3edb10899114b440476b613315
     HEAD_REF master
-    PATCHES zlib_include.patch
+    PATCHES
+        zlib_include.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)
@@ -49,11 +50,5 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-vcpkg_replace_string(
-    "${CURRENT_PACKAGES_DIR}/share/nifti/NIFTITargets.cmake"
-    [[INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/nifti"]]
-    [[INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include/nifti"]]
-    )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/nifticlib/portfile.cmake
+++ b/ports/nifticlib/portfile.cmake
@@ -50,4 +50,10 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_replace_string(
+    "${CURRENT_PACKAGES_DIR}/share/nifti/NIFTITargets.cmake"
+    [[INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/nifti"]]
+    [[INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include/nifti"]]
+    )
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/nifticlib/vcpkg.json
+++ b/ports/nifticlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nifticlib",
   "version-date": "2020-04-30",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Nifticlib is a C I/O library for reading and writing files in the nifti-1 data format.",
   "homepage": "https://github.com/NIFTI-Imaging/nifti_clib",
   "license": null,

--- a/ports/nifticlib/vcpkg.json
+++ b/ports/nifticlib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nifticlib",
-  "version-date": "2020-04-30",
-  "port-version": 5,
+  "version-date": "2022-07-04",
   "description": "Nifticlib is a C I/O library for reading and writing files in the nifti-1 data format.",
   "homepage": "https://github.com/NIFTI-Imaging/nifti_clib",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5830,7 +5830,7 @@
     },
     "nifticlib": {
       "baseline": "2020-04-30",
-      "port-version": 4
+      "port-version": 5
     },
     "nlohmann-fifo-map": {
       "baseline": "2018.05.07",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5829,8 +5829,8 @@
       "port-version": 1
     },
     "nifticlib": {
-      "baseline": "2020-04-30",
-      "port-version": 5
+      "baseline": "2022-07-04",
+      "port-version": 0
     },
     "nlohmann-fifo-map": {
       "baseline": "2018.05.07",

--- a/versions/n-/nifticlib.json
+++ b/versions/n-/nifticlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04096233d605e377c31588273d928c15538713ac",
+      "version-date": "2022-07-04",
+      "port-version": 0
+    },
+    {
       "git-tree": "d889870db5d6d2e5afc8e738c6f6451c7d237a4c",
       "version-date": "2020-04-30",
       "port-version": 4

--- a/versions/n-/nifticlib.json
+++ b/versions/n-/nifticlib.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "4c60bd256088eb75707a58a3ff51317b6eb564b9",
-      "version-date": "2020-04-30",
-      "port-version": 5
-    },
-    {
       "git-tree": "d889870db5d6d2e5afc8e738c6f6451c7d237a4c",
       "version-date": "2020-04-30",
       "port-version": 4

--- a/versions/n-/nifticlib.json
+++ b/versions/n-/nifticlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c60bd256088eb75707a58a3ff51317b6eb564b9",
+      "version-date": "2020-04-30",
+      "port-version": 5
+    },
+    {
       "git-tree": "d889870db5d6d2e5afc8e738c6f6451c7d237a4c",
       "version-date": "2020-04-30",
       "port-version": 4


### PR DESCRIPTION
Fixes #34444
Updated to commit 2022-07-04 applying upstream changes https://github.com/NIFTI-Imaging/nifti_clib/pull/149/files allows users to include znzlib.h using:
````
#include <stdio.h>
#include "znzlib.h"

int main()
{
    printf("%s\n", "HELLO WORLD");
    return 0;
}
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Tested usage successfully by `nifticlib:x64-windows`:
````
nifticlib provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(NIFTI CONFIG REQUIRED)
  target_link_libraries(main PRIVATE NIFTI::znz NIFTI::nifti2 NIFTI::niftiio NIFTI::nifticdf)
````
