### PR TITLE
[libmagic] Add CMake config.

### DIFF
--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -66,5 +66,12 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/man5")
 
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "${CMAKE_CURRENT_LIST_DIR}/unofficial-${PORT}-config.cmake.in"
+    "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-${PORT}-config.cmake"
+    INSTALL_DESTINATION "share/unofficial-${PORT}"
+)
+
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -73,5 +73,6 @@ configure_package_config_file(
     INSTALL_DESTINATION "share/unofficial-${PORT}"
 )
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+# Handle copyright and usage
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libmagic/unofficial-libmagic-config.cmake.in
+++ b/ports/libmagic/unofficial-libmagic-config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-if(WIN32)
+if(WIN32 AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
     include(CMakeFindDependencyMacro)
     find_dependency(unofficial-tre)
 endif()
@@ -13,7 +13,7 @@ if(_IMPORT_PREFIX STREQUAL "/")
     set(_IMPORT_PREFIX "")
 endif()
 
-if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL static)
+if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
     add_library(unofficial::libmagic::libmagic STATIC IMPORTED)
 else()
     add_library(unofficial::libmagic::libmagic SHARED IMPORTED)
@@ -23,14 +23,14 @@ set_target_properties(unofficial::libmagic::libmagic PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
 )
 
-if(WIN32 AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL static)
+if(WIN32 AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
     set_target_properties(unofficial::libmagic::libmagic PROPERTIES
         INTERFACE_LINK_LIBRARIES "\$<LINK_ONLY:unofficial::tre::tre>"
     )
 endif()
 
 macro(add_library_config config prefix)
-    if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL static)
+    if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
         set_target_properties(unofficial::libmagic::libmagic PROPERTIES
             IMPORTED_LOCATION_${config} "${_IMPORT_PREFIX}/${prefix}lib/@VCPKG_TARGET_STATIC_LIBRARY_PREFIX@magic@VCPKG_TARGET_STATIC_LIBRARY_SUFFIX@"
         )
@@ -52,11 +52,11 @@ macro(add_library_config config prefix)
     endif()
 endmacro()
 
-if("@VCPKG_BUILD_TYPE@" STREQUAL "" OR "@VCPKG_BUILD_TYPE@" STREQUAL debug)
+if("@VCPKG_BUILD_TYPE@" STREQUAL "" OR "@VCPKG_BUILD_TYPE@" STREQUAL "debug")
     add_library_config(DEBUG "debug/")
 endif()
 
-if("@VCPKG_BUILD_TYPE@" STREQUAL "" OR "@VCPKG_BUILD_TYPE@" STREQUAL release)
+if("@VCPKG_BUILD_TYPE@" STREQUAL "" OR "@VCPKG_BUILD_TYPE@" STREQUAL "release")
     add_library_config(RELEASE "")
 endif()
 

--- a/ports/libmagic/unofficial-libmagic-config.cmake.in
+++ b/ports/libmagic/unofficial-libmagic-config.cmake.in
@@ -1,0 +1,67 @@
+@PACKAGE_INIT@
+
+if(WIN32)
+    include(CMakeFindDependencyMacro)
+    find_dependency(unofficial-tre)
+endif()
+
+# Compute the installation prefix relative to this file.
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+    set(_IMPORT_PREFIX "")
+endif()
+
+if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL static)
+    add_library(unofficial::libmagic::libmagic STATIC IMPORTED)
+else()
+    add_library(unofficial::libmagic::libmagic SHARED IMPORTED)
+endif()
+
+set_target_properties(unofficial::libmagic::libmagic PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+)
+
+if(WIN32 AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL static)
+    set_target_properties(unofficial::libmagic::libmagic PROPERTIES
+        INTERFACE_LINK_LIBRARIES "\$<LINK_ONLY:unofficial::tre::tre>"
+    )
+endif()
+
+macro(add_library_config config prefix)
+    if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL static)
+        set_target_properties(unofficial::libmagic::libmagic PROPERTIES
+            IMPORTED_LOCATION_${config} "${_IMPORT_PREFIX}/${prefix}lib/@VCPKG_TARGET_STATIC_LIBRARY_PREFIX@magic@VCPKG_TARGET_STATIC_LIBRARY_SUFFIX@"
+        )
+    else()
+        if(WIN32)
+            set(library_dir "${_IMPORT_PREFIX}/${prefix}bin/")
+            set(soversion_suffix "-1")
+            set_target_properties(unofficial::libmagic::libmagic PROPERTIES
+                IMPORTED_IMPLIB_${config} "${library_dir}@VCPKG_TARGET_IMPORT_LIBRARY_PREFIX@magic@VCPKG_TARGET_IMPORT_LIBRARY_SUFFIX@"
+            )
+        else()
+            set(library_dir "${_IMPORT_PREFIX}/${prefix}lib/")
+        endif()
+        set_target_properties(unofficial::libmagic::libmagic PROPERTIES
+            IMPORTED_LOCATION_${config} "${library_dir}@VCPKG_TARGET_SHARED_LIBRARY_PREFIX@magic${soversion_suffix}@VCPKG_TARGET_SHARED_LIBRARY_SUFFIX@"
+        )
+        unset(soversion_suffix)
+        unset(library_dir)
+    endif()
+endmacro()
+
+if("@VCPKG_BUILD_TYPE@" STREQUAL "" OR "@VCPKG_BUILD_TYPE@" STREQUAL debug)
+    add_library_config(DEBUG "debug/")
+endif()
+
+if("@VCPKG_BUILD_TYPE@" STREQUAL "" OR "@VCPKG_BUILD_TYPE@" STREQUAL release)
+    add_library_config(RELEASE "")
+endif()
+
+set_and_check(unofficial-libmagic_DICTIONARY "${_IMPORT_PREFIX}/share/libmagic/misc/magic.mgc")
+
+unset(_IMPORT_PREFIX)
+
+check_required_components(unofficial-libmagic)

