### PR TITLE
[stale bot] don't mark issues as stale and not stale in the same run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,14 +7,14 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v8
         with:
           stale-issue-message: 'This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 28 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment.'
           any-of-labels: 'category:question,requires:repro,requires:more-information'
           days-before-issue-stale: 28
           days-before-pr-stale: -1
           days-before-close: 14
-      - uses: actions/stale@v6
+      - uses: actions/stale@v8
         with:
           stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 60 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
           any-of-labels: 'category:new-port'
@@ -22,10 +22,11 @@ jobs:
           days-before-issue-stale: 60
           days-before-pr-stale: -1
           days-before-close: 14
-      - uses: actions/stale@v6
+      - uses: actions/stale@v8
         with:
           stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 180 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
           exempt-issue-labels: 'no-stale,category:new-port,category:question,requires:repro,requires:more-information'
           days-before-issue-stale: 180
           days-before-pr-stale: -1
           days-before-close: 14
+          operations-per-run: 50


### PR DESCRIPTION
Alternative to #35076 that really works. 

Since version https://github.com/actions/stale/releases/tag/v7.0.0 `exempt-issue-labels` issues gets ignored. Before this version they got processed even if they shouldn't. This resulted in situations like in https://github.com/microsoft/vcpkg/issues/31837 where a issue was marked as stale and marked as not stale in the same run. 
