### PR TITLE
[fribidi] Update to 1.0.13

### DIFF
--- a/ports/fribidi/portfile.cmake
+++ b/ports/fribidi/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fribidi/fribidi
-    REF v1.0.12
-    SHA512 a3a63e1dde1cffb097376df0b34522700cff600da61bdafd6f4f50db6937383b9f73a82081cb1a7f2e1946ba07fea13e2880a4250b1508850bffa500046a7fa5
+    REF v${VERSION}
+    SHA512 246c904f8e6cc7eee61c03162b42dd0e0ed2163ef02d9d15b8168f0084ccdd9b625b83092915fa42f301106247e3159ad6aee0af42c37643253f7c47d0a520ef
     HEAD_REF master
     PATCHES meson-crosscompile.patch
 )
@@ -30,13 +30,11 @@ vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 # Define static macro
-file(READ "${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" FRIBIDI_COMMON_H)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    string(REPLACE "#ifndef FRIBIDI_LIB_STATIC" "#if 0" FRIBIDI_COMMON_H "${FRIBIDI_COMMON_H}")
+	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" "# elif defined(_WIN32) && ! defined(FRIBIDI_LIB_STATIC)" "# elif defined(_WIN32) && false")
 else()
-    string(REPLACE "#ifndef FRIBIDI_LIB_STATIC" "#if 1" FRIBIDI_COMMON_H "${FRIBIDI_COMMON_H}")
+	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" "# elif defined(_WIN32) && ! defined(FRIBIDI_LIB_STATIC)" "# elif defined(_WIN32) && true")
 endif()
-file(WRITE "${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" "${FRIBIDI_COMMON_H}")
 
 if(VCPKG_CROSSCOMPILING)
     file(

--- a/ports/fribidi/portfile.cmake
+++ b/ports/fribidi/portfile.cmake
@@ -31,9 +31,9 @@ vcpkg_copy_pdbs()
 
 # Define static macro
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" "# elif defined(_WIN32) && ! defined(FRIBIDI_LIB_STATIC)" "# elif defined(_WIN32) && false")
+	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" "# elif defined(_WIN32) && ! defined(FRIBIDI_LIB_STATIC)" "# elif defined(_WIN32) && 0")
 else()
-	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" "# elif defined(_WIN32) && ! defined(FRIBIDI_LIB_STATIC)" "# elif defined(_WIN32) && true")
+	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" "# elif defined(_WIN32) && ! defined(FRIBIDI_LIB_STATIC)" "# elif defined(_WIN32) && 1")
 endif()
 
 if(VCPKG_CROSSCOMPILING)

--- a/ports/fribidi/vcpkg.json
+++ b/ports/fribidi/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fribidi",
-  "version": "1.0.12",
-  "port-version": 1,
+  "version": "1.0.13",
   "description": "GNU FriBidi is an implementation of the Unicode Bidirectional Algorithm (bidi)",
   "license": "LGPL-2.1-or-later",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2765,8 +2765,8 @@
       "port-version": 0
     },
     "fribidi": {
-      "baseline": "1.0.12",
-      "port-version": 1
+      "baseline": "1.0.13",
+      "port-version": 0
     },
     "frozen": {
       "baseline": "1.1.1",

--- a/versions/f-/fribidi.json
+++ b/versions/f-/fribidi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5ff3505999a05f67842caa8a145e838bcdf326dc",
+      "git-tree": "a946b16fa88c02cd11e2e3011fe9ca61e31214b6",
       "version": "1.0.13",
       "port-version": 0
     },

--- a/versions/f-/fribidi.json
+++ b/versions/f-/fribidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ff3505999a05f67842caa8a145e838bcdf326dc",
+      "version": "1.0.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "b611119763d80fa18b07cf2e3c99c02069b0ec55",
       "version": "1.0.12",
       "port-version": 1


### PR DESCRIPTION
https://github.com/fribidi/fribidi/compare/v1.0.12...v1.0.13

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
