### PR TITLE
[kubazip] update to 0.2.6

### DIFF
--- a/ports/kubazip/portfile.cmake
+++ b/ports/kubazip/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kuba--/zip
-    REF 42151612e8546c55485ec38cf0d57e57e51a8abd #v0.2.4
-    SHA512 9cbb7bcb8095c365c4529f06c883f3aa0c1038ed3aa6a0419dafb90355abf6e5cd02f7ffd5cbb54fe3893102bb21f568d415b71500630ad203a1f911b6e52ef5
+    REF "v${VERSION}"
+    SHA512 959805452f566b24ee78bc56794403733d19e86885a7f94581fca4218817a65ea4ea8b79457a452e0cc06992dc2165b3ff90360cec5f43cd8c0f934027ee9fd5
     HEAD_REF master
     PATCHES
         fix_targets.patch
@@ -18,4 +18,4 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/kubazip)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/UNLICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/UNLICENSE")

--- a/ports/kubazip/vcpkg.json
+++ b/ports/kubazip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kubazip",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "description": "A portable, simple zip library written in C",
   "homepage": "https://github.com/kuba--/zip",
   "license": "Unlicense",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3921,7 +3921,7 @@
       "port-version": 0
     },
     "kubazip": {
-      "baseline": "0.2.4",
+      "baseline": "0.2.6",
       "port-version": 0
     },
     "kubernetes": {

--- a/versions/k-/kubazip.json
+++ b/versions/k-/kubazip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a53b15054c06a67cd7ba9f19e54476893cddad72",
+      "version": "0.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "14bf9d5b15ecf5769d10e5000e74167e97b0ade1",
       "version": "0.2.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.