### PR TITLE
[libcap, libgpiod] Use tarballs from kernel.org.

### DIFF
--- a/ports/libcap/portfile.cmake
+++ b/ports/libcap/portfile.cmake
@@ -1,8 +1,11 @@
-vcpkg_from_git(
-    OUT_SOURCE_PATH SOURCE_PATH
-    URL git://git.kernel.org/pub/scm/libs/libcap/libcap.git
-    FETCH_REF "libcap-${VERSION}"
-    REF 3c7dda330bd9a154bb5b878d31fd591e4951fe17
+vcpkg_download_distfile(ARCHIVE
+    URLS https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-3c7dda330bd9a154bb5b878d31fd591e4951fe17.tar.gz
+    FILENAME libpcap-${VERSION}.tar.gz
+    SHA512 0732c9f07be38c2bb06409f1f31d7ed5ad31b38ae380650b334074856f89b885deabb9603e21a989e81b530050c068bbbf60157adbf3ca3893e4bca7d61f63d2
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/configure" DESTINATION "${SOURCE_PATH}")

--- a/ports/libcap/vcpkg.json
+++ b/ports/libcap/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libcap",
   "version": "2.69",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for getting and setting POSIX.1e (formerly POSIX 6) draft 15 capabilities.",
   "homepage": "https://git.kernel.org/pub/scm/libs/libcap/libcap.git",
   "license": "BSD-3-Clause OR GPL-2.0-only",

--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -1,8 +1,11 @@
-vcpkg_from_git(
-    OUT_SOURCE_PATH SOURCE_PATH
-    URL git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
-    FETCH_REF "v${VERSION}"
-    REF d350f67ffd52e948ac81280d87b51b715d95044c
+vcpkg_download_distfile(ARCHIVE
+    URLS https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-9068bb08dc3bf183eee6de2577ad266fe6b8f434.tar.gz
+    FILENAME libgpiod-${VERSION}.tar.gz
+    SHA512 3c569471007d12d94cb74377187dfe8b979de08f3747dca6348a4212ffb6d5f699af1d1135c25c70bcd17d533b09499fd0f1b3c5deac7d0a2d1bbf31092033c3
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/libgpiod/vcpkg.json
+++ b/ports/libgpiod/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libgpiod",
   "version": "2.0.2",
+  "port-version": 1,
   "description": "C library and tools for interacting with the linux GPIO character device",
   "homepage": "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4018,7 +4018,7 @@
     },
     "libcap": {
       "baseline": "2.69",
-      "port-version": 1
+      "port-version": 2
     },
     "libcbor": {
       "baseline": "0.10.2",
@@ -4238,7 +4238,7 @@
     },
     "libgpiod": {
       "baseline": "2.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libgpod": {
       "baseline": "2019-08-29",

--- a/versions/l-/libcap.json
+++ b/versions/l-/libcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d699cd38c2cf76ab59628fc3437c381ccabd2383",
+      "version": "2.69",
+      "port-version": 2
+    },
+    {
       "git-tree": "3f8091b1a094e5a0ab51652478289c040e98e7ca",
       "version": "2.69",
       "port-version": 1

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c470b2f0c5a31ebee904f7486e50b2adf0f8e8c2",
+      "version": "2.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "e78935fc408abcc2e62d8d1ca1831b0fd5510b7d",
       "version": "2.0.2",
       "port-version": 0


### PR DESCRIPTION
I noticed this while reviewing https://github.com/microsoft/vcpkg/pull/34472 that these would be better to use tarballs which are eligible to be asset cached.

