### PR TITLE
[libyuv] update libyuv to 1880

### DIFF
--- a/ports/libyuv/fix-cmakelists.patch
+++ b/ports/libyuv/fix-cmakelists.patch
@@ -1,88 +1,52 @@
-Subject: [PATCH] patch cmakelist for vcpkg
----
-Index: CMakeLists.txt
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt	(revision 010dea8ba4158896e5608a52dd4372ca7f57cdca)
-+++ b/CMakeLists.txt	(revision da9ae4ff969b9722ce90b800d514fa26ad1fdf87)
-@@ -2,18 +2,21 @@
+index 7a4a199..50b431c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,10 +2,14 @@
  # Originally created for "roxlu build system" to compile libyuv on windows
  # Run with -DTEST=ON to build unit tests
-
-+CMAKE_MINIMUM_REQUIRED( VERSION 3.12)
+ 
+-PROJECT ( YUV C CXX )	# "C" is required even for C++ projects
+ CMAKE_MINIMUM_REQUIRED( VERSION 2.8.12 )
++CMAKE_POLICY( SET CMP0022 NEW )
 +
- PROJECT ( YUV C CXX )	# "C" is required even for C++ projects
--CMAKE_MINIMUM_REQUIRED( VERSION 2.8.12 )
- OPTION( TEST "Built unit tests" OFF )
-
++PROJECT ( YUV C CXX )	# "C" is required even for C++ projects
+ OPTION( UNIT_TEST "Built unit tests" OFF )
+ 
 +SET( CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON )
 +
  SET ( ly_base_dir	${PROJECT_SOURCE_DIR} )
  SET ( ly_src_dir	${ly_base_dir}/source )
  SET ( ly_inc_dir	${ly_base_dir}/include )
- SET ( ly_tst_dir	${ly_base_dir}/unit_test )
- SET ( ly_lib_name	yuv )
+@@ -14,6 +18,7 @@ SET ( ly_lib_name	yuv )
  SET ( ly_lib_static	${ly_lib_name} )
