### PR TITLE
[gz-gui7] New port

### DIFF
--- a/ports/gz-gui7/dependencies.patch
+++ b/ports/gz-gui7/dependencies.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -80,13 +80,17 @@
+ set(GZ_TOOLS_VER 2)
+ 
+ #--------------------------------------
+ # Find QT
++set(qt_pkgconfig "Qt5Core Qt5Quick Qt5QuickControls2 Qt5Widgets")
++if (WIN32)
++set(qt_pkgconfig "")
++endif()
+ gz_find_package (Qt5
+   COMPONENTS
+     Core
+     Quick
+     QuickControls2
+     Widgets
+   REQUIRED
+-  PKGCONFIG "Qt5Core Qt5Quick Qt5QuickControls2 Qt5Widgets"
++  PKGCONFIG ${qt_pkgconfig}
+ )

--- a/ports/gz-gui7/portfile.cmake
+++ b/ports/gz-gui7/portfile.cmake
@@ -1,25 +1,28 @@
-set(PACKAGE_NAME physics)
+set(PACKAGE_NAME gui)
 
 ignition_modular_library(
    NAME ${PACKAGE_NAME}
    REF ${PORT}_${VERSION}
    VERSION ${VERSION}
-   SHA512 c29594663509234e25c7d0a33848c0fe222c2b9471513978c18ea6873a17c66c43b4037c74e8849995fa6449c2dddc0f2ee669605893daf65119c277a17f39e1
+   SHA512 29f37a31bbf90dd35f37e80053c1aff9fb404b7a09c8c10e640da505cc6261387e6ce77e3bf379a911e6131c684f866cf1ef8d83777112b3c7f148b1f95cc72f
    OPTIONS 
    PATCHES
       dependencies.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)   
-   file(GLOB plugins "${CURRENT_PACKAGES_DIR}/lib/gz-physics-6/engine-plugins/*.dll")
+   file(GLOB plugins "${CURRENT_PACKAGES_DIR}/lib/gz-gui-7/plugins/*.dll")
    if (NOT plugins STREQUAL "")
       file(COPY ${plugins} DESTINATION "${CURRENT_PACKAGES_DIR}/engine-plugins/")
       file(REMOVE ${plugins})
    endif()
 
-   file(GLOB plugins_debug "${CURRENT_PACKAGES_DIR}/debug/lib/gz-physics-6/engine-plugins/*.dll")
+   file(GLOB plugins_debug "${CURRENT_PACKAGES_DIR}/debug/lib/gz-gui-7/plugins/*.dll")
    if (NOT plugins_debug STREQUAL "")
       file(COPY ${plugins_debug} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/engine-plugins/")
       file(REMOVE ${plugins_debug})
    endif()
+
+    # Lacking pc files for Qt
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 endif()

--- a/ports/gz-gui7/vcpkg.json
+++ b/ports/gz-gui7/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "gz-gui7",
+  "version": "7.2.1",
+  "description": "Gazebo GUI builds on top of Qt to provide widgets which are useful when developing robotics applications, such as a 3D view, plots, dashboard, etc, and can be used together in a convenient unified interface.",
+  "homepage": "https://gazebosim.org/libs/gui",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "gz-cmake3",
+    "gz-common5",
+    "gz-math7",
+    "gz-msgs9",
+    "gz-plugin2",
+    "gz-rendering7",
+    "gz-transport12",
+    "gz-utils2",
+    {
+      "name": "ignition-modularscripts",
+      "host": true
+    },
+    "protobuf",
+    {
+      "name": "qt5-base",
+      "default-features": false
+    },
+    {
+      "name": "qt5-quickcontrols2",
+      "default-features": false
+    },
+    "sdformat13",
+    "tinyxml2"
+  ]
+}

--- a/ports/gz-physics6/vcpkg.json
+++ b/ports/gz-physics6/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gz-physics6",
   "version": "6.5.1",
+  "port-version": 1,
   "description": "component of Gazebo, provides an abstract physics interface designed to support simulation and rapid development of robot applications.",
   "homepage": "https://gazebosim.org/libs/physics",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3188,6 +3188,10 @@
       "baseline": "8.1.0",
       "port-version": 0
     },
+    "gz-gui7": {
+      "baseline": "7.2.1",
+      "port-version": 0
+    },
     "gz-math7": {
       "baseline": "7.3.0",
       "port-version": 0
@@ -3198,7 +3202,7 @@
     },
     "gz-physics6": {
       "baseline": "6.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "gz-plugin2": {
       "baseline": "2.0.1",

--- a/versions/g-/gz-gui7.json
+++ b/versions/g-/gz-gui7.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3fc2d2bd35c8d9c5dad86739f113b952cb65913a",
+      "version": "7.2.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/g-/gz-physics6.json
+++ b/versions/g-/gz-physics6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f21733a38332420967e218df27d7adfc125c6f07",
+      "version": "6.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "9e84a89c5e37806e67295d51b6bd1ec565ccaede",
       "version": "6.5.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

