### PR TITLE
[SDL2] update to 2.28.5

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL
     REF "release-${VERSION}"
-    SHA512 3199e535033c8728bd12b97931d5c5d7a7dcc9b0f502109ff722982601b6fbb00995d71cbaab7d3b780c738deece235ef76ab1963ce946084c482c2d31a4abe8
+    SHA512 d3cf7d356b79184dd211c9fbbfcb2a83d1acb68ee549ab82be109cd899039f18f0dbf3aedbf0800793c3a68580688014863b5d9bf79bcd366ff0e88252955e3c
     HEAD_REF main
     PATCHES
         deps.patch

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdl2",
-  "version": "2.28.4",
-  "port-version": 1,
+  "version": "2.28.5",
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -19,7 +19,18 @@
     }
   ],
   "default-features": [
-    "base"
+    {
+      "name": "ibus",
+      "platform": "linux"
+    },
+    {
+      "name": "wayland",
+      "platform": "linux"
+    },
+    {
+      "name": "x11",
+      "platform": "!windows"
+    }
   ],
   "features": {
     "alsa": {
@@ -27,21 +38,6 @@
       "dependencies": [
         {
           "name": "alsa",
-          "platform": "linux"
-        }
-      ]
-    },
-    "base": {
-      "description": "Base functionality for SDL",
-      "dependencies": [
-        {
-          "name": "sdl2",
-          "default-features": false,
-          "features": [
-            "ibus",
-            "wayland",
-            "x11"
-          ],
           "platform": "linux"
         }
       ]

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "x11",
-      "platform": "!windows"
+      "platform": "linux"
     }
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7709,8 +7709,8 @@
       "port-version": 6
     },
     "sdl2": {
-      "baseline": "2.28.4",
-      "port-version": 1
+      "baseline": "2.28.5",
+      "port-version": 0
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f63284dd0db982caff7bcae190c9ca7670dbea64",
+      "git-tree": "c231b108356c1db49601c4e77ce84a602656a486",
       "version": "2.28.5",
       "port-version": 0
     },

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c231b108356c1db49601c4e77ce84a602656a486",
+      "git-tree": "06cf4722fa0f5f8467136faebe34cef0e85e1a4c",
       "version": "2.28.5",
       "port-version": 0
     },

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f63284dd0db982caff7bcae190c9ca7670dbea64",
+      "version": "2.28.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d625914314454b36d303ce86753840f6193f2bd",
       "version": "2.28.4",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/35338
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
```
Feature passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static 

```
