### PR TITLE
[opentelemetry-cpp] Fix otlp-grpc feature does not support uwp

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -29,12 +29,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 # opentelemetry-proto is a third party submodule and opentelemetry-cpp release did not pack it.
-if(WITH_OTLP)
-    set(OTEL_PROTO_VERSION "0.19.0")
+if(WITH_OTLP_GRPC)
+    set(OTEL_PROTO_VERSION "1.0.0")
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/open-telemetry/opentelemetry-proto/archive/v${OTEL_PROTO_VERSION}.tar.gz"
         FILENAME "opentelemetry-proto-${OTEL_PROTO_VERSION}.tar.gz"
-        SHA512 b6d47aaa90ff934eb24047757d5fdb8a5be62963a49b632460511155f09a725937fb7535cf34f738b81cc799600adbbc3809442aba584d760891c0a1f0ce8c03
+        SHA512 74de78304a91fe72cfcdbd87fcb19c0d6338c161d6624ce09eac0527b1b43b8a5d8790ae055e1d3d44319eaa070a506f47e740f888c91d724a0aef8b509688f0
     )
 
     vcpkg_extract_source_archive(src ARCHIVE "${ARCHIVE}")

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -51,7 +51,6 @@
     },
     "otlp-grpc": {
       "description": "Whether to include the OTLP gRPC exporter in the SDK",
-      "supports": "!uwp",
       "dependencies": [
         "grpc",
         {

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.12.0",
+  "port-version": 1,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."
@@ -50,6 +51,7 @@
     },
     "otlp-grpc": {
       "description": "Whether to include the OTLP gRPC exporter in the SDK",
+      "supports": "!uwp",
       "dependencies": [
         "grpc",
         {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6318,7 +6318,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.12.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opentelemetry-fluentd": {
       "baseline": "2.0.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13178b82919223387a0d8d8efffae396a95d8110",
+      "version-semver": "1.12.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5fd8cacd9fd3aaa30b0ad133f2de052ba3ff869f",
       "version-semver": "1.12.0",
       "port-version": 0

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "13178b82919223387a0d8d8efffae396a95d8110",
+      "git-tree": "71dd31a63ee43f477bad710ccce04ffac2be5238",
       "version-semver": "1.12.0",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/34847

Specify the path of `gRPC_CPP_PLUGIN_EXECUTABLE` as `${CURRENT_HOST_INSTALLED_DIR}/tools/grpc/grpc_cpp_plugin${VCPKG_HOST_EXECUTABLE_SUFFIX}`.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
x64-windows-static
```