### PR TITLE
[liblemon] Supports recent compilers.

### DIFF
--- a/ports/liblemon/portfile.cmake
+++ b/ports/liblemon/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_extract_source_archive(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DCMAKE_CXX_STANDARD=14
         -DLEMON_ENABLE_GLPK=OFF
         -DLEMON_ENABLE_ILOG=OFF
         -DLEMON_ENABLE_COIN=OFF

--- a/ports/liblemon/vcpkg.json
+++ b/ports/liblemon/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "liblemon",
   "version-date": "2019-06-13",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Library for Efficient Modeling and Optimization in Networks",
   "homepage": "https://lemon.cs.elte.hu/trac/lemon",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4362,7 +4362,7 @@
     },
     "liblemon": {
       "baseline": "2019-06-13",
-      "port-version": 7
+      "port-version": 8
     },
     "liblinear": {
       "baseline": "243",

--- a/versions/l-/liblemon.json
+++ b/versions/l-/liblemon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6bdd7ed9804fee3e743082bb048916a213777a79",
+      "version-date": "2019-06-13",
+      "port-version": 8
+    },
+    {
       "git-tree": "e7357874ce9b71f43cb1c298dbb1228ac9241a69",
       "version-date": "2019-06-13",
       "port-version": 7


### PR DESCRIPTION
Recent compilers (e.g. clang>=16) changed the default c++ standard to cxx17. This will break compilation of liblemon. This commit forces code to be compiled in cxx14 mode.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
