### PR TITLE
[reproc] Fix gcc 13 build error

### DIFF
--- a/ports/reproc/fix-gcc13-build-error.patch
+++ b/ports/reproc/fix-gcc13-build-error.patch
@@ -1,0 +1,28 @@
+diff --git a/reproc++/include/reproc++/reproc.hpp b/reproc++/include/reproc++/reproc.hpp
+index ab6f139..d4b370f 100644
+--- a/reproc++/include/reproc++/reproc.hpp
++++ b/reproc++/include/reproc++/reproc.hpp
+@@ -88,18 +88,18 @@ struct redirect {
+ 
+ struct options {
+   struct {
+-    env::type behavior;
++    reproc::env::type behavior;
+     /*! Implicitly converts from any STL container of string pairs to the
+     environment format expected by `reproc_start`. */
+-    class env extra;
++    reproc::env extra;
+   } env = {};
+ 
+   const char *working_directory = nullptr;
+ 
+   struct {
+-    redirect in;
+-    redirect out;
+-    redirect err;
++    struct redirect in;
++    struct redirect out;
++    struct redirect err;
+     bool parent;
+     bool discard;
+     FILE *file;

--- a/ports/reproc/portfile.cmake
+++ b/ports/reproc/portfile.cmake
@@ -4,7 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 c592521960f1950d626261738091d25efdf764ee1a0c72a58c28c66eaebf6073b2c978f1dc2c8dbe89b0be7ec1629a3a45cb1fafa0ebe21b5df8d4d27c992675
     HEAD_REF main
-	PATCHES fix-gcc13-build-error.patch
+    PATCHES
+        fix-gcc13-build-error.patch #Please remove it in the next release version
 )
 
 vcpkg_cmake_configure(

--- a/ports/reproc/portfile.cmake
+++ b/ports/reproc/portfile.cmake
@@ -1,9 +1,10 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DaanDeMeyer/reproc
-    REF v14.2.4
+    REF "v${VERSION}"
     SHA512 c592521960f1950d626261738091d25efdf764ee1a0c72a58c28c66eaebf6073b2c978f1dc2c8dbe89b0be7ec1629a3a45cb1fafa0ebe21b5df8d4d27c992675
     HEAD_REF main
+	PATCHES fix-gcc13-build-error.patch
 )
 
 vcpkg_cmake_configure(
@@ -24,8 +25,4 @@ foreach(TARGET reproc reproc++)
     )
 endforeach()
 
-file(
-    INSTALL "${SOURCE_PATH}/LICENSE"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-    RENAME copyright
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/reproc/vcpkg.json
+++ b/ports/reproc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "reproc",
   "version": "14.2.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Cross-platform (C99/C++11) process library",
   "homepage": "https://github.com/DaanDeMeyer/reproc",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7398,7 +7398,7 @@
     },
     "reproc": {
       "baseline": "14.2.4",
-      "port-version": 1
+      "port-version": 2
     },
     "rest-rpc": {
       "baseline": "0.07",

--- a/versions/r-/reproc.json
+++ b/versions/r-/reproc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6fc63b3c029742441d22a288db9f37f5e016abbe",
+      "version": "14.2.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "eeac14685480439ee52ac05ec68faebb2cbaffad",
       "version": "14.2.4",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/34709

This issue has been fixed by upstream's commits:
https://github.com/DaanDeMeyer/reproc/commit/0b23d88894ccedde04537fa23ea55cb2f8365342
https://github.com/DaanDeMeyer/reproc/commit/9f399675b821e175f85ac3ee6e3fd2e6056573eb

In the absence of these two commits in the latest upstream release, and with no newer release available, I have added a patch to address this issue.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
