### PR TITLE
[litehtml] update to 0.8

### DIFF
--- a/ports/litehtml/fix-relative-includes.patch
+++ b/ports/litehtml/fix-relative-includes.patch
@@ -1,17 +1,8 @@
-From 42cf79c0292d655eec41c486710bf610063bdfd8 Mon Sep 17 00:00:00 2001
-From: Sean Farrell <sean.farrell@rioki.org>
-Date: Thu, 23 Feb 2023 14:17:52 +0100
-Subject: [PATCH] Fix relative includes.
-
----
- include/litehtml.h | 10 +++++-----
- 1 file changed, 5 insertions(+), 5 deletions(-)
-
 diff --git a/include/litehtml.h b/include/litehtml.h
-index 98a24e0..d20addd 100644
+index 2537aee..f4f3163 100644
 --- a/include/litehtml.h
 +++ b/include/litehtml.h
-@@ -1,10 +1,10 @@
+@@ -1,11 +1,11 @@
  #ifndef LITEHTML_H
  #define LITEHTML_H
  
@@ -20,13 +11,12 @@ index 98a24e0..d20addd 100644
 -#include <litehtml/html_tag.h>
 -#include <litehtml/stylesheet.h>
 -#include <litehtml/element.h>
+-#include <litehtml/utf8_strings.h>
 +#include "html.h"
 +#include "document.h"
 +#include "html_tag.h"
 +#include "stylesheet.h"
 +#include "element.h"
++#include "utf8_strings.h"
  
  #endif  // LITEHTML_H
--- 
-2.33.0.windows.2
-

--- a/ports/litehtml/portfile.cmake
+++ b/ports/litehtml/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO litehtml/litehtml
-    REF v0.6
-    SHA512 b774ed96e53780865e789875f571f96ebce1cd2ff0c05a06ae68a67aec44375cc282c07f77fc87131d422aceddba32bbf3e8e498c870883d8e042adb30834c39
+    REF "v${VERSION}"
+    SHA512 e2df205258c4e6f48cc0d8f900fb62c2da1b18c9ca007f1e222e51a59a632eb122eb2dc6136de6641ed96b3c6c823f7f90d098f2f40f9966b0cb831b180776a4
     PATCHES 
       use-vcpkg-gumbo.patch
       fix-relative-includes.patch

--- a/ports/litehtml/use-vcpkg-gumbo.patch
+++ b/ports/litehtml/use-vcpkg-gumbo.patch
@@ -1,16 +1,5 @@
-From 4ca6d9846bfc39c4aa98d6a41f298078b4bebf8d Mon Sep 17 00:00:00 2001
-From: Sean Farrell <sean.farrell@rioki.org>
-Date: Thu, 23 Feb 2023 08:15:37 +0100
-Subject: [PATCH] Use vcpkg's gumbo
-
----
- CMakeLists.txt             | 8 ++------
- cmake/litehtmlConfig.cmake | 2 +-
- src/document.cpp           | 2 +-
- 3 files changed, 4 insertions(+), 8 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fe71729..21e77c8 100644
+index 34d6b15..fb1996a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -10,11 +10,7 @@ enable_testing()
@@ -25,9 +14,9 @@ index fe71729..21e77c8 100644
 +find_package(unofficial-gumbo CONFIG REQUIRED)
  
  set(SOURCE_LITEHTML
-     src/background.cpp
-@@ -153,7 +149,7 @@ if (LITEHTML_UTF8)
- endif()
+     src/codepoint.cpp
+@@ -160,7 +156,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
+ target_include_directories(${PROJECT_NAME} PRIVATE include/${PROJECT_NAME})
  
  # Gumbo
 -target_link_libraries(${PROJECT_NAME} PUBLIC gumbo)
@@ -45,18 +34,15 @@ index 5eedcf4..1027913 100644
 +find_dependency(unofficial-gumbo)
  include(${CMAKE_CURRENT_LIST_DIR}/litehtmlTargets.cmake)
 diff --git a/src/document.cpp b/src/document.cpp
-index 8bd1ea8..51a9d42 100644
+index 8623bff..3435eeb 100644
 --- a/src/document.cpp
 +++ b/src/document.cpp
-@@ -26,7 +26,7 @@
+@@ -24,7 +24,7 @@
+ #include <cmath>
  #include <cstdio>
  #include <algorithm>
- #include <functional>
 -#include "gumbo.h"
 +#include <gumbo.h>
  #include "utf8_strings.h"
+ #include "render_item.h"
  
- litehtml::document::document(litehtml::document_container* objContainer, litehtml::context* ctx)
--- 
-2.33.0.windows.2
-

--- a/ports/litehtml/vcpkg.json
+++ b/ports/litehtml/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "litehtml",
-  "version": "0.6.0",
-  "port-version": 2,
+  "version": "0.8",
   "description": "litehtml is the lightweight HTML rendering engine with CSS2/CSS3 support.",
   "homepage": "https://github.com/litehtml/litehtml",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5125,8 +5125,8 @@
       "port-version": 0
     },
     "litehtml": {
-      "baseline": "0.6.0",
-      "port-version": 2
+      "baseline": "0.8",
+      "port-version": 0
     },
     "live555": {
       "baseline": "2023-07-24",

--- a/versions/l-/litehtml.json
+++ b/versions/l-/litehtml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80be1c1569a1ff9c61d2da814e14040c853d3dc6",
+      "version": "0.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "fbbd4d593d570ec75f5a02fea10a236aecc810d4",
       "version": "0.6.0",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

