### PR TITLE
[clap-cleveraudio] New port

### DIFF
--- a/ports/clap-cleveraudio/portfile.cmake
+++ b/ports/clap-cleveraudio/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO free-audio/clap
+    REF 1.1.10
+    SHA512 50d2b8e35ebcb3dfd4e057ddcf22e92204ca90a700527fe802c7f3ae678e77c970f789f2fbbedd58964a1d1ec72376e7c8d488c10fe03d39fbd1cd5d6a8630a1
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    -UCMAKE_INSTALL_LIBDIR
+    -DCMAKE_INSTALL_LIBDIR=share
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH "lib/cmake/clap"
+)
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/clap-cleveraudio/portfile.cmake
+++ b/ports/clap-cleveraudio/portfile.cmake
@@ -8,9 +8,6 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-    -UCMAKE_INSTALL_LIBDIR
-    -DCMAKE_INSTALL_LIBDIR=share
 )
 
 vcpkg_cmake_install()

--- a/ports/clap-cleveraudio/vcpkg.json
+++ b/ports/clap-cleveraudio/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "clap-cleveraudio",
+  "version-semver": "1.1.10",
+  "description": "CLAP is an audio plugin ABI which defines a standard for Digital Audio Workstations and audio plugins to work together",
+  "homepage": "https://cleveraudio.org/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1596,6 +1596,10 @@
       "baseline": "0.103.0",
       "port-version": 4
     },
+    "clap-cleveraudio": {
+      "baseline": "1.1.10",
+      "port-version": 0
+    },
     "clapack": {
       "baseline": "3.2.1",
       "port-version": 22

--- a/versions/c-/clap-cleveraudio.json
+++ b/versions/c-/clap-cleveraudio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4e5ba6fc827e785942f9713cce68002b95df39d6",
+      "git-tree": "53d2e109c8c510419c0e2ecfc15beb707bb1215a",
       "version-semver": "1.1.10",
       "port-version": 0
     }

--- a/versions/c-/clap-cleveraudio.json
+++ b/versions/c-/clap-cleveraudio.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4e5ba6fc827e785942f9713cce68002b95df39d6",
+      "version-semver": "1.1.10",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
