### PR TITLE
[log4cplus] Update to 2.1.1

### DIFF
--- a/ports/log4cplus/portfile.cmake
+++ b/ports/log4cplus/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO log4cplus/log4cplus
-    REF REL_2_1_0
-    SHA512 fd26ae73e898af6896046e5e567bfc664bc8e81568c8cdbe5ff6316054b875af7fa946f7b1f011a96b0d3b53dc3f7f9411cbc2ffa07b674777cb0def2743ede8
+    REF REL_2_1_1
+    SHA512 ddc63ad574aed7d13980308c1f4d3a31a7fa9c7d4a14de923f9b3a851492d17f64f34166b6be77fc8584c0e98cd1f34ed3d9ba268e7456fd1ff3b7d8125dbe3a
     HEAD_REF master
 )
 
@@ -40,13 +40,17 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/log4cplus)
 
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+# debug version of pkgconfig misses D postfix of the library, therefore unusable
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/share/${PORT}/ChangeLog"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/README.md")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/log4cplus/portfile.cmake
+++ b/ports/log4cplus/portfile.cmake
@@ -40,15 +40,16 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/log4cplus)
-
 vcpkg_copy_pdbs()
+
+if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/log4cplus.pc" "-llog4cplus" "-llog4cplusD")
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-# debug version of pkgconfig misses D postfix of the library, therefore unusable
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
 file(REMOVE "${CURRENT_PACKAGES_DIR}/share/${PORT}/ChangeLog"
     "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE"
     "${CURRENT_PACKAGES_DIR}/share/${PORT}/README.md")

--- a/ports/log4cplus/vcpkg.json
+++ b/ports/log4cplus/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "log4cplus",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A simple to use C++ logging API providing thread--safe, flexible, and arbitrarily granular control over log management and configuration",
   "homepage": "https://github.com/log4cplus/log4cplus",
+  "license": "Apache-2.0 AND BSD-2-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5241,7 +5241,7 @@
       "port-version": 0
     },
     "log4cplus": {
-      "baseline": "2.1.0",
+      "baseline": "2.1.1",
       "port-version": 0
     },
     "log4cpp-log4cpp": {

--- a/versions/l-/log4cplus.json
+++ b/versions/l-/log4cplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d1ae4f2e50b19b1a9bfab6645e5441473a49e20",
+      "version": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c0a2d8577299ff33c61cbb08d3eb4d4616e4e392",
       "version": "2.1.0",
       "port-version": 0

--- a/versions/l-/log4cplus.json
+++ b/versions/l-/log4cplus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d1ae4f2e50b19b1a9bfab6645e5441473a49e20",
+      "git-tree": "450db8aa0bcccc8479b3f3d2d1c63b71510c5dd4",
       "version": "2.1.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
