### PR TITLE
[libressl] update to 3.8.1

### DIFF
--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_download_distfile(
     URLS "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${PORT}-${VERSION}.tar.gz"
          "https://ftp.fau.de/openbsd/LibreSSL/${PORT}-${VERSION}.tar.gz"
     FILENAME "${PORT}-${VERSION}.tar.gz"
-    SHA512 8fc81e05d1c9f9259d06508ca97d5a1ba5d46b857088c273c20e6b242921f7eac58a1136564ad9831c923758ee63f7b0897c8c6c7b1e53ab8132a995cc559aeb
+    SHA512 0
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libressl/vcpkg.json
+++ b/ports/libressl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libressl",
-  "version": "3.6.2",
-  "port-version": 1,
+  "version": "3.8.1",
   "description": "LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014, with goals of modernizing the codebase, improving security, and applying best practice development processes.",
   "license": "ISC",
   "supports": "!(uwp | arm)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4653,8 +4653,8 @@
       "port-version": 2
     },
     "libressl": {
-      "baseline": "3.6.2",
-      "port-version": 1
+      "baseline": "3.8.1",
+      "port-version": 0
     },
     "librsvg": {
       "baseline": "2.40.20",

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0604acdd7d6c8998faac5e8f9dd8ecc163f1eb6f",
+      "version": "3.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ad22d9c62107c65630cd57d97749920a02016095",
       "version": "3.6.2",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

