### PR TITLE
[opencv] turn openvino dependency as optional feature

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -71,6 +71,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  "jpeg"      WITH_JPEG
  "lapack"    WITH_LAPACK
  "nonfree"   OPENCV_ENABLE_NONFREE
+ "openvino"  WITH_OPENVINO
  "openexr"   WITH_OPENEXR
  "opengl"    WITH_OPENGL
  "ovis"      CMAKE_REQUIRE_FIND_PACKAGE_OGRE
@@ -86,13 +87,9 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 # Cannot use vcpkg_check_features() for "dnn", "gtk", ipp", "openmp", "ovis", "python", "qt", "tbb"
 set(BUILD_opencv_dnn OFF)
-set(WITH_OPENVINO OFF)
 if("dnn" IN_LIST FEATURES)
   if(NOT VCPKG_TARGET_IS_ANDROID)
     set(BUILD_opencv_dnn ON)
-    if(NOT VCPKG_TARGET_IS_UWP)
-      set(WITH_OPENVINO ON)
-    endif()
   else()
     message(WARNING "The dnn module cannot be enabled on Android")
   endif()

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
-  "port-version": 8,
+  "port-version": 9,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -108,10 +108,6 @@
           "name": "flatbuffers",
           "host": true,
           "default-features": false
-        },
-        {
-          "name": "openvino",
-          "platform": "!uwp"
         },
         "protobuf"
       ]
@@ -246,6 +242,37 @@
     },
     "openmp": {
       "description": "Enable openmp support for opencv"
+    },
+    "openvino": {
+      "description": "OpenVINO support for OpenCV DNN",
+      "supports": "!uwp",
+      "dependencies": [
+        {
+          "name": "opencv4",
+          "default-features": false,
+          "features": [
+            "dnn"
+          ]
+        },
+        {
+          "name": "openvino",
+          "default-features": false,
+          "features": [
+            "auto",
+            "cpu",
+            "hetero"
+          ],
+          "platform": "!uwp"
+        },
+        {
+          "name": "openvino",
+          "default-features": false,
+          "features": [
+            "gpu"
+          ],
+          "platform": "x64 & !(osx | uwp) & !static"
+        }
+      ]
     },
     "ovis": {
       "description": "opencv_ovis module",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6198,7 +6198,7 @@
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 8
+      "port-version": 9
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ed8c48a9b2be5df262ccbcfa876f5314f429c10",
+      "version": "4.8.0",
+      "port-version": 9
+    },
+    {
       "git-tree": "48c97b54fceaef9a96d374693f47e3ea91383f3c",
       "version": "4.8.0",
       "port-version": 8


### PR DESCRIPTION
Addressing complains from https://github.com/microsoft/vcpkg/pull/34727
Closes https://github.com/microsoft/vcpkg/issues/34913

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.
