### PR TITLE
[oatpp-sqlite] fix usage of oatpp-sqlite

### DIFF
--- a/ports/oatpp-sqlite/fix-usage.patch
+++ b/ports/oatpp-sqlite/fix-usage.patch
@@ -1,27 +1,14 @@
 diff --git a/cmake/module-config.cmake.in b/cmake/module-config.cmake.in
-index 5cc12b0..abf0ed9 100644
+index 5cc12b0..5d94df8 100644
 --- a/cmake/module-config.cmake.in
 +++ b/cmake/module-config.cmake.in
 @@ -1,5 +1,9 @@
  @PACKAGE_INIT@
  
 +include(CMakeFindDependencyMacro)
-+find_dependency(oatpp)
++find_dependency(oatpp REQUIRED)
 +find_dependency(unofficial-sqlite3 REQUIRED)
 +
  if(NOT TARGET oatpp::@OATPP_MODULE_NAME@)
      include("${CMAKE_CURRENT_LIST_DIR}/@OATPP_MODULE_NAME@Targets.cmake")
  endif()
-diff --git a/cmake/module-utils.cmake b/cmake/module-utils.cmake
-index 8f1d35a..cade49d 100644
---- a/cmake/module-utils.cmake
-+++ b/cmake/module-utils.cmake
-@@ -5,7 +5,7 @@ macro(target_link_oatpp target)
-         message("target_link_oatpp(${target}) to installed oatpp lib")
- 
-         target_link_libraries(${target}
--                PRIVATE oatpp::oatpp
-+                PUBLIC oatpp::oatpp
-                 PRIVATE oatpp::oatpp-test
-         )
- 

--- a/ports/oatpp-sqlite/fix-usage.patch
+++ b/ports/oatpp-sqlite/fix-usage.patch
@@ -1,0 +1,27 @@
+diff --git a/cmake/module-config.cmake.in b/cmake/module-config.cmake.in
+index 5cc12b0..abf0ed9 100644
+--- a/cmake/module-config.cmake.in
++++ b/cmake/module-config.cmake.in
+@@ -1,5 +1,9 @@
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(oatpp)
++find_dependency(unofficial-sqlite3 REQUIRED)
++
+ if(NOT TARGET oatpp::@OATPP_MODULE_NAME@)
+     include("${CMAKE_CURRENT_LIST_DIR}/@OATPP_MODULE_NAME@Targets.cmake")
+ endif()
+diff --git a/cmake/module-utils.cmake b/cmake/module-utils.cmake
+index 8f1d35a..cade49d 100644
+--- a/cmake/module-utils.cmake
++++ b/cmake/module-utils.cmake
+@@ -5,7 +5,7 @@ macro(target_link_oatpp target)
+         message("target_link_oatpp(${target}) to installed oatpp lib")
+ 
+         target_link_libraries(${target}
+-                PRIVATE oatpp::oatpp
++                PUBLIC oatpp::oatpp
+                 PRIVATE oatpp::oatpp-test
+         )
+ 

--- a/ports/oatpp-sqlite/fix-usage.patch
+++ b/ports/oatpp-sqlite/fix-usage.patch
@@ -6,8 +6,8 @@ index 5cc12b0..5d94df8 100644
  @PACKAGE_INIT@
  
 +include(CMakeFindDependencyMacro)
-+find_dependency(oatpp REQUIRED)
-+find_dependency(unofficial-sqlite3 REQUIRED)
++find_dependency(oatpp CONFIG)
++find_dependency(unofficial-sqlite3 CONFIG)
 +
  if(NOT TARGET oatpp::@OATPP_MODULE_NAME@)
      include("${CMAKE_CURRENT_LIST_DIR}/@OATPP_MODULE_NAME@Targets.cmake")

--- a/ports/oatpp-sqlite/portfile.cmake
+++ b/ports/oatpp-sqlite/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF ${OATPP_VERSION}
     SHA512 8a208145ee10ed858767b4b56c220b6befd83e6858759128103ce679b889e6218a95ed6627af5098e4d26367be8add82de26e1f1f8ef581b1913b8386f9d56de
     HEAD_REF master
+    PATCHES
+        fix-usage.patch
 )
 
 vcpkg_cmake_configure(
@@ -21,4 +23,4 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME oatpp-sqlite CONFIG_PATH lib/cmake/oatpp-s
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/oatpp-sqlite/vcpkg.json
+++ b/ports/oatpp-sqlite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "oatpp-sqlite",
   "version": "1.3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Oat++ SQLite adapter for Oat++ ORM.",
   "homepage": "https://github.com/oatpp/oatpp-sqlite",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6082,7 +6082,7 @@
     },
     "oatpp-sqlite": {
       "baseline": "1.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "oatpp-ssdp": {
       "baseline": "1.3.0",

--- a/versions/o-/oatpp-sqlite.json
+++ b/versions/o-/oatpp-sqlite.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "30e004b91d823cf62c87c874cd4004f8428528ec",
+      "git-tree": "615d996271d1e2192aae8adbbb10e92264bd95fa",
       "version": "1.3.0",
       "port-version": 2
     },

--- a/versions/o-/oatpp-sqlite.json
+++ b/versions/o-/oatpp-sqlite.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "615d996271d1e2192aae8adbbb10e92264bd95fa",
+      "git-tree": "9bde9ba480ed1c17d74a09b924c849595f795b9c",
       "version": "1.3.0",
       "port-version": 2
     },

--- a/versions/o-/oatpp-sqlite.json
+++ b/versions/o-/oatpp-sqlite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "30e004b91d823cf62c87c874cd4004f8428528ec",
+      "version": "1.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b28e241610e463b41e9c3e3f16f5805b19fb5fa5",
       "version": "1.3.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #35303

Fix usage error:
````
1> [CMake]   The link interface of target "oatpp::oatpp-sqlite" contains:
1> [CMake] 
1> [CMake]     unofficial::sqlite3::sqlite3
1> [CMake] 
1> [CMake]   but the target was not found.  Possible reasons include:
1> [CMake] 
1> [CMake]     * There is a typo in the target name.
1> [CMake]     * A find_package call is missing for an IMPORTED target.
1> [CMake]     * An ALIAS target is missing.
1> [CMake] 
1> [CMake] Call Stack (most recent call first):
1> [CMake]   C:/dev/vcpkg/installed/x64-windows/share/oatpp-sqlite/oatpp-sqliteConfig.cmake:18 (include)
1> [CMake]   C:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
1> [CMake]   CMakeLists.txt:30 (find_package)
1> [CMake] -- Generating done (0.0s)
1> [CMake] CMake Generate step failed.  Build files cannot be regenerated correctly.
````
Usage tested successfully by `oatpp-sqlite:x64-windows`:
````
oatpp-sqlite provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(oatpp-sqlite CONFIG REQUIRED)
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
