### PR TITLE
[halide] use supports expression

### DIFF
--- a/ports/halide/vcpkg.json
+++ b/ports/halide/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "halide",
   "version": "16.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Halide is a programming language designed to make it easier to write high-performance image and array processing code on modern machines.",
   "homepage": "https://github.com/halide/Halide",
   "license": "MIT",
-  "supports": "!uwp",
+  "supports": "!uwp & !staticcrt",
   "dependencies": [
     {
       "name": "halide",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -438,7 +438,6 @@ gul14:x64-android=fail
 gz-tools2:arm-neon-android=fail
 gz-tools2:x64-android=fail
 gz-tools2:arm64-android=fail
-halide:x64-windows-static=fail
 hdf5:arm64-windows=fail
 hdf5:arm-neon-android=fail
 hdf5:arm64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3246,7 +3246,7 @@
     },
     "halide": {
       "baseline": "16.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "happly": {
       "baseline": "2021-03-19",

--- a/versions/h-/halide.json
+++ b/versions/h-/halide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ab14c4abeba94df190cc2319227c0da6d959873",
+      "version": "16.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "c12d736ad0a8329d09a23dc7ae3a094d4ce02df1",
       "version": "16.0.0",
       "port-version": 1


### PR DESCRIPTION
```
2547/4262 halide[core,target-opengl-compute]:x64-windows-static
Installing 1/1 halide:x64-windows-static...
Building halide[core,target-opengl-compute,target-x86]:x64-windows-static...
-- Note: halide only supports dynamic library linkage. Building dynamic library.
CMake Error at scripts/cmake/vcpkg_check_linkage.cmake:25 (message):
  Refusing to build unexpected dynamic library against the static CRT.

      If this is desired, please configure your triplet to directly request this configuration.
Call Stack (most recent call first):
  ports/halide/portfile.cmake:1 (vcpkg_check_linkage)
  scripts/ports.cmake:170 (include)
```