### PR TITLE
[matio] update to 1.5.25

### DIFF
--- a/ports/matio/portfile.cmake
+++ b/ports/matio/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tbeu/matio
-    REF b07ee6c1512ab788f91e71910d07fc3ea954f812 # v1.5.24
-    SHA512 b9a1abe88565bb01db9aa826248b63927e8576d4e9b72665dee53cc29e0baf6c7af232f298fb6a22b3b96d820cb692ff29f98e2d0d751edc22a5f1ee884fc2df
+    REF "v${VERSION}"
+    SHA512 cc9703b6f3ce12a7a4807f339cb844b535ae2febeab192250409a930193ac73e0d9b54d41f4a95696c6b41416b811865ff97ff00d5b3ca7d26b4f0d8f7717621
     HEAD_REF master
     PATCHES fix-dependencies.patch
 )

--- a/ports/matio/vcpkg.json
+++ b/ports/matio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "matio",
-  "version": "1.5.24",
+  "version": "1.5.25",
   "description": "MATLAB MAT File I/O Library",
   "homepage": "https://github.com/tbeu/matio",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5417,7 +5417,7 @@
       "port-version": 5
     },
     "matio": {
-      "baseline": "1.5.24",
+      "baseline": "1.5.25",
       "port-version": 0
     },
     "matplotlib-cpp": {

--- a/versions/m-/matio.json
+++ b/versions/m-/matio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "811df28d92dd7a28f95cdb5aea3939c2ea66f621",
+      "version": "1.5.25",
+      "port-version": 0
+    },
+    {
       "git-tree": "08eada66141696ad861d881ac1639d41682916e1",
       "version": "1.5.24",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

