### PR TITLE
[nanobind] New port

### DIFF
--- a/ports/nanobind/find_dependency_python.patch
+++ b/ports/nanobind/find_dependency_python.patch
@@ -1,0 +1,62 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 919ce1d..25956c7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -107,29 +107,11 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+   add_compile_options(-Wall -Wextra -Wno-unused-local-typedefs)
+ endif()
+ 
+-# ---------------------------------------------------------------------------
+-# Find the Python interpreter and development libraries
+-# ---------------------------------------------------------------------------
+-
+-if (NOT TARGET Python::Module OR NOT TARGET Python::Interpreter)
+-  set(Python_FIND_FRAMEWORK LAST) # Prefer Brew/Conda to Apple framework python
+-
+-  if (CMAKE_VERSION VERSION_LESS 3.18)
+-    set(NB_PYTHON_DEV_MODULE Development)
+-  else()
+-    set(NB_PYTHON_DEV_MODULE Development.Module)
+-  endif()
+-
+-  find_package(Python 3.8
+-    REQUIRED COMPONENTS Interpreter ${NB_PYTHON_DEV_MODULE}
+-    OPTIONAL_COMPONENTS Development.SABIModule)
+-endif()
+-
+ # ---------------------------------------------------------------------------
+ # Include nanobind cmake functionality
+ # ---------------------------------------------------------------------------
+ 
+-find_package(nanobind
++find_package(nanobind REQUIRED
+   PATHS ${CMAKE_CURRENT_SOURCE_DIR}/cmake
+   NO_DEFAULT_PATH)
+ 
+diff --git a/cmake/nanobind-config.cmake b/cmake/nanobind-config.cmake
+index cb6cfb0..a456f3f 100644
+--- a/cmake/nanobind-config.cmake
++++ b/cmake/nanobind-config.cmake
+@@ -1,9 +1,20 @@
+ include_guard(GLOBAL)
+ 
+-if (NOT TARGET Python::Module)
+-  message(FATAL_ERROR "You must invoke 'find_package(Python COMPONENTS Interpreter Development REQUIRED)' prior to including nanobind.")
++# ---------------------------------------------------------------------------
++# Find the Python interpreter and development libraries
++# ---------------------------------------------------------------------------
++if (CMAKE_VERSION VERSION_LESS 3.18)
++  set(NB_PYTHON_DEV_MODULE Development)
++else()
++  set(NB_PYTHON_DEV_MODULE Development.Module)
+ endif()
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(Python 3.8
++  COMPONENTS Interpreter ${NB_PYTHON_DEV_MODULE}
++  OPTIONAL_COMPONENTS Development.SABIModule
++)
++
+ # Determine the right suffix for ordinary and stable ABI extensions.
+ 
+ # We always need to know the extension

--- a/ports/nanobind/move_include_dir.patch
+++ b/ports/nanobind/move_include_dir.patch
@@ -1,0 +1,129 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e8fda9f..b27dc07 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,7 +52,7 @@ if(NB_CREATE_INSTALL_RULES AND NOT CMAKE_SKIP_INSTALL_RULES)
+ 
+   # Normally these would be configurable by the user, but we can't allow that
+   # because the lookup paths are hard-coded in 'cmake/nanobind-config.cmake'
+-  set(NB_INSTALL_INC_DIR "${NB_INSTALL_DATADIR}/include")
++  set(NB_INSTALL_INC_DIR "${NB_INSTALL_DATADIR}/../../include")
+   set(NB_INSTALL_SRC_DIR "${NB_INSTALL_DATADIR}/src")
+   set(NB_INSTALL_EXT_DIR "${NB_INSTALL_DATADIR}/ext")
+   set(NB_INSTALL_MODULE_DIR "${NB_INSTALL_DATADIR}")
+diff --git a/cmake/nanobind-config.cmake b/cmake/nanobind-config.cmake
+index a456f3f..92406dc 100644
+--- a/cmake/nanobind-config.cmake
++++ b/cmake/nanobind-config.cmake
+@@ -113,54 +113,54 @@ function (nanobind_build_library TARGET_NAME)
+ 
+   add_library(${TARGET_NAME} ${TARGET_TYPE}
+     EXCLUDE_FROM_ALL
+-    ${NB_DIR}/include/nanobind/make_iterator.h
+-    ${NB_DIR}/include/nanobind/nanobind.h
+-    ${NB_DIR}/include/nanobind/nb_accessor.h
+-    ${NB_DIR}/include/nanobind/nb_attr.h
+-    ${NB_DIR}/include/nanobind/nb_call.h
+-    ${NB_DIR}/include/nanobind/nb_cast.h
+-    ${NB_DIR}/include/nanobind/nb_class.h
+-    ${NB_DIR}/include/nanobind/nb_defs.h
+-    ${NB_DIR}/include/nanobind/nb_descr.h
+-    ${NB_DIR}/include/nanobind/nb_enums.h
+-    ${NB_DIR}/include/nanobind/nb_error.h
+-    ${NB_DIR}/include/nanobind/nb_func.h
+-    ${NB_DIR}/include/nanobind/nb_lib.h
+-    ${NB_DIR}/include/nanobind/nb_misc.h
+-    ${NB_DIR}/include/nanobind/nb_python.h
+-    ${NB_DIR}/include/nanobind/nb_traits.h
+-    ${NB_DIR}/include/nanobind/nb_tuple.h
+-    ${NB_DIR}/include/nanobind/nb_types.h
+-    ${NB_DIR}/include/nanobind/ndarray.h
+-    ${NB_DIR}/include/nanobind/trampoline.h
+-    ${NB_DIR}/include/nanobind/operators.h
+-    ${NB_DIR}/include/nanobind/stl/array.h
+-    ${NB_DIR}/include/nanobind/stl/bind_map.h
+-    ${NB_DIR}/include/nanobind/stl/bind_vector.h
+-    ${NB_DIR}/include/nanobind/stl/detail
+-    ${NB_DIR}/include/nanobind/stl/detail/nb_array.h
+-    ${NB_DIR}/include/nanobind/stl/detail/nb_dict.h
+-    ${NB_DIR}/include/nanobind/stl/detail/nb_list.h
+-    ${NB_DIR}/include/nanobind/stl/detail/nb_set.h
+-    ${NB_DIR}/include/nanobind/stl/detail/traits.h
+-    ${NB_DIR}/include/nanobind/stl/filesystem.h
+-    ${NB_DIR}/include/nanobind/stl/function.h
+-    ${NB_DIR}/include/nanobind/stl/list.h
+-    ${NB_DIR}/include/nanobind/stl/map.h
+-    ${NB_DIR}/include/nanobind/stl/optional.h
+-    ${NB_DIR}/include/nanobind/stl/pair.h
+-    ${NB_DIR}/include/nanobind/stl/set.h
+-    ${NB_DIR}/include/nanobind/stl/shared_ptr.h
+-    ${NB_DIR}/include/nanobind/stl/string.h
+-    ${NB_DIR}/include/nanobind/stl/string_view.h
+-    ${NB_DIR}/include/nanobind/stl/tuple.h
+-    ${NB_DIR}/include/nanobind/stl/unique_ptr.h
+-    ${NB_DIR}/include/nanobind/stl/unordered_map.h
+-    ${NB_DIR}/include/nanobind/stl/unordered_set.h
+-    ${NB_DIR}/include/nanobind/stl/variant.h
+-    ${NB_DIR}/include/nanobind/stl/vector.h
+-    ${NB_DIR}/include/nanobind/eigen/dense.h
+-    ${NB_DIR}/include/nanobind/eigen/sparse.h
++    ${NB_DIR}/../../include/nanobind/make_iterator.h
++    ${NB_DIR}/../../include/nanobind/nanobind.h
++    ${NB_DIR}/../../include/nanobind/nb_accessor.h
++    ${NB_DIR}/../../include/nanobind/nb_attr.h
++    ${NB_DIR}/../../include/nanobind/nb_call.h
++    ${NB_DIR}/../../include/nanobind/nb_cast.h
++    ${NB_DIR}/../../include/nanobind/nb_class.h
++    ${NB_DIR}/../../include/nanobind/nb_defs.h
++    ${NB_DIR}/../../include/nanobind/nb_descr.h
++    ${NB_DIR}/../../include/nanobind/nb_enums.h
++    ${NB_DIR}/../../include/nanobind/nb_error.h
++    ${NB_DIR}/../../include/nanobind/nb_func.h
++    ${NB_DIR}/../../include/nanobind/nb_lib.h
++    ${NB_DIR}/../../include/nanobind/nb_misc.h
++    ${NB_DIR}/../../include/nanobind/nb_python.h
++    ${NB_DIR}/../../include/nanobind/nb_traits.h
++    ${NB_DIR}/../../include/nanobind/nb_tuple.h
++    ${NB_DIR}/../../include/nanobind/nb_types.h
++    ${NB_DIR}/../../include/nanobind/ndarray.h
++    ${NB_DIR}/../../include/nanobind/trampoline.h
++    ${NB_DIR}/../../include/nanobind/operators.h
++    ${NB_DIR}/../../include/nanobind/stl/array.h
++    ${NB_DIR}/../../include/nanobind/stl/bind_map.h
++    ${NB_DIR}/../../include/nanobind/stl/bind_vector.h
++    ${NB_DIR}/../../include/nanobind/stl/detail
++    ${NB_DIR}/../../include/nanobind/stl/detail/nb_array.h
++    ${NB_DIR}/../../include/nanobind/stl/detail/nb_dict.h
++    ${NB_DIR}/../../include/nanobind/stl/detail/nb_list.h
++    ${NB_DIR}/../../include/nanobind/stl/detail/nb_set.h
++    ${NB_DIR}/../../include/nanobind/stl/detail/traits.h
++    ${NB_DIR}/../../include/nanobind/stl/filesystem.h
++    ${NB_DIR}/../../include/nanobind/stl/function.h
++    ${NB_DIR}/../../include/nanobind/stl/list.h
++    ${NB_DIR}/../../include/nanobind/stl/map.h
++    ${NB_DIR}/../../include/nanobind/stl/optional.h
++    ${NB_DIR}/../../include/nanobind/stl/pair.h
++    ${NB_DIR}/../../include/nanobind/stl/set.h
++    ${NB_DIR}/../../include/nanobind/stl/shared_ptr.h
++    ${NB_DIR}/../../include/nanobind/stl/string.h
++    ${NB_DIR}/../../include/nanobind/stl/string_view.h
++    ${NB_DIR}/../../include/nanobind/stl/tuple.h
++    ${NB_DIR}/../../include/nanobind/stl/unique_ptr.h
++    ${NB_DIR}/../../include/nanobind/stl/unordered_map.h
++    ${NB_DIR}/../../include/nanobind/stl/unordered_set.h
++    ${NB_DIR}/../../include/nanobind/stl/variant.h
++    ${NB_DIR}/../../include/nanobind/stl/vector.h
++    ${NB_DIR}/../../include/nanobind/eigen/dense.h
++    ${NB_DIR}/../../include/nanobind/eigen/sparse.h
+ 
+     ${NB_DIR}/src/buffer.h
+     ${NB_DIR}/src/hash.h
+@@ -230,7 +230,7 @@ function (nanobind_build_library TARGET_NAME)
+ 
+   target_include_directories(${TARGET_NAME} PUBLIC
+     ${Python_INCLUDE_DIRS}
+-    ${NB_DIR}/include)
++    ${NB_DIR}/../../include)
+ 
+   target_compile_features(${TARGET_NAME} PUBLIC cxx_std_17)
+   nanobind_set_visibility(${TARGET_NAME})

--- a/ports/nanobind/portfile.cmake
+++ b/ports/nanobind/portfile.cmake
@@ -4,31 +4,15 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 set(VCPKG_BUILD_TYPE release)
 
-# Both of these patches will be included in the next release, and they are
-# required for packaging nanobind
-# https://github.com/wjakob/nanobind/pull/356
-vcpkg_download_distfile(INSTALL_RULES
-    URLS https://github.com/wjakob/nanobind/commit/5bde6527dc43535982a36ffa02d41275c5e484d9.patch?full_index=1
-    SHA512 67bb606483f91bf5dce80881e5ec9f290679c244a745f4c22ef13fd67268cdc81f66f0f1bca9331e567dad06293777a943beaeadf92b7e4e1436e88533daed48
-    FILENAME nanobind-5bde6527dc43535982a36ffa02d41275c5e484d9.patch
-)
-# https://github.com/wjakob/nanobind/pull/359
-vcpkg_download_distfile(MINIMIZE_CMAKE_DEPENDENCIES
-    URLS https://github.com/wjakob/nanobind/commit/978dbb1d6aaeee7530d57cf3e8d558e099a4eec6.patch?full_index=1
-    SHA512 2737235a7aeb111e6dcb4f6d4a96ce7a41f4737a7032a18ebd2a632083849f1a8e48180eda4bdca39d284c0997a546806bcbc7b648cb0c01a9a35f96ba587c8e
-    FILENAME nanobind-978dbb1d6aaeee7530d57cf3e8d558e099a4eec6.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wjakob/nanobind
     REF "v${VERSION}"
-    SHA512 72bb066f6884c0ceb2672f26087daf4eb6453a339b7bc81d8abc6b52a0380663d69797193d863979118a5fbc29487a9f6aed4b0e60a53be297ab6b4e0f7f828c
+    SHA512 40311f6416b9fdce764bf80baf156b42e1f00e03f3427b9f9db401fa4eeeb9db83b79c04ebefec2f6ed185419d1b22065f8f12eba3ad57056d2e0f825444b785
     HEAD_REF master
     PATCHES
-        "${INSTALL_RULES}"
-        "${MINIMIZE_CMAKE_DEPENDENCIES}"
         find_dependency_python.patch
+        move_include_dir.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/nanobind/portfile.cmake
+++ b/ports/nanobind/portfile.cmake
@@ -4,12 +4,30 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 set(VCPKG_BUILD_TYPE release)
 
+# Both of these patches will be included in the next release, and they are
+# required for packaging nanobind
+# https://github.com/wjakob/nanobind/pull/356
+vcpkg_download_distfile(INSTALL_RULES
+    URLS https://github.com/wjakob/nanobind/commit/5bde6527dc43535982a36ffa02d41275c5e484d9.patch?full_index=1
+    SHA512 67bb606483f91bf5dce80881e5ec9f290679c244a745f4c22ef13fd67268cdc81f66f0f1bca9331e567dad06293777a943beaeadf92b7e4e1436e88533daed48
+    FILENAME nanobind-5bde6527dc43535982a36ffa02d41275c5e484d9.patch
+)
+# https://github.com/wjakob/nanobind/pull/359
+vcpkg_download_distfile(MINIMIZE_CMAKE_DEPENDENCIES
+    URLS https://github.com/wjakob/nanobind/commit/978dbb1d6aaeee7530d57cf3e8d558e099a4eec6.patch?full_index=1
+    SHA512 2737235a7aeb111e6dcb4f6d4a96ce7a41f4737a7032a18ebd2a632083849f1a8e48180eda4bdca39d284c0997a546806bcbc7b648cb0c01a9a35f96ba587c8e
+    FILENAME nanobind-978dbb1d6aaeee7530d57cf3e8d558e099a4eec6.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wjakob/nanobind
-    REF 94fa30e22cf2b762a109b7518cd113d2d00dd66a
-    SHA512 f0b9b829ede76b815e5d631c6d6c6ebea029252859d8ca7af74fb179b46e09731204d0743776a1b1034123fbef21894d4cd4e3cfaeb1c28f707aec55b456fc24
+    REF "v${VERSION}"
+    SHA512 72bb066f6884c0ceb2672f26087daf4eb6453a339b7bc81d8abc6b52a0380663d69797193d863979118a5fbc29487a9f6aed4b0e60a53be297ab6b4e0f7f828c
     HEAD_REF master
+    PATCHES
+        "${INSTALL_RULES}"
+        "${MINIMIZE_CMAKE_DEPENDENCIES}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/nanobind/portfile.cmake
+++ b/ports/nanobind/portfile.cmake
@@ -1,0 +1,25 @@
+# nanobind distributes source code to build on-demand.
+# The source code is installed into the 'share/${PORT}' directory with
+# subdirectories for source `src` and header `include` files
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wjakob/nanobind
+    REF 94fa30e22cf2b762a109b7518cd113d2d00dd66a
+    SHA512 f0b9b829ede76b815e5d631c6d6c6ebea029252859d8ca7af74fb179b46e09731204d0743776a1b1034123fbef21894d4cd4e3cfaeb1c28f707aec55b456fc24
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DNB_USE_SUBMODULE_DEPS:BOOL=OFF
+        -DNB_TEST:BOOL=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/nanobind/portfile.cmake
+++ b/ports/nanobind/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_from_github(
     PATCHES
         "${INSTALL_RULES}"
         "${MINIMIZE_CMAKE_DEPENDENCIES}"
+        find_dependency_python.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/nanobind/usage
+++ b/ports/nanobind/usage
@@ -1,0 +1,12 @@
+The package nanobind provides CMake functions:
+
+    # Import all Python components potentially needed by nanobind
+    find_package(Python 3.8
+      REQUIRED COMPONENTS Interpreter Development.Module
+      OPTIONAL_COMPONENTS Development.SABIModule)
+
+    find_package(nanobind REQUIRED)
+    nanobind_add_module(my_ext source.cpp)
+
+    # See docs for more configuration options
+    # https://nanobind.readthedocs.io/en/latest/api_cmake.html

--- a/ports/nanobind/usage
+++ b/ports/nanobind/usage
@@ -1,9 +1,5 @@
-The package nanobind provides CMake functions:
-
-    # Import all Python components potentially needed by nanobind
-    find_package(Python 3.8
-      REQUIRED COMPONENTS Interpreter Development.Module
-      OPTIONAL_COMPONENTS Development.SABIModule)
+The package nanobind provides CMake functions and source code rather than
+libraries:
 
     find_package(nanobind REQUIRED)
     nanobind_add_module(my_ext source.cpp)

--- a/ports/nanobind/vcpkg.json
+++ b/ports/nanobind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanobind",
-  "version-semver": "1.8.0",
+  "version-semver": "1.9.2",
   "description": "Tiny and efficient C++/Python bindings",
   "homepage": "https://nanobind.readthedocs.io/en/latest/",
   "license": "BSD-3-Clause",

--- a/ports/nanobind/vcpkg.json
+++ b/ports/nanobind/vcpkg.json
@@ -5,6 +5,7 @@
   "homepage": "https://nanobind.readthedocs.io/en/latest/",
   "license": "BSD-3-Clause",
   "dependencies": [
+    "python3",
     "robin-map",
     {
       "name": "vcpkg-cmake",

--- a/ports/nanobind/vcpkg.json
+++ b/ports/nanobind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanobind",
-  "version-date": "2023-12-16",
+  "version-semver": "1.8.0",
   "description": "Tiny and efficient C++/Python bindings",
   "homepage": "https://nanobind.readthedocs.io/en/latest/",
   "license": "BSD-3-Clause",

--- a/ports/nanobind/vcpkg.json
+++ b/ports/nanobind/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "nanobind",
+  "version-date": "2023-12-16",
+  "description": "Tiny and efficient C++/Python bindings",
+  "homepage": "https://nanobind.readthedocs.io/en/latest/",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "robin-map",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1325,6 +1325,7 @@ vcpkg-ci-mathgl:x64-windows=pass
 vcpkg-ci-mathgl:x64-windows-static=pass
 vcpkg-ci-mathgl:x64-windows-static-md=pass
 vcpkg-ci-mathgl:x86-windows=pass
+vcpkg-ci-nanobind:arm64-windows=fail # cross-compilation failure is expected
 vcpkg-ci-opencv:arm64-uwp=pass
 vcpkg-ci-opencv:arm64-windows=pass
 vcpkg-ci-opencv:x64-linux=pass

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1325,7 +1325,6 @@ vcpkg-ci-mathgl:x64-windows=pass
 vcpkg-ci-mathgl:x64-windows-static=pass
 vcpkg-ci-mathgl:x64-windows-static-md=pass
 vcpkg-ci-mathgl:x86-windows=pass
-vcpkg-ci-nanobind:arm64-windows=fail # cross-compilation failure is expected
 vcpkg-ci-opencv:arm64-uwp=pass
 vcpkg-ci-opencv:arm64-windows=pass
 vcpkg-ci-opencv:x64-linux=pass

--- a/scripts/test_ports/vcpkg-ci-nanobind/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-nanobind/portfile.cmake
@@ -10,8 +10,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wjakob/nanobind_example
-    REF cc116d7c87d2e19c9c8146464c6ae7ed17620eec
-    SHA512 cdb0eb09b1c03c0dea291daf876a85f9d5641f57747786cd2289d0aa4c8e3f34bd2809c351b3231fb80a358615086ee0e687ce23999a9ae012f75b000bdeef10
+    REF 4b5c9bd484dec77e085a188dcefc536aed69aae9
+    SHA512 ec7eeb25b5c5ee2e8bbcc48e78719dc6e5211cf54794dd3c370ad3e8d685fbc8b79435890da3b9481656169efaa87b77e3ea55ce864efd670dd9ea0600dee77d
     HEAD_REF master
 )
 

--- a/scripts/test_ports/vcpkg-ci-nanobind/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-nanobind/portfile.cmake
@@ -1,0 +1,19 @@
+# This test does not support cross-compilation due to nanobind's usage of the
+# Python interpreter to figure out Python module suffix.
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wjakob/nanobind_example
+    REF cc116d7c87d2e19c9c8146464c6ae7ed17620eec
+    SHA512 cdb0eb09b1c03c0dea291daf876a85f9d5641f57747786cd2289d0aa4c8e3f34bd2809c351b3231fb80a358615086ee0e687ce23999a9ae012f75b000bdeef10
+    HEAD_REF master
+)
+
+# This is needed to correctly build/link against a debug build of Python on
+# Windows
+string(APPEND VCPKG_CXX_FLAGS_DEBUG " -DPy_DEBUG")
+string(APPEND VCPKG_C_FLAGS_DEBUG " -DPy_DEBUG")
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-nanobind/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-nanobind/portfile.cmake
@@ -1,6 +1,12 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
 # This test does not support cross-compilation due to nanobind's usage of the
 # Python interpreter to figure out Python module suffix.
-set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+if(VCPKG_CROSSCOMPILING)
+    message(WARNING "Skipping vcpkg-ci-nanobind because it is not expected to work when cross-compiling")
+    return()
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wjakob/nanobind_example

--- a/scripts/test_ports/vcpkg-ci-nanobind/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-nanobind/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "vcpkg-ci-nanobind",
+  "version": "0.0.1",
+  "description": "A nanobind example project",
+  "homepage": "https://nanobind.readthedocs.io/en/latest/",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "nanobind",
+    "python3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}
+

--- a/scripts/test_ports/vcpkg-ci-nanobind/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-nanobind/vcpkg.json
@@ -6,7 +6,6 @@
   "license": "BSD-3-Clause",
   "dependencies": [
     "nanobind",
-    "python3",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5853,7 +5853,7 @@
       "port-version": 0
     },
     "nanobind": {
-      "baseline": "1.8.0",
+      "baseline": "1.9.2",
       "port-version": 0
     },
     "nanodbc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5852,6 +5852,10 @@
       "baseline": "4.3.11",
       "port-version": 0
     },
+    "nanobind": {
+      "baseline": "1.8.0",
+      "port-version": 0
+    },
     "nanodbc": {
       "baseline": "2.13.0",
       "port-version": 8

--- a/versions/n-/nanobind.json
+++ b/versions/n-/nanobind.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "b0b1ae8e5d8f023d1bc4882d66b4c754962f196e",
-      "version-semver": "1.8.0",
+      "git-tree": "5909cb43391a92558443572c7bc0b4b6b1f84fab",
+      "version-semver": "1.9.2",
       "port-version": 0
     }
   ]

--- a/versions/n-/nanobind.json
+++ b/versions/n-/nanobind.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5909cb43391a92558443572c7bc0b4b6b1f84fab",
+      "git-tree": "14a09776a3248629b8efbf096dcb787c01abcfe9",
       "version-semver": "1.9.2",
       "port-version": 0
     }

--- a/versions/n-/nanobind.json
+++ b/versions/n-/nanobind.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b0b1ae8e5d8f023d1bc4882d66b4c754962f196e",
+      "version-semver": "1.8.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Nanobind distributes its source files to build on-demand, so I have added a CI port to make sure this continues to work with the [provided upstream example](https://github.com/wjakob/nanobind_example) by the author of nanobind.

After testing, cross-compilation for a different architecture (arm64-windows in CI) is not supported due to the execution of the Python executable to figure out the Python module extension.

Closes: #33401 

Supersedes: #31323 


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.