### PR TITLE
[ncnn] Update to 20231027

### DIFF
--- a/ports/ncnn/portfile.cmake
+++ b/ports/ncnn/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tencent/ncnn
-    REF 20221128
-    SHA512 589e52b63eabfac1f8e47acc34bef6a87ce365851a5c4d551665c321938a2d8e622ab211babac38771695b9f4443516577ba1634409a55c2436498a7d28d8218
+    REF "${VERSION}"
+    SHA512 722966b3b30c5a4df81c6d45237b1821acc69db0c78350a41e3bc60e3f40c3dc64587ae0ab223635c468314c665e477ee7e0c2d3d4cccbc72bb15aeb56dcda6c
     HEAD_REF master
 )
 
@@ -26,4 +26,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/ncnn/vcpkg.json
+++ b/ports/ncnn/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ncnn",
-  "version": "20221128",
+  "version": "20231027",
   "description": "ncnn is a high-performance neural network inference computing framework.",
   "homepage": "https://github.com/Tencent/ncnn",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5825,7 +5825,7 @@
       "port-version": 2
     },
     "ncnn": {
-      "baseline": "20221128",
+      "baseline": "20231027",
       "port-version": 0
     },
     "ncurses": {

--- a/versions/n-/ncnn.json
+++ b/versions/n-/ncnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a6a2a9cc4c71cac799469f587478b987a63e0ed",
+      "version": "20231027",
+      "port-version": 0
+    },
+    {
       "git-tree": "792660456e6b0e405ad0c67b0474ae80fea47878",
       "version": "20221128",
       "port-version": 0


### PR DESCRIPTION
Fixes #34993, update `ncnn` to 20231027.

No feature needs to be tested, the usage test passed on `x64-windows` (header files found):
```
ncnn provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(ncnn CONFIG REQUIRED)
  target_link_libraries(main PRIVATE ncnn)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.