### PR TITLE
[geographiclib] Remove unnecessary and broken cross-compile check.

### DIFF
--- a/ports/geographiclib/portfile.cmake
+++ b/ports/geographiclib/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_sourceforge(
     REF distrib-C++
     FILENAME "GeographicLib-2.3.tar.gz"
     SHA512 1a1bd0fc2dc3e1372cf22618af3a4340bbc6497f94c64226c97654dfff92a4bf3acf47d91592741fe0c643d401d9721f680bdb4974b8ee258fb09d525fbaec67
+    PATCHES remove-broken-and-unnecessary-cross-compile-check.patch
     )
 
 vcpkg_check_features(

--- a/ports/geographiclib/remove-broken-and-unnecessary-cross-compile-check.patch
+++ b/ports/geographiclib/remove-broken-and-unnecessary-cross-compile-check.patch
@@ -1,0 +1,14 @@
+diff -Naur a/cmake/project-config-version.cmake.in b/cmake/project-config-version.cmake.in
+--- a/cmake/project-config-version.cmake.in	2023-07-25 07:37:40.000000000 -0500
++++ b/cmake/project-config-version.cmake.in	2023-11-10 16:58:52.835325073 -0600
+@@ -48,10 +48,6 @@
+   # Reject if the user asks for an incompatible precsision.
+   set (REASON "GEOGRAPHICLIB_PRECISION = @GEOGRAPHICLIB_PRECISION@")
+   set (PACKAGE_VERSION_UNSUITABLE TRUE)
+-elseif (NOT CMAKE_CROSSCOMPILING_STR STREQUAL "@CMAKE_CROSSCOMPILING_STR@")
+-  # Reject if there's a mismatch in ${CMAKE_CROSSCOMPILING}.
+-  set (REASON "cross-compiling = @CMAKE_CROSSCOMPILING@")
+-  set (PACKAGE_VERSION_UNSUITABLE TRUE)
+ elseif (CMAKE_CROSSCOMPILING AND
+     NOT (CMAKE_SYSTEM_NAME STREQUAL "@CMAKE_SYSTEM_NAME@" AND
+       CMAKE_SYSTEM_PROCESSOR STREQUAL "@CMAKE_SYSTEM_PROCESSOR@"))

--- a/ports/geographiclib/vcpkg.json
+++ b/ports/geographiclib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "geographiclib",
   "version": "2.3",
+  "port-version": 1,
   "description": "GeographicLib, a C++ library for performing geographic conversions",
   "homepage": "https://geographiclib.sourceforge.io",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2890,7 +2890,7 @@
     },
     "geographiclib": {
       "baseline": "2.3",
-      "port-version": 0
+      "port-version": 1
     },
     "geos": {
       "baseline": "3.11.2",

--- a/versions/g-/geographiclib.json
+++ b/versions/g-/geographiclib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d81b3f7975338273ed42ce6544734e24b6c7915a",
+      "version": "2.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "f24840f27f1c858b85e449c3066cec7978c304c6",
       "version": "2.3",
       "port-version": 0


### PR DESCRIPTION
The check is broken, and as far as I can tell, unnecessary.
The target is still validated, but whether or not cross-compiling is
occuring is not. Related to #8104.