### PR TITLE
[libmediainfo] Update to 23.10

### DIFF
--- a/ports/libmediainfo/portfile.cmake
+++ b/ports/libmediainfo/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MediaArea/MediaInfoLib
     REF "v${MEDIAINFO_VERSION}"
-    SHA512 6bc58f98ac1fc9637db0e8dd3a2e15b62036a2d33763e148cde425fceea798324f7c5f53cd51fc698d5b5b05fe1fc0fbfc4f391d2ec135eba6763eedfa5bd101
+    SHA512 1407f5690415ccb7997cc9bcbe7d90980a52b1d06e543a446a0da8e4cb3f09ba8fcfbf6be80b043d7f76eeb2ba219242da1c34f3225e0f0bfe044b2394c0c3ae
     HEAD_REF master
     PATCHES
         msvc-arm.diff

--- a/ports/libmediainfo/vcpkg.json
+++ b/ports/libmediainfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmediainfo",
-  "version": "23.4",
+  "version": "23.10",
   "description": "Get most relevant technical and tag data from video and audio files",
   "homepage": "https://github.com/MediaArea/MediaInfoLib",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4405,7 +4405,7 @@
       "port-version": 3
     },
     "libmediainfo": {
-      "baseline": "23.4",
+      "baseline": "23.10",
       "port-version": 0
     },
     "libmesh": {

--- a/versions/l-/libmediainfo.json
+++ b/versions/l-/libmediainfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2bccca86faecebdacabafa1ff7b63e34168d342",
+      "version": "23.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "a5adf3a515c6144124fe9bb1825505de0f234b8c",
       "version": "23.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
