### PR TITLE
[libxslt] do not require default features of libxml2

### DIFF
--- a/ports/libxslt/vcpkg.json
+++ b/ports/libxslt/vcpkg.json
@@ -1,13 +1,16 @@
 {
   "name": "libxslt",
   "version": "1.1.37",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Libxslt is a XSLT library implemented in C for XSLT 1.0 and most of EXSLT",
   "homepage": "https://github.com/GNOME/libxslt",
   "license": null,
   "supports": "!uwp",
   "dependencies": [
-    "libxml2",
+    {
+      "name": "libxml2",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5146,7 +5146,7 @@
     },
     "libxslt": {
       "baseline": "1.1.37",
-      "port-version": 2
+      "port-version": 3
     },
     "libxt": {
       "baseline": "1.2.1",

--- a/versions/l-/libxslt.json
+++ b/versions/l-/libxslt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c34fe62d32f65f3a4b188a327eda7a4f134fea2",
+      "version": "1.1.37",
+      "port-version": 3
+    },
+    {
       "git-tree": "b5013956f82220811954d9ed3b68e122c11e88a0",
       "version": "1.1.37",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Mark the libxml2 dependency as not requiring default features. This allows the user to reduce the feature set of the libxml2 transitive dependency.

Before:

```
$ .\vcpkg install libxslt[core] libxml2[core] --dry-run
Computing installation plan...
The following packages will be built and installed:
  * libiconv:x64-windows -> 1.17#1
  * liblzma:x64-windows -> 5.4.4
    libxml2[core,iconv,lzma,zlib]:x64-windows -> 2.11.6#1
    libxslt:x64-windows -> 1.1.37#2
  * vcpkg-cmake:x64-windows -> 2023-05-04
  * vcpkg-cmake-config:x64-windows -> 2022-02-06#1
  * zlib:x64-windows -> 1.3
Additional packages (*) will be modified to complete this operation.
```

After:

```
$ .\vcpkg install libxslt[core] libxml2[core] --dry-run
Computing installation plan...
The following packages will be built and installed:
    libxml2:x64-windows -> 2.11.6#1
    libxslt:x64-windows -> 1.1.37#3
  * vcpkg-cmake:x64-windows -> 2023-05-04
  * vcpkg-cmake-config:x64-windows -> 2022-02-06#1
Additional packages (*) will be modified to complete this operation.
```