### PR TITLE
[fmt] add option FMT_MODULE

### DIFF
--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -9,12 +9,19 @@ vcpkg_from_github(
         fix-format-conflict.patch
 )
 
+if ("modules" IN_LIST FEATURES)
+	set(CXX_MODULES enabled)
+else()
+	set(CXX_MODULES disabled)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DFMT_CMAKE_DIR=share/fmt
         -DFMT_TEST=OFF
         -DFMT_DOC=OFF
+	-DFMT_MODULE=${CXX_MODULES}
 )
 
 vcpkg_cmake_install()

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -10,9 +10,9 @@ vcpkg_from_github(
 )
 
 if ("modules" IN_LIST FEATURES)
-	set(CXX_MODULES enabled)
+    set(CXX_MODULES ON)
 else()
-	set(CXX_MODULES disabled)
+    set(CXX_MODULES OFF)
 endif()
 
 vcpkg_cmake_configure(
@@ -36,7 +36,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     )
 endif()
 
-file(REMOVE_RECURSE 
+file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fmt",
   "version": "10.1.1",
+  "port-version": 1,
   "description": "Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.",
   "homepage": "https://github.com/fmtlib/fmt",
   "license": "MIT",
@@ -13,5 +14,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "modules": {
+      "description": "Enable c++20 modules"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2666,7 +2666,7 @@
     },
     "fmt": {
       "baseline": "10.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "folly": {
       "baseline": "2023.10.02.00",

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d80999e3792b4a780ed74dbfd27be2f86931cc69",
+      "git-tree": "855e25d25104de37ce5982cde1c851fc9326cf46",
       "version": "10.1.1",
       "port-version": 1
     },

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d80999e3792b4a780ed74dbfd27be2f86931cc69",
+      "version": "10.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "dfe9aa860f5a8317f341a21d317be1cf44e89f18",
       "version": "10.1.1",
       "port-version": 0


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
