### PR TITLE
[qtbase] Fix build failed with libxkbcommon 1.6.0

### DIFF
--- a/ports/qtbase/fix-xkbcommon160.patch
+++ b/ports/qtbase/fix-xkbcommon160.patch
@@ -1,0 +1,19 @@
+diff --git a/src/gui/platform/unix/qxkbcommon.cpp b/src/gui/platform/unix/qxkbcommon.cpp
+index d254aee..56eb8a3 100644
+--- a/src/gui/platform/unix/qxkbcommon.cpp
++++ b/src/gui/platform/unix/qxkbcommon.cpp
+@@ -239,10 +239,14 @@ static constexpr const auto KeyTbl = qMakeArray(
+         Xkb2Qt<XKB_KEY_dead_small_schwa,        Qt::Key_Dead_Small_Schwa>,
+         Xkb2Qt<XKB_KEY_dead_capital_schwa,      Qt::Key_Dead_Capital_Schwa>,
+         Xkb2Qt<XKB_KEY_dead_greek,              Qt::Key_Dead_Greek>,
++/* The following four XKB_KEY_dead keys got removed in libxkbcommon 1.6.0
++   The define check is kind of version check here. */
++#ifdef XKB_KEY_dead_lowline
+         Xkb2Qt<XKB_KEY_dead_lowline,            Qt::Key_Dead_Lowline>,
+         Xkb2Qt<XKB_KEY_dead_aboveverticalline,  Qt::Key_Dead_Aboveverticalline>,
+         Xkb2Qt<XKB_KEY_dead_belowverticalline,  Qt::Key_Dead_Belowverticalline>,
+         Xkb2Qt<XKB_KEY_dead_longsolidusoverlay, Qt::Key_Dead_Longsolidusoverlay>,
++#endif
+ 
+         // Special keys from X.org - This include multimedia keys,
+         // wireless/bluetooth/uwb keys, special launcher keys, etc.

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -42,7 +42,7 @@ if(VCPKG_TARGET_IS_LINUX)
     "libxkbcommon-x11-dev.")
     list(APPEND ${PORT}_PATCHES 
         fix-xkbcommon160.patch
-    )
+    ) # Upstream bug: https://bugreports.qt.io/browse/QTBUG-117950
 endif()
 
 # Features can be found via searching for qt_feature in all configure.cmake files in the source:

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -40,6 +40,9 @@ if(VCPKG_TARGET_IS_LINUX)
     "They can be installed on Ubuntu systems via sudo apt-get install " 
     "'^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev "
     "libxkbcommon-x11-dev.")
+    list(APPEND ${PORT}_PATCHES 
+        fix-xkbcommon160.patch
+    )
 endif()
 
 # Features can be found via searching for qt_feature in all configure.cmake files in the source:

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7090,7 +7090,7 @@
     },
     "qtbase": {
       "baseline": "6.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "qtcharts": {
       "baseline": "6.6.0",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "56fea613d9f9cc5fda87d2ca1a061eb107e82fc7",
+      "git-tree": "f4895b1904ec4356979f2c3382c3374859fcae06",
       "version": "6.6.0",
       "port-version": 2
     },

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "56fea613d9f9cc5fda87d2ca1a061eb107e82fc7",
+      "version": "6.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "11861d085aeee91737a5dede66bb78845d99b0e7",
       "version": "6.6.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #35396. The related upstream bug: https://bugreports.qt.io/browse/QTBUG-117950
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
