### PR TITLE
[matio] update to 1.5.26

### DIFF
--- a/ports/matio/portfile.cmake
+++ b/ports/matio/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tbeu/matio
-    REF b07ee6c1512ab788f91e71910d07fc3ea954f812 # v1.5.24
-    SHA512 b9a1abe88565bb01db9aa826248b63927e8576d4e9b72665dee53cc29e0baf6c7af232f298fb6a22b3b96d820cb692ff29f98e2d0d751edc22a5f1ee884fc2df
+    REF "v${VERSION}"
+    SHA512 b0ff73b7d39b68c87f371e397ed8f46040f1334e8d81d2b462f62bf7d14c6566e4f5a0c55955696cbbc035ff7b41e5811ce7429476ae48c1465f48f77b4dc6b2
     HEAD_REF master
     PATCHES fix-dependencies.patch
 )

--- a/ports/matio/vcpkg.json
+++ b/ports/matio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "matio",
-  "version": "1.5.24",
+  "version": "1.5.26",
   "description": "MATLAB MAT File I/O Library",
   "homepage": "https://github.com/tbeu/matio",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5417,7 +5417,7 @@
       "port-version": 5
     },
     "matio": {
-      "baseline": "1.5.24",
+      "baseline": "1.5.26",
       "port-version": 0
     },
     "matplotlib-cpp": {

--- a/versions/m-/matio.json
+++ b/versions/m-/matio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9fd8ec3eacecc04384ff5a048c0962f852cdb793",
+      "version": "1.5.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "08eada66141696ad861d881ac1639d41682916e1",
       "version": "1.5.24",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
