### PR TITLE
[libgnutls] Fix build error when cross-compiling for mingw-w64

### DIFF
--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -41,6 +41,8 @@ if(VCPKG_CROSSCOMPILING)
 endif()
 
 set(ENV{GTKDOCIZE} true) # true, the program
+set(ENV{CFLAGS} " -D_POSIX_C_SOURCE -Wno-int-conversion")
+set(ENV{CXXFLAGS} " -D_POSIX_C_SOURCE -Wno-int-conversion")
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
@@ -57,6 +59,7 @@ vcpkg_configure_make(
         --with-tpm=no
         --with-tpm2=no
         --with-zstd=no
+        --disable-hardware-acceleration
         ${options}
         YACC=false # false, the program - not used here
     OPTIONS_DEBUG

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libgnutls",
   "version": "3.8.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols.",
   "homepage": "https://www.gnutls.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4306,7 +4306,7 @@
     },
     "libgnutls": {
       "baseline": "3.8.1",
-      "port-version": 1
+      "port-version": 2
     },
     "libgo": {
       "baseline": "3.1",

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6283924d819d57746bec09c53a8b6b86dff1761d",
+      "version": "3.8.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "cdcde91b6757c786647f9bfafef1e0f02591a859",
       "version": "3.8.1",
       "port-version": 1


### PR DESCRIPTION
Fixes #32085
Fix error:
````
x86_64-w64-mingw32-ar: coff/aesni-x86_64.o: No such file or directory
make[5]: *** [libx86.la] Error 1
make[4]: *** [all-recursive] Error 1
make[3]: *** [all-recursive] Error 1
make[2]: *** [all] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
