### PR TITLE
[llhttp]fix to build llhttp_shared

### DIFF
--- a/ports/llhttp/fix-export.patch
+++ b/ports/llhttp/fix-export.patch
@@ -1,0 +1,13 @@
+diff --git a/include/llhttp.h b/include/llhttp.h
+index bdef288..72555c6 100644
+--- a/include/llhttp.h
++++ b/include/llhttp.h
+@@ -547,6 +547,8 @@ extern "C" {
+ 
+ #if defined(__wasm__)
+ #define LLHTTP_EXPORT __attribute__((visibility("default")))
++#elif defined(_WIN32)
++#define LLHTTP_EXPORT __declspec(dllexport)
+ #else
+ #define LLHTTP_EXPORT
+ #endif

--- a/ports/llhttp/fix-usage.patch
+++ b/ports/llhttp/fix-usage.patch
@@ -2,6 +2,14 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index bdef288..72555c6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -61,6 +61,7 @@
+ 
+   install(TARGETS ${target}
+     EXPORT llhttp
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 @@ -77,6 +77,10 @@ function(config_library target)
      NAMESPACE llhttp::
      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp

--- a/ports/llhttp/portfile.cmake
+++ b/ports/llhttp/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nodejs/llhttp
@@ -7,6 +5,7 @@ vcpkg_from_github(
     SHA512 971ec2cb403942bc43e4b67a6dd392bca10d4233a25f453550d9f2bfbcb9572df309bde77af030e94e2af840aec1d96de164df0cbb1183bb2f5623e8fcf3162c
     PATCHES
         fix-usage.patch
+        fix-export.patch
 )
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LLHTTP_BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LLHTTP_BUILD_SHARED)

--- a/ports/llhttp/vcpkg.json
+++ b/ports/llhttp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "llhttp",
   "version": "9.1.3",
+  "port-version": 1,
   "description": "Port of http_parser to llparse.",
   "homepage": "https://github.com/nodejs/llhttp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5186,7 +5186,7 @@
     },
     "llhttp": {
       "baseline": "9.1.3",
-      "port-version": 0
+      "port-version": 1
     },
     "llvm": {
       "baseline": "17.0.2",

--- a/versions/l-/llhttp.json
+++ b/versions/l-/llhttp.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "3422384dc0ec7e58827c138826bb666efe850eaa",
+      "git-tree": "15d9ce3e40a5850ebd87be52ada7437766c08589",
+      "version": "9.1.3",
+      "port-version": 1
+    },
+    {
+      "git-tree": "ac3be0799f6a0888351f3c82b5f89ec06f30addd",
       "version": "9.1.3",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix #35015 

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
