### PR TITLE
[crc32c] add license

### DIFF
--- a/ports/crc32c/vcpkg.json
+++ b/ports/crc32c/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "crc32c",
   "version": "1.1.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "CRC32C implementation with support for CPU-specific acceleration instructions.",
   "homepage": "https://github.com/google/crc32c",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1926,7 +1926,7 @@
     },
     "crc32c": {
       "baseline": "1.1.2",
-      "port-version": 1
+      "port-version": 2
     },
     "crfsuite": {
       "baseline": "2020-08-27",

--- a/versions/c-/crc32c.json
+++ b/versions/c-/crc32c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "65cab652a6fffba3e3b25332d7935bf57aa3c4f0",
+      "version": "1.1.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "9704ed68003973bdffcd5224f720b97c424d1fa5",
       "version": "1.1.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
