### PR TITLE
[libspng]: New port

### DIFF
--- a/ports/libspng/fix-spngconfig-cmake.patch
+++ b/ports/libspng/fix-spngconfig-cmake.patch
@@ -1,0 +1,11 @@
+diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
+index d0123db..5756179 100644
+--- a/cmake/Config.cmake.in
++++ b/cmake/Config.cmake.in
+@@ -1,5 +1,6 @@
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
+ find_dependency(ZLIB REQUIRED)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")

--- a/ports/libspng/portfile.cmake
+++ b/ports/libspng/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO randy408/libspng
+    REF "v${VERSION}"
+    SHA512 cd729653599ed97f80d19f3048c1b3bc2ac16f922b3465804b1913bc45d9fc8b28b56bc2121fda36e9d3dcdd12612cced5383313b722a5342b613f8781879f1a
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SPNG_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SPNG_BUILD_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSPNG_STATIC=${SPNG_BUILD_STATIC}
+        -DSPNG_SHARED=${SPNG_BUILD_SHARED}
+        -DBUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/spng PACKAGE_NAME spng)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libspng/portfile.cmake
+++ b/ports/libspng/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 cd729653599ed97f80d19f3048c1b3bc2ac16f922b3465804b1913bc45d9fc8b28b56bc2121fda36e9d3dcdd12612cced5383313b722a5342b613f8781879f1a
     HEAD_REF master
+    PATCHES
+        fix-spngconfig-cmake.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SPNG_BUILD_STATIC)

--- a/ports/libspng/usage
+++ b/ports/libspng/usage
@@ -1,0 +1,4 @@
+libspng provides CMake targets:
+
+    find_package(spng CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE spng::spng)

--- a/ports/libspng/usage
+++ b/ports/libspng/usage
@@ -1,4 +1,4 @@
 libspng provides CMake targets:
 
-    find_package(spng CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE spng::spng)
+    find_package(SPNG CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:spng::spng>,spng::spng,spng::spng_static>) 

--- a/ports/libspng/vcpkg.json
+++ b/ports/libspng/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libspng",
+  "version": "0.7.4",
+  "description": "Simple, modern libpng alternative",
+  "homepage": "https://github.com/randy408/libspng",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4832,6 +4832,10 @@
       "baseline": "0.2.3",
       "port-version": 2
     },
+    "libspng": {
+      "baseline": "0.7.4",
+      "port-version": 0
+    },
     "libsquish": {
       "baseline": "1.15",
       "port-version": 13

--- a/versions/l-/libspng.json
+++ b/versions/l-/libspng.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8efb5a57f5115864001d6eddad855e2958f14fee",
+      "version": "0.7.4",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libspng.json
+++ b/versions/l-/libspng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8efb5a57f5115864001d6eddad855e2958f14fee",
+      "git-tree": "ed674df56d8b39d76443c7db3ae893c08394bf9c",
       "version": "0.7.4",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
