### PR TITLE
[thomasmonkman-filewatch] Add patch for fixing Unix version

### DIFF
--- a/ports/thomasmonkman-filewatch/fix-unix-listen.patch
+++ b/ports/thomasmonkman-filewatch/fix-unix-listen.patch
@@ -1,0 +1,37 @@
+diff --git a/FileWatch.hpp b/FileWatch.hpp
+index 4eba08b..2c0ff6d 100644
+--- a/FileWatch.hpp
++++ b/FileWatch.hpp
+@@ -276,7 +276,7 @@ namespace filewatch {
+ 
+ 		FolderInfo  _directory;
+ 
+-		const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE;
++		const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVE;
+ 
+ 		const static std::size_t event_size = (sizeof(struct inotify_event));
+ #endif // __unix__
+@@ -604,7 +604,7 @@ namespace filewatch {
+ 				}
+ 			}();
+ 
+-			const auto watch = inotify_add_watch(folder, watch_path.c_str(), IN_MODIFY | IN_CREATE | IN_DELETE);
++			const auto watch = inotify_add_watch(folder, watch_path.c_str(), IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVE);
+ 			if (watch < 0) 
+ 			{
+ 				throw std::system_error(errno, std::system_category());
+@@ -644,6 +644,14 @@ namespace filewatch {
+ 								{
+ 									parsed_information.emplace_back(StringType{ changed_file }, Event::modified);
+ 								}
++                               			else if (event->mask & IN_MOVED_FROM)
++                               			{
++                               			    parsed_information.emplace_back(T{ changed_file }, Event::renamed_old);
++                               			}
++                               			else if (event->mask & IN_MOVED_TO)
++                               			{
++                               			    parsed_information.emplace_back(T{ changed_file }, Event::renamed_new);
++                               			}
+ 							}
+ 						}
+ 						i += event_size + event->len;

--- a/ports/thomasmonkman-filewatch/portfile.cmake
+++ b/ports/thomasmonkman-filewatch/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF a59891baf375b73ff28144973a6fafd3fe40aa21
     SHA512 9a110b42a499ed7047bb8a79029134943582b388db810974ad6b5f91d1ec720e45a9a3543c4a56ee97d51439f5a34222bada0fb43281dcbc2e65bdee38f836d5
     HEAD_REF master
+    PATCHES
+        fix-unix-listen.patch
 )
 
 file(COPY "${SOURCE_PATH}/FileWatch.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/thomasmonkman-filewatch")

--- a/ports/thomasmonkman-filewatch/vcpkg.json
+++ b/ports/thomasmonkman-filewatch/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "thomasmonkman-filewatch",
   "version-date": "2023-01-16",
+  "port-version": 1,
   "description": "File watcher in C++.",
   "homepage": "https://github.com/ThomasMonkman/filewatch",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8338,7 +8338,7 @@
     },
     "thomasmonkman-filewatch": {
       "baseline": "2023-01-16",
-      "port-version": 0
+      "port-version": 1
     },
     "thor": {
       "baseline": "2022-04-16",

--- a/versions/t-/thomasmonkman-filewatch.json
+++ b/versions/t-/thomasmonkman-filewatch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6dede6ba1ac505ea4bd64c60bf97edfe7b8d5647",
+      "version-date": "2023-01-16",
+      "port-version": 1
+    },
+    {
       "git-tree": "e4d9f0bb41f94c53faf7c7eb9f2566eaf8d0fb94",
       "version-date": "2023-01-16",
       "port-version": 0

--- a/versions/t-/thomasmonkman-filewatch.json
+++ b/versions/t-/thomasmonkman-filewatch.json
@@ -6,7 +6,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "e4d9f0bb41f94c53faf7c7eb9f2566eaf8d0fb94",
+      "git-tree": "09215796e0a4591e54d9aa37ab46dc5edc7bd491",
       "version-date": "2023-01-16",
       "port-version": 0
     }

--- a/versions/t-/thomasmonkman-filewatch.json
+++ b/versions/t-/thomasmonkman-filewatch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "09215796e0a4591e54d9aa37ab46dc5edc7bd491",
+      "git-tree": "e4d9f0bb41f94c53faf7c7eb9f2566eaf8d0fb94",
       "version-date": "2023-01-16",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
