### PR TITLE
[gstreamer] nvcodec feature

### DIFF
--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -94,6 +94,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         libde265        gst-plugins-bad:libde265
         microdns        gst-plugins-bad:microdns
         modplug         gst-plugins-bad:modplug
+        nvcodec         gst-plugins-bad:nvcodec
         openal          gst-plugins-bad:openal
         openh264        gst-plugins-bad:openh264
         openjpeg        gst-plugins-bad:openjpeg
@@ -249,7 +250,6 @@ vcpkg_configure_meson(
         -Dgst-plugins-bad:msdk=disabled
         -Dgst-plugins-bad:musepack=disabled
         -Dgst-plugins-bad:neon=disabled
-        -Dgst-plugins-bad:nvcodec=disabled
         -Dgst-plugins-bad:onnx=disabled # libonnxruntime not found
         -Dgst-plugins-bad:openaptx=disabled
         -Dgst-plugins-bad:opencv=disabled # opencv not found

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.22.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",
@@ -418,6 +418,19 @@
           "default-features": false,
           "features": [
             "plugins-base"
+          ]
+        }
+      ]
+    },
+    "nvcodec": {
+      "description": "Enable support for the NVCODEC encoders and decoders",
+      "supports": "!uwp",
+      "dependencies": [
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "features": [
+            "plugins-bad"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3094,7 +3094,7 @@
     },
     "gstreamer": {
       "baseline": "1.22.5",
-      "port-version": 3
+      "port-version": 4
     },
     "gtest": {
       "baseline": "1.14.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b18eecdb79cdeb95b0c5e003cf14ababd9bca7c9",
+      "version": "1.22.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "5bcd4e4f541fb90ffef24a354db74f5555f2ba6d",
       "version": "1.22.5",
       "port-version": 3


### PR DESCRIPTION
Reverts hard-coded disable in https://github.com/microsoft/vcpkg/pull/34152

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