--- a/ports/libmagic/unofficial-libmagic-config.cmake.in
+++ b/ports/libmagic/unofficial-libmagic-config.cmake.in
@@ -30,9 +30,11 @@ if(WIN32 AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
 endif()
 
 macro(add_library_config config prefix)
+    set_property(TARGET unofficial::libmagic::libmagic APPEND PROPERTY IMPORTED_CONFIGURATIONS ${config})
     if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
         set_target_properties(unofficial::libmagic::libmagic PROPERTIES
             IMPORTED_LOCATION_${config} "${_IMPORT_PREFIX}/${prefix}lib/@VCPKG_TARGET_STATIC_LIBRARY_PREFIX@magic@VCPKG_TARGET_STATIC_LIBRARY_SUFFIX@"
+            IMPORTED_LINK_INTERFACE_LANGUAGES_${config} "C"
         )
     else()
         if(WIN32)

--- a/ports/libmagic/unofficial-libmagic-config.cmake.in
+++ b/ports/libmagic/unofficial-libmagic-config.cmake.in
@@ -41,7 +41,7 @@ macro(add_library_config config prefix)
             set(library_dir "${_IMPORT_PREFIX}/${prefix}bin/")
             set(soversion_suffix "-1")
             set_target_properties(unofficial::libmagic::libmagic PROPERTIES
-                IMPORTED_IMPLIB_${config} "${library_dir}@VCPKG_TARGET_IMPORT_LIBRARY_PREFIX@magic@VCPKG_TARGET_IMPORT_LIBRARY_SUFFIX@"
+                IMPORTED_IMPLIB_${config} "${_IMPORT_PREFIX}/${prefix}/lib/@VCPKG_TARGET_IMPORT_LIBRARY_PREFIX@magic@VCPKG_TARGET_IMPORT_LIBRARY_SUFFIX@"
             )
         else()
             set(library_dir "${_IMPORT_PREFIX}/${prefix}lib/")

--- a/ports/libmagic/usage
+++ b/ports/libmagic/usage
@@ -1,0 +1,6 @@
+libmagic provides CMake targets:
+
+    find_package(unofficial-libmagic REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::libmagic::libmagic)
+
+The magic.mgc file can be accessed from the unofficial-libmagic_DICTIONARY variable.

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 1,
   "description": "This library can be used to classify files according to magic number tests.",
   "homepage": "https://github.com/file/file",
+  "license": "BSD-2-Clause",
   "dependencies": [
     {
       "name": "dirent",

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmagic",
   "version": "5.45",
+  "port-version": 1,
   "description": "This library can be used to classify files according to magic number tests.",
   "homepage": "https://github.com/file/file",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4482,7 +4482,7 @@
     },
     "libmagic": {
       "baseline": "5.45",
-      "port-version": 0
+      "port-version": 1
     },
     "libmariadb": {
       "baseline": "3.3.1",

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "65715ba20e3afecd46e0fb81326503257174585f",
+      "version": "5.45",
+      "port-version": 1
+    },
+    {
       "git-tree": "30ebcd2ff5522b8c72ba5a5cadd840df34350382",
       "version": "5.45",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.