### PR TITLE
[spirv-*] update versions

### DIFF
--- a/ports/spirv-headers/portfile.cmake
+++ b/ports/spirv-headers/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/SPIRV-Headers
-    REF sdk-1.3.231.1
-    SHA512 d2c47127fd81430383e8656917f76933b713ca6cb93b2a9c16c9e0b125e2f62f8c497cab3a4fcc2a711decd911ec5d15f1eb0270add05442aff6672e08c890d7
+    REF "sdk-${VERSION}"
+    SHA512 436c6ce11d918091ce4a5ef2821f51af811c9a289e220b4a2b0bb4417b1f9f3b1f56a6366cfdf56848a9b1fb612ee3ba31d35c3d73d3d24de964ee05f96a7bbc
     HEAD_REF master
 )
 
@@ -17,5 +17,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_fixup_pkgconfig()
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/spirv-headers/vcpkg.json
+++ b/ports/spirv-headers/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "spirv-headers",
-  "version": "1.3.231.1",
-  "port-version": 1,
+  "version": "1.3.246.1",
   "description": "Machine-readable files for the SPIR-V Registry",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Headers",
   "dependencies": [

--- a/ports/spirv-tools/cmake-config-dir.diff
+++ b/ports/spirv-tools/cmake-config-dir.diff
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1b8fe92..8f3f91a 100644
+index 75830b44..367fe889 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -269,7 +269,7 @@ else()
+@@ -270,7 +270,7 @@ else()
  endif()
  
  if(ENABLE_SPIRV_TOOLS_INSTALL)
--  if(WIN32)
+-  if(WIN32 AND NOT MINGW)
 +  if(0)
      macro(spvtools_config_package_dir TARGET PATH)
        set(${PATH} ${TARGET}/cmake)

--- a/ports/spirv-tools/fix-tool-deps.diff
+++ b/ports/spirv-tools/fix-tool-deps.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2cf1e40..5f2a86c 100644
+index 75830b44..9c9e7ba8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -280,8 +280,13 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
+@@ -281,8 +281,13 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
    endif()
  
    macro(spvtools_generate_config_file TARGET)

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/SPIRV-Tools
-    REF v2022.4
-    SHA512 d93e97e168c50f545cc42418603ffc5fa6299bb3cc30d927444e4de0d955abc5dd481c9662a59cd49fc379da6bcc6df6fb747947e3dc144cee9b489aff7c4785
+    REF "v${VERSION}"
+    SHA512 988f5e31508e3f19c1dd9d9a013c8e9ff89eba86207a769d7d804f9ee0201c794f412a874c860167b2c040b2c5e1fb1c835ae3684c70feaac86e47f90c1a5010
     PATCHES
         cmake-config-dir.diff
         spirv-tools-shared.diff

--- a/ports/spirv-tools/spirv-tools-shared.diff
+++ b/ports/spirv-tools/spirv-tools-shared.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8f3f91a..2cf1e40 100644
+index 75830b44..39cc039e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -389,10 +389,14 @@ add_custom_target(spirv-tools-shared-pkg-config ALL
+@@ -390,10 +390,14 @@ add_custom_target(spirv-tools-shared-pkg-config ALL
  
  # Install pkg-config file
  if (ENABLE_SPIRV_TOOLS_INSTALL)
@@ -19,10 +19,10 @@ index 8f3f91a..2cf1e40 100644
        ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
  endif()
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
-index 668579a..7874c1a 100644
+index acfa0c12..b3286db3 100644
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
-@@ -421,6 +421,10 @@ if (ANDROID)
+@@ -425,6 +425,10 @@ if (ANDROID)
  endif()
  
  if(ENABLE_SPIRV_TOOLS_INSTALL)
@@ -30,6 +30,6 @@ index 668579a..7874c1a 100644
 +    set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES EXCLUDE_FROM_ALL 1)
 +    list(REMOVE_ITEM SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-shared)
 +  endif()
-   install(TARGETS ${SPIRV_TOOLS_TARGETS} EXPORT ${SPIRV_TOOLS}Targets
-     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   install(TARGETS ${SPIRV_TOOLS_TARGETS} EXPORT ${SPIRV_TOOLS}Targets)
+   export(EXPORT ${SPIRV_TOOLS}Targets FILE ${SPIRV_TOOLS}Target.cmake)
+ 

--- a/ports/spirv-tools/vcpkg.json
+++ b/ports/spirv-tools/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "spirv-tools",
-  "version": "2022.4",
-  "port-version": 1,
+  "version": "2023.2",
   "description": "API and commands for processing SPIR-V modules",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Tools",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8069,16 +8069,16 @@
       "port-version": 2
     },
     "spirv-headers": {
-      "baseline": "1.3.231.1",
-      "port-version": 1
+      "baseline": "1.3.246.1",
+      "port-version": 0
     },
     "spirv-reflect": {
       "baseline": "1.3.236.0",
       "port-version": 0
     },
     "spirv-tools": {
-      "baseline": "2022.4",
-      "port-version": 1
+      "baseline": "2023.2",
+      "port-version": 0
     },
     "spout2": {
       "baseline": "2.007.010",

--- a/versions/s-/spirv-headers.json
+++ b/versions/s-/spirv-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9745c8474cd0d67262164092fe7283b7ecb36914",
+      "version": "1.3.246.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1975a40807faf80ae5a8513b15f707ec9d583763",
       "version": "1.3.231.1",
       "port-version": 1

--- a/versions/s-/spirv-tools.json
+++ b/versions/s-/spirv-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47e4151499f10ce55584fc6818822bdc4a913353",
+      "version": "2023.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "082a2b7ca21aeafe82dc89765facb7c34675b7b9",
       "version": "2022.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Update `spirv-tools` and `spirv-headers`. `spirv-headers` is intentionally not the newest version, but the latest version at the state of the `spirv-tools` release. Using the newest version of the headers would break `spirv-tools`.