### PR TITLE
[status-code] Disable building of tests

### DIFF
--- a/ports/status-code/portfile.cmake
+++ b/ports/status-code/portfile.cmake
@@ -13,6 +13,7 @@ set(VCPKG_BUILD_TYPE release)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DBUILD_TESTING=OFF
         -Dstatus-code_IS_DEPENDENCY=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON
     MAYBE_UNUSED_VARIABLES

--- a/ports/status-code/vcpkg.json
+++ b/ports/status-code/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "status-code",
   "version-date": "2023-11-06",
+  "port-version": 1,
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8166,7 +8166,7 @@
     },
     "status-code": {
       "baseline": "2023-11-06",
-      "port-version": 0
+      "port-version": 1
     },
     "status-value-lite": {
       "baseline": "1.1.0",

--- a/versions/s-/status-code.json
+++ b/versions/s-/status-code.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0ce8f71e6eb79014ecd92a629a245a1a25870cc",
+      "version-date": "2023-11-06",
+      "port-version": 1
+    },
+    {
       "git-tree": "dca3b484e4be516afae962ee6760d3eef5eb4779",
       "version-date": "2023-11-06",
       "port-version": 0


### PR DESCRIPTION
`status-code`'s test code makes use of `std::is_literal_type` which has been removed in C++20. Therefore compiling the tests may fail for some compiler toolchains.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
