### PR TITLE
[gstreamer] Add correct support for feature nvcodec

### DIFF
--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -424,7 +424,7 @@
     },
     "nvcodec": {
       "description": "Enable support for the NVCODEC encoders and decoders",
-      "supports": "!(osx & arm) & !ios & !android & !emscripten",
+      "supports": "!osx & !ios & !android & !emscripten",
       "dependencies": [
         {
           "name": "gstreamer",

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.22.5",
-  "port-version": 4,
+  "port-version": 5,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",
@@ -424,7 +424,7 @@
     },
     "nvcodec": {
       "description": "Enable support for the NVCODEC encoders and decoders",
-      "supports": "!uwp",
+      "supports": "!(osx & arm) & !ios & !android & !emscripten",
       "dependencies": [
         {
           "name": "gstreamer",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3098,7 +3098,7 @@
     },
     "gstreamer": {
       "baseline": "1.22.5",
-      "port-version": 4
+      "port-version": 5
     },
     "gtest": {
       "baseline": "1.14.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "856d971f06e79269be0eef404e9fa695b5ed9e86",
+      "version": "1.22.5",
+      "port-version": 5
+    },
+    {
       "git-tree": "b18eecdb79cdeb95b0c5e003cf14ababd9bca7c9",
       "version": "1.22.5",
       "port-version": 4

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "856d971f06e79269be0eef404e9fa695b5ed9e86",
+      "git-tree": "c6339c24dbe60ed13ff8d6b5e646d11e192f4ec0",
       "version": "1.22.5",
       "port-version": 5
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/34740
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Related: https://github.com/microsoft/vcpkg/pull/34690 
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/1.22.5/subprojects/gst-plugins-bad/gst-libs/gst/cuda/meson.build?ref_type=tags#L22
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
