### PR TITLE
[llvm] Add patch to fix missing LinkageSpec of getCursorKindForDecl

### DIFF
--- a/ports/llvm/0008-add-missing-case.patch
+++ b/ports/llvm/0008-add-missing-case.patch
@@ -1,0 +1,71 @@
+diff --git a/clang/lib/Sema/SemaCodeComplete.cpp b/clang/lib/Sema/SemaCodeComplete.cpp
+index b5d29b2e9..b4fc088a1 100644
+--- a/clang/lib/Sema/SemaCodeComplete.cpp
++++ b/clang/lib/Sema/SemaCodeComplete.cpp
+@@ -4088,6 +4088,9 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
+   case Decl::Concept:
+     return CXCursor_ConceptDecl;
+ 
++  case Decl::LinkageSpec:
++    return CXCursor_LinkageSpec;
++
+   default:
+     if (const auto *TD = dyn_cast<TagDecl>(D)) {
+       switch (TD->getTagKind()) {
+diff --git a/clang/test/Index/recursive-cxx-member-calls.cpp b/clang/test/Index/recursive-cxx-member-calls.cpp
+index 09f3f4141..be908c506 100644
+--- a/clang/test/Index/recursive-cxx-member-calls.cpp
++++ b/clang/test/Index/recursive-cxx-member-calls.cpp
+@@ -216,9 +216,9 @@ AttributeList::Kind AttributeList::getKind(const IdentifierInfo * Name) {
+ // CHECK-tokens: Punctuation: "}" [4:63 - 4:64] ClassTemplate=pair:4:44 (Definition)
+ // CHECK-tokens: Punctuation: ";" [4:64 - 4:65] Namespace=std:3:11 (Definition)
+ // CHECK-tokens: Punctuation: "}" [5:1 - 5:2] Namespace=std:3:11 (Definition)
+-// CHECK-tokens: Keyword: "extern" [6:1 - 6:7]
+-// CHECK-tokens: Literal: ""C"" [6:8 - 6:11] UnexposedDecl=:6:8 (Definition)
+-// CHECK-tokens: Punctuation: "{" [6:12 - 6:13] UnexposedDecl=:6:8 (Definition)
++// CHECK-tokens: Keyword: "extern" [6:1 - 6:7] LinkageSpec=:6:8 (Definition)
++// CHECK-tokens: Literal: ""C"" [6:8 - 6:11] LinkageSpec=:6:8 (Definition)
++// CHECK-tokens: Punctuation: "{" [6:12 - 6:13] LinkageSpec=:6:8 (Definition)
+ // CHECK-tokens: Keyword: "int" [7:3 - 7:6] FunctionDecl=memcmp:7:7
+ // CHECK-tokens: Identifier: "memcmp" [7:7 - 7:13] FunctionDecl=memcmp:7:7
+ // CHECK-tokens: Punctuation: "(" [7:13 - 7:14] FunctionDecl=memcmp:7:7
+@@ -232,7 +232,7 @@ AttributeList::Kind AttributeList::getKind(const IdentifierInfo * Name) {
+ // CHECK-tokens: Punctuation: "," [7:40 - 7:41] FunctionDecl=memcmp:7:7
+ // CHECK-tokens: Identifier: "size_t" [7:42 - 7:48] TypeRef=size_t:2:25
+ // CHECK-tokens: Punctuation: ")" [7:48 - 7:49] FunctionDecl=memcmp:7:7
+-// CHECK-tokens: Punctuation: ";" [7:49 - 7:50] UnexposedDecl=:6:8 (Definition)
++// CHECK-tokens: Punctuation: ";" [7:49 - 7:50] LinkageSpec=:6:8 (Definition)
+ // CHECK-tokens: Identifier: "size_t" [8:3 - 8:9] TypeRef=size_t:2:25
+ // CHECK-tokens: Identifier: "strlen" [8:10 - 8:16] FunctionDecl=strlen:8:10
+ // CHECK-tokens: Punctuation: "(" [8:16 - 8:17] FunctionDecl=strlen:8:10
+@@ -1532,7 +1532,7 @@ AttributeList::Kind AttributeList::getKind(const IdentifierInfo * Name) {
+ // CHECK: 4:20: TemplateTypeParameter=_T1:4:20 (Definition) Extent=[4:14 - 4:23]
+ // CHECK: 4:31: TemplateTypeParameter=_T2:4:31 (Definition) Extent=[4:25 - 4:34]
+ // CHECK: 4:55: FieldDecl=second:4:55 (Definition) Extent=[4:51 - 4:61]
+-// CHECK: 6:8: UnexposedDecl=:6:8 (Definition) Extent=[6:1 - 9:2]
++// CHECK: 6:8: LinkageSpec=:6:8 (Definition) Extent=[6:1 - 9:2]
+ // CHECK: 7:7: FunctionDecl=memcmp:7:7 Extent=[7:3 - 7:49]
+ // CHECK: 7:26: ParmDecl=:7:26 (Definition) Extent=[7:14 - 7:26]
+ // CHECK: 7:40: ParmDecl=:7:40 (Definition) Extent=[7:28 - 7:40]
+diff --git a/clang/tools/c-index-test/c-index-test.c b/clang/tools/c-index-test/c-index-test.c
+index 9d66a22f3..2c0c9cb8e 100644
+--- a/clang/tools/c-index-test/c-index-test.c
++++ b/clang/tools/c-index-test/c-index-test.c
+@@ -1838,6 +1838,8 @@ static enum CXChildVisitResult PrintMangledName(CXCursor cursor, CXCursor p,
+   CXString MangledName;
+   if (clang_isUnexposed(clang_getCursorKind(cursor)))
+     return CXChildVisit_Recurse;
++  if (clang_getCursorKind(cursor) == CXCursor_LinkageSpec)
++    return CXChildVisit_Recurse;
+   PrintCursor(cursor, NULL);
+   MangledName = clang_Cursor_getMangling(cursor);
+   printf(" [mangled=%s]\n", clang_getCString(MangledName));
+@@ -1853,6 +1855,8 @@ static enum CXChildVisitResult PrintManglings(CXCursor cursor, CXCursor p,
+     return CXChildVisit_Recurse;
+   if (!clang_isDeclaration(clang_getCursorKind(cursor)))
+     return CXChildVisit_Recurse;
++  if (clang_getCursorKind(cursor) == CXCursor_LinkageSpec)
++    return CXChildVisit_Recurse;
+   if (clang_getCursorKind(cursor) == CXCursor_ParmDecl)
+     return CXChildVisit_Continue;
+   PrintCursor(cursor, NULL);

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
         0005-remove-numpy.patch
         0006-create-destination-mlir-directory.patch
         0007-fix-compiler-rt-warnings.patch # fixed in upstream
+        0008-add-missing-case.patch # From upstream https://github.com/llvm/llvm-project/pull/72401
 )
 
 vcpkg_check_features(

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "17.0.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5222,7 +5222,7 @@
     },
     "llvm": {
       "baseline": "17.0.2",
-      "port-version": 1
+      "port-version": 2
     },
     "lmdb": {
       "baseline": "0.9.31",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af2e23c1205568f576321133141a51439ef1059f",
+      "version": "17.0.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "3d195e85c468428553d0aed0eeb76e3714231e3a",
       "version": "17.0.2",
       "port-version": 1


### PR DESCRIPTION
Fixes #35268.

Add patch `0008-add-missing-case.patch` to fix missing LinkageSpec of getCursorKindForDecl, it comes from upstream: https://github.com/llvm/llvm-project/pull/72401

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
