### PR TITLE
[graphviz] Fix installation prompts under Linux

### DIFF
--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -19,7 +19,7 @@ vcpkg_from_gitlab(
 if(VCPKG_TARGET_IS_OSX)
     message("${PORT} currently requires the following libraries from the system package manager:\n    libtool\n\nThey can be installed with brew install libtool")
 elseif(VCPKG_TARGET_IS_LINUX)
-    message("${PORT} currently requires the following libraries from the system package manager:\n    libtool\n\nThey can be installed with apt-get install libtool")
+    message("${PORT} currently requires the following libraries from the system package manager:\n    libtool\n\nThey can be install with `apt-get install libtool` on Ubuntu systems or `dnf install libtool-ltdl-devel` on Fedora systems")
 endif()
 
 vcpkg_list(SET OPTIONS)

--- a/ports/graphviz/vcpkg.json
+++ b/ports/graphviz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "graphviz",
   "version-semver": "9.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Graph Visualization Tools",
   "homepage": "https://graphviz.org/",
   "license": "EPL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3062,7 +3062,7 @@
     },
     "graphviz": {
       "baseline": "9.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "greatest": {
       "baseline": "1.5.0",

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "83813d9389be10cbd741a2e6dbd32924972e6b82",
+      "version-semver": "9.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "ba712eb597e2f6b4cd9113689ccb72cb95025d6f",
       "version-semver": "9.0.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/34608

Fix the installation prompt under Linux and add the prompt that `libtool-ltdl-devel` tool needs to be installed under Fedora system.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

