### PR TITLE
[ace] Respect VCPKG_BUILD_TYPE 

### DIFF
--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -294,89 +294,94 @@ elseif(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
   get_filename_component(WORKING_DIR "${WORKSPACE}" DIRECTORY)
   set(ENV{PWD} "${WORKING_DIR}")
 
-  message(STATUS "Building ${TARGET_TRIPLET}-dbg")
-  vcpkg_execute_build_process(
-    COMMAND make ${_ace_makefile_macros} "debug=1" "optimize=0" "-j${VCPKG_CONCURRENCY}"
-    WORKING_DIRECTORY "${WORKING_DIR}"
-    LOGNAME make-${TARGET_TRIPLET}-dbg
-  )
-  if("xml" IN_LIST FEATURES)
+  if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    message(STATUS "Building ${TARGET_TRIPLET}-dbg")
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} "debug=1" "optimize=0" "-j${VCPKG_CONCURRENCY}"
-      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-      LOGNAME make-xml-${TARGET_TRIPLET}-dbg
+      WORKING_DIRECTORY "${WORKING_DIR}"
+      LOGNAME make-${TARGET_TRIPLET}-dbg
     )
-  endif()
-  message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
-  message(STATUS "Packaging ${TARGET_TRIPLET}-dbg")
-  vcpkg_execute_build_process(
-    COMMAND make ${_ace_makefile_macros} install
-    WORKING_DIRECTORY "${WORKING_DIR}"
-    LOGNAME install-${TARGET_TRIPLET}-dbg
-  )
-  if("xml" IN_LIST FEATURES)
+    if("xml" IN_LIST FEATURES)
+      vcpkg_execute_build_process(
+        COMMAND make ${_ace_makefile_macros} "debug=1" "optimize=0" "-j${VCPKG_CONCURRENCY}"
+        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+        LOGNAME make-xml-${TARGET_TRIPLET}-dbg
+      )
+    endif()
+    message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
+    message(STATUS "Packaging ${TARGET_TRIPLET}-dbg")
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} install
-      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-      LOGNAME install-xml-${TARGET_TRIPLET}-dbg
+      WORKING_DIRECTORY "${WORKING_DIR}"
+      LOGNAME install-${TARGET_TRIPLET}-dbg
     )
-  endif()
-
-  file(COPY "${CURRENT_PACKAGES_DIR}/lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")
-
-  file(GLOB _pkg_components "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
-  foreach(_pkg_comp ${_pkg_components})
-    file(READ ${_pkg_comp} _content)
-    string(REPLACE "libdir=${CURRENT_PACKAGES_DIR}/lib" "libdir=${CURRENT_PACKAGES_DIR}/debug/lib" _content ${_content})
-    file(WRITE ${_pkg_comp} ${_content})
-  endforeach()
-  message(STATUS "Packaging ${TARGET_TRIPLET}-dbg done")
-
-  vcpkg_execute_build_process(
-    COMMAND make ${_ace_makefile_macros} realclean
-    WORKING_DIRECTORY "${WORKING_DIR}"
-    LOGNAME realclean-${TARGET_TRIPLET}-dbg
-  )
-  if("xml" IN_LIST FEATURES)
+    if("xml" IN_LIST FEATURES)
+      vcpkg_execute_build_process(
+        COMMAND make ${_ace_makefile_macros} install
+        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+        LOGNAME install-xml-${TARGET_TRIPLET}-dbg
+      )
+    endif()
+  
+    file(COPY "${CURRENT_PACKAGES_DIR}/lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")
+  
+    file(GLOB _pkg_components "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
+    foreach(_pkg_comp ${_pkg_components})
+      file(READ ${_pkg_comp} _content)
+      string(REPLACE "libdir=${CURRENT_PACKAGES_DIR}/lib" "libdir=${CURRENT_PACKAGES_DIR}/debug/lib" _content ${_content})
+      file(WRITE ${_pkg_comp} ${_content})
+    endforeach()
+    message(STATUS "Packaging ${TARGET_TRIPLET}-dbg done")
+  
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} realclean
-      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-      LOGNAME realclean-xml-${TARGET_TRIPLET}-dbg
+      WORKING_DIRECTORY "${WORKING_DIR}"
+      LOGNAME realclean-${TARGET_TRIPLET}-dbg
     )
