### PR TITLE
[freeglut,gl2ps,glui,mdl-sdk] Platform support corrections

### DIFF
--- a/ports/freeglut/vcpkg.json
+++ b/ports/freeglut/vcpkg.json
@@ -1,9 +1,11 @@
 {
   "name": "freeglut",
   "version": "3.4.0",
+  "port-version": 1,
   "description": "A free OpenGL utility toolkit, the open-sourced alternative to the GLUT library.",
   "homepage": "https://sourceforge.net/projects/freeglut/",
   "license": null,
+  "supports": "!ios",
   "dependencies": [
     "opengl",
     {

--- a/ports/gl2ps/portfile.cmake
+++ b/ports/gl2ps/portfile.cmake
@@ -1,20 +1,27 @@
 vcpkg_from_gitlab(
-    GITLAB_URL http://gitlab.onelab.info
+    GITLAB_URL https://gitlab.onelab.info
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gl2ps/gl2ps
     REF gl2ps_1_4_2
     SHA512 cb4abd79f6790e229a0b05a6d12e4bd4d24885c89c4cb8644e49b0459361565c5c5379b53d85f59eeaba16144d3288dbd06c90f55a739f0928a788224ccb8085
     HEAD_REF master
-    PATCHES separate-static-dynamic-build.patch
+    PATCHES
+        separate-static-dynamic-build.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
+    OPTIONS
+        -DCMAKE_DISABLE_FIND_PACKAGE_GLUT=ON
+    OPTIONS_DEBUG
+        -DDISABLE_INSTALL_HEADERS=ON
 )
 
 vcpkg_cmake_install()
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING.GL2PS" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-file(INSTALL "${SOURCE_PATH}/COPYING.LGPL" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright.LGPL)
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/README.txt"
+        "${SOURCE_PATH}/COPYING.LGPL"
+        "${SOURCE_PATH}/COPYING.GL2PS"
+)

--- a/ports/gl2ps/vcpkg.json
+++ b/ports/gl2ps/vcpkg.json
@@ -1,12 +1,14 @@
 {
   "name": "gl2ps",
   "version": "1.4.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "OpenGL to PostScript Printing Library",
   "homepage": "https://gitlab.onelab.info/gl2ps/gl2ps",
+  "supports": "!android",
   "dependencies": [
     "freeglut",
     "libpng",
+    "opengl",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/gl2ps/vcpkg.json
+++ b/ports/gl2ps/vcpkg.json
@@ -6,7 +6,6 @@
   "homepage": "https://gitlab.onelab.info/gl2ps/gl2ps",
   "supports": "!android",
   "dependencies": [
-    "freeglut",
     "libpng",
     "opengl",
     {

--- a/ports/glui/vcpkg.json
+++ b/ports/glui/vcpkg.json
@@ -1,11 +1,13 @@
 {
   "name": "glui",
   "version-date": "2019-11-30",
-  "port-version": 3,
+  "port-version": 4,
   "description": "GLUI is a GLUT-based C++ user interface library",
   "homepage": "https://github.com/libglui/glui",
+  "supports": "!android",
   "dependencies": [
     "freeglut",
+    "opengl",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/mdl-sdk/001-freeimage-from-vcpkg.patch
+++ b/ports/mdl-sdk/001-freeimage-from-vcpkg.patch
@@ -30,7 +30,7 @@ index b11573a..703458e 100644
      set(FREEIMAGE_DIR "NOT-SPECIFIED" CACHE PATH "Directory that contains the freeimage library and the corresponding headers.")
      #-----------------------------------------------------------------------------------------------
  
-@@ -90,6 +93,35 @@ function(FIND_FREEIMAGE_EXT)
+@@ -90,6 +93,37 @@ function(FIND_FREEIMAGE_EXT)
          endif()
      endif()
  
@@ -55,6 +55,8 @@ index b11573a..703458e 100644
 +            if(NOT _FREEIMAGE_LIB)
 +                get_target_property(_FREEIMAGE_LIB freeimage::FreeImage IMPORTED_IMPLIB_DEBUG)
 +            endif()
++        elseif(WINDOWS)
++            set(_FREEIMAGE_LIB "${_FREEIMAGE_SHARED}")
 +        endif()
 +        
 +        find_file(_FREEIMAGE_HEADER_FILE "FreeImage.h"

--- a/ports/mdl-sdk/vcpkg.json
+++ b/ports/mdl-sdk/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "mdl-sdk",
   "version": "2021.1.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "NVIDIA Material Definition Language SDK",
   "homepage": "https://github.com/NVIDIA/MDL-SDK",
   "license": "BSD-3-Clause",
-  "supports": "!arm & !x86 & !(windows & static)",
+  "supports": "!arm & !x86 & !staticcrt",
   "dependencies": [
     "boost-algorithm",
     "boost-any",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -612,7 +612,7 @@ libqcow:x64-linux=skip
 libqcow:x86-windows=skip
 libqcow:arm64-windows=skip
 # needs ftello
-libraw:arm-neon-android
+libraw:arm-neon-android=fail
 # Conflicts with openssl
 libressl:arm-neon-android=skip
 libressl:arm64-android=skip

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -341,9 +341,7 @@ fmi4cpp:arm64-uwp=fail
 fmi4cpp:x64-uwp=fail
 folly:arm64-android=fail
 folly:x64-android=fail
-freeglut:arm-neon-android=fail
-freeglut:arm64-android=fail
-freeglut:x64-android=fail
+# Needs XQuartz
 freeglut:x64-osx=fail
 # Needs /bigobj
 freeopcua:arm-neon-android=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -611,6 +611,8 @@ libqcow:x64-windows=skip
 libqcow:x64-linux=skip
 libqcow:x86-windows=skip
 libqcow:arm64-windows=skip
+# needs ftello
+libraw:arm-neon-android
 # Conflicts with openssl
 libressl:arm-neon-android=skip
 libressl:arm64-android=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2958,7 +2958,7 @@
     },
     "gl2ps": {
       "baseline": "1.4.2",
-      "port-version": 3
+      "port-version": 4
     },
     "gl3w": {
       "baseline": "2018-05-31",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5478,7 +5478,7 @@
     },
     "mdl-sdk": {
       "baseline": "2021.1.2",
-      "port-version": 3
+      "port-version": 4
     },
     "mdns": {
       "baseline": "1.4.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3022,7 +3022,7 @@
     },
     "glui": {
       "baseline": "2019-11-30",
-      "port-version": 3
+      "port-version": 4
     },
     "gmime": {
       "baseline": "3.2.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2750,7 +2750,7 @@
     },
     "freeglut": {
       "baseline": "3.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "freeimage": {
       "baseline": "3.18.0",

--- a/versions/f-/freeglut.json
+++ b/versions/f-/freeglut.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f948f7bed9cac147c0687d4b170b99bc6b59f157",
+      "version": "3.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "51a55df4538f3ecdeeb6d9846afd156ec3255630",
       "version": "3.4.0",
       "port-version": 0

--- a/versions/g-/gl2ps.json
+++ b/versions/g-/gl2ps.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "173e4cad0c1ca768e492fb154269bd385f01b18f",
+      "version": "1.4.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "3607998f92ba0e61fbcae891aa6a8aa996e3bf0a",
       "version": "1.4.2",
       "port-version": 3

--- a/versions/g-/gl2ps.json
+++ b/versions/g-/gl2ps.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "173e4cad0c1ca768e492fb154269bd385f01b18f",
+      "git-tree": "1f0cdea5ea747e24f3a5fba076e645e1292a832f",
       "version": "1.4.2",
       "port-version": 4
     },

--- a/versions/g-/glui.json
+++ b/versions/g-/glui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c2b09ac7fb9d890c835c7580c3e0addb996752d",
+      "version-date": "2019-11-30",
+      "port-version": 4
+    },
+    {
       "git-tree": "5fb1a005d3f676d62e974dbb3b96dba5c3c7369a",
       "version-date": "2019-11-30",
       "port-version": 3

--- a/versions/m-/mdl-sdk.json
+++ b/versions/m-/mdl-sdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "65fe141ea6ffce572c4bbfc3b021c40b21c8c775",
+      "git-tree": "7c4084ba04dcadc57086603e341b7d74e6926f00",
       "version": "2021.1.2",
       "port-version": 4
     },

--- a/versions/m-/mdl-sdk.json
+++ b/versions/m-/mdl-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "65fe141ea6ffce572c4bbfc3b021c40b21c8c775",
+      "version": "2021.1.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "a8fcd0cdebe6b073993485aba6fa0dd24445f9f5",
       "version": "2021.1.2",
       "port-version": 3


### PR DESCRIPTION
Forked from work on ogre-next:

Fixes `freeglut` build on android.
Marks `gl2ps` and `glui` as unsupported on android. (Used to be failure cascade form `freeglut`.)
Drops `gl2ps` dependency on `freeglut`. (Skip building test programs.)
Aligns `mdl-sdk` `supports` expression with `vcpkg_check_library_linkage`, and fixed the build error for `x64-windows-static-md`. (Used to be "unsupported".)
Marks `libraw:arm-neon-android=fail`. (Used to be failure cascade from `freeglut`. Might work with some NDK/ABI configurations.)