### PR TITLE
[tre] Add CMake config files.

### DIFF
--- a/ports/tre/CMakeLists.txt
+++ b/ports/tre/CMakeLists.txt
@@ -32,9 +32,21 @@ add_library(tre ${SRCS})
 
 install(
   TARGETS tre
+  EXPORT unofficial-tre-targets
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
+
+install(
+  EXPORT unofficial-tre-targets
+  NAMESPACE unofficial::tre::
+  DESTINATION share/unofficial-tre)
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/unofficial-tre-config.cmake
+  "include(\"\${CMAKE_CURRENT_LIST_DIR}/unofficial-tre-targets.cmake\")")
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-tre-config.cmake
+  DESTINATION share/unofficial-tre)
 
 install(FILES ${HEADERS} DESTINATION include/tre)

--- a/ports/tre/CMakeLists.txt
+++ b/ports/tre/CMakeLists.txt
@@ -30,6 +30,8 @@ if (WIN32)
 endif()
 add_library(tre ${SRCS})
 
+target_include_directories(tre PUBLIC "$<INSTALL_INTERFACE:include>")
+
 install(
   TARGETS tre
   EXPORT unofficial-tre-targets
@@ -41,12 +43,7 @@ install(
 install(
   EXPORT unofficial-tre-targets
   NAMESPACE unofficial::tre::
-  DESTINATION share/unofficial-tre)
-
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/unofficial-tre-config.cmake
-  "include(\"\${CMAKE_CURRENT_LIST_DIR}/unofficial-tre-targets.cmake\")")
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-tre-config.cmake
+  FILE unofficial-tre-config.cmake
   DESTINATION share/unofficial-tre)
 
 install(FILES ${HEADERS} DESTINATION include/tre)

--- a/ports/tre/portfile.cmake
+++ b/ports/tre/portfile.cmake
@@ -13,13 +13,17 @@ if(VCPKG_TARGET_IS_MINGW)
 endif()
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/unofficial-${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/tre" RENAME copyright)

--- a/ports/tre/portfile.cmake
+++ b/ports/tre/portfile.cmake
@@ -26,4 +26,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/unofficial-${PORT})
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/tre" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tre/portfile.cmake
+++ b/ports/tre/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/unofficial-${PORT})
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/tre/usage
+++ b/ports/tre/usage
@@ -1,0 +1,4 @@
+tre provides CMake targets:
+
+  find_package(unofficial-tre CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unofficial::tre::tre)

--- a/ports/tre/vcpkg.json
+++ b/ports/tre/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "tre",
   "version": "0.8.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "TRE is a lightweight, robust, and efficient POSIX compliant regexp matching library with some exciting features such as approximate (fuzzy) matching.",
   "homepage": "https://github.com/laurikari/tre",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/ports/tre/vcpkg.json
+++ b/ports/tre/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 6,
   "description": "TRE is a lightweight, robust, and efficient POSIX compliant regexp matching library with some exciting features such as approximate (fuzzy) matching.",
   "homepage": "https://github.com/laurikari/tre",
+  "license": "BSD-2-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8526,7 +8526,7 @@
     },
     "tre": {
       "baseline": "0.8.0",
-      "port-version": 5
+      "port-version": 6
     },
     "tree-similarity": {
       "baseline": "0.1.1",

--- a/versions/t-/tre.json
+++ b/versions/t-/tre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "307fd730a8de00228602333743300ebadc2b301c",
+      "version": "0.8.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "601cf1197e7f531cf374926d949163b9c4bb8331",
       "version": "0.8.0",
       "port-version": 5


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.