+    if("xml" IN_LIST FEATURES)
+      vcpkg_execute_build_process(
+        COMMAND make ${_ace_makefile_macros} realclean
+        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+        LOGNAME realclean-xml-${TARGET_TRIPLET}-dbg
+      )
+    endif()
   endif()
-
-  message(STATUS "Building ${TARGET_TRIPLET}-rel")
-  vcpkg_execute_build_process(
-    COMMAND make ${_ace_makefile_macros} "-j${VCPKG_CONCURRENCY}"
-    WORKING_DIRECTORY "${WORKING_DIR}"
-    LOGNAME make-${TARGET_TRIPLET}-rel
-  )
-  if("xml" IN_LIST FEATURES)
+  
+  if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    message(STATUS "Building ${TARGET_TRIPLET}-rel")
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} "-j${VCPKG_CONCURRENCY}"
-      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-      LOGNAME make-xml-${TARGET_TRIPLET}-rel
+      WORKING_DIRECTORY "${WORKING_DIR}"
+      LOGNAME make-${TARGET_TRIPLET}-rel
     )
-  endif()
-  message(STATUS "Building ${TARGET_TRIPLET}-rel done")
-  message(STATUS "Packaging ${TARGET_TRIPLET}-rel")
-  vcpkg_execute_build_process(
-    COMMAND make ${_ace_makefile_macros} install
-    WORKING_DIRECTORY "${WORKING_DIR}"
-    LOGNAME install-${TARGET_TRIPLET}-rel
-  )
-  if("xml" IN_LIST FEATURES)
+    if("xml" IN_LIST FEATURES)
+      vcpkg_execute_build_process(
+        COMMAND make ${_ace_makefile_macros} "-j${VCPKG_CONCURRENCY}"
+        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+        LOGNAME make-xml-${TARGET_TRIPLET}-rel
+      )
+    endif()
+    message(STATUS "Building ${TARGET_TRIPLET}-rel done")
+    message(STATUS "Packaging ${TARGET_TRIPLET}-rel")
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} install
-      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-      LOGNAME install-xml-${TARGET_TRIPLET}-rel
+      WORKING_DIRECTORY "${WORKING_DIR}"
+      LOGNAME install-${TARGET_TRIPLET}-rel
     )
+    if("xml" IN_LIST FEATURES)
+      vcpkg_execute_build_process(
+        COMMAND make ${_ace_makefile_macros} install
+        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+        LOGNAME install-xml-${TARGET_TRIPLET}-rel
+      )
+    endif()
+    if("tao" IN_LIST FEATURES)
+      file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
+      file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    endif()
+    message(STATUS "Packaging ${TARGET_TRIPLET}-rel done")
   endif()
-  if("tao" IN_LIST FEATURES)
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-  endif()
-  message(STATUS "Packaging ${TARGET_TRIPLET}-rel done")
+  
   # Restore `PWD` environment variable
   set($ENV{PWD} _prev_env)
 

--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -294,93 +294,93 @@ elseif(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
   get_filename_component(WORKING_DIR "${WORKSPACE}" DIRECTORY)
   set(ENV{PWD} "${WORKING_DIR}")
 
-  if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    message(STATUS "Building ${TARGET_TRIPLET}-dbg")
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+  message(STATUS "Building ${TARGET_TRIPLET}-dbg")
+  vcpkg_execute_build_process(
+    COMMAND make ${_ace_makefile_macros} "debug=1" "optimize=0" "-j${VCPKG_CONCURRENCY}"
+    WORKING_DIRECTORY "${WORKING_DIR}"
+    LOGNAME make-${TARGET_TRIPLET}-dbg
+  )
+  if("xml" IN_LIST FEATURES)
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} "debug=1" "optimize=0" "-j${VCPKG_CONCURRENCY}"
-      WORKING_DIRECTORY "${WORKING_DIR}"
-      LOGNAME make-${TARGET_TRIPLET}-dbg
+      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+      LOGNAME make-xml-${TARGET_TRIPLET}-dbg
     )
