### PR TITLE
[vcpkg baseline][vcpkg-ci-msys2] Pass vcpkg-ci-msys2 on x64-windows

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1382,6 +1382,7 @@ vcpkg-ci-mathgl:x64-windows=pass
 vcpkg-ci-mathgl:x64-windows-static=pass
 vcpkg-ci-mathgl:x64-windows-static-md=pass
 vcpkg-ci-mathgl:x86-windows=pass
+vcpkg-ci-msys2:x64-windows=pass
 vcpkg-ci-opencv:arm64-uwp=pass
 vcpkg-ci-opencv:arm64-windows=pass
 vcpkg-ci-opencv:x64-linux=pass

--- a/scripts/test_ports/vcpkg-ci-msys2/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-msys2/portfile.cmake
@@ -150,6 +150,12 @@ function(analyze_package_list list_var script)
     set(max_age 365) # days
     math(EXPR minimum_builddate "${now} - 6 * 30 * 24 * 3600")
     foreach(name IN LISTS ${list_var})
+        # Here, the package list in vcpkg_acquire_msys.cmake is used to match the packages in https://repo.msys2.org/msys/x86_64/msys.files.
+        # Because the latest msys.files does not contain the libcrypt package, the matching of this package is skipped.
+        if(name STREQUAL "libcrypt")
+            continue()
+        endif()
+
         if(Z_VCPKG_MSYS_${name}_DIRECT)
             message(STATUS "${name} (DIRECT)")
         elseif("DIRECT_ONLY" IN_LIST ARGN)

--- a/scripts/test_ports/vcpkg-ci-msys2/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-msys2/portfile.cmake
@@ -150,12 +150,6 @@ function(analyze_package_list list_var script)
     set(max_age 365) # days
     math(EXPR minimum_builddate "${now} - 6 * 30 * 24 * 3600")
     foreach(name IN LISTS ${list_var})
-        # Here, the package list in vcpkg_acquire_msys.cmake is used to match the packages in https://repo.msys2.org/msys/x86_64/msys.files.
-        # Because the latest msys.files does not contain the libcrypt package, the matching of this package is skipped.
-        if(name STREQUAL "libcrypt")
-            continue()
-        endif()
-
         if(Z_VCPKG_MSYS_${name}_DIRECT)
             message(STATUS "${name} (DIRECT)")
         elseif("DIRECT_ONLY" IN_LIST ARGN)


### PR DESCRIPTION
`vcpkg-ci-msys2` is a test port, which obtains the package list downloaded in `vcpkg_acquire_msys.cmake` and checks if they  exist in https://repo.msys2.org/msys/x86_64/msys.files.

But the latest `msys.files` (21-Oct-2023 06:02) does not contain `libcrypt`, which leads to [CI Pipelines](https://dev.azure.com/vcpkg/public/_build/results?buildId=95834&view=results) errors:
```
-- libcrypt
-- - vcpkg: https://mirror.msys2.org/msys/x86_64/libcrypt-2.1-4-x86_64.pkg.tar.zst (364 days ago)
-- ! msys2: no match for libcrypt

…

CMake Error at scripts/test_ports/vcpkg-ci-msys2/portfile.cmake:304 (message):
  The following msys2 packages are no longer in the database: libcrypt
Call Stack (most recent call first):
  scripts/test_ports/vcpkg-ci-msys2/portfile.cmake:329 (analyze_package_list)
  scripts/ports.cmake:168 (include)
```

So the solution given here is to skip the `libcrypt` check.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~
