### PR TITLE
[curl] fix config on iOS

### DIFF
--- a/ports/curl/cmake-config-ios.patch
+++ b/ports/curl/cmake-config-ios.patch
@@ -1,0 +1,12 @@
+diff --git a/CMake/OtherTests.cmake b/CMake/OtherTests.cmake
+index d67a905..d8f6e55 100644
+--- a/CMake/OtherTests.cmake
++++ b/CMake/OtherTests.cmake
+@@ -142,6 +142,7 @@ elseif(NOT HAVE_GETADDRINFO)
+   set(HAVE_GETADDRINFO_THREADSAFE FALSE)
+ elseif(CMAKE_SYSTEM_NAME STREQUAL "AIX" OR
+        CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
++       CMAKE_SYSTEM_NAME STREQUAL "iOS" OR
+        CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR
+        CMAKE_SYSTEM_NAME STREQUAL "HP-UX" OR
+        CMAKE_SYSTEM_NAME STREQUAL "MidnightBSD" OR

--- a/ports/curl/cmake-config-ios.patch
+++ b/ports/curl/cmake-config-ios.patch
@@ -1,12 +1,24 @@
 diff --git a/CMake/OtherTests.cmake b/CMake/OtherTests.cmake
-index d67a905..d8f6e55 100644
+index d67a905..dcd1eee 100644
 --- a/CMake/OtherTests.cmake
 +++ b/CMake/OtherTests.cmake
-@@ -142,6 +142,7 @@ elseif(NOT HAVE_GETADDRINFO)
+@@ -87,7 +87,7 @@ endif()
+ unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
+ 
+ if(NOT CMAKE_CROSSCOMPILING)
+-  if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "iOS")
++  if(NOT APPLE)
+     # only try this on non-apple platforms
+ 
+     # if not cross-compilation...
+@@ -140,8 +140,8 @@ if(WIN32)
+   set(HAVE_GETADDRINFO_THREADSAFE ${HAVE_GETADDRINFO})
+ elseif(NOT HAVE_GETADDRINFO)
    set(HAVE_GETADDRINFO_THREADSAFE FALSE)
- elseif(CMAKE_SYSTEM_NAME STREQUAL "AIX" OR
-        CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
-+       CMAKE_SYSTEM_NAME STREQUAL "iOS" OR
+-elseif(CMAKE_SYSTEM_NAME STREQUAL "AIX" OR
+-       CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
++elseif(APPLE OR
++       CMAKE_SYSTEM_NAME STREQUAL "AIX" OR
         CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR
         CMAKE_SYSTEM_NAME STREQUAL "HP-UX" OR
         CMAKE_SYSTEM_NAME STREQUAL "MidnightBSD" OR

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         export-components.patch
         dependencies.patch
         cmake-config.patch # https://github.com/curl/curl/pull/11913
+        cmake-config-ios.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "curl",
   "version": "8.4.0",
+  "port-version": 1,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2038,7 +2038,7 @@
     },
     "curl": {
       "baseline": "8.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "curlpp": {
       "baseline": "2018-06-15",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "448772fb486e84aef02247589b12250f4b369596",
+      "version": "8.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6125c796d6e2913a89a2996d7082375ce16b02dd",
       "version": "8.4.0",
       "port-version": 0

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "448772fb486e84aef02247589b12250f4b369596",
+      "git-tree": "8ad22809b9ba0e1e140a8ef45c4502bb2d669e1f",
       "version": "8.4.0",
       "port-version": 1
     },


### PR DESCRIPTION
This PR fixes the CMake configuration step of curl on iOS (community triplets: `arm64-ios`, `x64-ios`)

Another PR is opened to the CURL repository with this fix: https://github.com/curl/curl/pull/12515

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Thank you very much for reviewing!