### PR TITLE
[baresip-libre] update to version 3.5.1

### DIFF
--- a/ports/baresip-libre/portfile.cmake
+++ b/ports/baresip-libre/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO baresip/re
     REF "v${VERSION}"
-    SHA512 97ea35e4d4f36a9b3e47bb942497d495247e01106bcceef98fba4ab8e36061acaca88d12568990f9c8014b1061941ea5e2c6e8c0287e6dcd83a60a70400b083d
+    SHA512 08e92b223993ef13af3f4f8f019f33da762be8059099536fa3f1f6a9edd4c95bd35a91e4816bc761e227dc8e08e34e6b75421d18d4aa5dedd8bd5fe95547e214
     HEAD_REF main
     PATCHES
         fix-static-library-build.patch

--- a/ports/baresip-libre/vcpkg.json
+++ b/ports/baresip-libre/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "baresip-libre",
-  "version": "3.4.0",
+  "version": "3.5.1",
   "description": "Generic library for real-time communications with async IO support",
   "homepage": "https://github.com/baresip/re",
   "license": "BSD-3-Clause",

--- a/versions/b-/baresip-libre.json
+++ b/versions/b-/baresip-libre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b000665b80ffaa20107836324b4360bad62861a7",
+      "version": "3.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "db0ceb9ad55c2c774fac30663522efc247a1ce04",
       "version": "3.4.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -517,7 +517,7 @@
       "port-version": 1
     },
     "baresip-libre": {
-      "baseline": "3.4.0",
+      "baseline": "3.5.1",
       "port-version": 0
     },
     "basisu": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
