### PR TITLE
[proxsuite] add new port

### DIFF
--- a/ports/proxsuite/portfile.cmake
+++ b/ports/proxsuite/portfile.cmake
@@ -1,0 +1,37 @@
+set(VCPKG_BUILD_TYPE release) # header-only
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Simple-Robotics/proxsuite
+    REF "v${VERSION}"
+    SHA512 ce9d20f689cabf7668f8bd801017613a83ed816c8cab0190ae7116b2dc4880d0b5fa31bf11053f653f326b68984e3e63cdb3b43d9fd50a345554777d3d801a1b
+    HEAD_REF main
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH MODULES_SOURCE_PATH
+    REPO jrl-umi3218/jrl-cmakemodules
+    REF e1a71520cd2f0e6f2a611e1a70df4d8edf4d5a65
+    SHA512 a9dec01a4b4b30b42bf7f6e07c7102d58242c431f59875dac6bfc296473266f927e2ac3b823dcfa9364dad5cdbf46532d94eb65c41aa7d1ddfd7ec5212466ffa
+    HEAD_REF master
+)
+file(REMOVE_RECURSE "${SOURCE_PATH}/cmake-module")
+file(RENAME "${MODULES_SOURCE_PATH}" "${SOURCE_PATH}/cmake-module")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_WITH_VECTORIZATION_SUPPORT=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/proxsuite/vcpkg.json
+++ b/ports/proxsuite/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "proxsuite",
+  "version": "0.5.0",
+  "description": "The Advanced Proximal Optimization Toolbox",
+  "homepage": "https://github.com/Simple-Robotics/proxsuite",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    "eigen3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6680,6 +6680,10 @@
       "baseline": "1.7.1",
       "port-version": 0
     },
+    "proxsuite": {
+      "baseline": "0.5.0",
+      "port-version": 0
+    },
     "proxy": {
       "baseline": "1.1.1",
       "port-version": 0

--- a/versions/p-/proxsuite.json
+++ b/versions/p-/proxsuite.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d43b63f01c1240a12c85794fdde566064996b845",
+      "version": "0.5.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
