### PR TITLE
[wxWidgets] Update to 3.2.4

### DIFF
--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
     REF "v${VERSION}"
-    SHA512 d9cfad429c5c160944cd9c23c3a32ca72740e2d25d7392a06c22374bcbdd099affee5f541d59ac4a9983fb3d82f90bda7eaf92a93a1e8b5ace2c5bf29962ed53
+    SHA512 f1ba875e6dfa3970e6f03741573f96ac224a8d0bace5a4c44dcf95dd4e861031fe086e2dc4429c1c6bcb22d40656fc2c6c287abe0b4678eb9af9698691eda3d9
     HEAD_REF master
     PATCHES
         install-layout.patch

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wxwidgets",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9097,7 +9097,7 @@
       "port-version": 0
     },
     "wxwidgets": {
-      "baseline": "3.2.3",
+      "baseline": "3.2.4",
       "port-version": 0
     },
     "wyhash": {

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea1e14e3f7e09e6bb23baec9ac1194eec01cd8e7",
+      "version": "3.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "8dfaace5786af8de744ecf9e02622b7b3e39087a",
       "version": "3.2.3",
       "port-version": 0


### PR DESCRIPTION
Update to new version only, no other changes.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
