### PR TITLE
[asio] update 1.28.2

### DIFF
--- a/ports/asio/portfile.cmake
+++ b/ports/asio/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO chriskohlhoff/asio
     REF asio-1-28-2
-    SHA512 0
+    SHA512 435c13f6f14a35bde042c6d86965ec104ae33be0b6a3c156518b29f851ad2b69c67bf760a20932d847e3b171f571bedc541c6a0d0541980aee8558b09e70357f
     HEAD_REF master
 )
 

--- a/ports/asio/portfile.cmake
+++ b/ports/asio/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO chriskohlhoff/asio
-    REF asio-1-28-1
-    SHA512 4ba0944b203e18524016de2e21ffa0fa6325414af5f6cff6d02450c15e0d7111cec91f7f125ae78d3b3a6f76c6b2c7155738d1830b3250e98c68b5304328f345
+    REF asio-1-28-2
+    SHA512 0
     HEAD_REF master
 )
 

--- a/ports/asio/vcpkg.json
+++ b/ports/asio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "asio",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "description": "Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach.",
   "homepage": "https://github.com/chriskohlhoff/asio",
   "documentation": "https://think-async.com/Asio/asio-1.28.0/doc/",

--- a/versions/a-/asio.json
+++ b/versions/a-/asio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "98898f87384938e684ac8828b22271620669f7a1",
+      "git-tree": "4c8d95a50172d0fd6bf736540379a37a4ec0a512",
       "version": "1.28.2",
       "port-version": 0
     },

--- a/versions/a-/asio.json
+++ b/versions/a-/asio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98898f87384938e684ac8828b22271620669f7a1",
+      "version": "1.28.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c0b1256bf350481cdba09fb8586852ca0560e024",
       "version": "1.28.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -249,7 +249,7 @@
       "port-version": 0
     },
     "asio": {
-      "baseline": "1.28.1",
+      "baseline": "1.28.2",
       "port-version": 0
     },
     "asio-grpc": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.