### PR TITLE
[protobuf] Update to 3.24.4

### DIFF
--- a/ports/protobuf/fix-default-proto-file-path.patch
+++ b/ports/protobuf/fix-default-proto-file-path.patch
@@ -1,9 +1,9 @@
 diff --git a/src/google/protobuf/compiler/command_line_interface.cc b/src/google/protobuf/compiler/command_line_interface.cc
-index 5e9a2c4..8eaa6e0 100644
+index f9e9666..d453a4c 100644
 --- a/src/google/protobuf/compiler/command_line_interface.cc
 +++ b/src/google/protobuf/compiler/command_line_interface.cc
-@@ -261,12 +261,15 @@ void AddDefaultProtoPaths(
-         std::pair<std::string, std::string>("", path + "/include"));
+@@ -280,12 +280,15 @@ void AddDefaultProtoPaths(
+     paths->emplace_back("", std::move(include_path));
      return;
    }
 -  // Check if the upper level directory has an "include" subdirectory.
@@ -16,6 +16,6 @@ index 5e9a2c4..8eaa6e0 100644
    }
    path = path.substr(0, pos);
 +  }
-   if (IsInstalledProtoPath(path + "/include")) {
-     paths->push_back(
-         std::pair<std::string, std::string>("", path + "/include"));
+   include_path = absl::StrCat(path, "/include");
+   if (IsInstalledProtoPath(include_path)) {
+     paths->emplace_back("", std::move(include_path));

--- a/ports/protobuf/fix-dependencies.patch
+++ b/ports/protobuf/fix-dependencies.patch
@@ -1,0 +1,23 @@
+diff --git a/third_party/utf8_range/CMakeLists.txt b/third_party/utf8_range/CMakeLists.txt
+index 344952d..72fae0f 100644
+--- a/third_party/utf8_range/CMakeLists.txt
++++ b/third_party/utf8_range/CMakeLists.txt
+@@ -21,6 +21,9 @@ add_library (utf8_range STATIC
+ # A heavier-weight C++ wrapper that supports Abseil.
+ add_library (utf8_validity STATIC utf8_validity.cc)
+ 
++set_target_properties(utf8_range PROPERTIES OUTPUT_NAME protobuf_utf8_range)
++set_target_properties(utf8_validity PROPERTIES OUTPUT_NAME protobuf_utf8_validity)
++
+ # Load Abseil dependency.
+ if (NOT TARGET absl::strings)
+   if (NOT ABSL_ROOT_DIR)
+@@ -77,7 +80,7 @@ if (utf8_range_ENABLE_INSTALL)
+                  ${CMAKE_CURRENT_BINARY_DIR}/utf8_range.pc @ONLY)
+   install(
+     FILES ${CMAKE_CURRENT_BINARY_DIR}/utf8_range.pc
+-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" RENAME protobuf_utf8_range.pc)
+ 
+   # Install public headers explicitly.
+   install(FILES utf8_range.h utf8_validity.h

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "protobuf",
-  "version": "3.21.12",
+  "version": "3.24.4",
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",
   "dependencies": [
+    "abseil",
     {
       "name": "protobuf",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6061,7 +6061,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "3.21.12",
+      "baseline": "3.24.4",
       "port-version": 0
     },
     "protobuf-c": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "277795da58f88c433ef7096968bb389796c7e2a4",
+      "version": "3.24.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b145508ba614fe26989b23f6317f15bf6467be4",
       "version": "3.21.12",
       "port-version": 0


### PR DESCRIPTION
Fixes #34396, update `protobuf` to 3.24.4.

* Remove outdated patch file: `compile_options.patch`.

* Add patch file to fix dependency `utf8_range`: `fix-dependencies.patch`.

* Add the following code to handle the dependencies so they are correctly linked to protobuf: 
    ```
    vcpkg_replace_string(${_file} "absl_abseil_dll" "abseil_dll") # Use abseil in vcpkg, which is named abseil_dll
    vcpkg_replace_string(${_file} "utf8_range" "protobuf_utf8_range") # Add prefix protobuf_ to utr8_range to prevent conflicts with other ports
    ```


* All features are tested successfully in the following triplet:
    ```
    x86-windows
    x64-windows
    x64-windows-static
    ```

* The usage test passed on `x64-windows` (header files found):
    ```
    protobuf provides CMake targets:

      # this is heuristically generated, and may not be correct
      find_package(protobuf CONFIG REQUIRED)
      target_link_libraries(main PRIVATE protobuf::libprotoc protobuf::libprotobuf protobuf::libprotobuf-lite)
    ```


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
