### PR TITLE
[aom] Bump to 3.7.0

### DIFF
--- a/ports/aom/aom-rename-static.diff
+++ b/ports/aom/aom-rename-static.diff
@@ -1,12 +1,33 @@
-diff -pruN aom-3.0.0.o/CMakeLists.txt aom-3.0.0/CMakeLists.txt
---- aom-3.0.0.o/CMakeLists.txt	2021-04-15 20:05:52.695181200 +0300
-+++ aom-3.0.0/CMakeLists.txt	2021-04-15 22:34:16.147522600 +0300
-@@ -249,7 +249,7 @@ endif()
- add_library(aom ${AOM_SOURCES} $<TARGET_OBJECTS:aom_rtcd>)
- if(BUILD_SHARED_LIBS)
-   add_library(aom_static STATIC ${AOM_SOURCES} $<TARGET_OBJECTS:aom_rtcd>)
--  set_target_properties(aom_static PROPERTIES OUTPUT_NAME aom)
-+  set_target_properties(aom_static PROPERTIES OUTPUT_NAME aom_static)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2e5b623..bed61da 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -314,6 +314,15 @@ if(BUILD_SHARED_LIBS)
+     set_target_properties(aom PROPERTIES SOVERSION ${SO_VERSION})
+     set_target_properties(aom PROPERTIES VERSION ${SO_FILE_VERSION})
+   endif()
++
++  # override conditional changes
++  set_target_properties(aom PROPERTIES
++      ARCHIVE_OUTPUT_NAME aom
++  )
++  set_target_properties(aom_static PROPERTIES
++      ARCHIVE_OUTPUT_NAME aom_static
++      EXCLUDE_FROM_ALL 1
++  )
+ endif()
  
-   if(NOT MSVC)
-     # Extract version string and set VERSION/SOVERSION for the aom target.
+ if(NOT WIN32 AND NOT APPLE)
+diff --git a/build/cmake/aom_install.cmake b/build/cmake/aom_install.cmake
+index b02c7b9..c219841 100644
+--- a/build/cmake/aom_install.cmake
++++ b/build/cmake/aom_install.cmake
+@@ -79,7 +79,7 @@ macro(setup_aom_install_targets)
+     endif()
+ 
+     if(BUILD_SHARED_LIBS)
+-      set(AOM_INSTALL_LIBS aom aom_static)
++      set(AOM_INSTALL_LIBS aom)
+     else()
+       set(AOM_INSTALL_LIBS aom)
+     endif()

--- a/ports/aom/aom-uninitialized-pointer.diff
+++ b/ports/aom/aom-uninitialized-pointer.diff
@@ -1,8 +1,8 @@
 diff --git a/build/cmake/aom_configure.cmake b/build/cmake/aom_configure.cmake
-index 43d60ae..35c510b 100644
+index aaef2c310..5500ad4a3 100644
 --- a/build/cmake/aom_configure.cmake
 +++ b/build/cmake/aom_configure.cmake
-@@ -265,6 +265,8 @@ if(MSVC)
+@@ -309,6 +309,8 @@ if(MSVC)
  
    # Disable MSVC warnings that suggest making code non-portable.
    add_compiler_flag_if_supported("/wd4996")

--- a/ports/aom/portfile.cmake
+++ b/ports/aom/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_add_to_path(${PERL_PATH})
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL "https://aomedia.googlesource.com/aom"
-    REF 9a83c6a5a55c176adbce740e47d3512edfc9ae71 # v3.5.0
+    REF 6054fae218eda6e53e1e3b4f7ef0fff4877c7bf1 # v3.7.0
     PATCHES
         aom-rename-static.diff
         aom-uninitialized-pointer.diff
@@ -24,6 +24,10 @@ if(VCPKG_TARGET_IS_UWP OR (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE
     # UWP + aom's assembler files result in weirdness and build failures
     # Also, disable assembly on ARM and ARM64 Windows to fix compilation issues.
     set(aom_target_cpu "-DAOM_TARGET_CPU=generic")
+endif()
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" AND VCPKG_TARGET_IS_LINUX)
+  set(aom_target_cpu "-DENABLE_NEON=OFF")
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/aom/vcpkg.json
+++ b/ports/aom/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "aom",
-  "version-semver": "3.5.0",
-  "port-version": 1,
+  "version-semver": "3.7.0",
   "description": "AV1 codec library",
   "homepage": "https://aomedia.googlesource.com/aom",
   "license": "BSD-2-Clause",

--- a/versions/a-/aom.json
+++ b/versions/a-/aom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "71fe99b6007b153a98a5058a2d2212117af8031a",
+      "version-semver": "3.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "daaa6d5ccf417cb9e4997d35b9574f18eaa98cd3",
       "version-semver": "3.5.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -153,8 +153,8 @@
       "port-version": 2
     },
     "aom": {
-      "baseline": "3.5.0",
-      "port-version": 1
+      "baseline": "3.7.0",
+      "port-version": 0
     },
     "apache-datasketches": {
       "baseline": "4.1.0",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
