### PR TITLE
[zlib] ensure interface compatibility with cmake's FindZlib script

### DIFF
--- a/ports/zlib/vcpkg-cmake-wrapper.cmake
+++ b/ports/zlib/vcpkg-cmake-wrapper.cmake
@@ -10,3 +10,13 @@ if(CMAKE_VERSION VERSION_LESS 3.4)
     unset(ZLIB_FOUND)
 endif()
 _find_package(${ARGS})
+
+# To conform with cmake's find script interface,
+# ensure that not just
+#   ZLIB_INCLUDE_DIR
+# is set, but also
+#   ZLIB_INCLUDE_DIRS
+if (NOT DEFINED ${ZLIB_INCLUDE_DIRS})
+    set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
+endif()
+


### PR DESCRIPTION
Regular CMake FindZlib.cmake presents include directories as ZLIB_INCLUDE_DIRS. Extend the wrapper script to also set this variable.