### PR TITLE
[mpark-patterns] add new port

### DIFF
--- a/ports/mpark-patterns/portfile.cmake
+++ b/ports/mpark-patterns/portfile.cmake
@@ -6,15 +6,17 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+set(VCPKG_BUILD_TYPE release) #header-only library
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME mpark-patterns CONFIG_PATH "lib/cmake/mpark_patterns")
+vcpkg_cmake_config_fixup(PACKAGE_NAME mpark_patterns CONFIG_PATH "lib/cmake/mpark_patterns")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
 

--- a/ports/mpark-patterns/portfile.cmake
+++ b/ports/mpark-patterns/portfile.cmake
@@ -14,9 +14,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME mpark-patterns CONFIG_PATH "lib/cmake/mpark_patterns")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
 

--- a/ports/mpark-patterns/portfile.cmake
+++ b/ports/mpark-patterns/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mpark/patterns 
+    REF b3270e0dd7b6312f7a4fe8647e2333dbb86e355e
+    SHA512 ca8062b92cf0d5874aba7067615ff8cb089c22cb921d6131762a8dcb2f50d4f47d80c59b62b1c9b7e70dae2dfb68a44c2a4feeb78ab5e5473e0fbdd089538314
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME mpark-patterns CONFIG_PATH "lib/cmake/mpark_patterns")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/mpark-patterns/usage
+++ b/ports/mpark-patterns/usage
@@ -1,0 +1,5 @@
+The package mpark-patterns provides CMake targets:
+
+    find_package(mpark_patterns CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE mpark_patterns)
+

--- a/ports/mpark-patterns/vcpkg.json
+++ b/ports/mpark-patterns/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "mpark-patterns",
+  "version-date": "2019-10-03",
+  "description": "MPark.Patterns is an experimental pattern matching library for C++17.",
+  "homepage": "https://github.com/mpack/patterns/",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/mpark-patterns/vcpkg.json
+++ b/ports/mpark-patterns/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "mpark-patterns",
   "version-date": "2019-10-03",
   "description": "MPark.Patterns is an experimental pattern matching library for C++17.",
-  "homepage": "https://github.com/mpack/patterns/",
+  "homepage": "https://github.com/mpack/patterns",
   "license": "BSL-1.0",
   "dependencies": [
     {

--- a/ports/mpark-patterns/vcpkg.json
+++ b/ports/mpark-patterns/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "mpark-patterns",
   "version-date": "2019-10-03",
   "description": "MPark.Patterns is an experimental pattern matching library for C++17.",
-  "homepage": "https://github.com/mpack/patterns",
+  "homepage": "https://github.com/mpark/patterns",
   "license": "BSL-1.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5592,6 +5592,10 @@
       "baseline": "3.100",
       "port-version": 11
     },
+    "mpark-patterns": {
+      "baseline": "2019-10-03",
+      "port-version": 0
+    },
     "mpark-variant": {
       "baseline": "1.4.0",
       "port-version": 3

--- a/versions/m-/mpark-patterns.json
+++ b/versions/m-/mpark-patterns.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fab773bb15602242526335b0add8804bbf18e6a6",
+      "git-tree": "d55d20029bf298365cd5b040bbf05b6778bf4185",
       "version-date": "2019-10-03",
       "port-version": 0
     }

--- a/versions/m-/mpark-patterns.json
+++ b/versions/m-/mpark-patterns.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fab773bb15602242526335b0add8804bbf18e6a6",
+      "version-date": "2019-10-03",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/m-/mpark-patterns.json
+++ b/versions/m-/mpark-patterns.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d55d20029bf298365cd5b040bbf05b6778bf4185",
+      "git-tree": "75908918c4631871c1527b2a536b1fe3478acddc",
       "version-date": "2019-10-03",
       "port-version": 0
     }

--- a/versions/m-/mpark-patterns.json
+++ b/versions/m-/mpark-patterns.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "75908918c4631871c1527b2a536b1fe3478acddc",
+      "git-tree": "f8b22778a3c1393308468021303beb56ff392a03",
       "version-date": "2019-10-03",
       "port-version": 0
     }


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.


