### PR TITLE
Support building in specific modes without a custom triplet.

### DIFF
--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -12,7 +12,7 @@ parameters:
   - name: tripletPattern
     displayName: 'Enable triplets which contain this substring'
     type: string
-    default: '-'
+    default: 'STOP'
 
 jobs:
 - job: mintsas

--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -155,6 +155,13 @@ if(CMD STREQUAL "BUILD")
     endif()
     file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}" "${CURRENT_PACKAGES_DIR}")
 
+    # VCPKG_DEFAULT_BUILD_TYPE is set by the -x-build-type option when installing in manifest mode.
+    # Set VCPKG_BUILD_TYPE to it right before including the triplet file, to give the triplet file
+    # a chance to override the build type.
+    if(VCPKG_DEFAULT_BUILD_TYPE)
+        set(VCPKG_BUILD_TYPE "${VCPKG_DEFAULT_BUILD_TYPE}")
+    endif()
+
     include("${CMAKE_TRIPLET_FILE}")
 
     set(HOST_TRIPLET "${_HOST_TRIPLET}")


### PR DESCRIPTION
This PR introduces the `VCPKG_DEFAULT_BUILD_TYPE` option in the CMake toolchain file, that provides a default value to `VCPKG_BUILD_TYPE` when building the ports.

Besides `debug` or `release`, this option can also be set to `auto`. In that case, vcpkg will consider the `CMAKE_BUILD_TYPE` or `CMAKE_CONFIGURATION_TYPES` variables, and if all configurations are known (`Debug`, `Release`, `RelWithDebInfo`, `MinSizeRel`) and map to only `debug` or `release`, it will build the ports in only that mode. If `VCPKG_DEFAULT_BUILD_TYPE` is not specified, or the CMake project is being built in an unknown configuration, the existing behavior is preserved and vcpkg will default to building in both modes.

Let's talk about how it works. When `VCPKG_DEFAULT_BUILD_TYPE` is specified, its value (after resolving `auto`) will be passed to the vcpkg tool via the `--x-build-type` setting, introduced in microsoft/vcpkg-tool#1231. The tool will propagate `VCPKG_DEFAULT_BUILD_TYPE` when running the portfile in script mode, and `ports.cmake` will default `VCPKG_BUILD_TYPE` to `VCPKG_DEFAULT_BUILD_TYPE` if the latter is specified. This will happen before the triplet file gets `include`d, to allow the triplet to override the build type and maintain compatibility.

`VCPKG_DEFAULT_BUILD_TYPE` is supported only in manifest mode.

Fixes #10683

Depends on microsoft/vcpkg-tool#1231