### PR TITLE
[bgfx] Update to 1.122.8595-458

### DIFF
--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -1,33 +1,13 @@
-vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO "bkaradzic/bgfx.cmake"
-  HEAD_REF master
-  REF v${VERSION}
-  SHA512 5d19e3ba50db25c203d87b1f47e9151a21f2afced35a7306d33c4fd2fc44f4d56826a1920023bd6de5cebbed2301e39e152f4c17e63905e34f56b39e34b235d1
+vcpkg_download_distfile(
+    ARCHIVE_FILE
+    URLS https://github.com/bkaradzic/bgfx.cmake/releases/download/v${VERSION}/bgfx.cmake.v${VERSION}.tar.gz
+    FILENAME bgfx.cmake.v${VERSION}.tar.gz
+    SHA512 369943ce0f8f2b5332d7334247d3a9ef0e28a6b1ff5ee250a01f83d1a0bd865687397da791e4c861d1c1b18ec4285f50153139f3c0e398611c7f3b672d1c751c
 )
 
-vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH_BX
-  REPO "bkaradzic/bx"
-  HEAD_REF master
-  REF 9b1805ea8bdc63552e4e32ff72842fce0238bb10
-  SHA512 9032b160204faf939b33d46123b7220de441377b2fc95447b87714ce12d31f0c220ee9b53d9a7807f8ae3e807f7d2bea6dd255a4443bb66e4aa0679f10696e96
-)
-
-vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH_BIMG
-  REPO "bkaradzic/bimg"
-  HEAD_REF master
-  REF ec02df824a763b2e2ae31e19c674ba0bc88c0695
-  SHA512 e0f26afae510244e85758ddaada83e3d6b48745b447e197bffcb972f1fd8f42269f2e9f3ee48a6d54ea99d0ad66062a6212a3604f7e61d616681b815fb8a6d8f
-)
-
-vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH_BGFX
-  REPO "bkaradzic/bgfx"
-  HEAD_REF master
-  REF e2c5b1d3e1320145baebc405a3c894cd851f8dc1
-  SHA512 5bde6c2b4f147c01c7949eff529b940b8981e06a3b72e8389e991b98e3052a83762e59a798b1b0eb3292c35889f8f3fb68f54613c270c4f3f0f942e11cc9f3e9
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${ARCHIVE_FILE}
 )
 
 vcpkg_check_features(
@@ -48,10 +28,7 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-inject-packages.cmake" DESTINATION "$
 
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
-  OPTIONS -DBX_DIR=${SOURCE_PATH_BX}
-          -DBIMG_DIR=${SOURCE_PATH_BIMG}
-          -DBGFX_DIR=${SOURCE_PATH_BGFX}
-          -DBGFX_LIBRARY_TYPE=${BGFX_LIBRARY_TYPE}
+  OPTIONS -DBGFX_LIBRARY_TYPE=${BGFX_LIBRARY_TYPE}
           -DBX_AMALGAMATED=ON
           -DBGFX_AMALGAMATED=ON
           -DBGFX_BUILD_EXAMPLES=OFF

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bgfx",
-  "version": "1.121.8534-453",
+  "version": "1.122.8595-458",
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c5af63ea2a285a9577943683a6e1347d17487402",
+      "version": "1.122.8595-458",
+      "port-version": 0
+    },
+    {
       "git-tree": "11c8b127eab949129fb5adf3006c9655ab1bb525",
       "version": "1.121.8534-453",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -593,7 +593,7 @@
       "port-version": 0
     },
     "bgfx": {
-      "baseline": "1.121.8534-453",
+      "baseline": "1.122.8595-458",
       "port-version": 0
     },
     "bigint": {


### PR DESCRIPTION
Use release artifact file for submodules instead of checking them out manually.
This prevents future mistakes of bad references of submodules. Future updates will only requires updates to the version and sha.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.