### PR TITLE
[libgpiod] update to 2.0.2

### DIFF
--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
     FETCH_REF "v${VERSION}"
-    REF ae275c375477f207912113e5cf190fada78f3f90
+    REF d350f67ffd52e948ac81280d87b51b715d95044c
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
     FETCH_REF "v${VERSION}"
-    REF ae275c375477f207912113e5cf190fada78f3f90 # v2.0.1
+    REF ae275c375477f207912113e5cf190fada78f3f90
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/libgpiod/vcpkg.json
+++ b/ports/libgpiod/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgpiod",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "C library and tools for interacting with the linux GPIO character device",
   "homepage": "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4213,7 +4213,7 @@
       "port-version": 0
     },
     "libgpiod": {
-      "baseline": "2.0.1",
+      "baseline": "2.0.2",
       "port-version": 0
     },
     "libgpod": {

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c3e885e753b0bf04e4469afb5a48bcf4162b85d3",
+      "git-tree": "e78935fc408abcc2e62d8d1ca1831b0fd5510b7d",
       "version": "2.0.2",
       "port-version": 0
     },

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3e885e753b0bf04e4469afb5a48bcf4162b85d3",
+      "version": "2.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d5fde793827568c4be74cb76793650e37e3e5354",
       "version": "2.0.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

