### PR TITLE
 [librsvg] Fix pixbufloader-svg caching problem 

### DIFF
--- a/ports/librsvg/CMakeLists.txt
+++ b/ports/librsvg/CMakeLists.txt
@@ -136,6 +136,7 @@ install(
 set(gdk_pixbuf_pc_requires_private gdk-pixbuf-2.0)
 pkg_check_modules(GDK_PIXBUF ${gdk_pixbuf_pc_requires_private} IMPORTED_TARGET REQUIRED)
 pkg_get_variable(GDK_PIXBUF_MODULEDIR ${gdk_pixbuf_pc_requires_private} gdk_pixbuf_moduledir)
+pkg_get_variable(GDK_PIXBUF_LIBDIR ${gdk_pixbuf_pc_requires_private} libdir)
 
 set(PIXBUFLOADERSVG_SOURCES
     gdk-pixbuf-loader/io-svg.c
@@ -159,9 +160,14 @@ target_link_libraries(pixbufloader-svg
         ${LIBRSVG_TARGET}
         PkgConfig::GDK_PIXBUF
 )
+
+# Extract the GdkPixbuf module dir in the lib dir to install the plugin in the package directory of librsvg.
+# Installing into the GDK_PIXBUF_MODULEDIR breaks the caching mechanism.
+string(REPLACE "${GDK_PIXBUF_LIBDIR}" "" GDK_PIXBUF_LOADER_DIR "${GDK_PIXBUF_MODULEDIR}")
+set(LOADER_DIR "lib${GDK_PIXBUF_LOADER_DIR}")
 install(TARGETS pixbufloader-svg
-    RUNTIME DESTINATION "${GDK_PIXBUF_MODULEDIR}"
-    LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}"
+    RUNTIME DESTINATION "${LOADER_DIR}"
+    LIBRARY DESTINATION "${LOADER_DIR}"
 )
 
 

--- a/ports/librsvg/vcpkg.json
+++ b/ports/librsvg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "librsvg",
   "version": "2.40.20",
-  "port-version": 10,
+  "port-version": 11,
   "description": "A small library to render Scalable Vector Graphics (SVG)",
   "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4718,7 +4718,7 @@
     },
     "librsvg": {
       "baseline": "2.40.20",
-      "port-version": 10
+      "port-version": 11
     },
     "librsync": {
       "baseline": "2.3.4",

--- a/versions/l-/librsvg.json
+++ b/versions/l-/librsvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "642663528f89aada43122ad16ebd71e5834d8450",
+      "version": "2.40.20",
+      "port-version": 11
+    },
+    {
       "git-tree": "ba6e6aad1557505c8ede7b320d554bd2cab6bb7d",
       "version": "2.40.20",
       "port-version": 10


### PR DESCRIPTION
Installing the pixbufloader-svg in the GDK_PIXBUF_MODULEDIR breaks the vcpkg caching mechanism. By extracting the GdkPixbuf module dir and installing the pixbufloader-svg in the librsvg package directory, caching will work as expected.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] ~Only one version is added to each modified port's versions file.~