### PR TITLE
[openssl] Update version to 3.1.4

### DIFF
--- a/ports/openssl/disable-install-docs.patch
+++ b/ports/openssl/disable-install-docs.patch
@@ -1,5 +1,5 @@
 diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
-index 110ba06..5b6b1c7 100644
+index a48fae5..c82c086 100644
 --- a/Configurations/unix-Makefile.tmpl
 +++ b/Configurations/unix-Makefile.tmpl
 @@ -611,7 +611,7 @@ install_sw: install_dev install_engines install_modules install_runtime
@@ -10,12 +10,12 @@ index 110ba06..5b6b1c7 100644
 +install_docs:
  
  uninstall_docs: uninstall_man_docs uninstall_html_docs
- 	$(RM) -r $(DESTDIR)$(DOCDIR)
+ 	$(RM) -r "$(DESTDIR)$(DOCDIR)"
 diff --git a/Configurations/windows-makefile.tmpl b/Configurations/windows-makefile.tmpl
-index d054431..b5c1c88 100644
+index 9250b98..2b63c85 100644
 --- a/Configurations/windows-makefile.tmpl
 +++ b/Configurations/windows-makefile.tmpl
-@@ -487,7 +487,7 @@ install_sw: install_dev install_engines install_modules install_runtime
+@@ -493,7 +493,7 @@ install_sw: install_dev install_engines install_modules install_runtime
  
  uninstall_sw: uninstall_runtime uninstall_modules uninstall_engines uninstall_dev
  

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -19,7 +19,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
     REF "openssl-${VERSION}"
-    SHA512 248353b000ef6b9a3434bf808b147eb4672c82f36968b2995c159373680f80208183bb70c02effa36ae4a1705fe5a5e315960075e8899352c4e84069d6c651c2
+    SHA512 04349ba554ddc5a9c26ff44714c1adca3c6431e98d11af5e7b6a5f58ed44e016da68c09cc53415716ab1936c6aaac04887ced470707dbc3f7816c04e06be69c1
     PATCHES
         disable-apps.patch
         disable-install-docs.patch

--- a/ports/openssl/unix/move-openssldir.patch
+++ b/ports/openssl/unix/move-openssldir.patch
@@ -1,15 +1,16 @@
 diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
-index dd96254..c4458ca 100644
+index c82c086..6c5402d 100644
 --- a/Configurations/unix-Makefile.tmpl
 +++ b/Configurations/unix-Makefile.tmpl
-@@ -689,6 +689,10 @@ install_ssldirs:
- 		cp $(SRCDIR)/apps/ct_log_list.cnf $(DESTDIR)$(OPENSSLDIR)/ct_log_list.cnf; \
- 		chmod 644 $(DESTDIR)$(OPENSSLDIR)/ct_log_list.cnf; \
+@@ -690,6 +690,11 @@ install_ssldirs:
+ 		chmod 644 "$(DESTDIR)$(OPENSSLDIR)/ct_log_list.cnf"; \
  	fi
+ 
 +	$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)$(OPENSSLDIR)
 +	for I in $(DESTDIR)$(OPENSSLDIR)/*; do \
 +		mv $$I $(DESTDIR)$(INSTALLTOP)$(OPENSSLDIR)/; \
 +	done
- 
++
  install_dev: install_runtime_libs
  	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
+ 	@$(ECHO) "*** Installing development files"

--- a/ports/openssl/unix/no-empty-dirs.patch
+++ b/ports/openssl/unix/no-empty-dirs.patch
@@ -1,21 +1,21 @@
 diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
-index 5b6b1c7..4c8c916 100644
+index 6c5402d..fc982df 100644
 --- a/Configurations/unix-Makefile.tmpl
 +++ b/Configurations/unix-Makefile.tmpl
-@@ -818,7 +818,7 @@ _install_modules_deps: install_runtime_libs build_modules
+@@ -823,7 +823,7 @@ _install_modules_deps: install_runtime_libs build_modules
  
  install_engines: _install_modules_deps
  	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
--	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(ENGINESDIR)/
+-	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(ENGINESDIR)/"
 +	@[ -z "$(INSTALL_ENGINES)" ] || $(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(ENGINESDIR)/
  	@$(ECHO) "*** Installing engines"
  	@set -e; for e in dummy $(INSTALL_ENGINES); do \
  		if [ "$$e" = "dummy" ]; then continue; fi; \
-@@ -842,7 +842,7 @@ uninstall_engines:
+@@ -847,7 +847,7 @@ uninstall_engines:
  
  install_modules: _install_modules_deps
  	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
--	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(MODULESDIR)/
+-	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(MODULESDIR)/"
 +	@[ -z "$(INSTALL_MODULES)" ] || $(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(MODULESDIR)/
  	@$(ECHO) "*** Installing modules"
  	@set -e; for e in dummy $(INSTALL_MODULES); do \

--- a/ports/openssl/unix/no-static-libs-for-shared.patch
+++ b/ports/openssl/unix/no-static-libs-for-shared.patch
@@ -1,12 +1,12 @@
 diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
-index 4c8c916..dd96254 100644
+index fc982df..10f1c54 100644
 --- a/Configurations/unix-Makefile.tmpl
 +++ b/Configurations/unix-Makefile.tmpl
-@@ -708,6 +708,7 @@ install_dev: install_runtime_libs
+@@ -713,6 +713,7 @@ install_dev: install_runtime_libs
  	done
- 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(libdir)
+ 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(libdir)"
  	@set -e; for l in $(INSTALL_LIBS); do \
-+		if [ -n "$(INSTALL_SHLIBS)" ] ; then continue ; fi ; \
++        if [ -n "$(INSTALL_SHLIBS)" ] ; then continue ; fi ; \
  		fn=`basename $$l`; \
  		$(ECHO) "install $$l -> $(DESTDIR)$(libdir)/$$fn"; \
- 		cp $$l $(DESTDIR)$(libdir)/$$fn.new; \
+ 		cp $$l "$(DESTDIR)$(libdir)/$$fn.new"; \

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openssl",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6213,7 +6213,7 @@
       "port-version": 3
     },
     "openssl": {
-      "baseline": "3.1.3",
+      "baseline": "3.1.4",
       "port-version": 0
     },
     "openssl-unix": {

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3dc34c6428cc5a086a56695e0e0e8c2363e029b5",
+      "version": "3.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "e57c0f392fd8486892a91ca82b7bf2e34c59e374",
       "version": "3.1.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/34714
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
