### PR TITLE
[libics] update to 1.6.6

### DIFF
--- a/ports/libics/fix-integral-include.patch
+++ b/ports/libics/fix-integral-include.patch
@@ -1,0 +1,12 @@
+diff --git a/support/cpp_interface/libics.hpp b/support/cpp_interface/libics.hpp
+index 73f76e6..4ea2b1e 100644
+--- a/support/cpp_interface/libics.hpp
++++ b/support/cpp_interface/libics.hpp
+@@ -40,6 +40,7 @@
+ #include <string>
+ #include <utility>
+ #include <vector>
++#include <cstdint>
+ 
+ #if defined(__WIN32__) && !defined(WIN32)
+ #  define WIN32

--- a/ports/libics/portfile.cmake
+++ b/ports/libics/portfile.cmake
@@ -1,9 +1,10 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO svi-opensource/libics
-    REF ae55128e0532d78aaea4adce21a3fa553d208b83 # 1.6.5
-    SHA512 37a1e9034d7e32954840e18f3e3c19f6ed2f8c651ce0da53f678e2f04653be0fc4d9ab3dca8b6f0bfcaec2a9cc560ccfbc7d9034977faa14036281d6a3ca662a
+    REF "${VERSION}"
+    SHA512 290d6d7bd3f5611d0b46aa6406ef10449ee768bc14d0b34f0bb365ca46f98b7fd4065c94fd9594e357427a4d0644f2724a1f773c7f3b43adc3db2389b94ee88e
     HEAD_REF master
+    PATCHES fix-integral-include.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/libics/vcpkg.json
+++ b/ports/libics/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libics",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Reference library for ICS (Image Cytometry Standard), an open standard for writing images of any dimensionality and data type to file, together with associated information regarding the recording equipment or recorded subject.",
   "homepage": "https://github.com/svi-opensource/libics",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4273,7 +4273,7 @@
       "port-version": 1
     },
     "libics": {
-      "baseline": "1.6.5",
+      "baseline": "1.6.6",
       "port-version": 0
     },
     "libideviceactivation": {

--- a/versions/l-/libics.json
+++ b/versions/l-/libics.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f9e307f0012cebce534960f7b2d22020a9ba6af",
+      "git-tree": "dd79bb59a4716358360e475a7aaa3ec6a20c80e1",
       "version": "1.6.6",
       "port-version": 0
     },

--- a/versions/l-/libics.json
+++ b/versions/l-/libics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f9e307f0012cebce534960f7b2d22020a9ba6af",
+      "version": "1.6.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "aea77d2369ae831edee51b05bc8dcad585795990",
       "version": "1.6.5",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

