### PR TITLE
[gz-physics6] new port

### DIFF
--- a/ports/gz-physics6/dependencies.patch
+++ b/ports/gz-physics6/dependencies.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -73,9 +73,8 @@
+     collision-bullet
+     collision-ode
+     utils
+     utils-urdf
+   CONFIG
+   VERSION 6.9
+   REQUIRED_BY dartsim
+-  PKGCONFIG dart
+   PKGCONFIG_VER_COMPARISON >=)
+@@ -82,7 +82,6 @@
+ #--------------------------------------
+ # Find bullet for the bullet plugin wrapper
+ gz_find_package(GzBullet
+   VERSION 2.87
+   REQUIRED_BY bullet bullet-featherstone
+-  PKGCONFIG bullet
+   PKGCONFIG_VER_COMPARISON >=)

--- a/ports/gz-physics6/portfile.cmake
+++ b/ports/gz-physics6/portfile.cmake
@@ -1,0 +1,25 @@
+set(PACKAGE_NAME physics)
+
+ignition_modular_library(
+   NAME ${PACKAGE_NAME}
+   REF ${PORT}_${VERSION}
+   VERSION ${VERSION}
+   SHA512 c29594663509234e25c7d0a33848c0fe222c2b9471513978c18ea6873a17c66c43b4037c74e8849995fa6449c2dddc0f2ee669605893daf65119c277a17f39e1
+   OPTIONS 
+   PATCHES
+      dependencies.patch
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)   
+   file(GLOB plugins "${CURRENT_PACKAGES_DIR}/lib/gz-physics-6/engine-plugins/*.dll")
+   if (NOT plugins STREQUAL "")
+      file(COPY ${plugins} DESTINATION "${CURRENT_PACKAGES_DIR}/bin/engine-plugins/")
+      file(REMOVE ${plugins})
+   endif()
+
+   file(GLOB plugins_debug "${CURRENT_PACKAGES_DIR}/debug/lib/gz-physics-6/engine-plugins/*.dll")
+   if (NOT plugins_debug STREQUAL "")
+      file(COPY ${plugins_debug} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/engine-plugins/")
+      file(REMOVE ${plugins_debug})
+   endif()
+endif()

--- a/ports/gz-physics6/vcpkg.json
+++ b/ports/gz-physics6/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "gz-physics6",
+  "version": "6.5.1",
+  "description": "component of Gazebo, provides an abstract physics interface designed to support simulation and rapid development of robot applications.",
+  "homepage": "https://gazebosim.org/libs/physics",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "bullet3",
+    "dartsim",
+    "eigen3",
+    "gz-cmake3",
+    "gz-common5",
+    "gz-math7",
+    "gz-plugin2",
+    "gz-utils2",
+    {
+      "name": "ignition-modularscripts",
+      "host": true
+    },
+    "sdformat13"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3180,6 +3180,10 @@
       "baseline": "9.5.0",
       "port-version": 0
     },
+    "gz-physics6": {
+      "baseline": "6.5.1",
+      "port-version": 0
+    },
     "gz-plugin2": {
       "baseline": "2.0.1",
       "port-version": 0

--- a/versions/g-/gz-physics6.json
+++ b/versions/g-/gz-physics6.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9e84a89c5e37806e67295d51b6bd1ec565ccaede",
+      "version": "6.5.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

