### PR TITLE
[cnats] Update to 3.7.0

### DIFF
--- a/ports/cnats/portfile.cmake
+++ b/ports/cnats/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nats-io/nats.c
-    REF 66cec7fce9a64f911015f0c516a086c1a74cd22a #v3.6.1
-    SHA512 c0d3ad62c9453dca1799e69c3fe9df63c57c29c3c596ba4a9c5053b4886014741b8ce1563adb28d3e64b6b221748884ef71d6b288fae2855ae1ed1fdd2d028fb
-    HEAD_REF master
+    REF 5d057f66f897279975f1c8eb61c1ccaaf1a7ae01 #v3.7.0
+    SHA512 07d560ac2e1c043e6fb3d182cdec28ac080f9c85f9618198f9db52a53d4d95401c5992e7c9e5c7d7dd0979f919ebb21f0fbba26beb66905068b06e0f4e7cae38
+    HEAD_REF main
     PATCHES
         fix-sodium-dep.patch
 )

--- a/ports/cnats/portfile.cmake
+++ b/ports/cnats/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nats-io/nats.c
-    REF 5d057f66f897279975f1c8eb61c1ccaaf1a7ae01 #v3.7.0
-    SHA512 07d560ac2e1c043e6fb3d182cdec28ac080f9c85f9618198f9db52a53d4d95401c5992e7c9e5c7d7dd0979f919ebb21f0fbba26beb66905068b06e0f4e7cae38
+    REF "v${VERSION}"
+    SHA512 0670a2b7fb70a49e2b1f5cbccf2406a3ecaf04b48b4147dc2ead9cb106f1673efa79b5e40d3bb557986ade35da2158b58b324603f98a58258a497dc57cb5d700
     HEAD_REF main
     PATCHES
         fix-sodium-dep.patch

--- a/ports/cnats/vcpkg.json
+++ b/ports/cnats/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cnats",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "A C client for the NATS messaging system",
   "homepage": "https://github.com/nats-io/nats.c",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1677,7 +1677,7 @@
       "port-version": 3
     },
     "cnats": {
-      "baseline": "3.6.1",
+      "baseline": "3.7.0",
       "port-version": 0
     },
     "cnl": {

--- a/versions/c-/cnats.json
+++ b/versions/c-/cnats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc26cbff47151645d07b50565cfccf8d9267cf78",
+      "version": "3.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "809d101d1791bc6cd3f51c8c9fa8e86dc923113b",
       "version": "3.6.1",
       "port-version": 0

--- a/versions/c-/cnats.json
+++ b/versions/c-/cnats.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dc26cbff47151645d07b50565cfccf8d9267cf78",
+      "git-tree": "438cfff2ee224f9d414bda9bcf796c13534443ba",
       "version": "3.7.0",
       "port-version": 0
     },


### PR DESCRIPTION

This updates the version to the latest release 3.7.0.  I tested it on `x64-macos`, `x64-linux`, and `x64-windows` successfully.    


- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