-    if("xml" IN_LIST FEATURES)
-      vcpkg_execute_build_process(
-        COMMAND make ${_ace_makefile_macros} "debug=1" "optimize=0" "-j${VCPKG_CONCURRENCY}"
-        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-        LOGNAME make-xml-${TARGET_TRIPLET}-dbg
-      )
-    endif()
-    message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
-    message(STATUS "Packaging ${TARGET_TRIPLET}-dbg")
+  endif()
+  message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
+  message(STATUS "Packaging ${TARGET_TRIPLET}-dbg")
+  vcpkg_execute_build_process(
+    COMMAND make ${_ace_makefile_macros} install
+    WORKING_DIRECTORY "${WORKING_DIR}"
+    LOGNAME install-${TARGET_TRIPLET}-dbg
+  )
+  if("xml" IN_LIST FEATURES)
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} install
-      WORKING_DIRECTORY "${WORKING_DIR}"
-      LOGNAME install-${TARGET_TRIPLET}-dbg
+      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+      LOGNAME install-xml-${TARGET_TRIPLET}-dbg
     )
-    if("xml" IN_LIST FEATURES)
-      vcpkg_execute_build_process(
-        COMMAND make ${_ace_makefile_macros} install
-        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-        LOGNAME install-xml-${TARGET_TRIPLET}-dbg
-      )
-    endif()
-  
-    file(COPY "${CURRENT_PACKAGES_DIR}/lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")
-  
-    file(GLOB _pkg_components "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
-    foreach(_pkg_comp ${_pkg_components})
-      file(READ ${_pkg_comp} _content)
-      string(REPLACE "libdir=${CURRENT_PACKAGES_DIR}/lib" "libdir=${CURRENT_PACKAGES_DIR}/debug/lib" _content ${_content})
-      file(WRITE ${_pkg_comp} ${_content})
-    endforeach()
-    message(STATUS "Packaging ${TARGET_TRIPLET}-dbg done")
-  
+  endif()
+
+  file(COPY "${CURRENT_PACKAGES_DIR}/lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")
+
+  file(GLOB _pkg_components "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
+  foreach(_pkg_comp ${_pkg_components})
+    file(READ ${_pkg_comp} _content)
+    string(REPLACE "libdir=${CURRENT_PACKAGES_DIR}/lib" "libdir=${CURRENT_PACKAGES_DIR}/debug/lib" _content ${_content})
+    file(WRITE ${_pkg_comp} ${_content})
+  endforeach()
+  message(STATUS "Packaging ${TARGET_TRIPLET}-dbg done")
+
+  vcpkg_execute_build_process(
+    COMMAND make ${_ace_makefile_macros} realclean
+    WORKING_DIRECTORY "${WORKING_DIR}"
+    LOGNAME realclean-${TARGET_TRIPLET}-dbg
+  )
+  if("xml" IN_LIST FEATURES)
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} realclean
-      WORKING_DIRECTORY "${WORKING_DIR}"
-      LOGNAME realclean-${TARGET_TRIPLET}-dbg
+      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+      LOGNAME realclean-xml-${TARGET_TRIPLET}-dbg
     )
-    if("xml" IN_LIST FEATURES)
-      vcpkg_execute_build_process(
-        COMMAND make ${_ace_makefile_macros} realclean
-        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-        LOGNAME realclean-xml-${TARGET_TRIPLET}-dbg
-      )
-    endif()
   endif()
+endif()
   
