### PR TITLE
[zlib-ng] Update to 2.1.4

### DIFF
--- a/ports/zlib-ng/portfile.cmake
+++ b/ports/zlib-ng/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/zlib-ng
     REF "${VERSION}"
-    SHA512 cb987c0b20a11fca5361dce94e53dead7364e739a984545c38ad4bf0c7fedd83d5d62530d979eca2182da88d7507a9bec8d3f5abff41e92ab5a63ac61001502e
+    SHA512 5afda5ea4be84f7d7b016416a6eed18e2aab6c698f006cdfbc8f8b43ce3dc73c7994ab9d1ca090c1b93cb1aadc8747bfd8216afb22b44633d49127f01b77cfa2
     HEAD_REF develop
     PATCHES
         fix-cflags.patch

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zlib-ng",
-  "version": "2.1.3",
-  "port-version": 1,
+  "version": "2.1.4",
   "description": "zlib replacement with optimizations for 'next generation' systems",
   "homepage": "https://github.com/zlib-ng/zlib-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9329,8 +9329,8 @@
       "port-version": 0
     },
     "zlib-ng": {
-      "baseline": "2.1.3",
-      "port-version": 1
+      "baseline": "2.1.4",
+      "port-version": 0
     },
     "zlmediakit": {
       "baseline": "2023-08-12",

--- a/versions/z-/zlib-ng.json
+++ b/versions/z-/zlib-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f05a7ce2c95cfcf4720d911a72dc3b60b46eb1c9",
+      "version": "2.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "48a2a573758db5e1b96e889043fffaf453fa9cf4",
       "version": "2.1.3",
       "port-version": 1


### PR DESCRIPTION
Update to latest release https://github.com/zlib-ng/zlib-ng/releases/tag/2.1.4

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
