### PR TITLE
[libssh] no alternatives in features

### DIFF
--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -14,7 +14,6 @@ vcpkg_extract_source_archive(SOURCE_PATH
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        mbedtls WITH_MBEDTLS
         zlib    WITH_ZLIB
 )
 

--- a/ports/libssh/vcpkg.json
+++ b/ports/libssh/vcpkg.json
@@ -1,18 +1,15 @@
 {
   "name": "libssh",
   "version": "0.10.5",
+  "port-version": 1,
   "description": "libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side",
   "homepage": "https://www.libssh.org/",
   "license": "LGPL-2.1-only",
   "supports": "!uwp & !xbox",
   "dependencies": [
     {
-      "name": "libssh",
-      "default-features": false,
-      "features": [
-        "mbedtls"
-      ],
-      "platform": "android"
+      "name": "openssl",
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",
@@ -23,43 +20,7 @@
       "host": true
     }
   ],
-  "default-features": [
-    "crypto"
-  ],
   "features": {
-    "crypto": {
-      "description": "Default crypto backend",
-      "dependencies": [
-        {
-          "name": "libssh",
-          "features": [
-            "mbedtls"
-          ]
-        }
-      ]
-    },
-    "mbedtls": {
-      "description": "Crypto support (mbedTLS)",
-      "dependencies": [
-        {
-          "name": "mbedtls",
-          "default-features": false
-        },
-        {
-          "name": "mbedtls",
-          "features": [
-            "pthreads"
-          ],
-          "platform": "!android"
-        }
-      ]
-    },
-    "openssl": {
-      "description": "Crypto support (OpenSSL)",
-      "dependencies": [
-        "openssl"
-      ]
-    },
     "zlib": {
       "description": "libssh with zlib",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4838,7 +4838,7 @@
     },
     "libssh": {
       "baseline": "0.10.5",
-      "port-version": 0
+      "port-version": 1
     },
     "libssh2": {
       "baseline": "1.11.0",

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "000173abb6b45433339e0c85179bd3b4e4a36684",
+      "version": "0.10.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "d6af07ebaeb4ab52ff509bc7637ad1d278d3d16b",
       "version": "0.10.5",
       "port-version": 0


### PR DESCRIPTION
Fixes https://learn.microsoft.com/en-us/vcpkg/contributing/maintainer-guide#do-not-use-features-to-implement-alternatives.

The core build was not functional since you have to select a ssl backend. 
```
vcpkg install openssl
vcpkg install libssh[core] # would use openssl even if it should not
```
openssl is also the only backend in libssh2 and was the default backend in the past