### PR TITLE
[magnum] remove empty dirs

### DIFF
--- a/ports/magnum/portfile.cmake
+++ b/ports/magnum/portfile.cmake
@@ -142,6 +142,18 @@ else()
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum/fontconverters")
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/fonts")
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/fontconverters")
+
+        # remove maybe empty dirs
+        file(GLOB maybe_empty "${CURRENT_PACKAGES_DIR}/lib/magnum/importers/*")
+        if(maybe_empty STREQUAL "")
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum/importers")
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/importers")
+            file(GLOB maybe_empty "${CURRENT_PACKAGES_DIR}/lib/magnum/*")
+            if(maybe_empty STREQUAL "")
+                file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum")
+                file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d")
+            endif()
+        endif()
     endif()
 
     file(COPY "${CMAKE_CURRENT_LIST_DIR}/magnumdeploy.ps1" DESTINATION "${CURRENT_PACKAGES_DIR}/bin/magnum")

--- a/ports/magnum/vcpkg.json
+++ b/ports/magnum/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "magnum",
   "version-string": "2020.06",
-  "port-version": 15,
+  "port-version": 16,
   "description": "C++11/C++14 graphics middleware for games and data visualization",
   "homepage": "https://magnum.graphics/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5326,7 +5326,7 @@
     },
     "magnum": {
       "baseline": "2020.06",
-      "port-version": 15
+      "port-version": 16
     },
     "magnum-extras": {
       "baseline": "2020.06",

--- a/versions/m-/magnum.json
+++ b/versions/m-/magnum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d923e5792a77042485ffd4b32afecca23f18c7d9",
+      "version-string": "2020.06",
+      "port-version": 16
+    },
+    {
       "git-tree": "b1b8f84dd450902aec2b555eb577dfd2a0129592",
       "version-string": "2020.06",
       "port-version": 15


### PR DESCRIPTION
Fixes 
```
-- Performing post-build validation
warning: There should be no empty directories in C:\v\vcpkg3\packages\magnum_x64-windows. The following empty directories were found:

    C:\v\vcpkg3\packages\magnum_x64-windows\debug\lib\magnum-d\importers
    C:\v\vcpkg3\packages\magnum_x64-windows\lib\magnum\importers

warning: If a directory should be populated but is not, this might indicate an error in the portfile.
If the directories are not needed and their creation cannot be disabled, use something like this in the portfile to remove them:
    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/importers" "${CURRENT_PACKAGES_DIR}/lib/magnum/importers")
```