### PR TITLE
[glaze] update to 1.5.3

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 f9730a9b572d50f4d7f50cb7d8584d3c1169ecf34e58017e96cc581de066e864fa5551f6a8d32aaf1a99ddbcebe3b3cbc2961b77a9b33dc83fb75f4558007531
+    SHA512 59895a4a43092ad2c77151cd57db56e87cddcb9e2f8c97eefc148360471cf4c54cf0c49eddc793caebfe81a85505fc329b0c8aeda03ebbbf319c3c041a22f253
 )
 
 vcpkg_cmake_configure(

--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 59895a4a43092ad2c77151cd57db56e87cddcb9e2f8c97eefc148360471cf4c54cf0c49eddc793caebfe81a85505fc329b0c8aeda03ebbbf319c3c041a22f253
+    SHA512 c4f89aa0fd28a821f977a7b363985ba6a88b54a22d76beea27d2750d3d912a46092ed436b010f679237a83f6375d2fba7c4e54cbf4650f2ba1e7bdf7b1804c59
 )
 
 vcpkg_cmake_configure(

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "1.5.1",
+  "version": "1.5.3",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2929,7 +2929,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "1.5.3",
+      "baseline": "1.5.4",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2929,7 +2929,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "1.5.1",
+      "baseline": "1.5.3",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f9816dd9339bd58f5e10278a8441d6244a9f88d",
+      "version": "1.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "bfeb3e970fc4dd67fcf667cc5e50d3833a07561b",
       "version": "1.5.1",
       "port-version": 0

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "7f9816dd9339bd58f5e10278a8441d6244a9f88d",
-      "version": "1.5.3",
+      "git-tree": "c4b6e2335f681c7d5183776b595718244791df78",
+      "version": "1.5.4",
       "port-version": 0
     },
     {


### PR DESCRIPTION
Fixes #34596
Update glaze to the latest version 1.5.3, no feature need to test.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
