### PR TITLE
[baresip-libre] update to version 3.7.0

### DIFF
--- a/ports/baresip-libre/portfile.cmake
+++ b/ports/baresip-libre/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO baresip/re
     REF "v${VERSION}"
-    SHA512 054227c3cbd41d8801d1d0aed38029adb63d52e33e8becafbdba3e973d55863e40e9be0463b6a2d91b34b3b2aea7d80e9d7ec7adadd5e63ca844e416f4d6c411
+    SHA512 95bfc11d73e8eda76ece51b0e91550e3cb45fc91927d01d024318e74bb0c3893b5bb0716582672490e0131be0314abd1bf2dfd815960b00741e78a55b2a0bbd4
     HEAD_REF main
     PATCHES
         fix-static-library-build.patch

--- a/ports/baresip-libre/vcpkg.json
+++ b/ports/baresip-libre/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "baresip-libre",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Generic library for real-time communications with async IO support",
   "homepage": "https://github.com/baresip/re",
   "license": "BSD-3-Clause",

--- a/versions/b-/baresip-libre.json
+++ b/versions/b-/baresip-libre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e34b5bc2855e62826520ee68fb21d063d42b53d4",
+      "version": "3.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "00dc0e14dfa16f98420ac3a15b9b158af7cf87f8",
       "version": "3.6.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -517,7 +517,7 @@
       "port-version": 1
     },
     "baresip-libre": {
-      "baseline": "3.6.0",
+      "baseline": "3.7.0",
       "port-version": 0
     },
     "basisu": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
