### PR TITLE
[minizip-ng] update to v4.0.1

### DIFF
--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/minizip-ng
     REF "${VERSION}"
-    SHA512 be3a9e9580847d595abbd200ec89a97e38086cab5b34d3a4db1507247ed04f9209290945989b200225ea412ee0e37fb9f1947404d1631d2dfeb5c6dc55ce3d05
+    SHA512 857450c3a51a75269afdffdcbaaa6d05894913dd98a91e307129b5e61766f6e3d20bca5841afa41bbe6ca88ad0666c462079a5e1fe73718c2dffd05219c8f258
     HEAD_REF master
     PATCHES
         fix_find_zstd.patch

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -38,7 +38,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/minizip-ng)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -17,7 +17,6 @@ vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         pkcrypt MZ_PKCRYPT
-        signing MZ_SIGNING
         wzaes MZ_WZAES
         openssl MZ_OPENSSL
         bzip2 MZ_BZIP2

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "minizip-ng",
-  "version": "4.0.0",
-  "port-version": 4,
+  "version": "4.0.1",
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "license": "Zlib",

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -19,7 +19,6 @@
     "bzip2",
     "lzma",
     "pkcrypt",
-    "signing",
     "wzaes",
     "zlib",
     "zstd"
@@ -45,19 +44,6 @@
     },
     "pkcrypt": {
       "description": "Enables PKWARE traditional encryption"
-    },
-    "signing": {
-      "description": "Enables zip signing support",
-      "dependencies": [
-        {
-          "name": "minizip-ng",
-          "default-features": false,
-          "features": [
-            "openssl"
-          ],
-          "platform": "!windows & !osx"
-        }
-      ]
     },
     "wzaes": {
       "description": "Enables WinZIP AES encryption",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5509,8 +5509,8 @@
       "port-version": 1
     },
     "minizip-ng": {
-      "baseline": "4.0.0",
-      "port-version": 4
+      "baseline": "4.0.1",
+      "port-version": 0
     },
     "mio": {
       "baseline": "2023-03-03",

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d77f713bae64d416bf60adb3395a3b295feccc9b",
+      "version": "4.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "fb59eb8b735f74193a79326e33fb6f9abc66846a",
       "version": "4.0.0",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


