### PR TITLE
[fastgltf] Update to 0.6.1

### DIFF
--- a/ports/fastgltf/portfile.cmake
+++ b/ports/fastgltf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO spnda/fastgltf
     REF "v${VERSION}"
-    SHA512 85b946f9ea849bcbbb77ff5d4dc8196d3348757cf6a940be1a50923158a31aa7b43aebed2799256cb3d303a81fa28e5eaeb000b6ecca3ab15f6a7a20908d8e8f
+    SHA512 6cda7e50d7fe01428e0a03d3f590fe7b680bfa4b6fcdbd1c6a118ac01c925099e63b34380b053adc323e2aaaaead42bda450d1eaf66b60af6ad2aafb68828d01
     HEAD_REF main
     PATCHES find_package.patch
 )

--- a/ports/fastgltf/vcpkg.json
+++ b/ports/fastgltf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastgltf",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "port-version": 1,
   "description": "Blazing fast C++17 glTF 2.0 loader powered by SIMD",
   "homepage": "https://github.com/spnda/fastgltf",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2541,7 +2541,7 @@
       "port-version": 4
     },
     "fastgltf": {
-      "baseline": "0.5.0",
+      "baseline": "0.6.1",
       "port-version": 1
     },
     "fastio": {

--- a/versions/f-/fastgltf.json
+++ b/versions/f-/fastgltf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b098e0b272a75e2c12b898a54b6b83a49f981599",
+      "version": "0.6.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "28cc725ac91ea72117083d152661ba131f8bca94",
       "version": "0.5.0",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

