### PR TITLE
[angle] Fix class WebSwapCGLLayer is implemented in both WebKit.framework and angle on macOS

### DIFF
--- a/ports/angle/004-fix-webswapcgllayer-both-implemented.patch
+++ b/ports/angle/004-fix-webswapcgllayer-both-implemented.patch
@@ -1,0 +1,53 @@
+diff --git a/src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.h b/src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.h
+index 7101cd271..707d899f7 100644
+--- a/src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.h
++++ b/src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.h
+@@ -18,7 +18,7 @@ struct __IOSurface;
+ typedef __IOSurface *IOSurfaceRef;
+ 
+ // WebKit's build process requires that every Objective-C class name has the prefix "Web".
+-@class WebSwapCGLLayer;
++@class SwapCGLLayer;
+ 
+ namespace rx
+ {
+@@ -89,7 +89,7 @@ class WindowSurfaceCGL : public SurfaceGL
+                                      gl::Framebuffer *framebuffer) override;
+ 
+   private:
+-    WebSwapCGLLayer *mSwapLayer;
++    SwapCGLLayer *mSwapLayer;
+     SharedSwapState mSwapState;
+     uint64_t mCurrentSwapId;
+ 
+diff --git a/src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.mm b/src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.mm
+index 27990e9c2..9c5e1934f 100644
+--- a/src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.mm
++++ b/src/libANGLE/renderer/gl/cgl/WindowSurfaceCGL.mm
+@@ -24,7 +24,7 @@
+ #    include "libANGLE/renderer/gl/StateManagerGL.h"
+ #    include "libANGLE/renderer/gl/cgl/DisplayCGL.h"
+ 
+-@interface WebSwapCGLLayer : CAOpenGLLayer {
++@interface SwapCGLLayer : CAOpenGLLayer {
+     CGLContextObj mDisplayContext;
+ 
+     bool initialized;
+@@ -38,7 +38,7 @@
+             withFunctions:(const rx::FunctionsGL *)functions;
+ @end
+ 
+-@implementation WebSwapCGLLayer
++@implementation SwapCGLLayer
+ - (id)initWithSharedState:(rx::SharedSwapState *)swapState
+               withContext:(CGLContextObj)displayContext
+             withFunctions:(const rx::FunctionsGL *)functions
+@@ -220,7 +220,7 @@ egl::Error WindowSurfaceCGL::initialize(const egl::Display *display)
+     mSwapState.lastRendered   = &mSwapState.textures[1];
+     mSwapState.beingPresented = &mSwapState.textures[2];
+ 
+-    mSwapLayer = [[WebSwapCGLLayer alloc] initWithSharedState:&mSwapState
++    mSwapLayer = [[SwapCGLLayer alloc] initWithSharedState:&mSwapState
+                                                   withContext:mContext
+                                                 withFunctions:mFunctions];
+     [mLayer addSublayer:mSwapLayer];

--- a/ports/angle/portfile.cmake
+++ b/ports/angle/portfile.cmake
@@ -46,6 +46,7 @@ vcpkg_from_github(
         001-fix-uwp.patch
         002-fix-builder-error.patch
         003-fix-mingw.patch
+        004-fix-webswapcgllayer-both-implemented.patch
 )
 
 # Generate angle_commit.h

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_5414",
-  "port-version": 7,
+  "port-version": 8,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b366d05f4fb104f30470d55224ea9727a1656821",
+      "version-string": "chromium_5414",
+      "port-version": 8
+    },
+    {
       "git-tree": "b5502570ef18abdcf0535470f3ea6589db70607b",
       "version-string": "chromium_5414",
       "port-version": 7

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -130,7 +130,7 @@
     },
     "angle": {
       "baseline": "chromium_5414",
-      "port-version": 7
+      "port-version": 8
     },
     "ankurvdev-embedresource": {
       "baseline": "0.0.10",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix #34843