### PR TITLE
[sqlite-orm] test feature unsupport uwp

### DIFF
--- a/ports/sqlite-orm/vcpkg.json
+++ b/ports/sqlite-orm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sqlite-orm",
   "version": "1.8.2",
+  "port-version": 1,
   "description": "SQLite ORM light header only library for modern C++",
   "homepage": "https://github.com/fnc12/sqlite_orm",
   "license": "AGPL-3.0-or-later OR MIT",
@@ -21,6 +22,7 @@
     },
     "test": {
       "description": "Build sqlite_orm unit tests",
+      "supports": "!uwp",
       "dependencies": [
         "catch2"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8118,7 +8118,7 @@
     },
     "sqlite-orm": {
       "baseline": "1.8.2",
-      "port-version": 0
+      "port-version": 1
     },
     "sqlite3": {
       "baseline": "3.43.2",

--- a/versions/s-/sqlite-orm.json
+++ b/versions/s-/sqlite-orm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13e0d0b90109dcaf60af5d316ece18d4cf6ef50e",
+      "version": "1.8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "d46221e51b059d05e7f65620b5e377fdc3673d74",
       "version": "1.8.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/33769
```
MSVCRTD.lib(exe_main.obj) : error LNK2019: unresolved external symbol main referenced in function "int __cdecl invoke_main(void)" (?invoke_main@@YAHXZ)
tests\unit_tests.exe : fatal error LNK1120: 1 unresolved externals
```
The test feature generates `unit_tests.exe` executable program. The executable program needs to link the `main` function, but the `main` function is not defined in test, causing the link to fail. Therefore, test feature is not supported under `uwp`.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
```

