### PR TITLE
[libtins] update to 4.5

### DIFF
--- a/ports/libtins/portfile.cmake
+++ b/ports/libtins/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mfontanini/libtins
-    REF v4.3
-    SHA512 29d606004fe9a440c9a53eede42fd5c6dbd049677d2cca2c5cfd26311ee2ca4c64ca3e665fbc81efd5bfab5577a5181ed0754c617e139317d9ae0cabba05aff7
+    REF "v${VERSION}"
+    SHA512 d8887949cb545dbaf4247c8405feb5cc1032f370bb418dd5344043dc97555b1b826a8d33cfc7dd0a7a9a9af6f3a46bd6fcbed89f98d5eb23fdd10294f823fcd6
     HEAD_REF master
     PATCHES
         fix-source-writes.patch

--- a/ports/libtins/vcpkg.json
+++ b/ports/libtins/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libtins",
-  "version": "4.3",
-  "port-version": 7,
+  "version": "4.5",
   "description": "High-level, multiplatform C++ network packet sniffing and crafting library",
   "license": "BSD-2-Clause",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4781,8 +4781,8 @@
       "port-version": 6
     },
     "libtins": {
-      "baseline": "4.3",
-      "port-version": 7
+      "baseline": "4.5",
+      "port-version": 0
     },
     "libtomcrypt": {
       "baseline": "1.18.2",

--- a/versions/l-/libtins.json
+++ b/versions/l-/libtins.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2aca4b43d1b64057b5316e609514d41ee7013c4b",
+      "version": "4.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "30fbfd14d90e9aedac77f8272135a7e51444b01f",
       "version": "4.3",
       "port-version": 7


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

