### PR TITLE
[libhv] update to 1.3.2

### DIFF
--- a/ports/libhv/portfile.cmake
+++ b/ports/libhv/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ithewei/libhv
-    REF v${VERSION} #v1.3.0
-    SHA512 7d8f552947eb464a8dd644515b9543a7961631e427033de4e1f51f1e9d2b9ca1801553a478b0a20935b50dbc274632e38a6f0438732efed9fcbf0738738ddac5
+    REF "v${VERSION}"
+    SHA512 9dffb6e844df8ba825df88ef984c280923fbf1d50edcbbbe0b36927172ad82c057d65b9b752163c3e2383eb44db0261fd4e3623e3630a55a3f8987088bef0bd7
     HEAD_REF master
 )
 
@@ -30,4 +30,4 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libhv)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libhv/vcpkg.json
+++ b/ports/libhv/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libhv",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Libhv is a C/C++ network library similar to libevent/libuv.",
   "homepage": "https://github.com/ithewei/libhv",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4305,7 +4305,7 @@
       "port-version": 0
     },
     "libhv": {
-      "baseline": "1.3.1",
+      "baseline": "1.3.2",
       "port-version": 0
     },
     "libhydrogen": {

--- a/versions/l-/libhv.json
+++ b/versions/l-/libhv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f76c5430e5899a88a85fa7366d046310882f9223",
+      "version": "1.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "3cccf7a4fde6f5c23138ac228d6d581dba11a76b",
       "version": "1.3.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #34799

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature ssl tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static