### PR TITLE
[lerc] update to 4.0.1

### DIFF
--- a/ports/lerc/portfile.cmake
+++ b/ports/lerc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Esri/lerc
-    REF  v4.0.0
-    SHA512 36fe453b6e732f6bed554d1c1c5cd4668aec63593d6de11f12b659c7b9cbc059ac9aaacc6cea483b3257d522f1b07e13c299914d08b1f8aeb0bb2cde42ba47cf
+    REF "js_v${VERSION}"
+    SHA512 e7389576210e1fcc122b93194c20e5ea9c514514283695b8d770c3133ea1fdffdc06729552041aab2840c5aade676762b0d86e79bfc018fd57578987ad18e43a
     HEAD_REF master
     PATCHES
         "create_package.patch"

--- a/ports/lerc/vcpkg.json
+++ b/ports/lerc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "lerc",
-  "version": "4.0",
-  "port-version": 1,
+  "version": "4.0.1",
   "description": "An open-source image or raster format which supports rapid encoding and decoding for any pixel type",
   "homepage": "https://github.com/Esri/lerc",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3909,8 +3909,8 @@
       "port-version": 0
     },
     "lerc": {
-      "baseline": "4.0",
-      "port-version": 1
+      "baseline": "4.0.1",
+      "port-version": 0
     },
     "lest": {
       "baseline": "1.35.1",

--- a/versions/l-/lerc.json
+++ b/versions/l-/lerc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c3b059b86753037a24c9567b98556dfb8b6d262",
+      "version": "4.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b7391a7d4c1b31d4fcd7160f305c7b9de9621ff2",
       "version": "4.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

