### PR TITLE
[protobuf] update to 3.25.1

### DIFF
--- a/ports/protobuf/fix-default-proto-file-path.patch
+++ b/ports/protobuf/fix-default-proto-file-path.patch
@@ -1,9 +1,9 @@
 diff --git a/src/google/protobuf/compiler/command_line_interface.cc b/src/google/protobuf/compiler/command_line_interface.cc
-index 5e9a2c4..8eaa6e0 100644
+index f9e9666..d453a4c 100644
 --- a/src/google/protobuf/compiler/command_line_interface.cc
 +++ b/src/google/protobuf/compiler/command_line_interface.cc
-@@ -261,12 +261,15 @@ void AddDefaultProtoPaths(
-         std::pair<std::string, std::string>("", path + "/include"));
+@@ -280,12 +280,15 @@ void AddDefaultProtoPaths(
+     paths->emplace_back("", std::move(include_path));
      return;
    }
 -  // Check if the upper level directory has an "include" subdirectory.
@@ -16,6 +16,6 @@ index 5e9a2c4..8eaa6e0 100644
    }
    path = path.substr(0, pos);
 +  }
-   if (IsInstalledProtoPath(path + "/include")) {
-     paths->push_back(
-         std::pair<std::string, std::string>("", path + "/include"));
+   include_path = absl::StrCat(path, "/include");
+   if (IsInstalledProtoPath(include_path)) {
+     paths->emplace_back("", std::move(include_path));

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -3,13 +3,12 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF v3.21.12
-    SHA512 152f8441c325e808b942153c15e82fdb533d5273b50c25c28916ec568ada880f79242bb61ee332ac5fb0d20f21239ed6f8de02ef6256cc574b1fc354d002c6b0
+    REF "v${VERSION}"
+    SHA512 c2212d46c08f5ea7797769bbfb90a853f015da4a1ddb3d36fc4b9cae687b50a7578485e2caf4f6324848475220c1c46e2ce1a7e15adc9fddebbc9907c74e7dcc
     HEAD_REF master
     PATCHES
         fix-static-build.patch
         fix-default-proto-file-path.patch
-        compile_options.patch
 )
 
 string(COMPARE EQUAL "${TARGET_TRIPLET}" "${HOST_TRIPLET}" protobuf_BUILD_PROTOC_BINARIES)

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "protobuf",
-  "version": "3.21.12",
+  "version": "3.25.1",
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",
   "dependencies": [
+    "abseil",
     {
       "name": "protobuf",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6769,7 +6769,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "3.21.12",
+      "baseline": "3.25.1",
       "port-version": 0
     },
     "protobuf-c": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f94235e552599141950d7a4a3eaf93bc87d1b22",
+      "version": "3.25.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b145508ba614fe26989b23f6317f15bf6467be4",
       "version": "3.21.12",
       "port-version": 0


### PR DESCRIPTION
Fixes #34995
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
