### PR TITLE
[configcat] Update to version 3.1.0 

### DIFF
--- a/ports/configcat/portfile.cmake
+++ b/ports/configcat/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO configcat/cpp-sdk
     REF "v${VERSION}"
-    SHA512 cb86f575e1917edf10ec423d4ae85b47c979370bdb4381e1eecdb32bc64637f5088b3a3d91fa1b0aa2604fb0fe3011bc0964b3a45e5aa32aba1d53ba0da99fd5
+    SHA512 f5a2217e0b451cb2390091dfec4e89e0fb3abfa22d74ed75e1038e060fe3009d0e114bf6f6556949e6574c3e82ca72bc6aad8be8fb5d3f0dea36a867f992d27f
     HEAD_REF master
 )
 

--- a/ports/configcat/vcpkg.json
+++ b/ports/configcat/vcpkg.json
@@ -5,8 +5,19 @@
   "homepage": "https://configcat.com/",
   "license": "MIT",
   "dependencies": [
+    {
+      "name": "curl",
+      "default-features": false,
+      "features": [
+        "ssl"
+      ]
+    },
     "hash-library",
     "nlohmann-json",
+    {
+      "name": "openssl",
+      "platform": "linux"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -15,17 +26,6 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "z4kn4fein-semver",
-    {
-      "name": "curl",
-      "default-features": false,
-      "features": [
-        "ssl"
-      ]
-    },
-    {
-      "name": "openssl",
-      "platform": "linux"
-    }
+    "z4kn4fein-semver"
   ]
 }

--- a/ports/configcat/vcpkg.json
+++ b/ports/configcat/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "configcat",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "ConfigCat SDK for C++ provides easy integration for your application to ConfigCat. ConfigCat is a feature flag and configuration management service that lets you separate feature releases from deployments. Alternative to LaunchDarkly.",
   "homepage": "https://configcat.com/",
   "license": "MIT",
   "dependencies": [
-    "cpr",
     "hash-library",
     "nlohmann-json",
     {
@@ -16,6 +15,17 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "z4kn4fein-semver"
+    "z4kn4fein-semver",
+    {
+      "name": "curl",
+      "default-features": false,
+      "features": [
+        "ssl"
+      ]
+    },
+    {
+      "name": "openssl",
+      "platform": "linux"
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1757,7 +1757,7 @@
       "port-version": 0
     },
     "configcat": {
-      "baseline": "3.0.0",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "console-bridge": {

--- a/versions/c-/configcat.json
+++ b/versions/c-/configcat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8beddf56b4ad53f7c2bbd1e457c31858f1906e9c",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5a5b038429eeed3e978742cb13ea7c207ad57d33",
       "version": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
