### PR TITLE
[log4cxx] fix find_package error

### DIFF
--- a/ports/log4cxx/fix-find-package.patch
+++ b/ports/log4cxx/fix-find-package.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 61c0479..3bd3327 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,7 +60,7 @@ find_package(APR-Util REQUIRED)
+ find_package( Threads REQUIRED )
+ 
+ # Find expat for XML parsing
+-find_package(EXPAT REQUIRED)
++find_package(expat CONFIG REQUIRED)
+ if(TARGET EXPAT::EXPAT)
+   set(EXPAT_LIBRARIES EXPAT::EXPAT)
+ elseif(TARGET expat::expat)

--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(
     SOURCE_PATH ARCHIVE "${ARCHIVE}"
+    PATCHES
+        fix-find-package.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "log4cxx",
   "version": "1.1.0",
+  "port-version": 1,
   "description": "Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR",
   "homepage": "https://logging.apache.org/log4cxx",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5214,7 +5214,7 @@
     },
     "log4cxx": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "loguru": {
       "baseline": "2.1.0",

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c030a796829f4525b2369a135d7bdc615b6fb14b",
+      "version": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "eca29ecb5127d26bd46aad143468b069a045d104",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #34897

Change the port log4cxx upstream function `find_package(EXPAT REQUIRED)` to `find_package(expat CONFIG REQUIRED)` to fix the usage of port log4cxx.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Tested usage successfully by log4cxx:x64-linux:
````
log4cxx provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(log4cxx CONFIG REQUIRED)
  target_link_libraries(main PRIVATE log4cxx)

````

