### PR TITLE
[matio] update to 1.5.24

### DIFF
--- a/ports/matio/portfile.cmake
+++ b/ports/matio/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tbeu/matio
-    REF e9e063e08ef2a27fcc22b1e526258fea5a5de329 # v1.5.23
-    SHA512 78b13f4796870158f5cf2b8234c0ab6dc8b449cba49608ce40c51a3f91994c33c29b8a6de1ceed94a81fc7faa798d8c3a45a275f3a3abba70a0cd7be731e1d9c
+    REF b07ee6c1512ab788f91e71910d07fc3ea954f812 # v1.5.24
+    SHA512 b9a1abe88565bb01db9aa826248b63927e8576d4e9b72665dee53cc29e0baf6c7af232f298fb6a22b3b96d820cb692ff29f98e2d0d751edc22a5f1ee884fc2df
     HEAD_REF master
     PATCHES fix-dependencies.patch
 )

--- a/ports/matio/vcpkg.json
+++ b/ports/matio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "matio",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "port-version": 3,
   "description": "MATLAB MAT File I/O Library",
   "homepage": "https://github.com/tbeu/matio",

--- a/ports/matio/vcpkg.json
+++ b/ports/matio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "matio",
   "version": "1.5.24",
-  "port-version": 3,
   "description": "MATLAB MAT File I/O Library",
   "homepage": "https://github.com/tbeu/matio",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5358,7 +5358,7 @@
     },
     "matio": {
       "baseline": "1.5.24",
-      "port-version": 3
+      "port-version": 0
     },
     "matplotlib-cpp": {
       "baseline": "2020-08-27",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5357,7 +5357,7 @@
       "port-version": 5
     },
     "matio": {
-      "baseline": "1.5.23",
+      "baseline": "1.5.24",
       "port-version": 3
     },
     "matplotlib-cpp": {

--- a/versions/m-/matio.json
+++ b/versions/m-/matio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b93c6b1b3b9c39190a5269f8c9e412c1e84e74a5",
+      "version": "1.5.24",
+      "port-version": 3
+    },
+    {
       "git-tree": "42d087530e333855d74225712aab7755d2eb6be2",
       "version": "1.5.23",
       "port-version": 3

--- a/versions/m-/matio.json
+++ b/versions/m-/matio.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "b93c6b1b3b9c39190a5269f8c9e412c1e84e74a5",
+      "git-tree": "08eada66141696ad861d881ac1639d41682916e1",
       "version": "1.5.24",
-      "port-version": 3
+      "port-version": 0
     },
     {
       "git-tree": "42d087530e333855d74225712aab7755d2eb6be2",


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

