### PR TITLE
[libtorch] Fix core dependencies

### DIFF
--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -16,6 +16,8 @@
     },
     "fmt",
     "foxi",
+    "fp16",
+    "fxdiv",
     "gemmlowp",
     "gflags",
     "glog",
@@ -31,6 +33,7 @@
       "platform": "windows"
     },
     "protobuf",
+    "pthreadpool",
     {
       "name": "protobuf",
       "host": true

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "1.12.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,
@@ -33,11 +33,11 @@
       "platform": "windows"
     },
     "protobuf",
-    "pthreadpool",
     {
       "name": "protobuf",
       "host": true
     },
+    "pthreadpool",
     "sleef",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4914,7 +4914,7 @@
     },
     "libtorch": {
       "baseline": "1.12.1",
-      "port-version": 3
+      "port-version": 4
     },
     "libtorrent": {
       "baseline": "2.0.9",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4196ddb319be9d926d9f91de348882b49a224cee",
+      "version": "1.12.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "7f8ee520ffcef31a008c2c73b1155b38151ebae4",
       "version": "1.12.1",
       "port-version": 3


### PR DESCRIPTION
`vcpkg install libtorch[core]` fails to configure/build on windows-x64 (potentially on other platforms too - I haven't tested) because it seems to depend on fp16, fxdiv and pthreadpool - see below errors.

This problem has probably not come up yet because `vcpkg install libtorch` works - it has xnnpack as default feature, and xnnpack depends on the above libraries - so for people that do `vcpkg install libtorch`, it will transitively fetch these needed libtorch dependencies. However, if you do `vcpkg install libtorch[core]`, the configure/build fails because these dependencies are missing.

```
CMake Error at cmake/vcpkg-dependencies.cmake:26 (find_path):
  Could not find FP16_INCLUDE_DIRS using the following files: fp16.h
  
CMake Error at cmake/vcpkg-dependencies.cmake:28 (find_path):
  Could not find FXDIV_INCLUDE_DIRS using the following files: fxdiv.h
  
CMake Error at C:/Users/PatrikHuber/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package):
  Could not find a package configuration file provided by
  "unofficial-pthreadpool" with any of the following names:

    unofficial-pthreadpoolConfig.cmake
    unofficial-pthreadpool-config.cmake

  Add the installation prefix of "unofficial-pthreadpool" to
  CMAKE_PREFIX_PATH or set "unofficial-pthreadpool_DIR" to a directory
  containing one of the above files.  If "unofficial-pthreadpool" provides a
  separate development package or SDK, be sure it has been installed.
```

CC @jimwang118 @luncliff 

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
