### PR TITLE
[rivers] add new port

### DIFF
--- a/ports/rivers/add-install-configuration.patch
+++ b/ports/rivers/add-install-configuration.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 981ef20..3ad208e 100644
+index 981ef20..89c5a6e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -9,7 +9,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+@@ -9,20 +9,45 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
  
  add_library(rivers INTERFACE)
  add_library(rivers::rivers ALIAS rivers)
@@ -15,7 +15,15 @@ index 981ef20..3ad208e 100644
  
  option(RVR_IMPORT_FMT Off)
  if(RVR_IMPORT_FMT)
-@@ -24,5 +28,33 @@ if(RVR_IMPORT_FMT)
+-    include(FetchContent)
+-    FetchContent_Declare(
+-        fmt
+-        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+-        GIT_TAG 713c7c7c62044329d26c19323ffa0e64d69d2d64
+-        )
+-    FetchContent_MakeAvailable(fmt)
+-
++    find_package(fmt CONFIG REQUIRED)
      target_link_libraries(rivers INTERFACE fmt::fmt)
  endif()
  
@@ -53,12 +61,13 @@ index 981ef20..3ad208e 100644
 +
 diff --git a/cmake/unofficial-rivers-config.cmake.in b/cmake/unofficial-rivers-config.cmake.in
 new file mode 100644
-index 0000000..bd44e17
+index 0000000..d9bd6d6
 --- /dev/null
 +++ b/cmake/unofficial-rivers-config.cmake.in
-@@ -0,0 +1,5 @@
+@@ -0,0 +1,6 @@
 +
 +@PACKAGE_INIT@
 +
 +include("${CMAKE_CURRENT_LIST_DIR}/unofficial-rivers-targets.cmake")
++find_dependency(fmt CONFIG)
 +

--- a/ports/rivers/add-install-configuration.patch
+++ b/ports/rivers/add-install-configuration.patch
@@ -61,12 +61,13 @@ index 981ef20..89c5a6e 100644
 +
 diff --git a/cmake/unofficial-rivers-config.cmake.in b/cmake/unofficial-rivers-config.cmake.in
 new file mode 100644
-index 0000000..b6c63ec
+index 0000000..a347972
 --- /dev/null
 +++ b/cmake/unofficial-rivers-config.cmake.in
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,9 @@
 +
 +@PACKAGE_INIT@
++include(CMakeFindDependencyMacro)
 +
 +include("${CMAKE_CURRENT_LIST_DIR}/unofficial-rivers-targets.cmake")
 +if(@RVR_IMPORT_FMT@)

--- a/ports/rivers/add-install-configuration.patch
+++ b/ports/rivers/add-install-configuration.patch
@@ -1,0 +1,64 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 981ef20..3ad208e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,7 +9,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ 
+ add_library(rivers INTERFACE)
+ add_library(rivers::rivers ALIAS rivers)
+-target_include_directories(rivers INTERFACE include)
++target_include_directories(rivers
++                           INTERFACE
++                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++                            $<INSTALL_INTERFACE:include>
++                           )
+ 
+ option(RVR_IMPORT_FMT Off)
+ if(RVR_IMPORT_FMT)
+@@ -24,5 +28,33 @@ if(RVR_IMPORT_FMT)
+     target_link_libraries(rivers INTERFACE fmt::fmt)
+ endif()
+ 
+-add_subdirectory(bench)
+-add_subdirectory(test)
++include(CMakePackageConfigHelpers)
++
++configure_package_config_file(
++  cmake/unofficial-rivers-config.cmake.in
++  "${CMAKE_CURRENT_BINARY_DIR}/cmake/unofficial-rivers-config.cmake"
++  INSTALL_DESTINATION lib/cmake/unofficial-rivers/
++  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
++
++
++# Export.
++export(
++  TARGETS rivers
++  FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/unofficial-rivers-targets.cmake")
++
++# Install.
++install(TARGETS rivers EXPORT unofficial-rivers)
++
++install(
++  EXPORT unofficial-rivers
++  NAMESPACE unofficial-rivers::
++  FILE unofficial-rivers-targets.cmake
++  DESTINATION lib/cmake/unofficial-rivers)
++
++install(DIRECTORY include/rivers DESTINATION include)
++
++install(
++  FILES
++  "${CMAKE_CURRENT_BINARY_DIR}/cmake/unofficial-rivers-config.cmake"
++  DESTINATION lib/cmake/unofficial-rivers)
++
+diff --git a/cmake/unofficial-rivers-config.cmake.in b/cmake/unofficial-rivers-config.cmake.in
+new file mode 100644
+index 0000000..bd44e17
+--- /dev/null
++++ b/cmake/unofficial-rivers-config.cmake.in
+@@ -0,0 +1,5 @@
++
++@PACKAGE_INIT@
++
++include("${CMAKE_CURRENT_LIST_DIR}/unofficial-rivers-targets.cmake")
++

--- a/ports/rivers/add-install-configuration.patch
+++ b/ports/rivers/add-install-configuration.patch
@@ -61,13 +61,15 @@ index 981ef20..89c5a6e 100644
 +
 diff --git a/cmake/unofficial-rivers-config.cmake.in b/cmake/unofficial-rivers-config.cmake.in
 new file mode 100644
-index 0000000..d9bd6d6
+index 0000000..b6c63ec
 --- /dev/null
 +++ b/cmake/unofficial-rivers-config.cmake.in
-@@ -0,0 +1,6 @@
+@@ -0,0 +1,8 @@
 +
 +@PACKAGE_INIT@
 +
 +include("${CMAKE_CURRENT_LIST_DIR}/unofficial-rivers-targets.cmake")
-+find_dependency(fmt CONFIG)
++if(@RVR_IMPORT_FMT@)
++  find_dependency(fmt CONFIG)
++endif()
 +

--- a/ports/rivers/portfile.cmake
+++ b/ports/rivers/portfile.cmake
@@ -7,6 +7,8 @@ vcpkg_from_github(
     PATCHES add-install-configuration.patch
 )
 
+set(VCPKG_BUILD_TYPE release) # header-only
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         fmt RVR_IMPORT_FMT
@@ -21,8 +23,6 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH "lib/cmake/unofficial-rivers")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rivers/portfile.cmake
+++ b/ports/rivers/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO brevzin/rivers
+    REF cfbd4c3e0ca9fcde03075327d6dd628e57589342
+    SHA512 4dfa4a1e657c6a12446abe6d7c54d5bc3d47d82e8639eb91f98c7120b3ca79a6cfa761a357dc2285027823177ee76be346adddc7861f0f213cd0bc7cde041ab8
+    HEAD_REF main
+    PATCHES add-install-configuration.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH "lib/cmake/unofficial-rivers")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rivers/portfile.cmake
+++ b/ports/rivers/portfile.cmake
@@ -7,8 +7,14 @@ vcpkg_from_github(
     PATCHES add-install-configuration.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        fmt RVR_IMPORT_FMT
+)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/rivers/vcpkg.json
+++ b/ports/rivers/vcpkg.json
@@ -14,9 +14,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "fmt"
-  ],
   "features": {
     "fmt": {
       "description": "Use fmt as rivers fommatter",

--- a/ports/rivers/vcpkg.json
+++ b/ports/rivers/vcpkg.json
@@ -13,5 +13,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "fmt": {
+      "description": "Use fmt as rivers fommatter",
+      "dependencies": [
+        "fmt"
+      ]
+    }
+  }
 }

