### PR TITLE
[ada-url] Update to 2.7.4

### DIFF
--- a/ports/ada-url/no-cpm.patch
+++ b/ports/ada-url/no-cpm.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b206edb6..1db4099d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,7 +30,6 @@ option(ADA_TESTING "Build tests" ${BUILD_TESTING})
+ # errors due to CPM, so this is here to support disabling all the testing
+ # and tooling for ada if one only wishes to use the ada library.
+ if(ADA_TESTING OR ADA_BENCHMARKS OR ADA_TOOLS)
+-  include(cmake/CPM.cmake)
+   # CPM requires git as an implicit dependency
+   find_package(Git QUIET)
+   # We use googletest in the tests
+diff --git a/tools/cli/CMakeLists.txt b/tools/cli/CMakeLists.txt
+index ff57220b..a6d90f29 100644
+--- a/tools/cli/CMakeLists.txt
++++ b/tools/cli/CMakeLists.txt
+@@ -8,12 +8,8 @@ if(MSVC AND BUILD_SHARED_LIBS)
+         "$<TARGET_FILE:ada>"      # <--this is in-file
+         "$<TARGET_FILE_DIR:adaparse>")                 # <--this is out-file path
+ endif()
+-CPMAddPackage("gh:fmtlib/fmt#7.1.3")
+-CPMAddPackage(
+-  GITHUB_REPOSITORY jarro2783/cxxopts
+-  VERSION 3.1.1
+-  OPTIONS "CXXOPTS_BUILD_EXAMPLES NO" "CXXOPTS_BUILD_TESTS NO" "CXXOPTS_ENABLE_INSTALL YES"
+-)
++find_package(fmt CONFIG REQUIRED)
++find_package(cxxopts CONFIG REQUIRED)
+ target_link_libraries(adaparse PRIVATE cxxopts::cxxopts fmt::fmt)
+ 
+ if(MSVC OR MINGW)

--- a/ports/ada-url/portfile.cmake
+++ b/ports/ada-url/portfile.cmake
@@ -2,8 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ada-url/ada
     REF "v${VERSION}"
-    SHA512 bd9af16dee99a2b3f43e823b9ae6f8893741172d63ffe38337a4b3eab632167241b95df56d4220bc3240a3593e751df6a562e52e31b73e0ba99d41f5bf9922d5
+    SHA512 1814365f98cc85e97fe135a840241c66ddd8a9d6d10f0be548f72bc22b840673ea30291633e4d90e2023b99b59533fa7c77eab65ed41bf9c2bf79fd261cfeba0
     HEAD_REF main
+    PATCHES
+        no-cpm.patch
 )
 
 vcpkg_check_features(
@@ -14,11 +16,13 @@ vcpkg_check_features(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DADA_BENCHMARKS=OFF
         -DBUILD_TESTING=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_Python3=ON
         ${FEATURE_OPTIONS}
+    OPTIONS_DEBUG
+        -DADA_TOOLS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/ada-url/vcpkg.json
+++ b/ports/ada-url/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ada-url",
-  "version": "2.6.8",
+  "version": "2.7.4",
   "description": "WHATWG-compliant and fast URL parser written in modern C++",
   "homepage": "https://ada-url.com/",
   "license": "MIT",
@@ -17,7 +17,11 @@
   "features": {
     "tools": {
       "description": "Build CLI tools (adaparse)",
-      "supports": "!uwp"
+      "supports": "!uwp",
+      "dependencies": [
+        "cxxopts",
+        "fmt"
+      ]
     }
   }
 }

--- a/versions/a-/ada-url.json
+++ b/versions/a-/ada-url.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da619020bc25fc94014a434ab3e2ea77937d00f8",
+      "version": "2.7.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "793a12bdf6a056b11297c61d8129764722fd04b0",
       "version": "2.6.8",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -37,7 +37,7 @@
       "port-version": 15
     },
     "ada-url": {
-      "baseline": "2.6.8",
+      "baseline": "2.7.4",
       "port-version": 0
     },
     "ade": {


### PR DESCRIPTION
This PR also fixes the tools feature. Previously, CPM was used to fetch dependencies. This made it impossible to install the tools feature on air-gapped devices.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
