### PR TITLE
[enkits] Fix config file name

### DIFF
--- a/ports/enkits/portfile.cmake
+++ b/ports/enkits/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 # Must specify args due to case sensitivity on some filesystems
 vcpkg_cmake_config_fixup(PACKAGE_NAME enkiTS CONFIG_PATH share/enkiTS)
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/enkiTS/enkiTS-config.cmake" "${CURRENT_PACKAGES_DIR}/share/enkiTS/enkiTSConfig.cmake")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/enkits/vcpkg.json
+++ b/ports/enkits/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "enkits",
   "version": "1.11",
+  "port-version": 1,
   "description": "A permissively licensed C and C++ Task Scheduler for creating parallel programs.",
   "homepage": "https://github.com/dougbinks/enkiTS",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2394,7 +2394,7 @@
     },
     "enkits": {
       "baseline": "1.11",
-      "port-version": 0
+      "port-version": 1
     },
     "ensmallen": {
       "baseline": "2.19.1",

--- a/versions/e-/enkits.json
+++ b/versions/e-/enkits.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d83be5a37b104f4c67030a8184af78bfa248137c",
+      "version": "1.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "8fe0e538a1d8685844297f35b7e00f4984d4bb09",
       "version": "1.11",
       "port-version": 0


### PR DESCRIPTION
`enkiTS-config.cmake` doesn't work on case-sensitive filesystems:
~~~
  Could not find a package configuration file provided by "enkiTS" with any
  of the following names:

    enkiTSConfig.cmake
    enkits-config.cmake
~~~

(cf. https://github.com/microsoft/vcpkg/pull/34277#discussion_r1351242632)

Upstream: https://github.com/dougbinks/enkiTS/pull/103