### PR TITLE
[libmaxminddb] update to 1.7.1

### DIFF
--- a/ports/libmaxminddb/fix-linux-build.patch
+++ b/ports/libmaxminddb/fix-linux-build.patch
@@ -1,5 +1,5 @@
 diff --git a/include/maxminddb.h b/include/maxminddb.h
-index 13b276f..6c70e49 100644
+index 4002ec6..65482c5 100644
 --- a/include/maxminddb.h
 +++ b/include/maxminddb.h
 @@ -24,11 +24,12 @@ extern "C" {
@@ -7,13 +7,13 @@ index 13b276f..6c70e49 100644
  #include <sys/types.h>
  
 +/* libmaxminddb package version from configure */
-+#define PACKAGE_VERSION "1.4.3"
++#define PACKAGE_VERSION "1.7.1"
 +
  #ifdef _WIN32
  #include <winsock2.h>
  #include <ws2tcpip.h>
 -/* libmaxminddb package version from configure */
--#define PACKAGE_VERSION "1.4.3"
+-#define PACKAGE_VERSION "1.7.1"
  
  typedef ADDRESS_FAMILY sa_family_t;
  

--- a/ports/libmaxminddb/portfile.cmake
+++ b/ports/libmaxminddb/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO maxmind/libmaxminddb
-    REF 07797e9dfb6771190f9fa41a33babe19425ef552 #1.4.3
-    SHA512 94f7fbd46a7846c804edad9759ceedf2f7c4b2085430322f74bea5c89f6c3fa0824f154f551119a8c69becec5120650efef89c6d7f5a2ef3df476086070c8c7e
+    REF "${VERSION}"
+    SHA512 0a5caa267712310ef5de4c33e008d02dff76f8a9672e370719cd1d3e0f8de1146b9120991f5c2e34ed81a4ee011510dcc4b30051f6e23a6fd0634f50d35252ec
     HEAD_REF master
     PATCHES fix-linux-build.patch
 )

--- a/ports/libmaxminddb/vcpkg.json
+++ b/ports/libmaxminddb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmaxminddb",
-  "version": "1.4.3",
-  "port-version": 3,
+  "version": "1.7.1",
   "description": "C library for the MaxMind DB file format",
   "homepage": "https://github.com/maxmind/libmaxminddb",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4401,8 +4401,8 @@
       "port-version": 3
     },
     "libmaxminddb": {
-      "baseline": "1.4.3",
-      "port-version": 3
+      "baseline": "1.7.1",
+      "port-version": 0
     },
     "libmediainfo": {
       "baseline": "23.4",

--- a/versions/l-/libmaxminddb.json
+++ b/versions/l-/libmaxminddb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a396718bfaa9c8e9e950cb3aaedb7bd562a157a7",
+      "version": "1.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2bac54e78c424e4420145ae4a407e7b88229a387",
       "version": "1.4.3",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

