### PR TITLE
[assimp] Use unofficial-minizip for find_dependency to fix a configure warning

### DIFF
--- a/ports/assimp/build_fixes.patch
+++ b/ports/assimp/build_fixes.patch
@@ -80,7 +80,7 @@ index 6551dcb..0796448 100644
 +find_dependency(pugixml CONFIG)
 +if(NOT @BUILD_SHARED_LIBS@)
 +    find_dependency(kubazip CONFIG)
-+    find_dependency(minizip CONFIG)
++    find_dependency(unofficial-minizip CONFIG)
 +    #find_dependency(openddlparser CONFIG)
 +    find_dependency(poly2tri CONFIG)
 +    find_dependency(polyclipping CONFIG)

--- a/ports/assimp/vcpkg.json
+++ b/ports/assimp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "assimp",
   "version": "5.3.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Open Asset import library",
   "homepage": "https://github.com/assimp/assimp",
   "license": "BSD-3-Clause",

--- a/versions/a-/assimp.json
+++ b/versions/a-/assimp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a825878e38726e638f29d4defeadb9108ac20697",
+      "version": "5.3.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "572034c626843af86fe62b64905fd4e79f19535f",
       "version": "5.3.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -266,7 +266,7 @@
     },
     "assimp": {
       "baseline": "5.3.1",
-      "port-version": 1
+      "port-version": 2
     },
     "async-mqtt": {
       "baseline": "2.0.0",


### PR DESCRIPTION
This was supposed to be fixed in 1e0eede790b6, but I missed the call to find_dependency. Apologies for the noise!

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
