### PR TITLE
[ableton-link] Fix broken find_package

### DIFF
--- a/ports/ableton-link/portfile.cmake
+++ b/ports/ableton-link/portfile.cmake
@@ -76,8 +76,8 @@ vcpkg_apply_patches(
         correct_cmake_include_directory.patch
 )
 
-file(INSTALL "${SOURCE_PATH}/AbletonLinkConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/")
-file(INSTALL "${SOURCE_PATH}/cmake_include/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/cmake_include/")
+file(INSTALL "${SOURCE_PATH}/AbletonLinkConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/abletonlink")
+file(INSTALL "${SOURCE_PATH}/cmake_include/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/abletonlink/cmake_include/")
 file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" PATTERN "CMakeLists.txt" EXCLUDE)
 
 # Handle copyright

--- a/ports/ableton-link/vcpkg.json
+++ b/ports/ableton-link/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ableton-link",
   "version": "3.0.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Ableton Link, a technology that synchronizes musical beat, tempo, and phase across multiple applications running on one or more devices.",
   "homepage": "https://www.ableton.com/en/link/",
   "documentation": "http://ableton.github.io/link/",

--- a/versions/a-/ableton-link.json
+++ b/versions/a-/ableton-link.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c37c3cf9ca37c0c0d9ddffec58b8deb9c968723",
+      "version": "3.0.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "e88d1fcc5959b44924c1bec7ae3b5535327f41ef",
       "version": "3.0.6",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -14,7 +14,7 @@
     },
     "ableton-link": {
       "baseline": "3.0.6",
-      "port-version": 1
+      "port-version": 2
     },
     "abseil": {
       "baseline": "20230802.1",


### PR DESCRIPTION
I could not use `find_package(Ableton-Link CONFIG REQUIRED)` nor `AbletonLink` with this port.

By renaming the config file to include the `-` that the port name uses the issue goes away.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x]  The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.