### PR TITLE
[brpc] update to 1.6.1

### DIFF
--- a/ports/brpc/portfile.cmake
+++ b/ports/brpc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/incubator-brpc
     REF "${VERSION}"
-    SHA512 2c69a1eaaca26da494c1a10d4f6c67ca53c5cfe43243457263e4966101a77207dee5f29b7372895230978c729254b156b7e4223a41d8e909919fbdac6badc75c
+    SHA512 da0004b7b50cc48da018627c9361ae62b006bb7cd2af53a5cfa1601aab7ad31174d37778a42809bdf2e0f2021a860dcbb02e2c3c938eae6c02808267c3b85025
     HEAD_REF master
     PATCHES
         fix-build.patch

--- a/ports/brpc/vcpkg.json
+++ b/ports/brpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "brpc",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Industrial-grade RPC framework used throughout Baidu, with 1,000,000+ instances and thousands kinds of services, called \"baidu-rpc\" inside Baidu.",
   "homepage": "https://github.com/apache/incubator-brpc",
   "license": "Apache-2.0",

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8671f4e4a1523a2f58b71e7413ad0b8dab7c1c4",
+      "version": "1.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a2cedfb3411d57def85e6337b08570e518c2f992",
       "version": "1.6.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1325,7 +1325,7 @@
       "port-version": 1
     },
     "brpc": {
-      "baseline": "1.6.0",
+      "baseline": "1.6.1",
       "port-version": 0
     },
     "brunocodutra-metal": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

