### PR TITLE
[wcslib] Update wcslib to 8.2.1

### DIFF
--- a/ports/wcslib/portfile.cmake
+++ b/ports/wcslib/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(archive
-    URLS "https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-7.12.tar.bz2"
-    FILENAME "wcslib-7.12.tar.bz2"
-    SHA512 7f38f725992d3c4bd3c1b908d494ac361c17f6b60f091d987fda596211423bb7396b3a5e2f1f6dd6215835016d302083472a7ad0822f17cdfe230c8f556b3e23
+    URLS "http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-8.2.1.tar.bz2"
+    FILENAME "wcslib-8.2.1.tar.bz2"
+    SHA512 0d1ab63445974c2a4f425225cde197866187a9e7ae0195a33dcb33ad299018294338bc16ab4cbe6a3a27fb40aded75c60377348eaa91713d16a934cd95532c25
 )
 
 vcpkg_extract_source_archive(

--- a/ports/wcslib/vcpkg.json
+++ b/ports/wcslib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wcslib",
-  "version": "7.12",
+  "version": "8.2.1",
   "description": "World Coordinate System (WCS) (Library)",
   "homepage": "https://www.atnf.csiro.au/people/mcalabre/WCS/",
   "supports": "!windows"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8969,7 +8969,7 @@
       "port-version": 1
     },
     "wcslib": {
-      "baseline": "7.12",
+      "baseline": "8.2.1",
       "port-version": 0
     },
     "websocketpp": {

--- a/versions/w-/wcslib.json
+++ b/versions/w-/wcslib.json
@@ -4,6 +4,11 @@
       "git-tree": "2e33104b54c3db79012234ded4db319a3464885b",
       "version": "7.12",
       "port-version": 0
+    },
+    {
+      "git-tree": "a68a2412a39e7458698f2e4110d8a50dc8619c96",
+      "version": "8.2.1",
+      "port-version": 0
     }
   ]
 }


### PR DESCRIPTION
WCSLIB 8.2.1 was recently released:

https://www.atnf.csiro.au/people/mcalabre/WCS/index.html

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
