### PR TITLE
[magnum] fix features

### DIFF
--- a/ports/magnum/portfile.cmake
+++ b/ports/magnum/portfile.cmake
@@ -128,36 +128,40 @@ else()
             file(REMOVE ${LIB_TO_REMOVE})
         endif()
 
-        file(GLOB_RECURSE LIB_TO_REMOVE_DBG "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/*")
-        file(GLOB_RECURSE LIB_TO_KEEP_DBG "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/*Any*")
+        if (VCPKG_TARGET_IS_UWP)
+            set(debug_dir "magnum")
+        else()
+            set(debug_dir "magnum-d")
+        endif()
+
+        file(GLOB_RECURSE LIB_TO_REMOVE_DBG "${CURRENT_PACKAGES_DIR}/debug/lib/${debug_dir}/*")
+        file(GLOB_RECURSE LIB_TO_KEEP_DBG "${CURRENT_PACKAGES_DIR}/debug/lib/${debug_dir}/*Any*")
         if(LIB_TO_KEEP_DBG)
             list(REMOVE_ITEM LIB_TO_REMOVE_DBG ${LIB_TO_KEEP_DBG})
         endif()
         if(LIB_TO_REMOVE_DBG)
             file(REMOVE ${LIB_TO_REMOVE_DBG})
         endif()
-
-        # fonts and fontconverters don't have Any* plugins
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum/fonts")
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum/fontconverters")
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/fonts")
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/fontconverters")
-
+        
         # remove maybe empty dirs
-        file(GLOB maybe_empty "${CURRENT_PACKAGES_DIR}/lib/magnum/importers/*")
-        if(maybe_empty STREQUAL "")
-            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum/importers")
-            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/importers")
-            file(GLOB maybe_empty "${CURRENT_PACKAGES_DIR}/lib/magnum/*")
+        foreach(subdir "fonts" "importers" "fontconverters" "imageconverters" "audioimporters")
+            file(GLOB maybe_empty "${CURRENT_PACKAGES_DIR}/lib/magnum/${subdir}/*")
             if(maybe_empty STREQUAL "")
-                file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum")
-                file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d")
+                file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum/${subdir}")
+                file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/${debug_dir}/${subdir}")
             endif()
+        endforeach()
+
+        file(GLOB maybe_empty "${CURRENT_PACKAGES_DIR}/lib/magnum/*")
+        if(maybe_empty STREQUAL "")
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum")
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/${debug_dir}")
         endif()
+        
     endif()
 
     file(COPY "${CMAKE_CURRENT_LIST_DIR}/magnumdeploy.ps1" DESTINATION "${CURRENT_PACKAGES_DIR}/bin/magnum")
-    file(COPY "${CMAKE_CURRENT_LIST_DIR}/magnumdeploy.ps1" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/magnum-d")
+    file(COPY "${CMAKE_CURRENT_LIST_DIR}/magnumdeploy.ps1" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/${debug_dir}")
 endif()
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/magnum/vcpkg.json
+++ b/ports/magnum/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "magnum",
   "version-string": "2020.06",
-  "port-version": 16,
+  "port-version": 17,
   "description": "C++11/C++14 graphics middleware for games and data visualization",
   "homepage": "https://magnum.graphics/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5326,7 +5326,7 @@
     },
     "magnum": {
       "baseline": "2020.06",
-      "port-version": 16
+      "port-version": 17
     },
     "magnum-extras": {
       "baseline": "2020.06",

--- a/versions/m-/magnum.json
+++ b/versions/m-/magnum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa47736590b34d1ce7158f0ebf783c2b54dcb004",
+      "version-string": "2020.06",
+      "port-version": 17
+    },
+    {
       "git-tree": "d923e5792a77042485ffd4b32afecca23f18c7d9",
       "version-string": "2020.06",
       "port-version": 16


### PR DESCRIPTION
Fixes for example
```
warning: There should be no empty directories in G:\v\vcpkg3\packages\magnum_x64-windows. The following empty directories were found:

  G:\v\vcpkg3\packages\magnum_x64-windows\debug\lib\magnum-d\imageconverters
  G:\v\vcpkg3\packages\magnum_x64-windows\lib\magnum\imageconverters

warning: If a directory should be populated but is not, this might indicate an error in the portfile.
If the directories are not needed and their creation cannot be disabled, use something like this in the portfile to remove them:
    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/imageconverters" "${CURRENT_PACKAGES_DIR}/lib/magnum/imageconverters")
```

Tested with `test-features` on `x64-windows`, `x64-windows-static`, `x64-uwp`