### PR TITLE
[glm] Bump to 2023-08-18

### DIFF
--- a/ports/glm/portfile.cmake
+++ b/ports/glm/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO g-truc/glm
-    REF 5c46b9c07008ae65cb81ab79cd677ecc1934b903 # commit on 2023-06-08
-    SHA512 17315dd05059accf3d4084d35dd037d4001f88a1d91da9a6fd5cedecab652c8bef8efa89cd45e21cd227f964a03408401edc2384c22e50caa449abf71b23fd6a
+    REF 47585fde0c49fa77a2bf2fb1d2ead06999fd4b6e # commit on 2023-08-18
+    SHA512 55f7dcd9380bd010b500cd0369dfff2356385da29ce238a99e09007c2d1ae9bb13c01adc1a46bdf957709668f7fe2c7aacf35dd11f446b64445dc6ebfd5850b2
     HEAD_REF master
 )
 

--- a/ports/glm/vcpkg.json
+++ b/ports/glm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glm",
-  "version-date": "2023-06-08",
+  "version-date": "2023-08-18",
   "description": "OpenGL Mathematics (GLM)",
   "homepage": "https://glm.g-truc.net",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2953,7 +2953,7 @@
       "port-version": 1
     },
     "glm": {
-      "baseline": "2023-06-08",
+      "baseline": "2023-08-18",
       "port-version": 0
     },
     "globjects": {

--- a/versions/g-/glm.json
+++ b/versions/g-/glm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d3d2a050959330a71aba2e177f3f4132f2ce5ae",
+      "version-date": "2023-08-18",
+      "port-version": 0
+    },
+    {
       "git-tree": "6687c48e237aab1c30cf4c589d08f698f73cf178",
       "version-date": "2023-06-08",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix `GLM_FORCE_QUAT_DATA_XYZW ` not working.
See also https://github.com/microsoft/vcpkg/pull/32685#issuecomment-1764289386