### PR TITLE
[tinyorm] Disable warnings as errors.

### DIFF
--- a/ports/tinyorm/portfile.cmake
+++ b/ports/tinyorm/portfile.cmake
@@ -27,6 +27,7 @@ vcpkg_cmake_configure(
         -DTINY_PORT:STRING=${PORT}
         -DTINY_VCPKG:BOOL=ON
         -DVERBOSE_CONFIGURE:BOOL=ON
+        -DWARNINGS_AS_ERRORS=FALSE
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/tinyorm/vcpkg.json
+++ b/ports/tinyorm/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tinyorm",
   "version-semver": "0.36.5",
+  "port-version": 1,
   "maintainers": "Silver Zachara <silver.zachara@gmail.com>",
   "description": "Modern C++ ORM library for Qt framework",
   "homepage": "https://github.com/silverqx/TinyORM",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8422,7 +8422,7 @@
     },
     "tinyorm": {
       "baseline": "0.36.5",
-      "port-version": 0
+      "port-version": 1
     },
     "tinyply": {
       "baseline": "2.3.4",

--- a/versions/t-/tinyorm.json
+++ b/versions/t-/tinyorm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a9e99fe4b4dca20d2e2a7c3bc9d575e5f1700ba",
+      "version-semver": "0.36.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "b21b31342cfe5d58cce629fab598e6f968e5118e",
       "version-semver": "0.36.5",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix `tinyorm` depends  on `Qt` this warns as error.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
See also:
* https://github.com/microsoft/STL/pull/3818
* [MSVC warns as error on stdext::checked_array_iterator in QtCore/qvector.h](https://bugreports.qt.io/browse/QTBUG-118993)
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
