### PR TITLE
[at-spi2-core, at-spi2-atk] Add dependency dbus

### DIFF
--- a/ports/at-spi2-atk/portfile.cmake
+++ b/ports/at-spi2-atk/portfile.cmake
@@ -1,7 +1,3 @@
-if(VCPKG_TARGET_IS_LINUX)
-    message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n    libdbus-1\n\nThese can be installed on Ubuntu systems via apt-get install libdbus-1-dev")
-endif()
-
 vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     GITLAB_URL https://gitlab.gnome.org
@@ -22,7 +18,7 @@ vcpkg_copy_pdbs()
 
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/at-spi2-atk/vcpkg.json
+++ b/ports/at-spi2-atk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "at-spi2-atk",
   "version": "2.38.0",
+  "port-version": 1,
   "description": "Implementation of the ATK interfaces in terms of the libatspi2 API.",
   "homepage": "https://www.gtk.org/",
   "license": null,
@@ -8,6 +9,10 @@
   "dependencies": [
     "at-spi2-core",
     "atk",
+    {
+      "name": "dbus",
+      "platform": "linux"
+    },
     "libxml2",
     {
       "name": "vcpkg-tool-meson",

--- a/ports/at-spi2-core/portfile.cmake
+++ b/ports/at-spi2-core/portfile.cmake
@@ -1,5 +1,5 @@
 if(VCPKG_TARGET_IS_LINUX)
-    message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n    libdbus-1-dev\n    libxi-dev\n    libxtst-dev\n\nThese can be installed on Ubuntu systems via apt-get install libdbus-1-dev libxi-dev libxtst-dev")
+    message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n    libxi-dev\n    libxtst-dev\n\nThese can be installed on Ubuntu systems via apt-get install libxi-dev libxtst-dev")
 endif()
 
 vcpkg_from_gitlab(
@@ -36,7 +36,7 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     )
 endif()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/share/defaults")
 

--- a/ports/at-spi2-core/vcpkg.json
+++ b/ports/at-spi2-core/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "at-spi2-core",
   "version": "2.44.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Base DBus XML interfaces for accessibility, the accessibility registry daemon, and atspi library.",
   "homepage": "https://www.gtk.org/",
   "license": null,
   "supports": "linux",
   "dependencies": [
+    {
+      "name": "dbus",
+      "platform": "linux"
+    },
     "glib",
     {
       "name": "glib",

--- a/versions/a-/at-spi2-atk.json
+++ b/versions/a-/at-spi2-atk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "97535464d9f15ce3bcadaf78ad8031fa3df5eda5",
+      "version": "2.38.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ebb28a9cdbd06d3185ba2e0cfc1945be23a0a608",
       "version": "2.38.0",
       "port-version": 0

--- a/versions/a-/at-spi2-core.json
+++ b/versions/a-/at-spi2-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5143414003b96ead1ffe40c57c9bf764bf64b0c0",
+      "version": "2.44.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "897df7693a8a1addc3a5ab84efabef89e4cef1d8",
       "version": "2.44.1",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -286,11 +286,11 @@
     },
     "at-spi2-atk": {
       "baseline": "2.38.0",
-      "port-version": 0
+      "port-version": 1
     },
     "at-spi2-core": {
       "baseline": "2.44.1",
-      "port-version": 2
+      "port-version": 3
     },
     "atk": {
       "baseline": "2.38.0",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #34351.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
