### PR TITLE
[cnats] Repair installation path

### DIFF
--- a/ports/cnats/fix_install_path.patch
+++ b/ports/cnats/fix_install_path.patch
@@ -1,0 +1,28 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b3f376c..8e6d06a 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -60,7 +60,10 @@ if(NATS_BUILD_LIB_SHARED)
+   target_include_directories(nats PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+         $<INSTALL_INTERFACE:include>)
+-  install(TARGETS nats EXPORT cnats-targets DESTINATION ${NATS_LIBDIR})
++  install(TARGETS nats EXPORT cnats-targets
++        ARCHIVE DESTINATION lib
++		LIBRARY DESTINATION lib
++		RUNTIME DESTINATION bin)
+   install(EXPORT cnats-targets
+         NAMESPACE cnats::
+         FILE cnats-targets.cmake
+@@ -72,7 +75,10 @@ if(NATS_BUILD_LIB_STATIC)
+   target_include_directories(nats_static PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+         $<INSTALL_INTERFACE:include>)
+-  install(TARGETS nats_static EXPORT cnats-targets ARCHIVE DESTINATION ${NATS_LIBDIR})
++  install(TARGETS nats_static EXPORT cnats-targets
++        ARCHIVE DESTINATION lib
++		LIBRARY DESTINATION lib
++		RUNTIME DESTINATION bin)
+   install(EXPORT cnats-targets
+         NAMESPACE cnats::
+         FILE cnats-targets.cmake

--- a/ports/cnats/portfile.cmake
+++ b/ports/cnats/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         fix-sodium-dep.patch
+        fix_install_path.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -74,5 +75,5 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 

--- a/ports/cnats/vcpkg.json
+++ b/ports/cnats/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cnats",
   "version": "3.7.0",
+  "port-version": 1,
   "description": "A C client for the NATS messaging system",
   "homepage": "https://github.com/nats-io/nats.c",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1678,7 +1678,7 @@
     },
     "cnats": {
       "baseline": "3.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cnl": {
       "baseline": "1.1.7",
@@ -2024,7 +2024,7 @@
       "baseline": "10.1",
       "port-version": 13
     },
-    "cuda-api-wrappers" : {
+    "cuda-api-wrappers": {
       "baseline": "0.6.6",
       "port-version": 0
     },

--- a/versions/c-/cnats.json
+++ b/versions/c-/cnats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cce27b1efc5af15e4222a5fdc5502959f24e9d03",
+      "version": "3.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "438cfff2ee224f9d414bda9bcf796c13534443ba",
       "version": "3.7.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/35421
Repair the installation path of the dynamic library from lib to the bin directory.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
x64-windows-static
```