### PR TITLE
[libvpx] Bump to 1.13.1

### DIFF
--- a/ports/libvpx/0003-add-uwp-v142-and-v143-support.patch
+++ b/ports/libvpx/0003-add-uwp-v142-and-v143-support.patch
@@ -1,5 +1,5 @@
 diff --git a/build/make/configure.sh b/build/make/configure.sh
-index 119d206..41bac75 100644
+index 110f16e..c161d0e 100644
 --- a/build/make/configure.sh
 +++ b/build/make/configure.sh
 @@ -1038,7 +1038,7 @@ EOF
@@ -85,21 +85,19 @@ index 58bb66b..b4cad6c 100644
                  fi
              fi
 diff --git a/configure b/configure
-index beea650..91ae3c8 100644
+index ae289f7..78f5fc1 100644
 --- a/configure
 +++ b/configure
-@@ -102,16 +102,24 @@ all_platforms="${all_platforms} arm64-darwin-gcc"
- all_platforms="${all_platforms} arm64-darwin20-gcc"
+@@ -103,6 +103,8 @@ all_platforms="${all_platforms} arm64-darwin20-gcc"
  all_platforms="${all_platforms} arm64-darwin21-gcc"
+ all_platforms="${all_platforms} arm64-darwin22-gcc"
  all_platforms="${all_platforms} arm64-linux-gcc"
 +all_platforms="${all_platforms} arm64-uwp-vs16"
 +all_platforms="${all_platforms} arm64-uwp-vs17"
  all_platforms="${all_platforms} arm64-win64-gcc"
  all_platforms="${all_platforms} arm64-win64-vs15"
-+all_platforms="${all_platforms} arm64-win64-vs16"
-+all_platforms="${all_platforms} arm64-win64-vs17"
- all_platforms="${all_platforms} armv7-android-gcc"   #neon Cortex-A8
- all_platforms="${all_platforms} armv7-darwin-gcc"    #neon Cortex-A8
+ all_platforms="${all_platforms} arm64-win64-vs16"
+@@ -112,6 +114,8 @@ all_platforms="${all_platforms} armv7-darwin-gcc"    #neon Cortex-A8
  all_platforms="${all_platforms} armv7-linux-rvct"    #neon Cortex-A8
  all_platforms="${all_platforms} armv7-linux-gcc"     #neon Cortex-A8
  all_platforms="${all_platforms} armv7-none-rvct"     #neon Cortex-A8
@@ -108,12 +106,7 @@ index beea650..91ae3c8 100644
  all_platforms="${all_platforms} armv7-win32-gcc"
  all_platforms="${all_platforms} armv7-win32-vs14"
  all_platforms="${all_platforms} armv7-win32-vs15"
-+all_platforms="${all_platforms} armv7-win32-vs16"
-+all_platforms="${all_platforms} armv7-win32-vs17"
- all_platforms="${all_platforms} armv7s-darwin-gcc"
- all_platforms="${all_platforms} armv8-linux-gcc"
- all_platforms="${all_platforms} loongarch32-linux-gcc"
-@@ -138,6 +146,8 @@ all_platforms="${all_platforms} x86-linux-gcc"
+@@ -143,6 +147,8 @@ all_platforms="${all_platforms} x86-linux-gcc"
  all_platforms="${all_platforms} x86-linux-icc"
  all_platforms="${all_platforms} x86-os2-gcc"
  all_platforms="${all_platforms} x86-solaris-gcc"
@@ -122,7 +115,7 @@ index beea650..91ae3c8 100644
  all_platforms="${all_platforms} x86-win32-gcc"
  all_platforms="${all_platforms} x86-win32-vs14"
  all_platforms="${all_platforms} x86-win32-vs15"
-@@ -161,6 +171,8 @@ all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
+@@ -167,6 +173,8 @@ all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
  all_platforms="${all_platforms} x86_64-linux-gcc"
  all_platforms="${all_platforms} x86_64-linux-icc"
  all_platforms="${all_platforms} x86_64-solaris-gcc"
