### PR TITLE
[qt5-base] fix arm64 compiling

### DIFF
--- a/ports/qt5-base/patches/fix-arm64.patch
+++ b/ports/qt5-base/patches/fix-arm64.patch
@@ -1,0 +1,13 @@
+diff --git a/mkspecs/features/toolchain.prf b/mkspecs/features/toolchain.prf
+index 0c505fc..7c3be04 100644
+--- a/mkspecs/features/toolchain.prf
++++ b/mkspecs/features/toolchain.prf
+@@ -324,6 +324,8 @@ isEmpty($${target_prefix}.INCDIRS) {
+         hostArch = $$QMAKE_HOST.arch
+         equals(hostArch, x86_64): \
+             hostArch = amd64
++        contains(hostArch, arm64): \
++            hostArch = arm64
+         !equals(arch, $$hostArch): \
+             arch = $${hostArch}_$$arch
+ 

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -78,6 +78,7 @@ qt_download_submodule(  OUT_SOURCE_PATH SOURCE_PATH
                             patches/Qt5GuiConfigExtras.patch   # Patches the library search behavior for EGL since angle is not build with Qt
                             patches/fix_angle.patch            # Failed to create OpenGL context for format QSurfaceFormat ...
                             patches/mingw9.patch               # Fix compile with MinGW-W64 9.0.0: Redefinition of 'struct _FILE_ID_INFO'
+                            patches/fix-arm64.patch            # Fix corss compile with arm64          
                     )
 
 # Remove vendored dependencies to ensure they are not picked up by the build

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.11",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6878,7 +6878,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.11",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-canvas3d": {
       "baseline": "0",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a933d187f73235c3aacebfce6e344f29bca48f9",
+      "version": "5.15.11",
+      "port-version": 2
+    },
+    {
       "git-tree": "c09b409166a1cb3e4881ee5b0081069227a7ae45",
       "version": "5.15.11",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/35031
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
