### PR TITLE
[openimageio] Separate feature flags for tools and viewer (#34556)

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -39,6 +39,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         webp        USE_WEBP
         libheif     USE_LIBHEIF
         pybind11    USE_PYTHON
+        tools       OIIO_BUILD_TOOLS
         viewer      USE_QT
 )
 
@@ -48,7 +49,6 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DBUILD_TESTING=OFF
         -DOIIO_BUILD_TESTS=OFF
-        -DOIIO_BUILD_TOOLS=ON
         -DUSE_DCMTK=OFF
         -DUSE_NUKE=OFF
         -DUSE_OpenVDB=OFF
@@ -73,10 +73,12 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/OpenImageIO)
 
-vcpkg_copy_tools(
-    TOOL_NAMES iconvert idiff igrep iinfo maketx oiiotool
-    AUTO_CLEAN
-)
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(
+        TOOL_NAMES iconvert idiff igrep iinfo maketx oiiotool
+        AUTO_CLEAN
+    )
+endif()
 
 if("viewer" IN_LIST FEATURES)
     vcpkg_copy_tools(

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -43,6 +43,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         viewer      USE_QT
 )
 
+if(NOT "viewer" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS -DUSE_QT=BOOL:OFF)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -39,8 +39,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         webp        USE_WEBP
         libheif     USE_LIBHEIF
         pybind11    USE_PYTHON
-        tools       OIIO_BUILD_TOOLS
-        tools       USE_QT
+        viewer      USE_QT
 )
 
 vcpkg_cmake_configure(
@@ -49,6 +48,7 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DBUILD_TESTING=OFF
         -DOIIO_BUILD_TESTS=OFF
+        -DOIIO_BUILD_TOOLS=ON
         -DUSE_DCMTK=OFF
         -DUSE_NUKE=OFF
         -DUSE_OpenVDB=OFF
@@ -73,9 +73,14 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/OpenImageIO)
 
-if("tools" IN_LIST FEATURES)
+vcpkg_copy_tools(
+    TOOL_NAMES iconvert idiff igrep iinfo maketx oiiotool
+    AUTO_CLEAN
+)
+
+if("viewer" IN_LIST FEATURES)
     vcpkg_copy_tools(
-        TOOL_NAMES iconvert idiff igrep iinfo maketx oiiotool iv
+        TOOL_NAMES iv
         AUTO_CLEAN
     )
 endif()

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -40,12 +40,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         libheif     USE_LIBHEIF
         pybind11    USE_PYTHON
         tools       OIIO_BUILD_TOOLS
-        viewer      USE_QT
+        viewer      ENABLE_IV
 )
-
-if(NOT "viewer" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -DUSE_QT=OFF)
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -44,7 +44,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 if(NOT "viewer" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -DUSE_QT=BOOL:OFF)
+    list(APPEND FEATURE_OPTIONS -DUSE_QT=OFF)
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -103,10 +103,19 @@
         "python3"
       ]
     },
+    "tools": {
+      "description": "Build openimageio tools"
+    },
     "viewer": {
       "description": "Build openimageio viewer",
       "dependencies": [
         "opengl",
+        {
+          "name": "openimageio",
+          "features": [
+            "tools"
+          ]
+        },
         {
           "name": "qtbase",
           "default-features": false

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openimageio",
   "version": "2.4.14.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",
@@ -103,8 +103,8 @@
         "python3"
       ]
     },
-    "tools": {
-      "description": "Build openimageio tools",
+    "viewer": {
+      "description": "Build openimageio viewer",
       "dependencies": [
         "opengl",
         {

--- a/ports/theia/vcpkg.json
+++ b/ports/theia/vcpkg.json
@@ -20,7 +20,12 @@
       "platform": "!osx"
     },
     "glew",
-    "openimageio",
+    {
+      "name": "openimageio",
+      "features": [
+        "viewer"
+      ]
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6170,7 +6170,7 @@
     },
     "openimageio": {
       "baseline": "2.4.14.0",
-      "port-version": 2
+      "port-version": 3
     },
     "openjpeg": {
       "baseline": "2.5.0",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "96a94546980699cb7af5a5b1e3a5a6c7d2afd81a",
+      "git-tree": "76cadb5ec79b57f840f2dae9dc39501b027f6a9f",
       "version": "2.4.14.0",
       "port-version": 3
     },

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "66405ebe72b16379d7bff5e26fdff2b1338501df",
+      "git-tree": "96a94546980699cb7af5a5b1e3a5a6c7d2afd81a",
       "version": "2.4.14.0",
       "port-version": 3
     },

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f22b6f8b638d685c3ac8a1c473e6cc269d7b836",
+      "version": "2.4.14.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "fed3a9ba9a7731e30376ded1d6bdaba3e41b1ec6",
       "version": "2.4.14.0",
       "port-version": 2

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0f22b6f8b638d685c3ac8a1c473e6cc269d7b836",
+      "git-tree": "66405ebe72b16379d7bff5e26fdff2b1338501df",
       "version": "2.4.14.0",
       "port-version": 3
     },

--- a/versions/t-/theia.json
+++ b/versions/t-/theia.json
@@ -3,6 +3,11 @@
     {
       "git-tree": "244b1ee4928a23a5394691a642a1b56125198228",
       "version": "0.8",
+      "port-version": 10
+    },
+    {
+      "git-tree": "f33100aa143474a7207ee0f2ec7daf0fda3a74a5",
+      "version": "0.8",
       "port-version": 9
     },
     {


### PR DESCRIPTION
Add feature flag "viewer" which controls building the viewer "iv". Drop feature flag "tools", build tools (excluding the viewer) unconditionally.

Fixes #34556.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [N/A] SHA512s are updated for each updated download
- [N/A] The "supports" clause reflects platforms that may be fixed by this new version
- [N/A] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [N/A] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
