### PR TITLE
[octomap] update to 1.9.8

### DIFF
--- a/ports/octomap/portfile.cmake
+++ b/ports/octomap/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OctoMap/octomap
-    REF c4a4304895f6cfc31723dc95df252fe7e756a0ef # v1.9.6
-    SHA512 ec321a5355091acbd3d3fda7c858e2078c29195e73461c8a34db2c4614c6b2e38b35a59671f1071f7eb397cac4df78869f14a13af2e68d64e5a2e2d8727846cd
+    REF "v${VERSION}"
+    SHA512 60afeecc36a190f136dcbe33cb9cd6c06c16233988b383b0b010f65f81e6a3630b55902c5b5ad756ac35dee4c4ec26ec5722d6bd9b8e079f70b7d286293c518e
     HEAD_REF master
     PATCHES
       001-fix-exported-targets.patch

--- a/ports/octomap/vcpkg.json
+++ b/ports/octomap/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "octomap",
-  "version": "1.9.6",
-  "port-version": 1,
+  "version": "1.9.8",
   "description": "An Efficient Probabilistic 3D Mapping Framework Based on Octrees",
   "homepage": "https://octomap.github.io/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6085,8 +6085,8 @@
       "port-version": 0
     },
     "octomap": {
-      "baseline": "1.9.6",
-      "port-version": 1
+      "baseline": "1.9.8",
+      "port-version": 0
     },
     "ode": {
       "baseline": "0.16.3",

--- a/versions/o-/octomap.json
+++ b/versions/o-/octomap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d24dd4ca217fd0e4b7fcb86301556f96d8f8d0c7",
+      "version": "1.9.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "b778b0aef20fee697a18865995fff021501e8509",
       "version": "1.9.6",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

