### PR TITLE
[usrsctp] add license

### DIFF
--- a/ports/usrsctp/vcpkg.json
+++ b/ports/usrsctp/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "usrsctp",
   "version": "0.9.5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A userland SCTP stack supporting FreeBSD, Linux, Mac OS X and Windows.",
+  "homepage": "https://github.com/sctplab/usrsctp",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8574,7 +8574,7 @@
     },
     "usrsctp": {
       "baseline": "0.9.5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "utf8h": {
       "baseline": "2021-11-18",

--- a/versions/u-/usrsctp.json
+++ b/versions/u-/usrsctp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ac1cb14a09660bf33bd8f3dc7727bcf8080ae02",
+      "version": "0.9.5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "fcf79007e70c0b2872453841199dae68e7ac01fa",
       "version": "0.9.5.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
