### PR TITLE
[jsoncpp] Disable distributing obj files

### DIFF
--- a/ports/jsoncpp/portfile.cmake
+++ b/ports/jsoncpp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-source-parsers/jsoncpp
-    REF 1.9.5
+    REF "${VERSION}"
     SHA512 1d06e044759b1e1a4cc4960189dd7e001a0a4389d7239a6d59295af995a553518e4e0337b4b4b817e70da5d9731a4c98655af90791b6287870b5ff8d73ad8873
     HEAD_REF master
 )
@@ -19,6 +19,7 @@ vcpkg_cmake_configure(
         -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF
         -DJSONCPP_WITH_TESTS=OFF
         -DJSONCPP_WITH_EXAMPLE=OFF
+        -DBUILD_OBJECT_LIBS=OFF
 )
 
 vcpkg_cmake_install()
@@ -28,7 +29,6 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/jsoncpp)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_copy_pdbs()
-
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
 vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/jsoncpp/vcpkg.json
+++ b/ports/jsoncpp/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "jsoncpp",
   "version": "1.9.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "jsoncpp is an implementation of a JSON reader and writer in C++. JSON (JavaScript Object Notation) is a lightweight data-interchange format that it is easy to parse and redeable for human.",
   "homepage": "https://github.com/open-source-parsers/jsoncpp",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3682,7 +3682,7 @@
     },
     "jsoncpp": {
       "baseline": "1.9.5",
-      "port-version": 1
+      "port-version": 2
     },
     "jsonifier": {
       "baseline": "0.9.91",

--- a/versions/j-/jsoncpp.json
+++ b/versions/j-/jsoncpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "203c873c5425a71cb8a0d0ada6e5263a3bd13ff4",
+      "version": "1.9.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "0213314186f58bfac60d8dee9895c137291db35d",
       "version": "1.9.5",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.