### PR TITLE
[dcmtk] Fix link xml2 error

### DIFF
--- a/ports/dcmtk/fix_link_xml2.patch
+++ b/ports/dcmtk/fix_link_xml2.patch
@@ -1,12 +1,13 @@
 diff --git a/CMake/3rdparty.cmake b/CMake/3rdparty.cmake
-index 2c974e8..36201a0 100644
+index 2c974e8..90707bd 100644
 --- a/CMake/3rdparty.cmake
 +++ b/CMake/3rdparty.cmake
-@@ -95,6 +95,7 @@ if(DCMTK_USE_FIND_PACKAGE)
+@@ -94,7 +94,7 @@ if(DCMTK_USE_FIND_PACKAGE)
+     else()
        message(STATUS "Info: DCMTK XML support will be enabled")
        set(WITH_LIBXML 1)
-       include_directories(${LIBXML2_INCLUDE_DIR})
-+      set(LIBXML2_LIBRARIES LibXml2::LibXml2)
+-      include_directories(${LIBXML2_INCLUDE_DIR})
++      include_directories(${LIBXML2_INCLUDE_DIRS})
        set(LIBXML_LIBS ${LIBXML2_LIBRARIES} ${LIBXML2_EXTRA_LIBS_STATIC})
      endif()
    endif()

--- a/ports/dcmtk/fix_link_xml2.patch
+++ b/ports/dcmtk/fix_link_xml2.patch
@@ -1,22 +1,12 @@
 diff --git a/CMake/3rdparty.cmake b/CMake/3rdparty.cmake
-index 2c974e8..a6a5d65 100644
+index 2c974e8..36201a0 100644
 --- a/CMake/3rdparty.cmake
 +++ b/CMake/3rdparty.cmake
-@@ -86,7 +86,7 @@ if(DCMTK_USE_FIND_PACKAGE)
- 
-   # Find libXML2
-   if(DCMTK_WITH_XML)
--    find_package(LibXml2 QUIET)
-+    find_package(LibXml2 REQUIRED)
-     if(NOT LIBXML2_FOUND)
-       message(STATUS "Warning: XML support will be disabled because libxml2 was not found.")
-       set(WITH_LIBXML "")
-@@ -95,7 +95,7 @@ if(DCMTK_USE_FIND_PACKAGE)
+@@ -95,6 +95,7 @@ if(DCMTK_USE_FIND_PACKAGE)
        message(STATUS "Info: DCMTK XML support will be enabled")
        set(WITH_LIBXML 1)
        include_directories(${LIBXML2_INCLUDE_DIR})
--      set(LIBXML_LIBS ${LIBXML2_LIBRARIES} ${LIBXML2_EXTRA_LIBS_STATIC})
-+      set(LIBXML_LIBS LibXml2::LibXml2 ${LIBXML2_EXTRA_LIBS_STATIC})
++      set(LIBXML2_LIBRARIES LibXml2::LibXml2)
+       set(LIBXML_LIBS ${LIBXML2_LIBRARIES} ${LIBXML2_EXTRA_LIBS_STATIC})
      endif()
    endif()
- 

--- a/ports/dcmtk/fix_link_xml2.patch
+++ b/ports/dcmtk/fix_link_xml2.patch
@@ -1,0 +1,22 @@
+diff --git a/CMake/3rdparty.cmake b/CMake/3rdparty.cmake
+index 2c974e8..a6a5d65 100644
+--- a/CMake/3rdparty.cmake
++++ b/CMake/3rdparty.cmake
+@@ -86,7 +86,7 @@ if(DCMTK_USE_FIND_PACKAGE)
+ 
+   # Find libXML2
+   if(DCMTK_WITH_XML)
+-    find_package(LibXml2 QUIET)
++    find_package(LibXml2 REQUIRED)
+     if(NOT LIBXML2_FOUND)
+       message(STATUS "Warning: XML support will be disabled because libxml2 was not found.")
+       set(WITH_LIBXML "")
+@@ -95,7 +95,7 @@ if(DCMTK_USE_FIND_PACKAGE)
+       message(STATUS "Info: DCMTK XML support will be enabled")
+       set(WITH_LIBXML 1)
+       include_directories(${LIBXML2_INCLUDE_DIR})
+-      set(LIBXML_LIBS ${LIBXML2_LIBRARIES} ${LIBXML2_EXTRA_LIBS_STATIC})
++      set(LIBXML_LIBS LibXml2::LibXml2 ${LIBXML2_EXTRA_LIBS_STATIC})
+     endif()
+   endif()
+ 

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         dcmtk.patch
         windows-patch.patch
         fix-pc-format.patch
+        fix_link_xml2.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/dcmtk/vcpkg.json
+++ b/ports/dcmtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dcmtk",
   "version": "3.6.7",
-  "port-version": 5,
+  "port-version": 6,
   "description": "This DICOM ToolKit (DCMTK) package consists of source code, documentation and installation instructions for a set of software libraries and applications implementing part of the DICOM/MEDICOM Standard.",
   "homepage": "https://github.com/DCMTK/dcmtk",
   "license": "BSD-3-Clause OR BSD-2-Clause OR libtiff OR MIT OR Zlib OR Libpng",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2138,7 +2138,7 @@
     },
     "dcmtk": {
       "baseline": "3.6.7",
-      "port-version": 5
+      "port-version": 6
     },
     "debug-assert": {
       "baseline": "1.3.3",

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4fd6685692de9c75974b21b5c23ad0953b2fca7f",
+      "git-tree": "a21242a5c661abbff0c13bb0f0d6a04a469f837b",
       "version": "3.6.7",
       "port-version": 6
     },

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a21242a5c661abbff0c13bb0f0d6a04a469f837b",
+      "git-tree": "bea28d42632b9740c795d645252307fe02c273cc",
       "version": "3.6.7",
       "port-version": 6
     },

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4fd6685692de9c75974b21b5c23ad0953b2fca7f",
+      "version": "3.6.7",
+      "port-version": 6
+    },
+    {
       "git-tree": "a66dd62879ace07389aae2f77cc909744f9d7458",
       "version": "3.6.7",
       "port-version": 5


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/33473
`F:\vcpkg\installed\x64-windows\include\libxml2\libxml/encoding.h(28): fatal error C1083: Cannot open include file: 'iconv.h': No such file or directory`
Fix the linking `xml2` method to the linking method in vcpkg.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
```