### PR TITLE
[lpeg] update to 1.1.0

### DIFF
--- a/ports/lpeg/CMakeLists.txt
+++ b/ports/lpeg/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(lpeg
     lpprint.c
     lpcap.c
     lpcode.c
+    lpcset.c
     lpeg.def)
 
 target_include_directories(lpeg PRIVATE ${LPEG_INCLUDES})

--- a/ports/lpeg/portfile.cmake
+++ b/ports/lpeg/portfile.cmake
@@ -1,9 +1,7 @@
-set(LPEG_VER 1.0.2)
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-${LPEG_VER}.tar.gz"
-    FILENAME "lpeg-${LPEG_VER}.tar.gz"
-    SHA512 110527ddf9f8e5e8a80ef0ae8847c8ba8cd2597dba3bfe2865cba9af60daafbb885f21e74231952f5ab793d021e050b482066a821c6954d52090a5eae77e9814
+    URLS "https://www.inf.puc-rio.br/~roberto/lpeg/lpeg-${VERSION}.tar.gz"
+    FILENAME "lpeg-${VERSION}.tar.gz"
+    SHA512 01b2a4ceb2d110e143603bc63c84a59736ea735dd0ed9866286ba115d41be48d09c9ff21c8e2327974d2296944f6508d50a5c3a18f26ac1d81b8b2fc41f61222
 )
 
 vcpkg_extract_source_archive(

--- a/ports/lpeg/vcpkg.json
+++ b/ports/lpeg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "lpeg",
-  "version": "1.0.2",
-  "port-version": 4,
+  "version": "1.1.0",
   "description": "LPeg is a pattern-matching library for Lua, based on Parsing Expression Grammars (PEGs).",
   "homepage": "https://www.inf.puc-rio.br/~roberto/lpeg",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5277,8 +5277,8 @@
       "port-version": 3
     },
     "lpeg": {
-      "baseline": "1.0.2",
-      "port-version": 4
+      "baseline": "1.1.0",
+      "port-version": 0
     },
     "ltla-aarand": {
       "baseline": "2023-03-19",

--- a/versions/l-/lpeg.json
+++ b/versions/l-/lpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a1832dfc0fc6e11738a1653cdf7a65ccde8903ba",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e364c24f0029fc6589aae6051eec09af14cc02d2",
       "version": "1.0.2",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.