### PR TITLE
[libheif] update to 1.17.1

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  strukturag/libheif 
     REF "v${VERSION}"
-    SHA512 1b88197c23f19f1f877e19242a47f6e1e6dcfe60a92c0a58b64ca555cc39111c14fe592ef9d287ca383da2fc33fd5e41f21e0e0bc20b9cc668bd6b99b26aadc8
+    SHA512 a4dbb0b1bcd6957841ce218f931a2d836e58d0b60323753020c684e97e4920f7802316f8979d1276904cd2e5809dc8e0dcf85ff9474d5f70e59380c290716fe7
     HEAD_REF master
     PATCHES
         gdk-pixbuf.patch

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libheif",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Open h.265 video codec implementation.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4273,7 +4273,7 @@
       "port-version": 5
     },
     "libheif": {
-      "baseline": "1.17.0",
+      "baseline": "1.17.1",
       "port-version": 0
     },
     "libhsplasma": {

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32b640f029df01a4322b7d36d9405cf366c7811d",
+      "version": "1.17.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "bfddf765a3840434bd1306bc48193566642e9bef",
       "version": "1.17.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.