### PR TITLE
[libpcap] update to 1.10.4

### DIFF
--- a/ports/libpcap/add-disable-packet-option.patch
+++ b/ports/libpcap/add-disable-packet-option.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2f675d1..e9d6d96 100644
+index 650be01..7565e58 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -244,6 +244,7 @@ set(SEPTEL_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../septel" CACHE PATH "Path to dire
+@@ -521,6 +521,7 @@ set(SEPTEL_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../septel" CACHE PATH "Path to dire
  option(DISABLE_SNF "Disable Myricom SNF support" OFF)
  
  option(DISABLE_TC "Disable Riverbed TurboCap support" OFF)
@@ -10,22 +10,20 @@ index 2f675d1..e9d6d96 100644
  
  #
  # Debugging options.
-@@ -302,7 +303,7 @@ if(WIN32)
+@@ -579,7 +580,7 @@ if(WIN32)
      if(IS_DIRECTORY ${CMAKE_HOME_DIRECTORY}/../../Common)
          include_directories(${CMAKE_HOME_DIRECTORY}/../../Common)
      endif(IS_DIRECTORY ${CMAKE_HOME_DIRECTORY}/../../Common)
 -
 +    if(NOT DISABLE_PACKET)
      find_package(Packet)
-     if(PACKET_FOUND)
+     if(Packet_FOUND)
          set(HAVE_PACKET32 TRUE)
-@@ -317,7 +318,8 @@ if(WIN32)
+@@ -594,6 +595,7 @@ if(WIN32)
          check_function_exists(PacketGetTimestampModes HAVE_PACKET_GET_TIMESTAMP_MODES)
          cmake_pop_check_state()
-     endif(PACKET_FOUND)
--
+     endif(Packet_FOUND)
 +    endif()
-+    
+ 
      message(STATUS "checking for Npcap's version.h")
      check_symbol_exists(WINPCAP_PRODUCT_NAME "${CMAKE_SOURCE_DIR}/../../version.h" HAVE_VERSION_H)
-     if(HAVE_VERSION_H)

--- a/ports/libpcap/add-disable-packet-option.patch
+++ b/ports/libpcap/add-disable-packet-option.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 650be01..7565e58 100644
+index 2f675d1..e9d6d96 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -521,6 +521,7 @@ set(SEPTEL_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../septel" CACHE PATH "Path to dire
+@@ -244,6 +244,7 @@ set(SEPTEL_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../septel" CACHE PATH "Path to dire
  option(DISABLE_SNF "Disable Myricom SNF support" OFF)
  
  option(DISABLE_TC "Disable Riverbed TurboCap support" OFF)
@@ -10,20 +10,22 @@ index 650be01..7565e58 100644
  
  #
  # Debugging options.
-@@ -579,7 +580,7 @@ if(WIN32)
+@@ -302,7 +303,7 @@ if(WIN32)
      if(IS_DIRECTORY ${CMAKE_HOME_DIRECTORY}/../../Common)
          include_directories(${CMAKE_HOME_DIRECTORY}/../../Common)
      endif(IS_DIRECTORY ${CMAKE_HOME_DIRECTORY}/../../Common)
 -
 +    if(NOT DISABLE_PACKET)
      find_package(Packet)
-     if(Packet_FOUND)
+     if(PACKET_FOUND)
          set(HAVE_PACKET32 TRUE)
-@@ -594,6 +595,7 @@ if(WIN32)
+@@ -317,7 +318,8 @@ if(WIN32)
          check_function_exists(PacketGetTimestampModes HAVE_PACKET_GET_TIMESTAMP_MODES)
          cmake_pop_check_state()
-     endif(Packet_FOUND)
+     endif(PACKET_FOUND)
+-
 +    endif()
- 
++    
      message(STATUS "checking for Npcap's version.h")
      check_symbol_exists(WINPCAP_PRODUCT_NAME "${CMAKE_SOURCE_DIR}/../../version.h" HAVE_VERSION_H)
+     if(HAVE_VERSION_H)

--- a/ports/libpcap/install-pc-on-msvc.patch
+++ b/ports/libpcap/install-pc-on-msvc.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b83fbbd..2f675d1 100644
+index 58c5159..650be01 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -2678,9 +2678,12 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pcap.h DESTINATION include)
+@@ -3238,9 +3238,12 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pcap.h DESTINATION include)
  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pcap-bpf.h DESTINATION include)
  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pcap-namedb.h DESTINATION include)
  
@@ -18,20 +18,20 @@ index b83fbbd..2f675d1 100644
      set(prefix ${CMAKE_INSTALL_PREFIX})
      set(exec_prefix "\${prefix}")
      set(includedir "\${prefix}/include")
