### PR TITLE
[dbus] add lz4 as a dependency

### DIFF
--- a/ports/dbus/vcpkg.json
+++ b/ports/dbus/vcpkg.json
@@ -1,13 +1,14 @@
 {
   "name": "dbus",
   "version": "1.15.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "D-Bus specification and reference implementation, including libdbus and dbus-daemon",
   "homepage": "https://gitlab.freedesktop.org/dbus/dbus",
   "license": "AFL-2.1 OR GPL-2.0-or-later",
   "supports": "!uwp & !staticcrt",
   "dependencies": [
     "expat",
+    "lz4",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2126,7 +2126,7 @@
     },
     "dbus": {
       "baseline": "1.15.8",
-      "port-version": 1
+      "port-version": 2
     },
     "dcmtk": {
       "baseline": "3.6.7",

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "949871c58815c9c47b66d6dc0bf03c417a48081e",
+      "version": "1.15.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "9104cc6d890ace8c14067e7cbf29c39f7a93b937",
       "version": "1.15.8",
       "port-version": 1


### PR DESCRIPTION
Update dbus port to include lz4 as a dependency

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This PR fixes an issue that I have when building the dbus package. Rather than submitting an issue, I am proposing the fix directly.  Here is shortend version of the error, full log is attached. 
```
[89/121] : && /usr/bin/clang -fPIC -fPIC -fno-common  -Wall -Warray-bounds -Wcast-align -Wchar-subscripts -Wdeclaration-after-statement -Wdouble-promotion -Wextra -Wfloat-equal -Wformat-nonliteral -Wformat-security -Wformat=2 -Wimplicit-function-declaration -Winit-self -Wmissing-declarations -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wmissing-prototypes -Wnested-externs -Wno-error=missing-field-initializers -Wno-error=unused-label -Wno-error=unused-parameter -Wno-missing-field-initializers -Wno-unused-label -Wno-unused-parameter -Wnull-dereference -Wold-style-definition -Wpacked -Wpointer-arith -Wpointer-sign -Wredundant-decls -Wreturn-type -Wshadow -Wsign-compare -Wstrict-aliasing -Wstrict-prototypes -Wswitch-default -Wswitch-enum -Wundef -Wunused-but-set-variable -Wwrite-strings -Wno-error=inline -Wno-error=overloaded-virtual -Wno-error=missing-field-initializers -Wno-error=null-dereference -Wno-error=strict-aliasing -Wno-error=unused-parameter -Wno-unused-parameter -g -D_DEBUG  -Wl,--export-dynamic  -Wl,--version-script=/home/mchristy/.vcpkg/buildtrees/dbus/x64-linux-dbg/dbus/Version -shared -Wl,-soname,libdbus-1.so.3 -o lib/libdbus-1.so.3.38.0 dbus/CMakeFiles/dbus-1.dir/dbus-address.c.o dbus/CMakeFiles/dbus-1.dir/dbus-auth.c.o dbus/CMakeFiles/dbus-1.dir/dbus-bus.c.o dbus/CMakeFiles/dbus-1.dir/dbus-connection.c.o dbus/CMakeFiles/dbus-1.dir/dbus-credentials.c.o dbus/CMakeFiles/dbus-1.dir/dbus-errors.c.o dbus/CMakeFiles/dbus-1.dir/dbus-keyring.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-header.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-byteswap.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-recursive.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-validate.c.o dbus/CMakeFiles/dbus-1.dir/dbus-message.c.o dbus/CMakeFiles/dbus-1.dir/dbus-misc.c.o dbus/CMakeFiles/dbus-1.dir/dbus-nonce.c.o dbus/CMakeFiles/dbus-1.dir/dbus-object-tree.c.o dbus/CMakeFiles/dbus-1.dir/dbus-pending-call.c.o dbus/CMakeFiles/dbus-1.dir/dbus-resources.c.o dbus/CMakeFiles/dbus-1.dir/dbus-server.c.o dbus/CMakeFiles/dbus-1.dir/dbus-server-socket.c.o dbus/CMakeFiles/dbus-1.dir/dbus-server-debug-pipe.c.o dbus/CMakeFiles/dbus-1.dir/dbus-sha.c.o dbus/CMakeFiles/dbus-1.dir/dbus-signature.c.o dbus/CMakeFiles/dbus-1.dir/dbus-syntax.c.o dbus/CMakeFiles/dbus-1.dir/dbus-timeout.c.o dbus/CMakeFiles/dbus-1.dir/dbus-threads.c.o dbus/CMakeFiles/dbus-1.dir/dbus-transport.c.o dbus/CMakeFiles/dbus-1.dir/dbus-transport-socket.c.o dbus/CMakeFiles/dbus-1.dir/dbus-watch.c.o dbus/CMakeFiles/dbus-1.dir/dbus-uuidgen.c.o dbus/CMakeFiles/dbus-1.dir/dbus-transport-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-server-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-dataslot.c.o dbus/CMakeFiles/dbus-1.dir/dbus-file.c.o dbus/CMakeFiles/dbus-1.dir/dbus-hash.c.o dbus/CMakeFiles/dbus-1.dir/dbus-internals.c.o dbus/CMakeFiles/dbus-1.dir/dbus-list.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-basic.c.o dbus/CMakeFiles/dbus-1.dir/dbus-memory.c.o dbus/CMakeFiles/dbus-1.dir/dbus-mempool.c.o dbus/CMakeFiles/dbus-1.dir/dbus-string.c.o dbus/CMakeFiles/dbus-1.dir/dbus-sysdeps.c.o dbus/CMakeFiles/dbus-1.dir/dbus-pipe.c.o dbus/CMakeFiles/dbus-1.dir/dbus-file-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-pipe-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-sysdeps-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-sysdeps-pthread.c.o dbus/CMakeFiles/dbus-1.dir/dbus-userdb.c.o -L/home/mchristy/.vcpkg/buildtrees/dbus/x64-linux-dbg/lib -Wl,-rpath,/home/mchristy/.vcpkg/buildtrees/dbus/x64-linux-dbg/lib:  -lsystemd  -lrt  -lcap  -lcrypt  -llz4d  -llzma  -lzstd  -lmount  -lblkid  /usr/lib/librt.a && :
FAILED: lib/libdbus-1.so.3.38.0 
: && /usr/bin/clang -fPIC -fPIC -fno-common  -Wall -Warray-bounds -Wcast-align -Wchar-subscripts -Wdeclaration-after-statement -Wdouble-promotion -Wextra -Wfloat-equal -Wformat-nonliteral -Wformat-security -Wformat=2 -Wimplicit-function-declaration -Winit-self -Wmissing-declarations -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wmissing-prototypes -Wnested-externs -Wno-error=missing-field-initializers -Wno-error=unused-label -Wno-error=unused-parameter -Wno-missing-field-initializers -Wno-unused-label -Wno-unused-parameter -Wnull-dereference -Wold-style-definition -Wpacked -Wpointer-arith -Wpointer-sign -Wredundant-decls -Wreturn-type -Wshadow -Wsign-compare -Wstrict-aliasing -Wstrict-prototypes -Wswitch-default -Wswitch-enum -Wundef -Wunused-but-set-variable -Wwrite-strings -Wno-error=inline -Wno-error=overloaded-virtual -Wno-error=missing-field-initializers -Wno-error=null-dereference -Wno-error=strict-aliasing -Wno-error=unused-parameter -Wno-unused-parameter -g -D_DEBUG  -Wl,--export-dynamic  -Wl,--version-script=/home/mchristy/.vcpkg/buildtrees/dbus/x64-linux-dbg/dbus/Version -shared -Wl,-soname,libdbus-1.so.3 -o lib/libdbus-1.so.3.38.0 dbus/CMakeFiles/dbus-1.dir/dbus-address.c.o dbus/CMakeFiles/dbus-1.dir/dbus-auth.c.o dbus/CMakeFiles/dbus-1.dir/dbus-bus.c.o dbus/CMakeFiles/dbus-1.dir/dbus-connection.c.o dbus/CMakeFiles/dbus-1.dir/dbus-credentials.c.o dbus/CMakeFiles/dbus-1.dir/dbus-errors.c.o dbus/CMakeFiles/dbus-1.dir/dbus-keyring.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-header.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-byteswap.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-recursive.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-validate.c.o dbus/CMakeFiles/dbus-1.dir/dbus-message.c.o dbus/CMakeFiles/dbus-1.dir/dbus-misc.c.o dbus/CMakeFiles/dbus-1.dir/dbus-nonce.c.o dbus/CMakeFiles/dbus-1.dir/dbus-object-tree.c.o dbus/CMakeFiles/dbus-1.dir/dbus-pending-call.c.o dbus/CMakeFiles/dbus-1.dir/dbus-resources.c.o dbus/CMakeFiles/dbus-1.dir/dbus-server.c.o dbus/CMakeFiles/dbus-1.dir/dbus-server-socket.c.o dbus/CMakeFiles/dbus-1.dir/dbus-server-debug-pipe.c.o dbus/CMakeFiles/dbus-1.dir/dbus-sha.c.o dbus/CMakeFiles/dbus-1.dir/dbus-signature.c.o dbus/CMakeFiles/dbus-1.dir/dbus-syntax.c.o dbus/CMakeFiles/dbus-1.dir/dbus-timeout.c.o dbus/CMakeFiles/dbus-1.dir/dbus-threads.c.o dbus/CMakeFiles/dbus-1.dir/dbus-transport.c.o dbus/CMakeFiles/dbus-1.dir/dbus-transport-socket.c.o dbus/CMakeFiles/dbus-1.dir/dbus-watch.c.o dbus/CMakeFiles/dbus-1.dir/dbus-uuidgen.c.o dbus/CMakeFiles/dbus-1.dir/dbus-transport-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-server-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-dataslot.c.o dbus/CMakeFiles/dbus-1.dir/dbus-file.c.o dbus/CMakeFiles/dbus-1.dir/dbus-hash.c.o dbus/CMakeFiles/dbus-1.dir/dbus-internals.c.o dbus/CMakeFiles/dbus-1.dir/dbus-list.c.o dbus/CMakeFiles/dbus-1.dir/dbus-marshal-basic.c.o dbus/CMakeFiles/dbus-1.dir/dbus-memory.c.o dbus/CMakeFiles/dbus-1.dir/dbus-mempool.c.o dbus/CMakeFiles/dbus-1.dir/dbus-string.c.o dbus/CMakeFiles/dbus-1.dir/dbus-sysdeps.c.o dbus/CMakeFiles/dbus-1.dir/dbus-pipe.c.o dbus/CMakeFiles/dbus-1.dir/dbus-file-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-pipe-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-sysdeps-unix.c.o dbus/CMakeFiles/dbus-1.dir/dbus-sysdeps-pthread.c.o dbus/CMakeFiles/dbus-1.dir/dbus-userdb.c.o -L/home/mchristy/.vcpkg/buildtrees/dbus/x64-linux-dbg/lib -Wl,-rpath,/home/mchristy/.vcpkg/buildtrees/dbus/x64-linux-dbg/lib:  -lsystemd  -lrt  -lcap  -lcrypt  -llz4d  -llzma  -lzstd  -lmount  -lblkid  /usr/lib/librt.a && :
/usr/bin/ld: cannot find -llz4d: No such file or directory
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```
[install-x64-linux-dbg-out.log](https://github.com/microsoft/vcpkg/files/13366479/install-x64-linux-dbg-out.log)
