### PR TITLE
[libenvpp] update to 1.3.0

### DIFF
--- a/ports/libenvpp/portfile.cmake
+++ b/ports/libenvpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ph3at/libenvpp
     REF v${VERSION}
-    SHA512 d8d2e6405311be1cba47cdf1c8b29018c84716a0d34a18bf3b6fa8c05f5eddf447ddee407a407d765e92296c5d7e7b5f2fe4561fb66f5165826825158ef82fc8
+    SHA512 0b4ed6496efc54165e8e161510146146cfefb90c303a913bab6a6749ae4292823c19f34734d417a2bd4d44d8d05a68c60acd852c03487f40ba6126eeb3db16bd
     HEAD_REF main
     PATCHES
         fix-dependencies.patch

--- a/ports/libenvpp/vcpkg.json
+++ b/ports/libenvpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libenvpp",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "A modern C++ library for type-safe environment variable parsing ",
   "homepage": "https://github.com/ph3at/libenvpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4109,7 +4109,7 @@
       "port-version": 2
     },
     "libenvpp": {
-      "baseline": "1.0.0",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "libepoxy": {

--- a/versions/l-/libenvpp.json
+++ b/versions/l-/libenvpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5388e430f77d77307fe2d4358241e684886390bb",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8eb66698367b380452b1f693237d383381e2373e",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

