### PR TITLE
[vcpkg baseline][ogre] Fix compiler selection

### DIFF
--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -10,6 +10,15 @@ if(VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_EMSCRIPTEN)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
+if(VCPKG_TARGET_IS_OSX)
+      file(GLOB_RECURSE llvm_files "${VCPKG_ROOT_DIR}/buildtrees/llvm/*")
+      if(NOT llvm_files STREQUAL "")
+          file(REMOVE_RECURSE "${VCPKG_ROOT_DIR}/buildtrees/llvm/")
+          file(REMOVE_RECURSE "${CURRENT_INSTALLED_DIR}/tools/llvm/")
+          file(REMOVE_RECURSE "${VCPKG_ROOT_DIR}/packages/llvm_${TARGET_TRIPLET}/")
+      endif()
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OGRECave/ogre

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -11,11 +11,9 @@ if(VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_EMSCRIPTEN)
 endif()
 
 if(VCPKG_TARGET_IS_OSX)
-      file(GLOB_RECURSE llvm_files "${VCPKG_ROOT_DIR}/buildtrees/llvm/*")
+      file(GLOB_RECURSE llvm_files "${CURRENT_INSTALLED_DIR}/tools/llvm/*")
       if(NOT llvm_files STREQUAL "")
-          file(REMOVE_RECURSE "${VCPKG_ROOT_DIR}/buildtrees/llvm/")
           file(REMOVE_RECURSE "${CURRENT_INSTALLED_DIR}/tools/llvm/")
-          file(REMOVE_RECURSE "${VCPKG_ROOT_DIR}/packages/llvm_${TARGET_TRIPLET}/")
       endif()
 endif()
 

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ogre",
   "version": "14.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6030,7 +6030,7 @@
     },
     "ogre": {
       "baseline": "14.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "ogre-next": {
       "baseline": "2.3.1",

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ab93f9718e0cd4f7ed51f0446d3681af3db3fe4f",
+      "git-tree": "85ca1a08f12a3d1d7f3eed5e2fefb2130f74f261",
       "version": "14.0.1",
       "port-version": 3
     },

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab93f9718e0cd4f7ed51f0446d3681af3db3fe4f",
+      "version": "14.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "a445b3c7be57d018422e139945ff622292cd5cff",
       "version": "14.0.1",
       "port-version": 2


### PR DESCRIPTION
Fix CI issue: https://dev.azure.com/vcpkg/public/_build/results?buildId=95530&view=results
````
ogre:x64-osx failed with BUILD_FAILED
````

````
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/wchar.h:89:10: fatal error: 'stdarg.h' file not found
   89 | #include <stdarg.h>
      |          ^~~~~~~~~~
`````

Ogre prefers Clang on Linux which causes build failure if LLVM is installed before.
 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

