### PR TITLE
[gz-rendering7] new port

### DIFF
--- a/ports/gz-cmake3/dependencies.patch
+++ b/ports/gz-cmake3/dependencies.patch
@@ -108,3 +108,104 @@ index 4eb7a0d..11dae8a 100644
            gz_string_append(${component}_CMAKE_DEPENDENCIES "${${PACKAGE_NAME}_find_dependency}" DELIM "\n")
          endif()
        endforeach()
+diff --git a/cmake/FindGzOGRE2.cmake b/cmake/FindGzOGRE2.cmake
+--- a/cmake/FindGzOGRE2.cmake
++++ b/cmake/FindGzOGRE2.cmake
+@@ -143,11 +143,11 @@
+   endif ()
+ endmacro()
+ 
+ find_package(PkgConfig QUIET)
+-if (PkgConfig_FOUND)
++if (NOT WIN32)
+   set(PKG_CONFIG_PATH_ORIGINAL $ENV{PKG_CONFIG_PATH})
+-  foreach (GZ_OGRE2_PROJECT_NAME "OGRE2" "OGRE-Next")
++  foreach (GZ_OGRE2_PROJECT_NAME "OGRE")
+     message(STATUS "Looking for OGRE using the name: ${GZ_OGRE2_PROJECT_NAME}")
+     if (GZ_OGRE2_PROJECT_NAME STREQUAL "OGRE2")
+       set(OGRE2_INSTALL_PATH "OGRE-2.${GzOGRE2_FIND_VERSION_MINOR}")
+       # For OGRE 2.3 debs built via OpenRobotics buildfarms, we use OgreNext
+@@ -159,10 +159,10 @@
+         set(OGRE2LIBNAME "Ogre")
+       endif()
+     else()
+       # This matches OGRE2.2 debs built in upstream Ubuntu
+-      set(OGRE2_INSTALL_PATH "OGRE-Next")
+-      set(OGRE2LIBNAME "OgreNext")
++      set(OGRE2_INSTALL_PATH "OGRE")
++      set(OGRE2LIBNAME "Ogre")
+     endif()
+ 
+     # Note: OGRE2 installed from debs is named OGRE-2.2 while the version
+     # installed from source does not have the 2.2 suffix
+@@ -172,8 +172,9 @@
+     if (${GZ_OGRE2_PROJECT_NAME}_FOUND)
+       set(GZ_PKG_NAME ${OGRE2_INSTALL_PATH})
+       set(OGRE2_FOUND ${${GZ_OGRE2_PROJECT_NAME}_FOUND})  # sync possible OGRE-Next to OGRE2
+       fix_pkgconfig_prefix_jammy_bug("${${GZ_OGRE2_PROJECT_NAME}_LIBRARY_DIRS}" OGRE2_LIBRARY_DIRS)
++      set(OGRE2_LIBRARY_DIRS ${${GZ_OGRE2_PROJECT_NAME}_LIBRARY_DIRS})
+       set(OGRE2_LIBRARIES ${${GZ_OGRE2_PROJECT_NAME}_LIBRARIES})  # sync possible Ogre-Next ot OGRE2
+     else()
+       # look for OGRE2 installed from source
+       set(PKG_CONFIG_PATH_TMP ${PKG_CONFIG_PATH_ORIGINAL})
+@@ -308,8 +309,10 @@
+           "${OGRE2LIBNAME}${component}_d.${OGRE2_VERSION}"
+           "${OGRE2LIBNAME}${component}_d"
+           "${OGRE2LIBNAME}${component}.${OGRE2_VERSION}"
+           "${OGRE2LIBNAME}${component}"
++          "${OGRE2LIBNAME}${component}Static"
++          "${OGRE2LIBNAME}${component}Static_d"          
+         HINTS ${OGRE2_LIBRARY_DIRS})
+       if (NOT "${OGRE2-${component}}" STREQUAL "OGRE2-${component}-NOTFOUND")
+         message(STATUS "  + component ${component}: found")
+         # create a new target for each component
+@@ -403,15 +406,24 @@
+   set(OGRE2_SEARCH_VER "OGRE-${GzOGRE2_FIND_VERSION_MAJOR}.${GzOGRE2_FIND_VERSION_MINOR}")
+   set(OGRE2_PATHS "")
+   set(OGRE2_INC_PATHS "")
+   foreach(_rootPath ${VCPKG_CMAKE_FIND_ROOT_PATH})
+-      list(APPEND OGRE2_PATHS "${_rootPath}/lib/${OGRE2_SEARCH_VER}/")
+-      list(APPEND OGRE2_PATHS "${_rootPath}/lib/${OGRE2_SEARCH_VER}/manual-link/")
+-      list(APPEND OGRE2_INC_PATHS "${_rootPath}/include/${OGRE2_SEARCH_VER}")
++      get_filename_component(debug_dir "${_rootPath}" NAME)
++      if(debug_dir MATCHES "debug" AND CMAKE_BUILD_TYPE MATCHES Debug OR NOT debug_dir MATCHES "debug" AND CMAKE_BUILD_TYPE MATCHES Release)
++        list(APPEND OGRE2_PATHS "${_rootPath}/lib/")
++        list(APPEND OGRE2_PATHS "${_rootPath}/lib/manual-link/")
++      endif()
++      list(APPEND OGRE2_INC_PATHS "${_rootPath}/include/OGRE")
+   endforeach()
+ 
++  if(CMAKE_BUILD_TYPE MATCHES Debug)
++    set(OGRE_MAIN_LIB "OgreMain_d")
++  else()
++    set(OGRE_MAIN_LIB "OgreMain")
++  endif()
++
+   find_library(OGRE2_LIBRARY
+-    NAMES "OgreMain"
++    NAMES "${OGRE_MAIN_LIB}"
+     HINTS ${OGRE2_PATHS}
+     NO_DEFAULT_PATH)
+ 
+   find_path(OGRE2_INCLUDE
+@@ -509,8 +521,9 @@
+ 
+   ogre_find_plugin(Plugin_ParticleFX OgreParticleFXPrerequisites.h PlugIns/ParticleFX/include)
+   ogre_find_plugin(RenderSystem_GL3Plus OgreGL3PlusRenderSystem.h RenderSystems/GL3Plus/include)
+   ogre_find_plugin(RenderSystem_Direct3D11 OgreD3D11RenderSystem.h RenderSystems/Direct3D11/include)
++  ogre_find_component(PlanarReflections OgrePlanarReflections.h PlanarReflections)
+ 
+   foreach(component ${GzOGRE2_FIND_COMPONENTS})
+     set(PREFIX OGRE2_${component})
+     if(${PREFIX}_FOUND)
+@@ -520,9 +533,9 @@
+       string(FIND ${component} "Hlms" HLMS_POS)
+       if(${HLMS_POS} GREATER -1)
+         foreach (dir ${OGRE2_INCLUDE_DIRS})
+           get_filename_component(dir_name "${dir}" NAME)
+-          if ("${dir_name}" STREQUAL "OGRE-${OGRE2_VERSION_MAJOR}.${OGRE2_VERSION_MINOR}")
++          if ("${dir_name}" STREQUAL "OGRE")
+             set(dir_include "${dir}/Hlms/Common")
+             if (EXISTS ${dir_include})
+               list(APPEND component_INCLUDE_DIRS ${dir_include})
+             endif()

--- a/ports/gz-cmake3/vcpkg.json
+++ b/ports/gz-cmake3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gz-cmake3",
   "version": "3.4.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "CMake helper functions for building robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/cmake",
   "license": null,

--- a/ports/gz-rendering7/fix-dependencies.patch
+++ b/ports/gz-rendering7/fix-dependencies.patch
@@ -1,0 +1,47 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65,12 +65,12 @@
+ 
+ if (APPLE)
+   gz_find_package(OpenGL
+     REQUIRED_BY ogre ogre2
+-    PKGCONFIG gl)
++    PKGCONFIG opengl)
+ else()
+   gz_find_package(OpenGL REQUIRED
+     COMPONENTS OpenGL
+     OPTIONAL_COMPONENTS EGL
+     REQUIRED_BY ogre ogre2
+-    PKGCONFIG gl)
++    PKGCONFIG opengl)
+ endif()
+@@ -81,5 +81,6 @@
+ 
+ #--------------------------------------
+ # Find OGRE
++if(0)
+ list(APPEND gz_ogre_components "RTShaderSystem" "Terrain" "Overlay" "Paging")
+ 
+@@ -97,5 +98,6 @@
+                       "The software might compile and even work but support from upstream"
+                       "could be reduced to accepting patches for newer versions")
+   endif()
+ endif()
++endif()
+ 
+diff --git a/ogre2/src/terrain/Terra/CMakeLists.txt b/ogre2/src/terrain/Terra/CMakeLists.txt
+--- a/ogre2/src/terrain/Terra/CMakeLists.txt
++++ b/ogre2/src/terrain/Terra/CMakeLists.txt
+@@ -34,8 +34,10 @@
+     # we must add this one manually for this to build correctly
+     ${OGRE2_INCLUDE}/Hlms/Pbs
+     ${OGRE2_INCLUDE}/Hlms/Common
+   PUBLIC
+-    ${CMAKE_CURRENT_LIST_DIR}/include
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>  
++    $<INSTALL_INTERFACE:include>
+ )
+ 
+ target_link_libraries(${PROJECT_NAME} PRIVATE GzOGRE2::GzOGRE2)
++install(TARGETS ${PROJECT_NAME} EXPORT gz-rendering7-ogre2)

