### PR TITLE
[kuku] Minor fixes

### DIFF
--- a/ports/kuku/portfile.cmake
+++ b/ports/kuku/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
 )
 
 vcpkg_cmake_install()

--- a/ports/kuku/portfile.cmake
+++ b/ports/kuku/portfile.cmake
@@ -1,16 +1,17 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/Kuku
-    REF 1338c4ae2211ab4c739022ff57f48ce5a76531d5
-    SHA512 6cba13b7fc8c453acbfcb4921ee3acc9c3e91d4bba0e01480ea396e17f85288d0179342090111a2e3c056b6918c7b09ec63c41116eb4021e63c54acc19631156
-    HEAD_REF master
+    REF "v${VERSION}"
+    SHA512 4b0f0cae191c70d20337fb1581fa06a8fe363a942cf3a3b6be59fbef551b70446405fb1e4e5e7ec917d5519e8d2ad0ea59bd59c36dbf917e838fc1a1cd6a3bef
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
 )
 
 vcpkg_cmake_install()
@@ -18,5 +19,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Kuku-2.1)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/kuku/vcpkg.json
+++ b/ports/kuku/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "kuku",
-  "version": "2.1",
-  "port-version": 3,
-  "description": "Kuku is a simple open-source (MIT licensed) cuckoo hashing library developed by the Cryptography and Privacy Research group at Microsoft.",
+  "version": "2.1.0",
+  "description": "Kuku is a compact and convenient cuckoo hashing library written in C++.",
   "homepage": "https://github.com/microsoft/Kuku",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3941,8 +3941,8 @@
       "port-version": 1
     },
     "kuku": {
-      "baseline": "2.1",
-      "port-version": 3
+      "baseline": "2.1.0",
+      "port-version": 0
     },
     "kvasir-mpl": {
       "baseline": "2019-08-06",

--- a/versions/k-/kuku.json
+++ b/versions/k-/kuku.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c4c449dc8231a64bfe8392e8b768910728b36e07",
+      "git-tree": "55d5b6509ad53b413c0f4bd71a15f71ab79d8c8b",
       "version": "2.1.0",
       "port-version": 0
     },

--- a/versions/k-/kuku.json
+++ b/versions/k-/kuku.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4c449dc8231a64bfe8392e8b768910728b36e07",
+      "version": "2.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1a78898dbb7cbacda021768b5468af708035474b",
       "version": "2.1",
       "port-version": 3


### PR DESCRIPTION
**Note: This PR doesn't update the port to a new version!**

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