-  if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-    message(STATUS "Building ${TARGET_TRIPLET}-rel")
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+  message(STATUS "Building ${TARGET_TRIPLET}-rel")
+  vcpkg_execute_build_process(
+    COMMAND make ${_ace_makefile_macros} "-j${VCPKG_CONCURRENCY}"
+    WORKING_DIRECTORY "${WORKING_DIR}"
+    LOGNAME make-${TARGET_TRIPLET}-rel
+  )
+  if("xml" IN_LIST FEATURES)
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} "-j${VCPKG_CONCURRENCY}"
-      WORKING_DIRECTORY "${WORKING_DIR}"
-      LOGNAME make-${TARGET_TRIPLET}-rel
+      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+      LOGNAME make-xml-${TARGET_TRIPLET}-rel
     )
-    if("xml" IN_LIST FEATURES)
-      vcpkg_execute_build_process(
-        COMMAND make ${_ace_makefile_macros} "-j${VCPKG_CONCURRENCY}"
-        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-        LOGNAME make-xml-${TARGET_TRIPLET}-rel
-      )
-    endif()
-    message(STATUS "Building ${TARGET_TRIPLET}-rel done")
-    message(STATUS "Packaging ${TARGET_TRIPLET}-rel")
+  endif()
+  message(STATUS "Building ${TARGET_TRIPLET}-rel done")
+  message(STATUS "Packaging ${TARGET_TRIPLET}-rel")
+  vcpkg_execute_build_process(
+    COMMAND make ${_ace_makefile_macros} install
+    WORKING_DIRECTORY "${WORKING_DIR}"
+    LOGNAME install-${TARGET_TRIPLET}-rel
+  )
+  if("xml" IN_LIST FEATURES)
     vcpkg_execute_build_process(
       COMMAND make ${_ace_makefile_macros} install
-      WORKING_DIRECTORY "${WORKING_DIR}"
-      LOGNAME install-${TARGET_TRIPLET}-rel
+      WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
+      LOGNAME install-xml-${TARGET_TRIPLET}-rel
     )
-    if("xml" IN_LIST FEATURES)
-      vcpkg_execute_build_process(
-        COMMAND make ${_ace_makefile_macros} install
-        WORKING_DIRECTORY "${WORKING_DIR}/../ACEXML"
-        LOGNAME install-xml-${TARGET_TRIPLET}-rel
-      )
-    endif()
-    if("tao" IN_LIST FEATURES)
-      file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
-      file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-    endif()
-    message(STATUS "Packaging ${TARGET_TRIPLET}-rel done")
   endif()
+  if("tao" IN_LIST FEATURES)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  endif()
+  message(STATUS "Packaging ${TARGET_TRIPLET}-rel done")
+endif()
   
   # Restore `PWD` environment variable
   set($ENV{PWD} _prev_env)

--- a/ports/ace/vcpkg.json
+++ b/ports/ace/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ace",
   "version": "7.1.2",
+  "port-version": 1,
   "maintainers": "Johnny Willemsen <jwillemsen@remedy.nl>",
   "description": "The ADAPTIVE Communication Environment",
   "homepage": "https://github.com/DOCGroup/ACE_TAO",

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b4352c2cc356fb9ae723cdeabbee955ee5718f6",
+      "version": "7.1.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "696c1096e0de3cd394392720aa34e0ceceac52e7",
       "version": "7.1.2",
       "port-version": 0

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1b4352c2cc356fb9ae723cdeabbee955ee5718f6",
+      "git-tree": "00c6b2eb50cad87d13e5a6a59f38e30cfa954651",
       "version": "7.1.2",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -26,7 +26,7 @@
     },
     "ace": {
       "baseline": "7.1.2",
-      "port-version": 0
+      "port-version": 1
     },
     "acl": {
       "baseline": "2.3.1",


### PR DESCRIPTION
Fixes #34446.

Make `ace` respect `set(VCPKG_BUILD_TYPE release)` in the `vcpkg/triplets/ibstall_triplet.cmake`. For example, x64-osx-release should not build the `debug` variant of this library.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
