### PR TITLE
[copypp] New port #35309

### DIFF
--- a/ports/copypp/portfile.cmake
+++ b/ports/copypp/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/copypp)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/copypp)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/ports/copypp/portfile.cmake
+++ b/ports/copypp/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH
+  SOURCE_PATH
+  REPO
+  i-curve/copypp
+  REF
+  0c54fe4175064c0e5e545a725a851a050a430c67 
+  SHA512
+  cd20275b6c823df4dd2e27b0e7fa74094ac73d5e77b69cdeb5746a9943088daffee26f5e00b57f33d486e1b4afbf5f5c5a34dcab3faa53f35774f873cdc14d6d
+  HEAD_REF
+  main)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS "-DCOPYPP_TEST=OFF"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/copypp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/copypp/portfile.cmake
+++ b/ports/copypp/portfile.cmake
@@ -1,14 +1,12 @@
+set(VCPKG_BUILD_TYPE release)
+
 vcpkg_from_github(
-  OUT_SOURCE_PATH
-  SOURCE_PATH
-  REPO
-  i-curve/copypp
-  REF
-  0c54fe4175064c0e5e545a725a851a050a430c67 
-  SHA512
-  cd20275b6c823df4dd2e27b0e7fa74094ac73d5e77b69cdeb5746a9943088daffee26f5e00b57f33d486e1b4afbf5f5c5a34dcab3faa53f35774f873cdc14d6d
-  HEAD_REF
-  main)
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO i-curve/copypp
+    REF "v${VERSION}"
+    SHA512 a13a3ee105b3802f585c086846dbce7d5e9c23d11bf55fcc0c63e1a4b21fc6798f1a324cfb3da66b715dfc22a4f1f7ba51a2f4e10db331f7d4fd6b20a9be6d41
+    HEAD_REF main
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -19,8 +17,8 @@ vcpkg_cmake_install()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/copypp)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug/lib")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 

--- a/ports/copypp/portfile.cmake
+++ b/ports/copypp/portfile.cmake
@@ -1,4 +1,4 @@
-set(VCPKG_BUILD_TYPE release)
+set(VCPKG_BUILD_TYPE release) # header-only
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/copypp/usage
+++ b/ports/copypp/usage
@@ -1,4 +1,4 @@
-The package copypp provides CMake targets:
+copypp provides CMake targets:
 
     find_package(copypp CONFIG REQUIRED)
     target_link_libraries(main PRIVATE icurve::copypp)

--- a/ports/copypp/usage
+++ b/ports/copypp/usage
@@ -1,0 +1,4 @@
+The package copypp provides CMake targets:
+
+    find_package(copypp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE icurve::copypp)

--- a/ports/copypp/vcpkg.json
+++ b/ports/copypp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "copypp",
+  "version": "0.1.0",
+  "description": "support field copy in different c++ struct.",
+  "homepage": "https://github.com/i-curve/copypp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1788,6 +1788,10 @@
       "baseline": "6.4.3",
       "port-version": 3
     },
+    "copypp": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "coroutine": {
       "baseline": "1.5.0",
       "port-version": 5

--- a/versions/c-/copypp.json
+++ b/versions/c-/copypp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8f478ed1f325fc57baee01e3fc3a437c18659e10",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/copypp.json
+++ b/versions/c-/copypp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cace503346ebb83cc09056eb5531ce43ab85f34f",
+      "git-tree": "af220feec2e69da5f809eb1594b3c72690abb135",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/c-/copypp.json
+++ b/versions/c-/copypp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "af220feec2e69da5f809eb1594b3c72690abb135",
+      "git-tree": "30342b837d13819393c9f898e82f5c2cf25bed32",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/c-/copypp.json
+++ b/versions/c-/copypp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8f478ed1f325fc57baee01e3fc3a437c18659e10",
+      "git-tree": "cace503346ebb83cc09056eb5531ce43ab85f34f",
       "version": "0.1.0",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
