### PR TITLE
[libbson] Fix libbson when Python3 isn't on the PATH

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -25,6 +25,7 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        "-DBUILD_VERSION=${VERSION}"
         -DENABLE_BSON=ON
         -DENABLE_EXAMPLES=OFF
         -DENABLE_ICU=OFF

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libbson",
   "version": "1.25.1",
+  "port-version": 1,
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4090,7 +4090,7 @@
     },
     "libbson": {
       "baseline": "1.25.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libcaer": {
       "baseline": "3.3.15",

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e2365e51faaf5bea56b3466e7c94342cb43a9e4",
+      "version": "1.25.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "9cc5cb4ec6ee37e4a07e65f6e8aee04f83f535ec",
       "version": "1.25.1",
       "port-version": 0


### PR DESCRIPTION
Probably broken by https://github.com/microsoft/vcpkg/pull/34994

Detected in https://github.com/microsoft/vcpkg/pull/35116

where this REGEX is expected to be output from the python script

```
CMake Error at build/cmake/LoadVersion.cmake:9 (string):
  string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:20 (LoadVersion)
```
