### PR TITLE
Gtiff deadlock fix

### DIFF
--- a/ports/gdal/gtiff-deadlock-fix.patch
+++ b/ports/gdal/gtiff-deadlock-fix.patch
@@ -1,0 +1,33 @@
+From b5858ed5bc5004c97f7cd6000674015bdc70b33b Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 14 Oct 2023 00:52:46 +0200
+Subject: [PATCH] GTiff multithreaded reading/writing: fix a deadlock situation
+
+Fix a deadlock encountered with
+gdalwarp test1.tif test2.tif -co  COMPRESS=LZW   -co TILED=YES  -co BLOCKXSIZE=256  -co  BLOCKYSIZE=256   -co   BIGTIFF=YES  -multi  -co  NUM_THREADS=ALL_CPUS out.tif -overwrite
+on the test datasets provided in https://github.com/OSGeo/gdal/issues/8470#issuecomment-1760639682
+---
+ frmts/gtiff/geotiff.cpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/frmts/gtiff/geotiff.cpp b/frmts/gtiff/geotiff.cpp
+index ed79c0972e0..33846d66513 100644
+--- a/frmts/gtiff/geotiff.cpp
++++ b/frmts/gtiff/geotiff.cpp
+@@ -2886,8 +2886,16 @@ static void ThreadDecompressionFunc(void *pData)
+                 psJob->nXBlock, psJob->nYBlock);
+             if (apoBlocks[i] == nullptr)
+             {
++                // Temporary disabling of dirty block fushing, otherwise
++                // we can be in a deadlock situation, where the
++                // GTiffDataset::SubmitCompressionJob() method waits for jobs
++                // to be finished, that can't finish (actually be started)
++                // because this task and its siblings are taking all the
++                // available workers allowed by the global thread pool.
++                GDALRasterBlock::EnterDisableDirtyBlockFlush();
+                 apoBlocks[i] = poDS->GetRasterBand(iBand)->GetLockedBlockRef(
+                     psJob->nXBlock, psJob->nYBlock, TRUE);
++                GDALRasterBlock::LeaveDisableDirtyBlockFlush();
+                 if (apoBlocks[i] == nullptr)
+                     return false;
+             }

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         find-link-libraries.patch
         fix-gdal-target-interfaces.patch
         libkml.patch
+        gtiff-deadlock-fix.patch
 )
 # `vcpkg clean` stumbles over one subdir
 file(REMOVE_RECURSE "${SOURCE_PATH}/autotest")

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.6.4",
+  "port-version": 1,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2702,7 +2702,7 @@
     },
     "gdal": {
       "baseline": "3.6.4",
-      "port-version": 0
+      "port-version": 1
     },
     "gdcm": {
       "baseline": "3.0.12",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7241cbba04340f432b132de26ee7ae3315cb83ed",
+      "version-semver": "3.6.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "f83039e70646a59b782781b3c805f276fb4c72be",
       "version-semver": "3.6.4",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

Fixes #34577 (maybe?)

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
