### PR TITLE
[cglm] Allow building for arm platforms.

### DIFF
--- a/ports/cglm/vcpkg.json
+++ b/ports/cglm/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "cglm",
   "version-semver": "0.9.1",
+  "port-version": 1,
   "description": "Highly Optimized Graphics Math (glm) for C",
   "homepage": "https://github.com/recp/cglm",
   "license": "MIT",
-  "supports": "!(arm | uwp)",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1518,7 +1518,7 @@
     },
     "cglm": {
       "baseline": "0.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "cgltf": {
       "baseline": "1.13",

--- a/versions/c-/cglm.json
+++ b/versions/c-/cglm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "996a91ff669c42bc3976231465129ab0f706eb54",
+      "version-semver": "0.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "bd33408300b3151706176a80ff4ef80bf6e10284",
       "version-semver": "0.9.1",
       "port-version": 0


### PR DESCRIPTION
This works for arm (at least on macOS).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
