### PR TITLE
[avro-c] update to 1.11.3

### DIFF
--- a/ports/avro-c/portfile.cmake
+++ b/ports/avro-c/portfile.cmake
@@ -6,8 +6,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/avro
-    REF 4e1fefca493029ace961b7ef8889a3722458565a #release-1.11.0
-    SHA512 6e787983d68bc6ecffd14ca585917f695bc1ae554de9146a436d342f32321c3e7878cdfa32989742e682ac12a6eb914b3e3b515ca3164f386c0281c8b50b53ad
+    REF "release-${VERSION}"
+    SHA512 728609f562460e1115366663ede2c5d4acbdd6950c1ee3e434ffc65d28b72e3a43c3ebce93d0a8459f0c4f6c492ebb9444e2127a0385f38eb7cdf74b28f0c3ed
     HEAD_REF master
     PATCHES
         avro.patch          # Private vcpkg build fixes

--- a/ports/avro-c/vcpkg.json
+++ b/ports/avro-c/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "avro-c",
-  "version": "1.11.0",
-  "port-version": 3,
+  "version": "1.11.3",
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/versions/a-/avro-c.json
+++ b/versions/a-/avro-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76ef10758076c92faaae286e1d38c1770dc4f23c",
+      "version": "1.11.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "7b07da3abd56565c8d2e75942aab468ece0f3115",
       "version": "1.11.0",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -345,8 +345,8 @@
       "port-version": 2
     },
     "avro-c": {
-      "baseline": "1.11.0",
-      "port-version": 3
+      "baseline": "1.11.3",
+      "port-version": 0
     },
     "avro-cpp": {
       "baseline": "1.11.3",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

