### PR TITLE
[sentencepiece] update to 0.1.99

### DIFF
--- a/ports/sentencepiece/portfile.cmake
+++ b/ports/sentencepiece/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/sentencepiece
-    REF 58f256cf6f01bb86e6fa634a5cc560de5bd1667d #v0.1.97
-    SHA512 9abe21f76aa025d35a0210bc1a5b0c6f2bb2ab9f626ef9d59bcd8950442036af048ca3945db311d80ff378d41f984a941f39c206e2aa006f1ca0278426d03932
+    REF "v${VERSION}"
+    SHA512 31dc4dc3f2ff4a7effc1ed2d6ad219bcd5d28c0bac89fdeae0336f23e93f954c597313788529e692a0d694d5fa7c3c285a485dfb84a96921efc4b49bcd465358
     HEAD_REF master
 )
 
@@ -26,7 +26,7 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_BUILD_TYPE)
     file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/sentencepiece_train.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/sentencepiece_traind.lib")
 endif()
 
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_copy_pdbs()
 

--- a/ports/sentencepiece/vcpkg.json
+++ b/ports/sentencepiece/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sentencepiece",
-  "version": "0.1.97",
-  "port-version": 2,
+  "version": "0.1.99",
   "description": "SentencePiece is an unsupervised text tokenizer and detokenizer mainly for Neural Network-based text generation systems where the vocabulary size is predetermined prior to the neural model training",
   "license": "Apache-2.0",
   "supports": "!((windows | uwp) & !static)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7657,8 +7657,8 @@
       "port-version": 6
     },
     "sentencepiece": {
-      "baseline": "0.1.97",
-      "port-version": 2
+      "baseline": "0.1.99",
+      "port-version": 0
     },
     "sentry-native": {
       "baseline": "0.6.6",

--- a/versions/s-/sentencepiece.json
+++ b/versions/s-/sentencepiece.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4113b95c56e98d9c59787730bdc69978d23e290",
+      "version": "0.1.99",
+      "port-version": 0
+    },
+    {
       "git-tree": "301c8902039b2ebb65ede78d6d17174a2ca4e8f6",
       "version": "0.1.97",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/34739

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Compile test pass with following triplets:
```
x64-linux
```