### PR TITLE
[libaes-siv] New port

### DIFF
--- a/ports/libaes-siv/CMakeLists.txt
+++ b/ports/libaes-siv/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.19)
+set(no_lib_project_name "aes_siv")
 project(libaes-siv LANGUAGES C)
 set(PROJECT_VERSION "${VERSION}")
 
-set(Header_Files "aes_siv.h")
-set(Source_Files "aes_siv.c")
+set(Header_Files "${no_lib_project_name}.h")
+set(Source_Files "${no_lib_project_name}.c")
 
 add_library("${PROJECT_NAME}" "${Header_Files}" "${Source_Files}")
 
@@ -16,7 +17,7 @@ target_include_directories(
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 target_compile_features("${PROJECT_NAME}" PRIVATE c_std_99)
-set(config_file "${CMAKE_BINARY_DIR}/include/aes_siv_config.h")
+set(config_file "${CMAKE_BINARY_DIR}/include/${no_lib_project_name}_config.h")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in" "${config_file}")
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_C_FLAGS_DEBUG "-Wall -Wextra -Wstrict-prototypes -Wconversion -Og -ggdb3 -ftree-vectorize")
@@ -43,6 +44,13 @@ install(
   LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake.in"
+        [[include(CMakeFindDependencyMacro)
+find_dependency(OpenSSL)
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-${PROJECT_NAME}Targets.cmake")
+]])
+configure_file("${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake" @ONLY)
 
 include(CMakePackageConfigHelpers)
 set(VERSION_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}ConfigVersion.cmake")

--- a/ports/libaes-siv/CMakeLists.txt
+++ b/ports/libaes-siv/CMakeLists.txt
@@ -62,7 +62,7 @@ write_basic_package_version_file(
         VERSION       "${PROJECT_VERSION}"
         COMPATIBILITY SameMajorVersion
 )
