### PR TITLE
[tinyorm] added initial port TinyORM v0.36.5

### DIFF
--- a/ports/tinyorm/portfile.cmake
+++ b/ports/tinyorm/portfile.cmake
@@ -1,0 +1,39 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO silverqx/TinyORM
+    REF v0.36.5
+    SHA512 ba3bf73972a6265663122e2c260354cf213dcdcf7bfd1f7a6a7eb43eb11e06fbed581b3f6ce28898eb60a85d0c9bfe45bfaa9596d92b62ca40702ede9856b183
+    HEAD_REF main
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    PREFIX TINYORM
+    FEATURES
+        disable-thread-local DISABLE_THREAD_LOCAL
+        inline-constants     INLINE_CONSTANTS
+        mysql-ping           MYSQL_PING
+        orm                  ORM
+        strict-mode          STRICT_MODE
+        tom                  TOM
+        tom-example          TOM_EXAMPLE
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_EXPORT_PACKAGE_REGISTRY:BOOL=OFF
+        -DBUILD_TESTS:BOOL=OFF
+        -DTINY_PORT:STRING=${PORT}
+        -DTINY_VCPKG:BOOL=ON
+        -DVERBOSE_CONFIGURE:BOOL=ON
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+
+if(TINYORM_TOM_EXAMPLE)
+    vcpkg_copy_tools(TOOL_NAMES tom AUTO_CLEAN)
+endif()

--- a/ports/tinyorm/vcpkg.json
+++ b/ports/tinyorm/vcpkg.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "tinyorm",
+  "version-semver": "0.36.5",
+  "maintainers": "Silver Zachara <silver.zachara@gmail.com>",
+  "description": "Modern C++ ORM library for Qt framework",
+  "homepage": "https://github.com/silverqx/TinyORM",
+  "documentation": "https://www.tinyorm.org",
+  "license": "MIT",
+  "supports": "!(uwp | arm | android | emscripten | osx | ios | xbox | freebsd | openbsd | wasm32)",
+  "dependencies": [
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "sql"
+      ]
+    },
+    "range-v3",
+    "tabulate",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "orm",
+    "sql-sqlite",
+    "tom"
+  ],
+  "features": {
+    "disable-thread-local": {
+      "description": "Remove all thread_local storage duration specifiers (disables multi-threading support)"
+    },
+    "inline-constants": {
+      "description": "Use inline constants instead of extern constants in shared builds"
+    },
+    "mysql-ping": {
+      "description": "Install MySQL C client library (libmysql) to support the mysql_ping()",
+      "dependencies": [
+        "libmysql"
+      ]
+    },
+    "orm": {
+      "description": "Enable ORM-related source code (without it only the query builder is compiled)"
+    },
+    "sql-mysql": {
+      "description": "Build Qt SQL Driver for MySQL",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "sql-mysql"
+          ]
+        }
+      ]
+    },
+    "sql-psql": {
+      "description": "Build Qt SQL Driver for PostgreSQL",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "sql-psql"
+          ]
+        }
+      ]
+    },
+    "sql-sqlite": {
+      "description": "Build Qt SQL Driver for SQLite",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "sql-sqlite"
+          ]
+        }
+      ]
+    },
+    "strict-mode": {
+      "description": "Propagate strict compiler/linker options and Qt definitions"
+    },
+    "tom": {
+      "description": "Enable Tom-related source code (command-line interface)"
+    },
+    "tom-example": {
+      "description": "Build Tom command-line application example",
+      "dependencies": [
+        {
+          "name": "tinyorm",
+          "default-features": false,
+          "features": [
+            "tom"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8416,6 +8416,10 @@
       "baseline": "2.0.0-rc9",
       "port-version": 0
     },
+    "tinyorm": {
+      "baseline": "0.36.5",
+      "port-version": 0
+    },
     "tinyply": {
       "baseline": "2.3.4",
       "port-version": 0

--- a/versions/t-/tinyorm.json
+++ b/versions/t-/tinyorm.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b21b31342cfe5d58cce629fab598e6f968e5118e",
+      "version-semver": "0.36.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add the TinyORM v0.36.5 port [www.tinyorm.org](https://www.tinyorm.org/).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Fixes #31087