### PR TITLE
[libtracepoint,libtracepoint-control,libtracepoint-decode,libeventheader-tracepoint,libeventheader-decode] Update to 1.2.1

### DIFF
--- a/ports/libeventheader-decode/portfile.cmake
+++ b/ports/libeventheader-decode/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
-    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
-    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
+    REF "v${VERSION}"
+    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libeventheader-decode/vcpkg.json
+++ b/ports/libeventheader-decode/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libeventheader-decode",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "C++ classes for decoding EventHeader-encoded Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -8,11 +8,11 @@
   "dependencies": [
     {
       "name": "libeventheader-tracepoint",
-      "version>=": "1.1.0"
+      "version>=": "1.2.1"
     },
     {
       "name": "libtracepoint-decode",
-      "version>=": "1.1.0"
+      "version>=": "1.2.1"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libeventheader-tracepoint/portfile.cmake
+++ b/ports/libeventheader-tracepoint/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
-    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
-    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
+    REF "v${VERSION}"
+    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libeventheader-tracepoint/vcpkg.json
+++ b/ports/libeventheader-tracepoint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libeventheader-tracepoint",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "C/C++ interface for generating EventHeader-encoded Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "libtracepoint",
-      "version>=": "1.1.0"
+      "version>=": "1.2.1"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libtracepoint-control/portfile.cmake
+++ b/ports/libtracepoint-control/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
-    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
-    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
+    REF "v${VERSION}"
+    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint-control/vcpkg.json
+++ b/ports/libtracepoint-control/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtracepoint-control",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "C++ classes for collecting Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "libtracepoint-decode",
-      "version>=": "1.1.0"
+      "version>=": "1.2.1"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libtracepoint-decode/portfile.cmake
+++ b/ports/libtracepoint-decode/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
-    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
-    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
+    REF "v${VERSION}"
+    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint-decode/vcpkg.json
+++ b/ports/libtracepoint-decode/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtracepoint-decode",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "C++ classes for decoding Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",

--- a/ports/libtracepoint/portfile.cmake
+++ b/ports/libtracepoint/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
-    REF 3173fa8180eb5bb7167a686c8c18baf8ef0bf31b
-    SHA512 9bd2e16da96e37df58e4281d1341051eb90574cb29d380f04f90bba7507dc9b3037ded91206d5e1808b53734fc0fc1fd06c4a220b0f34d0078ac168e6c639462
+    REF "v${VERSION}"
+    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint/vcpkg.json
+++ b/ports/libtracepoint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtracepoint",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "C/C++ interface for generating Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4129,7 +4129,7 @@
       "port-version": 0
     },
     "libeventheader-tracepoint": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.1",
       "port-version": 0
     },
     "libevhtp": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4125,7 +4125,7 @@
       "port-version": 0
     },
     "libeventheader-decode": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.1",
       "port-version": 0
     },
     "libeventheader-tracepoint": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4777,15 +4777,15 @@
       "port-version": 0
     },
     "libtracepoint": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.1",
       "port-version": 0
     },
     "libtracepoint-control": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.1",
       "port-version": 0
     },
     "libtracepoint-decode": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.1",
       "port-version": 0
     },
     "libu2f-server": {

--- a/versions/l-/libeventheader-decode.json
+++ b/versions/l-/libeventheader-decode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75e4da728961822b82de47fb036aeae025893fb6",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e830f1815ed8de8c73a7e90841533854b54261c",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/l-/libeventheader-tracepoint.json
+++ b/versions/l-/libeventheader-tracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "076106bc342a9e9253ced5bfd4e13ac16b360d20",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ba5030dde966e742b068efb77cab8f820f0ab7ea",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/l-/libtracepoint-control.json
+++ b/versions/l-/libtracepoint-control.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "410f33d930822507551474d486031021c4fea1dd",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "46fe85ffc8eb1f431685a49dace1cf330d54d6c9",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/l-/libtracepoint-decode.json
+++ b/versions/l-/libtracepoint-decode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51ab3448c97daa75b873c3e4b70f2894908fc2f4",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3559772cf7c926b54b92bdc0e72ecaa9e06534d6",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/l-/libtracepoint.json
+++ b/versions/l-/libtracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f85708521c851b4c64ad10c04ad0261343fef25",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0106479d49132d017d8c89f4189bce8cb4251479",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] <del> The "supports" clause reflects platforms that may be fixed by this new version </del>
- [ ] <del> Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. </del>
- [ ] <del> Any patches that are no longer applied are deleted from the port's directory. </del>
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

