### PR TITLE
[ogre next] update to 2.3.2

### DIFF
--- a/ports/gz-cmake3/dependencies.patch
+++ b/ports/gz-cmake3/dependencies.patch
@@ -120,24 +120,11 @@ diff --git a/cmake/FindGzOGRE2.cmake b/cmake/FindGzOGRE2.cmake
 +if (NOT WIN32)
    set(PKG_CONFIG_PATH_ORIGINAL $ENV{PKG_CONFIG_PATH})
 -  foreach (GZ_OGRE2_PROJECT_NAME "OGRE2" "OGRE-Next")
-+  foreach (GZ_OGRE2_PROJECT_NAME "OGRE")
++  foreach (GZ_OGRE2_PROJECT_NAME "OGRE-Next")
      message(STATUS "Looking for OGRE using the name: ${GZ_OGRE2_PROJECT_NAME}")
      if (GZ_OGRE2_PROJECT_NAME STREQUAL "OGRE2")
        set(OGRE2_INSTALL_PATH "OGRE-2.${GzOGRE2_FIND_VERSION_MINOR}")
        # For OGRE 2.3 debs built via OpenRobotics buildfarms, we use OgreNext
-@@ -159,10 +159,10 @@
-         set(OGRE2LIBNAME "Ogre")
-       endif()
-     else()
-       # This matches OGRE2.2 debs built in upstream Ubuntu
--      set(OGRE2_INSTALL_PATH "OGRE-Next")
--      set(OGRE2LIBNAME "OgreNext")
-+      set(OGRE2_INSTALL_PATH "OGRE")
-+      set(OGRE2LIBNAME "Ogre")
-     endif()
- 
-     # Note: OGRE2 installed from debs is named OGRE-2.2 while the version
-     # installed from source does not have the 2.2 suffix
 @@ -172,8 +172,9 @@
      if (${GZ_OGRE2_PROJECT_NAME}_FOUND)
        set(GZ_PKG_NAME ${OGRE2_INSTALL_PATH})
@@ -172,13 +159,13 @@ diff --git a/cmake/FindGzOGRE2.cmake b/cmake/FindGzOGRE2.cmake
 +        list(APPEND OGRE2_PATHS "${_rootPath}/lib/")
 +        list(APPEND OGRE2_PATHS "${_rootPath}/lib/manual-link/")
 +      endif()
-+      list(APPEND OGRE2_INC_PATHS "${_rootPath}/include/OGRE")
++      list(APPEND OGRE2_INC_PATHS "${_rootPath}/include/OGRE-Next")
    endforeach()
  
 +  if(CMAKE_BUILD_TYPE MATCHES Debug)
-+    set(OGRE_MAIN_LIB "OgreMain_d")
++    set(OGRE_MAIN_LIB "OgreNextMain_d")
 +  else()
-+    set(OGRE_MAIN_LIB "OgreMain")
++    set(OGRE_MAIN_LIB "OgreNextMain")
 +  endif()
 +
    find_library(OGRE2_LIBRARY
@@ -188,6 +175,19 @@ diff --git a/cmake/FindGzOGRE2.cmake b/cmake/FindGzOGRE2.cmake
      NO_DEFAULT_PATH)
  
    find_path(OGRE2_INCLUDE
+@@ -449,10 +461,10 @@
+               ${PATH_HINTS} ${COMPONENT} ${OGRE2_SEARCH_VER}/${COMPONENT})
+ 
+       find_library(${PREFIX}_LIBRARY
+           NAMES
+-              "Ogre${COMPONENT}"
+-              "Ogre${COMPONENT}_d"
++              "OgreNext${COMPONENT}"
++              "OgreNext${COMPONENT}_d"
+           HINTS
+               ${OGRE2_LIBRARY_DIRS}
+           NO_DEFAULT_PATH)
+ 
 @@ -509,8 +521,9 @@
  
    ogre_find_plugin(Plugin_ParticleFX OgreParticleFXPrerequisites.h PlugIns/ParticleFX/include)
@@ -204,7 +204,7 @@ diff --git a/cmake/FindGzOGRE2.cmake b/cmake/FindGzOGRE2.cmake
          foreach (dir ${OGRE2_INCLUDE_DIRS})
            get_filename_component(dir_name "${dir}" NAME)
 -          if ("${dir_name}" STREQUAL "OGRE-${OGRE2_VERSION_MAJOR}.${OGRE2_VERSION_MINOR}")
-+          if ("${dir_name}" STREQUAL "OGRE")
++          if ("${dir_name}" STREQUAL "OGRE-Next")
              set(dir_include "${dir}/Hlms/Common")
              if (EXISTS ${dir_include})
                list(APPEND component_INCLUDE_DIRS ${dir_include})

