### PR TITLE
[geos,libspatialite] Fix various quirks

### DIFF
--- a/ports/geos/fix-exported-config.patch
+++ b/ports/geos/fix-exported-config.patch
@@ -66,11 +66,11 @@ index 6eff1eb14..8827f6ac6 100644
        ;;
      --static-clibs)
 -      echo -L${libdir} -lgeos_c -lgeos -lstdc++ -lm
-+      echo -L${libdir} -lgeos_c -lgeos -lstdc++ @EXTRA_LIBS@
++      echo -L${libdir} -lgeos_c -lgeos @EXTRA_LIBS@
        ;;
      --static-cclibs)
 -      echo -L${libdir} -lgeos -lstdc++ -lm
-+      echo -L${libdir} -lgeos -lstdc++ @EXTRA_LIBS@
++      echo -L${libdir} -lgeos @EXTRA_LIBS@
        ;;
      --cflags)
        echo -I${includedir}

--- a/ports/geos/vcpkg.json
+++ b/ports/geos/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "geos",
   "version": "3.11.3",
+  "port-version": 1,
   "description": "Geometry Engine Open Source",
   "homepage": "https://libgeos.org/",
   "license": "LGPL-2.1-only",

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -19,7 +19,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS unused
     FEATURES
         freexl          ENABLE_FREEXL
         gcp             ENABLE_GCP
-        geocallbacks    ENABLE_GEOCALLBACKS
         rttopo          ENABLE_RTTOPO
 )
 
@@ -38,9 +37,6 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     endif()
     if(ENABLE_GCP)
         string(APPEND CL_FLAGS " /DENABLE_GCP")
-    endif()
-    if(NOT ENABLE_GEOCALLBACKS)
-        string(APPEND CL_FLAGS " /DOMIT_GEOCALLBACKS")
     endif()
     if(ENABLE_RTTOPO)
         string(APPEND CL_FLAGS " /DENABLE_RTTOPO")
@@ -184,10 +180,10 @@ else()
             ${TARGET_ALIAS}
             ${FREEXL_OPTION}
             ${GCP_OPTION}
-            ${GEOCALLBACKS_OPTION}
             ${RTTOPO_OPTION}
             "--disable-examples"
             "--disable-minizip"
+            "cross_compiling=yes" # avoid conftest rpath trouble
         OPTIONS_DEBUG
             "LIBS=${PKGCONFIG_LIBS_DEBUG} ${SYSTEM_LIBS}"
         OPTIONS_RELEASE

--- a/ports/libspatialite/vcpkg.json
+++ b/ports/libspatialite/vcpkg.json
@@ -1,14 +1,16 @@
 {
   "name": "libspatialite",
   "version": "5.1.0",
+  "port-version": 1,
   "description": "SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.",
-  "homepage": "https://www.gaia-gis.it/gaia-sins/libspatialite-sources",
+  "homepage": "https://www.gaia-gis.it/fossil/libspatialite/index",
   "license": null,
   "dependencies": [
     "geos",
     "libiconv",
     {
       "name": "libxml2",
+      "default-features": false,
       "features": [
         "http"
       ]
@@ -28,8 +30,7 @@
     "zlib"
   ],
   "default-features": [
-    "freexl",
-    "geocallbacks"
+    "freexl"
   ],
   "features": {
     "freexl": {
@@ -40,9 +41,6 @@
     },
     "gcp": {
       "description": "Ground control points support. This feature reduces the license options to GPLv2+."
-    },
-    "geocallbacks": {
-      "description": "Geometry callbacks support."
     },
     "rttopo": {
       "description": "RTTOPO support. This feature reduces the license options to GPLv2+.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4834,7 +4834,7 @@
     },
     "libspatialite": {
       "baseline": "5.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libspnav": {
       "baseline": "0.2.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2914,7 +2914,7 @@
     },
     "geos": {
       "baseline": "3.11.3",
-      "port-version": 0
+      "port-version": 1
     },
     "geotrans": {
       "baseline": "3.9",

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41bb89a641e2fd76a21cdf259893ef3ab187aeaf",
+      "version": "3.11.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "74ed7ac2ba209cbd984174705b2e3fc7fcf99e9a",
       "version": "3.11.3",
       "port-version": 0

--- a/versions/l-/libspatialite.json
+++ b/versions/l-/libspatialite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "583ff9e938f0ca09b16f01fc5fb228b42dc13c7a",
+      "version": "5.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6c988a575680cb06fded62a1f63d43426d683dfd",
       "version": "5.1.0",
       "port-version": 0


### PR DESCRIPTION
# geos

Don't hard-code libstdc++ dependency.

# libspatialite

Always build as if cross-compiling. Fixes #33840, rpath trouble in dynamic triplets.
Drop obsolete feature.
Don't depend on default features of libxml2.