### PR TITLE
[google-cloud-cpp] update to the latest release (2.19.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 18c3fc4fabd1fabfbfb33760636e9403f5b5965cde9e2feab38ac76063ba82fd4aa59a895ded7288ff7552e5806714b5428765b673b5eff95080cd1718bd6792
+    SHA512 a392da19ac353409ecbf30e390803b2e34670552fd54466a08ee554a77c893d447289b30d5841c7f79b2a23244a269d8ecac8f7fbd8a34dda45ce2d8b1d46817
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -564,6 +564,18 @@
     },
     "edgecontainer": {
       "description": "Distributed Cloud Edge Container API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "edgenetwork": {
+      "description": "Distributed Cloud Edge Network API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -1228,6 +1240,18 @@
         }
       ]
     },
+    "sql": {
+      "description": "The Google Cloud SQL Admin C++ client library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "rest-common"
+          ]
+        }
+      ]
+    },
     "storage": {
       "description": "The Google Cloud Storage C++ client library",
       "dependencies": [
@@ -1291,6 +1315,18 @@
     },
     "tasks": {
       "description": "The Google Cloud Tasks C++ client library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "telcoautomation": {
+      "description": "Cloud Telco Automation API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3053,7 +3053,7 @@
       "port-version": 5
     },
     "google-cloud-cpp": {
-      "baseline": "2.18.0",
+      "baseline": "2.19.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cda5a5192b0d1310376b1370890e1d38755c076a",
+      "version": "2.19.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "21cf84757dd988f8b1ea4aa318002a4cc047b697",
       "version": "2.18.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.