### PR TITLE
[fakeit] fix header files copy

### DIFF
--- a/ports/fakeit/portfile.cmake
+++ b/ports/fakeit/portfile.cmake
@@ -6,6 +6,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY "${SOURCE_PATH}/single_header/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/single_header/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}" FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fakeit/vcpkg.json
+++ b/ports/fakeit/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fakeit",
   "version": "2.4.0",
+  "port-version": 1,
   "description": "FakeIt is a simple mocking framework for C++. It supports GCC, Clang and MS Visual C++.",
   "homepage": "https://github.com/eranpeer/FakeIt",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2526,7 +2526,7 @@
     },
     "fakeit": {
       "baseline": "2.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "fameta-counter": {
       "baseline": "2021-02-13",

--- a/versions/f-/fakeit.json
+++ b/versions/f-/fakeit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4975f837bbd496c621a2b6cd11fc6745357c61c5",
+      "version": "2.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a226f1d679f9c3acf8c67d69d24086e236b67a29",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
Fixes the following:
1. `file(COPY ...)` command in port now only copies header files (previously it copied everything including an unused `CMakeLists.txt` file)
2. Headers (in subfolders such as `boost`, `doctest`, `catch` etc.) are copied to `${CURRENT_PACKAGES_DIR}/include/${PORT}` instead of `${CURRENT_PACKAGES_DIR}/include`. This is to prevent collisions/mixing with ports such as `doctest` which installs to `${CURRENT_PACKAGES_DIR}/include/${PORT}`.

Usage example (`boost` header):
```
    find_path(FAKEIT_INCLUDE_DIRS "fakeit/boost/fakeit.hpp")
    target_include_directories(main PRIVATE ${FAKEIT_INCLUDE_DIRS})
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

