### PR TITLE
[pocketfft] add new port

### DIFF
--- a/ports/pocketfft/portfile.cmake
+++ b/ports/pocketfft/portfile.cmake
@@ -1,0 +1,13 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH src_path
+    REPO mreineck/pocketfft
+    REF 9efd4da52cf8d28d14531d14e43ad9d913807546
+    SHA512 e8c2b65b23feb53f1077b3ae1e0e20d21d8f55601bd1216443af0fbc916638c3649527494ec2f23bed42d562341e0cf1fcde54c37068333161f289d23d8a9009
+    HEAD_REF cpp
+)
+
+set(VCPKG_BUILD_TYPE release) # header only
+
+file(COPY "${src_path}/pocketfft_hdronly.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${src_path}/LICENSE.md")

--- a/ports/pocketfft/vcpkg.json
+++ b/ports/pocketfft/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "pocketfft",
+  "version-date": "2023-09-25",
+  "description": "This is a heavily modified implementation of FFTPack",
+  "homepage": "https://github.com/mreineck/pocketfft",
+  "license": "BSD-3-Clause"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6604,6 +6604,10 @@
       "baseline": "0.7.0",
       "port-version": 5
     },
+    "pocketfft": {
+      "baseline": "2023-09-25",
+      "port-version": 0
+    },
     "poco": {
       "baseline": "1.12.4",
       "port-version": 4

--- a/versions/p-/pocketfft.json
+++ b/versions/p-/pocketfft.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "46ffdbd8c95362eee33d5cdf0dce36c77f332a7f",
+      "version-date": "2023-09-25",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.  <--- hopefully correct
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
