### PR TITLE
[gstreamer] add feature to enable aom support

### DIFF
--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -80,6 +80,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
         plugins-bad     bad
         aes             gst-plugins-bad:aes
+        aom             gst-plugins-bad:aom
         assrender       gst-plugins-bad:assrender
         bzip2-bad       gst-plugins-bad:bz2
         chromaprint     gst-plugins-bad:chromaprint
@@ -214,7 +215,6 @@ vcpkg_configure_meson(
         -Dgst-plugins-ugly:mpeg2dec=disabled # libmpeg2 not found
         -Dgst-plugins-ugly:sidplay=disabled
         # gst-plugins-bad
-        -Dgst-plugins-bad:aom=disabled # Error during plugin build
         -Dgst-plugins-bad:avtp=disabled
         -Dgst-plugins-bad:androidmedia=auto
         -Dgst-plugins-bad:applemedia=auto

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.22.5",
-  "port-version": 5,
+  "port-version": 6,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",
@@ -51,6 +51,19 @@
           "default-features": false,
           "features": [
             "plugins-base"
+          ]
+        }
+      ]
+    },
+    "aom": {
+      "description": "Enable support for the Alliance for Open Media (AOM) AV1 encoder and decoder",
+      "dependencies": [
+        "aom",
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "features": [
+            "plugins-bad"
           ]
         }
       ]

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -57,6 +57,7 @@
     },
     "aom": {
       "description": "Enable support for the Alliance for Open Media (AOM) AV1 encoder and decoder",
+      "supports": "!windows",
       "dependencies": [
         "aom",
         {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3146,7 +3146,7 @@
     },
     "gstreamer": {
       "baseline": "1.22.5",
-      "port-version": 5
+      "port-version": 6
     },
     "gtest": {
       "baseline": "1.14.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8bb874b7abea368b9773b3c6bcd97c8a07b194f",
+      "version": "1.22.5",
+      "port-version": 6
+    },
+    {
       "git-tree": "c6339c24dbe60ed13ff8d6b5e646d11e192f4ec0",
       "version": "1.22.5",
       "port-version": 5

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e8bb874b7abea368b9773b3c6bcd97c8a07b194f",
+      "git-tree": "27425db97df2c329de0baf5d00c719982659c9c4",
       "version": "1.22.5",
       "port-version": 6
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
