### PR TITLE
[ace] Upgrade to ACE/TAO 7.1.2

### DIFF
--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -8,14 +8,14 @@ if("tao" IN_LIST FEATURES)
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE%2BTAO-src-${VERSION}.tar.gz"
         FILENAME "ACE-TAO-${VERSION}.tar.gz"
-        SHA512 ab1317e626f1b312cd72e6c10f7b51088e5de4db8fa3bca013a98b07aad4edfb5e1f42a4f58c970f968417852b305f298a34e0fde053a1f52754ebe3761f314c
+        SHA512 afa26e0579ebbac5db82df80a4ce6c2350d4665043bb549688dce4db08b3b1a7c6b072544d651b90bd521ae477de069f280ab8d52fe957143d1f8a7cbd23eb29
     )
 else()
     # Don't change to vcpkg_from_github! This points to a release and not an archive
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE-src-${VERSION}.tar.gz"
         FILENAME "ACE-src-${VERSION}.tar.gz"
-        SHA512 1605fdf7a78bfce090bc8b14137f9aafd23019712672f6cd041284656ce2bae0baff954124166aeb16a0565887e1d87b2d10dc2ec5981c4e38fc8d0b39a97934
+        SHA512 a06cae5a5770d12f3bfbaabf54ed8c6400dc766abc530f37a7defb18a7c12a8d775d549014872e1e7c0fe18bd2d6f823e488b16a1f66cc84a41e7f8344a26601
     )
 endif()
 

--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -15,7 +15,7 @@ else()
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE-src-${VERSION}.tar.gz"
         FILENAME "ACE-src-${VERSION}.tar.gz"
-        SHA512 a06cae5a5770d12f3bfbaabf54ed8c6400dc766abc530f37a7defb18a7c12a8d775d549014872e1e7c0fe18bd2d6f823e488b16a1f66cc84a41e7f8344a26601
+        SHA512 b08c8cf98b622248cfbf167ca91c8314284c84c4dcb1c48fedb9180be2bc354c1d647372eb046e75d426ac4f2ad0318a8dd9e3f233d36bc30f744d5f9e37c5ec
     )
 endif()
 

--- a/ports/ace/vcpkg.json
+++ b/ports/ace/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ace",
   "version": "7.1.2",
-  "port-version": 0,
   "maintainers": "Johnny Willemsen <jwillemsen@remedy.nl>",
   "description": "The ADAPTIVE Communication Environment",
   "homepage": "https://github.com/DOCGroup/ACE_TAO",

--- a/ports/ace/vcpkg.json
+++ b/ports/ace/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ace",
-  "version": "7.1.1",
-  "port-version": 2,
+  "version": "7.1.2",
+  "port-version": 0,
   "maintainers": "Johnny Willemsen <jwillemsen@remedy.nl>",
   "description": "The ADAPTIVE Communication Environment",
   "homepage": "https://github.com/DOCGroup/ACE_TAO",

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2b1ed6763acacf55ae74221e9c6995d9f301276e",
+      "git-tree": "696c1096e0de3cd394392720aa34e0ceceac52e7",
       "version": "7.1.2",
       "port-version": 0
     },

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2421e04b72327e06e25e056e503fe549ab2fd7f2",
+      "git-tree": "2b1ed6763acacf55ae74221e9c6995d9f301276e",
       "version": "7.1.2",
       "port-version": 0
     },

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2421e04b72327e06e25e056e503fe549ab2fd7f2",
+      "version": "7.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "acebbd833daa493d4e2075ce547646719d8cd080",
       "version": "7.1.1",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -25,8 +25,8 @@
       "port-version": 3
     },
     "ace": {
-      "baseline": "7.1.1",
-      "port-version": 2
+      "baseline": "7.1.2",
+      "port-version": 0
     },
     "acl": {
       "baseline": "2.3.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

