### PR TITLE
[glog] Set GLOG_STATIC_DEFINE in export.h

### DIFF
--- a/ports/glog/portfile.cmake
+++ b/ports/glog/portfile.cmake
@@ -35,4 +35,10 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/${PORT}/export.h" "#ifdef GLOG_STATIC_DEFINE" "#if 1")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/${PORT}/export.h" "#ifdef GLOG_STATIC_DEFINE" "#if 0")
+endif()
+    
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/glog/vcpkg.json
+++ b/ports/glog/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glog",
   "version": "0.6.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "C++ implementation of the Google logging module",
   "homepage": "https://github.com/google/glog",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2998,7 +2998,7 @@
     },
     "glog": {
       "baseline": "0.6.0",
-      "port-version": 2
+      "port-version": 3
     },
     "gloo": {
       "baseline": "20201203",

--- a/versions/g-/glog.json
+++ b/versions/g-/glog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e4dcaa54d409ed758073ef4964cf41d57996e90",
+      "version": "0.6.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "cce45164ee522a505686c1794e7c228e44f52d76",
       "version": "0.6.0",
       "port-version": 2


### PR DESCRIPTION
Fixes #35160.

Set `GLOG_STATIC_DEFINE` in `export.h` according to `VCPKG_LIBRARY_LINKAGE`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.