### PR TITLE
[CImg] Update and install the header files

### DIFF
--- a/ports/cimg/CMakeLists.txt
+++ b/ports/cimg/CMakeLists.txt
@@ -19,3 +19,6 @@ install(
     FILES ${CMAKE_CURRENT_SOURCE_DIR}/CImg.h
     DESTINATION include
 )
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/plugins DESTINATION include)

--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -1,7 +1,8 @@
+
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO dtschump/CImg
-    REF b33dcc8f9f1acf1f276ded92c04f8231f6c23fcd # v2.9.9
-    SHA512 327c72320e7cac386ba72d417c45b9e8b40df34650370c34e687c362731919af1b447b2ee498f21278d4af155f0d9dbfabd222856d5f18c2e05569fa638a5909
+    REF d6c022169271fa3c73abf94002a557c4e6f8327f #v3.3.2
+    SHA512 0cb2e0cc41902bdb3a21bac079104d4c49bbf51ae0eef6497fdb645934311aa75480bffcc2fc9d11c5b54912397fb4910c4c20ccd766a83e317a8e861b9b513b
     HEAD_REF master
 )
 
@@ -17,5 +18,8 @@ vcpkg_cmake_install()
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-file(INSTALL "${SOURCE_PATH}/Licence_CeCILL-C_V1-en.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-file(INSTALL "${SOURCE_PATH}/Licence_CeCILL_V2-en.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright2)
+vcpkg_install_copyright(
+    FILE_LIST 
+        "${SOURCE_PATH}/Licence_CeCILL-C_V1-en.txt"
+        "${SOURCE_PATH}/Licence_CeCILL_V2-en.txt"
+)

--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -1,8 +1,9 @@
+set(VCPKG_BUILD_TYPE release) # header-only
 
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO dtschump/CImg
-    REF d6c022169271fa3c73abf94002a557c4e6f8327f #v3.3.2
-    SHA512 0cb2e0cc41902bdb3a21bac079104d4c49bbf51ae0eef6497fdb645934311aa75480bffcc2fc9d11c5b54912397fb4910c4c20ccd766a83e317a8e861b9b513b
+    REF "v.${VERSION}"
+    SHA512 c38910e8b93bcb65fbfd7fe11a036bae9f22e229d903cd044c26223473b02ec48ec46b3ad398e2cc02f25184e16a2e27a687f18479d3ae7edaee2bab69028ae9
     HEAD_REF master
 )
 
@@ -13,10 +14,6 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-
-# Move cmake files, ensuring they will be 3 directories up the import prefix
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_install_copyright(
     FILE_LIST 

--- a/ports/cimg/vcpkg.json
+++ b/ports/cimg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cimg",
-  "version": "2.9.9",
+  "version": "3.3.2",
   "description": "The CImg Library is a small, open-source, and modern C++ toolkit for image processing",
   "homepage": "https://github.com/dtschump/CImg",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1573,7 +1573,7 @@
       "port-version": 0
     },
     "cimg": {
-      "baseline": "2.9.9",
+      "baseline": "3.3.2",
       "port-version": 0
     },
     "cista": {

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "74b459d6672e405dd90e683686a2371f3f116a46",
+      "git-tree": "0b73bf0046233dd69f0dc7962a7e0c3f961be2bc",
       "version": "3.3.2",
       "port-version": 0
     },

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74b459d6672e405dd90e683686a2371f3f116a46",
+      "version": "3.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2eac332b873f6a2b9108c3e71e59feec8efe5026",
       "version": "2.9.9",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/35217
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
