### PR TITLE
[ecm] add license

### DIFF
--- a/ports/ecm/vcpkg.json
+++ b/ports/ecm/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "ecm",
   "version": "5.98.0",
+  "port-version": 1,
   "description": "Extra CMake Modules (ECM), extra modules and scripts for CMake",
   "homepage": "https://github.com/KDE/extra-cmake-modules",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2330,7 +2330,7 @@
     },
     "ecm": {
       "baseline": "5.98.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ecos": {
       "baseline": "2.0.10",

--- a/versions/e-/ecm.json
+++ b/versions/e-/ecm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1df895632bc721e761b581f4d438ea9291d89228",
+      "version": "5.98.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b23a9acfc30e1fb1cd894d5fea25665a1f8fb145",
       "version": "5.98.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.