### PR TITLE
[materialx] update to 1.38.8

### DIFF
--- a/ports/materialx/portfile.cmake
+++ b/ports/materialx/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/MaterialX
-    REF b1ba83b312576fc58f02a6a7db40b18ddbe4f87f # 1.38.4
-    SHA512 3988c42d487e391f9f0f3ab5f34eaa26c7f450079695d96954b871e078eecfe692daa9917279560ba3f10bf771685df3da6e26273d575a23a11c3d17fb897c62
+    REF "v${VERSION}"
+    SHA512 64d5b989fdddfd9d1b21f9dccf914d2674a23c9fd9d24f121ff451ab333e359dc8ab253f72827d68cd2ed59b0c03a51818cc71aa2adf5adfe74eabe0fd58c682
     HEAD_REF main
 )
 

--- a/ports/materialx/vcpkg.json
+++ b/ports/materialx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "materialx",
-  "version": "1.38.4",
+  "version": "1.38.8",
   "description": "MaterialX is an open standard for the exchange of rich material and look-development content across applications and renderers.",
   "homepage": "https://www.materialx.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5357,7 +5357,7 @@
       "port-version": 0
     },
     "materialx": {
-      "baseline": "1.38.4",
+      "baseline": "1.38.8",
       "port-version": 0
     },
     "mathc": {

--- a/versions/m-/materialx.json
+++ b/versions/m-/materialx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8895aa1059cf4106a82265c242871ae6db5b815",
+      "version": "1.38.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "f0dc3a4ac664a5b4fe18a946a35965b519c148e7",
       "version": "1.38.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

