### PR TITLE
[mbedtls] update to 2.28.5

### DIFF
--- a/ports/mbedtls/enable-pthread.patch
+++ b/ports/mbedtls/enable-pthread.patch
@@ -1,16 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8833246..f68ab02 100644
+index b001bb7..a5e0479 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -28,6 +28,7 @@ set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+@@ -44,6 +44,7 @@ set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
  
- option(USE_PKCS11_HELPER_LIBRARY "Build mbed TLS with the pkcs11-helper library." OFF)
- option(ENABLE_ZLIB_SUPPORT "Build mbed TLS with zlib library." OFF)
-+option(ENABLE_PTHREAD "Build mbed TLS with pthread" OFF)
+ option(USE_PKCS11_HELPER_LIBRARY "Build Mbed TLS with the pkcs11-helper library." OFF)
+ option(ENABLE_ZLIB_SUPPORT "Build Mbed TLS with zlib library." OFF)
++option(ENABLE_PTHREAD "Build Mbed TLS with pthread" OFF)
  
- option(ENABLE_PROGRAMS "Build mbed TLS programs." ON)
+ option(ENABLE_PROGRAMS "Build Mbed TLS programs." ON)
  
-@@ -231,6 +232,8 @@ else()
+@@ -263,6 +264,8 @@ else()
      set(LIB_INSTALL_DIR lib)
  endif()
  
@@ -19,7 +19,7 @@ index 8833246..f68ab02 100644
  if(ENABLE_ZLIB_SUPPORT)
      find_package(ZLIB)
  
-@@ -239,6 +242,17 @@ if(ENABLE_ZLIB_SUPPORT)
+@@ -271,6 +274,17 @@ if(ENABLE_ZLIB_SUPPORT)
      endif(ZLIB_FOUND)
  endif(ENABLE_ZLIB_SUPPORT)
  
@@ -38,11 +38,11 @@ index 8833246..f68ab02 100644
  
  add_subdirectory(3rdparty)
 diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
-index 62c0f62..7923202 100644
+index 11b417b..5ca44c3 100644
 --- a/include/CMakeLists.txt
 +++ b/include/CMakeLists.txt
 @@ -1,10 +1,14 @@
- option(INSTALL_MBEDTLS_HEADERS "Install mbed TLS headers." ON)
+ option(INSTALL_MBEDTLS_HEADERS "Install Mbed TLS headers." ON)
  
 +configure_file(mbedtls/config_threading.h.in mbedtls/config_threading.h)
 +
@@ -58,7 +58,7 @@ index 62c0f62..7923202 100644
          DESTINATION include/mbedtls
          PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
-index 1e6e052..51c20da 100644
+index 7b1f38a..5f29ba5 100644
 --- a/include/mbedtls/config.h
 +++ b/include/mbedtls/config.h
 @@ -24,6 +24,8 @@
@@ -84,10 +84,10 @@ index 0000000..9d5d42e
 +#endif
 \ No newline at end of file
 diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
-index 33e2cfc..4b99331 100644
+index 8d88101..2ba764c 100644
 --- a/library/CMakeLists.txt
 +++ b/library/CMakeLists.txt
-@@ -137,7 +137,11 @@ if(ENABLE_ZLIB_SUPPORT)
+@@ -149,7 +149,11 @@ if(ENABLE_ZLIB_SUPPORT)
  endif(ENABLE_ZLIB_SUPPORT)
  
  if(LINK_WITH_PTHREAD)

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_LIBRARY_LINKAGE static)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ARMmbed/mbedtls
-    REF v2.28.1
-    SHA512 b71d052acfb83daff11e0182f32b0ad0af7c59d2b74bd19f270531a3da9ed3ce1d3adcaf756e161bf05a10fe1b6b7753e360e9dbb5b7b123f09201b1202ef689
+    REF "v${VERSION}"
+    SHA512 7b19dff013910b5300662d48be5adb0e7c4d2c54b79116992642e5c9850cd62a14aea69b121458d3441154e3f2a13fd9a33ad86a26f17e4d94a872970ea841e0
     HEAD_REF mbedtls-2.28
     PATCHES
         enable-pthread.patch

--- a/ports/mbedtls/vcpkg.json
+++ b/ports/mbedtls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mbedtls",
-  "version": "2.28.1",
+  "version": "2.28.5",
   "description": "An open source, portable, easy to use, readable and flexible SSL library",
   "homepage": "https://github.com/ARMmbed/mbedtls",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5373,7 +5373,7 @@
       "port-version": 2
     },
     "mbedtls": {
-      "baseline": "2.28.1",
+      "baseline": "2.28.5",
       "port-version": 0
     },
     "mchehab-zbar": {

--- a/versions/m-/mbedtls.json
+++ b/versions/m-/mbedtls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "909516904f06e3379f7ac434b967cb165d8020c2",
+      "version": "2.28.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "f6fd876a24f60e3034438c6793627be091ab6426",
       "version": "2.28.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/31666

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

