### PR TITLE
[cpr] fix error hash

### DIFF
--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libcpr/cpr
     REF ${VERSION}
-    SHA512 aad193202ce0f24ed12c3992914c9a374f12fe9d84d5a375fc6e9ec6215cca6abf50372b71a11284aea039e00dd35b528fe5285667671dbb43b1b1fe4b7a74ef
+    SHA512 5e2fe69d5b4dfaa67f636098c8da904b43a22b21cc78bc52446e572ea47f492ce1de0f47fdc2cf34207729ccf007449278f218d8cdeef21f0b98356bca2e5e49
     HEAD_REF master
     PATCHES
         001-cpr-config.patch

--- a/ports/cpr/vcpkg.json
+++ b/ports/cpr/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cpr",
   "version-semver": "1.10.5",
+  "port-version": 1,
   "description": "C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.",
   "homepage": "https://github.com/libcpr/cpr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1898,7 +1898,7 @@
     },
     "cpr": {
       "baseline": "1.10.5",
-      "port-version": 0
+      "port-version": 1
     },
     "cpu-features": {
       "baseline": "0.9.0",

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,9 +1,14 @@
 {
   "versions": [
     {
-        "git-tree": "b734e9b119682ee4c98e2b4a127a8e29fc750844",
-        "version-semver": "1.10.5",
-        "port-version": 0
+      "git-tree": "83379af62bd0d170537dd4ee3abba017d4a54659",
+      "version-semver": "1.10.5",
+      "port-version": 1
+    },
+    {
+      "git-tree": "b734e9b119682ee4c98e2b4a127a8e29fc750844",
+      "version-semver": "1.10.5",
+      "port-version": 0
     },
     {
       "git-tree": "96f05ba23a7dc5ba102ba451210b2c367669c1ad",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/34572
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
