### PR TITLE
Add debug suffix to Botan build

### DIFF
--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -100,6 +100,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
             "--prefix=${CURRENT_PACKAGES_DIR}/debug"
             "--msvc-runtime=${BOTAN_MSVC_RUNTIME}d"
             "--with-external-libdir=${CURRENT_INSTALLED_DIR}/debug/lib"
+            "--library-suffix=d"
             --debug-mode
         OPTIONS_RELEASE
             "ZLIB_LIBS=${ZLIB_LIBS_RELEASE}"

--- a/ports/botan/vcpkg.json
+++ b/ports/botan/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "botan",
   "version": "3.1.1",
+  "port-version": 1,
   "description": "A cryptography library written in C++11",
   "homepage": "https://botan.randombit.net",
   "license": "BSD-2-Clause",

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8c773657b6aa67530b1065a42475fc740935c60",
+      "version": "3.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d66e60d97a7a4e77df4e559fed1926a45dac3f52",
       "version": "3.1.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1302,7 +1302,7 @@
     },
     "botan": {
       "baseline": "3.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "box2d": {
       "baseline": "2.4.1",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

This was discussed with the Botan maintainers and the recommended solution applied and tested with vcpkg. See https://github.com/randombit/botan/issues/3813 for discussion.