### PR TITLE
[libtorch] Fix core dependencies

### DIFF
--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "1.12.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,
@@ -16,6 +16,7 @@
     },
     "fmt",
     "foxi",
+    "fp16",
     "gemmlowp",
     "gflags",
     "glog",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4914,7 +4914,7 @@
     },
     "libtorch": {
       "baseline": "1.12.1",
-      "port-version": 3
+      "port-version": 4
     },
     "libtorrent": {
       "baseline": "2.0.9",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de2d4bfd4a26268b29c3be02790c16d23ecd3d5e",
+      "version": "1.12.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "7f8ee520ffcef31a008c2c73b1155b38151ebae4",
       "version": "1.12.1",
       "port-version": 3


### PR DESCRIPTION
Fixes #35509, solve the following errors:
```
CMake Error at cmake/vcpkg-dependencies.cmake:26 (find_path):
  Could not find FP16_INCLUDE_DIRS using the following files: fp16.h
  
CMake Error at cmake/vcpkg-dependencies.cmake:28 (find_path):
  Could not find FXDIV_INCLUDE_DIRS using the following files: fxdiv.h
  
CMake Error at C:/Users/PatrikHuber/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package):
  Could not find a package configuration file provided by
  "unofficial-pthreadpool" with any of the following names:

    unofficial-pthreadpoolConfig.cmake
    unofficial-pthreadpool-config.cmake

  Add the installation prefix of "unofficial-pthreadpool" to
  CMAKE_PREFIX_PATH or set "unofficial-pthreadpool_DIR" to a directory
  containing one of the above files.  If "unofficial-pthreadpool" provides a
  separate development package or SDK, be sure it has been installed.
```

* `fp16` should be included as a `libtorch[core]` dependency because `caffe2` depends on it: [cmake/Dependencies.cmake#L955](https://github.com/pytorch/pytorch/blob/v1.12.1/cmake/Dependencies.cmake#L955)

* Fix `vcpkg-dependencies.cmake` to make dependency `fxdiv` required under the following conditions: [cmake/Dependencies.cmake#L375](https://github.com/pytorch/pytorch/blob/v1.12.1/cmake/Dependencies.cmake#L375)
   ```
   if(USE_NNPACK OR USE_QNNPACK OR USE_PYTORCH_QNNPACK OR USE_XNNPACK)
   ```

* Fix `vcpkg-dependencies.cmake` to make dependency `pthreadpool` required under the following conditions: [cmake/Dependencies.cmake#L400-L402](https://github.com/pytorch/pytorch/blob/v1.12.1/cmake/Dependencies.cmake#L400-L402)
   ```
   if(INTERN_BUILD_MOBILE OR USE_NNPACK OR USE_QNNPACK OR USE_PYTORCH_QNNPACK OR USE_XNNPACK)
   ```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
