### PR TITLE
[libsystemd] Add dependency gperf

### DIFF
--- a/ports/libsystemd/portfile.cmake
+++ b/ports/libsystemd/portfile.cmake
@@ -7,6 +7,8 @@ vcpkg_from_github(
     pkgconfig.patch
 )
 
+vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/gperf")
+
 vcpkg_configure_meson(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS

--- a/ports/libsystemd/vcpkg.json
+++ b/ports/libsystemd/vcpkg.json
@@ -1,11 +1,16 @@
 {
   "name": "libsystemd",
   "version": "254",
+  "port-version": 1,
   "description": "Libsystemd",
   "homepage": "https://github.com/systemd/systemd",
   "license": "LGPL-2.1+",
   "supports": "linux",
   "dependencies": [
+    {
+      "name": "gperf",
+      "host": true
+    },
     "libcap",
     "liblzma",
     "libmount",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4878,7 +4878,7 @@
     },
     "libsystemd": {
       "baseline": "254",
-      "port-version": 0
+      "port-version": 1
     },
     "libtar": {
       "baseline": "1.2.20",

--- a/versions/l-/libsystemd.json
+++ b/versions/l-/libsystemd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ac525bd287e8a58992f263adce78483b0513cb0",
+      "version": "254",
+      "port-version": 1
+    },
+    {
       "git-tree": "bc87d660ee35fa2665c12cbd8cb80896f21f99af",
       "version": "254",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix the build error of `libsystemd`:
```
Program gperf found: NO

../src/v254-832da4078b.clean/meson.build:752:0: ERROR: Program 'gperf' not found or not executable
```
`libsystemd` request `gperf` by `gperf = find_program('gperf')` in `meson.build`.
https://github.com/systemd/systemd/blob/9f640614a66cc7e3aba5abb92d7bbf68800af889/meson.build#L703C1-L703C30

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
