### PR TITLE
[vcpkg baseline][highs] Fix compiler selection

### DIFF
--- a/ports/highs/fix-cmake-output.patch
+++ b/ports/highs/fix-cmake-output.patch
@@ -10,15 +10,11 @@ index 605a1e2..148c006 100644
              return 0;
          }"
      HIGHS_HAVE_BITSCAN_REVERSE)
-@@ -568,9 +569,9 @@ else(FAST_BUILD)
-   endif()
- 
+@@ -570,7 +572,6 @@ else(FAST_BUILD)
    # Add tests in examples/tests
--  add_subdirectory(examples)
-+  #add_subdirectory(examples)
+   add_subdirectory(examples)
  
 -  add_subdirectory(app)
-+  #add_subdirectory(app)
  
    if(EXP)
      add_executable(doctest)

--- a/ports/highs/fix-compiler.patch
+++ b/ports/highs/fix-compiler.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 605a1e275..47233aa10 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,7 @@
+ cmake_minimum_required(VERSION 3.15)
+ 
+ # set preference for clang compiler and intel compiler over gcc and other compilers
++if(0)
+ include(Platform/${CMAKE_SYSTEM_NAME}-Determine-C OPTIONAL)
+ include(Platform/${CMAKE_SYSTEM_NAME}-C OPTIONAL)
+ set(CMAKE_C_COMPILER_NAMES clang icc cc ${CMAKE_C_COMPILER_NAMES})
+@@ -12,6 +13,7 @@ set(CMAKE_C_COMPILER_NAMES clang icc cc ${CMAKE_C_COMPILER_NAMES})
+ include(Platform/${CMAKE_SYSTEM_NAME}-Determine-CXX OPTIONAL)
+ include(Platform/${CMAKE_SYSTEM_NAME}-CXX OPTIONAL)
+ set(CMAKE_CXX_COMPILER_NAMES clang++ icpc c++ ${CMAKE_CXX_COMPILER_NAMES})
++endif()
+ 
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+ 

--- a/ports/highs/portfile.cmake
+++ b/ports/highs/portfile.cmake
@@ -8,12 +8,16 @@ vcpkg_from_github(
         fix-hconfig-path.patch
         fix-cmake-output.patch
         fix-threads.patch
+        fix-compiler.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
         -DFAST_BUILD=ON
+        -DBUILD_TESTING=OFF
+        -DBUILD_EXAMPLES=OFF
+        -DCMAKE_REQUIRE_FIND_PACKAGE_ZLIB=ON
 )
 
 vcpkg_cmake_install()
@@ -22,4 +26,3 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/highs")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/highs/usage
+++ b/ports/highs/usage
@@ -1,4 +1,0 @@
-The package highs is compatible with built-in CMake targets:
-
-    find_package(highs REQUIRED)
-    target_link_libraries(main PRIVATE highs::highs)

--- a/ports/highs/vcpkg.json
+++ b/ports/highs/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "highs",
   "version": "1.6.0",
