### PR TITLE
[cppgraphqlgen] Update to v4.5.5

### DIFF
--- a/ports/cppgraphqlgen/portfile.cmake
+++ b/ports/cppgraphqlgen/portfile.cmake
@@ -2,8 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/cppgraphqlgen
     REF "v${VERSION}"
-    SHA512 0a41306862bc9f370fb369bd0cdc015fd15b95179ac2de60d8d412a26d385044177d1ca6e730e96e2ff0b0ffabcfe0246fdd3d926348641a145cd2894eb9cb7f
+    SHA512 8079b2690ef4fba491e96ef2ed3da61d0c0b7bee3f61fa6d1fb95c771f1a8220a7b15b489b21bf9b1627e8616f95c65b43b8f63ee93cb0193edac4cb54307b3a
     HEAD_REF main
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        rapidjson   GRAPHQL_USE_RAPIDJSON
 )
 
 vcpkg_cmake_configure(
@@ -13,6 +19,7 @@ vcpkg_cmake_configure(
         -DGRAPHQL_UPDATE_VERSION=OFF 
         -DGRAPHQL_UPDATE_SAMPLES=OFF 
         -DGRAPHQL_INSTALL_CONFIGURATIONS=Release
+        ${FEATURE_OPTIONS}
     OPTIONS_RELEASE 
         -DGRAPHQL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share 
         -DGRAPHQL_INSTALL_TOOLS_DIR=${CURRENT_PACKAGES_DIR}/tools

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -1,13 +1,23 @@
 {
   "name": "cppgraphqlgen",
-  "version": "4.5.3",
+  "version": "4.5.5",
   "description": "C++ GraphQL schema service generator",
   "homepage": "https://github.com/microsoft/cppgraphqlgen",
   "license": "MIT",
+  "features": {
+    "rapidjson": {
+      "description": "Build the graphqljson library with RapidJSON.",
+      "dependencies": [
+        "rapidjson"
+      ]
+    }
+  },
+  "default-features": [
+    "rapidjson"
+  ],
   "dependencies": [
     "boost-program-options",
     "pegtl",
-    "rapidjson",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -4,17 +4,6 @@
   "description": "C++ GraphQL schema service generator",
   "homepage": "https://github.com/microsoft/cppgraphqlgen",
   "license": "MIT",
-  "features": {
-    "rapidjson": {
-      "description": "Build the graphqljson library with RapidJSON.",
-      "dependencies": [
-        "rapidjson"
-      ]
-    }
-  },
-  "default-features": [
-    "rapidjson"
-  ],
   "dependencies": [
     "boost-program-options",
     "pegtl",
@@ -26,5 +15,16 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "rapidjson"
+  ],
+  "features": {
+    "rapidjson": {
+      "description": "Build the graphqljson library with RapidJSON.",
+      "dependencies": [
+        "rapidjson"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1861,7 +1861,7 @@
       "port-version": 3
     },
     "cppgraphqlgen": {
-      "baseline": "4.5.3",
+      "baseline": "4.5.5",
       "port-version": 0
     },
     "cppitertools": {

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e5e70f3ccff87b9b39412aaf1f2c0382a3d3274",
+      "version": "4.5.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d87ba9b4921a48271c8c6abbe7e9c3f96651b4f",
       "version": "4.5.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.