### PR TITLE
[ms-gsl] add license

### DIFF
--- a/ports/ms-gsl/vcpkg.json
+++ b/ports/ms-gsl/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "ms-gsl",
   "version": "4.0.0",
+  "port-version": 1,
   "description": "Microsoft implementation of the Guidelines Support Library",
   "homepage": "https://github.com/Microsoft/GSL",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5622,7 +5622,7 @@
     },
     "ms-gsl": {
       "baseline": "4.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ms-quic": {
       "baseline": "1.2.0",

--- a/versions/m-/ms-gsl.json
+++ b/versions/m-/ms-gsl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d8da50e7ffaa4a1460036950f527b0a5e64c02a",
+      "version": "4.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9d8d320f8c5db1a6b0c7517d110b854bc4b551e5",
       "version": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.