### PR TITLE
[hwinfo] create a new port

### DIFF
--- a/ports/hwinfo/portfile.cmake
+++ b/ports/hwinfo/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY) 
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lfreist/hwinfo
+    REF 5cb31dbdb2c40413a837ce52ffadee23578c9069
+    SHA512 7c431528d5bf2f91843a3f6f8de908f6bc5b1427f85961bb885ab95e7765a875cb0358638e0e1e1f9a9336476ba74dc22819c97189251391fd8459c334c1092a
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DNO_OCL=ON
+)
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hwinfo/portfile.cmake
+++ b/ports/hwinfo/portfile.cmake
@@ -10,7 +10,9 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DNO_OCL=ON
+        -DNO_OCL # disable OpenCL usage
+    MAYBE_UNUSED_VARIABLES
+        NO_OCL
 )
 vcpkg_cmake_install()
 

--- a/ports/hwinfo/portfile.cmake
+++ b/ports/hwinfo/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DNO_OCL # disable OpenCL usage
+        -DNO_OCL=TRUE # disable OpenCL usage
     MAYBE_UNUSED_VARIABLES
         NO_OCL
 )

--- a/ports/hwinfo/vcpkg.json
+++ b/ports/hwinfo/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "cross platform C++ library for hardware information (CPU, RAM, GPU, ...)",
   "homepage": "https://github.com/lfreist/hwinfo",
   "license": "MIT",
-  "supports": "windows | linux",
+  "supports": "(windows | linux) & !uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/hwinfo/vcpkg.json
+++ b/ports/hwinfo/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "hwinfo",
+  "version-date": "2023-12-02",
+  "description": "cross platform C++ library for hardware information (CPU, RAM, GPU, ...)",
+  "homepage": "https://github.com/lfreist/hwinfo",
+  "license": "MIT",
+  "supports": "windows | linux",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3364,6 +3364,10 @@
       "baseline": "1.7.2",
       "port-version": 0
     },
+    "hwinfo": {
+      "baseline": "2023-12-02",
+      "port-version": 0
+    },
     "hwloc": {
       "baseline": "2.9.3",
       "port-version": 0

--- a/versions/h-/hwinfo.json
+++ b/versions/h-/hwinfo.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "75b0ccaad64e21524f27c7e7d82f7630f36523f2",
+      "version-date": "2023-12-02",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/h-/hwinfo.json
+++ b/versions/h-/hwinfo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3d338636fd227c61f86ef80a4d54c243d6f0fde6",
+      "git-tree": "75e06682da06c2b28e10f57d72dc30618b833848",
       "version-date": "2023-12-02",
       "port-version": 0
     }

--- a/versions/h-/hwinfo.json
+++ b/versions/h-/hwinfo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3a728e9454511a841e7ac2b8ed09b4dbea5086fe",
+      "git-tree": "3d338636fd227c61f86ef80a4d54c243d6f0fde6",
       "version-date": "2023-12-02",
       "port-version": 0
     }

--- a/versions/h-/hwinfo.json
+++ b/versions/h-/hwinfo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "75b0ccaad64e21524f27c7e7d82f7630f36523f2",
+      "git-tree": "3a728e9454511a841e7ac2b8ed09b4dbea5086fe",
       "version-date": "2023-12-02",
       "port-version": 0
     }


### PR DESCRIPTION
### Description

New port with https://github.com/lfreist/hwinfo/pull/68

#### `"supports"`

* Need to check the project's macOS CI (discarded in this version)
* Targets Windows and Linux for now

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
