### PR TITLE
[jsonifier] Remove duplicate header files

### DIFF
--- a/ports/jsonifier/portfile.cmake
+++ b/ports/jsonifier/portfile.cmake
@@ -4,14 +4,16 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 e2611b116cd6d73426b32fea11b3b52527466e7e59d8e8c842ccca9dac2b42679457d7ad77e11512c15fb319e650c74bbee0dce3ae7d24c127b756790eebf020
     HEAD_REF main
+    PATCHES
+        uninstall-head.patch
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 
 vcpkg_cmake_install()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.md")

--- a/ports/jsonifier/uninstall-head.patch
+++ b/ports/jsonifier/uninstall-head.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fc4ed65..23a9738 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -63,7 +63,7 @@ set_target_properties(
+ 	OUTPUT_NAME "jsonifier"
+ 	CXX_STANDARD_REQUIRED ON
+ 	CXX_EXTENSIONS OFF
+-	PUBLIC_HEADER "${HEADERS}"
++	#PUBLIC_HEADER "${HEADERS}"
+ )
+ 
+ target_include_directories(

--- a/ports/jsonifier/vcpkg.json
+++ b/ports/jsonifier/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "jsonifier",
   "version": "0.9.91",
+  "port-version": 1,
   "description": "A few classes for parsing and serializing json - very rapidly.",
   "homepage": "https://github.com/realtimechris/jsonifier",
   "license": "MIT",
@@ -8,10 +9,6 @@
   "dependencies": [
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3674,7 +3674,7 @@
     },
     "jsonifier": {
       "baseline": "0.9.91",
-      "port-version": 0
+      "port-version": 1
     },
     "jsonnet": {
       "baseline": "0.20.0",

--- a/versions/j-/jsonifier.json
+++ b/versions/j-/jsonifier.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be9213f10f70e56d8f7fad547c9691558f9babc9",
+      "version": "0.9.91",
+      "port-version": 1
+    },
+    {
       "git-tree": "b8901c8d3fee5951e101c1b8a3b64de58c6ebeed",
       "version": "0.9.91",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix CI baseline issue `openvino` failed with below error:
```
D:\installed\x64-windows\include\jsonifier/TypeEntities.hpp(53): error C2955: 'jsonifier::array': use of class template requires template argument list
Line 537: D:\installed\x64-windows\include\jsonifier/TypeEntities.hpp(53): error C3928: '->': trailing return type is not allowed after a parenthesized declarator
Line 538: D:\installed\x64-windows\include\jsonifier/TypeEntities.hpp(53): error C2365: 'value_type': redefinition; previous definition was 'template parameter'
```

The issue arises because `jsonifier` redundantly installs its header files into the include folder, and these files are mistakenly being referenced by `openvino`, causing errors. This problem stems from the fact that `jsonifier` only functions under C++20, while `openvino` is utilizing C++14, leading to the aforementioned errors.

I resolved the issue by commenting out the `PUBLIC_HEADER` property of `jsonifier`, preventing it from redundantly installing header files.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
