### PR TITLE
[vcpkg baseline][vcpkg-ci-msys2] Silence error from libcrypt delisting

### DIFF
--- a/scripts/test_ports/vcpkg-ci-msys2/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-msys2/portfile.cmake
@@ -10,6 +10,12 @@ vcpkg_list(SET ignored_updates
     https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-ca-certificates-20211016-3-any.pkg.tar.zst
 )
 
+# Known removals that shall not be reported as errors
+# (Packages to be removed from vcpkg scripts ASAP.)
+vcpkg_list(SET known_delisted
+    libcrypt
+)
+
 # Ignore these dependencies (e.g. interactive or effectively optional)
 vcpkg_list(SET ignored_dependencies
     autoconf2.13 autoconf2.69
@@ -262,7 +268,7 @@ function(analyze_package_list list_var script)
                 endif()
             endif()
         endforeach()
-        if(NOT found)
+        if(NOT found AND NOT name IN_LIST known_delisted)
             vcpkg_list(APPEND vanished "${name}")
             get_vcpkg_builddate(vcpkg_builddate "${name}")
             age_in_days(vcpkg_age "${vcpkg_builddate}")

--- a/scripts/test_ports/vcpkg-ci-msys2/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-msys2/portfile.cmake
@@ -6,7 +6,7 @@ set(mingw32_repo_url "https://mirror.msys2.org/mingw/mingw32")
 set(clangarm64_repo_url "https://mirror.msys2.org/mingw/clangarm64")
 
 # Ignore these updates (e.g. for known problems)
-vcpkg_list(SET ignored_packages
+vcpkg_list(SET ignored_updates
     https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-ca-certificates-20211016-3-any.pkg.tar.zst
 )
 
@@ -183,7 +183,7 @@ function(analyze_package_list list_var script)
             set(found 1)
             set(current_url "${${repo}_repo_url}/${CMAKE_MATCH_1}")
             # Check the URL
-            if(NOT vcpkg_url STREQUAL current_url AND NOT current_url IN_LIST ignored_packages)
+            if(NOT vcpkg_url STREQUAL current_url AND NOT current_url IN_LIST ignored_updates)
                 get_vcpkg_builddate(vcpkg_builddate "${name}")
                 age_in_days(vcpkg_age "${vcpkg_builddate}")
                 pretty_age(vcpkg_age_pretty "${vcpkg_age}")


### PR DESCRIPTION
Hook for temporary solutions while updating msys2 is blocked.
Alternative to #34721.