### PR TITLE
[libremidi] Fix install path of the lib file

### DIFF
--- a/ports/libremidi/fix-install.patch
+++ b/ports/libremidi/fix-install.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/libremidi.install.cmake b/cmake/libremidi.install.cmake
+index 08e17f5..985e9a5 100644
+--- a/cmake/libremidi.install.cmake
++++ b/cmake/libremidi.install.cmake
+@@ -1,7 +1,7 @@
+ if(NOT LIBREMIDI_HEADER_ONLY)
+   install(TARGETS libremidi
+           EXPORT libremidi-targets
+-          ARCHIVE DESTINATION lib/static
++          ARCHIVE DESTINATION lib
+           RUNTIME DESTINATION bin
+           LIBRARY DESTINATION lib
+   )

--- a/ports/libremidi/portfile.cmake
+++ b/ports/libremidi/portfile.cmake
@@ -2,9 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jcelerier/libremidi
     REF "v${VERSION}"
-
     SHA512 de7092c70af6fc0a23c8e6018fbd9f380632ac9dec8794171726fda9a6e7ba45479a8e8317919ba7a8a0267524bab8d5430782a54bc50a914658cf277e18145b
     HEAD_REF master
+    PATCHES
+        fix-install.patch
 )
 
 vcpkg_list(SET options)
@@ -22,7 +23,7 @@ vcpkg_cmake_configure(
         -DLIBREMIDI_NO_JACK=ON
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libremidi PACKAGE_NAME libremidi)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/libremidi/vcpkg.json
+++ b/ports/libremidi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libremidi",
   "version": "4.2.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A modern C++ MIDI real-time & file I/O library",
   "homepage": "https://github.com/jcelerier/libremidi",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4638,7 +4638,7 @@
     },
     "libremidi": {
       "baseline": "4.2.3",
-      "port-version": 1
+      "port-version": 2
     },
     "libressl": {
       "baseline": "3.6.2",

--- a/versions/l-/libremidi.json
+++ b/versions/l-/libremidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4269a93684ffd5145f2b5a79421824b6efd87372",
+      "version": "4.2.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "4427d9259242a0dbc53753710b42b6531276f392",
       "version": "4.2.3",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
The related issue: https://github.com/microsoft/vcpkg/issues/20623#issuecomment-1777667501
Usage test passed on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