@@ -131,7 +124,7 @@ index beea650..91ae3c8 100644
  all_platforms="${all_platforms} x86_64-win64-gcc"
  all_platforms="${all_platforms} x86_64-win64-vs14"
  all_platforms="${all_platforms} x86_64-win64-vs15"
-@@ -485,11 +497,10 @@ process_targets() {
+@@ -491,11 +499,10 @@ process_targets() {
      ! enabled multithread && DIST_DIR="${DIST_DIR}-nomt"
      ! enabled install_docs && DIST_DIR="${DIST_DIR}-nodocs"
      DIST_DIR="${DIST_DIR}-${tgt_isa}-${tgt_os}"
@@ -147,7 +140,7 @@ index beea650..91ae3c8 100644
      if [ -f "${source_path}/build/make/version.sh" ]; then
          ver=`"$source_path/build/make/version.sh" --bare "$source_path"`
          DIST_DIR="${DIST_DIR}-${ver}"
-@@ -578,6 +589,10 @@ process_detect() {
+@@ -584,6 +591,10 @@ process_detect() {
  
              # Specialize windows and POSIX environments.
              case $toolchain in

--- a/ports/libvpx/0005-fix-arm64-build.patch
+++ b/ports/libvpx/0005-fix-arm64-build.patch
@@ -1,0 +1,13 @@
+diff --git a/vp9/encoder/arm/neon/vp9_diamond_search_sad_neon.c b/vp9/encoder/arm/neon/vp9_diamond_search_sad_neon.c
+index 33753f7..997775a 100644
+--- a/vp9/encoder/arm/neon/vp9_diamond_search_sad_neon.c
++++ b/vp9/encoder/arm/neon/vp9_diamond_search_sad_neon.c
+@@ -220,7 +220,7 @@ int vp9_diamond_search_sad_neon(const MACROBLOCK *x,
+       // Look up the component cost of the residual motion vector
+       {
+         uint32_t cost[4];
+-        int16_t __attribute__((aligned(16))) rowcol[8];
++        DECLARE_ALIGNED(16, int16_t, rowcol[8]);
+         vst1q_s16(rowcol, v_diff_mv_w);
+ 
+         // Note: This is a use case for gather instruction

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -1,17 +1,16 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(LIBVPX_VERSION 1.12.0)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libvpx
-    REF v${LIBVPX_VERSION}
-    SHA512 dc059bc3102b75524ae29989372334b3e0f2acf1520e5a4daa4073831bb55949d82897c498fb9d2d38b59f1a66bb0ad24407d0d086b1e3a8394a4933f04f2ed0
+    REF "v${VERSION}"
+    SHA512 49706838563c92fab7334376848d0f374efcbc1729ef511e967c908fd2ecd40e8d197f1d85da6553b3a7026bdbc17e5a76595319858af26ce58cb9a4c3854897
     HEAD_REF master
     PATCHES
         0002-Fix-nasm-debug-format-flag.patch
         0003-add-uwp-v142-and-v143-support.patch
         0004-remove-library-suffixes.patch
+        0005-fix-arm64-build.patch # Upstream commit: https://github.com/webmproject/libvpx/commit/858a8c611f4c965078485860a6820e2135e6611b
 )
 
 vcpkg_find_acquire_program(PERL)
@@ -108,11 +107,11 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     )
 
     if (VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
-        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nopost-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${LIBVPX_VERSION}/include/vpx")
+        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nopost-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${VERSION}/include/vpx")
     elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
-        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nopost-nomt-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${LIBVPX_VERSION}/include/vpx")
+        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nopost-nomt-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${VERSION}/include/vpx")
     else()
-        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${LIBVPX_VERSION}/include/vpx")
+        set(LIBVPX_INCLUDE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-vp8-vp9-nodocs-${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${VERSION}/include/vpx")
     endif()
     file(
         INSTALL
@@ -137,6 +136,7 @@ else()
 
     set(OPTIONS_DEBUG "--enable-debug-libs --enable-debug --prefix=${CURRENT_PACKAGES_DIR}/debug")
     set(OPTIONS_RELEASE "--prefix=${CURRENT_PACKAGES_DIR}")
+    set(AS_NASM "--as=nasm")
 
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         set(OPTIONS "${OPTIONS} --disable-static --enable-shared")
@@ -156,20 +156,58 @@ else()
         set(LIBVPX_TARGET_ARCH "x86")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
         set(LIBVPX_TARGET_ARCH "x86_64")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+        set(LIBVPX_TARGET_ARCH "armv7")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
         set(LIBVPX_TARGET_ARCH "arm64")
     else()
         message(FATAL_ERROR "libvpx does not support architecture ${VCPKG_TARGET_ARCHITECTURE}")
     endif()
 
-	if(VCPKG_TARGET_IS_MINGW)
-		if(LIBVPX_TARGET_ARCH STREQUAL "x86")
-			set(LIBVPX_TARGET "x86-win32-gcc")
-		else()
-			set(LIBVPX_TARGET "x86_64-win64-gcc")
-		endif()
-	elseif(VCPKG_TARGET_IS_LINUX)
+    vcpkg_cmake_get_vars(cmake_vars_file)
+    include("${cmake_vars_file}")
+
+    # Set environment variables for configure
+    if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "([^\/]*-)gcc$")
+        message(STATUS "Cross-building for ${TARGET_TRIPLET} with ${CMAKE_MATCH_1}")
+        set(ENV{CROSS} ${CMAKE_MATCH_1})
+        unset(AS_NASM)
+    else()
+        set(ENV{CC} ${VCPKG_DETECTED_CMAKE_C_COMPILER})
+        set(ENV{CXX} ${VCPKG_DETECTED_CMAKE_CXX_COMPILER})
+        set(ENV{AR} ${VCPKG_DETECTED_CMAKE_AR})
+        set(ENV{LD} ${VCPKG_DETECTED_CMAKE_LINKER})
+        set(ENV{RANLIB} ${VCPKG_DETECTED_CMAKE_RANLIB})
+        set(ENV{STRIP} ${VCPKG_DETECTED_CMAKE_STRIP})
+    endif()
+
+    if(VCPKG_TARGET_IS_MINGW)
+        if(LIBVPX_TARGET_ARCH STREQUAL "x86")
+            set(LIBVPX_TARGET "x86-win32-gcc")
+        else()
+            set(LIBVPX_TARGET "x86_64-win64-gcc")
+        endif()
+    elseif(VCPKG_TARGET_IS_LINUX)
         set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-linux-gcc")
+    elseif(VCPKG_TARGET_IS_ANDROID)
+        set(LIBVPX_TARGET "generic-gnu")
+        # Settings
+        if(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
+            set(OPTIONS "${OPTIONS} --disable-sse4_1 --disable-avx --disable-avx2 --disable-avx512")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+            set(OPTIONS "${OPTIONS} --disable-avx --disable-avx2 --disable-avx512")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+            set(OPTIONS "${OPTIONS} --enable-thumb --disable-neon")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+            set(OPTIONS "${OPTIONS} --enable-thumb")
+        endif()
+        # Set environment variables for configure
+        set(ENV{AS} ${VCPKG_DETECTED_CMAKE_C_COMPILER})
+        set(ENV{LDFLAGS} "${LDFLAGS} --target=${VCPKG_DETECTED_CMAKE_C_COMPILER_TARGET}")
+        # Set clang target
+        set(OPTIONS "${OPTIONS} --extra-cflags=--target=${VCPKG_DETECTED_CMAKE_C_COMPILER_TARGET} --extra-cxxflags=--target=${VCPKG_DETECTED_CMAKE_CXX_COMPILER_TARGET}")
+        # Unset nasm and let AS do its job
+        unset(AS_NASM)
     elseif(VCPKG_TARGET_IS_OSX)
         if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
             set(LIBVPX_TARGET "arm64-darwin20-gcc")
@@ -178,6 +216,14 @@ else()
             endif()
         else()
             set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-darwin17-gcc") # enable latest CPU instructions for best performance and less CPU usage on MacOS
+        endif()
+    elseif(VCPKG_TARGET_IS_IOS)
+        if(VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+            set(LIBVPX_TARGET "armv7-darwin-gcc")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+            set(LIBVPX_TARGET "arm64-darwin-gcc")
+        else()
+            message(FATAL_ERROR "libvpx does not support architecture ${VCPKG_TARGET_ARCHITECTURE} on iOS")
         endif()
     else()
         set(LIBVPX_TARGET "generic-gnu") # use default target
@@ -196,14 +242,14 @@ else()
             ${OPTIONS}
             ${OPTIONS_RELEASE}
             ${MAC_OSX_MIN_VERSION_CFLAGS}
-            --as=nasm
+            ${AS_NASM}
         WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
         LOGNAME configure-${TARGET_TRIPLET}-rel)
 
         message(STATUS "Building libvpx for Release")
         vcpkg_execute_required_process(
             COMMAND
-                ${BASH} --noprofile --norc -c "make -j8"
+                ${BASH} --noprofile --norc -c "make -j${VCPKG_CONCURRENCY}"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
             LOGNAME build-${TARGET_TRIPLET}-rel
         )
@@ -230,14 +276,14 @@ else()
             ${OPTIONS}
             ${OPTIONS_DEBUG}
             ${MAC_OSX_MIN_VERSION_CFLAGS}
-            --as=nasm
+            ${AS_NASM}
         WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
         LOGNAME configure-${TARGET_TRIPLET}-dbg)
 
         message(STATUS "Building libvpx for Debug")
         vcpkg_execute_required_process(
             COMMAND
-                ${BASH} --noprofile --norc -c "make -j8"
+                ${BASH} --noprofile --norc -c "make -j${VCPKG_CONCURRENCY}"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
             LOGNAME build-${TARGET_TRIPLET}-dbg
         )
@@ -265,4 +311,4 @@ endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/unofficial-libvpx-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/unofficial-libvpx/unofficial-libvpx-config.cmake" @ONLY)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,11 +1,14 @@
 {
   "name": "libvpx",
-  "version": "1.12.0",
-  "port-version": 2,
+  "version": "1.13.1",
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
     {
       "name": "vcpkg-msbuild",
       "host": true,

--- a/ports/libvpx/vpx.pc.in
+++ b/ports/libvpx/vpx.pc.in
@@ -1,12 +1,11 @@
 prefix=@LIBVPX_PREFIX@
-# pkg-config file from libvpx v1.10.0
 exec_prefix=${prefix}
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
 Name: vpx
 Description: WebM Project VPx codec implementation
-Version: @LIBVPX_VERSION@
+Version: @VERSION@
 Requires:
 Conflicts:
 Libs: -L"${libdir}" -lvpx

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4953,8 +4953,8 @@
       "port-version": 2
     },
     "libvpx": {
-      "baseline": "1.12.0",
-      "port-version": 2
+      "baseline": "1.13.1",
+      "port-version": 0
     },
     "libwandio": {
       "baseline": "4.2.1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1484fb529e99fdedd95f2b46f65738a9e95fcaa1",
+      "version": "1.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "255c8c5ca6526bd7a0ac6f3a6a7838c77ee97e5e",
       "version": "1.12.0",
       "port-version": 2


### PR DESCRIPTION
Based on https://github.com/microsoft/vcpkg/pull/34814 by @LilyWangLL
Fixes https://github.com/microsoft/vcpkg/issues/34809
but tailored for RustDesk to build on arm64-ios, arm*-linux etc.

Signed-off-by: Vasyl Gello <vasek.gello@gmail.com>

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
