### PR TITLE
[gdal] Add upstream TIFF fix

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix-gdal-target-interfaces.patch
         libkml.patch
         fix-jpeg.patch
+        upstream-b5858ed.diff
 )
 # `vcpkg clean` stumbles over one subdir
 file(REMOVE_RECURSE "${SOURCE_PATH}/autotest")

--- a/ports/gdal/upstream-b5858ed.diff
+++ b/ports/gdal/upstream-b5858ed.diff
@@ -1,0 +1,21 @@
+diff --git a/frmts/gtiff/geotiff.cpp b/frmts/gtiff/geotiff.cpp
+index ed79c0972e0..33846d66513 100644
+--- a/frmts/gtiff/geotiff.cpp
++++ b/frmts/gtiff/geotiff.cpp
+@@ -2886,8 +2886,16 @@ static void ThreadDecompressionFunc(void *pData)
+                 psJob->nXBlock, psJob->nYBlock);
+             if (apoBlocks[i] == nullptr)
+             {
++                // Temporary disabling of dirty block fushing, otherwise
++                // we can be in a deadlock situation, where the
++                // GTiffDataset::SubmitCompressionJob() method waits for jobs
++                // to be finished, that can't finish (actually be started)
++                // because this task and its siblings are taking all the
++                // available workers allowed by the global thread pool.
++                GDALRasterBlock::EnterDisableDirtyBlockFlush();
+                 apoBlocks[i] = poDS->GetRasterBand(iBand)->GetLockedBlockRef(
+                     psJob->nXBlock, psJob->nYBlock, TRUE);
++                GDALRasterBlock::LeaveDisableDirtyBlockFlush();
+                 if (apoBlocks[i] == nullptr)
+                     return false;
+             }

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.7.2",
+  "port-version": 1,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2826,7 +2826,7 @@
     },
     "gdal": {
       "baseline": "3.7.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gdcm": {
       "baseline": "3.0.22",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3931fc54de192cbee6b4683bc2261b2f3093130f",
+      "version-semver": "3.7.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "d01864aaa21a85e1e8f7bb6748d607e953c52e77",
       "version-semver": "3.7.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #34577.
Patch from https://github.com/OSGeo/gdal/pull/8561#issuecomment-1763372147.
Next release is not before November 01, 2023.