### PR TITLE
[sdbus-cpp] fixup config package name

### DIFF
--- a/ports/sdbus-cpp/portfile.cmake
+++ b/ports/sdbus-cpp/portfile.cmake
@@ -22,7 +22,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sdbus-c++)
+vcpkg_cmake_config_fixup(PACKAGE_NAME sdbus-c++ CONFIG_PATH lib/cmake/sdbus-c++)
 vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/sdbus-cpp/vcpkg.json
+++ b/ports/sdbus-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdbus-cpp",
   "version": "1.3.0",
+  "port-version": 1,
   "description": "High-level C++ D-Bus library for Linux designed to provide easy-to-use yet powerful API in modern C++",
   "homepage": "https://github.com/Kistler-Group/sdbus-cpp",
   "license": "LGPL-2.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7678,7 +7678,7 @@
     },
     "sdbus-cpp": {
       "baseline": "1.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sdformat10": {
       "baseline": "10.0.0",

--- a/versions/s-/sdbus-cpp.json
+++ b/versions/s-/sdbus-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "31c0a3bedc3ced9d4ffdeb92b241546f13b9a1fc",
+      "version": "1.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cae6cd5686aeefb86b4b97cda6d258d80a9eb5b6",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


