### PR TITLE
[fftw3] Fix the build error and usage of feature openmp

### DIFF
--- a/ports/fftw3/fix-openmp.patch
+++ b/ports/fftw3/fix-openmp.patch
@@ -1,8 +1,14 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ce438a3..43c74be 100644
+index 18f8460..065838c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -356,7 +356,7 @@ if (OPENMP_FOUND)
+@@ -351,12 +351,12 @@ if (Threads_FOUND)
+ endif ()
+ 
+ if (OPENMP_FOUND)
+-  add_library (${fftw3_lib}_omp ${fftw_omp_SOURCE})
++  add_library (${fftw3_lib}_omp ${SOURCEFILES} ${fftw_omp_SOURCE})
+   target_include_directories (${fftw3_lib}_omp INTERFACE $<INSTALL_INTERFACE:include>)
    target_link_libraries (${fftw3_lib}_omp ${fftw3_lib})
    target_link_libraries (${fftw3_lib}_omp ${CMAKE_THREAD_LIBS_INIT})
    list (APPEND subtargets ${fftw3_lib}_omp)

--- a/ports/fftw3/install-subtargets.patch
+++ b/ports/fftw3/install-subtargets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d1e4dff..ea5d579 100644
+index 065838c..1e4c2b3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -361,12 +361,8 @@ endif ()

--- a/ports/fftw3/portfile.cmake
+++ b/ports/fftw3/portfile.cmake
@@ -66,4 +66,22 @@ file(WRITE "${SOURCE_PATH}/include/fftw3.h" "${_contents}")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
+if("openmp" IN_LIST FEATURES)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/FFTW3Config.cmake"
+"# defined since 2.8.3"
+[[# defined since 2.8.3
+include(CMakeFindDependencyMacro)
+find_dependency(OpenMP)]])
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}f/FFTW3fConfig.cmake"
+"# defined since 2.8.3"
+[[# defined since 2.8.3
+include(CMakeFindDependencyMacro)
+find_dependency(OpenMP)]])
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}l/FFTW3lConfig.cmake"
+"# defined since 2.8.3"
+[[# defined since 2.8.3
+include(CMakeFindDependencyMacro)
+find_dependency(OpenMP)]])
+endif()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/fftw3/vcpkg.json
+++ b/ports/fftw3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fftw3",
   "version": "3.3.10",
-  "port-version": 8,
+  "port-version": 9,
   "description": "FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data (as well as of even/odd data, i.e. the discrete cosine/sine transforms or DCT/DST).",
   "homepage": "https://www.fftw.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2610,7 +2610,7 @@
     },
     "fftw3": {
       "baseline": "3.3.10",
-      "port-version": 8
+      "port-version": 9
     },
     "fftwpp": {
       "baseline": "2019-12-19",

--- a/versions/f-/fftw3.json
+++ b/versions/f-/fftw3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa91b2e346c356e2e420e8ce98d4dd5bde652b2c",
+      "version": "3.3.10",
+      "port-version": 9
+    },
+    {
       "git-tree": "824a4cda47df1a63c0b13f2a603e7d0fb0dac900",
       "version": "3.3.10",
       "port-version": 8


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #10930, fix the build error and usage of feature `fftw3[openmp]`.
About the build error, the related upstream issue: https://github.com/FFTW/fftw3/issues/120.

Feature `fftw3[openmp]` passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```
Usage test passed on `x64-windows`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