-install(FILES "${VERSION_FILE_PATH}" DESTINATION "share/unofficial-${PROJECT_NAME}")
+install(FILES "${cmake_config_file}" "${VERSION_FILE_PATH}" DESTINATION "share/unofficial-${PROJECT_NAME}")
 install(FILES ${Header_Files} "${config_file}"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 

--- a/ports/libaes-siv/CMakeLists.txt
+++ b/ports/libaes-siv/CMakeLists.txt
@@ -44,13 +44,16 @@ install(
   LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake.in"
-        [[include(CMakeFindDependencyMacro)
+set(cmake_config_file "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake")
+file(CONFIGURE
+        OUTPUT  "${cmake_config_file}"
+        CONTENT [[
+include(CMakeFindDependencyMacro)
 find_dependency(OpenSSL)
-include("${CMAKE_CURRENT_LIST_DIR}/unofficial-${PROJECT_NAME}Targets.cmake")
-]])
-configure_file("${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake.in"
-               "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake" @ONLY)
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-@PROJECT_NAME@Targets.cmake")
+]]
+        @ONLY
+)
 
 include(CMakePackageConfigHelpers)
 set(VERSION_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}ConfigVersion.cmake")

--- a/ports/libaes-siv/CMakeLists.txt
+++ b/ports/libaes-siv/CMakeLists.txt
@@ -72,4 +72,3 @@ install(
   NAMESPACE   "unofficial::${PROJECT_NAME}::"
   DESTINATION "share/unofficial-${PROJECT_NAME}")
 
-export(PACKAGE "${PROJECT_NAME}")

--- a/ports/libaes-siv/CMakeLists.txt
+++ b/ports/libaes-siv/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.19)
+project(libaes-siv LANGUAGES C)
+set(PROJECT_VERSION "${VERSION}")
+
+set(Header_Files "aes_siv.h")
+set(Source_Files "aes_siv.c"
+        "bench.c"
+        "demo.c")
+
+add_library("${PROJECT_NAME}" "${Header_Files}" "${Source_Files}")
+
+include(GNUInstallDirs)
+target_include_directories(
+  "${PROJECT_NAME}"
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
+  "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+target_compile_features("${PROJECT_NAME}" PRIVATE c_std_99)
+set(config_file "${CMAKE_BINARY_DIR}/include/aes_siv_config.h")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in" "${config_file}")
+
+install(
+  TARGETS                   "${PROJECT_NAME}"
+  EXPORT                    "unofficial-${PROJECT_NAME}Config"
+  RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+include(CMakePackageConfigHelpers)
+set(VERSION_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}ConfigVersion.cmake")
+write_basic_package_version_file(
+        "${VERSION_FILE_PATH}"
+        VERSION       "${PROJECT_VERSION}"
+        COMPATIBILITY SameMajorVersion
+)
+install(FILES "${VERSION_FILE_PATH}" DESTINATION "share/unofficial-${PROJECT_NAME}")
+install(FILES ${Header_Files} "${config_file}"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+install(
+  EXPORT      "unofficial-${PROJECT_NAME}Config"
+  FILE        "unofficial-${PROJECT_NAME}Config.cmake"
+  NAMESPACE   "unofficial::${PROJECT_NAME}::"
+  DESTINATION "share/unofficial-${PROJECT_NAME}")
+
+export(PACKAGE "${PROJECT_NAME}")

--- a/ports/libaes-siv/CMakeLists.txt
+++ b/ports/libaes-siv/CMakeLists.txt
@@ -3,9 +3,7 @@ project(libaes-siv LANGUAGES C)
 set(PROJECT_VERSION "${VERSION}")
 
 set(Header_Files "aes_siv.h")
-set(Source_Files "aes_siv.c"
-        "bench.c"
-        "demo.c")
+set(Source_Files "aes_siv.c")
 
 add_library("${PROJECT_NAME}" "${Header_Files}" "${Source_Files}")
 
@@ -20,6 +18,22 @@ target_include_directories(
 target_compile_features("${PROJECT_NAME}" PRIVATE c_std_99)
 set(config_file "${CMAKE_BINARY_DIR}/include/aes_siv_config.h")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in" "${config_file}")
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_C_FLAGS_DEBUG "-Wall -Wextra -Wstrict-prototypes -Wconversion -Og -ggdb3 -ftree-vectorize")
+    set(CMAKE_C_FLAGS_RELEASE "-Wall -Wextra -Wstrict-prototypes -Wconversion -O3 -fomit-frame-pointer -funroll-loops -ftree-vectorize -DNDEBUG")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "-Wall -Wextra -Wstrict-prototypes -Wconversion  -ggdb3 -O3 -funroll-loops -ftree-vectorize -DNDEBUG")
+    set(CMAKE_C_FLAGS_MINSIZEREL "-Wall -Wextra -Wstrict-prototypes -Wconversion -Os -fomit-frame-pointer -ftree-vectorize -DNDEBUG")
+endif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+
+if(CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL AppleClang)
+    set(CMAKE_C_FLAGS_DEBUG "-Wall -Wextra -Wstrict-prototypes -Wconversion -O0 -ggdb3 -ftree-vectorize")
+    set(CMAKE_C_FLAGS_RELEASE "-Wall -Wextra -Wstrict-prototypes -Wconversion -O3 -fomit-frame-pointer -funroll-loops -ftree-vectorize -DNDEBUG")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "-Wall -Wextra -Wstrict-prototypes -Wconversion -ggdb3 -O3 -funroll-loops -ftree-vectorize -DNDEBUG")
+    set(CMAKE_C_FLAGS_MINSIZEREL "-Wall -Wextra -Wstrict-prototypes -Wconversion -Os -fomit-frame-pointer -ftree-vectorize -DNDEBUG")
+endif(CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL AppleClang)
+
+find_package(OpenSSL REQUIRED COMPONENTS Crypto)
+target_link_libraries("${PROJECT_NAME}" PRIVATE OpenSSL::Crypto)
 
 install(
   TARGETS                   "${PROJECT_NAME}"

--- a/ports/libaes-siv/CMakeLists.txt
+++ b/ports/libaes-siv/CMakeLists.txt
@@ -68,7 +68,7 @@ install(FILES ${Header_Files} "${config_file}"
 
 install(
   EXPORT      "unofficial-${PROJECT_NAME}Config"
-  FILE        "unofficial-${PROJECT_NAME}Config.cmake"
+  FILE        "unofficial-${PROJECT_NAME}Targets.cmake"
   NAMESPACE   "unofficial::${PROJECT_NAME}::"
   DESTINATION "share/unofficial-${PROJECT_NAME}")
 

--- a/ports/libaes-siv/header_rename.patch
+++ b/ports/libaes-siv/header_rename.patch
@@ -1,0 +1,39 @@
+diff --git a/aes_siv.c b/aes_siv.c
+index 00a510d..2b31ed3 100644
+--- a/aes_siv.c
++++ b/aes_siv.c
+@@ -5,7 +5,7 @@
+ #define _POSIX_C_SOURCE 200112L
+ #define _ISOC99_SOURCE 1
+
+-#include "config.h"
++#include "aes_siv_config.h"
+ #include "aes_siv.h"
+
+ #include <assert.h>
+diff --git a/bench.c b/bench.c
+index ea5a29b..61cb485 100644
+--- a/bench.c
++++ b/bench.c
+@@ -2,7 +2,7 @@
+  * SPDX-License-Identifier: Apache-2.0
+  */
+
+-#include "config.h"
++#include "aes_siv_config.h"
+ #include "aes_siv.h"
+
+ #define _POSIX_C_SOURCE 200112L
+diff --git a/tests.c b/tests.c
+index 996cc58..9ff9637 100644
+--- a/tests.c
++++ b/tests.c
+@@ -5,7 +5,7 @@
+ #define _POSIX_C_SOURCE 200112L
+ #define _ISOC99_SOURCE 1
+
+-#include "config.h"
++#include "aes_siv_config.h"
+ #include "aes_siv.h"
+
+ #undef NDEBUG

--- a/ports/libaes-siv/portfile.cmake
+++ b/ports/libaes-siv/portfile.cmake
@@ -1,4 +1,4 @@
-if(WIN32)
+if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 

--- a/ports/libaes-siv/portfile.cmake
+++ b/ports/libaes-siv/portfile.cmake
@@ -1,0 +1,34 @@
+if(WIN32)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            dfoxfranke/libaes_siv
+    REF             9681279cfaa6e6399bb7ca3afbbc27fc2e19df4b
+    SHA512          96441420339bd11f37f4feff29f9306afa60e5b07ac7e7b879778c0e6964f8f679ffb7c1deca43ca054b7851e4e7bf5fca548dc60c92469fe9d3235cb5a37776
+    HEAD_REF        master
+    PATCHES
+        header_rename.patch
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
+     DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+        "-DVERSION=${VERSION}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libaes-siv/usage
+++ b/ports/libaes-siv/usage
@@ -1,0 +1,3 @@
+libaes-siv provides CMake targets:
+    find_package(unofficial-libaes-siv CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::libaes-siv::libaes-siv)

--- a/ports/libaes-siv/vcpkg.json
+++ b/ports/libaes-siv/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libaes-siv",
+  "version-date": "2020-10-15",
+  "description": "An RFC5297-compliant C implementation of AES-SIV.",
+  "homepage": "https://github.com/dfoxfranke/libaes_siv",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3960,6 +3960,10 @@
       "baseline": "1.3.2",
       "port-version": 1
     },
+    "libaes-siv": {
+      "baseline": "2020-10-15",
+      "port-version": 0
+    },
     "libaiff": {
       "baseline": "5.0",
       "port-version": 9

--- a/versions/l-/libaes-siv.json
+++ b/versions/l-/libaes-siv.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8912d6212f04f9901ef237077e84883465953e79",
+      "version-date": "2020-10-15",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libaes-siv.json
+++ b/versions/l-/libaes-siv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9a55df49f2f45114cd8aec090de590e67f94b9b",
+      "git-tree": "ecae087c343539db9225d7a31c076e245925d30b",
       "version-date": "2020-10-15",
       "port-version": 0
     }

--- a/versions/l-/libaes-siv.json
+++ b/versions/l-/libaes-siv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9ec2adbfb333e6eb27b2ee62850315b8ac53698c",
+      "git-tree": "4110d30ed9fa671d80649db3da28a223af761135",
       "version-date": "2020-10-15",
       "port-version": 0
     }

--- a/versions/l-/libaes-siv.json
+++ b/versions/l-/libaes-siv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4110d30ed9fa671d80649db3da28a223af761135",
+      "git-tree": "09f7dc5455858954e575f223dc2050005343efce",
       "version-date": "2020-10-15",
       "port-version": 0
     }

--- a/versions/l-/libaes-siv.json
+++ b/versions/l-/libaes-siv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "09f7dc5455858954e575f223dc2050005343efce",
+      "git-tree": "b9a55df49f2f45114cd8aec090de590e67f94b9b",
       "version-date": "2020-10-15",
       "port-version": 0
     }

--- a/versions/l-/libaes-siv.json
+++ b/versions/l-/libaes-siv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8912d6212f04f9901ef237077e84883465953e79",
+      "git-tree": "9ec2adbfb333e6eb27b2ee62850315b8ac53698c",
       "version-date": "2020-10-15",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.