### PR TITLE
[vcpkg baseline][mongo-c-driver] fix mongo-c-driver when Python3 isn't on the PATH

### DIFF
--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -47,6 +47,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${OPTIONS}
+        "-DBUILD_VERSION=${VERSION}"
         -DUSE_SYSTEM_LIBBSON=ON
         -DENABLE_EXAMPLES=OFF
         -DENABLE_SHM_COUNTERS=OFF

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mongo-c-driver",
   "version": "1.25.1",
+  "port-version": 1,
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5654,7 +5654,7 @@
     },
     "mongo-c-driver": {
       "baseline": "1.25.1",
-      "port-version": 0
+      "port-version": 1
     },
     "mongo-cxx-driver": {
       "baseline": "3.9.0",

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "988570f6f3cad6a77c519990851d9d2208d5970d",
+      "version": "1.25.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "7bc0eb795e698bac0f4d77bed4b6ecbde0f57857",
       "version": "1.25.1",
       "port-version": 0


### PR DESCRIPTION
Fix CI baseline:
````
REGRESSION: mongo-c-driver:x64-linux failed with BUILD_FAILED.
````
````
CMake Error at build/cmake/LoadVersion.cmake:9 (string):
  string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:20 (LoadVersion) 
````
This issue was introduced by https://github.com/microsoft/vcpkg/pull/34994, reference PR https://github.com/microsoft/vcpkg/pull/35276.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.