### PR TITLE
[kerbal] Add new port

### DIFF
--- a/ports/kerbal/portfile.cmake
+++ b/ports/kerbal/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO WentsingNee/Kerbal
+        REF "v${VERSION}"
+        SHA512 d974fbf29ae7226a26a73db58b4c7c6c9f2e826b6524c1b861a824e85bd2c4fbdd52d1ff0c930a026fca0f795d871bac074481ac45023a25e894c23b685f784c
+        HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+        CONFIG_PATH "share/cmake/Kerbal"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/kerbal/vcpkg.json
+++ b/ports/kerbal/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "kerbal",
+  "version": "2023.12.1",
+  "description": "Kerbal C++ Template Library",
+  "homepage": "https://github.com/WentsingNee/Kerbal",
+  "license": "LGPL-3.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3756,6 +3756,10 @@
       "baseline": "20230531",
       "port-version": 0
     },
+    "kerbal": {
+      "baseline": "2023.12.1",
+      "port-version": 0
+    },
     "keystone": {
       "baseline": "0.9.2",
       "port-version": 3

--- a/versions/k-/kerbal.json
+++ b/versions/k-/kerbal.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b4d5ce6370b4c2a345ba96cbebbce8632667fac1",
+      "version": "2023.12.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
