### PR TITLE
[dartsim] update to 6.13.0

### DIFF
--- a/ports/dartsim/disable_unit_tests_examples_and_tutorials.patch
+++ b/ports/dartsim/disable_unit_tests_examples_and_tutorials.patch
@@ -1,8 +1,8 @@
 ﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 100bfb8b59be..b0779885c788 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -292,7 +292,7 @@ add_subdirectory(dart)
+@@ -323,8 +323,8 @@
+ add_subdirectory(dart)
  
  set(DART_IN_SOURCE_BUILD TRUE)
  
@@ -12,15 +12,13 @@ index 100bfb8b59be..b0779885c788 100644
    # Add a "tests" target to build unit tests.
    enable_testing()
 diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
-index 08ef983cdcfa..7092d89bb17d 100644
 --- a/python/CMakeLists.txt
 +++ b/python/CMakeLists.txt
-@@ -1,6 +1,8 @@
- set(DART_DARTPY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/dartpy")
- 
+@@ -19,5 +10,7 @@
  add_subdirectory(dartpy)
 +if(0)
  add_subdirectory(tests)
  add_subdirectory(examples)
  add_subdirectory(tutorials)
 +endif()
+ 

--- a/ports/dartsim/fix-pc-dependencies.patch
+++ b/ports/dartsim/fix-pc-dependencies.patch
@@ -1,0 +1,8 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -74,3 +74,3 @@
+ set(DART_PKG_DESC "Dynamic Animation and Robotics Toolkit.")
+-set(DART_PKG_EXTERNAL_DEPS "eigen, ccd, fcl, assimp")
++set(DART_PKG_EXTERNAL_DEPS "assimp, ccd, eigen3, fcl, octomap")
+ 

--- a/ports/dartsim/portfile.cmake
+++ b/ports/dartsim/portfile.cmake
@@ -4,11 +4,12 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dartsim/dart
-    REF v6.12.2
-    SHA512 6d04da37d0eb40a35a3aaec583af024e2edf71d68bb38b6832760de21a349221387644ed9be0cc1e451c669bbf48eb53d8d0cd3be1b1b265a30be2aa17c7e48b
+    REF v${VERSION}
+    SHA512 7af47f2eb2b97f5a18a39800e07ad8ba2a2876e26c1bc09935ebd3e8554310259a3a7c9097a6be9978a61550926b5a43de60463bcb8da4dddfac74ebc3864287
     HEAD_REF main
     PATCHES
         disable_unit_tests_examples_and_tutorials.patch
+        fix-pc-dependencies.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/dartsim/vcpkg.json
+++ b/ports/dartsim/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dartsim",
-  "version": "6.12.2",
-  "port-version": 2,
+  "version": "6.13.0",
   "description": "Dynamic Animation and Robotics Toolkit",
   "homepage": "https://dartsim.github.io/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2077,8 +2077,8 @@
       "port-version": 3
     },
     "dartsim": {
-      "baseline": "6.12.2",
-      "port-version": 2
+      "baseline": "6.13.0",
+      "port-version": 0
     },
     "dataframe": {
       "baseline": "2.1.0",

--- a/versions/d-/dartsim.json
+++ b/versions/d-/dartsim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2fe7a74cf5e6b318a837630b7f18687f0ebd549",
+      "version": "6.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "af3970efb060832f60efe9ad00eef7bc0e824a90",
       "version": "6.12.2",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