--- a/ports/gz-cmake3/vcpkg.json
+++ b/ports/gz-cmake3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gz-cmake3",
   "version": "3.4.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "CMake helper functions for building robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/cmake",
   "license": null,

--- a/ports/ogre-next/fix-pc-file.patch
+++ b/ports/ogre-next/fix-pc-file.patch
@@ -1,0 +1,21 @@
+diff --git a/CMake/Templates/OGREStatic.pc.in b/CMake/Templates/OGREStatic.pc.in
+--- a/CMake/Templates/OGREStatic.pc.in
++++ b/CMake/Templates/OGREStatic.pc.in
+@@ -1,13 +1,13 @@
+ prefix=@OGRE_PREFIX_PATH@
+ exec_prefix=${prefix}
+ libdir=${prefix}/@OGRE_LIB_DIRECTORY@
+ includedir=${prefix}/include
+-plugindir=${libdir}/OGRE
++plugindir=${libdir}/@OGRE_NEXT_PREFIX@
+ 
+-Name: OGRE (static lib)
++Name: @OGRE_NEXT_PREFIX@ (static lib)
+ Description: Object-Oriented Graphics Rendering Engine
+ Version: @OGRE_VERSION@
+ URL: http://www.ogre3d.org
+ Requires: freetype2, zziplib, x11, xt, xaw7, gl
+-Libs: -L${libdir} -L${plugindir} -lOgreMain@OGRE_LIB_SUFFIX@ @OGRE_ADDITIONAL_LIBS@
+-Cflags: -I${includedir} -I${includedir}/OGRE @OGRE_CFLAGS@
++Libs: -L${libdir} -L${plugindir} -l@OGRE_NEXT@Main@OGRE_LIB_SUFFIX@ @OGRE_ADDITIONAL_LIBS@
++Cflags: -I${includedir} -I${includedir}/@OGRE_NEXT_PREFIX@ @OGRE_CFLAGS@

--- a/ports/ogre-next/portfile.cmake
+++ b/ports/ogre-next/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OGRECave/ogre-next
     REF v${VERSION}
-    SHA512 62c721680ed77e74b6e1649ab7324bd49fc3c7c2e60ad76a62ec5f899f327d65a140462d75300eac4f41567a8903a748d07a760dc376eddcadf0aeea5a3ca5a7
+    SHA512 fbc1969244db07d013118fbce12b319e83cdae93a822cb2d90bbd12108ac3ce48d1f5437b4375b3daf5640b9ec6f1764daeef742161a101f77c3e25ccaf4b154
     HEAD_REF master
     PATCHES
         toolchain_fixes.patch
@@ -56,6 +56,7 @@ vcpkg_cmake_configure(
         -DOGRE_BUILD_RENDERSYSTEM_GLES=OFF
         -DOGRE_BUILD_RENDERSYSTEM_GLES2=OFF
         -DOGRE_CMAKE_DIR=share/ogre-next
+        -DOGRE_USE_NEW_PROJECT_NAME=ON
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
@@ -78,15 +79,15 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-#Remove OgreMain*.lib from lib/ folder, because autolink would complain, since it defines a main symbol
+#Remove OgreNextMain*.lib from lib/ folder, because autolink would complain, since it defines a main symbol
 #manual-link subfolder is here to the rescue!
 if(VCPKG_TARGET_IS_WINDOWS)
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Release")
         file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/manual-link")
         if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/release/OgreMain.lib" "${CURRENT_PACKAGES_DIR}/lib/manual-link/OgreMain.lib")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/release/OgreNextMain.lib" "${CURRENT_PACKAGES_DIR}/lib/manual-link/OgreNextMain.lib")
         else()
-            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/release/OgreMainStatic.lib" "${CURRENT_PACKAGES_DIR}/lib/manual-link/OgreMainStatic.lib")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/release/OgreNextMainStatic.lib" "${CURRENT_PACKAGES_DIR}/lib/manual-link/OgreNextMainStatic.lib")
         endif()
         file(GLOB LIBS "${CURRENT_PACKAGES_DIR}/lib/release/*")
         file(GLOB DLLS "${CURRENT_PACKAGES_DIR}/bin/release/*")
@@ -97,9 +98,9 @@ if(VCPKG_TARGET_IS_WINDOWS)
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Debug")
         file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link")
         if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/debug/OgreMain_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMain_d.lib")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/debug/OgreNextMain_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreNextMain_d.lib")
         else()
-            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/debug/OgreMainStatic_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMainStatic_d.lib")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/debug/OgreNextMainStatic_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreNextMainStatic_d.lib")
         endif()
         file(GLOB LIBS "${CURRENT_PACKAGES_DIR}/debug/lib/debug/*")
         file(GLOB DLLS "${CURRENT_PACKAGES_DIR}/debug/bin/debug/*")
