### PR TITLE
[tbb] explicitly disable hwloc feature for UWP

### DIFF
--- a/ports/tbb/vcpkg.json
+++ b/ports/tbb/vcpkg.json
@@ -2,11 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tbb",
   "version": "2021.10.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Intel's Threading Building Blocks.",
   "homepage": "https://github.com/oneapi-src/oneTBB",
   "license": "Apache-2.0",
-  "supports": "(windows & !uwp) | linux | osx | ios | android",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -20,13 +20,13 @@
   "default-features": [
     {
       "name": "hwloc",
-      "platform": "!static & !osx"
+      "platform": "!static & !osx & !uwp"
     }
   ],
   "features": {
     "hwloc": {
       "description": "Builds TBB with TBBBind support for Hybrid CPUs or NUMA architectures.",
-      "supports": "!static & !osx",
+      "supports": "!static & !osx & !uwp",
       "dependencies": [
         "hwloc"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8182,7 +8182,7 @@
     },
     "tbb": {
       "baseline": "2021.10.0",
-      "port-version": 2
+      "port-version": 3
     },
     "tcb-span": {
       "baseline": "2022-06-15",

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4cde1e2a3654b8540b76ac295675a37bdbca311",
+      "version": "2021.10.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "376c59cda9f516006ce87b0f5da05be5a67fed7d",
       "version": "2021.10.0",
       "port-version": 2


### PR DESCRIPTION
Actually, TBB should support UWP according to https://www.intel.com/content/www/us/en/developer/articles/technical/using-intel-performance-libraries-in-universal-windows-drivers.html, so I will create an issue for TBB team to fix it.
Once it's fixed, `hwloc` should still be disabled for UWP as it does not support this platform.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.