### PR TITLE
[utf8-range] New port

### DIFF
--- a/ports/utf8-range/fix-cmake.patch
+++ b/ports/utf8-range/fix-cmake.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/utf8_range/CMakeLists.txt b/third_party/utf8_range/CMakeLists.txt
+index 344952d38..dd855df17 100644
+--- a/third_party/utf8_range/CMakeLists.txt
++++ b/third_party/utf8_range/CMakeLists.txt
+@@ -63,6 +63,7 @@ if (utf8_range_ENABLE_INSTALL)
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+   )
+ 
+   configure_package_config_file(

--- a/ports/utf8-range/portfile.cmake
+++ b/ports/utf8-range/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO protocolbuffers/protobuf
+    REF d30e326ca1f511ab537d9b2f73ce69b2f8f0c865
+    SHA512 5f22493cfb6536d3a8a7bd752505baccacb85b0eade53b35763c3a30fab9197a8ff04bc9d4b6c2f66dc295b77c09a1b670d242f509f8705c0d699767d222eb38
+    HEAD_REF main
+    PATCHES
+        fix-cmake.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/third_party/utf8_range"
+    OPTIONS
+        "-Dutf8_range_ENABLE_TESTS=off"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "utf8_range" CONFIG_PATH "lib/cmake/utf8_range")
+
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/third_party/utf8_range/LICENSE")

--- a/ports/utf8-range/vcpkg.json
+++ b/ports/utf8-range/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "utf8-range",
+  "version-date": "2023-11-09",
+  "description": "Fast UTF-8 validation with Range algorithm (NEON+SSE4+AVX2)",
+  "homepage": "https://github.com/protocolbuffers/protobuf",
+  "license": "MIT",
+  "dependencies": [
+    "abseil",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8736,6 +8736,10 @@
       "baseline": "0.9.5.0",
       "port-version": 2
     },
+    "utf8-range": {
+      "baseline": "2023-11-09",
+      "port-version": 0
+    },
     "utf8h": {
       "baseline": "2021-11-18",
       "port-version": 1

--- a/versions/u-/utf8-range.json
+++ b/versions/u-/utf8-range.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "dd54a8c4b774935b2c164d0902185fa56a8694bb",
+      "version-date": "2023-11-09",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

