### PR TITLE
[arrow] Update to 14.0.1

### DIFF
--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE_PATH
     URLS "https://archive.apache.org/dist/arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
     FILENAME apache-arrow-${VERSION}.tar.gz
-    SHA512 9e1f8179e37279a47baa3587c66d8b385362478d998601b5f0a8bb2f360ec8cdb954705f397dac413ac1411e72d4dd740e3785823cc063ca35eb80585d2eedf2
+    SHA512 31d19f0ca80349f63db74bae813256b47907f85725a9bf01ef6f32406e79828ebb4701faedb52696b6a5b3bb89ad4e136485fd5eb35d396dd42147c11d4d2713
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arrow",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "port-version": 1,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3517d0d8bf39d98d806b0c84eac2f5f1acbbf32",
+      "version": "14.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c1c1beba87b3d9ac5ffc73764c62622cbd31eace",
       "version": "14.0.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -237,7 +237,7 @@
       "port-version": 5
     },
     "arrow": {
-      "baseline": "14.0.0",
+      "baseline": "14.0.1",
       "port-version": 1
     },
     "arsenalgear": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