-@@ -2715,10 +2718,14 @@ if(NOT MSVC)
-     foreach(LIB ${PCAP_LINK_LIBRARIES})
-         set(LIBS "${LIBS} -l${LIB}")
-     endforeach(LIB)
+@@ -3308,10 +3311,14 @@ if(NOT MSVC)
+             set(RPATH "")
+         endif()
+     endif()
 -    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pcap-config.in ${CMAKE_CURRENT_BINARY_DIR}/pcap-config @ONLY)
      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libpcap.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libpcap.pc @ONLY)
 -    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pcap-config DESTINATION bin)
      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libpcap.pc DESTINATION lib/pkgconfig)
-+    
 +# On UN*X, and on Windows when not using MSVC, generate libpcap.pc and
 +# pcap-config and process man pages and arrange that they be installed.
 +if(NOT MSVC)
 +    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pcap-config.in ${CMAKE_CURRENT_BINARY_DIR}/pcap-config @ONLY)
 +    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pcap-config DESTINATION bin)
++  
  
      #
      # Man pages.

--- a/ports/libpcap/install-pc-on-msvc.patch
+++ b/ports/libpcap/install-pc-on-msvc.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 58c5159..650be01 100644
+index b83fbbd..2f675d1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -3238,9 +3238,12 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pcap.h DESTINATION include)
+@@ -2678,9 +2678,12 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pcap.h DESTINATION include)
  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pcap-bpf.h DESTINATION include)
  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pcap-namedb.h DESTINATION include)
  
@@ -18,20 +18,20 @@ index 58c5159..650be01 100644
      set(prefix ${CMAKE_INSTALL_PREFIX})
      set(exec_prefix "\${prefix}")
      set(includedir "\${prefix}/include")
-@@ -3308,10 +3311,14 @@ if(NOT MSVC)
-             set(RPATH "")
-         endif()
-     endif()
+@@ -2715,10 +2718,14 @@ if(NOT MSVC)
+     foreach(LIB ${PCAP_LINK_LIBRARIES})
+         set(LIBS "${LIBS} -l${LIB}")
+     endforeach(LIB)
 -    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pcap-config.in ${CMAKE_CURRENT_BINARY_DIR}/pcap-config @ONLY)
      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libpcap.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libpcap.pc @ONLY)
 -    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pcap-config DESTINATION bin)
      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libpcap.pc DESTINATION lib/pkgconfig)
++    
 +# On UN*X, and on Windows when not using MSVC, generate libpcap.pc and
 +# pcap-config and process man pages and arrange that they be installed.
 +if(NOT MSVC)
 +    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pcap-config.in ${CMAKE_CURRENT_BINARY_DIR}/pcap-config @ONLY)
 +    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pcap-config DESTINATION bin)
-+  
  
      #
      # Man pages.

--- a/ports/libpcap/portfile.cmake
+++ b/ports/libpcap/portfile.cmake
@@ -14,8 +14,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO the-tcpdump-group/libpcap
-    REF c7642e2cc0c5bd65754685b160d25dc23c76c6bd #1.10.1
-    SHA512 ed46095863aaee79ca2833d26438f6c837cc3e64acb73efd5a388a11ff7d0d1245d23e5404070a9f2c2c77840c93c09328746761e4481e9a530593a5cbf2ad6f
+    REF "libpcap-${VERSION}"
+    SHA512 7352ff4d5bded916c0802e4a846fcb6b26e3ea8025dbbf58543abd9d9f6e8f7f5d60e03bcadb222d20434b7e052f663a560d7487af4b81fba74cf5aea040d733
     HEAD_REF master
     PATCHES 
         install-pc-on-msvc.patch

--- a/ports/libpcap/vcpkg.json
+++ b/ports/libpcap/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libpcap",
-  "version-semver": "1.10.1",
-  "port-version": 3,
+  "version-semver": "1.10.4",
   "description": "A portable C/C++ library for network traffic capture",
   "homepage": "https://www.tcpdump.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4549,8 +4549,8 @@
       "port-version": 4
     },
     "libpcap": {
-      "baseline": "1.10.1",
-      "port-version": 3
+      "baseline": "1.10.4",
+      "port-version": 0
     },
     "libpff": {
       "baseline": "2021-11-14",

--- a/versions/l-/libpcap.json
+++ b/versions/l-/libpcap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "618b057943a2ea0bb0fd5e40f6944f9e221c9ef6",
+      "git-tree": "3af367bec0a2e0049f723ffb3654d262e775ac45",
       "version-semver": "1.10.4",
       "port-version": 0
     },

--- a/versions/l-/libpcap.json
+++ b/versions/l-/libpcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "618b057943a2ea0bb0fd5e40f6944f9e221c9ef6",
+      "version-semver": "1.10.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "6cf3667c0320e2ff5d92d45e91b07fb3bf2fe05e",
       "version-semver": "1.10.1",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

