### PR TITLE
[libpqxx] add cxx20 feature

### DIFF
--- a/ports/libpqxx/portfile.cmake
+++ b/ports/libpqxx/portfile.cmake
@@ -11,10 +11,21 @@ vcpkg_from_github(
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/config-public-compiler.h.in" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/config-internal-compiler.h.in" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cxx20 LIBPQXX_USE_CXX20
+)
+
+if (LIBPQXX_USE_CXX20)
+    set(LIBPQXX_USE_CXX20_OPTION "-DCMAKE_CXX_STANDARD=20")
+    message(STATUS "Force CMAKE_CXX_STANDARD to 20")
+endif ()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSKIP_BUILD_TEST=ON
+        ${LIBPQXX_USE_CXX20_OPTION}  
 )
 
 vcpkg_cmake_install()

--- a/ports/libpqxx/vcpkg.json
+++ b/ports/libpqxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpqxx",
   "version": "7.8.1",
+  "port-version": 1,
   "description": "The official C++ client API for PostgreSQL",
   "homepage": "https://www.postgresql.org/",
   "license": "BSD-3-Clause",
@@ -17,5 +18,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "cxx20": {
+      "description": "Enable compiler C++20."
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4642,7 +4642,7 @@
     },
     "libpqxx": {
       "baseline": "7.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libprotobuf-mutator": {
       "baseline": "1.1",

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "417af18b0c345d75b31323392ebba35e7906df8d",
+      "version": "7.8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "8083e94ed4ded4546cbad5263a7efb4b9b154b73",
       "version": "7.8.1",
       "port-version": 0


### PR DESCRIPTION
According discussion add cxx20 feature
https://github.com/jtv/libpqxx/issues/743#issuecomment-1794714813
 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



