### PR TITLE
[websocketpp] fix cpp20.patch

### DIFF
--- a/ports/websocketpp/cxx20.patch
+++ b/ports/websocketpp/cxx20.patch
@@ -64,3 +64,30 @@ index 8451413..4c9d836 100644
       : m_static_channels(other.m_static_channels)
       , m_dynamic_channels(other.m_dynamic_channels)
       , m_out(other.m_out)
+diff --git a/websocketpp/roles/server_endpoint.hpp b/websocketpp/roles/server_endpoint.hpp
+index 4a5865eff..04fee18f9 100644
+--- a/websocketpp/roles/server_endpoint.hpp
++++ b/websocketpp/roles/server_endpoint.hpp
+@@ -75,11 +75,11 @@ class server : public endpoint<connection<config>,config> {
+     }
+ 
+     /// Destructor
+-    ~server<config>() {}
++    ~server() {}
+ 
+ #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+     // no copy constructor because endpoints are not copyable
+-    server<config>(server<config> &) = delete;
++    server(server<config> &) = delete;
+ 
+     // no copy assignment operator because endpoints are not copyable
+     server<config> & operator=(server<config> const &) = delete;
+@@ -87,7 +87,7 @@ class server : public endpoint<connection<config>,config> {
+ 
+ #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+     /// Move constructor
+-    server<config>(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
++    server(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
+ 
+ #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+     // no move assignment operator because of const member variables

--- a/ports/websocketpp/vcpkg.json
+++ b/ports/websocketpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "websocketpp",
   "version": "0.8.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Library that implements RFC6455 The WebSocket Protocol",
   "homepage": "https://github.com/zaphoyd/websocketpp",
   "documentation": "http://docs.websocketpp.org/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8938,7 +8938,7 @@
     },
     "websocketpp": {
       "baseline": "0.8.2",
-      "port-version": 2
+      "port-version": 3
     },
     "webview2": {
       "baseline": "1.0.2088.41",

--- a/versions/w-/websocketpp.json
+++ b/versions/w-/websocketpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb46cff6f9a23caefbc56ac8089d1fbee523e13e",
+      "version": "0.8.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "70d3b037559f580fa52bc50bb2dc26e58f5107d9",
       "version": "0.8.2",
       "port-version": 2


### PR DESCRIPTION
in #23669 cpp20.patch backports the patch [0] from the upstream websocketpp repo.
But it was added incomplete as it left out the part for `websocketpp/roles/server_endpoint.hpp` for unknown reasons.
This MR fixes this.

[0] https://github.com/zaphoyd/websocketpp/commit/3197a520eb4c1e4754860441918a5930160373eb

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file~~.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
