### PR TITLE
[pcre2] add utf support feature

### DIFF
--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         jit   PCRE2_SUPPORT_JIT
+        utf   CMAKE_CXX_FLAGS=-DPCRE2_UTF
 )
 
 vcpkg_cmake_configure(

--- a/ports/pcre2/vcpkg.json
+++ b/ports/pcre2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pcre2",
   "version": "10.42",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Regular Expression pattern matching using the same syntax and semantics as Perl 5.",
   "homepage": "https://github.com/PCRE2Project/pcre2",
   "license": "BSD-3-Clause",
@@ -34,6 +34,9 @@
           "platform": "!emscripten"
         }
       ]
+    },
+    "utf": {
+      "description": "Enable utf support"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6482,7 +6482,7 @@
     },
     "pcre2": {
       "baseline": "10.42",
-      "port-version": 1
+      "port-version": 2
     },
     "pdal": {
       "baseline": "2.5.3",

--- a/versions/p-/pcre2.json
+++ b/versions/p-/pcre2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "72fed5afb381b082ac614a98d232fde2ce9ae64e",
+      "version": "10.42",
+      "port-version": 2
+    },
+    {
       "git-tree": "678c2336c4102c5a8868570c60140fdc2a8d1dcf",
       "version": "10.42",
       "port-version": 1


### PR DESCRIPTION
add utf support feature
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
