### PR TITLE
[sentencepiece] Fix port

### DIFF
--- a/ports/sentencepiece/portfile.cmake
+++ b/ports/sentencepiece/portfile.cmake
@@ -10,17 +10,12 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_check_features(
-    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        protobuf SPM_USE_BUILTIN_PROTOBUF
-        absl SPM_USE_EXTERNAL_ABSL
-)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSPM_ENABLE_SHARED=OFF
+        -DSPM_USE_BUILTIN_PROTOBUF=ON
+        -DSPM_USE_EXTERNAL_ABSL=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/sentencepiece/portfile.cmake
+++ b/ports/sentencepiece/portfile.cmake
@@ -10,6 +10,13 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        protobuf SPM_USE_BUILTIN_PROTOBUF
+        absl SPM_USE_EXTERNAL_ABSL
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -18,15 +25,11 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
-if(NOT VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_BUILD_TYPE)
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/sentencepiece.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/sentencepieced.lib")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/sentencepiece_train.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/sentencepiece_traind.lib")
-endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+vcpkg_copy_tools(TOOL_NAMES spm_decode spm_encode spm_export_vocab spm_normalize spm_train AUTO_CLEAN)
 
 vcpkg_copy_pdbs()
 

--- a/ports/sentencepiece/vcpkg.json
+++ b/ports/sentencepiece/vcpkg.json
@@ -1,13 +1,21 @@
 {
   "name": "sentencepiece",
   "version": "0.1.99",
+  "port-version": 1,
   "description": "SentencePiece is an unsupervised text tokenizer and detokenizer mainly for Neural Network-based text generation systems where the vocabulary size is predetermined prior to the neural model training",
   "license": "Apache-2.0",
-  "supports": "!((windows | uwp) & !static)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "absl": {
+      "description": "Use external abseil"
+    },
+    "protobuf": {
+      "description": "Use built-in protobuf"
+    }
+  }
 }

--- a/ports/sentencepiece/vcpkg.json
+++ b/ports/sentencepiece/vcpkg.json
@@ -10,13 +10,5 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ],
-  "features": {
-    "absl": {
-      "description": "Use external abseil"
-    },
-    "protobuf": {
-      "description": "Use built-in protobuf"
-    }
-  }
+  ]
 }

--- a/ports/sentencepiece/vcpkg.json
+++ b/ports/sentencepiece/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 1,
   "description": "SentencePiece is an unsupervised text tokenizer and detokenizer mainly for Neural Network-based text generation systems where the vocabulary size is predetermined prior to the neural model training",
   "license": "Apache-2.0",
+  "supports": "static",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7762,7 +7762,7 @@
     },
     "sentencepiece": {
       "baseline": "0.1.99",
-      "port-version": 0
+      "port-version": 1
     },
     "sentry-native": {
       "baseline": "0.6.7",

--- a/versions/s-/sentencepiece.json
+++ b/versions/s-/sentencepiece.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1ad7b56aa7534848484d2fd0a40d60d73580d615",
+      "git-tree": "7c21445dada5c5ad8efb9bcf2729648155a7c391",
       "version": "0.1.99",
       "port-version": 1
     },

--- a/versions/s-/sentencepiece.json
+++ b/versions/s-/sentencepiece.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce29dcc01f4fd99de6605d4aea253172cdc44d1c",
+      "version": "0.1.99",
+      "port-version": 1
+    },
+    {
       "git-tree": "e4113b95c56e98d9c59787730bdc69978d23e290",
       "version": "0.1.99",
       "port-version": 0

--- a/versions/s-/sentencepiece.json
+++ b/versions/s-/sentencepiece.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce29dcc01f4fd99de6605d4aea253172cdc44d1c",
+      "git-tree": "1ad7b56aa7534848484d2fd0a40d60d73580d615",
       "version": "0.1.99",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #34953

Fixed:
1. Port does rename import libraries!
2. Port does not fix the name in the pc files after changing the names o.O
3. Support statement is wrong. 
4. Options `SPM_USE_BUILTIN_PROTOBUF (DEFAULT ON)` and `SPM_USE_EXTERNAL_ABSL (DEFAULT OFF)` are not controlled by the portfile

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
