### PR TITLE
[libmt32emu] update to 2.7.1

### DIFF
--- a/ports/libmt32emu/portfile.cmake
+++ b/ports/libmt32emu/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO munt/munt
-    REF 08aba2f0018f4e7c2af855c268a97b8b84f8dc06  #vlibmt32emu_2_7_0
-    SHA512 ef277767c6c18b1aa341b2e2cdac04c27bc19ef0aa2f1e0a4125c92128f64d5938eab53cf1d6bf2f9abaa5a59d14873e91e1518878165af48ac6b93c3e208aa5
+    REF libmt32emu_2_7_1
+    SHA512 369d1c5f16b37f3d8544ad30a30c3aa9d0796f67fcf5988e789958bff14bba119f7c5fd4c43816eb369a14b56f22f0c7eb3016ff838cd36d1d6f22ed84a2e8b9
     HEAD_REF master
 )
 

--- a/ports/libmt32emu/vcpkg.json
+++ b/ports/libmt32emu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmt32emu",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A MT-32 emulator",
   "homepage": "https://github.com/munt/munt/tree/master/mt32emu",
   "license": "GPL-2.0-or-later",

--- a/ports/libmt32emu/vcpkg.json
+++ b/ports/libmt32emu/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "libmt32emu",
   "version": "2.7.1",
   "description": "A MT-32 emulator",
-  "homepage": "https://github.com/munt/munt/tree/master/mt32emu",
+  "homepage": "https://github.com/munt/munt",
   "license": "GPL-2.0-or-later",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4477,7 +4477,7 @@
       "port-version": 0
     },
     "libmt32emu": {
-      "baseline": "2.7.0",
+      "baseline": "2.7.1",
       "port-version": 0
     },
     "libmupdf": {

--- a/versions/l-/libmt32emu.json
+++ b/versions/l-/libmt32emu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79abf5ad1ccf06edac9ecca252be851a1ff54a1e",
+      "version": "2.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "bf84211f16b9b598e1ebd2cee0be2487d2e49fca",
       "version": "2.7.0",
       "port-version": 0

--- a/versions/l-/libmt32emu.json
+++ b/versions/l-/libmt32emu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "79abf5ad1ccf06edac9ecca252be851a1ff54a1e",
+      "git-tree": "5e0ccfe803d0e3248671df0f3db4d1374a5a31c5",
       "version": "2.7.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

