### PR TITLE
[itk] Fix download failure

### DIFF
--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_buildpath_length_warning(37)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO InsightSoftwareConsortium/ITK
-    REF v5.3-rc02
-    SHA512 fe703bc6ed681cb9983d7d6e21c8ffa7650337e470c09a7241de58a463c23e315516b1a81a18c14f682706056a0ec66932b63d2e24945bdcea03169bc1122bb2
+    REF "v${VERSION}"
+    SHA512 48e38864d7cd20b4ff23cfca1a29b4cbf453ce842e037ca473ce5c7e9a5b1c0bf6b12e4c544c812bff2b4bb9feca409587175b6570929c9ac172cb4402d679da
     HEAD_REF master
     PATCHES
         double-conversion.patch

--- a/ports/itk/vcpkg.json
+++ b/ports/itk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "itk",
   "version-string": "5.3rc02",
-  "port-version": 7,
   "description": "Insight Segmentation and Registration Toolkit (ITK) is used for image processing and analysis.",
   "homepage": "https://github.com/InsightSoftwareConsortium/ITK",
   "license": "Apache-2.0",

--- a/ports/itk/vcpkg.json
+++ b/ports/itk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "itk",
-  "version": "5.3-rc02",
-  "port-version": 6,
+  "version-string": "5.3rc02",
+  "port-version": 7,
   "description": "Insight Segmentation and Registration Toolkit (ITK) is used for image processing and analysis.",
   "homepage": "https://github.com/InsightSoftwareConsortium/ITK",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3526,7 +3526,7 @@
     },
     "itk": {
       "baseline": "5.3rc02",
-      "port-version": 7
+      "port-version": 0
     },
     "itpp": {
       "baseline": "4.3.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3525,8 +3525,8 @@
       "port-version": 0
     },
     "itk": {
-      "baseline": "5.3-rc02",
-      "port-version": 6
+      "baseline": "5.3rc02",
+      "port-version": 7
     },
     "itpp": {
       "baseline": "4.3.1",

--- a/versions/i-/itk.json
+++ b/versions/i-/itk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b74bb68b58026e759112afb8155d44650cee24b4",
+      "version-string": "5.3rc02",
+      "port-version": 0
+    },
+    {
       "git-tree": "9da4bc8949edd65bc3e0afa8e694480e330f5f40",
       "version": "5.3-rc02",
       "port-version": 6

--- a/versions/i-/itk.json
+++ b/versions/i-/itk.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "6a73ecdf61dd3e1e20fb392912bf4b15e4bab9dc",
-      "version-string": "5.3rc02",
-      "port-version": 7
-    },
-    {
       "git-tree": "9da4bc8949edd65bc3e0afa8e694480e330f5f40",
       "version": "5.3-rc02",
       "port-version": 6

--- a/versions/i-/itk.json
+++ b/versions/i-/itk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a73ecdf61dd3e1e20fb392912bf4b15e4bab9dc",
+      "version-string": "5.3rc02",
+      "port-version": 7
+    },
+    {
       "git-tree": "9da4bc8949edd65bc3e0afa8e694480e330f5f40",
       "version": "5.3-rc02",
       "port-version": 6


### PR DESCRIPTION
Fixes #34512

Change "version" to  fix download failure. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

