### PR TITLE
[uwebsockets] update to 20.47.0

### DIFF
--- a/ports/uwebsockets/portfile.cmake
+++ b/ports/uwebsockets/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uNetworking/uWebSockets
     REF "v${VERSION}"
-    SHA512 38022fc555a89654828d872ef2b4ef3a6b01e8eccfe511cb8df37dff772c6c09b379933da73606970ac8581333b3be26ad7b0a8cdec8d19fe05b326fbf4f6c84
+    SHA512 f6324663db534a0c70fbe94f77900ac0dedfd837abe091c7bf41c92865309dea01dc91703ac435a2e4d4f71342beb595fabba9477743c932cd1dfee8b2a7c3e2
     HEAD_REF master
 )
 

--- a/ports/uwebsockets/vcpkg.json
+++ b/ports/uwebsockets/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uwebsockets",
-  "version-semver": "20.45.0",
+  "version-semver": "20.47.0",
   "description": "Simple, secure & standards compliant web I/O for the most demanding of applications",
   "homepage": "https://github.com/uWebSockets/uWebSockets",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8629,7 +8629,7 @@
       "port-version": 0
     },
     "uwebsockets": {
-      "baseline": "20.45.0",
+      "baseline": "20.47.0",
       "port-version": 0
     },
     "v-hacd": {

--- a/versions/u-/uwebsockets.json
+++ b/versions/u-/uwebsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "accbc9586fca80fd1345c5f2f3cf8449c76dcb24",
+      "version-semver": "20.47.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "db7e8088e0a542c51cea89ed081e8bcae6baec8c",
       "version-semver": "20.45.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

