### PR TITLE
[libmariadb][baseline] skip libmariadb

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -576,6 +576,7 @@ libmariadb:x64-uwp            = skip
 libmariadb:x64-windows        = skip
 libmariadb:x64-windows-static = skip
 libmariadb:x64-windows-static-md=skip
+libmariadb:x86-windows=skip
 # libmesh installs tons of problematic files that conflict with other ports (boost, eigen, etc)
 libmesh:x64-linux=skip
 libmikmod:arm-neon-android=fail


### PR DESCRIPTION
`libmysql` and `libmariadb` both provide `mysql.h`. We've chosen to skip `libmariadb` to avoid the conflict. https://dev.azure.com/vcpkg/public/_build/results?buildId=96261&view=results