### PR TITLE
[eigen3] Cleanup

### DIFF
--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -1,5 +1,6 @@
 vcpkg_buildpath_length_warning(37)
 
+block(SCOPE_FOR VARIABLES PROPAGATE SOURCE_PATH)
 set(VCPKG_BUILD_TYPE release) # header-only
 
 vcpkg_from_gitlab(
@@ -26,6 +27,11 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
+endblock()
+
+if(NOT VCPKG_BUILD_TYPE)
+    file(INSTALL "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/eigen3.pc" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+endif()
 vcpkg_fixup_pkgconfig()
 
 file(GLOB INCLUDES "${CURRENT_PACKAGES_DIR}/include/eigen3/*")

--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -1,10 +1,12 @@
 vcpkg_buildpath_length_warning(37)
 
+set(VCPKG_BUILD_TYPE release) # header-only
+
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.com
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libeigen/eigen
-    REF 3.4.0
+    REF "${VERSION}"
     SHA512 ba75ecb760e32acf4ceaf27115468e65d4f77c44f8d519b5a13e7940af2c03a304ad433368cb6d55431f307c5c39e2666ab41d34442db3cf441638e51f5c3b6a
     HEAD_REF master
     PATCHES
@@ -16,13 +18,10 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
+        -DEIGEN_BUILD_DOC=OFF
         -DEIGEN_BUILD_PKGCONFIG=ON
-    OPTIONS_RELEASE
-        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/share/eigen3
-        -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib/pkgconfig
-    OPTIONS_DEBUG
-        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/share/eigen3
-        -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig
+        "-DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/share/eigen3"
+        "-DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib/pkgconfig"
 )
 
 vcpkg_cmake_install()
@@ -32,6 +31,5 @@ vcpkg_fixup_pkgconfig()
 file(GLOB INCLUDES "${CURRENT_PACKAGES_DIR}/include/eigen3/*")
 # Copy the eigen header files to conventional location for user-wide MSBuild integration
 file(COPY ${INCLUDES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING.README" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.README")

--- a/ports/eigen3/remove_configure_checks.patch
+++ b/ports/eigen3/remove_configure_checks.patch
@@ -1,37 +1,48 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f3e69b845..12fb2188d 100644
+index f3e69b8..f32ffee 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -66,12 +66,14 @@ option(EIGEN_TEST_CXX11 "Enable testing with C++11 and C++11 features (e.g. Tens
+@@ -59,6 +59,7 @@ include(CheckCXXCompilerFlag)
+ include(GNUInstallDirs)
+ include(CMakeDependentOption)
+ 
++if(0)
+ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
  
  
- macro(ei_add_cxx_compiler_flag FLAG)
-+  if(FALSE) # Since eigen3 is header only and vcpkg does not build tests this can be disabled by default. 
-   string(REGEX REPLACE "-" "" SFLAG1 ${FLAG})
-   string(REGEX REPLACE "\\+" "p" SFLAG ${SFLAG1})
-   check_cxx_compiler_flag(${FLAG} COMPILER_SUPPORT_${SFLAG})
-   if(COMPILER_SUPPORT_${SFLAG})
-     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
+@@ -419,6 +420,7 @@ endif()
+ set(EIGEN_CUDA_COMPUTE_ARCH 30 CACHE STRING "The CUDA compute architecture level to target when compiling CUDA code")
+ 
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
++endif()
+ 
+ # Backward compatibility support for EIGEN_INCLUDE_INSTALL_DIR
+ if(EIGEN_INCLUDE_INSTALL_DIR)
+@@ -495,6 +497,7 @@ if(BUILD_TESTING)
+   add_subdirectory(failtest)
+ endif()
+ 
++if(0)
+ if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
+   add_subdirectory(blas)
+   add_subdirectory(lapack)
+@@ -532,9 +535,11 @@ if(EIGEN_TEST_SYCL)
+     add_definitions(-DEIGEN_DONT_VECTORIZE_SYCL=1)
    endif()
-+  endif()
- endmacro()
+ endif()
++endif()
  
- check_cxx_compiler_flag("-std=c++11" EIGEN_COMPILER_SUPPORT_CPP11)
-@@ -142,7 +144,7 @@ endif()
+ add_subdirectory(unsupported)
  
- set(EIGEN_TEST_MAX_SIZE "320" CACHE STRING "Maximal matrix/vector size, default is 320")
++if(0)
+ add_subdirectory(demos EXCLUDE_FROM_ALL)
  
--if(NOT MSVC)
-+if(NOT MSVC AND FALSE)
-   # We assume that other compilers are partly compatible with GNUCC
+ # must be after test and unsupported, for configuring buildtests.in
+@@ -554,6 +559,7 @@ configure_file(scripts/cdashtesting.cmake.in cdashtesting.cmake @ONLY)
+ if(BUILD_TESTING)
+   ei_testing_print_summary()
+ endif()
++endif()
  
-   # clang outputs some warnings for unknown flags that are not caught by check_cxx_compiler_flag
-@@ -330,7 +332,7 @@ if(NOT MSVC)
-     endif()
-   endif()
- 
--else()
-+elseif(FALSE)
- 
-   # C4127 - conditional expression is constant
-   # C4714 - marked as __forceinline not inlined (I failed to deactivate it selectively)
+ message(STATUS "")
+ message(STATUS "Configured Eigen ${EIGEN_VERSION_NUMBER}")

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "eigen3",
   "version": "3.4.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "http://eigen.tuxfamily.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2406,7 +2406,7 @@
     },
     "eigen3": {
       "baseline": "3.4.0",
-      "port-version": 2
+      "port-version": 3
     },
     "elements": {
       "baseline": "2022-12-07",

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1510160204e8d904b8fac0d9cbf323f426f1fb55",
+      "version": "3.4.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "250d10d414a5542aaf832350264498ba727c4c03",
       "version": "3.4.0",
       "port-version": 2

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1510160204e8d904b8fac0d9cbf323f426f1fb55",
+      "git-tree": "38fc865a94dea7a84f8b1350936ed4fcc3e638cc",
       "version": "3.4.0",
       "port-version": 3
     },


### PR DESCRIPTION
Skip more configuration steps which are not needed for the header-only installation.
Fixes #33979.

~One change in installed files: By omitting the debug build, the port no longer installs `debug/lib/pkgconfig/eigen3.pc`. This is not a problem when using vcpkg maintainer function because they always set a complete search path (debug/lib/pkgconfig, lib/pkgconfig, share/pkgconfig).~ `vcpkg_fixup_pkgconfig` omits the alternative build type from the search path.