### PR TITLE
[tree-sitter] fix a typo in pkg-config file

### DIFF
--- a/ports/tree-sitter/pkgconfig.patch
+++ b/ports/tree-sitter/pkgconfig.patch
@@ -10,7 +10,7 @@ index f98816cb..71a3b4f9 100644
 -libdir=@LIBDIR@
 -includedir=@INCLUDEDIR@
 +prefix=@CMAKE_INSTALL_PREFIX@
-+libdir=${prefix}@/lib
++libdir=${prefix}/lib
 +includedir=${prefix}/include
  
  Name: tree-sitter

--- a/ports/tree-sitter/vcpkg.json
+++ b/ports/tree-sitter/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tree-sitter",
   "version-semver": "0.20.6",
+  "port-version": 1,
   "description": "An incremental parsing system for programming tools.",
   "homepage": "https://github.com/tree-sitter/tree-sitter",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8550,7 +8550,7 @@
     },
     "tree-sitter": {
       "baseline": "0.20.6",
-      "port-version": 0
+      "port-version": 1
     },
     "treehh": {
       "baseline": "3.18",

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f818e329af89033c591416456e9c630280bd4ef8",
+      "version-semver": "0.20.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "a96085943d7eb28c30fa8d53eb5452e4dccdfd93",
       "version-semver": "0.20.6",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.


