### PR TITLE
[opensubdiv] Fix feature cuda build with opening Visual Studio

### DIFF
--- a/ports/opensubdiv/fix-feature-cuda.patch
+++ b/ports/opensubdiv/fix-feature-cuda.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 098df7d..9314d03 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -730,7 +730,7 @@ endmacro()
+ # use when cross compiling or building multi-architecture binaries.
+ # We also provide a C++ binary implementation so that Python is not
+ # required (for backward compatibility).
+-if (OPENGL_FOUND OR OPENCL_FOUND OR DXSDK_FOUND OR METAL_FOUND)
++if (OPENGL_FOUND OR OPENCL_FOUND OR DXSDK_FOUND OR METAL_FOUND OR CUDA_FOUND)
+     if(Python_Interpreter_FOUND)
+         set(OSD_STRINGIFY_TOOL ${CMAKE_CURRENT_SOURCE_DIR}/tools/stringify/stringify.py)
+         set(OSD_STRINGIFY ${Python_EXECUTABLE} ${OSD_STRINGIFY_TOOL})

--- a/ports/opensubdiv/portfile.cmake
+++ b/ports/opensubdiv/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         fix-version-search.patch
         fix-build-type.patch
         fix-dependencies.patch
+        fix-feature-cuda.patch
 )
 
 if(VCPKG_TARGET_IS_LINUX)
@@ -135,4 +136,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
                     "${CURRENT_PACKAGES_DIR}/debug/bin"
 )
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/opensubdiv/vcpkg.json
+++ b/ports/opensubdiv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opensubdiv",
   "version-semver": "3.5.0",
+  "port-version": 1,
   "description": "An Open-Source subdivision surface library.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenSubdiv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6350,7 +6350,7 @@
     },
     "opensubdiv": {
       "baseline": "3.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opentelemetry-cpp": {
       "baseline": "1.12.0",

--- a/versions/o-/opensubdiv.json
+++ b/versions/o-/opensubdiv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8cc627798709caed394f31456098644f359f0936",
+      "version-semver": "3.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "38f4d0720a8f9f0610f327382977951421d3ce98",
       "version-semver": "3.5.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #35626.
Feature `cuda` passed with following triplets:
```
x64-windows
x64-windows-static
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
