### PR TITLE
[magnum-plugins] fix build of features

### DIFF
--- a/ports/magnum-plugins/portfile.cmake
+++ b/ports/magnum-plugins/portfile.cmake
@@ -53,10 +53,14 @@ endif()
 # Head only features
 set(ALL_SUPPORTED_FEATURES ${ALL_FEATURES})
 if(NOT VCPKG_USE_HEAD_VERSION)
-    list(REMOVE_ITEM ALL_SUPPORTED_FEATURES cgltfimporter glslangshaderconverter
-        ktximageconverter ktximporter openexrimageconverter openexrimporter
-        spirvtoolsshaderconverter stbdxtimageconverter)
-    message(WARNING "Features cgltfimporter, glslangshaderconverter, ktximageconverter, ktximporter, openexrimageconverter, openexrimporter, spirvtoolsshaderconverter and stbdxtimageconverter are not available when building non-head version.")
+    set(head_only cgltfimporter glslangshaderconverter ktximageconverter ktximporter openexrimageconverter openexrimporter spirvtoolsshaderconverter stbdxtimageconverter)
+    foreach(_feature ${head_only})
+        if("${_feature}" IN_LIST FEATURES)
+            list(JOIN head_only ", " features_list)
+            message(FATAL_ERROR "Features ${features_list} are not avaliable when building non-head version.")
+        endif()
+    endforeach()
+    list(REMOVE_ITEM ALL_SUPPORTED_FEATURES ${head_only})
 endif()
 
 set(_COMPONENTS "")
@@ -128,8 +132,14 @@ else()
     # We delete the import libraries here to avoid the auto-magic linking
     # for plugins which are loaded at runtime.
     if(WIN32)
+        set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/magnum")
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d")
+        file(GLOB maybe_empty "${CURRENT_PACKAGES_DIR}/lib/*")
+        if(maybe_empty STREQUAL "")
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/")
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/")
+        endif()
     endif()
 endif()
 

--- a/ports/magnum-plugins/vcpkg.json
+++ b/ports/magnum-plugins/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "magnum-plugins",
   "version-string": "2020.06",
-  "port-version": 11,
+  "port-version": 12,
   "description": "Plugins for magnum, C++11/C++14 graphics middleware for games and data visualization",
   "homepage": "https://magnum.graphics/",
   "license": null,
@@ -20,11 +20,8 @@
     }
   ],
   "default-features": [
-    "cgltfimporter",
     "ddsimporter",
     "icoimporter",
-    "ktximageconverter",
-    "ktximporter",
     "miniexrimageconverter",
     "opengeximporter",
     "stanfordimporter",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5366,7 +5366,7 @@
     },
     "magnum-plugins": {
       "baseline": "2020.06",
-      "port-version": 11
+      "port-version": 12
     },
     "mailio": {
       "baseline": "0.23.0",

--- a/versions/m-/magnum-plugins.json
+++ b/versions/m-/magnum-plugins.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1a7c4da316314fb8973e23a20c65fa926a96d44",
+      "version-string": "2020.06",
+      "port-version": 12
+    },
+    {
       "git-tree": "73324e7e695dd281c2813fc17b709af7cc2eed58",
       "version-string": "2020.06",
       "port-version": 11


### PR DESCRIPTION
Fixes:
```
-- Performing post-build validation
warning: Import libraries were not present in G:\v\vcpkg1\packages\magnum-plugins_x64-windows\debug\lib.
If this is intended, add the following line in the portfile:
set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
warning: Import libraries were not present in G:\v\vcpkg1\packages\magnum-plugins_x64-windows\lib.
If this is intended, add the following line in the portfile:
set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
warning: There should be no empty directories in G:\v\vcpkg1\packages\magnum-plugins_x64-windows. The following empty directories were found:

  G:\v\vcpkg1\packages\magnum-plugins_x64-windows\debug\lib
  G:\v\vcpkg1\packages\magnum-plugins_x64-windows\lib

warning: If a directory should be populated but is not, this might indicate an error in the portfile.
If the directories are not needed and their creation cannot be disabled, use something like this in the portfile to remove them:
    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib" "${CURRENT_PACKAGES_DIR}/lib")

error: Found 3 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: G:\v\vcpkg1\ports\magnum-plugins\portfile.cmake
error: building magnum-plugins:x64-windows failed with: POST_BUILD_CHECKS_FAILED
Elapsed time to handle magnum-plugins:x64-windows: 2.2 s
Total install time: 2.3 s
```