@@ -111,7 +112,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     file(GLOB SHARE_FILES "${CURRENT_PACKAGES_DIR}/share/ogre-next/*.cmake")
     foreach(SHARE_FILE ${SHARE_FILES})
         file(READ "${SHARE_FILE}" _contents)
-        string(REPLACE "lib/OgreMain" "lib/manual-link/OgreMain" _contents "${_contents}")
+        string(REPLACE "lib/OgreNextMain" "lib/manual-link/OgreNextMain" _contents "${_contents}")
         file(WRITE "${SHARE_FILE}" "${_contents}")
     endforeach()
 endif()

--- a/ports/ogre-next/portfile.cmake
+++ b/ports/ogre-next/portfile.cmake
@@ -1,8 +1,3 @@
-# This portfile is based (shamelessly copied and adapted a bit) on 'ogre' portfile.
-if (EXISTS "${CURRENT_INSTALLED_DIR}/Media/HLMS/Blendfunctions_piece_fs.glslt")
-    message(FATAL_ERROR "FATAL ERROR: ogre-next and ogre are incompatible.")
-endif()
-
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     message("${PORT} currently requires the following library from the system package manager:\n    Xaw\n\nIt can be installed on Ubuntu systems via apt-get install libxaw7-dev")
 endif()

--- a/ports/ogre-next/portfile.cmake
+++ b/ports/ogre-next/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
         avoid-name-clashes.patch
         fix-error-c2039.patch
         fix-dependencies.patch
+        fix-pc-file.patch
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)

