### PR TITLE
[yaml-cpp] Update patch with upstream fixes.

### DIFF
--- a/ports/yaml-cpp/vcpkg.json
+++ b/ports/yaml-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "yaml-cpp",
   "version-semver": "0.8.0",
+  "port-version": 1,
   "description": "yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec.",
   "homepage": "https://github.com/jbeder/yaml-cpp",
   "documentation": "https://codedocs.xyz/jbeder/yaml-cpp/index.html",

--- a/ports/yaml-cpp/yaml-cpp-pr-1212.patch
+++ b/ports/yaml-cpp/yaml-cpp-pr-1212.patch
@@ -46,12 +46,11 @@ index 46dc180..5055c24 100644
  
  if(YAML_CPP_BUILD_TESTS)
    add_subdirectory(test)
-
 diff --git a/yaml-cpp-config.cmake.in b/yaml-cpp-config.cmake.in
-index 799b9b418..f71e13b8f 100644
+index 799b9b4..cbbc773 100644
 --- a/yaml-cpp-config.cmake.in
 +++ b/yaml-cpp-config.cmake.in
-@@ -11,12 +11,20 @@ set_and_check(YAML_CPP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+@@ -11,12 +11,23 @@ set_and_check(YAML_CPP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
  set_and_check(YAML_CPP_LIBRARY_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
  
  # Are we building shared libraries?
@@ -66,12 +65,15 @@ index 799b9b418..f71e13b8f 100644
  set(YAML_CPP_LIBRARIES "@EXPORT_TARGETS@")
  
 -check_required_components(@EXPORT_TARGETS@)
-+add_library(yaml-cpp INTERFACE IMPORTED)
-+target_link_libraries(yaml-cpp INTERFACE yaml-cpp::yaml-cpp)
-+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-+  set_target_properties(yaml-cpp PROPERTIES 
-+    DEPRECATION "The target yaml-cpp is deprecated and will be removed in version 0.10.0. Use the yaml-cpp::yaml-cpp target instead."
-+  )
++# Protect against multiple inclusion, which would fail when already imported targets are added once more.
++if(NOT TARGET yaml-cpp)
++  add_library(yaml-cpp INTERFACE IMPORTED)
++  target_link_libraries(yaml-cpp INTERFACE yaml-cpp::yaml-cpp)
++  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
++    set_target_properties(yaml-cpp PROPERTIES
++      DEPRECATION "The target yaml-cpp is deprecated and will be removed in version 0.10.0. Use the yaml-cpp::yaml-cpp target instead."
++    )
++  endif()
 +endif()
 +
 +check_required_components(yaml-cpp)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9234,7 +9234,7 @@
     },
     "yaml-cpp": {
       "baseline": "0.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "yara": {
       "baseline": "4.3.2",

--- a/versions/y-/yaml-cpp.json
+++ b/versions/y-/yaml-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb1a38369faa80d2af500df32ef6d4a747336dcb",
+      "version-semver": "0.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "595f95f94e93c518b99e8c0e83ef35ced9e7867a",
       "version-semver": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #35041.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

Add the patch from https://github.com/jbeder/yaml-cpp/pull/1242. This prevents errors when the package is loaded more than once.