### PR TITLE
[glslang] fix tools

### DIFF
--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -45,10 +45,7 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/glslang-config.cmake
 vcpkg_copy_pdbs()
 
 if (ENABLE_GLSLANG_BINARIES)
-    vcpkg_copy_tools(TOOL_NAMES glslangValidator spirv-remap AUTO_CLEAN)
-    if(VCPKG_TARGET_IS_WINDOWS)
-        vcpkg_copy_tools(TOOL_NAMES glslang AUTO_CLEAN)
-    endif()
+    vcpkg_copy_tools(TOOL_NAMES glslang glslangValidator spirv-remap AUTO_CLEAN)
 endif ()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glslang",
   "version": "13.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Khronos-reference front end for GLSL/ESSL, partial front end for HLSL, and a SPIR-V generator.",
   "homepage": "https://github.com/KhronosGroup/glslang",
   "license": "Apache-2.0 AND BSD-3-Clause AND MIT AND GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3010,7 +3010,7 @@
     },
     "glslang": {
       "baseline": "13.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "glui": {
       "baseline": "2019-11-30",

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "488d78f12e3a376002a80d0058e3973ac75d4fe7",
+      "version": "13.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "c5c6c37e6477580e47bd5645a3760ff534c689f6",
       "version": "13.0.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Currently the tool glslangValidator is broken, because it is only a symbolic link to not existent file.
With 12.3.0 release glslang renamed the tool binary glslangValidator to glslang, but keeping the old name as copy (Windows) or symbolic link to the new one (other platforms), see https://github.com/KhronosGroup/glslang/releases/tag/12.3.0. It is required to install the new tool. #34700 fixed this for windows only, but the same solution is required on all platforms.


