### PR TITLE
[google-cloud-cpp] update to latest release (v2.18.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 a3d84785b024e31e909592bca5a6589873bcd342848fae9520a9e7715bcb736db71184eeedbcbf6086105e6145937cabdd731a80879fd177f80895fdf09c3b46
+    SHA512 18c3fc4fabd1fabfbfb33760636e9403f5b5965cde9e2feab38ac76063ba82fd4aa59a895ded7288ff7552e5806714b5428765b673b5eff95080cd1718bd6792
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.17.0",
-  "port-version": 2,
+  "version": "2.18.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -1111,6 +1110,18 @@
     },
     "secretmanager": {
       "description": "The Google Cloud Secret Manager C++ client library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "securesourcemanager": {
+      "description": "Secure Source Manager API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3037,8 +3037,8 @@
       "port-version": 5
     },
     "google-cloud-cpp": {
-      "baseline": "2.17.0",
-      "port-version": 2
+      "baseline": "2.18.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1bc2f1bb136931aadea6d6df8fc23b474d8071b7",
+      "git-tree": "21cf84757dd988f8b1ea4aa318002a4cc047b697",
       "version": "2.18.0",
       "port-version": 0
     },

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -6,7 +6,7 @@
       "port-version": 0
     },
     {
-      "git-tree": "8c7f31c6bcbfdb4dfee70c2503cc8a7abd276c53",
+      "git-tree": "2a52d32521f59da4d2ecfe7beffe13bab448ea64",
       "version": "2.17.0",
       "port-version": 2
     },

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "2a52d32521f59da4d2ecfe7beffe13bab448ea64",
+      "git-tree": "1bc2f1bb136931aadea6d6df8fc23b474d8071b7",
+      "version": "2.18.0",
+      "port-version": 0
+    },
+    {
+      "git-tree": "8c7f31c6bcbfdb4dfee70c2503cc8a7abd276c53",
       "version": "2.17.0",
       "port-version": 2
     },


### PR DESCRIPTION
Updates google-cloud-cpp to the latest release (v2.18.0)

Tested locally (on x64-linux) with:

```
for feature in securesourcemanager; do ./vcpkg remove google-cloud-cpp; ./vcpkg install "google-cloud-cpp[core,${feature}]" || break; done
```

and

```
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

