### PR TITLE
[geographiclib] Remove toolset restriction in the same way as proj

### DIFF
--- a/ports/geographiclib/portfile.cmake
+++ b/ports/geographiclib/portfile.cmake
@@ -4,8 +4,10 @@ vcpkg_from_sourceforge(
     REF distrib-C++
     FILENAME "GeographicLib-2.3.tar.gz"
     SHA512 1a1bd0fc2dc3e1372cf22618af3a4340bbc6497f94c64226c97654dfff92a4bf3acf47d91592741fe0c643d401d9721f680bdb4974b8ee258fb09d525fbaec67
-    PATCHES remove-broken-and-unnecessary-cross-compile-check.patch
-    )
+    PATCHES
+        remove-broken-and-unnecessary-cross-compile-check.patch
+        remove-toolset-restriction.patch
+)
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/geographiclib/remove-toolset-restriction.patch
+++ b/ports/geographiclib/remove-toolset-restriction.patch
@@ -1,0 +1,19 @@
+diff --git a/cmake/project-config-version.cmake.in b/cmake/project-config-version.cmake.in
+index 3b519608..0ffbdb78 100644
+--- a/cmake/project-config-version.cmake.in
++++ b/cmake/project-config-version.cmake.in
+@@ -35,14 +35,6 @@ elseif (NOT (APPLE OR (NOT DEFINED CMAKE_SIZEOF_VOID_P) OR
+   # since a multi-architecture library is built for that platform).
+   set (REASON "sizeof(*void) =  @CMAKE_SIZEOF_VOID_P@")
+   set (PACKAGE_VERSION_UNSUITABLE TRUE)
+-elseif (MSVC AND NOT (
+-    # toolset version must be at least as great as @PROJECT_NAME@'s.
+-    MSVC_TOOLSET_VERSION GREATER_EQUAL @MSVC_TOOLSET_VERSION@
+-    # and major versions must match
+-    AND MSVC_TOOLSET_MAJOR EQUAL @MSVC_TOOLSET_MAJOR@ ))
+-  # Reject if there's a mismatch in MSVC compiler versions.
+-  set (REASON "MSVC_TOOLSET_VERSION = @MSVC_TOOLSET_VERSION@")
+-  set (PACKAGE_VERSION_UNSUITABLE TRUE)
+ elseif (GEOGRAPHICLIB_PRECISION MATCHES "^[1-5]\$" AND NOT (
+       GEOGRAPHICLIB_PRECISION EQUAL @GEOGRAPHICLIB_PRECISION@ ))
+   # Reject if the user asks for an incompatible precsision.

--- a/ports/geographiclib/vcpkg.json
+++ b/ports/geographiclib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "geographiclib",
   "version": "2.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GeographicLib, a C++ library for performing geographic conversions",
   "homepage": "https://geographiclib.sourceforge.io",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2890,7 +2890,7 @@
     },
     "geographiclib": {
       "baseline": "2.3",
-      "port-version": 1
+      "port-version": 2
     },
     "geos": {
       "baseline": "3.11.2",

--- a/versions/g-/geographiclib.json
+++ b/versions/g-/geographiclib.json
@@ -6,6 +6,11 @@
       "port-version": 2
     },
     {
+      "git-tree": "d81b3f7975338273ed42ce6544734e24b6c7915a",
+      "version": "2.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "f24840f27f1c858b85e449c3066cec7978c304c6",
       "version": "2.3",
       "port-version": 0

--- a/versions/g-/geographiclib.json
+++ b/versions/g-/geographiclib.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "d81b3f7975338273ed42ce6544734e24b6c7915a",
+      "git-tree": "81c0f3349e222b65445a342a8ddade4395c6cec7",
       "version": "2.3",
-      "port-version": 1
+      "port-version": 2
     },
     {
       "git-tree": "f24840f27f1c858b85e449c3066cec7978c304c6",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

---

As described in https://github.com/geographiclib/geographiclib/pull/20, CMake fails if multiple versions of Visual Studio are installed.
So, I applied the same way as https://github.com/microsoft/vcpkg/pull/32858.
I've confirmed this fixes the issue for my environment.