### PR TITLE
[duckdb] Add new port

### DIFF
--- a/ports/duckdb/add_template_specialization.patch
+++ b/ports/duckdb/add_template_specialization.patch
@@ -1,0 +1,35 @@
+diff --git a/src/include/duckdb/common/limits.hpp b/src/include/duckdb/common/limits.hpp
+index bdf44d0c0a..42fc2056d9 100644
+--- a/src/include/duckdb/common/limits.hpp
++++ b/src/include/duckdb/common/limits.hpp
+@@ -10,6 +10,7 @@
+
+ #include "duckdb/common/hugeint.hpp"
+ #include "duckdb/common/types.hpp"
++#include "duckdb/common/types/datetime.hpp"
+
+ #include <type_traits>
+
+@@ -51,6 +52,22 @@ struct NumericLimits<hugeint_t> {
+ 	}
+ };
+
++template <>
++struct NumericLimits<dtime_tz_t> {
++	static constexpr dtime_tz_t Minimum() {
++		return std::numeric_limits<dtime_tz_t>::lowest();
++	};
++	static constexpr dtime_tz_t Maximum() {
++	    return std::numeric_limits<dtime_tz_t>::max();
++	};
++	static constexpr bool IsSigned() {
++		return std::is_signed<dtime_tz_t>::value;
++	}
++	static constexpr idx_t Digits() {
++		return 19;
++	}
++};
++
+ template <>
+ constexpr idx_t NumericLimits<int8_t>::Digits() {
+ 	return 3;

--- a/ports/duckdb/add_version_pass_through.patch
+++ b/ports/duckdb/add_version_pass_through.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 082bb28cdf..b891ce553f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -291,6 +291,14 @@ else()
+   set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}-dev${DUCKDB_DEV_ITERATION}")
+ endif()
+ 
++if (DEFINED DUCKDB_OVERWRITE_VERSION)
++  set(DUCKDB_VERSION ${DUCKDB_OVERWRITE_VERSION})
++endif()
++
++if (DEFINED DUCKDB_OVERWRITE_COMMIT_ID)
++  set(GIT_COMMIT_HASH ${DUCKDB_OVERWRITE_COMMIT_ID})
++endif()
++
+ message(STATUS "git hash ${GIT_COMMIT_HASH}, version ${DUCKDB_VERSION}")
+ 
+ option(AMALGAMATION_BUILD

--- a/ports/duckdb/fix_config_file_path.patch
+++ b/ports/duckdb/fix_config_file_path.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 082bb28cdf..80aa22c9a7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1112,7 +1112,7 @@ if(EXISTS ${CMAKE_CONFIG_TEMPLATE} AND EXISTS ${CMAKE_CONFIG_VERSION_TEMPLATE})
+                  "${PROJECT_BINARY_DIR}/DuckDBConfig.cmake" @ONLY)
+ 
+   # Configure cmake package config for the install tree
+-  file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}"
++  file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}/../"
+        "${INSTALL_INCLUDE_DIR}")
+   set(CONF_INCLUDE_DIRS "\${DuckDB_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+   configure_file(

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
             fix_config_file_path.patch
             set_third_party_libs_to_obj.patch
             add_version_pass_through.patch
+            add_template_specialization.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" DUCKDB_BUILD_STATIC)
@@ -29,9 +30,6 @@ endif()
 if(NOT "parquet" IN_LIST FEATURES)
     set(SKIP_PARQUET_FLAG "-DSKIP_EXTENSIONS=parquet")
 endif()
-if(NOT "cli" IN_LIST FEATURES)
-    set(DONT_BUILD_SHELL_FLAG "-DBUILD_SHELL=FALSE")
-endif()
 
 vcpkg_cmake_configure(
         SOURCE_PATH ${SOURCE_PATH}
@@ -39,9 +37,9 @@ vcpkg_cmake_configure(
             -DDUCKDB_OVERWRITE_COMMIT_ID=${DUCKDB_SHORT_HASH}
             -DDUCKDB_OVERWRITE_VERSION=${DUCKDB_VERSION}
             -DBUILD_UNITTESTS=OFF
+            -DBUILD_SHELL=FALSE
             "${SKIP_PARQUET_FLAG}"
             "${LOAD_EXTENSIONS_FLAG}"
-            "${DONT_BUILD_SHELL_FLAG}"
             -DENABLE_EXTENSION_AUTOLOADING=1
             -DENABLE_EXTENSION_AUTOINSTALL=1
 )
@@ -53,6 +51,10 @@ elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/DuckDB")
     vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/DuckDB")
 elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}")
     vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -1,9 +1,8 @@
-set(DUCKDB_VERSION v0.9.1)
 set(DUCKDB_SHORT_HASH 401c8061c6)
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO duckdb/duckdb
-        REF ${DUCKDB_VERSION}
+        REF v${VERSION}
         SHA512 5905d9f619618ba3d0d729424659a81b82809603747582aad9d568e2db1dc719a4e1d336e4a8f602ee0b01ab2b28caa99c242db4b13444150ca593f1d1e4006a
         HEAD_REF master
         PATCHES
@@ -35,7 +34,7 @@ vcpkg_cmake_configure(
         SOURCE_PATH ${SOURCE_PATH}
         OPTIONS
             -DDUCKDB_OVERWRITE_COMMIT_ID=${DUCKDB_SHORT_HASH}
-            -DDUCKDB_OVERWRITE_VERSION=${DUCKDB_VERSION}
+            -DDUCKDB_OVERWRITE_VERSION=v${VERSION}
             -DBUILD_UNITTESTS=OFF
             -DBUILD_SHELL=FALSE
             "${SKIP_PARQUET_FLAG}"

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -1,0 +1,55 @@
+set(DUCKDB_VERSION v0.9.1)
+set(DUCKDB_SHORT_HASH 401c8061c6)
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO duckdb/duckdb
+        REF ${DUCKDB_VERSION}
+        SHA512 5905d9f619618ba3d0d729424659a81b82809603747582aad9d568e2db1dc719a4e1d336e4a8f602ee0b01ab2b28caa99c242db4b13444150ca593f1d1e4006a
+        HEAD_REF master
+        PATCHES
+            fix_config_file_path.patch
+            set_third_party_libs_to_obj.patch
+            add_version_pass_through.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" DUCKDB_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DUCKDB_BUILD_DYNAMIC)
+
+set(EXTENSION_LIST "autocomplete;fts;httpfs;inet;icu;json;parquet;sqlsmith;tpcds;tpch")
+set(EXTENSION_LOAD_LIST "")
+foreach(EXT ${EXTENSION_LIST})
+    if(${EXT} IN_LIST FEATURES)
+        list(APPEND EXTENSION_LOAD_LIST ${EXT})
+    endif()
+endforeach()
+if(NOT "${EXTENSION_LOAD_LIST}" STREQUAL "")
+    set(LOAD_EXTENSIONS_FLAG "-DBUILD_EXTENSIONS='${EXTENSION_LOAD_LIST}'")
+endif()
+
+if(NOT "parquet" IN_LIST FEATURES)
+    set(SKIP_PARQUET_FLAG "-DSKIP_EXTENSIONS=parquet")
+endif()
+if(NOT "cli" IN_LIST FEATURES)
+    set(DONT_BUILD_SHELL_FLAG "-DBUILD_SHELL=FALSE")
+endif()
+
+vcpkg_cmake_configure(
+        SOURCE_PATH ${SOURCE_PATH}
+        OPTIONS
+            -DDUCKDB_OVERWRITE_COMMIT_ID=${DUCKDB_SHORT_HASH}
+            -DDUCKDB_OVERWRITE_VERSION=${DUCKDB_VERSION}
+            -DBUILD_UNITTESTS=OFF
+            "${SKIP_PARQUET_FLAG}"
+            "${LOAD_EXTENSIONS_FLAG}"
+            "${DONT_BUILD_SHELL_FLAG}"
+            -DENABLE_EXTENSION_AUTOLOADING=1
+            -DENABLE_EXTENSION_AUTOINSTALL=1
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/duckdb/storage/serialization")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -46,7 +46,14 @@ vcpkg_cmake_configure(
             -DENABLE_EXTENSION_AUTOINSTALL=1
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/CMake")
+    vcpkg_cmake_config_fixup(CONFIG_PATH CMake)
+elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/DuckDB")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/DuckDB")
+elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/duckdb/set_third_party_libs_to_obj.patch
+++ b/ports/duckdb/set_third_party_libs_to_obj.patch
@@ -1,0 +1,155 @@
+diff --git a/third_party/fastpforlib/CMakeLists.txt b/third_party/fastpforlib/CMakeLists.txt
+index 432deb3205..d6203f34f0 100644
+--- a/third_party/fastpforlib/CMakeLists.txt
++++ b/third_party/fastpforlib/CMakeLists.txt
+@@ -2,7 +2,7 @@ if(POLICY CMP0063)
+     cmake_policy(SET CMP0063 NEW)
+ endif()
+ 
+-add_library(duckdb_fastpforlib STATIC bitpacking.cpp)
++add_library(duckdb_fastpforlib OBJECT bitpacking.cpp)
+ 
+ target_include_directories(
+         duckdb_fastpforlib
+diff --git a/third_party/fmt/CMakeLists.txt b/third_party/fmt/CMakeLists.txt
+index 829bb1d03e..8a4a5f2ee4 100644
+--- a/third_party/fmt/CMakeLists.txt
++++ b/third_party/fmt/CMakeLists.txt
+@@ -2,7 +2,7 @@ if(POLICY CMP0063)
+     cmake_policy(SET CMP0063 NEW)
+ endif()
+ 
+-add_library(duckdb_fmt STATIC format.cc)
++add_library(duckdb_fmt OBJECT format.cc)
+ 
+ target_include_directories(duckdb_fmt PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+ set_target_properties(duckdb_fmt PROPERTIES EXPORT_NAME duckdb_fmt)
+diff --git a/third_party/fsst/CMakeLists.txt b/third_party/fsst/CMakeLists.txt
+index 72e04ae21c..d015bca703 100644
+--- a/third_party/fsst/CMakeLists.txt
++++ b/third_party/fsst/CMakeLists.txt
+@@ -26,7 +26,7 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+ #    )
+ #endif()
+ 
+-add_library(duckdb_fsst STATIC libfsst.cpp fsst_avx512.cpp fsst_avx512_unroll1.inc fsst_avx512_unroll2.inc fsst_avx512_unroll3.inc fsst_avx512_unroll4.inc)
++add_library(duckdb_fsst OBJECT libfsst.cpp fsst_avx512.cpp fsst_avx512_unroll1.inc fsst_avx512_unroll2.inc fsst_avx512_unroll3.inc fsst_avx512_unroll4.inc)
+ 
+ target_include_directories(duckdb_fsst PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+ set_target_properties(duckdb_fsst PROPERTIES EXPORT_NAME duckdb_fsst)
+diff --git a/third_party/hyperloglog/CMakeLists.txt b/third_party/hyperloglog/CMakeLists.txt
+index f1e4c98d38..2e25d93d81 100644
+--- a/third_party/hyperloglog/CMakeLists.txt
++++ b/third_party/hyperloglog/CMakeLists.txt
+@@ -2,7 +2,7 @@ if(POLICY CMP0063)
+     cmake_policy(SET CMP0063 NEW)
+ endif()
+ 
+-add_library(duckdb_hyperloglog STATIC hyperloglog.cpp sds.cpp)
++add_library(duckdb_hyperloglog OBJECT hyperloglog.cpp sds.cpp)
+ 
+ target_include_directories(
+   duckdb_hyperloglog
+diff --git a/third_party/imdb/CMakeLists.txt b/third_party/imdb/CMakeLists.txt
+index 2875dd87ff..29cf137e3e 100644
+--- a/third_party/imdb/CMakeLists.txt
++++ b/third_party/imdb/CMakeLists.txt
+@@ -9,6 +9,6 @@ project(imdb CXX)
+ include_directories(include)
+ 
+ set(CMAKE_BUILD_TYPE "Release")
+-add_library(imdb STATIC imdb.cpp ${ALL_OBJECT_FILES})
++add_library(imdb OBJECT imdb.cpp ${ALL_OBJECT_FILES})
+ 
+ disable_target_warnings(imdb)
+diff --git a/third_party/libpg_query/CMakeLists.txt b/third_party/libpg_query/CMakeLists.txt
+index cb1e13d071..183e649d5a 100644
+--- a/third_party/libpg_query/CMakeLists.txt
++++ b/third_party/libpg_query/CMakeLists.txt
+@@ -6,7 +6,7 @@ if(POLICY CMP0063)
+ endif()
+ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+ 
+-add_library(duckdb_pg_query STATIC
++add_library(duckdb_pg_query OBJECT
+             postgres_parser.cpp
+             pg_functions.cpp
+             src_backend_parser_parser.cpp
+diff --git a/third_party/mbedtls/CMakeLists.txt b/third_party/mbedtls/CMakeLists.txt
+index 78eea4ae09..196a3e00fd 100644
+--- a/third_party/mbedtls/CMakeLists.txt
++++ b/third_party/mbedtls/CMakeLists.txt
+@@ -6,7 +6,7 @@ include_directories(include)
+ 
+ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+ 
+-add_library(duckdb_mbedtls STATIC mbedtls_wrapper.cpp library/sha256.cpp library/rsa.cpp library/rsa_alt_helpers.cpp  library/md.cpp library/bignum.cpp library/oid.cpp library/constant_time.cpp library/platform_util.cpp library/base64.cpp library/pkparse.cpp library/pk.cpp library/pk_wrap.cpp library/asn1parse.cpp library/pem.cpp)
++add_library(duckdb_mbedtls OBJECT mbedtls_wrapper.cpp library/sha256.cpp library/rsa.cpp library/rsa_alt_helpers.cpp  library/md.cpp library/bignum.cpp library/oid.cpp library/constant_time.cpp library/platform_util.cpp library/base64.cpp library/pkparse.cpp library/pk.cpp library/pk_wrap.cpp library/asn1parse.cpp library/pem.cpp)
+ 
+ set_property(TARGET duckdb_mbedtls PROPERTY C_STANDARD 99)
+ 
+diff --git a/third_party/miniz/CMakeLists.txt b/third_party/miniz/CMakeLists.txt
+index 3d72e498d3..a3b1431d39 100644
+--- a/third_party/miniz/CMakeLists.txt
++++ b/third_party/miniz/CMakeLists.txt
+@@ -2,7 +2,7 @@ if(POLICY CMP0063)
+     cmake_policy(SET CMP0063 NEW)
+ endif()
+ 
+-add_library(duckdb_miniz STATIC miniz.cpp)
++add_library(duckdb_miniz OBJECT miniz.cpp)
+ 
+ target_include_directories(
+   duckdb_miniz
+diff --git a/third_party/re2/CMakeLists.txt b/third_party/re2/CMakeLists.txt
+index e7a7f586c7..934fe8b249 100644
+--- a/third_party/re2/CMakeLists.txt
++++ b/third_party/re2/CMakeLists.txt
+@@ -86,7 +86,7 @@ set(RE2_SOURCES
+     util/rune.cc
+     util/strutil.cc)
+ 
+-add_library(duckdb_re2 STATIC ${RE2_SOURCES})
++add_library(duckdb_re2 OBJECT ${RE2_SOURCES})
+ 
+ target_include_directories(
+   duckdb_re2
+diff --git a/third_party/snowball/CMakeLists.txt b/third_party/snowball/CMakeLists.txt
+index d55517d2b0..d8701f841d 100644
+--- a/third_party/snowball/CMakeLists.txt
++++ b/third_party/snowball/CMakeLists.txt
+@@ -7,7 +7,7 @@ project(Snowball)
+ include_directories(libstemmer runtime src_c)
+ 
+ add_library(
+-  snowball STATIC
++  snowball OBJECT
+   libstemmer/libstemmer.c
+   runtime/utilities.c
+   runtime/api.c
+diff --git a/third_party/tpce-tool/CMakeLists.txt b/third_party/tpce-tool/CMakeLists.txt
+index ba9a37a1f1..538279a93d 100644
+--- a/third_party/tpce-tool/CMakeLists.txt
++++ b/third_party/tpce-tool/CMakeLists.txt
+@@ -11,7 +11,7 @@ add_subdirectory(utilities)
+ 
+ add_definitions(-DCOMPILE_FLAT_FILE_LOAD)
+ 
+-add_library(tpce STATIC
++add_library(tpce OBJECT
+             ${TPCE_OBJECT_FILES}
+             duckdb_interface.cpp
+             tpce.cpp
+diff --git a/third_party/utf8proc/CMakeLists.txt b/third_party/utf8proc/CMakeLists.txt
+index 1824f60d0c..f9399ccc34 100644
+--- a/third_party/utf8proc/CMakeLists.txt
++++ b/third_party/utf8proc/CMakeLists.txt
+@@ -4,7 +4,7 @@ endif()
+ 
+ include_directories(include)
+ 
+-add_library(duckdb_utf8proc STATIC utf8proc.cpp utf8proc_wrapper.cpp)
++add_library(duckdb_utf8proc OBJECT utf8proc.cpp utf8proc_wrapper.cpp)
+ 
+ 
+ install(TARGETS duckdb_utf8proc

--- a/ports/duckdb/usage
+++ b/ports/duckdb/usage
@@ -1,0 +1,6 @@
+The package DuckDB provides CMake targets:
+
+    find_package(DuckDB CONFIG REQUIRED)
+    find_package(Threads REQUIRED)
+    target_link_libraries(main PRIVATE DuckDB_LIBRARIES)
+    target_link_libraries(main PRIVATE "$<IF:$<BOOL:${DUCKDB_BUILD_STATIC}>,duckdb_static,duckdb>")

--- a/ports/duckdb/usage
+++ b/ports/duckdb/usage
@@ -2,5 +2,5 @@ The package DuckDB provides CMake targets:
 
     find_package(DuckDB CONFIG REQUIRED)
     find_package(Threads REQUIRED)
-    target_link_libraries(main PRIVATE DuckDB_LIBRARIES)
+    target_include_directories(main PRIVATE ${DuckDB_INCLUDE_DIRS})
     target_link_libraries(main PRIVATE "$<IF:$<BOOL:${DUCKDB_BUILD_STATIC}>,duckdb_static,duckdb>")

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",
   "license": "MIT",
-  "supports": "x64 | (arm64 & !windows)",
+  "supports": "!(uwp | android | (windows & arm64))",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -22,9 +22,6 @@
     "autocomplete": {
       "description": "Statically link the autocomplete extension into DuckDB"
     },
-    "cli": {
-      "description": "Build the DuckDB cli"
-    },
     "fts": {
       "description": "Statically link the FTS extension into DuckDB"
     },
@@ -32,7 +29,7 @@
       "description": "Statically link the httpfs extension into DuckDB"
     },
     "icu": {
-      "description": "ICU support"
+      "description": "Statically link the icu extension into DuckDB"
     },
     "inet": {
       "description": "Statically link the inet extension into DuckDB"

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -26,7 +26,10 @@
       "description": "Statically link the FTS extension into DuckDB"
     },
     "httpfs": {
-      "description": "Statically link the httpfs extension into DuckDB"
+      "description": "Statically link the httpfs extension into DuckDB",
+      "dependencies": [
+        "openssl"
+      ]
     },
     "icu": {
       "description": "Statically link the icu extension into DuckDB"

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,0 +1,56 @@
+{
+  "name": "duckdb",
+  "version": "0.9.1",
+  "description": "High-performance in-process analytical database system",
+  "homepage": "https://duckdb.org",
+  "license": "MIT",
+  "supports": "x64 | (arm64 & !windows)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "parquet"
+  ],
+  "features": {
+    "autocomplete": {
+      "description": "Statically link the autocomplete extension into DuckDB"
+    },
+    "cli": {
+      "description": "Build the DuckDB cli"
+    },
+    "fts": {
+      "description": "Statically link the FTS extension into DuckDB"
+    },
+    "httpfs": {
+      "description": "Statically link the httpfs extension into DuckDB"
+    },
+    "icu": {
+      "description": "ICU support"
+    },
+    "inet": {
+      "description": "Statically link the inet extension into DuckDB"
+    },
+    "json": {
+      "description": "Statically link the json extension into DuckDB"
+    },
+    "parquet": {
+      "description": "Statically link the parquet extension into DuckDB"
+    },
+    "sqlsmith": {
+      "description": "Statically link the sqlsmith extension into DuckDB"
+    },
+    "tpcds": {
+      "description": "Statically link the tpcds extension into DuckDB"
+    },
+    "tpch": {
+      "description": "Statically link the tpch extension into DuckDB"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2228,6 +2228,10 @@
       "baseline": "1.20",
       "port-version": 0
     },
+    "duckdb": {
+      "baseline": "0.9.1",
+      "port-version": 0
+    },
     "duckx": {
       "baseline": "1.2.2",
       "port-version": 1

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "",
+      "version": "0.9.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3f3e0fe0c43ac2ec4a0008db22dafcd93c9068ec",
+      "git-tree": "74a960eb73dcfa1e0802283494f41779dda1c5f5",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "",
+      "git-tree": "19f8da53490e23ec9cf5ce9a33dfa80caaa9eefe",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "74a960eb73dcfa1e0802283494f41779dda1c5f5",
+      "git-tree": "116e3666bd274e97073636575f5c0095337643d5",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "19f8da53490e23ec9cf5ce9a33dfa80caaa9eefe",
+      "git-tree": "3f3e0fe0c43ac2ec4a0008db22dafcd93c9068ec",
       "version": "0.9.1",
       "port-version": 0
     }


### PR DESCRIPTION
Hi 👋 

Here's a port for [duckdb](https://github.com/duckdb/duckdb), checked all the boxes I think, but happy to take some feedback!

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
