### PR TITLE
[Glaze] Update 1.5.7

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 88bf8f152d0dbce38e97160a9fa0a5b1f708213d8b80e2c771ce981e6abfeecf4daa09d79b582b3b7c3ba6f932ff5fada9965a4db5d30db956f7d6152686f002
+    SHA512 4b9fb73790892cb7543ee94e773ff706f9fad46cd95c472b68d1f535413bc2b46c2d36970cbe31858444a5463ec19215ef50f4c37e8efe5f4f23c61acf7a53ed
 )
 
 vcpkg_cmake_configure(

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2961,7 +2961,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "1.5.6",
+      "baseline": "1.5.7",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50a00a801ec368382628caa2da7c8a0f09815456",
+      "version": "1.5.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "4146e402c56c4d3678ccf0fc30a303fe4a628bcb",
       "version": "1.5.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.