### PR TITLE
[rocksdb] Update to v8.9.1

### DIFF
--- a/ports/rocksdb/0001-fix-dependencies.patch
+++ b/ports/rocksdb/0001-fix-dependencies.patch
@@ -3,7 +3,7 @@
  2 files changed, 23 insertions(+), 21 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4e30f6631..b428c811b 100644
+index 23a4014bc..045f5a36d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -87,7 +87,7 @@ endif()
@@ -79,7 +79,7 @@ index 4e30f6631..b428c811b 100644
  endif()
  
  # Stall notifications eat some performance from inserts
-@@ -1195,8 +1194,6 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
+@@ -1202,8 +1201,6 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
      endforeach()
    endforeach()
  
@@ -120,4 +120,3 @@ index 0bd14be11..a420d8bfe 100644
  endif()
  
  find_dependency(Threads)
- 

--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb
   REF "v${VERSION}"
-  SHA512 2039a4afa9e6ee7d01aba3287f27f43cb48baf55be98b5be06f0b54982f7e28c1032ec1dbd1f10d946554c3c93a93686e7b51aab0d92f731ad4dd7d7c62bed74
+  SHA512 a93720ef2ecafe2e3d51594b8a8bf6b5d36b0dfeae571cec650ee9d7b3d0c166bd6d9fbe2acb6e57cf34e73b58a2277a6465cce56a5274dd68b03bc9009e0323
   HEAD_REF main
   PATCHES
     0001-fix-dependencies.patch

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rocksdb",
-  "version": "8.5.3",
+  "version": "8.9.1",
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7533,7 +7533,7 @@
       "port-version": 0
     },
     "rocksdb": {
-      "baseline": "8.5.3",
+      "baseline": "8.9.1",
       "port-version": 0
     },
     "rpclib": {

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0262aa76211da9eacdd5e70f88bf172eaef286bd",
+      "version": "8.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "caf00463e9aa52209110783d90fa39066eaa4249",
       "version": "8.5.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
