### PR TITLE
[libosip2] update to 5.3.1

### DIFF
--- a/ports/libosip2/portfile.cmake
+++ b/ports/libosip2/portfile.cmake
@@ -1,9 +1,7 @@
-set(LIBOSIP2_VER "5.2.0")
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnu.org/gnu/osip/libosip2-${LIBOSIP2_VER}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/osip/libosip2-${LIBOSIP2_VER}.tar.gz"
-    FILENAME "libosip2-${LIBOSIP2_VER}.tar.gz"
-    SHA512 cc714ab5669c466ee8f0de78cf74a8b7633f3089bf104c9c1474326840db3d791270159456f9deb877af2df346b04493e8f796b2bb7d2be134f6c08b25a29f83
+    URLS "https://ftp.gnu.org/gnu/osip/libosip2-${VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/osip/libosip2-${VERSION}.tar.gz"
+    FILENAME "libosip2-${VERSION}.tar.gz"
+    SHA512 cd9db7a736cca90c6862b84c4941ef025f5affab8af9bbc02ce0dd3310a2c555e0922c1bfa72d8ac08791fa1441bbcc30b627d52ca8b51f3471573a10ac82a00
 )
 
 set(PATCHES)

--- a/ports/libosip2/vcpkg.json
+++ b/ports/libosip2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libosip2",
-  "version": "5.2.0",
-  "port-version": 5,
+  "version": "5.3.1",
   "description": "oSIP is an LGPL implementation of SIP. It's stable, portable, flexible and compliant! -may be more-! It is used mostly with eXosip2 stack (GPL) which provides simpler API for User-Agent implementation.",
   "homepage": "https://www.gnu.org/software/osip/",
   "supports": "!(windows & arm) & !uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4597,8 +4597,8 @@
       "port-version": 3
     },
     "libosip2": {
-      "baseline": "5.2.0",
-      "port-version": 5
+      "baseline": "5.3.1",
+      "port-version": 0
     },
     "libosmium": {
       "baseline": "2.20.0",

--- a/versions/l-/libosip2.json
+++ b/versions/l-/libosip2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb02960c7156b49272969e224ccb0903c0a42a24",
+      "version": "5.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e2811fe1a0d4cb7faabaebfa4cf47e1296bcddd2",
       "version": "5.2.0",
       "port-version": 5


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

