### PR TITLE
[qt] apply cve fix

### DIFF
--- a/ports/qtbase/CVE-2023-43114-6.5.patch
+++ b/ports/qtbase/CVE-2023-43114-6.5.patch
@@ -1,0 +1,120 @@
+diff --git a/src/gui/text/windows/qwindowsfontdatabase.cpp b/src/gui/text/windows/qwindowsfontdatabase.cpp
+index 44cc7fe63e..e44d85a3cb 100644
+--- a/src/gui/text/windows/qwindowsfontdatabase.cpp
++++ b/src/gui/text/windows/qwindowsfontdatabase.cpp
+@@ -873,36 +873,70 @@ QT_WARNING_POP
+     return fontEngine;
+ }
+ 
+-static QList<quint32> getTrueTypeFontOffsets(const uchar *fontData)
++static QList<quint32> getTrueTypeFontOffsets(const uchar *fontData, const uchar *fileEndSentinel)
+ {
+     QList<quint32> offsets;
+-    const quint32 headerTag = *reinterpret_cast<const quint32 *>(fontData);
++    if (fileEndSentinel - fontData < 12) {
++        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++        return offsets;
++    }
++
++    const quint32 headerTag = qFromUnaligned<quint32>(fontData);
+     if (headerTag != MAKE_TAG('t', 't', 'c', 'f')) {
+         if (headerTag != MAKE_TAG(0, 1, 0, 0)
+             && headerTag != MAKE_TAG('O', 'T', 'T', 'O')
+             && headerTag != MAKE_TAG('t', 'r', 'u', 'e')
+-            && headerTag != MAKE_TAG('t', 'y', 'p', '1'))
++            && headerTag != MAKE_TAG('t', 'y', 'p', '1')) {
+             return offsets;
++        }
+         offsets << 0;
+         return offsets;
+     }
++
++    const quint32 maximumNumFonts = 0xffff;
+     const quint32 numFonts = qFromBigEndian<quint32>(fontData + 8);
+-    for (uint i = 0; i < numFonts; ++i) {
+-        offsets << qFromBigEndian<quint32>(fontData + 12 + i * 4);
++    if (numFonts > maximumNumFonts) {
++        qCWarning(lcQpaFonts) << "Font collection of" << numFonts << "fonts is too large. Aborting.";
++        return offsets;
++    }
++
++    if (quintptr(fileEndSentinel - fontData) > 12 + (numFonts - 1) * 4) {
++        for (quint32 i = 0; i < numFonts; ++i)
++            offsets << qFromBigEndian<quint32>(fontData + 12 + i * 4);
++    } else {
++        qCWarning(lcQpaFonts) << "Corrupted font data detected";
+     }
++
+     return offsets;
+ }
+ 
+-static void getFontTable(const uchar *fileBegin, const uchar *data, quint32 tag, const uchar **table, quint32 *length)
++static void getFontTable(const uchar *fileBegin, const uchar *fileEndSentinel, const uchar *data, quint32 tag, const uchar **table, quint32 *length)
+ {
+-    const quint16 numTables = qFromBigEndian<quint16>(data + 4);
+-    for (uint i = 0; i < numTables; ++i) {
+-        const quint32 offset = 12 + 16 * i;
+-        if (*reinterpret_cast<const quint32 *>(data + offset) == tag) {
+-            *table = fileBegin + qFromBigEndian<quint32>(data + offset + 8);
+-            *length = qFromBigEndian<quint32>(data + offset + 12);
+-            return;
++    if (fileEndSentinel - data >= 6) {
++        const quint16 numTables = qFromBigEndian<quint16>(data + 4);
++        if (fileEndSentinel - data >= 28 + 16 * (numTables - 1)) {
++            for (quint32 i = 0; i < numTables; ++i) {
++                const quint32 offset = 12 + 16 * i;
++                if (qFromUnaligned<quint32>(data + offset) == tag) {
++                    const quint32 tableOffset = qFromBigEndian<quint32>(data + offset + 8);
++                    if (quintptr(fileEndSentinel - fileBegin) <= tableOffset) {
++                        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++                        break;
++                    }
++                    *table = fileBegin + tableOffset;
++                    *length = qFromBigEndian<quint32>(data + offset + 12);
++                    if (quintptr(fileEndSentinel - *table) < *length) {
++                        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++                        break;
++                    }
++                    return;
++                }
++            }
++        } else {
++            qCWarning(lcQpaFonts) << "Corrupted font data detected";
+         }
++    } else {
++        qCWarning(lcQpaFonts) << "Corrupted font data detected";
+     }
+     *table = 0;
+     *length = 0;
+@@ -915,8 +949,9 @@ static void getFamiliesAndSignatures(const QByteArray &fontData,
+                                      QList<QFontValues> *values)
+ {
+     const uchar *data = reinterpret_cast<const uchar *>(fontData.constData());
++    const uchar *dataEndSentinel = data + fontData.size();
+ 
+-    QList<quint32> offsets = getTrueTypeFontOffsets(data);
++    QList<quint32> offsets = getTrueTypeFontOffsets(data, dataEndSentinel);
+     if (offsets.isEmpty())
+         return;
+ 
+@@ -924,7 +959,7 @@ static void getFamiliesAndSignatures(const QByteArray &fontData,
+         const uchar *font = data + offsets.at(i);
+         const uchar *table;
+         quint32 length;
+-        getFontTable(data, font, MAKE_TAG('n', 'a', 'm', 'e'), &table, &length);
++        getFontTable(data, dataEndSentinel, font, MAKE_TAG('n', 'a', 'm', 'e'), &table, &length);
+         if (!table)
+             continue;
+         QFontNames names = qt_getCanonicalFontNames(table, length);
+@@ -934,7 +969,7 @@ static void getFamiliesAndSignatures(const QByteArray &fontData,
+         families->append(std::move(names));
+ 
+         if (values || signatures)
+-            getFontTable(data, font, MAKE_TAG('O', 'S', '/', '2'), &table, &length);
++            getFontTable(data, dataEndSentinel, font, MAKE_TAG('O', 'S', '/', '2'), &table, &length);
+ 
+         if (values) {
+             QFontValues fontValues;
+-- 
+2.27.0.windows.1
+

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -19,6 +19,7 @@ set(${PORT}_PATCHES
         GLIB2-static.patch # alternative is to force pkg-config
         clang-cl_source_location.patch
         clang-cl_QGADGET_fix.diff
+        CVE-2023-43114-6.5.patch
         )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.5.3",
+  "port-version": 1,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
