### PR TITLE
[gapp] New port

### DIFF
--- a/ports/gapp/portfile.cmake
+++ b/ports/gapp/portfile.cmake
@@ -1,0 +1,29 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+  vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO KRM7/gapp
+  REF "v${VERSION}"
+  SHA512 463d36c3c41d14a9615dc48b43aebfccdf28177db766941607c2bdb2fed9ae5e876ae7b0bca541809503b35e9ce250a5d3b7246342c035f4a079d50539589ac2
+  HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    -DGAPP_BUILD_TESTS=OFF
+    -DGAPP_USE_LTO=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/gapp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc/gapp/api")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/gapp/usage
+++ b/ports/gapp/usage
@@ -1,0 +1,4 @@
+gapp provides CMake targets:
+
+    find_package(gapp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE gapp::gapp)

--- a/ports/gapp/vcpkg.json
+++ b/ports/gapp/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "gapp",
+  "version": "0.2.0",
+  "description": "A genetic algorithms library in C++ for single- and multi-objective optimization.",
+  "homepage": "https://github.com/KRM7/gapp",
+  "license": "MIT",
+  "supports": "(windows | linux) & !arm",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2848,6 +2848,10 @@
       "baseline": "gamma-2018-01-27",
       "port-version": 6
     },
+    "gapp": {
+      "baseline": "0.2.0",
+      "port-version": 0
+    },
     "gasol": {
       "baseline": "2018-01-04",
       "port-version": 4

--- a/versions/g-/gapp.json
+++ b/versions/g-/gapp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6b280cdc0493eab0cda85ea0ee053b8752bd3b31",
+      "git-tree": "31fc6c2ca0e58b6133db03eeaa3e31398810ccc2",
       "version": "0.2.0",
       "port-version": 0
     }

--- a/versions/g-/gapp.json
+++ b/versions/g-/gapp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6b280cdc0493eab0cda85ea0ee053b8752bd3b31",
+      "version": "0.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
