### PR TITLE
[catch2] Update to 3.5.0

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
     REF v${VERSION}
-    SHA512 3b452378201ac53c9ffba7801231aa3b32c5fb496f01d670fcee25baf95f405e565ae2aafba49ea5694f906fc61a8b04592c68b9fb12839767070587a48c89fa
+    SHA512 2ffdc8e7851cacc2ab3062ee2c9531d7d90e9a906da8e0f9b3db4a93967a34d3f25e674b03facd7b63367bc2545e39e00ec30f8e10896967993dd01af9a5af92
     HEAD_REF devel
     PATCHES
         fix-install-path.patch

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "catch2",
-  "version-semver": "3.4.0",
-  "description": "A modern, header-only test framework for unit testing.",
+  "version-semver": "3.5.0",
+  "description": "A modern, C++-native, test framework for unit-tests, TDD and BDD.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1461,7 +1461,7 @@
       "port-version": 2
     },
     "catch2": {
-      "baseline": "3.4.0",
+      "baseline": "3.5.0",
       "port-version": 0
     },
     "cccapstone": {

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6bac6509e806556e539c116680228c6df5802ed4",
+      "version-semver": "3.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5796c1c0513a7b49f135e8acdd1976f53e9944ea",
       "version-semver": "3.4.0",
       "port-version": 0


### PR DESCRIPTION
Also, update the description as v3 is no longer header-only.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
