### PR TITLE
[harfbuzz] Make use of SelectLibraryConfigurations()

### DIFF
--- a/ports/harfbuzz/harfbuzzConfig.cmake.in
+++ b/ports/harfbuzz/harfbuzzConfig.cmake.in
@@ -3,6 +3,8 @@ cmake_policy(SET CMP0012 NEW)
 cmake_policy(SET CMP0054 NEW)
 cmake_policy(SET CMP0057 NEW)
 
+include(CMakeFindDependencyMacro)
+
 # Traditional find module variables (vcpkg polyfill)
 set(HARFBUZZ_INCLUDE_DIR "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/harfbuzz" CACHE INTERNAL "")
 set(HARFBUZZ_INCLUDE_DIRS "${HARFBUZZ_INCLUDE_DIR}")
@@ -14,18 +16,25 @@ if(TARGET harfbuzz)
     return()
 endif()
 
-include(CMakeFindDependencyMacro)
-
-add_library(harfbuzz INTERFACE IMPORTED GLOBAL)
+add_library(harfbuzz UNKNOWN IMPORTED)
 add_library(harfbuzz::harfbuzz ALIAS harfbuzz)
 
 find_library(HARFBUZZ_LIBRARY_DEBUG NAMES harfbuzz PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" PATH_SUFFIXES lib NO_DEFAULT_PATH)
-if(HARFBUZZ_LIBRARY_DEBUG)
-    target_link_libraries(harfbuzz INTERFACE $<$<CONFIG:DEBUG>:${HARFBUZZ_LIBRARY_DEBUG}>)
-endif()
-
 find_library(HARFBUZZ_LIBRARY_RELEASE NAMES harfbuzz PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" PATH_SUFFIXES lib NO_DEFAULT_PATH)
-target_link_libraries(harfbuzz INTERFACE $<$<NOT:$<CONFIG:DEBUG>>:${HARFBUZZ_LIBRARY_RELEASE}>)
+if(NOT HARFBUZZ_LIBRARY_DEBUG)
+    set_target_properties(harfbuzz PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${HARFBUZZ_INCLUDE_DIR}"
+        IMPORTED_CONFIGURATIONS "RELEASE"
+        IMPORTED_LOCATION_RELEASE "${HARFBUZZ_LIBRARY_RELEASE}"
+    )
+else()
+    set_target_properties(harfbuzz PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${HARFBUZZ_INCLUDE_DIR}"
+        IMPORTED_CONFIGURATIONS "DEBUG;RELEASE"
+        IMPORTED_LOCATION_RELEASE "${HARFBUZZ_LIBRARY_RELEASE}"
+        IMPORTED_LOCATION_DEBUG "${HARFBUZZ_LIBRARY_DEBUG}"
+    )
+endif()
 
 set(HARFBUZZ_FEATURES @FEATURES@)
 
@@ -41,25 +50,21 @@ target_link_libraries(harfbuzz INTERFACE freetype)
 
 if ("graphite2" IN_LIST HARFBUZZ_FEATURES)
     find_library(GRAPHITE2_LIBRARY_DEBUG NAMES graphite2 PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" PATH_SUFFIXES lib NO_DEFAULT_PATH)
-    if(GRAPHITE2_LIBRARY_DEBUG)
-        target_link_libraries(harfbuzz INTERFACE $<$<CONFIG:DEBUG>:${GRAPHITE2_LIBRARY_DEBUG}>)
-    endif()
-
     find_library(GRAPHITE2_LIBRARY_RELEASE NAMES graphite2 PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" PATH_SUFFIXES lib NO_DEFAULT_PATH)
-    if(GRAPHITE2_LIBRARY_RELEASE)
-        target_link_libraries(harfbuzz INTERFACE $<$<NOT:$<CONFIG:DEBUG>>:${GRAPHITE2_LIBRARY_RELEASE}>)
+    if(NOT GRAPHITE2_LIBRARY_DEBUG)
+        target_link_libraries(harfbuzz INTERFACE "${GRAPHITE2_LIBRARY_RELEASE}")
+    else()
+        target_link_libraries(harfbuzz INTERFACE "$<$<NOT:$<CONFIG:DEBUG>>:${GRAPHITE2_LIBRARY_RELEASE}>$<$<CONFIG:DEBUG>:${GRAPHITE2_LIBRARY_DEBUG}>")
     endif()
 endif()
 
 if ("glib" IN_LIST HARFBUZZ_FEATURES)
     find_library(GLIB_LIBRARY_DEBUG NAMES glib glib-2.0 PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" PATH_SUFFIXES lib NO_DEFAULT_PATH)
-    if(GLIB_LIBRARY_DEBUG)
-        target_link_libraries(harfbuzz INTERFACE $<$<CONFIG:DEBUG>:${GLIB_LIBRARY_DEBUG}>)
-    endif()
-
     find_library(GLIB_LIBRARY_RELEASE NAMES glib glib-2.0 PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" PATH_SUFFIXES lib NO_DEFAULT_PATH)
-    if(GLIB_LIBRARY_RELEASE)
-        target_link_libraries(harfbuzz INTERFACE $<$<NOT:$<CONFIG:DEBUG>>:${GLIB_LIBRARY_RELEASE}>)
+    if(NOT GLIB_LIBRARY_DEBUG)
+        target_link_libraries(harfbuzz INTERFACE "${GLIB_LIBRARY_RELEASE}")
+    else()
+        target_link_libraries(harfbuzz INTERFACE "$<$<NOT:$<CONFIG:DEBUG>>:${GLIB_LIBRARY_RELEASE}>$<$<CONFIG:DEBUG>:${GLIB_LIBRARY_DEBUG}>")
     endif()
 endif()
 
@@ -67,5 +72,3 @@ if ("icu" IN_LIST HARFBUZZ_FEATURES)
     find_dependency(ICU 61 COMPONENTS uc)
     target_link_libraries(harfbuzz INTERFACE ICU::uc)
 endif()
-
-target_include_directories(harfbuzz INTERFACE "${HARFBUZZ_INCLUDE_DIR}")

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "harfbuzz",
   "version": "8.3.0",
+  "port-version": 1,
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3274,7 +3274,7 @@
     },
     "harfbuzz": {
       "baseline": "8.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e2d07391d009a33797b19b707bf5bc60cdb17e5",
+      "version": "8.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "43649e54cfda3d4673975cf61daf8e501edf63e6",
       "version": "8.3.0",
       "port-version": 0


### PR DESCRIPTION
This allows to use the Release library if the debug library is not build.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