--- a/ports/rivers/vcpkg.json
+++ b/ports/rivers/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "rivers",
+  "version-date": "2022-05-16",
+  "description": "A C++ internal iteration library based loosely on Java Streams",
+  "homepage": "https://github.com/brevzin/rivers/",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/rivers/vcpkg.json
+++ b/ports/rivers/vcpkg.json
@@ -14,6 +14,9 @@
       "host": true
     }
   ],
+  "default-features": [
+    "fmt"
+  ],
   "features": {
     "fmt": {
       "description": "Use fmt as rivers fommatter",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7376,6 +7376,10 @@
       "baseline": "0.2.1",
       "port-version": 0
     },
+    "rivers": {
+      "baseline": "2022-05-16",
+      "port-version": 0
+    },
     "rkcommon": {
       "baseline": "1.10.0",
       "port-version": 0

--- a/versions/r-/rivers.json
+++ b/versions/r-/rivers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a2e51876d5f7128ea4ee14725b032f7092685f76",
+      "git-tree": "c8ba8843e1f91d6da5f15161b5a9565df23e8144",
       "version-date": "2022-05-16",
       "port-version": 0
     }

--- a/versions/r-/rivers.json
+++ b/versions/r-/rivers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9863c7718e3f99f089ef48997a7ed90409dfbee9",
+      "git-tree": "9a0a33765347e8652eecf77097b57cfdbc7e4184",
       "version-date": "2022-05-16",
       "port-version": 0
     }

--- a/versions/r-/rivers.json
+++ b/versions/r-/rivers.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a2e51876d5f7128ea4ee14725b032f7092685f76",
+      "version-date": "2022-05-16",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/r-/rivers.json
+++ b/versions/r-/rivers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f22c8aadd22a4144cfaf34ad68c28fd1d4843914",
+      "git-tree": "9863c7718e3f99f089ef48997a7ed90409dfbee9",
       "version-date": "2022-05-16",
       "port-version": 0
     }

--- a/versions/r-/rivers.json
+++ b/versions/r-/rivers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c8ba8843e1f91d6da5f15161b5a9565df23e8144",
+      "git-tree": "f0fc7efc52736cb05b600d3cdf4cee64559275ff",
       "version-date": "2022-05-16",
       "port-version": 0
     }

--- a/versions/r-/rivers.json
+++ b/versions/r-/rivers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f0fc7efc52736cb05b600d3cdf4cee64559275ff",
+      "git-tree": "f22c8aadd22a4144cfaf34ad68c28fd1d4843914",
       "version-date": "2022-05-16",
       "port-version": 0
     }


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.