### PR TITLE
[icu] Fix x64-windows-static building icu will generate complete icudt.lib

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -39,11 +39,14 @@ if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
   list(APPEND CONFIG_TRIPLETS ${TARGET_TRIPLET}-dbg)
 endif()
 
-if("tools" IN_LIST FEATURES)
-  list(APPEND CONFIGURE_OPTIONS --enable-tools)
-else()
-  list(APPEND CONFIGURE_OPTIONS --disable-tools)
+if(VCPKG_TARGET_IS_IOS)
+    if("tools" IN_LIST FEATURES)
+      list(APPEND CONFIGURE_OPTIONS --enable-tools)
+    else()
+      list(APPEND CONFIGURE_OPTIONS --disable-tools)
+    endif()
 endif()
+
 if(CMAKE_HOST_WIN32 AND VCPKG_TARGET_IS_MINGW AND NOT HOST_TRIPLET MATCHES "mingw")
     # Assuming no cross compiling because the host (windows) pkgdata tool doesn't
     # use the '/' path separator when creating compiler commands for mingw bash.

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "73.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3378,7 +3378,7 @@
     },
     "icu": {
       "baseline": "73.1",
-      "port-version": 1
+      "port-version": 2
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c9c584254510ce10e69d7ee19e18961263c47aac",
+      "version": "73.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "deb5694d7965a264d6eb579df49aff4fe6362c24",
       "version": "73.1",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/33358
Make tools only generated under ios.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Compile test pass with following triplets:
```
x64-windows-static
```