### PR TITLE
[ktx] update to 4.3.0-alpha3

### DIFF
--- a/ports/ktx/0001-Use-vcpkg-zstd.patch
+++ b/ports/ktx/0001-Use-vcpkg-zstd.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 430cee4..9775c89 100644
+index 0653da5..1265f3d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -265,7 +265,6 @@ set(KTX_MAIN_SRC
@@ -18,13 +18,14 @@ index 430cee4..9775c89 100644
  
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/other_include>
          $<INSTALL_INTERFACE:other_include>
-@@ -538,6 +536,10 @@ macro(common_libktx_settings target enable_write library_type)
+@@ -538,6 +536,11 @@ macro(common_libktx_settings target enable_write library_type)
          target_compile_definitions(${target} PUBLIC KTX_FEATURE_KTX2)
      endif()
  
 +    # Use vcpkg zstd
 +    find_package(zstd CONFIG REQUIRED)
-+    target_link_libraries(${target} PRIVATE $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
++    set(ZSTD_LIBRARIES "$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>")
++    target_link_libraries(${target} PRIVATE ${ZSTD_LIBRARIES})
 +
      if(WIN32)
          if(MINGW)

--- a/ports/ktx/0001-Use-vcpkg-zstd.patch
+++ b/ports/ktx/0001-Use-vcpkg-zstd.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index bc679fd1..c726fa71 100644
+index 430cee4..9775c89 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -185,7 +185,6 @@ set(KTX_MAIN_SRC
+@@ -265,7 +265,6 @@ set(KTX_MAIN_SRC
      lib/basisu/transcoder/basisu_transcoder.cpp
      lib/basisu/transcoder/basisu_transcoder.h
      lib/basisu/transcoder/basisu.h
@@ -10,7 +10,7 @@ index bc679fd1..c726fa71 100644
      lib/checkheader.c
      lib/dfdutils/createdfd.c
      lib/dfdutils/colourspaces.c
-@@ -304,7 +303,6 @@ macro(commom_lib_settings lib write)
+@@ -448,7 +447,6 @@ macro(common_libktx_settings target enable_write library_type)
          $<INSTALL_INTERFACE:lib/basisu/transcoder>
  
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/basisu/zstd>
@@ -18,19 +18,19 @@ index bc679fd1..c726fa71 100644
  
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/other_include>
          $<INSTALL_INTERFACE:other_include>
-@@ -390,6 +388,10 @@ macro(commom_lib_settings lib write)
-         target_compile_definitions(${lib} PUBLIC KTX_FEATURE_KTX2)
+@@ -538,6 +536,10 @@ macro(common_libktx_settings target enable_write library_type)
+         target_compile_definitions(${target} PUBLIC KTX_FEATURE_KTX2)
      endif()
  
 +    # Use vcpkg zstd
 +    find_package(zstd CONFIG REQUIRED)
-+    target_link_libraries(${lib} PRIVATE $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
++    target_link_libraries(${target} PRIVATE $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
 +
      if(WIN32)
-         # By wrapping in generator expression we force multi configuration
-         # generators (like Visual Studio) to take the exact path and not
+         if(MINGW)
+             # Check if the Threads package is provided; if using Mingw it MIGHT be
 diff --git a/cmake/KtxConfig.cmake b/cmake/KtxConfig.cmake
-index 6386ba2f..537bf4f2 100644
+index 6386ba2..537bf4f 100644
 --- a/cmake/KtxConfig.cmake
 +++ b/cmake/KtxConfig.cmake
 @@ -1,7 +1,8 @@
@@ -45,7 +45,7 @@ index 6386ba2f..537bf4f2 100644
  
  include("${CMAKE_CURRENT_LIST_DIR}/KtxTargets.cmake")
 diff --git a/lib/basisu/CMakeLists.txt b/lib/basisu/CMakeLists.txt
-index 492233ae..8786d16c 100644
+index 492233a..2663169 100644
 --- a/lib/basisu/CMakeLists.txt
 +++ b/lib/basisu/CMakeLists.txt
 @@ -146,7 +146,7 @@ set(BASISU_SRC_LIST ${COMMON_SRC_LIST}
@@ -53,7 +53,7 @@ index 492233ae..8786d16c 100644
  
  if (ZSTD)
 -	set(BASISU_SRC_LIST ${BASISU_SRC_LIST} zstd/zstd.c)
-+	set(ZSTD_LIBRARIES "$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>")
++    set(ZSTD_LIBRARIES "$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>")
  endif()
  
  if (APPLE)
@@ -69,7 +69,7 @@ index 492233ae..8786d16c 100644
  	# For Non-Windows builds, let cmake try and find the system OpenCL headers/libs for us.
  	if (OPENCL_FOUND)
 diff --git a/lib/basisu/webgl/encoder/CMakeLists.txt b/lib/basisu/webgl/encoder/CMakeLists.txt
-index 588d91b4..0b380129 100644
+index 588d91b..edd7457 100644
 --- a/lib/basisu/webgl/encoder/CMakeLists.txt
 +++ b/lib/basisu/webgl/encoder/CMakeLists.txt
 @@ -34,9 +34,7 @@ if (EMSCRIPTEN)
@@ -79,7 +79,7 @@ index 588d91b4..0b380129 100644
 -  	set(SRC_LIST ${SRC_LIST}
 -		../../zstd/zstd.c
 -	)
-+    set(ZSTD_LIBRARIES "$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>")
++  	set(ZSTD_LIBRARIES "$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>")
  	set(ZSTD_DEFINITION BASISD_SUPPORT_KTX2_ZSTD=1)
    else()
    	set(ZSTD_DEFINITION BASISD_SUPPORT_KTX2_ZSTD=0)
@@ -95,7 +95,7 @@ index 588d91b4..0b380129 100644
        OUTPUT_NAME "basis_encoder"
        SUFFIX ".js"
 diff --git a/lib/basisu/webgl/transcoder/CMakeLists.txt b/lib/basisu/webgl/transcoder/CMakeLists.txt
-index 372653de..f75e3a35 100644
+index 372653d..3c9ed0c 100644
 --- a/lib/basisu/webgl/transcoder/CMakeLists.txt
 +++ b/lib/basisu/webgl/transcoder/CMakeLists.txt
 @@ -28,9 +28,7 @@ if (EMSCRIPTEN)
@@ -105,7 +105,7 @@ index 372653de..f75e3a35 100644
 - 	set(SRC_LIST ${SRC_LIST}
 -		../../zstd/zstddeclib.c
 -	)
-+    set(ZSTD_LIBRARIES "$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>")
++ 	set(ZSTD_LIBRARIES "$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>")
  	set(ZSTD_DEFINITION BASISD_SUPPORT_KTX2_ZSTD=1)
    else()
    	set(ZSTD_DEFINITION BASISD_SUPPORT_KTX2_ZSTD=0)

--- a/ports/ktx/0004-quirks.patch
+++ b/ports/ktx/0004-quirks.patch
@@ -1,17 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 068c6bb..84fa624 100644
+index 9775c89..a4dfc2a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -215,7 +215,7 @@ if(MSVC)
-     # With /W4 VS2015 (V19.0) issues many warnings that VS2017 & 2019 don't
-     # so only increase warning level for recent versions.
-     add_compile_options($<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},19.16>:/W4>)
+@@ -235,7 +235,7 @@ include(cmake/mkvk.cmake)
+ # Global compile & link options including optimization flags
+ if(MSVC)
+     add_compile_options( /W4;/WX )
 -    add_compile_options( $<IF:$<CONFIG:Debug>,/Gz,/O2> )
 +    add_compile_options( $<IF:$<CONFIG:Debug>,,/O2> )
  elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"
         OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-     add_compile_options(-Wall -Wextra)
-@@ -801,6 +801,7 @@ if(EMSCRIPTEN)
+     add_compile_options(-Wall -Wextra -Werror)
+@@ -851,6 +851,7 @@ if(EMSCRIPTEN)
  endif()
  
  add_library( objUtil STATIC

--- a/ports/ktx/portfile.cmake
+++ b/ports/ktx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/KTX-Software
     REF "v${VERSION}"
-    SHA512 bb8f728009ba7e15eecd2d9eb7985883a6a85f4ea8fccfa7f25a5567240980d1eb8bcde67d90e56e5c93de910d1bc93704bc5cbd390a8cb660051a698d7fd573
+    SHA512 9ef0100a402321b00faa822eb2a50fd0d1e17fa703edacdbacf9231484d911cc254aed1fa517988537dc5b7059921a793edaeb92e8b2965d25672cd9a2589a0f
     HEAD_REF master
     PATCHES
         0001-Use-vcpkg-zstd.patch
@@ -31,7 +31,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         tools   KTX_FEATURE_TOOLS
-        vulkan  KTX_FEATURE_VULKAN
+        vulkan  KTX_FEATURE_VK_UPLOAD
 )
 
 vcpkg_cmake_configure(
@@ -49,11 +49,11 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_copy_pdbs()
 
 if(tools IN_LIST FEATURES)
     vcpkg_copy_tools(
         TOOL_NAMES
+            ktx
             toktx
             ktxsc
             ktxinfo
@@ -61,12 +61,18 @@ if(tools IN_LIST FEATURES)
             ktx2check
         AUTO_CLEAN
     )
+else()
+    vcpkg_copy_pdbs()
 endif()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ktx)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-configure_file("${SOURCE_PATH}/LICENSE.md" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
 file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
 file(COPY ${LICENSE_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSES")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/ktx/vcpkg.json
+++ b/ports/ktx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ktx",
-  "version-semver": "4.1.0",
+  "version-semver": "4.3.0-alpha3",
   "description": [
     "The Khronos KTX library and tools.",
     "Functions for writing and reading KTX files, and instantiating OpenGL®, OpenGL ES™️ and Vulkan® textures from them."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3861,7 +3861,7 @@
       "port-version": 0
     },
     "ktx": {
-      "baseline": "4.1.0",
+      "baseline": "4.3.0-alpha3",
       "port-version": 0
     },
     "kubazip": {

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7584842f683115c6fdd3a330e52a3fc495fd4fac",
+      "version-semver": "4.3.0-alpha3",
+      "port-version": 0
+    },
+    {
       "git-tree": "74b3fa8f53d6a1d173c09c2f87f865125717d894",
       "version-semver": "4.1.0",
       "port-version": 0

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7584842f683115c6fdd3a330e52a3fc495fd4fac",
+      "git-tree": "47559725520a0015829f65dfda7f3b28a7a7d78f",
       "version-semver": "4.3.0-alpha3",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #33388
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
