### PR TITLE
[qtbase] Add feature for gtk3 platform theme

### DIFF
--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -258,12 +258,12 @@ endforeach()
     # )
 list(APPEND FEATURE_PRINTSUPPORT_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_CUPS:BOOL=ON)
 
-# widgets features:
-# vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_WIDGETS_OPTIONS
-    # "gtk3"             FEATURE_gtk3
-    # There are a lot of additional features here to deactivate parts of widgets.
-    # )
-list(APPEND FEATURE_WIDGETS_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_GTK3:BOOL=ON)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_WIDGETS_OPTIONS
+    FEATURES
+    "gtk3"              FEATURE_gtk3
+    INVERTED_FEATURES
+    "gtk3"              CMAKE_DISABLE_FIND_PACKAGE_GTK3
+)
 
 set(TOOL_NAMES
         androiddeployqt

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.6.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -205,6 +205,20 @@
       "description": "GLib",
       "dependencies": [
         "glib"
+      ]
+    },
+    "gtk3": {
+      "description": "GTK3 platform theme plugin",
+      "supports": "linux",
+      "dependencies": [
+        "gtk3",
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "glib"
+          ]
+        }
       ]
     },
     "gui": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7106,7 +7106,7 @@
     },
     "qtbase": {
       "baseline": "6.6.1",
-      "port-version": 2
+      "port-version": 3
     },
     "qtcharts": {
       "baseline": "6.6.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "979dcff773800c5f5e144f70f57650fdcf9c8161",
+      "version": "6.6.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "43986c6051eb870340850c13b94ea6cb9a28925c",
       "version": "6.6.1",
       "port-version": 2

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "979dcff773800c5f5e144f70f57650fdcf9c8161",
+      "git-tree": "b85d2c16c027edb173f51037d9c5a3e05746efa0",
       "version": "6.6.1",
       "port-version": 3
     },


### PR DESCRIPTION
Fixes #35594

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [X] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

