### PR TITLE
[wil] Configure only in release mode.

### DIFF
--- a/ports/wil/portfile.cmake
+++ b/ports/wil/portfile.cmake
@@ -7,6 +7,9 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# WIL is header-only, so we don't need to build it in both modes
+set(VCPKG_BUILD_TYPE release)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/wil/vcpkg.json
+++ b/ports/wil/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wil",
   "version-date": "2023-08-24",
+  "port-version": 1,
   "description": "The Windows Implementation Libraries (WIL) is a header-only C++ library created to make life easier for developers on Windows through readable type-safe C++ interfaces for common Windows coding patterns.",
   "homepage": "https://github.com/microsoft/wil",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8886,7 +8886,7 @@
     },
     "wil": {
       "baseline": "2023-08-24",
-      "port-version": 0
+      "port-version": 1
     },
     "wildmidi": {
       "baseline": "0.4.5",

--- a/versions/w-/wil.json
+++ b/versions/w-/wil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1305125361ca7587fdcdd0caac7609c15a94e48f",
+      "version-date": "2023-08-24",
+      "port-version": 1
+    },
+    {
       "git-tree": "ddb021c58bdc3c24a0440d2e6f808797cd698bf8",
       "version-date": "2023-08-24",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

WIL is a header-only library and configuring it in both Release and Debug modes is unnecessary.