### PR TITLE
[vcpkg baseline][open62541] passing remove from fail

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -819,7 +819,6 @@ omplapp:arm-neon-android=fail
 omplapp:arm64-android=fail
 omplapp:x64-android=fail
 onednn:x64-android=fail
-open62541:x64-windows-static-md=fail
 openblas:arm-neon-android=fail
 openblas:arm64-android=fail
 openblas:x64-android=fail


### PR DESCRIPTION
````
PASSING, REMOVE FROM FAIL LIST: open62541:x64-windows-static-md 
````
Passing on [Pipelines - Run 20231202.1 (azure.com)](https://dev.azure.com/vcpkg/public/_build/results?buildId=97259&view=results)
Fixed by PR https://github.com/microsoft/vcpkg/pull/35419

Since there are the codes `-DUA_MSVC_FORCE_STATIC_CRT=OFF` in portfile.cmake of open62541, fix the error:
````
warning: The following binaries should use the Dynamic Debug (/MDd) CRT.
  C:\dev\vcpkg\packages\open62541_x64-windows-v143\debug\lib\open62541d.lib links with: Static Debug (/MTd)
To inspect the lib files, use:
  dumpbin.exe /directives mylibfile.lib
warning: The following binaries should use the Dynamic Release (/MD) CRT.
  C:\dev\vcpkg\packages\open62541_x64-windows-v143\lib\open62541.lib links with: Static Release (/MT)
To inspect the lib files, use:
  dumpbin.exe /directives mylibfile.lib
error: Found 2 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: C:\dev\vcpkg_ports\ports\open62541\portfile.cmake
````