### PR TITLE
[breakpad] Fixing find_package(unofficial-breakpad) failure

### DIFF
--- a/ports/breakpad/unofficial-breakpadConfig.cmake
+++ b/ports/breakpad/unofficial-breakpadConfig.cmake
@@ -3,4 +3,4 @@ if(@USED_ZLIB@)
   find_dependency(ZLIB)
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/unofficial-breakpad-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-breakpadTargets.cmake")

--- a/ports/breakpad/vcpkg.json
+++ b/ports/breakpad/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "breakpad",
   "version-date": "2023-01-27",
+  "port-version": 1,
   "description": "a set of client and server components which implement a crash-reporting system.",
   "homepage": "https://github.com/google/breakpad",
   "license": "BSD-3-Clause",

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5643527026fecb43d487919191b02c41bfced6f9",
+      "version-date": "2023-01-27",
+      "port-version": 1
+    },
+    {
       "git-tree": "b2b2523acc1c56222313e8fe01065c1e130440e1",
       "version-date": "2023-01-27",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1314,7 +1314,7 @@
     },
     "breakpad": {
       "baseline": "2023-01-27",
-      "port-version": 0
+      "port-version": 1
     },
     "brigand": {
       "baseline": "1.3.0",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/35670

Usage passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static 
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
