### PR TITLE
[vcpkg_configure_make] fix case sensitive comparison in PATH system d…

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -235,22 +235,15 @@ function(vcpkg_configure_make)
         cmake_path(CONVERT "$ENV{PATH}" TO_CMAKE_PATH_LIST path_list NORMALIZE)
         cmake_path(CONVERT "$ENV{SystemRoot}" TO_CMAKE_PATH_LIST system_root NORMALIZE)
         cmake_path(CONVERT "$ENV{LOCALAPPDATA}" TO_CMAKE_PATH_LIST local_app_data NORMALIZE)
+        string(TOUPPER "${local_app_data}" local_app_data_upper)
         file(REAL_PATH "${system_root}" system_root)
         string(TOUPPER "${system_root}" system_root_upper)
 
         message(DEBUG "path_list:${path_list}") # Just to have --trace-expand output
 
         vcpkg_list(SET find_system_dirs 
-            "${system_root}/system32"
-            "${system_root}/System32"
-            "${system_root}/system32/"
-            "${system_root}/System32/"
-            "${system_root_upper}/system32"
-            "${system_root_upper}/System32"
-            "${system_root_upper}/system32/"
-            "${system_root_upper}/System32/"
-            "${local_app_data}/Microsoft/WindowsApps"
-            "${local_app_data}/Microsoft/WindowsApps/"
+            "${system_root_upper}/SYSTEM32"
+            "${local_app_data_upper}/MICROSOFT/WINDOWSAPPS"
         )
 
         string(TOUPPER "${find_system_dirs}" find_system_dirs_upper)
@@ -258,7 +251,8 @@ function(vcpkg_configure_make)
         set(index 0)
         set(appending TRUE)
         foreach(item IN LISTS path_list)
-            if(item IN_LIST find_system_dirs OR item IN_LIST find_system_dirs_upper)
+            string(TOUPPER "${item}" item_upper)
+            if(item_upper IN_LIST find_system_dirs_upper OR "${item_upper}/" IN_LIST find_system_dirs_upper)
                 set(appending FALSE)
                 break()
             endif()

--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -235,15 +235,15 @@ function(vcpkg_configure_make)
         cmake_path(CONVERT "$ENV{PATH}" TO_CMAKE_PATH_LIST path_list NORMALIZE)
         cmake_path(CONVERT "$ENV{SystemRoot}" TO_CMAKE_PATH_LIST system_root NORMALIZE)
         cmake_path(CONVERT "$ENV{LOCALAPPDATA}" TO_CMAKE_PATH_LIST local_app_data NORMALIZE)
-        string(TOUPPER "${local_app_data}" local_app_data_upper)
         file(REAL_PATH "${system_root}" system_root)
-        string(TOUPPER "${system_root}" system_root_upper)
 
         message(DEBUG "path_list:${path_list}") # Just to have --trace-expand output
 
         vcpkg_list(SET find_system_dirs 
-            "${system_root_upper}/SYSTEM32"
-            "${local_app_data_upper}/MICROSOFT/WINDOWSAPPS"
+            "${system_root}/System32"
+            "${system_root}/System32/"
+            "${local_app_data}/Microsoft/WindowsApps"
+            "${local_app_data}/Microsoft/WindowsApps/"
         )
 
         string(TOUPPER "${find_system_dirs}" find_system_dirs_upper)
@@ -252,7 +252,7 @@ function(vcpkg_configure_make)
         set(appending TRUE)
         foreach(item IN LISTS path_list)
             string(TOUPPER "${item}" item_upper)
-            if(item_upper IN_LIST find_system_dirs_upper OR "${item_upper}/" IN_LIST find_system_dirs_upper)
+            if(item_upper IN_LIST find_system_dirs_upper)
                 set(appending FALSE)
                 break()
             endif()


### PR DESCRIPTION
Fixes the `icu` build error with the following message on my system: `Unable to find system dir in the PATH variable! Appending required msys paths!`

Hopefully fixes #34450

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
