### PR TITLE
[realsense2] update to 2.54.2

### DIFF
--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO IntelRealSense/librealsense
-    REF v2.54.1
-    SHA512 9b7146a5f6a4152d95286f679e0f5314ab0b040f67a030e42dfe01ad995af486d3d158d1ac7ef0bbe783a90e067d32e4bb4ba1a524fe75a89be6c7fe9c3a30ed
+    REF "v${VERSION}"
+    SHA512 20561294da571e0e1f5f8c9ac1039828512f3361a4241e5ad320bbb684626c1e78cd18e6a6344ec80fcd86dc699742c51069bc2b6895aec1dcbd9f394d2c9998
     HEAD_REF master
     PATCHES
         fix_openni2.patch
@@ -70,5 +70,5 @@ if(BUILD_OPENNI2_BINDINGS)
     endif()
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 vcpkg_fixup_pkgconfig()

--- a/ports/realsense2/vcpkg.json
+++ b/ports/realsense2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "realsense2",
-  "version": "2.54.1",
-  "port-version": 1,
+  "version": "2.54.2",
   "description": "Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).",
   "homepage": "https://github.com/IntelRealSense/librealsense",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7257,8 +7257,8 @@
       "port-version": 4
     },
     "realsense2": {
-      "baseline": "2.54.1",
-      "port-version": 1
+      "baseline": "2.54.2",
+      "port-version": 0
     },
     "recast": {
       "baseline": "deprecated",

--- a/versions/r-/realsense2.json
+++ b/versions/r-/realsense2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c860a042c288cc1618ea5e728e8eb715b233ff44",
+      "version": "2.54.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "29719e1172d7bb950bc88a29ba009e4c4c2d5f27",
       "version": "2.54.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/34560 https://github.com/microsoft/vcpkg/issues/34448
All feature tested pass in the following triplets:

- x64-windows
- x64-windows-static
- x86-windows

Usage tested pass on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
