### PR TITLE
[plog] Update to 1.1.10

### DIFF
--- a/ports/plog/portfile.cmake
+++ b/ports/plog/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SergiusTheBest/plog
-    REF 1.1.9
-    SHA512 d979fdf0011ef9bb94a2271da5d17058dbab5bc47438a13769d084fdebe5e169e7c05a043d69acceb752896df7cdae4433f32bfbcc81e055dffd9c701be88003
+    REF ${VERSION}
+    SHA512 b1d55baadbd16bafa5165b05352f367455b51f2eec2102f1ebad2e6a049954d1b87ffdd96811b0acea2313877db1db837f780971fd027d0db683fe42aeb29573
     HEAD_REF master
 )
 

--- a/ports/plog/vcpkg.json
+++ b/ports/plog/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "plog",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Portable, simple and extensible C++ logging library.",
   "homepage": "https://github.com/SergiusTheBest/plog",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2024,7 +2024,7 @@
       "baseline": "10.1",
       "port-version": 13
     },
-    "cuda-api-wrappers" : {
+    "cuda-api-wrappers": {
       "baseline": "0.6.6",
       "port-version": 0
     },
@@ -6649,7 +6649,7 @@
       "port-version": 7
     },
     "plog": {
-      "baseline": "1.1.9",
+      "baseline": "1.1.10",
       "port-version": 0
     },
     "plplot": {

--- a/versions/p-/plog.json
+++ b/versions/p-/plog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "773c53426d316bfe1e35ae7cf9a5afe5c41b8a70",
+      "version": "1.1.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "8123d0f93ad451c1bbf9cb25b57ea290f4124030",
       "version": "1.1.9",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
