### PR TITLE
[tomlplusplus] update to 3.4.0

### DIFF
--- a/ports/tomlplusplus/fix-android-fileapi.patch
+++ b/ports/tomlplusplus/fix-android-fileapi.patch
@@ -1,9 +1,9 @@
 diff --git a/include/toml++/impl/parser.inl b/include/toml++/impl/parser.inl
-index 27de2b0..bb2fb46 100644
+index 6f0136f..be37f0d 100644
 --- a/include/toml++/impl/parser.inl
 +++ b/include/toml++/impl/parser.inl
 @@ -23,6 +23,12 @@
- #include "unicode.h"
+ #include "unicode.hpp"
  TOML_DISABLE_WARNINGS;
  #include <istream>
 +

--- a/ports/tomlplusplus/portfile.cmake
+++ b/ports/tomlplusplus/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO marzer/tomlplusplus
     REF "v${VERSION}"
-    SHA512 6ab2de83b7fc44de40e58a47c28a9507bf7c50fa9b08925b5a6d48958868a86e6790aff684d29ceb50ad18905e3832840719e1b7bfec3b8a0c00b15bb0f70f38
+    SHA512 c227fc8147c9459b29ad24002aaf6ab2c42fac22ea04c1c52b283a0172581ccd4527b33c1931e0ef0d1db6b6a53f9e9882c6d4231c7f3494cf070d0220741aa5
     HEAD_REF master
     PATCHES
         fix-android-fileapi.patch

--- a/ports/tomlplusplus/vcpkg.json
+++ b/ports/tomlplusplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tomlplusplus",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Header-only TOML config file parser and serializer for modern C++.",
   "homepage": "https://marzer.github.io/tomlplusplus/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8445,7 +8445,7 @@
       "port-version": 0
     },
     "tomlplusplus": {
-      "baseline": "3.3.0",
+      "baseline": "3.4.0",
       "port-version": 0
     },
     "torch-th": {

--- a/versions/t-/tomlplusplus.json
+++ b/versions/t-/tomlplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9866e66fa79aa1addd508e672062392313fc6085",
+      "version": "3.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e5d2f60be4fafc9cf2f8a9fbf5b69c8001e7f461",
       "version": "3.3.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

