### PR TITLE
[Workflow] Remove exempt-issue-lablels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/stale@v6
         with:
           stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 180 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
-          exempt-issue-labels: 'no-stale,category:new-port,category:question,requires:repro,requires:more-information'
           days-before-issue-stale: 180
           days-before-pr-stale: -1
           days-before-close: 14


### PR DESCRIPTION
Remove exempt-issue-lablels for fixing the following issue:

Looking at the GitHub action in issue # [31837](https://github.com/microsoft/vcpkg/issues/31837#issuecomment-1784577730), the bot added the Stale label to the issues and then removed it, the behavior is strange, and the comments said that the issue will be closed in 14 days, but actually it's not.

It looks [Stale](https://github.com/microsoft/vcpkg/blob/master/.github/workflows/stale.yml#L12C6-L16) added 'Stale' lable for question, repro and more information issues, But check https://github.com/microsoft/vcpkg/blob/master/.github/workflows/stale.yml#L28 will remove the 'Stale' lable, that cause the bot enter an infinite loop.

@BillyONeal  @autoantwort 

