### PR TITLE
[utfcpp] Update to 4.0.2

### DIFF
--- a/ports/assimp/build_fixes.patch
+++ b/ports/assimp/build_fixes.patch
@@ -171,7 +171,7 @@ index ca37ba1..2ce7bdd 100644
  #  include <utf8.h>
  #else
 -#  include "../contrib/utf8cpp/source/utf8.h"
-+#  include <utf8.h>
++#  include <utf8cpp/utf8.h>
  #endif
  #include <assimp/Exceptional.h>
  
@@ -184,7 +184,7 @@ index 7b66afa..5adbe1d 100644
  #include <utf8.h>
  #else
 -#include "../contrib/utf8cpp/source/utf8.h"
-+#include <utf8.h>
++#include <utf8cpp/utf8.h>
  #endif
  #include <assimp/importerdesc.h>
  #include <assimp/scene.h>
@@ -197,7 +197,7 @@ index d4456e6..812f29b 100644
  #  include <utf8.h>
  #else
 -#  include <contrib/utf8cpp/source/utf8.h>
-+#  include <utf8.h>
++#  include <utf8cpp/utf8.h>
  #endif
  
  #include <memory>
@@ -390,7 +390,8 @@ index 5339454..45e07c0 100644
 -      RapidJSON::rapidjson
 +      ZLIB::ZLIB
 +      rapidjson
-       utf8cpp
+-      utf8cpp
++      utf8cpp::utf8cpp
 +      PUBLIC
        pugixml
 -      stb::stb
@@ -500,7 +501,7 @@ index 383300e..03fdd9a 100644
  #include <utf8.h>
  #else
 -#include "../contrib/utf8cpp/source/utf8.h"
-+#include <utf8.h>
++#include <utf8cpp/utf8.h>
  #endif
  
  // ------------------------------------------------------------------------------------------------

--- a/ports/assimp/vcpkg.json
+++ b/ports/assimp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "assimp",
   "version": "5.3.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Open Asset import library",
   "homepage": "https://github.com/assimp/assimp",
   "license": "BSD-3-Clause",

--- a/ports/utfcpp/fix-include-path.patch
+++ b/ports/utfcpp/fix-include-path.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2ca50a6..d707dc7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,7 +10,7 @@ include(GNUInstallDirs)
+ 
+ target_include_directories(utf8cpp INTERFACE
+     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/source>"
+-    $<INSTALL_INTERFACE:include>
++    $<INSTALL_INTERFACE:include/utf8cpp>
+ )
+ 
+ include(CMakePackageConfigHelpers)
+@@ -44,5 +44,5 @@ install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+               "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+ 
+-install(FILES ${PROJECT_SOURCE_DIR}/source/utf8.h DESTINATION include)
+-install(DIRECTORY ${PROJECT_SOURCE_DIR}/source/utf8 DESTINATION include)
++install(FILES ${PROJECT_SOURCE_DIR}/source/utf8.h DESTINATION include/utf8cpp)
++install(DIRECTORY ${PROJECT_SOURCE_DIR}/source/utf8 DESTINATION include/utf8cpp)

--- a/ports/utfcpp/portfile.cmake
+++ b/ports/utfcpp/portfile.cmake
@@ -4,25 +4,16 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nemtrif/utfcpp
     REF "v${VERSION}"
-    SHA512 1ce12c8158a2f3bcddec104ceacedaea4031b4c88fc0fa1f1fae8dfa8df81c846861df9d01e8f294d79b9e4ab8c51bd1289f404eed24d07abc760688fee13090
+    SHA512 e02c10c7e9c8c6ee8b8d45bb7521997106be1bf6778d964d4c66a4f025b6ce46df43be12dc74b03639be9f99db8aa4d8c22a65880a057aeb0e76a90bb87c760c
     HEAD_REF master
+    PATCHES fix-include-path.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DUTF8_INSTALL=ON
-        -DUTF8_SAMPLES=OFF
-        -DUTF8_TESTS=OFF
 )
 
 vcpkg_cmake_install()
-
-if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-    vcpkg_cmake_config_fixup(PACKAGE_NAME utf8cpp CONFIG_PATH cmake)
-else()
-    vcpkg_cmake_config_fixup(PACKAGE_NAME utf8cpp CONFIG_PATH lib/cmake/utf8cpp)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-endif()
+vcpkg_cmake_config_fixup(PACKAGE_NAME utf8cpp CONFIG_PATH share/utf8cpp/cmake)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/utfcpp/vcpkg.json
+++ b/ports/utfcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "utfcpp",
-  "version": "3.2.5",
+  "version": "4.0.2",
   "description": "UTF-8 with C++ in a Portable Way",
   "homepage": "https://github.com/nemtrif/utfcpp",
   "license": "BSL-1.0",

--- a/versions/a-/assimp.json
+++ b/versions/a-/assimp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76ae4b01818ee27c5beac4d0b18cb566f94f27ec",
+      "version": "5.3.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "a825878e38726e638f29d4defeadb9108ac20697",
       "version": "5.3.1",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -270,7 +270,7 @@
     },
     "assimp": {
       "baseline": "5.3.1",
-      "port-version": 2
+      "port-version": 3
     },
     "async-mqtt": {
       "baseline": "2.0.0",
@@ -8677,7 +8677,7 @@
       "port-version": 1
     },
     "utfcpp": {
-      "baseline": "3.2.5",
+      "baseline": "4.0.2",
       "port-version": 0
     },
     "utfz": {

--- a/versions/u-/utfcpp.json
+++ b/versions/u-/utfcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3ceee3e19b95edf9e59c813da7764a68145bfd1",
+      "version": "4.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "323b2ffdbd38cf8e756a5ae5714ef2169c0cd6b3",
       "version": "3.2.5",
       "port-version": 0


### PR DESCRIPTION
Update utfcpp from 3.2.5 to 4.0.2 : 
https://github.com/nemtrif/utfcpp/releases/tag/v4.0.1
https://github.com/nemtrif/utfcpp/releases/tag/v4.0.2

The CMakeLists.txt file was [entirely rewritten](https://github.com/nemtrif/utfcpp/pull/110/commits/72527bda4b26b804d9e7569541b400ef1749e604) on the version 4.0.0, and I removed the CMake options and the MinGW fix because they aren't necessary anymore. The assimp port also required some minor tweaks to be able to build with this new version.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.