### PR TITLE
[libmspack] update to 0.11

### DIFF
--- a/ports/libmspack/portfile.cmake
+++ b/ports/libmspack/portfile.cmake
@@ -1,11 +1,11 @@
 set(LIB_NAME libmspack)
-set(LIB_VERSION 0.10.1alpha)
+set(LIB_VERSION 0.11alpha)
 set(LIB_FILENAME ${LIB_NAME}-${LIB_VERSION}.tar.gz)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.cabextract.org.uk/libmspack/${LIB_FILENAME}"
     FILENAME "${LIB_FILENAME}"
-    SHA512 a7b5f7caa49190c5021f3e768b92f2e51cc0ce685c9ab6ed6fb36de885c73231b58d47a8a3b5c5aa5c9ac56c25c500eb683d84dbf11f09f97f6cb4fff5adc245
+    SHA512 40c487e5b4e2f63a6cada26d29db51f605e8c29525a1cb088566d02cf2b1cc9dba263f80e2101d7f8e9d69cf7684a15bcaf791fb4891ad013a56afc7256dfa62
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libmspack/vcpkg.json
+++ b/ports/libmspack/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmspack",
-  "version": "0.10.1",
-  "port-version": 6,
+  "version": "0.11",
   "description": "libmspack is a portable library for some loosely related Microsoft compression formats.",
   "homepage": "https://www.cabextract.org.uk/libmspack",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4453,8 +4453,8 @@
       "port-version": 3
     },
     "libmspack": {
-      "baseline": "0.10.1",
-      "port-version": 6
+      "baseline": "0.11",
+      "port-version": 0
     },
     "libmt32emu": {
       "baseline": "2.7.0",

--- a/versions/l-/libmspack.json
+++ b/versions/l-/libmspack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "198f4c8a1eac2254110eaed939dc99744c78a58f",
+      "version": "0.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "b26826abcd6d912b526809624f838431cb470b3d",
       "version": "0.10.1",
       "port-version": 6


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

