### PR TITLE
Fix libspatialite osx dynamic

### DIFF
--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -189,9 +189,9 @@ else()
             "--disable-examples"
             "--disable-minizip"
         OPTIONS_DEBUG
-            "LIBS=${PKGCONFIG_LIBS_DEBUG} ${SYSTEM_LIBS}"
+            "--with-geosconfig=${CURRENT_INSTALLED_DIR}/tools/geos/debug/bin/geos-config"
         OPTIONS_RELEASE
-            "LIBS=${PKGCONFIG_LIBS_RELEASE} ${SYSTEM_LIBS}"
+            "--with-geosconfig=${CURRENT_INSTALLED_DIR}/tools/geos/bin/geos-config"
     )
 
     # automake adds the basedir of the generated config to `DEFAULT_INCLUDES`,

--- a/ports/libspatialite/vcpkg.json
+++ b/ports/libspatialite/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libspatialite",
   "version": "5.1.0",
+  "port-version": 1,
   "description": "SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.",
   "homepage": "https://www.gaia-gis.it/gaia-sins/libspatialite-sources",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4834,7 +4834,7 @@
     },
     "libspatialite": {
       "baseline": "5.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libspnav": {
       "baseline": "0.2.3",

--- a/versions/l-/libspatialite.json
+++ b/versions/l-/libspatialite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c295ed5647fb0c20acfd7b97636f04ef6b3a4d8b",
+      "version": "5.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6c988a575680cb06fded62a1f63d43426d683dfd",
       "version": "5.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #33840

- [Y] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [?] SHA512s are updated for each updated download
- [?] The "supports" clause reflects platforms that may be fixed by this new version
- [n/a] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [n/a] Any patches that are no longer applied are deleted from the port's directory.
- [Y] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [Y] Only one version is added to each modified port's versions file.

I have only tested on arm64-osx