### PR TITLE
[invalid] Check build times with msys2

### DIFF
--- a/ports/libunistring/portfile.cmake
+++ b/ports/libunistring/portfile.cmake
@@ -19,12 +19,17 @@ vcpkg_extract_source_archive(SOURCE_PATH
         parallelize-symbol-collection.patch
 )
 
+vcpkg_find_acquire_program(PKGCONFIG)
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     USE_WRAPPERS
     OPTIONS
         "--with-libiconv-prefix=${CURRENT_INSTALLED_DIR}"
+    ADDITIONAL_MSYS_PACKAGES
+        DIRECT_PACKAGES
+            "https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.10-2-x86_64.pkg.tar.zst"
+            da1fd58e00fb43b17f7191262136fa49829003a8a8bd0d0eee857bdc24c02668363b379a3cdcb098b74872059acd5c3852d95436855e86e094c2e7c26e476716
 )
 
 vcpkg_install_make()
@@ -40,3 +45,5 @@ The libunistring library and its header files are dual-licensed under
         "${SOURCE_PATH}/COPYING.LIB"
         "${SOURCE_PATH}/COPYING"
 )
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/share") # fail post-build check

--- a/ports/libunistring/portfile.cmake
+++ b/ports/libunistring/portfile.cmake
@@ -28,8 +28,8 @@ vcpkg_configure_make(
         "--with-libiconv-prefix=${CURRENT_INSTALLED_DIR}"
     ADDITIONAL_MSYS_PACKAGES
         DIRECT_PACKAGES
-            "https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.10-2-x86_64.pkg.tar.zst"
-            da1fd58e00fb43b17f7191262136fa49829003a8a8bd0d0eee857bdc24c02668363b379a3cdcb098b74872059acd5c3852d95436855e86e094c2e7c26e476716
+            "https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst"
+            fbdcf2572d242b14ef3b39f29a6119ee58705bad651c9da48ffd11e80637e8d767d20ed5d562f67d92eecd01f7fc3bc351af9d4f84fb9b321d2a9aff858b3619
 )
 
 vcpkg_install_make()

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -16,7 +16,7 @@ parameters:
   - name: tripletPattern
     displayName: 'Enable triplets which contain this substring'
     type: string
-    default: '-'
+    default: 'x64-windows$'
 
 jobs:
 - template: windows/azure-pipelines.yml


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/pull/35331#issuecomment-1843935604.

| msys-runtime | libunistring CI build time | remark |
|---|---|---|
| 3.4.6-1 | 10 min | before #35331 |
| 3.4.9-3 | 10 min | after #35331, [20231130.1](https://dev.azure.com/vcpkg/public/_build/results?buildId=97165&view=logs&j=7922e5c4-0103-5f8f-ad17-45ce9bb98e80&t=66eef212-08d6-5e6c-a560-7d01149d0188) |
| 3.4.9-3 | 55 min | after #35331 |
| 3.4.10-2 | 55 min | [20231207.14](https://dev.azure.com/vcpkg/public/_build/results?buildId=97459&view=logs&j=7922e5c4-0103-5f8f-ad17-45ce9bb98e80) |
| 3.4.6-1 |  55 min  | [20231207.25](https://dev.azure.com/vcpkg/public/_build/results?buildId=97470&view=logs&j=7922e5c4-0103-5f8f-ad17-45ce9bb98e80) |
