### PR TITLE
[libclipboard] new port 

### DIFF
--- a/ports/libclipboard/fix-libclipboard-cmake.patch
+++ b/ports/libclipboard/fix-libclipboard-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f251471..c7f1245 100644
+index f251471..7c59fa4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,6 +1,6 @@
@@ -143,7 +143,7 @@ index f251471..c7f1245 100644
 +    COPYONLY
 +)
 +
-+set(ConfigPackageLocation lib/cmake/LibClipboard)
++set(ConfigPackageLocation share/LibClipboard)
 +install(EXPORT LibClipboardTargets
 +    FILE
 +        LibClipboardTargets.cmake

--- a/ports/libclipboard/fix-libclipboard-cmake.patch
+++ b/ports/libclipboard/fix-libclipboard-cmake.patch
@@ -18,13 +18,14 @@ index f251471..aff497c 100644
  endif()
  
  if (NOT (LIBCLIPBOARD_BUILD_WIN32 OR LIBCLIPBOARD_BUILD_X11 OR LIBCLIPBOARD_BUILD_COCOA))
-@@ -57,24 +58,6 @@ if (CMAKE_COMPILER_IS_GNUCXX OR LIBCLIPBOARD_BUILD_COCOA)
+@@ -57,24 +58,9 @@ if (CMAKE_COMPILER_IS_GNUCXX OR LIBCLIPBOARD_BUILD_COCOA)
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -pedantic -g")
  endif()
  
 -# Dependencies
--if (LIBCLIPBOARD_BUILD_COCOA)
+ if (LIBCLIPBOARD_BUILD_COCOA)
 -    set_source_files_properties(src/clipboard_cocoa.c PROPERTIES COMPILE_FLAGS "-x objective-c")
++    set_source_files_properties(src/clipboard_cocoa.c PROPERTIES LANGUAGE OBJC)
 -    set(LIBCLIPBOARD_PRIVATE_LIBS ${LIBCLIPBOARD_PRIVATE_LIBS} "-framework Cocoa")
 -elseif(LIBCLIPBOARD_BUILD_X11)
 -    include(FindPkgConfig REQUIRED)
@@ -34,7 +35,7 @@ index f251471..aff497c 100644
 -    include_directories(${X11_INCLUDE_DIRS})
 -    link_directories(${X11_LIBRARY_DIRS})
 -    set(LIBCLIPBOARD_PRIVATE_LIBS ${LIBCLIPBOARD_PRIVATE_LIBS} ${X11_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
--endif()
+ endif()
 -
 -# Include directories
 -include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
@@ -62,8 +63,8 @@ index f251471..aff497c 100644
 -if (LIBCLIPBOARD_ADD_SOVERSION)
 -    # Not by default because my file system doesn't support symlinks
 -    set_target_properties(clipboard PROPERTIES SOVERSION ${LIBCLIPBOARD_VERSION} VERSION ${LIBCLIPBOARD_VERSION})
-+if(APPLE)
-+list(APPEND SOURCE src/clipboard_cocoa.m)
++if(LIBCLIPBOARD_BUILD_COCOA)
++list(APPEND SOURCE src/clipboard_cocoa.c)
  endif()
  
 -# Testing mode?
@@ -146,12 +147,12 @@ index f251471..aff497c 100644
 -    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
 -    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
 -    IMMEDIATE @ONLY)
-+configure_file(cmake/unofficial-libclipboard-config.cmake
++set(ConfigPackageLocation share/unofficial-libclipboard)
++configure_package_config_file(cmake/unofficial-libclipboard-config.cmake.in
 +	"${CMAKE_CURRENT_BINARY_DIR}/unofficial-libclipboard/unofficial-libclipboard-config.cmake"
-+    COPYONLY
++    INSTALL_DESTINATION ${ConfigPackageLocation}
 +)
 +
-+set(ConfigPackageLocation share/unofficial-libclipboard)
 +install(EXPORT LibClipboardTargets
 +    FILE
 +        unofficial-libclipboard-targets.cmake
@@ -162,7 +163,7 @@ index f251471..aff497c 100644
 +)
 +install(
 +    FILES
-+        cmake/unofficial-libclipboard-config.cmake
++   "${CMAKE_CURRENT_BINARY_DIR}/unofficial-libclipboard/unofficial-libclipboard-config.cmake"
 +	"${CMAKE_CURRENT_BINARY_DIR}/unofficial-libclipboard/unofficial-libclipboard-config-version.cmake"
 +    DESTINATION
 +        ${ConfigPackageLocation}
@@ -173,20 +174,17 @@ index f251471..aff497c 100644
 -add_custom_target(uninstall
 -    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 \ No newline at end of file
-diff --git a/cmake/unofficial-libclipboard-config.cmake b/cmake/unofficial-libclipboard-config.cmake
+diff --git a/cmake/unofficial-libclipboard-config.cmake b/cmake/unofficial-libclipboard-config.cmake.in
 new file mode 100644
 index 0000000..9d48704
 --- /dev/null
-+++ b/cmake/unofficial-libclipboard-config.cmake
-@@ -0,0 +0,7 @@
++++ b/cmake/unofficial-libclipboard-config.cmake.in
+@@ -0,0 +0,8 @@
++@PACKAGE_INIT@
 +include(CMakeFindDependencyMacro)
 +find_dependency(PkgConfig REQUIRED)
-+if(UNIX AND NOT APPLE)
++if(@LIBCLIPBOARD_BUILD_X11@)
 +pkg_check_modules(xcb REQUIRED IMPORTED_TARGET xcb)
 +endif()
 +find_dependency(Threads REQUIRED)
 +include("${CMAKE_CURRENT_LIST_DIR}/unofficial-libclipboard-targets.cmake")
-diff --git a/src/clipboard_cocoa.c b/src/clipboard_cocoa.m
-similarity index 100%
-rename from src/clipboard_cocoa.c
-rename to src/clipboard_cocoa.m

--- a/ports/libclipboard/fix-libclipboard-cmake.patch
+++ b/ports/libclipboard/fix-libclipboard-cmake.patch
@@ -1,0 +1,174 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f251471..c7f1245 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ # libclipboard cmake configuration file
+ 
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.14)
+ project(libclipboard)
+ 
+ # Defines and options
+@@ -35,6 +35,7 @@ endif()
+ 
+ if ((APPLE OR LIBCLIPBOARD_FORCE_COCOA) AND NOT (LIBCLIPBOARD_FORCE_WIN32 OR LIBCLIPBOARD_FORCE_X11))
+     set(LIBCLIPBOARD_BUILD_COCOA TRUE)
++    enable_language(OBJC)
+ endif()
+ 
+ if (NOT (LIBCLIPBOARD_BUILD_WIN32 OR LIBCLIPBOARD_BUILD_X11 OR LIBCLIPBOARD_BUILD_COCOA))
+@@ -57,24 +58,6 @@ if (CMAKE_COMPILER_IS_GNUCXX OR LIBCLIPBOARD_BUILD_COCOA)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -pedantic -g")
+ endif()
+ 
+-# Dependencies
+-if (LIBCLIPBOARD_BUILD_COCOA)
+-    set_source_files_properties(src/clipboard_cocoa.c PROPERTIES COMPILE_FLAGS "-x objective-c")
+-    set(LIBCLIPBOARD_PRIVATE_LIBS ${LIBCLIPBOARD_PRIVATE_LIBS} "-framework Cocoa")
+-elseif(LIBCLIPBOARD_BUILD_X11)
+-    include(FindPkgConfig REQUIRED)
+-    pkg_check_modules(X11 xcb REQUIRED)
+-    find_package(Threads REQUIRED)
+-
+-    include_directories(${X11_INCLUDE_DIRS})
+-    link_directories(${X11_LIBRARY_DIRS})
+-    set(LIBCLIPBOARD_PRIVATE_LIBS ${LIBCLIPBOARD_PRIVATE_LIBS} ${X11_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+-endif()
+-
+-# Include directories
+-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+-include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
+-
+ # Configure header
+ configure_file("include/libclipboard-config.h.in" "include/libclipboard-config.h")
+ 
+@@ -91,62 +74,72 @@ set(SOURCE
+     src/clipboard_common.c
+ )
+ 
+-# Set the output folders
+-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
++install(
++    FILES
++        ${HEADERS}
++    DESTINATION
++        include
++    COMPONENT
++        Devel
++)
+ 
+ # Make the library
+ add_library(clipboard ${HEADERS} ${SOURCE})
+-target_link_libraries(clipboard LINK_PRIVATE ${LIBCLIPBOARD_PRIVATE_LIBS})
+-if (LIBCLIPBOARD_ADD_SOVERSION)
+-    # Not by default because my file system doesn't support symlinks
+-    set_target_properties(clipboard PROPERTIES SOVERSION ${LIBCLIPBOARD_VERSION} VERSION ${LIBCLIPBOARD_VERSION})
+-endif()
+-
+-# Testing mode?
+-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googletest)
+-    # gtest does not play well with pthreads and mingw
+-    if (gtest_disable_pthreads)
+-        set(LIBCLIPBOARD_USE_PTHREADS_INIT ${CMAKE_USE_PTHREADS_INIT})
+-        unset(CMAKE_USE_PTHREADS_INIT)
+-    endif()
+-
+-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest EXCLUDE_FROM_ALL)
+-    enable_testing()
+-    include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
+-
+-    set(CMAKE_USE_PTHREADS_INIT ${LIBCLIPBOARD_USE_PTHREADS_INIT})
+-else()
++# Not by default because my file system doesn't support symlinks
++set_target_properties(clipboard PROPERTIES SOVERSION ${LIBCLIPBOARD_VERSION} VERSION ${LIBCLIPBOARD_VERSION})
++target_include_directories(clipboard PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR}/include)
++target_include_directories(clipboard INTERFACE $<INSTALL_INTERFACE:include/clipboard>)
+ 
+-endif()
+-
+-# Build sample executables
+-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/samples)
+-
+-# Pkgconfig
+-include(FindPkgConfig QUIET)
+-if (PKGCONFIG_FOUND)
+-    string(REPLACE "-l" "" LIBCLIPBOARD_PRIVATE_LIBS_LIST "${LIBCLIPBOARD_PRIVATE_LIBS}")
+-    string(REPLACE ";" " -l" LIBCLIPBOARD_PRIVATE_LIBS_LIST "${LIBCLIPBOARD_PRIVATE_LIBS_LIST}")
+-    string(STRIP "${LIBCLIPBOARD_PRIVATE_LIBS_LIST}" LIBCLIPBOARD_PRIVATE_LIBS_LIST)
+-    configure_file("libclipboard.pc.in" "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/pkgconfig/libclipboard.pc" @ONLY)
+-    install(FILES "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/pkgconfig/libclipboard.pc" DESTINATION "lib/pkgconfig")
++# Dependencies
++if (LIBCLIPBOARD_BUILD_COCOA)
++    target_link_libraries(clipboard PRIVATE "-framework Cocoa")
++elseif(LIBCLIPBOARD_BUILD_X11)
++    include(FindPkgConfig REQUIRED)
++    pkg_check_modules(xcb REQUIRED IMPORTED_TARGET xcb)
++    find_package(Threads REQUIRED)
++    target_link_libraries(clipboard PRIVATE PkgConfig::xcb Threads::Threads)
+ endif()
+ 
+ # Install options
+-install(TARGETS clipboard
++install(TARGETS clipboard EXPORT LibClipboardTargets
+         RUNTIME DESTINATION bin
+         LIBRARY DESTINATION lib
+-        ARCHIVE DESTINATION lib)
+-install(FILES ${HEADERS} DESTINATION include)
++        ARCHIVE DESTINATION lib
++    	INCLUDES DESTINATION include)
++
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file(
++    "${CMAKE_CURRENT_BINARY_DIR}/LibClipboard/LibClipboardConfigVersion.cmake"
++    VERSION 1.1
++    COMPATIBILITY AnyNewerVersion
++)
++
++export(EXPORT LibClipboardTargets
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/LibClipboard/LibClipboardTargets.cmake"
++    NAMESPACE LibClipboard::
++)
+ 
+-# Uninstall target
+-configure_file(
+-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+-    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+-    IMMEDIATE @ONLY)
++configure_file(cmake/LibClipboardConfig.cmake
++	"${CMAKE_CURRENT_BINARY_DIR}/LibClipboard/LibClipboardConfig.cmake"
++    COPYONLY
++)
++
++set(ConfigPackageLocation lib/cmake/LibClipboard)
++install(EXPORT LibClipboardTargets
++    FILE
++        LibClipboardTargets.cmake
++    NAMESPACE
++        LibClipboard::
++    DESTINATION
++        ${ConfigPackageLocation}
++)
++install(
++    FILES
++        cmake/LibClipboardConfig.cmake
++	"${CMAKE_CURRENT_BINARY_DIR}/LibClipboard/LibClipboardConfigVersion.cmake"
++    DESTINATION
++        ${ConfigPackageLocation}
++    COMPONENT
++        Devel
++)
+ 
+-add_custom_target(uninstall
+-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+\ No newline at end of file
+diff --git a/cmake/LibClipboardConfig.cmake b/cmake/LibClipboardConfig.cmake
+new file mode 100644
+index 0000000..9d48704
+--- /dev/null
++++ b/cmake/LibClipboardConfig.cmake
+@@ -0,0 +1 @@
++include("${CMAKE_CURRENT_LIST_DIR}/libclipboardTargets.cmake")

--- a/ports/libclipboard/fix-libclipboard-cmake.patch
+++ b/ports/libclipboard/fix-libclipboard-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f251471..845893c 100644
+index f251471..aff497c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,6 +1,6 @@
@@ -62,7 +62,7 @@ index f251471..845893c 100644
 -if (LIBCLIPBOARD_ADD_SOVERSION)
 -    # Not by default because my file system doesn't support symlinks
 -    set_target_properties(clipboard PROPERTIES SOVERSION ${LIBCLIPBOARD_VERSION} VERSION ${LIBCLIPBOARD_VERSION})
-+if(APPLE
++if(APPLE)
 +list(APPEND SOURCE src/clipboard_cocoa.m)
  endif()
  

--- a/ports/libclipboard/fix-libclipboard-cmake.patch
+++ b/ports/libclipboard/fix-libclipboard-cmake.patch
@@ -96,7 +96,7 @@ index f251471..aff497c 100644
 +# Not by default because my file system doesn't support symlinks
 +set_target_properties(clipboard PROPERTIES SOVERSION ${LIBCLIPBOARD_VERSION} VERSION ${LIBCLIPBOARD_VERSION})
 +target_include_directories(clipboard PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR}/include)
-+target_include_directories(clipboard INTERFACE $<INSTALL_INTERFACE:include/clipboard>)
++target_include_directories(clipboard INTERFACE $<INSTALL_INTERFACE:include>)
  
 -# Build sample executables
 -add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/samples)
@@ -131,13 +131,13 @@ index f251471..aff497c 100644
 +
 +include(CMakePackageConfigHelpers)
 +write_basic_package_version_file(
-+    "${CMAKE_CURRENT_BINARY_DIR}/libclipboard/LibClipboardConfigVersion.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/libclipboard/libclipboard-config-version.cmake"
 +    VERSION 1.1
 +    COMPATIBILITY AnyNewerVersion
 +)
 +
 +export(EXPORT LibClipboardTargets
-+    FILE "${CMAKE_CURRENT_BINARY_DIR}/libclipboard/LibClipboardTargets.cmake"
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/libclipboard/libclipboard-targets.cmake"
 +    NAMESPACE LibClipboard::
 +)
  
@@ -146,15 +146,15 @@ index f251471..aff497c 100644
 -    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
 -    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
 -    IMMEDIATE @ONLY)
-+configure_file(cmake/LibClipboardConfig.cmake
-+	"${CMAKE_CURRENT_BINARY_DIR}/libclipboard/LibClipboardConfig.cmake"
++configure_file(cmake/libclipboard-config.cmake
++	"${CMAKE_CURRENT_BINARY_DIR}/libclipboard/libclipboard-config.cmake"
 +    COPYONLY
 +)
 +
-+set(ConfigPackageLocation share/LibClipboard)
++set(ConfigPackageLocation share/libclipboard)
 +install(EXPORT LibClipboardTargets
 +    FILE
-+        LibClipboardTargets.cmake
++        libclipboard-targets.cmake
 +    NAMESPACE
 +        LibClipboard::
 +    DESTINATION
@@ -162,8 +162,8 @@ index f251471..aff497c 100644
 +)
 +install(
 +    FILES
-+        cmake/LibClipboardConfig.cmake
-+	"${CMAKE_CURRENT_BINARY_DIR}/libclipboard/LibClipboardConfigVersion.cmake"
++        cmake/libclipboard-config.cmake
++	"${CMAKE_CURRENT_BINARY_DIR}/libclipboard/libclipboard-config-version.cmake"
 +    DESTINATION
 +        ${ConfigPackageLocation}
 +    COMPONENT
@@ -173,13 +173,19 @@ index f251471..aff497c 100644
 -add_custom_target(uninstall
 -    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 \ No newline at end of file
-diff --git a/cmake/LibClipboardConfig.cmake b/cmake/LibClipboardConfig.cmake
+diff --git a/cmake/libclipboard-config.cmake b/cmake/libclipboard-config.cmake
 new file mode 100644
 index 0000000..9d48704
 --- /dev/null
-+++ b/cmake/LibClipboardConfig.cmake
-@@ -0,0 +1 @@
-+include("${CMAKE_CURRENT_LIST_DIR}/LibClipboardTargets.cmake")
++++ b/cmake/libclipboard-config.cmake
+@@ -0,0 +0,7 @@
++include(CMakeFindDependencyMacro)
++find_dependency(PkgConfig REQUIRED)
++if(UNIX AND NOT APPLE)
++pkg_check_modules(xcb REQUIRED IMPORTED_TARGET xcb)
++endif()
++find_dependency(Threads REQUIRED)
++include("${CMAKE_CURRENT_LIST_DIR}/libclipboard-targets.cmake")
 diff --git a/src/clipboard_cocoa.c b/src/clipboard_cocoa.m
 similarity index 100%
 rename from src/clipboard_cocoa.c

--- a/ports/libclipboard/fix-libclipboard-cmake.patch
+++ b/ports/libclipboard/fix-libclipboard-cmake.patch
@@ -131,13 +131,13 @@ index f251471..aff497c 100644
 +
 +include(CMakePackageConfigHelpers)
 +write_basic_package_version_file(
-+    "${CMAKE_CURRENT_BINARY_DIR}/libclipboard/libclipboard-config-version.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/unofficial-libclipboard/unofficial-libclipboard-config-version.cmake"
 +    VERSION 1.1
 +    COMPATIBILITY AnyNewerVersion
 +)
 +
 +export(EXPORT LibClipboardTargets
-+    FILE "${CMAKE_CURRENT_BINARY_DIR}/libclipboard/libclipboard-targets.cmake"
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-libclipboard/unofficial-libclipboard-targets.cmake"
 +    NAMESPACE LibClipboard::
 +)
  
@@ -146,24 +146,24 @@ index f251471..aff497c 100644
 -    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
 -    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
 -    IMMEDIATE @ONLY)
-+configure_file(cmake/libclipboard-config.cmake
-+	"${CMAKE_CURRENT_BINARY_DIR}/libclipboard/libclipboard-config.cmake"
++configure_file(cmake/unofficial-libclipboard-config.cmake
++	"${CMAKE_CURRENT_BINARY_DIR}/unofficial-libclipboard/unofficial-libclipboard-config.cmake"
 +    COPYONLY
 +)
 +
-+set(ConfigPackageLocation share/libclipboard)
++set(ConfigPackageLocation share/unofficial-libclipboard)
 +install(EXPORT LibClipboardTargets
 +    FILE
-+        libclipboard-targets.cmake
++        unofficial-libclipboard-targets.cmake
 +    NAMESPACE
-+        LibClipboard::
++        unofficial::libclipboard::
 +    DESTINATION
 +        ${ConfigPackageLocation}
 +)
 +install(
 +    FILES
-+        cmake/libclipboard-config.cmake
-+	"${CMAKE_CURRENT_BINARY_DIR}/libclipboard/libclipboard-config-version.cmake"
++        cmake/unofficial-libclipboard-config.cmake
++	"${CMAKE_CURRENT_BINARY_DIR}/unofficial-libclipboard/unofficial-libclipboard-config-version.cmake"
 +    DESTINATION
 +        ${ConfigPackageLocation}
 +    COMPONENT
@@ -173,11 +173,11 @@ index f251471..aff497c 100644
 -add_custom_target(uninstall
 -    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 \ No newline at end of file
-diff --git a/cmake/libclipboard-config.cmake b/cmake/libclipboard-config.cmake
+diff --git a/cmake/unofficial-libclipboard-config.cmake b/cmake/unofficial-libclipboard-config.cmake
 new file mode 100644
 index 0000000..9d48704
 --- /dev/null
-+++ b/cmake/libclipboard-config.cmake
++++ b/cmake/unofficial-libclipboard-config.cmake
 @@ -0,0 +0,7 @@
 +include(CMakeFindDependencyMacro)
 +find_dependency(PkgConfig REQUIRED)
@@ -185,7 +185,7 @@ index 0000000..9d48704
 +pkg_check_modules(xcb REQUIRED IMPORTED_TARGET xcb)
 +endif()
 +find_dependency(Threads REQUIRED)
-+include("${CMAKE_CURRENT_LIST_DIR}/libclipboard-targets.cmake")
++include("${CMAKE_CURRENT_LIST_DIR}/unofficial-libclipboard-targets.cmake")
 diff --git a/src/clipboard_cocoa.c b/src/clipboard_cocoa.m
 similarity index 100%
 rename from src/clipboard_cocoa.c

--- a/ports/libclipboard/fix-libclipboard-cmake.patch
+++ b/ports/libclipboard/fix-libclipboard-cmake.patch
@@ -131,13 +131,13 @@ index f251471..aff497c 100644
 +
 +include(CMakePackageConfigHelpers)
 +write_basic_package_version_file(
-+    "${CMAKE_CURRENT_BINARY_DIR}/LibClipboard/LibClipboardConfigVersion.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/libclipboard/LibClipboardConfigVersion.cmake"
 +    VERSION 1.1
 +    COMPATIBILITY AnyNewerVersion
 +)
 +
 +export(EXPORT LibClipboardTargets
-+    FILE "${CMAKE_CURRENT_BINARY_DIR}/LibClipboard/LibClipboardTargets.cmake"
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/libclipboard/LibClipboardTargets.cmake"
 +    NAMESPACE LibClipboard::
 +)
  
@@ -147,7 +147,7 @@ index f251471..aff497c 100644
 -    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
 -    IMMEDIATE @ONLY)
 +configure_file(cmake/LibClipboardConfig.cmake
-+	"${CMAKE_CURRENT_BINARY_DIR}/LibClipboard/LibClipboardConfig.cmake"
++	"${CMAKE_CURRENT_BINARY_DIR}/libclipboard/LibClipboardConfig.cmake"
 +    COPYONLY
 +)
 +
@@ -163,7 +163,7 @@ index f251471..aff497c 100644
 +install(
 +    FILES
 +        cmake/LibClipboardConfig.cmake
-+	"${CMAKE_CURRENT_BINARY_DIR}/LibClipboard/LibClipboardConfigVersion.cmake"
++	"${CMAKE_CURRENT_BINARY_DIR}/libclipboard/LibClipboardConfigVersion.cmake"
 +    DESTINATION
 +        ${ConfigPackageLocation}
 +    COMPONENT
@@ -179,7 +179,7 @@ index 0000000..9d48704
 --- /dev/null
 +++ b/cmake/LibClipboardConfig.cmake
 @@ -0,0 +1 @@
-+include("${CMAKE_CURRENT_LIST_DIR}/libclipboardTargets.cmake")
++include("${CMAKE_CURRENT_LIST_DIR}/LibClipboardTargets.cmake")
 diff --git a/src/clipboard_cocoa.c b/src/clipboard_cocoa.m
 similarity index 100%
 rename from src/clipboard_cocoa.c

--- a/ports/libclipboard/fix-libclipboard-cmake.patch
+++ b/ports/libclipboard/fix-libclipboard-cmake.patch
@@ -172,3 +172,7 @@ index 0000000..9d48704
 +++ b/cmake/LibClipboardConfig.cmake
 @@ -0,0 +1 @@
 +include("${CMAKE_CURRENT_LIST_DIR}/libclipboardTargets.cmake")
+diff --git a/src/clipboard_cocoa.c b/src/clipboard_cocoa.m
+similarity index 100%
+rename from src/clipboard_cocoa.c
+rename to src/clipboard_cocoa.m

--- a/ports/libclipboard/fix-libclipboard-cmake.patch
+++ b/ports/libclipboard/fix-libclipboard-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f251471..7c59fa4 100644
+index f251471..845893c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,6 +1,6 @@
@@ -43,7 +43,11 @@ index f251471..7c59fa4 100644
  # Configure header
  configure_file("include/libclipboard-config.h.in" "include/libclipboard-config.h")
  
-@@ -91,62 +74,72 @@ set(SOURCE
+@@ -87,66 +70,79 @@ set(HEADERS
+ set(SOURCE
+     src/clipboard_win32.c
+     src/clipboard_x11.c
+-    src/clipboard_cocoa.c
      src/clipboard_common.c
  )
  
@@ -51,23 +55,17 @@ index f251471..7c59fa4 100644
 -set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 -set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 -set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-+install(
-+    FILES
-+        ${HEADERS}
-+    DESTINATION
-+        include
-+    COMPONENT
-+        Devel
-+)
- 
- # Make the library
- add_library(clipboard ${HEADERS} ${SOURCE})
+-
+-# Make the library
+-add_library(clipboard ${HEADERS} ${SOURCE})
 -target_link_libraries(clipboard LINK_PRIVATE ${LIBCLIPBOARD_PRIVATE_LIBS})
 -if (LIBCLIPBOARD_ADD_SOVERSION)
 -    # Not by default because my file system doesn't support symlinks
 -    set_target_properties(clipboard PROPERTIES SOVERSION ${LIBCLIPBOARD_VERSION} VERSION ${LIBCLIPBOARD_VERSION})
--endif()
--
++if(APPLE
++list(APPEND SOURCE src/clipboard_cocoa.m)
+ endif()
+ 
 -# Testing mode?
 -if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googletest)
 -    # gtest does not play well with pthreads and mingw
@@ -83,13 +81,23 @@ index f251471..7c59fa4 100644
 -
 -    set(CMAKE_USE_PTHREADS_INIT ${LIBCLIPBOARD_USE_PTHREADS_INIT})
 -else()
++install(
++    FILES
++        ${HEADERS}
++    DESTINATION
++        include
++    COMPONENT
++        Devel
++)
+ 
+-endif()
++# Make the library
++add_library(clipboard ${HEADERS} ${SOURCE})
 +# Not by default because my file system doesn't support symlinks
 +set_target_properties(clipboard PROPERTIES SOVERSION ${LIBCLIPBOARD_VERSION} VERSION ${LIBCLIPBOARD_VERSION})
 +target_include_directories(clipboard PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR}/include)
 +target_include_directories(clipboard INTERFACE $<INSTALL_INTERFACE:include/clipboard>)
  
--endif()
--
 -# Build sample executables
 -add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/samples)
 -

--- a/ports/libclipboard/portfile.cmake
+++ b/ports/libclipboard/portfile.cmake
@@ -13,5 +13,6 @@ file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share
 
 # Satisfy CI.
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/libclipboard/portfile.cmake
+++ b/ports/libclipboard/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
 )
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "LibClipboard")
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 # Satisfy CI.

--- a/ports/libclipboard/portfile.cmake
+++ b/ports/libclipboard/portfile.cmake
@@ -7,7 +7,6 @@ vcpkg_from_github(
 )
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "LibClipboard")
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 # Satisfy CI.

--- a/ports/libclipboard/portfile.cmake
+++ b/ports/libclipboard/portfile.cmake
@@ -9,4 +9,7 @@ vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
+# Satisfy CI.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/libclipboard/portfile.cmake
+++ b/ports/libclipboard/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v1.1
     SHA512 763916e1be28c4d79556cb9e26bafe722e266726d26d76447d38c55c9d28a0e6f0718018636c1a16d36bb7c2567b1604a5fa8cf57163d50a313802d93a663bc4
     HEAD_REF master
+    PATCHES
+    	fix-libclipboard-cmake.patch
 )
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()

--- a/ports/libclipboard/portfile.cmake
+++ b/ports/libclipboard/portfile.cmake
@@ -1,0 +1,12 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jtanx/libclipboard
+    REF v1.1
+    SHA512 763916e1be28c4d79556cb9e26bafe722e266726d26d76447d38c55c9d28a0e6f0718018636c1a16d36bb7c2567b1604a5fa8cf57163d50a313802d93a663bc4
+    HEAD_REF master
+)
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_install()
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/libclipboard/usage
+++ b/ports/libclipboard/usage
@@ -1,5 +1,4 @@
-The package libclipboard can be imported via CMake FindPkgConfig module:
+The package libclipboard provides CMake targets:
 
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(libclipboard REQUIRED IMPORTED_TARGET libclipboard)
-    target_link_libraries(main PRIVATE PkgConfig::libclipboard)
+    find_package(LibClipboard CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE LibClipboard::clipboard)

--- a/ports/libclipboard/usage
+++ b/ports/libclipboard/usage
@@ -1,4 +1,4 @@
 The package libclipboard provides CMake targets:
 
-    find_package(LibClipboard CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE LibClipboard::clipboard)
+    find_package(unofficial-libclipboard CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::libclipboard::clipboard)

--- a/ports/libclipboard/usage
+++ b/ports/libclipboard/usage
@@ -1,0 +1,5 @@
+The package libclipboard can be imported via CMake FindPkgConfig module:
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(libclipboard REQUIRED IMPORTED_TARGET libclipboard)
+    target_link_libraries(main PRIVATE PkgConfig::libclipboard)

--- a/ports/libclipboard/vcpkg.json
+++ b/ports/libclipboard/vcpkg.json
@@ -10,6 +10,10 @@
       "host": true
     },
     {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "xcb",
       "platform": "linux"
     }

