### PR TITLE
[winsparkle] update to 0.8.1

### DIFF
--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/vslavik/winsparkle/releases/download/v0.7.0/WinSparkle-0.7.0.zip"
-    FILENAME "winsparkle-070.zip"
-    SHA512 c2cf29e1880534c170110f8e5a966939aecc9a9e05afc87868400074f1492fcac949b61e2ce4636eadd2f127caad3660e0f763476e9523aad3834d673f6edd77
+    URLS "https://github.com/vslavik/winsparkle/releases/download/v0.8.1/WinSparkle-0.8.1.zip"
+    FILENAME "winsparkle-081.zip"
+    SHA512 05588793272618ca13fe884620f1ed421276b011a906f15c92f4879b1787c71b175ae1a170b80fe2adfdb7669eac90c38fac929a9bcf382388983f9aea25ba9c
 )
 
 vcpkg_extract_source_archive(
@@ -14,11 +14,10 @@ file(INSTALL ${HEADER_LIST} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}
 file(GLOB TOOLS_LIST "${SOURCE_PATH}/bin/*.bat")
 file(INSTALL ${TOOLS_LIST} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
-
-# Note: It is an explicit design goal for WinSparkle to be a single 
-# self-contained DLL with no external dependencies (to the point that 
-# it even links to static CRT!). This matters for e.g. in-app delta updates 
-# or re-launching the app after update. It is not statically linked even if a 
+# Note: It is an explicit design goal for WinSparkle to be a single
+# self-contained DLL with no external dependencies (to the point that
+# it even links to static CRT!). This matters for e.g. in-app delta updates
+# or re-launching the app after update. It is not statically linked even if a
 # static linking is used for everything else.
 set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 
@@ -27,7 +26,7 @@ if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
     file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 
-    # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well  
+    # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well
     file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
     file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
     file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
@@ -36,7 +35,7 @@ elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
     file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 
-    # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well  
+    # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well
     file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
     file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
     file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
@@ -44,5 +43,4 @@ else()
     message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "winsparkle",
-  "version": "0.7.0",
-  "port-version": 2,
+  "version": "0.8.1",
   "description": "WinSparkle is an easy-to-use software update library for Windows developers.",
   "homepage": "https://winsparkle.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9009,8 +9009,8 @@
       "port-version": 5
     },
     "winsparkle": {
-      "baseline": "0.7.0",
-      "port-version": 2
+      "baseline": "0.8.1",
+      "port-version": 0
     },
     "wintoast": {
       "baseline": "1.2.0",

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "033cf81cd03bc5533ddb7e57d65f704db078ba44",
+      "version": "0.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c6c0404e941beb4139069e5a5cb03e7e59655a4",
       "version": "0.7.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.