### PR TITLE
[webview2] update to 1.0.2088.41

### DIFF
--- a/ports/webview2/portfile.cmake
+++ b/ports/webview2/portfile.cmake
@@ -2,12 +2,10 @@ if(VCPKG_TARGET_IS_UWP)
     vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
-set(VERSION 1.0.1210.39)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}"
     FILENAME "microsoft.web.webview2.${VERSION}.zip"
-    SHA512 c87812247a466f4aaeac8be8b32be49166b4ddb5bbf65581d5df81d69eda340e9911144a8dd8401baa6e51f95337001cd18ff90cd36ca0af86cc65227e8e2ccf
+    SHA512 59d2293d2becb03ed99ab0a70a753adf49d998294d318d331047c2ec7c7dcb163ed84a09ab35765873c2364c3367a8033e2b1a5ad52c5b8e99f8d7a69b8e915e
 )
 
 vcpkg_extract_source_archive(

--- a/ports/webview2/vcpkg.json
+++ b/ports/webview2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "webview2",
-  "version": "1.0.1210.39",
-  "port-version": 1,
+  "version": "1.0.2088.41",
   "description": "The WebView2 control allows you to embed web technologies (HTML, CSS, and JavaScript) using Microsoft Edge",
   "homepage": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",
   "documentation": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8861,8 +8861,8 @@
       "port-version": 2
     },
     "webview2": {
-      "baseline": "1.0.1210.39",
-      "port-version": 1
+      "baseline": "1.0.2088.41",
+      "port-version": 0
     },
     "wepoll": {
       "baseline": "1.5.8",

--- a/versions/w-/webview2.json
+++ b/versions/w-/webview2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5cd32d80f7fd65a498507ca2de77f8ce5449dd30",
+      "version": "1.0.2088.41",
+      "port-version": 0
+    },
+    {
       "git-tree": "8f620381c9d12e72ae72e693571bc98ab82510da",
       "version": "1.0.1210.39",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/34601
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
