### PR TITLE
[imgui] Update to 1.90

### DIFF
--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -4,7 +4,7 @@ if ("docking-experimental" IN_LIST FEATURES)
     vcpkg_from_github(
        OUT_SOURCE_PATH SOURCE_PATH
        REPO ocornut/imgui
-       REF "v1.90-docking"
+       REF "v${VERSION}-docking"
        SHA512 50953097ff809bca0e1cee55268eaa8dad001cf8fae85ae7623f484752d16bdf8e63c04227786361f27e73f7aeda5a8d1f9b0cee83c2aca108ce2712a21b74d9
        HEAD_REF docking
        )
@@ -12,7 +12,7 @@ else()
     vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
-    REF "v1.90"
+    REF "v${VERSION}"
     SHA512 f6b33027c7050acc617c728b04b04572a13bf11589d4d2cab566901e94d349a3d91f133f7980049857ee44768d4bad426c9b2e53baf953f2efbf1a7951c3ba8a
     HEAD_REF master
     )

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -4,16 +4,16 @@ if ("docking-experimental" IN_LIST FEATURES)
     vcpkg_from_github(
        OUT_SOURCE_PATH SOURCE_PATH
        REPO ocornut/imgui
-       REF a1b60fc1f5589d498ab1080c2572da725fcbd0e3
-       SHA512 ac6117f6adf9418af3a2db5392f1316be50a94c38e78cd1eadc0e0a71dfbb5536507aaf4d9d3b3468b5a30ebf143b806e2774f274e2098e1217ed93080fe81c7
+       REF "v1.90-docking"
+       SHA512 50953097ff809bca0e1cee55268eaa8dad001cf8fae85ae7623f484752d16bdf8e63c04227786361f27e73f7aeda5a8d1f9b0cee83c2aca108ce2712a21b74d9
        HEAD_REF docking
        )
 else()
     vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
-    REF v${VERSION}
-    SHA512 42021b06b611b58222b09fab8db2c34e992c3dc4fbaa175e09833c66c90d04b4a4e7def16a732535335c0ac5ff014d235835511a5d9a76d32b4395b302146919
+    REF "v1.90"
+    SHA512 f6b33027c7050acc617c728b04b04572a13bf11589d4d2cab566901e94d349a3d91f133f7980049857ee44768d4bad426c9b2e53baf953f2efbf1a7951c3ba8a
     HEAD_REF master
     )
 endif()

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.90.0",
+  "version": "1.90",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.89.9",
+  "version": "1.90.0",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3489,7 +3489,7 @@
       "port-version": 1
     },
     "imgui": {
-      "baseline": "1.90.0",
+      "baseline": "1.90",
       "port-version": 0
     },
     "imgui-node-editor": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3489,7 +3489,7 @@
       "port-version": 1
     },
     "imgui": {
-      "baseline": "1.89.9",
+      "baseline": "1.90.0",
       "port-version": 0
     },
     "imgui-node-editor": {

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "2387a0db75b66ad1d7a4a5b37c65611ac329767b",
-      "version": "1.90.0",
+      "git-tree": "f570e820b63f5f087134076b2343e390eb62daad",
+      "version": "1.90",
       "port-version": 0
     },
     {

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2387a0db75b66ad1d7a4a5b37c65611ac329767b",
+      "version": "1.90.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "37d78911bfdf98548568771acd72f7e6a88d1e58",
       "version": "1.89.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.