### PR TITLE
[stxxl] no uwp

### DIFF
--- a/ports/stxxl/vcpkg.json
+++ b/ports/stxxl/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "stxxl",
   "version-date": "2018-11-15",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Standard Template Library for Extra Large Data Sets",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1141,8 +1141,6 @@ stx:arm-neon-android=fail
 stx:arm64-android=fail
 stx:x64-android=fail
 stxxl:arm-neon-android=fail
-stxxl:arm64-uwp=fail
-stxxl:x64-uwp=fail
 # upstream issue https://github.com/stxxl/stxxl/issues/99
 stxxl:x86-windows=skip
 stxxl:x64-windows=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8222,7 +8222,7 @@
     },
     "stxxl": {
       "baseline": "2018-11-15",
-      "port-version": 6
+      "port-version": 7
     },
     "suitesparse": {
       "baseline": "5.8.0",

--- a/versions/s-/stxxl.json
+++ b/versions/s-/stxxl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa0c9adb40f2fa8c67d8d56b3b3e37c37fc55c76",
+      "version-date": "2018-11-15",
+      "port-version": 7
+    },
+    {
       "git-tree": "fa281074458ae24fb9e0cc56746476d52222fc51",
       "version-date": "2018-11-15",
       "port-version": 6


### PR DESCRIPTION
You get
```
G:\v\b3\stxxl\src\53f2b75236-6587e1991d.clean\lib\io\wfs_file_base.cpp(90): error C2039: 'CreateFileA': is not a member of '`global namespace''
G:\v\b3\stxxl\src\53f2b75236-6587e1991d.clean\lib\io\wfs_file_base.cpp(90): error C3861: 'CreateFileA': identifier not found
G:\v\b3\stxxl\src\53f2b75236-6587e1991d.clean\lib\io\wfs_file_base.cpp(103): error C2039: 'CreateFileA': is not a member of '`global namespace''
G:\v\b3\stxxl\src\53f2b75236-6587e1991d.clean\lib\io\wfs_file_base.cpp(103): error C3861: 'CreateFileA': identifier not found
```