### PR TITLE
[rtabmap] Fix link octomap failure

### DIFF
--- a/ports/rtabmap/fix_link.patch
+++ b/ports/rtabmap/fix_link.patch
@@ -1,0 +1,15 @@
+diff --git a/corelib/src/OctoMap.cpp b/corelib/src/OctoMap.cpp
+index 8a1e1bb..d7b60da 100644
+--- a/corelib/src/OctoMap.cpp
++++ b/corelib/src/OctoMap.cpp
+@@ -278,10 +278,8 @@ RtabmapColorOcTree::StaticMemberInitializer::StaticMemberInitializer() {
+ 	 AbstractOcTree::registerTreeType(tree);
+  }
+ 
+-#ifndef _WIN32
+ // On Windows, the app freezes on start if the following is defined
+ RtabmapColorOcTree::StaticMemberInitializer RtabmapColorOcTree::RtabmapColorOcTreeMemberInit;
+-#endif
+ 
+ 
+ //////////////////////////////////////

--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix_autouic.patch
+        fix_link.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rtabmap",
   "version": "0.21.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Real-Time Appearance-Based Mapping",
   "homepage": "https://introlab.github.io/rtabmap/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7546,7 +7546,7 @@
     },
     "rtabmap": {
       "baseline": "0.21.0",
-      "port-version": 2
+      "port-version": 3
     },
     "rtaudio": {
       "baseline": "2021-11-16",

--- a/versions/r-/rtabmap.json
+++ b/versions/r-/rtabmap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9764edeececed7fb37c356a6e00cb3f983dbf1fb",
+      "version": "0.21.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "63d580588bb49ec2767eed209af0c854cc2d5da2",
       "version": "0.21.0",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/35241

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
```