### PR TITLE
[tinyorm] Suppress warning STL4043

### DIFF
--- a/ports/tinyorm/portfile.cmake
+++ b/ports/tinyorm/portfile.cmake
@@ -1,9 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO silverqx/TinyORM
-    REF v0.36.5
+    REF "v${VERSION}"
     SHA512 ba3bf73972a6265663122e2c260354cf213dcdcf7bfd1f7a6a7eb43eb11e06fbed581b3f6ce28898eb60a85d0c9bfe45bfaa9596d92b62ca40702ede9856b183
     HEAD_REF main
+    PATCHES
+        suppress-warning-STL4043.patch
 )
 
 vcpkg_check_features(
@@ -27,7 +29,6 @@ vcpkg_cmake_configure(
         -DTINY_PORT:STRING=${PORT}
         -DTINY_VCPKG:BOOL=ON
         -DVERBOSE_CONFIGURE:BOOL=ON
-        -DWARNINGS_AS_ERRORS=FALSE
         ${FEATURE_OPTIONS}
 )
 
@@ -38,3 +39,5 @@ vcpkg_cmake_config_fixup()
 if(TINYORM_TOM_EXAMPLE)
     vcpkg_copy_tools(TOOL_NAMES tom AUTO_CLEAN)
 endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tinyorm/suppress-warning-STL4043.patch
+++ b/ports/tinyorm/suppress-warning-STL4043.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8b6f2cd..7a2e32f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,6 +41,13 @@ project(${TinyOrm_ns}
+ set(CMAKE_CXX_STANDARD 20)
+ set(CMAKE_CXX_STANDARD_REQUIRED YES)
+ set(CMAKE_CXX_EXTENSIONS OFF)
++
++if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
++    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.38.32914.95")
++        add_compile_options(-D_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)
++    endif()
++endif()
++
+ # Set the AUTOMOC property explicitly only when needed (eg. unit tests need AUTOMOC)
+ set(CMAKE_AUTOMOC OFF)
+ 

--- a/ports/tinyorm/vcpkg.json
+++ b/ports/tinyorm/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tinyorm",
   "version-semver": "0.36.5",
-  "port-version": 1,
+  "port-version": 2,
   "maintainers": "Silver Zachara <silver.zachara@gmail.com>",
   "description": "Modern C++ ORM library for Qt framework",
   "homepage": "https://github.com/silverqx/TinyORM",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8478,7 +8478,7 @@
     },
     "tinyorm": {
       "baseline": "0.36.5",
-      "port-version": 1
+      "port-version": 2
     },
     "tinyply": {
       "baseline": "2.3.4",

--- a/versions/t-/tinyorm.json
+++ b/versions/t-/tinyorm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c2e5cc9f6f5dc6e526f1aae55d90485a0b8562d",
+      "version-semver": "0.36.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "7a9e99fe4b4dca20d2e2a7c3bc9d575e5f1700ba",
       "version-semver": "0.36.5",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes `tinyorm` installation failed in an internal Visual Studio version with below errors:
```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.37.32822\include\xutility(1142): error C4996: 'stdext::checked_array_iterator<const T *>': warning STL4043: stdext::checked_array_iterator, stdext::unchecked_array_iterator, and related factory functions are non-Standard extensions and will be removed in the future. std::span (since C++20) and gsl::span can be used instead. You can define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING or _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.
        with
        [
            T=QVariantMap
        ]
```
Related info:
- https://github.com/microsoft/STL/pull/3818
- [MSVC warns as error on stdext::checked_array_iterator in QtCore/qvector.h](https://bugreports.qt.io/browse/QTBUG-118993)


<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
