### PR TITLE
[podofo] Update to 0.10.2

### DIFF
--- a/ports/podofo/fix-interface-include.patch
+++ b/ports/podofo/fix-interface-include.patch
@@ -1,0 +1,20 @@
+diff --git a/src/podofo/CMakeLists.txt b/src/podofo/CMakeLists.txt
+index 697e475..6c12036 100644
+--- a/src/podofo/CMakeLists.txt
++++ b/src/podofo/CMakeLists.txt
+@@ -72,6 +72,7 @@ if(PODOFO_BUILD_STATIC)
+     add_library(podofo_static STATIC ${PODOFO_SOURCES})
+     add_library(podofo::podofo ALIAS podofo_static)
+     target_link_libraries(podofo_static podofo_private ${PODOFO_LIB_DEPENDS})
++    target_include_directories(podofo_static PUBLIC "$<INSTALL_INTERFACE:include>")
+     set_target_properties(podofo_static PROPERTIES
+         VERSION "${PODOFO_VERSION}"
+         SOVERSION "${PODOFO_SOVERSION}"
+@@ -96,6 +97,7 @@ if(PODOFO_BUILD_SHARED)
+     add_library(podofo_shared SHARED ${PODOFO_SOURCES})
+     add_library(podofo::podofo ALIAS podofo_shared)
+     target_link_libraries(podofo_shared PRIVATE podofo_private ${PODOFO_LIB_DEPENDS})
++    target_include_directories(podofo_shared PUBLIC "$<INSTALL_INTERFACE:include>")
+     # TODO: set /wd4251 flag if we're doing a debug build with
+     # Visual Studio, since it produces invalid warnings about STL
+     # use.

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -1,9 +1,10 @@
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO podofo/podofo
     REF "${VERSION}"
-    SHA512 cbbd183cd940345f9b077b7da140414c27badc70fdf754e2f3c6f0e51c25072de46d7fe312b014c0eab359bd03e9dca0283260db00f079c5014e268d5c5ef5c9
+    SHA512 b5b7d4236a1f15b4eeee9d24210015b983910e88efa4727dd551f58b4d39cf7566314513b99099f54835b90a209cbf8231e04d19b63019223113abe6520fc932
+    PATCHES
+        fix-interface-include.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -26,6 +27,8 @@ vcpkg_cmake_configure(
         -DPODOFO_BUILD_LIB_ONLY=1
         -DPODOFO_BUILD_STATIC=${PODOFO_BUILD_STATIC}
         -DCMAKE_DISABLE_FIND_PACKAGE_Libidn=ON
+    MAYBE_UNUSED_VARIABLES
+        PKG_CONFIG_FOUND # Fix the warning of static build.
 )
 
 vcpkg_cmake_install()

--- a/ports/podofo/vcpkg.json
+++ b/ports/podofo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "podofo",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "PoDoFo is a library to work with the PDF file format",
   "homepage": "https://github.com/podofo/podofo",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6669,7 +6669,7 @@
       "port-version": 0
     },
     "podofo": {
-      "baseline": "0.10.1",
+      "baseline": "0.10.2",
       "port-version": 0
     },
     "poissonrecon": {

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0323e740780ecead10bd47ca5bfb89ca6140c3b7",
+      "version": "0.10.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "75683a46d35cfff92866f9c559833c7d1962cc55",
       "version": "0.10.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #35420.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

All features passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```
Usage test passed on `x64-windows`.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
