### PR TITLE
[cpp-sort] add new port

### DIFF
--- a/ports/cpp-sort/portfile.cmake
+++ b/ports/cpp-sort/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Morwenn/cpp-sort
+    REF "${VERSION}"
+    SHA512 85d9f68ff64ff23769c66d28153273e2072b2c12f2f94bb058afebc1fb68d852734d3907a51704212d795bff71f327de3497232ba3619179bbaa141ab55b2452
+    HEAD_REF 1.x.y-develop
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCPPSORT_BUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME cpp-sort CONFIG_PATH "lib/cmake/cpp-sort")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cpp-sort/portfile.cmake
+++ b/ports/cpp-sort/portfile.cmake
@@ -14,11 +14,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME cpp-sort CONFIG_PATH "lib/cmake/cpp-sort")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/cpp-sort")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
-
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cpp-sort/usage
+++ b/ports/cpp-sort/usage
@@ -1,4 +1,0 @@
-The package cpp-sort provides CMake targets:
-
-    find_package(cpp-sort CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE cpp-sort::cpp-sort)

--- a/ports/cpp-sort/usage
+++ b/ports/cpp-sort/usage
@@ -1,0 +1,4 @@
+The package bext-mp provides CMake targets:
+
+    find_package(cpp-sort CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE cpp-sort::cpp-sort)

--- a/ports/cpp-sort/usage
+++ b/ports/cpp-sort/usage
@@ -1,4 +1,4 @@
-The package bext-mp provides CMake targets:
+The package cpp-sort provides CMake targets:
 
     find_package(cpp-sort CONFIG REQUIRED)
     target_link_libraries(main PRIVATE cpp-sort::cpp-sort)

--- a/ports/cpp-sort/vcpkg.json
+++ b/ports/cpp-sort/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "cpp-sort",
+  "version": "1.15.0",
+  "description": "Sorting algorithms & related tools for C++14",
+  "homepage": "https://github.com/Morwenn/cpp-sort/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1820,6 +1820,10 @@
       "baseline": "4.3.1",
       "port-version": 5
     },
+    "cpp-sort": {
+      "baseline": "1.15.0",
+      "port-version": 0
+    },
     "cpp-taskflow": {
       "baseline": "2.6.0",
       "port-version": 2

--- a/versions/c-/cpp-sort.json
+++ b/versions/c-/cpp-sort.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3612af04d4ee7f9218b7d06b3f1cb3a58837d89e",
+      "git-tree": "297f3475b5d0c685a8474f59c07c0f1936409843",
       "version": "1.15.0",
       "port-version": 0
     }

--- a/versions/c-/cpp-sort.json
+++ b/versions/c-/cpp-sort.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3612af04d4ee7f9218b7d06b3f1cb3a58837d89e",
+      "version": "1.15.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/cpp-sort.json
+++ b/versions/c-/cpp-sort.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "297f3475b5d0c685a8474f59c07c0f1936409843",
+      "git-tree": "b474d4009aeb5dd69f5024899bff6fbbb92a78f6",
       "version": "1.15.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.


