### PR TITLE
[aws-c-common] update to 0.9.8

### DIFF
--- a/ports/aws-c-common/portfile.cmake
+++ b/ports/aws-c-common/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-common
     REF "v${VERSION}"
-    SHA512 203e6d313c0a435d0e042f79a4c87f91765206fd997b12c7d18cafe9551945fc1d976bd3a5c6fc9c60f4bbca52ebb15771a6ac2783666581b79d5d7153822485
+    SHA512 5f62ed421dd95c18121fe7fd4dec15dd0095c28873c629e6787f788461b5812b8fb0f8e614d0b69528e7bbe63b41562e057e7d9e2fbe124a79ea87e8f0e83aba
     HEAD_REF master
     PATCHES
         disable-internal-crt-option.patch # Disable internal crt option because vcpkg contains crt processing flow

--- a/ports/aws-c-common/vcpkg.json
+++ b/ports/aws-c-common/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-common",
-  "version": "0.9.4",
+  "version": "0.9.8",
   "description": "AWS common library for C",
   "homepage": "https://github.com/awslabs/aws-c-common",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-common.json
+++ b/versions/a-/aws-c-common.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c9dee5191b560843aa898d14f1104826f7b711b",
+      "version": "0.9.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "6d58a5944c2340297985dc05678671129c45d40f",
       "version": "0.9.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -361,7 +361,7 @@
       "port-version": 1
     },
     "aws-c-common": {
-      "baseline": "0.9.4",
+      "baseline": "0.9.8",
       "port-version": 0
     },
     "aws-c-compression": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

