### PR TITLE
[llhttp]fix to build llhttp_shared

### DIFF
--- a/ports/llhttp/fix-usage.patch
+++ b/ports/llhttp/fix-usage.patch
@@ -2,6 +2,14 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index bdef288..72555c6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -61,6 +61,7 @@
+ 
+   install(TARGETS ${target}
+     EXPORT llhttp
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 @@ -77,6 +77,10 @@ function(config_library target)
      NAMESPACE llhttp::
      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix #35015 

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
