### PR TITLE
[7zip] Add C headers to includes

### DIFF
--- a/ports/7zip/CMakeLists.txt
+++ b/ports/7zip/CMakeLists.txt
@@ -401,6 +401,7 @@ target_compile_definitions(7zip
 target_include_directories(7zip
     INTERFACE
         $<INSTALL_INTERFACE:include>/7zip/CPP
+        $<INSTALL_INTERFACE:include>/7zip/C
 )
 
 install(

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "7zip",
   "version-string": "23.01",
+  "port-version": 1,
   "description": "Library for archiving file with a high compression ratio.",
   "homepage": "https://www.7-zip.org",
   "license": "LGPL-2.1-or-later",

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f1fa323db9a88dd410e7d46ad651f7fe5cb620c",
+      "version-string": "23.01",
+      "port-version": 1
+    },
+    {
       "git-tree": "770ce8dc829180bfcf2c396aa780474a87289f89",
       "version-string": "23.01",
       "port-version": 0

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "770ce8dc829180bfcf2c396aa780474a87289f89",
+      "git-tree": "dad5a164db0226aeca0477b350044c66324b2dca",
       "version-string": "23.01",
       "port-version": 0
     },

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,12 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f1fa323db9a88dd410e7d46ad651f7fe5cb620c",
-      "version-string": "23.01",
-      "port-version": 1
-    },
-    {
-      "git-tree": "dad5a164db0226aeca0477b350044c66324b2dca",
+      "git-tree": "770ce8dc829180bfcf2c396aa780474a87289f89",
       "version-string": "23.01",
       "port-version": 0
     },

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f1fa323db9a88dd410e7d46ad651f7fe5cb620c",
+      "version-string": "23.01",
+      "port-version": 1
+    },
+    {
       "git-tree": "dad5a164db0226aeca0477b350044c66324b2dca",
       "version-string": "23.01",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6,7 +6,7 @@
     },
     "7zip": {
       "baseline": "23.01",
-      "port-version": 0
+      "port-version": 1
     },
     "ableton": {
       "baseline": "3.0.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6,7 +6,7 @@
     },
     "7zip": {
       "baseline": "23.01",
-      "port-version": 1
+      "port-version": 0
     },
     "ableton": {
       "baseline": "3.0.6",


### PR DESCRIPTION
The current 7zip port only adds the CPP headers to the includes. This PR adds the C headers, for consumers that need that.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download (not applicable)
- [x] The "supports" clause reflects platforms that may be fixed by this new version (not applicable)
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. (no changes here)
- [x] Any patches that are no longer applied are deleted from the port's directory. (no changes)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The 7zip version 23.01 has been overridden. This can be changed if necessary.

