### PR TITLE
[fmt] add c modules

### DIFF
--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -9,12 +9,19 @@ vcpkg_from_github(
         fix-format-conflict.patch
 )
 
+if ("modules" IN_LIST FEATURES)
+	set(CXX_MODULES enabled)
+else()
+	set(CXX_MODULES disabled)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DFMT_CMAKE_DIR=share/fmt
         -DFMT_TEST=OFF
         -DFMT_DOC=OFF
+	-DFMT_MODULE=${CXX_MODULES}
 )
 
 vcpkg_cmake_install()

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fmt",
   "version": "10.1.1",
+  "port-version": 1,
   "description": "Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.",
   "homepage": "https://github.com/fmtlib/fmt",
   "license": "MIT",
@@ -13,5 +14,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "modules": {
+      "description": "Enable c++20 modules"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2666,7 +2666,7 @@
     },
     "fmt": {
       "baseline": "10.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "folly": {
       "baseline": "2023.10.02.00",

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d80999e3792b4a780ed74dbfd27be2f86931cc69",
+      "version": "10.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "dfe9aa860f5a8317f341a21d317be1cf44e89f18",
       "version": "10.1.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