--- a/ports/libclipboard/vcpkg.json
+++ b/ports/libclipboard/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.1",
   "description": "A cross-platform clipboard library.",
   "license": "MIT",
-  "supports": "windows | osx | linux",
+  "supports": "(windows & !uwp) | osx | linux",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libclipboard/vcpkg.json
+++ b/ports/libclipboard/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "1.1",
   "description": "A cross-platform clipboard library.",
   "license": "MIT",
+  "supports": "windows | osx | linux",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -10,7 +11,7 @@
     },
     {
       "name": "xcb",
-      "platform": "linux | freebsd | openbsd | android"
+      "platform": "linux"
     }
   ]
 }

--- a/ports/libclipboard/vcpkg.json
+++ b/ports/libclipboard/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "libclipboard",
+  "version": "1.1",
+  "description": "A cross-platform clipboard library.",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "xcb",
+      "platform": "linux"
+    }
+  ]
+}

--- a/ports/libclipboard/vcpkg.json
+++ b/ports/libclipboard/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "xcb",
-      "platform": "linux"
+      "platform": "linux | freebsd | openbsd | android"
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4048,6 +4048,10 @@
       "baseline": "1.13",
       "port-version": 4
     },
+    "libclipboard": {
+      "baseline": "1.1",
+      "port-version": 0
+    },
     "libconfig": {
       "baseline": "1.7.3",
       "port-version": 4

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a03a939cb93a2415b84c62ee7df78ce2fbcf49d9",
+      "git-tree": "855a24139dbe4c595dd14a0cf1a0048c6c16b00d",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "855a24139dbe4c595dd14a0cf1a0048c6c16b00d",
+      "git-tree": "3a64153b353ee8c869ae45c8f2964229731884d7",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7291d17b0a738bfd93a16bd6cf549f70e3d548ba",
+      "git-tree": "50a23656e2e6133944e45bed306802b9060b946a",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "26e8582669e2f1c719aa6c7d3d7b48f33cd25104",
+      "git-tree": "4bf51e2d555e8cd2051c2a1ffd25a641c614e320",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "123691436d8db823c52d2766cbce14fea01eaa31",
+      "git-tree": "7291d17b0a738bfd93a16bd6cf549f70e3d548ba",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fe12da652932253f0db591ba4468ca4460f3d157",
+      "git-tree": "63cc88520ea59f1d927980f13058d5b09b0607a4",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "be30a37c0ab1db00d2553fb40f33060982a3b9ff",
+      "git-tree": "0fcaa1f4599cd50c1d84540589131b2bf20db1ce",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "114e32e4104744e65a2f9b29b6d95a0e005507be",
+      "git-tree": "a03a939cb93a2415b84c62ee7df78ce2fbcf49d9",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dea309242969ece3bf7e78052fd217837c5c5269",
+      "git-tree": "26e8582669e2f1c719aa6c7d3d7b48f33cd25104",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "63cc88520ea59f1d927980f13058d5b09b0607a4",
+      "git-tree": "dea309242969ece3bf7e78052fd217837c5c5269",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4bf51e2d555e8cd2051c2a1ffd25a641c614e320",
+      "git-tree": "ce2327e714fa56419af99710f0c2bb8824321db8",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "13ddb2ac92c8df002367601ee5de0292e9a0bd7a",
+      "version": "1.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "13ddb2ac92c8df002367601ee5de0292e9a0bd7a",
+      "git-tree": "114e32e4104744e65a2f9b29b6d95a0e005507be",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce2327e714fa56419af99710f0c2bb8824321db8",
+      "git-tree": "be30a37c0ab1db00d2553fb40f33060982a3b9ff",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0fcaa1f4599cd50c1d84540589131b2bf20db1ce",
+      "git-tree": "8a1f388b200d55efade4946de89822cd4725709e",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3a64153b353ee8c869ae45c8f2964229731884d7",
+      "git-tree": "fe12da652932253f0db591ba4468ca4460f3d157",
       "version": "1.1",
       "port-version": 0
     }

--- a/versions/l-/libclipboard.json
+++ b/versions/l-/libclipboard.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8a1f388b200d55efade4946de89822cd4725709e",
+      "git-tree": "123691436d8db823c52d2766cbce14fea01eaa31",
       "version": "1.1",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
