### PR TITLE
[luajit] Burn-in DLL linkage

### DIFF
--- a/ports/luajit/luajit.pc
+++ b/ports/luajit/luajit.pc
@@ -5,7 +5,7 @@ relver=0
 version=${majver}.${minver}.${relver}-beta3
 abiver=51
 
-prefix=@PREFIX@
+prefix=handled-by-fixup
 multilib=lib
 exec_prefix=${prefix}
 libdir=${exec_prefix}/${multilib}
@@ -21,4 +21,4 @@ URL: https://luajit.org
 Version: ${version}
 Requires:
 Libs: -L${libdir} -l${libname}
-Cflags: -I${includedir} @LJIT_MSVC_PC_CFLAGS@
+Cflags: -I${includedir}

--- a/ports/luajit/portfile.cmake
+++ b/ports/luajit/portfile.cmake
@@ -23,11 +23,8 @@ if(VCPKG_DETECTED_MSVC)
     # minilua tool with the target toolchain. This will work for native builds and
     # for targeting x86 from x64 hosts. (UWP and ARM64 is unsupported.)
     vcpkg_list(SET options)
-    set(PKGCONFIG_CFLAGS "")
     if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
         list(APPEND options "MSVCBUILD_OPTIONS=static")
-    else()
-        set(PKGCONFIG_CFLAGS "/DLUA_BUILD_AS_DLL=1")
     endif()
 
     vcpkg_install_nmake(SOURCE_PATH "${SOURCE_PATH}"
@@ -36,9 +33,13 @@ if(VCPKG_DETECTED_MSVC)
             ${options}
     )
 
-    configure_file("${CMAKE_CURRENT_LIST_DIR}/luajit.pc.win.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/luajit.pc" @ONLY)
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/luajit/luaconf.h" "defined(LUA_BUILD_AS_DLL)" "1")
+    endif()
+
+    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/luajit.pc" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
     if(NOT VCPKG_BUILD_TYPE)
-        configure_file("${CMAKE_CURRENT_LIST_DIR}/luajit.pc.win.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/luajit.pc" @ONLY)
+        file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/luajit.pc" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
     endif()
 
     vcpkg_copy_pdbs()

--- a/ports/luajit/vcpkg.json
+++ b/ports/luajit/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "luajit",
   "version-date": "2023-01-04",
-  "port-version": 4,
+  "port-version": 5,
   "description": "LuaJIT is a Just-In-Time (JIT) compiler for the Lua programming language.",
   "homepage": "https://github.com/LuaJIT/LuaJIT",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5326,7 +5326,7 @@
     },
     "luajit": {
       "baseline": "2023-01-04",
-      "port-version": 4
+      "port-version": 5
     },
     "luasec": {
       "baseline": "1.3.1",

--- a/versions/l-/luajit.json
+++ b/versions/l-/luajit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca00ef84f25e0b841d36d6aa5403c525ea476b9c",
+      "version-date": "2023-01-04",
+      "port-version": 5
+    },
+    {
       "git-tree": "53de073fe6d5962408626e251fce79e2d5bb49bf",
       "version-date": "2023-01-04",
       "port-version": 4


### PR DESCRIPTION
Amends #30608 which accidentally lost the `/DLUA_BUILD_AS_DLL=1` pc file export.