### PR TITLE
[xmlsec] no uwp

### DIFF
--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "xmlsec",
   "version": "1.3.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",
-  "supports": "!xbox",
+  "supports": "!xbox & !uwp",
   "dependencies": [
     "libxml2",
     "openssl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9158,7 +9158,7 @@
     },
     "xmlsec": {
       "baseline": "1.3.1",
-      "port-version": 1
+      "port-version": 2
     },
     "xnnpack": {
       "baseline": "2022-02-17",

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66d4ee9a9a576f6af80a2b830becab2f6ee7beb7",
+      "version": "1.3.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "9152aec5099de6e629c31adc81bd07fc6f87607e",
       "version": "1.3.1",
       "port-version": 1


### PR DESCRIPTION
```

x509.c.obj : error LNK2019: unresolved external symbol BN_print_fp referenced in function xmlSecOpenSSLX509CertDebugDump

libxmlsec1-openssl.dll : fatal error LNK1120: 1 unresolved externals
```
BN_print_fp is only defined by openssl when not used on uwp