### PR TITLE
[graphite2] provide path to python, add license in vcpkg.json

### DIFF
--- a/ports/graphite2/portfile.cmake
+++ b/ports/graphite2/portfile.cmake
@@ -7,9 +7,12 @@ vcpkg_from_github(
     PATCHES disable-tests.patch
 )
 
+vcpkg_find_acquire_program(PYTHON3)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DPYTHON_EXECUTABLE=${PYTHON3}
         -DDISABLE_TESTS=ON
 )
 
@@ -22,6 +25,6 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/libgraphite2.la" "${CURRENT_PACKAGES_DIR}/debug/lib/libgraphite2.la")
 
 file(COPY "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/graphite2/vcpkg.json
+++ b/ports/graphite2/vcpkg.json
@@ -7,7 +7,7 @@
     "Graphite2 is a rework of the original Graphite engine that is faster, smaller, and uses an API that is better suited to the layout architecture of most text-processing applications."
   ],
   "homepage": "https://github.com/silnrsi/graphite",
-  "license": "LGPL-2.1",
+  "license": "LGPL-2.1 OR MPL-2.0 OR MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/graphite2/vcpkg.json
+++ b/ports/graphite2/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "graphite2",
   "version": "1.3.14",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "Graphite is a \"smart font\" system developed specifically to handle the complexities of lesser-known languages of the world.",
     "Graphite2 is a rework of the original Graphite engine that is faster, smaller, and uses an API that is better suited to the layout architecture of most text-processing applications."
   ],
   "homepage": "https://github.com/silnrsi/graphite",
+  "license": "LGPL-2.1",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3086,7 +3086,7 @@
     },
     "graphite2": {
       "baseline": "1.3.14",
-      "port-version": 3
+      "port-version": 4
     },
     "graphqlparser": {
       "baseline": "0.7.0",

--- a/versions/g-/graphite2.json
+++ b/versions/g-/graphite2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d14b45c1e113b6e47006a06ec5f125f5152558cb",
+      "version": "1.3.14",
+      "port-version": 4
+    },
+    {
       "git-tree": "247c12c09e9766df6a90a8a45dad08320f4e0493",
       "version": "1.3.14",
       "port-version": 3


### PR DESCRIPTION
### Description/Changes

The port's build uses `PythonInterp`. 

```cmake
find_package(PythonInterp 3.6)
```

If the python is located under the LONG path, CMake fails with messages like the following.

```log
CMake Error: GetShortPath failed for C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1776.0_x64__qbz5n2kfra8p0\python3.11.exe
CMake Warning at CMakeLists.txt:78 (message):
  Python ctypes is incompatible with built DLL.  Disabling some tests.

```

With `vcpkg_find_acquire_program(PYTHON3)` in portfile.cmake, The probability may reduce.

### Checklist

Would you see if the `LICENSE` and `COPYING` files are correct?

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

