### PR TITLE
[libheif] Update to 1.17.5

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  strukturag/libheif 
     REF "v${VERSION}"
-    SHA512 790f4ac69ccc04b2015fc4f58f4c3b2deb0c123bb443fd90732f3fd9efce7a35b188cbfef36a2ac17fb8137f3a0c06bc3ae5effbd8ef847989e1e122876abd62
+    SHA512 e17f990fcb4b3ebfec19cbf304ae8f9b00a3d33aaf46802eff8b3c21c614ccd02cb0a92960324b4c579e579021615c88d16efe6df84a171ddbc05313d2c73931
     HEAD_REF master
     PATCHES
         gdk-pixbuf.patch

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libheif",
-  "version": "1.17.3",
+  "version": "1.17.5",
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4349,7 +4349,7 @@
       "port-version": 5
     },
     "libheif": {
-      "baseline": "1.17.3",
+      "baseline": "1.17.5",
       "port-version": 0
     },
     "libhsplasma": {

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5eb0bdc7d44de9fae5e799b6f5a34121daf181f2",
+      "version": "1.17.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "c2055d6d66f9ba0a12257bc2fa852b3c9e234091",
       "version": "1.17.3",
       "port-version": 0


### PR DESCRIPTION
Updates to latest release https://github.com/strukturag/libheif/releases/tag/v1.17.5

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
