### PR TITLE
[kdalgorithms] update to 1.2

### DIFF
--- a/ports/kdalgorithms/portfile.cmake
+++ b/ports/kdalgorithms/portfile.cmake
@@ -2,12 +2,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDAB/KDAlgorithms
-    REF 93023b7b6640a227cfa6b2e7f1b8e72d10a0b981
-    SHA512 151488c5ba30fceee204278e620bbc509464cb993d4207891ba627cb4384dc585927336f263ea80bfeb46f5100fdb31edcef13482d4b7f70b79480d1b153f087
-    HEAD_REF master
+    REF ${VERSION}
+    SHA512 2229712954c377e9167b78fc931988f33c82349baeae9a64e3506f66fd96508e8482ce777c4ef8928c2ab38cbeffc413e96c75a9f41902080230f8c434782232
 )
 
-file(INSTALL "${SOURCE_PATH}/src/kdalgorithms.h" "${SOURCE_PATH}/src/bits"
+file(INSTALL "${SOURCE_PATH}/src/kdalgorithms.h" "${SOURCE_PATH}/src/kdalgorithms_bits"
     DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/kdalgorithms/vcpkg.json
+++ b/ports/kdalgorithms/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kdalgorithms",
-  "version-date": "2023-02-11",
+  "version": "1.2",
   "description": "KDAB's algorithm helpers for C++14 and up",
   "homepage": "https://github.com/KDAB/KDAlgorithms",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3705,7 +3705,7 @@
       "port-version": 1
     },
     "kdalgorithms": {
-      "baseline": "2023-02-11",
+      "baseline": "1.2",
       "port-version": 0
     },
     "kdbindings": {

--- a/versions/k-/kdalgorithms.json
+++ b/versions/k-/kdalgorithms.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05bf1ff5e346918f8fa5e6ece05126d72a6409f4",
+      "version": "1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c1d9ec1859767d60adf003d94fe81eb7eaac668e",
       "version-date": "2023-02-11",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.