+  "port-version": 1,
   "description": "High performance library to solve linear, mixed-integer, and convex quadratic optimization problems.",
   "homepage": "https://highs.dev",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3254,7 +3254,7 @@
     },
     "highs": {
       "baseline": "1.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "highway": {
       "baseline": "1.0.7",

--- a/versions/h-/highs.json
+++ b/versions/h-/highs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70dcabf84d768dffa37123812c300637dc9231a5",
+      "version": "1.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf3c23e1f9f53ae9d35cd62b49a064556bf9ec13",
       "version": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Highs prefers Clang on Linux which causes build failure if LLVM is installed before.
Removed usage because default usage works fine.
Added some CMake flags to explicitly handle dependencies and to disable tests and examples.

Logs from [baseline regression](https://dev.azure.com/vcpkg/public/_build/results?buildId=95469&view=results):

```
[1/2] "/mnt/vcpkg-ci/downloads/tools/cmake-3.27.1-linux/cmake-3.27.1-linux-x86_64/bin/cmake" -E chdir "../../x64-linux-dbg" "/mnt/vcpkg-ci/downloads/tools/cmake-3.27.1-linux/cmake-3.27.1-linux-x86_64/bin/cmake" "/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean" "-G" "Ninja" "-DCMAKE_BUILD_TYPE=Debug" "-DCMAKE_INSTALL_PREFIX=/mnt/vcpkg-ci/packages/highs_x64-linux/debug" "-DFETCHCONTENT_FULLY_DISCONNECTED=ON" "-DFAST_BUILD=ON" "-DCMAKE_MAKE_PROGRAM=/mnt/vcpkg-ci/downloads/tools/ninja/1.10.2-linux/ninja" "-DCMAKE_SYSTEM_NAME=Linux" "-DBUILD_SHARED_LIBS=OFF" "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=/mnt/vss/_work/1/s/scripts/toolchains/linux.cmake" "-DVCPKG_TARGET_TRIPLET=x64-linux" "-DVCPKG_SET_CHARSET_FLAG=ON" "-DVCPKG_PLATFORM_TOOLSET=external" "-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON" "-DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON" "-DCMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY=ON" "-DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=TRUE" "-DCMAKE_VERBOSE_MAKEFILE=ON" "-DVCPKG_APPLOCAL_DEPS=OFF" "-DCMAKE_TOOLCHAIN_FILE=/mnt/vss/_work/1/s/scripts/buildsystems/vcpkg.cmake" "-DCMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION=ON" "-DVCPKG_CXX_FLAGS=" "-DVCPKG_CXX_FLAGS_RELEASE=" "-DVCPKG_CXX_FLAGS_DEBUG=" "-DVCPKG_C_FLAGS=" "-DVCPKG_C_FLAGS_RELEASE=" "-DVCPKG_C_FLAGS_DEBUG=" "-DVCPKG_CRT_LINKAGE=dynamic" "-DVCPKG_LINKER_FLAGS=" "-DVCPKG_LINKER_FLAGS_RELEASE=" "-DVCPKG_LINKER_FLAGS_DEBUG=" "-DVCPKG_TARGET_ARCHITECTURE=x64" "-DCMAKE_INSTALL_LIBDIR:STRING=lib" "-DCMAKE_INSTALL_BINDIR:STRING=bin" "-D_VCPKG_ROOT_DIR=/mnt/vss/_work/1/s" "-D_VCPKG_INSTALLED_DIR=/mnt/vcpkg-ci/installed" "-DVCPKG_MANIFEST_INSTALL=OFF"
-- The CXX compiler identification is Clang 17.0.2
-- The C compiler identification is Clang 17.0.2
```

```
Run Build Command(s): /mnt/vcpkg-ci/downloads/tools/ninja/1.10.2-linux/ninja -v -v -j33 install
[1/166] /mnt/vcpkg-ci/installed/x64-linux/tools/llvm/clang++ -DLIBHIGHS_STATIC_DEFINE -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src -I/mnt/vcpkg-ci/buildtrees/highs/x64-linux-dbg -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/interfaces -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/io -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/ipm -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/ipm/ipx -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/ipm/basiclu -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/lp_data -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/mip -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/model -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/parallel -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/presolve -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/qpsolver -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/simplex -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/util -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/test -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/extern -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/extern/filereader -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/extern/pdqsort -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/extern/zstr -isystem /mnt/vcpkg-ci/installed/x64-linux/include -fPIC -mpopcnt -g -fno-omit-frame-pointer -std=c++11 -fPIC -Wno-unused-variable -Wno-unused-const-variable -MD -MT src/CMakeFiles/highs.dir/mip/HighsDynamicRowMatrix.cpp.o -MF src/CMakeFiles/highs.dir/mip/HighsDynamicRowMatrix.cpp.o.d -o src/CMakeFiles/highs.dir/mip/HighsDynamicRowMatrix.cpp.o -c /mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/mip/HighsDynamicRowMatrix.cpp
FAILED: src/CMakeFiles/highs.dir/mip/HighsDynamicRowMatrix.cpp.o 
/mnt/vcpkg-ci/installed/x64-linux/tools/llvm/clang++ -DLIBHIGHS_STATIC_DEFINE -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src -I/mnt/vcpkg-ci/buildtrees/highs/x64-linux-dbg -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/interfaces -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/io -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/ipm -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/ipm/ipx -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/ipm/basiclu -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/lp_data -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/mip -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/model -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/parallel -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/presolve -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/qpsolver -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/simplex -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/util -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/test -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/extern -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/extern/filereader -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/extern/pdqsort -I/mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/extern/zstr -isystem /mnt/vcpkg-ci/installed/x64-linux/include -fPIC -mpopcnt -g -fno-omit-frame-pointer -std=c++11 -fPIC -Wno-unused-variable -Wno-unused-const-variable -MD -MT src/CMakeFiles/highs.dir/mip/HighsDynamicRowMatrix.cpp.o -MF src/CMakeFiles/highs.dir/mip/HighsDynamicRowMatrix.cpp.o.d -o src/CMakeFiles/highs.dir/mip/HighsDynamicRowMatrix.cpp.o -c /mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/mip/HighsDynamicRowMatrix.cpp
In file included from /mnt/vcpkg-ci/buildtrees/highs/src/v1.6.0-42c776a6f8.clean/src/mip/HighsDynamicRowMatrix.cpp:13:
In file included from /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/algorithm:62:
In file included from /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algo.h:59:
In file included from /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/cstdlib:75:
/usr/include/stdlib.h:32:10: fatal error: 'stddef.h' file not found
   32 | #include <stddef.h>
      |          ^~~~~~~~~~
1 error generated.
```
