### PR TITLE
[glslang] fix tools windows

### DIFF
--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -20,7 +20,7 @@ if (ENABLE_GLSLANG_BINARIES)
     vcpkg_add_to_path("${PYTHON_PATH}")
 endif ()
 
-if (WIN32)
+if (VCPKG_TARGET_IS_WINDOWS)
     set(PLATFORM_OPTIONS "-DOVERRIDE_MSVCCRT=OFF")
 endif ()
 
@@ -46,6 +46,9 @@ vcpkg_copy_pdbs()
 
 if (ENABLE_GLSLANG_BINARIES)
     vcpkg_copy_tools(TOOL_NAMES glslangValidator spirv-remap AUTO_CLEAN)
+    if(VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_copy_tools(TOOL_NAMES glslang AUTO_CLEAN)
+    endif()
 endif ()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glslang",
   "version": "13.0.0",
+  "port-version": 1,
   "description": "Khronos-reference front end for GLSL/ESSL, partial front end for HLSL, and a SPIR-V generator.",
   "homepage": "https://github.com/KhronosGroup/glslang",
   "license": "Apache-2.0 AND BSD-3-Clause AND MIT AND GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2978,7 +2978,7 @@
     },
     "glslang": {
       "baseline": "13.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "glui": {
       "baseline": "2019-11-30",

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c5c6c37e6477580e47bd5645a3760ff534c689f6",
+      "version": "13.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "07a60a91ac63383677c203954125ba981d08f53b",
       "version": "13.0.0",
       "port-version": 0


### PR DESCRIPTION
Fixes 
```
-- Performing post-build validation
warning: The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    C:\v\vcpkg3\packages\glslang_x64-uwp\bin\glslang.exe

warning: The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    C:\v\vcpkg3\packages\glslang_x64-uwp\debug\bin\glslang.exe

warning: There should be no bin\ directory in a static build, but C:\v\vcpkg3\packages\glslang_x64-uwp\bin is present.
warning: There should be no debug\bin\ directory in a static build, but C:\v\vcpkg3\packages\glslang_x64-uwp\debug\bin is present.
warning: If the creation of bin\ and/or debug\bin\ cannot be disabled, use this in the portfile to remove them
    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
    endif()

error: Found 3 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: C:\v\vcpkg3\ports\glslang\portfile.cmake
error: building glslang:x64-uwp failed with: POST_BUILD_CHECKS_FAILED
```