### PR TITLE
[gz-cmake3] fix FindGzBullet.cmake

### DIFF
--- a/ports/gz-cmake3/dependencies.patch
+++ b/ports/gz-cmake3/dependencies.patch
@@ -1,0 +1,22 @@
+diff --git a/cmake/FindGzBullet.cmake b/cmake/FindGzBullet.cmake
+--- a/cmake/FindGzBullet.cmake
++++ b/cmake/FindGzBullet.cmake
+@@ -30,16 +30,17 @@
+ 
+ # Bullet. Force MODULE mode to use the FindBullet.cmake file distributed with
+ # CMake. Otherwise, we may end up using the BulletConfig.cmake file distributed
+ # with Bullet, which uses relative paths and may break transitive dependencies.
+-find_package(Bullet MODULE ${gz_quiet_arg})
++find_package(Bullet CONFIG REQUIRED)
+ 
+ set(GzBullet_FOUND false)
+ # create Bullet target
+ if(BULLET_FOUND)
+   set(GzBullet_FOUND true)
+ 
+   gz_import_target(GzBullet
++    INTERFACE
+     TARGET_NAME GzBullet::GzBullet
+     LIB_VAR BULLET_LIBRARIES
+     INCLUDE_VAR BULLET_INCLUDE_DIRS
+   )

--- a/ports/gz-cmake3/portfile.cmake
+++ b/ports/gz-cmake3/portfile.cmake
@@ -5,6 +5,8 @@ ignition_modular_library(
     REF ${PORT}_${VERSION}
     VERSION ${VERSION}
     SHA512 30cf5aa69674bdc1a99762fc45d134b99da5e2faf846749392697ae41463a5304a43022bb0c2ca1b373af4171135d686fdd736573fe6e1cc26dc2cecc8333e69
+    PATCHES
+        dependencies.patch
 )
 
 # Install custom usage

--- a/ports/gz-cmake3/vcpkg.json
+++ b/ports/gz-cmake3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gz-cmake3",
   "version": "3.4.1",
+  "port-version": 1,
   "description": "CMake helper functions for building robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/cmake",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3142,7 +3142,7 @@
     },
     "gz-cmake3": {
       "baseline": "3.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "gz-common5": {
       "baseline": "5.4.1",

--- a/versions/g-/gz-cmake3.json
+++ b/versions/g-/gz-cmake3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d7ac07eb757d7a69f1df27ad7a1ef71c26957d4",
+      "version": "3.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c0061f3363187e8da74f252ff3c21c42e382e8c9",
       "version": "3.4.1",
       "port-version": 0


### PR DESCRIPTION
[gz-cmake3] fix FindGzBullet.cmake
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
