### PR TITLE
[libosip2, talib] Don't install include/makefile.am.

### DIFF
--- a/ports/libosip2/portfile.cmake
+++ b/ports/libosip2/portfile.cmake
@@ -34,7 +34,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         PROJECT_SUBPATH "platform/vsnet/osip2.vcxproj"
     )
 
-    file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" PATTERN Makefile.am EXCLUDE)
 
     vcpkg_msbuild_install(
         SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libosip2/portfile.cmake
+++ b/ports/libosip2/portfile.cmake
@@ -34,7 +34,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         PROJECT_SUBPATH "platform/vsnet/osip2.vcxproj"
     )
 
-    file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" PATTERN Makefile.am EXCLUDE)
+    file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" PATTERN Makefile.* EXCLUDE)
 
     vcpkg_msbuild_install(
         SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libosip2/vcpkg.json
+++ b/ports/libosip2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libosip2",
   "version": "5.2.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "oSIP is an LGPL implementation of SIP. It's stable, portable, flexible and compliant! -may be more-! It is used mostly with eXosip2 stack (GPL) which provides simpler API for User-Agent implementation.",
   "homepage": "https://www.gnu.org/software/osip/",
   "supports": "!(windows & arm) & !uwp",

--- a/ports/talib/portfile.cmake
+++ b/ports/talib/portfile.cmake
@@ -75,6 +75,7 @@ file(
 file(
     INSTALL "${SOURCE_PATH}/c/include"
     DESTINATION ${CURRENT_PACKAGES_DIR}
+    PATTERN Makefile.am EXCLUDE
 )
 
 # License file

--- a/ports/talib/portfile.cmake
+++ b/ports/talib/portfile.cmake
@@ -75,7 +75,7 @@ file(
 file(
     INSTALL "${SOURCE_PATH}/c/include"
     DESTINATION ${CURRENT_PACKAGES_DIR}
-    PATTERN Makefile.am EXCLUDE
+    PATTERN Makefile.* EXCLUDE
 )
 
 # License file

--- a/ports/talib/vcpkg.json
+++ b/ports/talib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "talib",
   "version-semver": "0.4.0",
+  "port-version": 1,
   "description": "TA-Lib - Technical Analysis Library",
   "homepage": "https://ta-lib.github.io/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4526,7 +4526,7 @@
     },
     "libosip2": {
       "baseline": "5.2.0",
-      "port-version": 4
+      "port-version": 5
     },
     "libosmium": {
       "baseline": "2.20.0",
@@ -8142,7 +8142,7 @@
     },
     "talib": {
       "baseline": "0.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "taocpp-json": {
       "baseline": "2020-09-14",

--- a/versions/l-/libosip2.json
+++ b/versions/l-/libosip2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a092372398be97d4fdb7338cf5c7fd9043d82364",
+      "version": "5.2.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "9b3b93c2039a5369ddd07c5dfb482644ce18c961",
       "version": "5.2.0",
       "port-version": 4

--- a/versions/l-/libosip2.json
+++ b/versions/l-/libosip2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a092372398be97d4fdb7338cf5c7fd9043d82364",
+      "git-tree": "e2811fe1a0d4cb7faabaebfa4cf47e1296bcddd2",
       "version": "5.2.0",
       "port-version": 5
     },

--- a/versions/t-/talib.json
+++ b/versions/t-/talib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "85cd8a391cd25eb07632fa3db8bf745d94ca369c",
+      "git-tree": "b21601e58da50f810bacb160a8960a131227aa28",
       "version-semver": "0.4.0",
       "port-version": 1
     },

--- a/versions/t-/talib.json
+++ b/versions/t-/talib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85cd8a391cd25eb07632fa3db8bf745d94ca369c",
+      "version-semver": "0.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "639b6ba11c1768faf5ab92f42d4cdf0a1bba2270",
       "version-semver": "0.4.0",
       "port-version": 0


### PR DESCRIPTION
Detected by https://dev.azure.com/vcpkg/public/_build/results?buildId=95376

```
error: The following files are already installed in D:/installed/x86-windows and are in conflict with talib:x86-windows
Installed by libosip2:x86-windows
include/Makefile.am

Stored binaries in 1 destinations in 446 ms.
Elapsed time to handle talib:x86-windows: 40 s
```

Broken by https://github.com/microsoft/vcpkg/pull/34316 which adds talib
