### PR TITLE
[pcl]  fix clang-cl builds

### DIFF
--- a/ports/pcl/fix-clang-cl.patch
+++ b/ports/pcl/fix-clang-cl.patch
@@ -1,0 +1,62 @@
+diff --git a/common/include/pcl/impl/instantiate.hpp b/common/include/pcl/impl/instantiate.hpp
+index ea73a0c..4cfc92b 100644
+--- a/common/include/pcl/impl/instantiate.hpp
++++ b/common/include/pcl/impl/instantiate.hpp
+@@ -95,7 +95,7 @@
+ //
+ //    ((x)(y)(z))((1)(2)(3))((dracula)(radu))
+ //
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) && ! defined(__clang__)
+ #define PCL_INSTANTIATE_PRODUCT_IMPL(r, product) \
+   BOOST_PP_CAT(PCL_INSTANTIATE_, BOOST_PP_SEQ_HEAD(product)) \
+           BOOST_PP_EXPAND(BOOST_PP_SEQ_TO_TUPLE(BOOST_PP_SEQ_TAIL(product))) 
+diff --git a/common/src/colors.cpp b/common/src/colors.cpp
+index 4d53ab1..ba0c114 100644
+--- a/common/src/colors.cpp
++++ b/common/src/colors.cpp
+@@ -39,6 +39,7 @@
+ #include <pcl/common/colors.h>
+ 
+ #include <array>
++#include <cassert>
+ 
+ /// Glasbey lookup table
+ static constexpr std::array<unsigned char, 256 * 3> GLASBEY_LUT =
+diff --git a/common/src/gaussian.cpp b/common/src/gaussian.cpp
+index 69bbd12..2b6a667 100644
+--- a/common/src/gaussian.cpp
++++ b/common/src/gaussian.cpp
+@@ -36,6 +36,7 @@
+  */
+ 
+ #include <pcl/common/gaussian.h>
++#include <cassert>
+ 
+ void 
+ pcl::GaussianKernel::compute (float sigma, 
+diff --git a/common/src/range_image_planar.cpp b/common/src/range_image_planar.cpp
+index 97b249b..dddd7f7 100644
+--- a/common/src/range_image_planar.cpp
++++ b/common/src/range_image_planar.cpp
+@@ -35,6 +35,7 @@
+ /** \author Bastian Steder */
+ 
+ #include <iostream>
++#include <cassert>
+ using std::cout;
+ using std::cerr;
+ 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fad95c9..b4ca305 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,7 +51,7 @@ set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
+ # Compiler identification
+ # Define a variable CMAKE_COMPILER_IS_X where X is the compiler short name.
+ # Note: CMake automatically defines one for GNUCXX, nothing to do in this case.
+-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT MSVC)
+   set(CMAKE_COMPILER_IS_CLANG 1)
+ elseif(__COMPILER_PATHSCALE)
+   set(CMAKE_COMPILER_IS_PATHSCALE 1)

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         install-examples.patch
         no-absolute.patch
         devendor-zlib.patch
+        fix-clang-cl.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PCL_SHARED_LIBS)

--- a/ports/pcl/vcpkg.json
+++ b/ports/pcl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pcl",
   "version": "1.13.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.",
   "homepage": "https://github.com/PointCloudLibrary/pcl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6514,7 +6514,7 @@
     },
     "pcl": {
       "baseline": "1.13.1",
-      "port-version": 1
+      "port-version": 2
     },
     "pcre": {
       "baseline": "8.45",

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55fa760d44b858555a5c350ec8b2a1f26e97e84e",
+      "version": "1.13.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "8f4bb7a9a1e628b9444dad7f5a36a2163df572ac",
       "version": "1.13.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
