### PR TITLE
[ginkgo] Update version to 1.7.0

### DIFF
--- a/ports/ginkgo/portfile.cmake
+++ b/ports/ginkgo/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ginkgo-project/ginkgo
     REF "v${VERSION}"
-    SHA512 507a17bc9ad010c235c4ae49ac4bef3f4d5b65b4ea02bfa5cad5ea578fa65d28f564d1faf0a1f5618a6e72d744217f58bdff68c5f1fffc9cfb484800f7f84c50
+    SHA512 a7e71eaae8dc62e0b670f0db82f82e23b82860b3f6a5428e28f4652ed2a496f53d04238039b95f43cdf465cf86d2724ed88113a65e5e761ab839244e1b58ea46
     HEAD_REF master
 )
 

--- a/ports/ginkgo/vcpkg.json
+++ b/ports/ginkgo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ginkgo",
-  "version-semver": "1.6.0",
-  "description": "Ginkgo is a high-performance linear algebra library for manycore systems, with a focus on sparse solution of linear systems. Note that the OpenMP feature is not available on Windows.",
+  "version-semver": "1.7.0",
+  "description": "Ginkgo is a high-performance linear algebra library for manycore systems, with a focus on sparse solution of linear systems.",
   "homepage": "https://github.com/ginkgo-project/ginkgo",
   "license": "BSD-3-Clause",
   "supports": "!(x86 | android)",
@@ -29,7 +29,8 @@
       ]
     },
     "openmp": {
-      "description": "Build the OpenMP backend of Ginkgo"
+      "description": "Build the OpenMP backend of Ginkgo",
+      "supports": "mingw | !windows"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2941,7 +2941,7 @@
       "port-version": 3
     },
     "ginkgo": {
-      "baseline": "1.6.0",
+      "baseline": "1.7.0",
       "port-version": 0
     },
     "gklib": {

--- a/versions/g-/ginkgo.json
+++ b/versions/g-/ginkgo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5bb942245eec037ad042ba29ec426573031513e7",
+      "version-semver": "1.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "09962781615d028b2b96be5aef56b0590fd7b54f",
       "version-semver": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.