### PR TITLE
[opencv3/opencv4] Fix supports QNX

### DIFF
--- a/ports/opencv3/0020-fix-supportqnx.patch
+++ b/ports/opencv3/0020-fix-supportqnx.patch
@@ -1,0 +1,21 @@
+diff --git a/modules/core/src/system.cpp b/modules/core/src/system.cpp
+index 9bade08..28f006e 100644
+--- a/modules/core/src/system.cpp
++++ b/modules/core/src/system.cpp
+@@ -129,11 +129,15 @@ void* allocSingletonNewBuffer(size_t size) { return malloc(size); }
+ #include <cstdlib>        // std::abort
+ #endif
+ 
+-#if defined __ANDROID__ || defined __unix__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __HAIKU__
++#if defined __ANDROID__ || defined __unix__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __HAIKU__ || defined __QNX__
+ #  include <unistd.h>
+ #  include <fcntl.h>
+ #if defined __QNX__
+ #  include <sys/elf.h>
++#  include <sys/auxv.h>
++using Elf64_auxv_t = auxv64_t;
++#  include <elfdefinitions.h>
++constexpr decltype(auto) AT_HWCAP = NT_GNU_HWCAP;
+ #else
+ #  include <elf.h>
+ #endif

--- a/ports/opencv3/portfile.cmake
+++ b/ports/opencv3/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_from_github(
       0012-fix-zlib.patch
       0019-missing-include.patch
       fix-tbb-error.patch
+      0020-fix-supportqnx.patch
 )
 # Disallow accidental build of vendored copies
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/openexr")

--- a/ports/opencv3/vcpkg.json
+++ b/ports/opencv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv3",
   "version": "3.4.18",
-  "port-version": 11,
+  "port-version": 12,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",

--- a/ports/opencv4/0022-fix-supportqnx.patch
+++ b/ports/opencv4/0022-fix-supportqnx.patch
@@ -1,0 +1,21 @@
+diff --git a/modules/core/src/system.cpp b/modules/core/src/system.cpp
+index 7811ab7..8f00891 100644
+--- a/modules/core/src/system.cpp
++++ b/modules/core/src/system.cpp
+@@ -120,11 +120,15 @@ void* allocSingletonNewBuffer(size_t size) { return malloc(size); }
+ #include <cstdlib>        // std::abort
+ #endif
+ 
+-#if defined __ANDROID__ || defined __unix__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __HAIKU__ || defined __Fuchsia__
++#if defined __ANDROID__ || defined __unix__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __HAIKU__ || defined __Fuchsia__ || defined __QNX__
+ #  include <unistd.h>
+ #  include <fcntl.h>
+ #if defined __QNX__
+ #  include <sys/elf.h>
++#  include <sys/auxv.h>
++using Elf64_auxv_t = auxv64_t;
++#  include <elfdefinitions.h>
++constexpr decltype(auto) AT_HWCAP = NT_GNU_HWCAP;
+ #else
+ #  include <elf.h>
+ #endif

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -31,6 +31,7 @@ vcpkg_from_github(
       0020-fix-compat-cuda12.2.patch
       0021-static-openvino.patch # https://github.com/opencv/opencv/pull/23963
       "${ARM64_WINDOWS_FIX}"
+      0022-fix-supportqnx.patch
 )
 # Disallow accidental build of vendored copies
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/openexr")

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
-  "port-version": 11,
+  "port-version": 12,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6238,11 +6238,11 @@
     },
     "opencv3": {
       "baseline": "3.4.18",
-      "port-version": 11
+      "port-version": 12
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 11
+      "port-version": 12
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5ee69ffa1b6c98a28fc805afffaeb799b4d22a8",
+      "version": "3.4.18",
+      "port-version": 12
+    },
+    {
       "git-tree": "8eca838beb277535a53756ceb5da17aa8b5050a8",
       "version": "3.4.18",
       "port-version": 11

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3d46b66df37511cf7b49ceffe96f5ff62acf6ea",
+      "version": "4.8.0",
+      "port-version": 12
+    },
+    {
       "git-tree": "9d3433d44aaf404378dff91625448de76738a95f",
       "version": "4.8.0",
       "port-version": 11


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #35209. The upstream issue: https://github.com/opencv/opencv/issues/24567
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
