### PR TITLE
[draco] Revise and fix build

### DIFF
--- a/ports/draco/install-linkage.diff
+++ b/ports/draco/install-linkage.diff
@@ -1,0 +1,19 @@
+diff --git a/cmake/draco_install.cmake b/cmake/draco_install.cmake
+index 3be1ba1..b91938c 100644
+--- a/cmake/draco_install.cmake
++++ b/cmake/draco_install.cmake
+@@ -65,10 +65,14 @@ macro(draco_setup_install_target)
+       ARCHIVE DESTINATION "${libs_path}"
+       LIBRARY DESTINATION "${libs_path}")
+   else()
++    if(BUILD_SHARED_LIBS)
++      set_target_properties(draco_static PROPERTIES EXCLUDE_FROM_ALL 1)
++    else()
+     install(
+       TARGETS draco_static
+       EXPORT dracoExport
+       DESTINATION "${libs_path}")
++    endif()
+ 
+     if(BUILD_SHARED_LIBS)
+       install(

--- a/ports/draco/portfile.cmake
+++ b/ports/draco/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/draco
@@ -11,24 +9,28 @@ vcpkg_from_github(
         fix-uwperror.patch
         fix-pkgconfig.patch
         disable-symlinks.patch
+        install-linkage.diff
 )
+
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    set(ENV{EMSCRIPTEN} "${EMSCRIPTEN_ROOT}")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DPYTHON_EXECUTABLE=: # unused with DRACO_JS_GLUE off
+        -DDRACO_JS_GLUE=OFF
 )
 
 vcpkg_cmake_install()
-
-vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/draco)
 vcpkg_fixup_pkgconfig()
 
 # Install tools and plugins
-vcpkg_copy_tools(
-    TOOL_NAMES
-        draco_encoder
-        draco_decoder
-    AUTO_CLEAN
-)
+if(NOT VCPKG_TARGET_IS_EMSCRIPTEN)
+    vcpkg_copy_tools(TOOL_NAMES draco_encoder draco_decoder AUTO_CLEAN)
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/draco/vcpkg.json
+++ b/ports/draco/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "draco",
   "version": "1.5.6",
+  "port-version": 1,
   "description": " A library for compressing and decompressing 3D geometric meshes and point clouds. It is intended to improve the storage and transmission of 3D graphics.",
   "homepage": "https://github.com/google/draco",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2270,7 +2270,7 @@
     },
     "draco": {
       "baseline": "1.5.6",
-      "port-version": 0
+      "port-version": 1
     },
     "drlibs": {
       "baseline": "2023-08-16",

--- a/versions/d-/draco.json
+++ b/versions/d-/draco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7766920ec32ef9da00121a0668edf41bf9d1d76b",
+      "version": "1.5.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "bed378402e689e540a924f99869f7134d74bbdfb",
       "version": "1.5.6",
       "port-version": 0


### PR DESCRIPTION
Enable dynamic library linkage.
Build the same lib for emscripten as for other platforms. Fixes #35387.