### PR TITLE
[luajit] add usage

### DIFF
--- a/ports/luajit/Usage
+++ b/ports/luajit/Usage
@@ -1,0 +1,5 @@
+luajit provides usage:
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LuaJIT REQUIRED IMPORTED_TARGET luajit)
+    target_link_libraries(main PRIVATE PkgConfig::LuaJIT)

--- a/ports/luajit/portfile.cmake
+++ b/ports/luajit/portfile.cmake
@@ -106,3 +106,4 @@ vcpkg_copy_tools(TOOL_NAMES luajit AUTO_CLEAN)
 vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/luajit/vcpkg.json
+++ b/ports/luajit/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "luajit",
   "version-date": "2023-01-04",
-  "port-version": 4,
+  "port-version": 5,
   "description": "LuaJIT is a Just-In-Time (JIT) compiler for the Lua programming language.",
   "homepage": "https://github.com/LuaJIT/LuaJIT",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5270,7 +5270,7 @@
     },
     "luajit": {
       "baseline": "2023-01-04",
-      "port-version": 4
+      "port-version": 5
     },
     "luasec": {
       "baseline": "1.3.1",

--- a/versions/l-/luajit.json
+++ b/versions/l-/luajit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8dee9c3be8da76e656c5970a07bff8fecd92da17",
+      "version-date": "2023-01-04",
+      "port-version": 5
+    },
+    {
       "git-tree": "53de073fe6d5962408626e251fce79e2d5bb49bf",
       "version-date": "2023-01-04",
       "port-version": 4


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/34954
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
