### PR TITLE
[opencascade] fix build using mingw

### DIFF
--- a/ports/opencascade/portfile.cmake
+++ b/ports/opencascade/portfile.cmake
@@ -72,9 +72,9 @@ foreach(file_name IN LISTS files)
 endforeach()
 
 # Remove libd to lib, libd just has cmake files we dont want too
-if( WIN32 )
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
-file(RENAME "${CURRENT_PACKAGES_DIR}/debug/libd" "${CURRENT_PACKAGES_DIR}/debug/lib")
+if(WIN32 AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "MinGW")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/libd" "${CURRENT_PACKAGES_DIR}/debug/lib")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
@@ -103,8 +103,10 @@ endif()
 
 if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     # debug creates libd and bind directories that need moving
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bind" "${CURRENT_PACKAGES_DIR}/debug/bin")
+    if (NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "MinGW")
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bind" "${CURRENT_PACKAGES_DIR}/debug/bin")
+    endif ()
 
     # the bin directory ends up with bat files that are noise, let's clean that up
     file(GLOB BATS "${CURRENT_PACKAGES_DIR}/bin/*.bat")

--- a/ports/opencascade/portfile.cmake
+++ b/ports/opencascade/portfile.cmake
@@ -72,7 +72,7 @@ foreach(file_name IN LISTS files)
 endforeach()
 
 # Remove libd to lib, libd just has cmake files we dont want too
-if(WIN32 AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "MinGW")
+if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
     file(RENAME "${CURRENT_PACKAGES_DIR}/debug/libd" "${CURRENT_PACKAGES_DIR}/debug/lib")
 endif()
@@ -102,8 +102,8 @@ if (NOT VCPKG_BUILD_TYPE)
 endif()
 
 if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    # debug creates libd and bind directories that need moving
-    if (NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "MinGW")
+  # debug creates libd and bind directories that need moving (mingw does not)
+  if (NOT VCPKG_TARGET_IS_MINGW)
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
         file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bind" "${CURRENT_PACKAGES_DIR}/debug/bin")
     endif ()

--- a/ports/opencascade/vcpkg.json
+++ b/ports/opencascade/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencascade",
   "version": "7.7.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Open CASCADE Technology (OCCT) is an open-source software development platform for 3D CAD, CAM, CAE.",
   "homepage": "https://github.com/Open-Cascade-SAS/OCCT",
   "license": "LGPL-2.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6166,7 +6166,7 @@
     },
     "opencascade": {
       "baseline": "7.7.2",
-      "port-version": 1
+      "port-version": 2
     },
     "opencc": {
       "baseline": "1.1.6",

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a5302418dd2908e80bca5bf0591b37d52b4b810",
+      "version": "7.7.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "8e9c9fb982bef129111ea811c3948ffd570a16dc",
       "version": "7.7.2",
       "port-version": 1

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1a5302418dd2908e80bca5bf0591b37d52b4b810",
+      "git-tree": "978ffcd8473809264e889c3bcf3a70108e397ee8",
       "version": "7.7.2",
       "port-version": 2
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

This PR fixes an issue when building using msys mingw setup on windows using the `x64-mingw` community triplet, where the generated `/bin` and `/lib` layout is not suffixed with `d` and therefore files dont need to be moved. 

Currently, cmake will end up throwing an error stating that `${CURRENT_PACKAGES_DIR}/debug/libd` does not exist... this PR fixes this issue(s).