### PR TITLE
[protobuf-c] Fix tools feature compilation error under uwp

### DIFF
--- a/ports/protobuf-c/vcpkg.json
+++ b/ports/protobuf-c/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "protobuf-c",
   "version-semver": "1.4.1",
+  "port-version": 1,
   "description": "This is protobuf-c, a C implementation of the Google Protocol Buffers data serialization format.",
   "homepage": "https://github.com/protobuf-c/protobuf-c",
   "dependencies": [
@@ -23,7 +24,8 @@
       ]
     },
     "tools": {
-      "description": "Build tools (protoc-gen-c)."
+      "description": "Build tools (protoc-gen-c).",
+      "supports": "!uwp"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6754,7 +6754,7 @@
     },
     "protobuf-c": {
       "baseline": "1.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "protopuf": {
       "baseline": "2.2.1",

--- a/versions/p-/protobuf-c.json
+++ b/versions/p-/protobuf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32d120b5b3a9225b973b135f632ee82be3e7860b",
+      "version-semver": "1.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "f1adcf184e617f9f77bd727e6f5085665e471826",
       "version-semver": "1.4.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/33778

Compiling the `tools` feature requires linking to `libprotoc.lib`, but `protobuf` fails to generate `libprotoc.lib` under the `uwp` platform, so the `tools` feature cannot be built on the `uwp` platform.
You can refer to the issue [13913](https://github.com/protocolbuffers/protobuf/issues/13913) to learn why `protobuf `failed to generate` libprotoc.lib` on the `uwp` platform.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Compile test pass with following triplets:
```
x64-windows
x64-uwp
```