### PR TITLE
[google-cloud-cpp] update to v2.17.0#2

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -67,7 +67,7 @@ foreach(feature IN LISTS FEATURES)
 endforeach()
 # These packages are automatically installed depending on what features are
 # enabled.
-foreach(suffix common googleapis grpc_utils rest_internal rest_protobuf_internal dialogflow_cx dialogflow_es)
+foreach(suffix common compute_protos googleapis grpc_utils iam_v2 logging_type rest_internal rest_protobuf_internal dialogflow_cx dialogflow_es)
     set(config_path "lib/cmake/google_cloud_cpp_${suffix}")
     if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
         continue()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.17.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -490,18 +490,6 @@
         }
       ]
     },
-    "debugger": {
-      "description": "Stackdriver Debugger API C++ Client Library",
-      "dependencies": [
-        {
-          "name": "google-cloud-cpp",
-          "default-features": false,
-          "features": [
-            "grpc-common"
-          ]
-        }
-      ]
-    },
     "deploy": {
       "description": "Google Cloud Deploy API C++ Client Library",
       "dependencies": [
@@ -635,18 +623,6 @@
         }
       ]
     },
-    "gameservices": {
-      "description": "Game Services API C++ Client Library",
-      "dependencies": [
-        {
-          "name": "google-cloud-cpp",
-          "default-features": false,
-          "features": [
-            "grpc-common"
-          ]
-        }
-      ]
-    },
     "gkehub": {
       "description": "GKE Hub C++ Client Library",
       "dependencies": [
@@ -724,18 +700,6 @@
     },
     "ids": {
       "description": "Cloud IDS API C++ Client Library",
-      "dependencies": [
-        {
-          "name": "google-cloud-cpp",
-          "default-features": false,
-          "features": [
-            "grpc-common"
-          ]
-        }
-      ]
-    },
-    "iot": {
-      "description": "Cloud IoT API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -322,6 +322,7 @@
     },
     "compute": {
       "description": "Compute Engine C++ Client Library",
+      "supports": "!windows",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3006,7 +3006,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.17.0",
-      "port-version": 1
+      "port-version": 2
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c986b3d0fb6b7f0fbbf5351457e15a28d83be3c",
+      "version": "2.17.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "eb4b2fd7eea450ced2e6f33dcd9af1237f2de3c2",
       "version": "2.17.0",
       "port-version": 1

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0c986b3d0fb6b7f0fbbf5351457e15a28d83be3c",
+      "git-tree": "2a52d32521f59da4d2ecfe7beffe13bab448ea64",
       "version": "2.17.0",
       "port-version": 2
     },


### PR DESCRIPTION
Removes `debugger`, `gameservices`, `iot`. These features were deprecated and removed upstream.

Fixes
- `iam`, `policytroubleshooter` by adding `iam_v2`
- `appengine`, `logging`, `servicecontrol` by adding `logging_type`
- `compute` by adding `compute_protos`

Tested with:
```
./vcpkg install 'google-cloud-cpp[*]'

GOOGLE_CLOUD_CPP=... # e.g. ${HOME}/code/git/google-cloud-cpp

cmake -S ${GOOGLE_CLOUD_CPP}/google/cloud/compute/quickstart -B .test-compute --toolchain $PWD/scripts/buildsystems/vcpkg.cmake && cmake --build .test-compute

cmake -S ${GOOGLE_CLOUD_CPP}/google/cloud/iam/quickstart -B .test-iam --toolchain $PWD/scripts/buildsystems/vcpkg.cmake && cmake --build .test-iam

cmake -S ${GOOGLE_CLOUD_CPP}/google/cloud/policytroubleshooter/quickstart -B .test-policytroubleshooter --toolchain $PWD/scripts/buildsystems/vcpkg.cmake && cmake --build .test-policytroubleshooter
```

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
