### PR TITLE
[libjuice] update to 1.3.1

### DIFF
--- a/ports/libjuice/portfile.cmake
+++ b/ports/libjuice/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO paullouisageneau/libjuice
-    REF eff89f7ae3450d66fcebe4d3d1d2aacca527eb8c #v1.0.6
-    SHA512 f28e8116e9437f7e2c114c0b6e296ec2c4bda264428ca94c3aa7356bfc3c76ac77f4664678579c933f70e6cb380c68ad42c03a83d5140bf41e20fc4272f1ae54
+    REF "v${VERSION}"
+    SHA512 187901d6d8e1210210667b0bca274ce9507d46cc5f3fe81e812fb7c16dc2739359a5d331ce03a9a3958252c4ea942a75ca29a624f486abb23c19dd10c71127bc
     HEAD_REF master
     PATCHES
         fix-for-vcpkg.patch

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libjuice",
-  "version": "1.0.6",
+  "version": "1.3.1",
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4333,7 +4333,7 @@
       "port-version": 2
     },
     "libjuice": {
-      "baseline": "1.0.6",
+      "baseline": "1.3.1",
       "port-version": 0
     },
     "libjxl": {

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ace25316c085db75ac26220e854bd83baa86294",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f93f38276ee4097f4b4e85f58b14aaa7e0cda3d4",
       "version": "1.0.6",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

