### PR TITLE
[aklomp-base64] update to 0.5.1

### DIFF
--- a/ports/aklomp-base64/portfile.cmake
+++ b/ports/aklomp-base64/portfile.cmake
@@ -1,13 +1,13 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aklomp/base64
-    REF e77bd70bdd860c52c561568cffb251d88bba064c
-    SHA512 bc0cf64f6a24226a64c51983e8b73b4d4e893b8242bc6ac39361d977996de453d9f95ed0ab68a7544f21b0be1d76ae53af96521207a651c95673b02954cc5bbe
+    REF "v${VERSION}"
+    SHA512 d63c6b36c99abcdfadf3730096c3a7cd36593526dd3dae815035ce196d3354ece7da1d92ecec800a81e1ab5e1d878b24f0b1de62b7aca516170d06a07c1b42a2
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
-        SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH ${SOURCE_PATH}
 )
 
 vcpkg_cmake_install()
@@ -19,4 +19,4 @@ vcpkg_cmake_config_fixup(
 	CONFIG_PATH "lib/cmake/base64"
 )
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/aklomp-base64/vcpkg.json
+++ b/ports/aklomp-base64/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "aklomp-base64",
-  "version-date": "2023-01-06",
-  "port-version": 1,
+  "version": "0.5.1",
   "description": "Implementation of a base64 stream encoding/decoding library in C99 with SIMD (AVX2, AVX512, NEON, AArch64/NEON, SSSE3, SSE4.1, SSE4.2, AVX) and OpenMP acceleration",
   "homepage": "https://github.com/aklomp/base64",
   "license": "BSD-2-Clause",

--- a/versions/a-/aklomp-base64.json
+++ b/versions/a-/aklomp-base64.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed49981a592ca849cbb3274159c8ed21392e73df",
+      "version": "0.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4785f09421c2636709249ad7a555c7420b9bcfe8",
       "version-date": "2023-01-06",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -61,8 +61,8 @@
       "port-version": 1
     },
     "aklomp-base64": {
-      "baseline": "2023-01-06",
-      "port-version": 1
+      "baseline": "0.5.1",
+      "port-version": 0
     },
     "alac": {
       "baseline": "2017-11-03-c38887c5",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

