### PR TITLE
[arrow] Fix COMPILER_LAUNCHER

### DIFF
--- a/ports/arrow/fix-cmake-path.patch
+++ b/ports/arrow/fix-cmake-path.patch
@@ -1,0 +1,26 @@
+diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+index 559ddf1..e9947d6 100644
+--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -964,6 +964,8 @@ set(EP_COMMON_CMAKE_ARGS
+ 
+ # Enable s/ccache if set by parent.
+ if(CMAKE_C_COMPILER_LAUNCHER AND CMAKE_CXX_COMPILER_LAUNCHER)
++  file(TO_CMAKE_PATH "${CMAKE_C_COMPILER_LAUNCHER}" CMAKE_C_COMPILER_LAUNCHER)
++  file(TO_CMAKE_PATH "${CMAKE_CXX_COMPILER_LAUNCHER}" CMAKE_CXX_COMPILER_LAUNCHER)
+   list(APPEND EP_COMMON_CMAKE_ARGS
+        -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
+        -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER})
+diff --git a/python/cmake_modules/ThirdpartyToolchain.cmake b/python/cmake_modules/ThirdpartyToolchain.cmake
+index 559ddf1..e9947d6 100644
+--- a/python/cmake_modules/ThirdpartyToolchain.cmake
++++ b/python/cmake_modules/ThirdpartyToolchain.cmake
+@@ -964,6 +964,8 @@ set(EP_COMMON_CMAKE_ARGS
+ 
+ # Enable s/ccache if set by parent.
+ if(CMAKE_C_COMPILER_LAUNCHER AND CMAKE_CXX_COMPILER_LAUNCHER)
++  file(TO_CMAKE_PATH "${CMAKE_C_COMPILER_LAUNCHER}" CMAKE_C_COMPILER_LAUNCHER)
++  file(TO_CMAKE_PATH "${CMAKE_CXX_COMPILER_LAUNCHER}" CMAKE_CXX_COMPILER_LAUNCHER)
+   list(APPEND EP_COMMON_CMAKE_ARGS
+        -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
+        -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER})

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive(
         utf8proc.patch
         thrift.patch
         fix-ci-error.patch
+        fix-cmake-path.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrow",
   "version": "14.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b413450bcc10983c22448fdc5f744b1703acdd06",
+      "version": "14.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "f3517d0d8bf39d98d806b0c84eac2f5f1acbbf32",
       "version": "14.0.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -238,7 +238,7 @@
     },
     "arrow": {
       "baseline": "14.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "arsenalgear": {
       "baseline": "2.1.0",


### PR DESCRIPTION
Fixes #35242.

Fix the path problem of CMAKE_C_COMPILER_LAUNCHER:
```
Change Dir: 'G:/v/b1/arrow/x64-windows-dbg'

Run Build Command(s): "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe" -v -v -j31 install
[1/193] cmd.exe /C "cd /D G:\v\b1\arrow\x64-windows-dbg && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -Dcfgdir= -P G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/tmp/mimalloc_ep-mkdirs.cmake && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E touch G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-mkdir"
[2/193] cmd.exe /C "cd /D G:\v\b1\arrow\x64-windows-dbg\mimalloc_ep-prefix\src && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -P G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-download-DEBUG.cmake && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E touch G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-download"
[3/193] cmd.exe /C "cd /D G:\v\b1\arrow\x64-windows-dbg && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E echo_append && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E touch G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-update"
[4/193] cmd.exe /C "cd /D G:\v\b1\arrow\x64-windows-dbg && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E echo_append && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E touch G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-patch"
[5/193] cmd.exe /C "cd /D G:\v\b1\arrow\x64-windows-dbg\mimalloc_ep-prefix\src\mimalloc_ep-build && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -P G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-configure-DEBUG.cmake && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E touch G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-configure"
FAILED: mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-configure G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-configure 
cmd.exe /C "cd /D G:\v\b1\arrow\x64-windows-dbg\mimalloc_ep-prefix\src\mimalloc_ep-build && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -P G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-configure-DEBUG.cmake && G:\v\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E touch G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-configure"
CMake Error at G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-configure-DEBUG.cmake:4 (set):
  Syntax error in cmake code at

    G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-stamp/mimalloc_ep-configure-DEBUG.cmake:4

  when parsing string

    G:/v/downloads/tools/cmake-3.27.1-windows/cmake-3.27.1-windows-i386/bin/cmake.exe;-DCMAKE_C_COMPILER=C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.37.32822/bin/Hostx64/x64/cl.exe;-DCMAKE_CXX_COMPILER=C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.37.32822/bin/Hostx64/x64/cl.exe;-DCMAKE_AR=C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.37.32822/bin/Hostx64/x64/lib.exe;-DBUILD_SHARED_LIBS=OFF;-DBUILD_STATIC_LIBS=ON;-DBUILD_TESTING=OFF;-DCMAKE_BUILD_TYPE=DEBUG;-DCMAKE_CXX_FLAGS= /nologo /DWIN32 /D_WINDOWS  /utf-8 /GR /EHsc /MP  /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING;-DCMAKE_CXX_FLAGS_DEBUG=/D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1  -MDd;-DCMAKE_CXX_FLAGS_MISIZEREL=/O1 /Ob1 /DNDEBUG -MD;-DCMAKE_CXX_FLAGS_RELEASE=/MD /O2 /Oi /Gy /DNDEBUG /Z7  -MD;-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=/Z7 /O2 /Ob1 /DNDEBUG -MD;-DCMAKE_CXX_STANDARD=17;-DCMAKE_C_FLAGS= /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /MP ;-DCMAKE_C_FLAGS_DEBUG=/D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1  -MDd;-DCMAKE_C_FLAGS_MISIZEREL=/O1 /Ob1 /DNDEBUG -MD;-DCMAKE_C_FLAGS_RELEASE=/MD /O2 /Oi /Gy /DNDEBUG /Z7  -MD;-DCMAKE_C_FLAGS_RELWITHDEBINFO=/Z7 /O2 /Ob1 /DNDEBUG -MD;-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON;-DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON;-DCMAKE_INSTALL_LIBDIR=lib;-DCMAKE_OSX_SYSROOT=;-DCMAKE_VERBOSE_MAKEFILE=ON;-DCMAKE_C_COMPILER_LAUNCHER=C:\Users\admin\git_projects\ccache.exe;-DCMAKE_CXX_COMPILER_LAUNCHER=C:\Users\admin\git_projects\ccache.exe;-DCMAKE_INSTALL_PREFIX=G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep/src/mimalloc_ep;-DMI_OVERRIDE=OFF;-DMI_LOCAL_DYNAMIC_TLS=ON;-DMI_BUILD_OBJECT=OFF;-DMI_BUILD_SHARED=OFF;-DMI_BUILD_TESTS=OFF;-GNinja;-S;G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep;-B;G:/v/b1/arrow/x64-windows-dbg/mimalloc_ep-prefix/src/mimalloc_ep-build

  Invalid character escape '\U'.


ninja: build stopped: subcommand failed.
```

The following paths are not recognized on Windows:
```
-DCMAKE_C_COMPILER_LAUNCHER=C:\Users\admin\git_projects\ccache.exe;-DCMAKE_CXX_COMPILER_LAUNCHER=C:\Users\admin\git_projects\ccache.exe;
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