--- a/ports/gz-rendering7/portfile.cmake
+++ b/ports/gz-rendering7/portfile.cmake
@@ -1,0 +1,25 @@
+set(PACKAGE_NAME rendering)
+
+ignition_modular_library(
+   NAME ${PACKAGE_NAME}
+   REF ${PORT}_${VERSION}
+   VERSION ${VERSION}
+   SHA512 7c14b268694600b8529fef21130b34f516b26baac771c019b4248a67f84420c40d655e0abedf0b36c53b7cdf19941b3f4f3494696c831a83070632d004b30678
+   OPTIONS 
+   PATCHES
+      fix-dependencies.patch
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)   
+   file(GLOB plugins "${CURRENT_PACKAGES_DIR}/lib/gz-rendering-7/engine-plugins/*.dll")
+   if (NOT plugins STREQUAL "")
+      file(COPY ${plugins} DESTINATION "${CURRENT_PACKAGES_DIR}/bin/engine-plugins/")
+      file(REMOVE ${plugins})
+   endif()
+
+   file(GLOB plugins_debug "${CURRENT_PACKAGES_DIR}/debug/lib/gz-rendering-7/engine-plugins/*.dll")
+   if (NOT plugins_debug STREQUAL "")
+      file(COPY ${plugins_debug} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/engine-plugins/")
+      file(REMOVE ${plugins_debug})
+   endif()
+endif()

--- a/ports/gz-rendering7/vcpkg.json
+++ b/ports/gz-rendering7/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "gz-rendering7",
+  "version": "7.4.1",
+  "description": "Gazebo Rendering is a C++ library designed to provide an abstraction for different rendering engines. It offers unified APIs for creating 3D graphics applications.",
+  "homepage": "https://gazebosim.org/libs/rendering",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "freeimage",
+    "gz-cmake3",
+    "gz-common5",
+    "gz-math7",
+    "gz-plugin2",
+    "gz-utils2",
+    {
+      "name": "ignition-modularscripts",
+      "host": true
+    },
+    {
+      "name": "ogre-next",
+      "features": [
+        "planar-reflections"
+      ]
+    },
+    "opengl"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3162,7 +3162,7 @@
     },
     "gz-cmake3": {
       "baseline": "3.4.1",
-      "port-version": 2
+      "port-version": 3
     },
     "gz-common5": {
       "baseline": "5.4.1",
@@ -3182,6 +3182,10 @@
     },
     "gz-plugin2": {
       "baseline": "2.0.1",
+      "port-version": 0
+    },
+    "gz-rendering7": {
+      "baseline": "7.4.1",
       "port-version": 0
     },
     "gz-tools2": {

--- a/versions/g-/gz-cmake3.json
+++ b/versions/g-/gz-cmake3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ac0952f283b1e4a700a12c0d616066b36fdeff2",
+      "version": "3.4.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "f0b0d35ac8f99280de71a64494d8597f09986362",
       "version": "3.4.1",
       "port-version": 2

--- a/versions/g-/gz-rendering7.json
+++ b/versions/g-/gz-rendering7.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5fa361453bcae9a0e8acee956057e9436f8d1377",
+      "version": "7.4.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

