### PR TITLE
[joltphysics] Update to 4.0.0

### DIFF
--- a/ports/joltphysics/fix-export.diff
+++ b/ports/joltphysics/fix-export.diff
@@ -1,8 +1,8 @@
 diff --git a/Build/CMakeLists.txt b/Build/CMakeLists.txt
-index e4fddc50..655cdc80 100644
+index cc4cf1d..330b987 100644
 --- a/Build/CMakeLists.txt
 +++ b/Build/CMakeLists.txt
-@@ -91,8 +91,8 @@ if (("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUA
+@@ -100,8 +100,8 @@ if (("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUA
  	endif()
  
  	# Set compiler flags for various configurations
@@ -13,7 +13,7 @@ index e4fddc50..655cdc80 100644
  	set(CMAKE_CXX_FLAGS_DISTRIBUTION "/GS- /Gy /O2 /Oi /Ot")
  	set(CMAKE_CXX_FLAGS_RELEASEASAN "-fsanitize=address /Od")
  	set(CMAKE_CXX_FLAGS_RELEASEUBSAN "-fsanitize=undefined,implicit-conversion,float-divide-by-zero,local-bounds -fno-sanitize-recover=all")
-@@ -148,8 +148,8 @@ elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR "${CMAKE_SYSTEM_NAME}" STREQU
+@@ -160,8 +160,8 @@ elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR "${CMAKE_SYSTEM_NAME}" STREQU
  	endif()
  
  	# Set compiler flags for various configurations
@@ -24,7 +24,7 @@ index e4fddc50..655cdc80 100644
  	set(CMAKE_CXX_FLAGS_DISTRIBUTION "-O3")
  	set(CMAKE_CXX_FLAGS_RELEASEASAN "-fsanitize=address")
  	set(CMAKE_CXX_FLAGS_RELEASEUBSAN "-fsanitize=undefined,implicit-conversion,float-divide-by-zero,local-bounds -fno-sanitize-recover=all")
-@@ -193,7 +193,11 @@ if (IOS)
+@@ -205,7 +205,11 @@ if (XCODE)
  endif()
  
  # Install Jolt library and includes
@@ -37,7 +37,7 @@ index e4fddc50..655cdc80 100644
  foreach(SRC_FILE ${JOLT_PHYSICS_SRC_FILES})
  	string(REPLACE ${PHYSICS_REPO_ROOT} "" RELATIVE_SRC_FILE ${SRC_FILE})
  	get_filename_component(DESTINATION_PATH ${RELATIVE_SRC_FILE} DIRECTORY)
-@@ -202,6 +206,17 @@ foreach(SRC_FILE ${JOLT_PHYSICS_SRC_FILES})
+@@ -214,6 +218,17 @@ foreach(SRC_FILE ${JOLT_PHYSICS_SRC_FILES})
  	endif()
  endforeach()
  
@@ -52,17 +52,17 @@ index e4fddc50..655cdc80 100644
 +  DESTINATION share/unofficial-joltphysics
 +)
 +
- # Check if we're the root CMakeLists.txt, if not we are included by another CMake file and we should disable everything except for the main library 
+ # Check if we're the root CMakeLists.txt, if not we are included by another CMake file and we should disable everything except for the main library
  if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
  	# Ability to turn ON/OFF individual applications
 diff --git a/Jolt/Jolt.cmake b/Jolt/Jolt.cmake
-index 176a7578..b31b2417 100644
+index c0f7099..d447a3f 100644
 --- a/Jolt/Jolt.cmake
 +++ b/Jolt/Jolt.cmake
-@@ -431,10 +431,13 @@ source_group(TREE ${JOLT_PHYSICS_ROOT} FILES ${JOLT_PHYSICS_SRC_FILES})
+@@ -474,10 +474,13 @@ if (BUILD_SHARED_LIBS)
+ 	target_compile_definitions(Jolt PRIVATE JPH_BUILD_SHARED_LIBRARY)
+ endif()
  
- # Create Jolt lib
- add_library(Jolt STATIC ${JOLT_PHYSICS_SRC_FILES})
 -target_include_directories(Jolt PUBLIC ${PHYSICS_REPO_ROOT})
 +target_include_directories(Jolt PUBLIC
 +  $<BUILD_INTERFACE:${PHYSICS_REPO_ROOT}>

--- a/ports/joltphysics/portfile.cmake
+++ b/ports/joltphysics/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jrouwe/JoltPhysics
-    REF "v${VERSION}"
-    SHA512 367e5b945e8f91a0c0c9eb699db6f49351aa39b0af9b8fd0be5f474d65b28a7244880eedad10cbd2db0e031daa28bbabb5f9fb8bf9af653dd1f86904bfde44a2
+    REF 4e038d190b7e97df01e6a81c8f74551fe487a09d # Commited on 2023-11-04
+    SHA512 d80383ac0dfadda6ff353bd241c3af9ab879de4f6cba04db7dc0e82ede2a4f120b1af9baca63000cefb06778447105bfd6bd26a9a6b8fa36fc5daaa75772bdf2
     HEAD_REF master
     PATCHES
       fix-export.diff

--- a/ports/joltphysics/portfile.cmake
+++ b/ports/joltphysics/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jrouwe/JoltPhysics
-    REF 4e038d190b7e97df01e6a81c8f74551fe487a09d # Commited on 2023-11-04
-    SHA512 d80383ac0dfadda6ff353bd241c3af9ab879de4f6cba04db7dc0e82ede2a4f120b1af9baca63000cefb06778447105bfd6bd26a9a6b8fa36fc5daaa75772bdf2
+    REF "v${VERSION}"
+    SHA512 9b7530c37fc865682c4a130afc87daef1b038d1f457d2330a5253f35e3a4b6399ad738e97961f0ca8a9ae41ed999179e1c864dc699c5c93341ce4b6e6b2a1a61
     HEAD_REF master
     PATCHES
       fix-export.diff

--- a/ports/joltphysics/vcpkg.json
+++ b/ports/joltphysics/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "joltphysics",
-  "version": "3.0.1",
-  "port-version": 1,
+  "version-date": "2023-11-04",
   "description": "A multi core friendly rigid body physics and collision detection library suitable for games and VR applications",
   "homepage": "https://github.com/jrouwe/JoltPhysics",
   "license": "MIT",

--- a/ports/joltphysics/vcpkg.json
+++ b/ports/joltphysics/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "joltphysics",
-  "version-date": "2023-11-04",
+  "version": "4.0.0",
   "description": "A multi core friendly rigid body physics and collision detection library suitable for games and VR applications",
   "homepage": "https://github.com/jrouwe/JoltPhysics",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3617,7 +3617,7 @@
       "port-version": 3
     },
     "joltphysics": {
-      "baseline": "2023-11-04",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "josuttis-jthread": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3617,8 +3617,8 @@
       "port-version": 3
     },
     "joltphysics": {
-      "baseline": "3.0.1",
-      "port-version": 1
+      "baseline": "2023-11-04",
+      "port-version": 0
     },
     "josuttis-jthread": {
       "baseline": "2020-07-21",

--- a/versions/j-/joltphysics.json
+++ b/versions/j-/joltphysics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8077d0a7c05b6a373d765af5a7e759746df37993",
+      "version-date": "2023-11-04",
+      "port-version": 0
+    },
+    {
       "git-tree": "f8fca568d1ae240c8d3ca23ae3b9a09f6fb518ba",
       "version": "3.0.1",
       "port-version": 1

--- a/versions/j-/joltphysics.json
+++ b/versions/j-/joltphysics.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "8077d0a7c05b6a373d765af5a7e759746df37993",
-      "version-date": "2023-11-04",
-      "port-version": 0
-    },
-    {
       "git-tree": "f8fca568d1ae240c8d3ca23ae3b9a09f6fb518ba",
       "version": "3.0.1",
       "port-version": 1

--- a/versions/j-/joltphysics.json
+++ b/versions/j-/joltphysics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7ea4a51e3f8cfa76e079f80d8ece87ef6695553",
+      "version": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8077d0a7c05b6a373d765af5a7e759746df37993",
       "version-date": "2023-11-04",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #34649, `joltphysics` build failed on gcc 13, and it has been fixed on the new version.
Usage test passed on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