--- a/ports/ogre-next/toolchain_fixes.patch
+++ b/ports/ogre-next/toolchain_fixes.patch
@@ -163,3 +163,13 @@ diff --git a/OgreMain/CMakeLists.txt b/OgreMain/CMakeLists.txt
 -    set(OGRE_OSX_BUILD_CONFIGURATION "$(PLATFORM_NAME)/$(CONFIGURATION)")
    
  	add_custom_command(TARGET ${OGRE_NEXT}Main POST_BUILD
+diff --git a/RenderSystems/Direct3D11/CMakeLists.txt b/RenderSystems/Direct3D11/CMakeLists.txt
+--- a/RenderSystems/Direct3D11/CMakeLists.txt
++++ b/RenderSystems/Direct3D11/CMakeLists.txt
+@@ -60,5 +60,5 @@
+   target_link_libraries(RenderSystem_Direct3D11 ${AMDAGS_LIBRARIES})
+ endif()
+ 
+ ogre_config_plugin(RenderSystem_Direct3D11)
+-install(FILES ${HEADER_FILES} DESTINATION include/OGRE/RenderSystems/Direct3D11)
++install(FILES ${HEADER_FILES} DESTINATION include/${OGRE_NEXT_PREFIX}/RenderSystems/Direct3D11)

--- a/ports/ogre-next/toolchain_fixes.patch
+++ b/ports/ogre-next/toolchain_fixes.patch
@@ -1,15 +1,14 @@
 diff --git a/CMake/CMakeLists.txt b/CMake/CMakeLists.txt
-index f3a62f2..b53df6f 100644
 --- a/CMake/CMakeLists.txt
 +++ b/CMake/CMakeLists.txt
-@@ -13,10 +13,12 @@
+@@ -13,8 +13,10 @@
  # directory, but can also be used for custom projects.
  #############################################################
  
 -if(WIN32 OR APPLE)
 -	set(OGRE_CMAKE_DIR "CMake")
 -else()
--	set(OGRE_CMAKE_DIR "${OGRE_LIB_DIRECTORY}/OGRE/cmake")
+-  set(OGRE_CMAKE_DIR "${OGRE_LIB_DIRECTORY}/${OGRE_NEXT_PREFIX}/cmake")
 +if(NOT DEFINED OGRE_CMAKE_DIR)
 +  if(WIN32 OR APPLE)
 +    set(OGRE_CMAKE_DIR "CMake")
@@ -17,8 +16,6 @@ index f3a62f2..b53df6f 100644
 +    set(OGRE_CMAKE_DIR "${OGRE_LIB_DIRECTORY}/OGRE/cmake")
 +  endif()
  endif()
- 
- set(INST_FILES
 diff --git a/CMake/Packages/FindGLSLOptimizer.cmake b/CMake/Packages/FindGLSLOptimizer.cmake
 index dd4b179..6f158fc 100644
 --- a/CMake/Packages/FindGLSLOptimizer.cmake
@@ -156,15 +153,13 @@ index 48af55b..b18ac57 100644
      string(REGEX REPLACE "(\r?\n)+$" "" CMAKE_OSX_SYSROOT "${CMAKE_OSX_SYSROOT}")
    else()
 diff --git a/OgreMain/CMakeLists.txt b/OgreMain/CMakeLists.txt
-index 0424ebb..b019269 100644
 --- a/OgreMain/CMakeLists.txt
 +++ b/OgreMain/CMakeLists.txt
-@@ -434,8 +434,6 @@ if (APPLE)
-     set_target_properties(OgreMain PROPERTIES
+@@ -438,7 +438,5 @@ if (APPLE)
+     set_target_properties(${OGRE_NEXT}Main PROPERTIES
          LINK_FLAGS "-framework IOKit -framework Cocoa -framework Carbon -framework OpenGL -framework CoreVideo"
      )
 -
 -    set(OGRE_OSX_BUILD_CONFIGURATION "$(PLATFORM_NAME)/$(CONFIGURATION)")
    
-   	add_custom_command(TARGET OgreMain POST_BUILD
- 		COMMAND mkdir ARGS -p ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/Threading
+ 	add_custom_command(TARGET ${OGRE_NEXT}Main POST_BUILD

--- a/ports/ogre-next/toolchain_fixes.patch
+++ b/ports/ogre-next/toolchain_fixes.patch
@@ -13,7 +13,7 @@ diff --git a/CMake/CMakeLists.txt b/CMake/CMakeLists.txt
 +  if(WIN32 OR APPLE)
 +    set(OGRE_CMAKE_DIR "CMake")
 +  else()
-+    set(OGRE_CMAKE_DIR "${OGRE_LIB_DIRECTORY}/OGRE/cmake")
++    set(OGRE_CMAKE_DIR "${OGRE_LIB_DIRECTORY}/${OGRE_NEXT_PREFIX}/cmake")
 +  endif()
  endif()
 diff --git a/CMake/Packages/FindGLSLOptimizer.cmake b/CMake/Packages/FindGLSLOptimizer.cmake

--- a/ports/ogre-next/vcpkg.json
+++ b/ports/ogre-next/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ogre-next",
-  "version": "2.3.1",
-  "port-version": 4,
+  "version": "2.3.2",
   "description": "Ogre 2.1 & 2.2 - scene-oriented, flexible 3D engine written in C++",
   "homepage": "https://github.com/OGRECave/ogre-next",
   "license": "MIT",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -814,17 +814,6 @@ offscale-libetcd-cpp:arm64-uwp=fail
 offscale-libetcd-cpp:x64-uwp=fail
 ogdf:arm64-android=fail
 ogre:arm64-osx=fail
-# Conflicts with ogre
-ogre-next:arm64-windows      = skip
-ogre-next:arm64-uwp            = skip
-ogre-next:x64-osx            = skip
-ogre-next:arm64-osx          = skip
-ogre-next:x64-linux          = skip
-ogre-next:x64-uwp            = skip
-ogre-next:x64-windows        = skip
-ogre-next:x64-windows-static = skip
-ogre-next:x64-windows-static-md=skip
-ogre-next:x86-windows        = skip
 ois:x64-android=fail
 # ompl is vulnerable to some form of race in its dependent ports, and adding 'ode' as a dependency
 # does not resolve the issue

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3178,7 +3178,7 @@
     },
     "gz-cmake3": {
       "baseline": "3.4.1",
-      "port-version": 3
+      "port-version": 4
     },
     "gz-common5": {
       "baseline": "5.4.1",
@@ -6097,8 +6097,8 @@
       "port-version": 2
     },
     "ogre-next": {
-      "baseline": "2.3.1",
-      "port-version": 4
+      "baseline": "2.3.2",
+      "port-version": 0
     },
     "ois": {
       "baseline": "1.5.1",

--- a/versions/g-/gz-cmake3.json
+++ b/versions/g-/gz-cmake3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0238546ece05d52d030eb6dd62373ae4b65d1503",
+      "version": "3.4.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "5ac0952f283b1e4a700a12c0d616066b36fdeff2",
       "version": "3.4.1",
       "port-version": 3

--- a/versions/o-/ogre-next.json
+++ b/versions/o-/ogre-next.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b9035ff75c5fce90071c09f449b6c847ac70ecc",
+      "version": "2.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "9005bf2b8f0d060493c44cd2c2f49d411faa2141",
       "version": "2.3.1",
       "port-version": 4

--- a/versions/o-/ogre-next.json
+++ b/versions/o-/ogre-next.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f0b1487314fbc98c529e2a50dca48153508be56d",
+      "git-tree": "e79346cd0f83209b8d6b14b8d486971918013ce9",
       "version": "2.3.2",
       "port-version": 0
     },

--- a/versions/o-/ogre-next.json
+++ b/versions/o-/ogre-next.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4b9035ff75c5fce90071c09f449b6c847ac70ecc",
+      "git-tree": "f0b1487314fbc98c529e2a50dca48153508be56d",
       "version": "2.3.2",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

From version 2.3.2 there is an option to change the lib name to new name to OgreNext that it will not conflict with OGRE lib names. compile it on the ci alongside. 

Compile it along side with ogre port on windows and linux, and also compile the gz-rendering7 that use this port.