### PR TITLE
[plog] update to 1.1.10

### DIFF
--- a/ports/plog/portfile.cmake
+++ b/ports/plog/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SergiusTheBest/plog
-    REF 1.1.9
-    SHA512 d979fdf0011ef9bb94a2271da5d17058dbab5bc47438a13769d084fdebe5e169e7c05a043d69acceb752896df7cdae4433f32bfbcc81e055dffd9c701be88003
+    REF "${VERSION}"
+    SHA512 b1d55baadbd16bafa5165b05352f367455b51f2eec2102f1ebad2e6a049954d1b87ffdd96811b0acea2313877db1db837f780971fd027d0db683fe42aeb29573
     HEAD_REF master
 )
 

--- a/ports/plog/vcpkg.json
+++ b/ports/plog/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "plog",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Portable, simple and extensible C++ logging library.",
   "homepage": "https://github.com/SergiusTheBest/plog",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6601,7 +6601,7 @@
       "port-version": 7
     },
     "plog": {
-      "baseline": "1.1.9",
+      "baseline": "1.1.10",
       "port-version": 0
     },
     "plplot": {

--- a/versions/p-/plog.json
+++ b/versions/p-/plog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c79e842dc4773ec5dfe0aa5e914421bf74ea3c9f",
+      "version": "1.1.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "8123d0f93ad451c1bbf9cb25b57ea290f4124030",
       "version": "1.1.9",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

