### PR TITLE
[libpq] Fix MinGW build

### DIFF
--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_extract_source_archive(
         windows/spin_delay.patch
 )
 
-if(NOT VCPKG_TARGET_IS_MINGW)
+if("python" IN_LIST FEATURES)
 # The problem is actually that on MinGW, CMake's file(WRITE) command converts
 # configure.ac line endings from UNIX-style (LF) to Windows-style (CRLF) and this
 # breaks autoconf.

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -21,10 +21,15 @@ vcpkg_extract_source_archive(
         windows/spin_delay.patch
 )
 
+if(NOT VCPKG_TARGET_IS_MINGW)
+# The problem is actually that on MinGW, CMake's file(WRITE) command converts
+# configure.ac line endings from UNIX-style (LF) to Windows-style (CRLF) and this
+# breaks autoconf.
 file(GLOB _py3_include_path "${CURRENT_HOST_INSTALLED_DIR}/include/python3*")
 string(REGEX MATCH "python3\\.([0-9]+)" _python_version_tmp "${_py3_include_path}")
 set(PYTHON_VERSION_MINOR "${CMAKE_MATCH_1}")
 vcpkg_replace_string("${SOURCE_PATH}/configure.ac" "python_version=3.REPLACEME" "python_version=3.${PYTHON_VERSION_MINOR}")
+endif()
 
 if("client" IN_LIST FEATURES)
     set(HAS_TOOLS TRUE)

--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpq",
   "version": "16.0",
+  "port-version": 1,
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "license": "PostgreSQL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4582,7 +4582,7 @@
     },
     "libpq": {
       "baseline": "16.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libpqxx": {
       "baseline": "7.8.1",

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6538afb75e7d6430390ac40a8d5a3dcb39a36a03",
+      "version": "16.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cbd6314cbfd04132985a7a6412184d368c3cd0b6",
       "version": "16.0",
       "port-version": 0

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6538afb75e7d6430390ac40a8d5a3dcb39a36a03",
+      "git-tree": "113b0291f7d2d86f5cf39ae93949f48c9cb0f644",
       "version": "16.0",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.