### PR TITLE
[opencv] added openvino support

### DIFF
--- a/ports/opencv4/0021-static-openvino.patch
+++ b/ports/opencv4/0021-static-openvino.patch
@@ -1,0 +1,25 @@
+diff --git a/cmake/OpenCVUtils.cmake b/cmake/OpenCVUtils.cmake
+index 437042958e..a90eb5a5ab 100644
+--- a/cmake/OpenCVUtils.cmake
++++ b/cmake/OpenCVUtils.cmake
+@@ -1632,13 +1632,19 @@ function(ocv_add_external_target name inc link def)
+   endif()
+ endfunction()
+ 
++set(__OPENCV_EXPORTED_EXTERNAL_TARGETS "" CACHE INTERNAL "")
+ function(ocv_install_used_external_targets)
+   if(NOT BUILD_SHARED_LIBS
+       AND NOT (CMAKE_VERSION VERSION_LESS "3.13.0")  # upgrade CMake: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/2152
+   )
+     foreach(tgt in ${ARGN})
+       if(tgt MATCHES "^ocv\.3rdparty\.")
+-        install(TARGETS ${tgt} EXPORT OpenCVModules)
++        list(FIND __OPENCV_EXPORTED_EXTERNAL_TARGETS "${tgt}" _found)
++        if(_found EQUAL -1)  # don't export target twice
++          install(TARGETS ${tgt} EXPORT OpenCVModules)
++          list(APPEND __OPENCV_EXPORTED_EXTERNAL_TARGETS "${tgt}")
++          set(__OPENCV_EXPORTED_EXTERNAL_TARGETS "${__OPENCV_EXPORTED_EXTERNAL_TARGETS}" CACHE INTERNAL "")
++        endif()
+       endif()
+     endforeach()
+   endif()

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -29,6 +29,7 @@ vcpkg_from_github(
       0017-fix-flatbuffers.patch
       0019-missing-include.patch
       0020-fix-compat-cuda12.2.patch
+      0021-static-openvino.patch # https://github.com/opencv/opencv/pull/23963
       "${ARM64_WINDOWS_FIX}"
 )
 # Disallow accidental build of vendored copies
@@ -85,9 +86,13 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 # Cannot use vcpkg_check_features() for "dnn", "gtk", ipp", "openmp", "ovis", "python", "qt", "tbb"
 set(BUILD_opencv_dnn OFF)
+set(WITH_OPENVINO OFF)
 if("dnn" IN_LIST FEATURES)
   if(NOT VCPKG_TARGET_IS_ANDROID)
     set(BUILD_opencv_dnn ON)
+    if(NOT VCPKG_TARGET_IS_UWP)
+      set(WITH_OPENVINO ON)
+    endif()
   else()
     message(WARNING "The dnn module cannot be enabled on Android")
   endif()
@@ -446,6 +451,7 @@ vcpkg_cmake_configure(
         -DWITH_PROTOBUF=${BUILD_opencv_dnn}
         -DWITH_PYTHON=${WITH_PYTHON}
         -DWITH_OPENCLAMDBLAS=OFF
+        -DWITH_OPENVINO=${WITH_OPENVINO}
         -DWITH_TBB=${WITH_TBB}
         -DWITH_OPENJPEG=OFF
         -DWITH_CPUFEATURES=OFF
@@ -525,6 +531,9 @@ find_dependency(Tesseract)")
   endif()
   if("lapack" IN_LIST FEATURES)
     string(APPEND DEPS_STRING "\nfind_dependency(LAPACK)")
+  endif()
+  if(WITH_OPENVINO)
+    string(APPEND DEPS_STRING "\nfind_dependency(OpenVINO CONFIG)")
   endif()
   if("openexr" IN_LIST FEATURES)
     string(APPEND DEPS_STRING "\nfind_dependency(OpenEXR CONFIG)")

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -108,6 +108,10 @@
           "name": "flatbuffers",
           "host": true,
           "default-features": false
+        },
+        {
+          "name": "openvino",
+          "platform": "!uwp"
         },
         "protobuf"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6142,7 +6142,7 @@
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 7
+      "port-version": 8
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48c97b54fceaef9a96d374693f47e3ea91383f3c",
+      "version": "4.8.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "ef78c1958b122045e9d1e353150049431b3162fa",
       "version": "4.8.0",
       "port-version": 7


### PR DESCRIPTION
**Reason:** Optimized OpenCV DNN module with OpenVINO, because by default OpenCV DNN module is slow as does not have any integrated performant backend.

Closes https://github.com/microsoft/vcpkg/issues/28357

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
