### PR TITLE
[libvpx] resolve bash by PATH rather then hard-coding its' location

### DIFF
--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -19,12 +19,12 @@ get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
 
 if(CMAKE_HOST_WIN32)
     vcpkg_acquire_msys(MSYS_ROOT PACKAGES make)
-    set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)
     set(ENV{PATH} "${MSYS_ROOT}/usr/bin;$ENV{PATH};${PERL_EXE_PATH}")
 else()
-    set(BASH /bin/bash)
     set(ENV{PATH} "${MSYS_ROOT}/usr/bin:$ENV{PATH}:${PERL_EXE_PATH}")
 endif()
+find_program(BASH NAME bash HINTS ${MSYS_ROOT}/usr/bin REQUIRED NO_CACHE)
+
 
 vcpkg_find_acquire_program(NASM)
 get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libvpx",
   "version": "1.13.1",
+  "port-version": 1,
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5006,7 +5006,7 @@
     },
     "libvpx": {
       "baseline": "1.13.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libwandio": {
       "baseline": "4.2.1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88491a53de6cdc69ec82882d44aab8cf3b315577",
+      "version": "1.13.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "1484fb529e99fdedd95f2b46f65738a9e95fcaa1",
       "version": "1.13.1",
       "port-version": 0


### PR DESCRIPTION
Use `find_program` to resolve the `bash` name.

On linux, `${MSYS_ROOT}` is undefined, so the HINT expands to `/usr/bin/bash`vwhich is either where `/bin/bash` points to, the location of `bash`, anyways, or a path that is skipped while resolving the `bash` name in `${PATH}`.

As `/usr/bin` and `/bin` are both system paths, no "sane" setup will have a `/usr/bin/bash` that is different to `/bin/bash`, so there "shouldn't" be a behavioral change, while writing `${MSYS_ROOT}` there allows merging the line with the WIN32 line.

Fixes some, but not all problems I could reproduce from #35220 .

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.