### PR TITLE
[dstorage] Update for version 1.2.2

### DIFF
--- a/ports/dstorage/portfile.cmake
+++ b/ports/dstorage/portfile.cmake
@@ -5,7 +5,7 @@ set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/${VERSION}"
     FILENAME "directstorage.${VERSION}.zip"
-    SHA512 5be6219888c89c5f590709d1528b3e6854eabd7b733af5c8f665aa9d7e987fa3bac34472362f845eb902b88d2d6e8afbbcead15e892d72678861a14b0bc13c41
+    SHA512 f24f681edf0c5e047573c68ca85ab62e0ffefaf87867d45231d779e9bc8e9525891b56314cc30e58eaef20132335f011f32aba22654d2e7caf23338aeb29c6ce
 )
 
 vcpkg_extract_source_archive(
@@ -25,6 +25,7 @@ file(COPY "${PACKAGE_PATH}/native/bin/${VCPKG_TARGET_ARCHITECTURE}/dstoragecore.
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug")
 file(COPY "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")
 
-file(INSTALL "${PACKAGE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/LICENSE.txt")
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/dstorage-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" COPYONLY)

--- a/ports/dstorage/usage
+++ b/ports/dstorage/usage
@@ -1,0 +1,4 @@
+The DirectStorage package is compatible with built-in CMake targets:
+
+    find_package(dstorage CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Microsoft::DirectStorage)

--- a/ports/dstorage/usage
+++ b/ports/dstorage/usage
@@ -1,4 +1,4 @@
-The DirectStorage package is compatible with built-in CMake targets:
+The DirectStorage package provides CMake targets:
 
     find_package(dstorage CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::DirectStorage)

--- a/ports/dstorage/vcpkg.json
+++ b/ports/dstorage/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "dstorage",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "DirectStorage for Windows",
   "homepage": "https://aka.ms/directstorage/",
   "documentation": "https://github.com/microsoft/DirectStorage",
   "license": null,
-  "supports": "windows & !uwp & !xbox"
+  "supports": "windows & !arm32 & !uwp & !xbox"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2265,7 +2265,7 @@
       "port-version": 1
     },
     "dstorage": {
-      "baseline": "1.2.0",
+      "baseline": "1.2.2",
       "port-version": 0
     },
     "dtl": {

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a39ef5ad834e586d7d7815e2f6550be319b64d1",
+      "version": "1.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "18440695231677ed659b391e4a31c0100996cdb6",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6a39ef5ad834e586d7d7815e2f6550be319b64d1",
+      "git-tree": "7577afa856f2cf3d3ce28d32f3272344987f2a71",
       "version": "1.2.2",
       "port-version": 0
     },


### PR DESCRIPTION
ARM 32 bit support has been retired for the OS, so this port drops support for it as well as the binaries are not included in the nupkg.