### PR TITLE
[ed25519] New port

### DIFF
--- a/ports/ed25519/CMakeLists.txt
+++ b/ports/ed25519/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.19)
 project(ed25519 LANGUAGES C)
 set(PROJECT_VERSION "${VERSION}")
 
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ed25519.h" "#elif defined(ED25519_DLL)" "#elif 1")
+endif()
 set(Header_Files "src/ed25519.h"
         "src/fe.h"
         "src/fixedint.h"
@@ -31,10 +34,8 @@ target_include_directories(
 )
 target_compile_features("${PROJECT_NAME}" PRIVATE c_std_90)
 set_target_properties("${PROJECT_NAME}" PROPERTIES C_VISIBILITY_PRESET hidden
-                      PUBLIC_HEADER "${Header_Files}")
-if (BUILD_SHARED_LIBS)
-    target_compile_definitions("${PROJECT_NAME}" PUBLIC ED25519_BUILD_DLL=1)
-endif (BUILD_SHARED_LIBS)
+                      PUBLIC_HEADER "src/ed25519.h")
+
 install(
   TARGETS                   "${PROJECT_NAME}"
   EXPORT                    "unofficial-${PROJECT_NAME}Config"
@@ -52,7 +53,7 @@ write_basic_package_version_file(
         COMPATIBILITY SameMajorVersion
 )
 install(FILES "${VERSION_FILE_PATH}" DESTINATION "share/unofficial-${PROJECT_NAME}")
-install(FILES ${Header_Files} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES "src/ed25519.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 install(
   EXPORT      "unofficial-${PROJECT_NAME}Config"

--- a/ports/ed25519/CMakeLists.txt
+++ b/ports/ed25519/CMakeLists.txt
@@ -32,7 +32,9 @@ target_include_directories(
 target_compile_features("${PROJECT_NAME}" PRIVATE c_std_90)
 set_target_properties("${PROJECT_NAME}" PROPERTIES C_VISIBILITY_PRESET hidden
                       PUBLIC_HEADER "${Header_Files}")
-
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions("${PROJECT_NAME}" PUBLIC ED25519_BUILD_DLL=1)
+endif (BUILD_SHARED_LIBS)
 install(
   TARGETS                   "${PROJECT_NAME}"
   EXPORT                    "unofficial-${PROJECT_NAME}Config"

--- a/ports/ed25519/CMakeLists.txt
+++ b/ports/ed25519/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.19)
+project(ed25519 LANGUAGES C)
+set(PROJECT_VERSION "${VERSION}")
+
+set(Header_Files "src/ed25519.h"
+        "src/fe.h"
+        "src/fixedint.h"
+        "src/ge.h"
+        "src/precomp_data.h"
+        "src/sc.h"
+        "src/sha512.h")
+set(Source_Files "src/add_scalar.c"
+        "src/fe.c"
+        "src/ge.c"
+        "src/key_exchange.c"
+        "src/keypair.c"
+        "src/sc.c"
+        "src/seed.c"
+        "src/sha512.c"
+        "src/sign.c"
+        "src/verify.c")
+
+add_library("${PROJECT_NAME}" "${Header_Files}" "${Source_Files}")
+
+include(GNUInstallDirs)
+target_include_directories(
+  "${PROJECT_NAME}"
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+target_compile_features("${PROJECT_NAME}" PRIVATE c_std_90)
+set_target_properties("${PROJECT_NAME}" PROPERTIES C_VISIBILITY_PRESET hidden
+                      PUBLIC_HEADER "${Header_Files}")
+
+install(
+  TARGETS                   "${PROJECT_NAME}"
+  EXPORT                    "unofficial-${PROJECT_NAME}Config"
+  RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+include(CMakePackageConfigHelpers)
+set(VERSION_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}ConfigVersion.cmake")
+write_basic_package_version_file(
+        "${VERSION_FILE_PATH}"
+        VERSION       "${PROJECT_VERSION}"
+        COMPATIBILITY SameMajorVersion
+)
+install(FILES "${VERSION_FILE_PATH}" DESTINATION "share/unofficial-${PROJECT_NAME}")
+install(FILES ${Header_Files} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+install(
+  EXPORT      "unofficial-${PROJECT_NAME}Config"
+  FILE        "unofficial-${PROJECT_NAME}Config.cmake"
+  NAMESPACE   "unofficial::${PROJECT_NAME}::"
+  DESTINATION "share/unofficial-${PROJECT_NAME}")
+
+export(PACKAGE "${PROJECT_NAME}")

--- a/ports/ed25519/portfile.cmake
+++ b/ports/ed25519/portfile.cmake
@@ -1,0 +1,30 @@
+if(WIN32)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            orlp/${PORT}
+    REF             b1f19fab4aebe607805620d25a5e42566ce46a0e
+    SHA512          fcbeba58591543304dd93ae7c1b62a720d89c80c4c07c323eabb6e1f41b93562660181973bda345976e5361e925f243ba9abaec19fc8a05235011957367c6e7e
+    HEAD_REF        master
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
+     DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+        "-DVERSION=${VERSION}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
+
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "Zlib")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/ed25519/usage
+++ b/ports/ed25519/usage
@@ -1,0 +1,3 @@
+ed25519 provides CMake targets:
+    find_package(unofficial-ed25519 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::ed25519::ed25519)

--- a/ports/ed25519/vcpkg.json
+++ b/ports/ed25519/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "ed25519",
+  "version-date": "2017-02-10",
+  "description": "Portable C implementation of Ed25519, a high-speed high-security public-key signature system.",
+  "homepage": "https://github.com/orlp/ed25519",
+  "license": "Zlib",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2340,6 +2340,10 @@
       "baseline": "1.0.7.15",
       "port-version": 5
     },
+    "ed25519": {
+      "baseline": "2017-02-10",
+      "port-version": 0
+    },
     "edflib": {
       "baseline": "1.24",
       "port-version": 0

--- a/versions/e-/ed25519.json
+++ b/versions/e-/ed25519.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "31d3b66ff160bd578b6ba1a510ae95719b2b1bda",
+      "git-tree": "a73f861ab994519066237224a119a3dcc23cd192",
       "version-date": "2017-02-10",
       "port-version": 0
     }

--- a/versions/e-/ed25519.json
+++ b/versions/e-/ed25519.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "31d3b66ff160bd578b6ba1a510ae95719b2b1bda",
+      "version-date": "2017-02-10",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/e-/ed25519.json
+++ b/versions/e-/ed25519.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a73f861ab994519066237224a119a3dcc23cd192",
+      "git-tree": "c62f7e2a6268b66c80e20287872725e8bc273032",
       "version-date": "2017-02-10",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
