### PR TITLE
[outcome] update to 2.2.7

### DIFF
--- a/ports/outcome/portfile.cmake
+++ b/ports/outcome/portfile.cmake
@@ -24,12 +24,9 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ned14/outcome
-    REF 90032f99503b4620f21d8160dc3af06fa343541f
-    SHA512 7eda0694098a118633c8ad0ef812f8b03db536548f51d1ca71ca98b9f9e445bcb24019cd4d1046da9215227ad85205c5b3631d0c66de6edc1fcc904b2d9e0e0f
+    REF "v${VERSION}"
+    SHA512 2057f2f967f7aad3f78d081c72130122c1f99b837ce23ec9de9bfe0cd0fc493ce7085071cb2a54a840252ba0d82e14d99d622c1e0fdf9a8a20f41e5f89fa4645
     HEAD_REF develop
-    PATCHES
-        fix-find-library.patch # incorporated into upstream after 2.2.4
-        fix-status-code-include.patch # incorporated into upstream after 2.2.4
 )
 
 # Because outcome's deployed files are header-only, the debug build is not necessary
@@ -43,8 +40,9 @@ vcpkg_cmake_configure(
         -Dquickcpplib_DIR=${CURRENT_INSTALLED_DIR}/share/quickcpplib
         -DOUTCOME_BUNDLE_EMBEDDED_STATUS_CODE=OFF
         -Dstatus-code_DIR=${CURRENT_INSTALLED_DIR}/share/status-code
-        -DOUTCOME_ENABLE_DEPENDENCY_SMOKE_TEST=ON  # Leave this always on to test everything compiles
+        -DOUTCOME_ENABLE_DEPENDENCY_SMOKE_TEST=OFF  
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
+        -DBUILD_TESTING=OFF
         -DCXX_CONCEPTS_FLAGS=
 )
 

--- a/ports/outcome/vcpkg.json
+++ b/ports/outcome/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "outcome",
-  "version": "2.2.4",
-  "port-version": 1,
+  "version": "2.2.7",
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/ports/status-code/fix-example.patch
+++ b/ports/status-code/fix-example.patch
@@ -1,0 +1,15 @@
+diff --git a/example/thrown_exception.cpp b/example/thrown_exception.cpp
+index 268ff55..4ec98cd 100644
+--- a/example/thrown_exception.cpp
++++ b/example/thrown_exception.cpp
+@@ -29,7 +29,9 @@ http://www.boost.org/LICENSE_1_0.txt)
+ 
+ #include <exception>
+ #include <mutex>
+-
++#include <stdexcept>
++#include <system_error>
++#include <new>
+ static constexpr size_t max_exception_ptrs = 16;
+ 
+ 

--- a/ports/status-code/portfile.cmake
+++ b/ports/status-code/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         add-missing-include.patch
+        fix-example.patch
 )
 
 # Because status-code's deployed files are header-only, the debug build is not necessary

--- a/ports/status-code/vcpkg.json
+++ b/ports/status-code/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "status-code",
   "version-date": "2023-01-27",
-  "port-version": 2,
+  "port-version": 3,
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8142,7 +8142,7 @@
     },
     "status-code": {
       "baseline": "2023-01-27",
-      "port-version": 2
+      "port-version": 3
     },
     "status-value-lite": {
       "baseline": "1.1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6385,8 +6385,8 @@
       "port-version": 0
     },
     "outcome": {
-      "baseline": "2.2.4",
-      "port-version": 1
+      "baseline": "2.2.7",
+      "port-version": 0
     },
     "p-ranav-csv": {
       "baseline": "2019-07-11",

--- a/versions/o-/outcome.json
+++ b/versions/o-/outcome.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "56284d0a13fa14d8688ac5815242711a994e150f",
+      "version": "2.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "504177d3c3f3d1a063db2ce6d12292141e874d37",
       "version": "2.2.4",
       "port-version": 1

--- a/versions/s-/status-code.json
+++ b/versions/s-/status-code.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d111bb4d8095fa95b05256d774f1b7d8f500fced",
+      "version-date": "2023-01-27",
+      "port-version": 3
+    },
+    {
       "git-tree": "40d6b3bdc23cdb7de14e9f07eb229d0124b9c550",
       "version-date": "2023-01-27",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