--SET ( ly_lib_shared	${ly_lib_name}_shared )
-
+ SET ( ly_lib_shared	${ly_lib_name}_shared )
+ 
 +FILE ( GLOB_RECURSE ly_include_files ${ly_inc_dir}/libyuv/*.h )
  FILE ( GLOB_RECURSE	ly_source_files ${ly_src_dir}/*.cc )
  LIST ( SORT			ly_source_files )
-
-@@ -28,27 +31,20 @@
-
+ 
+@@ -28,6 +33,7 @@ endif()
+ 
  # this creates the static library (.a)
  ADD_LIBRARY				( ${ly_lib_static} STATIC ${ly_source_files} )
--
--# this creates the shared library (.so)
--ADD_LIBRARY				( ${ly_lib_shared} SHARED ${ly_source_files} )
--SET_TARGET_PROPERTIES	( ${ly_lib_shared} PROPERTIES OUTPUT_NAME "${ly_lib_name}" )
--SET_TARGET_PROPERTIES	( ${ly_lib_shared} PROPERTIES PREFIX "lib" )
--if(WIN32)
--  SET_TARGET_PROPERTIES	( ${ly_lib_shared} PROPERTIES IMPORT_PREFIX "lib" )
--endif()
-+SET_TARGET_PROPERTIES     ( ${ly_lib_static} PROPERTIES PUBLIC_HEADER include/libyuv.h )
-
- # this creates the conversion tool
--ADD_EXECUTABLE			( yuvconvert ${ly_base_dir}/util/yuvconvert.cc )
--TARGET_LINK_LIBRARIES	( yuvconvert ${ly_lib_static} )
-+ADD_EXECUTABLE			( yuvconvert ${ly_base_dir}/util/yuvconvert.cc )
-+TARGET_LINK_LIBRARIES   ( yuvconvert ${ly_lib_static} )
-
- # this creates the yuvconstants tool
--ADD_EXECUTABLE      ( yuvconstants ${ly_base_dir}/util/yuvconstants.c )
--TARGET_LINK_LIBRARIES  ( yuvconstants ${ly_lib_static} )
-+ADD_EXECUTABLE          ( yuvconstants ${ly_base_dir}/util/yuvconstants.c )
-+TARGET_LINK_LIBRARIES   ( yuvconstants ${ly_lib_static} )
-
- find_package ( JPEG )
- if (JPEG_FOUND)
--  include_directories( ${JPEG_INCLUDE_DIR} )
--  target_link_libraries( ${ly_lib_shared} ${JPEG_LIBRARY} )
-+  include_directories( ${JPEG_INCLUDE_DIR})
-+  target_link_libraries(${ly_lib_static} PUBLIC ${JPEG_LIBRARY})
-   add_definitions( -DHAVE_JPEG )
- endif()
-
-@@ -87,14 +83,13 @@
-     target_link_libraries(libyuv_unittest gflags)
-     add_definitions(-DLIBYUV_USE_GFLAGS)
-   endif()
--endif()
-+endif()
-
--
++SET_TARGET_PROPERTIES( ${ly_lib_static} PROPERTIES PUBLIC_HEADER include/libyuv.h )
+ 
+ # this creates the shared library (.so)
+ ADD_LIBRARY				( ${ly_lib_shared} SHARED ${ly_source_files} )
+@@ -94,10 +100,12 @@ endif()
+ 
+ 
  # install the conversion tool, .so, .a, and all the header files
 -INSTALL ( PROGRAMS ${CMAKE_BINARY_DIR}/yuvconvert			DESTINATION bin )
 -INSTALL ( TARGETS ${ly_lib_static}						DESTINATION lib )
 -INSTALL ( TARGETS ${ly_lib_shared} LIBRARY				DESTINATION lib RUNTIME DESTINATION bin )
 -INSTALL ( DIRECTORY ${PROJECT_SOURCE_DIR}/include/		DESTINATION include )
-+INSTALL ( TARGETS yuvconvert DESTINATION tools )
++INSTALL ( TARGETS yuvconvert DESTINATION bin )
 +INSTALL ( FILES ${ly_include_files} DESTINATION include/libyuv )
 +INSTALL ( TARGETS ${ly_lib_static} EXPORT libyuv-targets DESTINATION lib INCLUDES DESTINATION include PUBLIC_HEADER DESTINATION include )
++INSTALL ( TARGETS ${ly_lib_shared} EXPORT libyuv-targets LIBRARY DESTINATION lib RUNTIME DESTINATION bin )
++
 +INSTALL( EXPORT libyuv-targets DESTINATION share/cmake/libyuv/ EXPORT_LINK_INTERFACE_LIBRARIES )
  
  # create the .deb and .rpm packages using cpack

--- a/ports/libyuv/portfile.cmake
+++ b/ports/libyuv/portfile.cmake
@@ -1,16 +1,16 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://chromium.googlesource.com/libyuv/libyuv
-    REF 0faf8dd0e004520a61a603a4d2996d5ecc80dc3f
+    REF fb6341d326846fbbe669ad5173e520f66b339621
     # Check https://chromium.googlesource.com/libyuv/libyuv/+/refs/heads/main/include/libyuv/version.h for a version!
     PATCHES
         fix-cmakelists.patch
 )
 
+set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${BUILD_OPTIONS}
     OPTIONS_DEBUG
@@ -22,11 +22,21 @@ vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/libyuv)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-configure_file(${CMAKE_CURRENT_LIST_DIR}/libyuv-config.cmake ${CURRENT_PACKAGES_DIR}/share/${PORT} COPYONLY)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(GLOB EXE "${CURRENT_PACKAGES_DIR}/bin/*.exe")
+file(GLOB DEBUG_EXE "${CURRENT_PACKAGES_DIR}/debug/bin/*.exe")
+if(EXE OR DEBUG_EXE)
+    file(REMOVE ${EXE} ${DEBUG_EXE})
+endif()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/libyuv-config.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_cmake_get_vars(cmake_vars_file)
 include("${cmake_vars_file}")

--- a/ports/libyuv/vcpkg.json
+++ b/ports/libyuv/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libyuv",
-  "version": "1857",
+  "version": "1880",
   "description": "libyuv is an open source project that includes YUV scaling and conversion functionality",
   "homepage": "https://chromium.googlesource.com/libyuv/libyuv",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5117,7 +5117,7 @@
       "port-version": 4
     },
     "libyuv": {
-      "baseline": "1857",
+      "baseline": "1880",
       "port-version": 0
     },
     "libzen": {

--- a/versions/l-/libyuv.json
+++ b/versions/l-/libyuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27ad97c8b702b84c82501af1a6a54cefb66a9243",
+      "version": "1880",
+      "port-version": 0
+    },
+    {
       "git-tree": "ee4cbd8592c2d5f3fd77c1478b679bc00671b316",
       "version": "1857",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/35095

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
