### PR TITLE
[workflow] update to v0.10.9

### DIFF
--- a/ports/workflow/portfile.cmake
+++ b/ports/workflow/portfile.cmake
@@ -2,7 +2,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO sogou/workflow
-        REF v0.10.9-win
+        REF "v${VERSION}-win"
         SHA512 c34518ca35f19ab5539ea82cc73ecbc9828413530cec8dbbe56b17517ec6b7b0326a29e5b343b950afe128829c8e23e75d19494e17f7be4fce9edb524c44ee56
         HEAD_REF windows
     )
@@ -10,7 +10,7 @@ else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO sogou/workflow
-        REF v0.10.9
+        REF "v${VERSION}"
         SHA512 25258e9dc161c5b30395caa3525a4ba5de5763cad5761cbdc8bb23d2468eb624ec49455a5c9ab628c219d7436f707da0138229c5fa82bcfccc24a485649acb56
         HEAD_REF master
     )

--- a/ports/workflow/portfile.cmake
+++ b/ports/workflow/portfile.cmake
@@ -2,16 +2,16 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO sogou/workflow
-        REF v0.10.5-win
-        SHA512 4299b2c8bc545676b5437086c666a7b0955524aae758a8753719439697b3dd4d5b46c0a8eba9dba80c0daa9ee9c4188e46fd085f0d2f68f61b33fad1f903c4c2
+        REF v0.10.9-win
+        SHA512 c34518ca35f19ab5539ea82cc73ecbc9828413530cec8dbbe56b17517ec6b7b0326a29e5b343b950afe128829c8e23e75d19494e17f7be4fce9edb524c44ee56
         HEAD_REF windows
     )
 else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO sogou/workflow
-        REF v0.10.5
-        SHA512 696e82a1f6a7e6c339fbabb7b1f98ffe40f5f5ee7e77f4c947c0c1532817409e7a61f020c6238a32acd9eb3e06cf3e522e6d67beda32d5bbb08ea1080c20277d
+        REF v0.10.9
+        SHA512 25258e9dc161c5b30395caa3525a4ba5de5763cad5761cbdc8bb23d2468eb624ec49455a5c9ab628c219d7436f707da0138229c5fa82bcfccc24a485649acb56
         HEAD_REF master
     )
 endif()

--- a/ports/workflow/vcpkg.json
+++ b/ports/workflow/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.10.5",
-  "port-version": 1,
+  "version": "0.10.9",
   "description": "About C++ Parallel Computing and Asynchronous Networking Engine",
   "homepage": "https://github.com/sogou/workflow",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9029,8 +9029,8 @@
       "port-version": 3
     },
     "workflow": {
-      "baseline": "0.10.5",
-      "port-version": 1
+      "baseline": "0.10.9",
+      "port-version": 0
     },
     "wpilib": {
       "baseline": "2023-08-24",

--- a/versions/w-/workflow.json
+++ b/versions/w-/workflow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45ebbbab01f76def4493876ef5475f4b7b4249e7",
+      "version": "0.10.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "6f084c7076efb69884874d9cccadf7317c42b370",
       "version": "0.10.5",
       "port-version": 1

--- a/versions/w-/workflow.json
+++ b/versions/w-/workflow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "45ebbbab01f76def4493876ef5475f4b7b4249e7",
+      "git-tree": "6b72e08d163acabe70e7804d7b3acc719c406ebf",
       "version": "0.10.9",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.