### PR TITLE
[poco] update to 1.12.5

### DIFF
--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
-    REF c04dfdbc37882f298d3178b3875cd67c38ea7d78 # poco-1.12.5-release
+    REF "poco-${VERSION}-release"
     SHA512 a9dfe8981ba15049a0824ce5dbe79df5032d96bf204e7780719f987ef86b21cde5bb8a19340c5d5c34a33d60955341a386057f14a6f16bad9657e8880b12294d
     HEAD_REF master
     PATCHES

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
     REF "poco-${VERSION}-release"
-    SHA512 a9dfe8981ba15049a0824ce5dbe79df5032d96bf204e7780719f987ef86b21cde5bb8a19340c5d5c34a33d60955341a386057f14a6f16bad9657e8880b12294d
+    SHA512 dfb7bc3241c78216ebd9eeacd6d091c069a342a7f92e73b348b07ff817997a16c8452fdb954954a182f65140567fc2e910036efb50d55d327a4de8063bac005b
     HEAD_REF master
     PATCHES
         # Fix embedded copy of pcre in static linking mode

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
-    REF 1211613642269b7d53bea58b02de7fcd25ece3b9 # poco-1.12.4-release
-    SHA512 bf390f7c8d7c4f0d7602afa434a933b429274944d12560159761b0f984316c76abfdb49ad422c869e02d88041058a04d66e7b5ae05142819a4f583870cc00f44
+    REF c04dfdbc37882f298d3178b3875cd67c38ea7d78 # poco-1.12.5-release
+    SHA512 a9dfe8981ba15049a0824ce5dbe79df5032d96bf204e7780719f987ef86b21cde5bb8a19340c5d5c34a33d60955341a386057f14a6f16bad9657e8880b12294d
     HEAD_REF master
     PATCHES
         # Fix embedded copy of pcre in static linking mode
@@ -120,4 +120,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "poco",
-  "version": "1.12.4",
-  "port-version": 4,
+  "version": "1.12.5",
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6621,8 +6621,8 @@
       "port-version": 0
     },
     "poco": {
-      "baseline": "1.12.4",
-      "port-version": 4
+      "baseline": "1.12.5",
+      "port-version": 0
     },
     "podofo": {
       "baseline": "0.10.1",

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9ba89a484b251aa3b4de93723ef3f961ec2ac615",
+      "git-tree": "baaee315b717f3b0a819aed2f78b8a2059cb1726",
       "version": "1.12.5",
       "port-version": 0
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "043ef7ffbbf14910779930f0c9394bb998a0893b",
+      "git-tree": "9ba89a484b251aa3b4de93723ef3f961ec2ac615",
       "version": "1.12.5",
       "port-version": 0
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "043ef7ffbbf14910779930f0c9394bb998a0893b",
+      "version": "1.12.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "5fb22214a00901cbf3697a76442f5f360cbc74ef",
       "version": "1.12.4",
       "port-version": 4


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/34860

All features passed with following triplets:
x64-windows 
x64-windows-static 

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
