### PR TITLE
[jasper] Update to 4.1.0

### DIFF
--- a/ports/jasper/no_stdc_check.patch
+++ b/ports/jasper/no_stdc_check.patch
@@ -1,24 +1,24 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 840908739..c485b830c 100644
+index ba6f117..8d2e9f9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -414,7 +414,7 @@ if((DEFINED JAS_CROSSCOMPILING AND JAS_CROSSCOMPILING) OR
- 	# will need to be set manually from the command line
+@@ -424,7 +424,7 @@ if((DEFINED JAS_CROSSCOMPILING AND JAS_CROSSCOMPILING) OR
  	# (e.g., using -DJAS_STDC_VERSION=YYYYMML) or by changing the line below.
+ if(NOT JAS_WASM)
  	set(JAS_STDC_VERSION "0L" CACHE INTERNAL "The value of __STDC_VERSION__.")
 -	if (JAS_STDC_VERSION STREQUAL "0L")
 +	if (0)
  		message(FATAL_ERROR
  		  "The value of __STDC_VERSION__ cannot be automatically determined "
  		  "when cross-compiling.  Please set JAS_STDC_VERSION to the value "
-@@ -423,8 +423,9 @@ if((DEFINED JAS_CROSSCOMPILING AND JAS_CROSSCOMPILING) OR
- 		  "appropriately.")
+@@ -434,8 +434,9 @@ if(NOT JAS_WASM)
  	endif()
+ endif()
  else()
 -	jas_get_stdc_version(status JAS_STDC_VERSION)
 -	if(NOT status)
 +	#jas_get_stdc_version(status JAS_STDC_VERSION)
-+    set(JAS_STDC_VERSION 0L)
++	set(JAS_STDC_VERSION 0L)
 +	if(0)
  		message(FATAL_ERROR "Cannot determine the value of __STDC_VERSION__.")
  	endif()

--- a/ports/jasper/portfile.cmake
+++ b/ports/jasper/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jasper-software/jasper
-    REF 402d096b39f4f618ad9e6ff2b4fc1b5eb260a2e4 # version-4.0.0
-    SHA512 b2c2a2514479ec4a3d634d42d0a614951c06f6177e43a80b9a31797b7d4ad248fcdff632596806fcf811c87779990ba7c19aa2f9b91afafbc172dd85f96bb239
+    REF "version-${VERSION}"
+    SHA512 940841f4094987526ee23aed84f2b028b0f4d58cd2be91dcf737102018d8da111870959ad64710b14ae1ca4ca8361fc900ff6ecee31f0f23ef435bf7f0935462
     HEAD_REF master
     PATCHES
         no_stdc_check.patch

--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "jasper",
-  "version": "4.0.0",
-  "port-version": 2,
+  "version": "4.1.0",
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/jasper-software/jasper",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3605,8 +3605,8 @@
       "port-version": 1
     },
     "jasper": {
-      "baseline": "4.0.0",
-      "port-version": 2
+      "baseline": "4.1.0",
+      "port-version": 0
     },
     "jbig2dec": {
       "baseline": "0.20",

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bbbc1e3a2819d3e823e778a5a35045cc44946c23",
+      "version": "4.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d7f51c26899ba9433a5a3ab92fc5b5887d5c764c",
       "version": "4.0.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.