### PR TITLE
[vcpkg baseline][czmq] Disable build with systemd

### DIFF
--- a/ports/czmq/portfile.cmake
+++ b/ports/czmq/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeromq/czmq
-    REF v4.2.1
+    REF "v${VERSION}"
     SHA512 65a21f7bd5935b119e1b24ce3b2ce8462031ab7c9a4ba587bb99fe618c9f8cb672cfa202993ddd79e0fb0f154ada06560b79a1b4f762fcce8f88f2f450ecee01
     HEAD_REF master
     PATCHES
@@ -40,6 +40,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DCZMQ_BUILD_SHARED=${BUILD_SHARED}
         -DCZMQ_BUILD_STATIC=${BUILD_STATIC}
+        -DCZMQ_WITH_SYSTEMD=OFF
         -DBUILD_TESTING=OFF
         ${FEATURE_OPTIONS}
 )

--- a/ports/czmq/vcpkg.json
+++ b/ports/czmq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "czmq",
   "version-semver": "4.2.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "High-level C binding for ZeroMQ",
   "homepage": "https://github.com/zeromq/czmq",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2062,7 +2062,7 @@
     },
     "czmq": {
       "baseline": "4.2.1",
-      "port-version": 3
+      "port-version": 4
     },
     "d3d12-memory-allocator": {
       "baseline": "2021-05-05",

--- a/versions/c-/czmq.json
+++ b/versions/c-/czmq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2c4f3cb55eecf90232bdaabef1fd9b6d0426c7c",
+      "version-semver": "4.2.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "ec9f27596e7ff9e8b8aa401f27525075abec28ea",
       "version-semver": "4.2.1",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
`czmq` build failed with the following errors on pipeline run [Pipelines - Run 20231123.1 (azure.com)](https://dev.azure.com/vcpkg/public/_build/results?buildId=96913&view=results).
```
/mnt/vcpkg-ci/buildtrees/libsystemd/x64-linux-dbg/../src/v254-832da4078b.clean/src/basic/capability-util.c:446: undefined reference to `cap_get_proc'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/libsystemd/x64-linux-dbg/../src/v254-832da4078b.clean/src/basic/capability-util.c:574: undefined reference to `cap_set_flag'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/libsystemd/x64-linux-dbg/../src/v254-832da4078b.clean/src/basic/capability-util.c:577: undefined reference to `cap_compare'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/libsystemd/x64-linux-dbg/../src/v254-832da4078b.clean/src/basic/capability-util.c:579: undefined reference to `cap_free'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/libsystemd/x64-linux-dbg/../src/v254-832da4078b.clean/src/basic/capability-util.c:588: undefined reference to `cap_set_proc'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/libsystemd/x64-linux-dbg/../src/v254-832da4078b.clean/src/basic/capability-util.c:604: undefined reference to `cap_set_proc'
collect2: error: ld returned 1 exit status
```
`libsystemd` is not a strong dependency of `czmq`, so disable option `CZMQ_WITH_SYSTEMD`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
