### PR TITLE
[mp-units] Update to version 2.1.0

### DIFF
--- a/ports/mp-units/config.patch
+++ b/ports/mp-units/config.patch
@@ -1,13 +1,16 @@
 diff --git a/src/mp-unitsConfig.cmake b/src/mp-unitsConfig.cmake
-index 519b180b..dc86e3dd 100644
+index 519b180b..6005e9f8 100644
 --- a/src/mp-unitsConfig.cmake
 +++ b/src/mp-unitsConfig.cmake
-@@ -23,7 +23,7 @@
+@@ -23,9 +23,9 @@
  include(CMakeFindDependencyMacro)
  
  if(MP_UNITS_USE_LIBFMT)
 -    find_dependency(fmt)
-+    find_dependency(fmt CONFIG)
++  find_dependency(fmt CONFIG)
  endif()
  
- find_dependency(gsl-lite)
+-find_dependency(gsl-lite)
++find_dependency(gsl-lite CONFIG)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/mp-unitsTargets.cmake")

--- a/ports/mp-units/config.patch
+++ b/ports/mp-units/config.patch
@@ -1,8 +1,8 @@
 diff --git a/src/mp-unitsConfig.cmake b/src/mp-unitsConfig.cmake
-index 10f82a82..ea637abd 100644
+index 519b180b..dc86e3dd 100644
 --- a/src/mp-unitsConfig.cmake
 +++ b/src/mp-unitsConfig.cmake
-@@ -42,10 +42,10 @@ endfunction()
+@@ -23,7 +23,7 @@
  include(CMakeFindDependencyMacro)
  
  if(MP_UNITS_USE_LIBFMT)
@@ -10,8 +10,4 @@ index 10f82a82..ea637abd 100644
 +    find_dependency(fmt CONFIG)
  endif()
  
--find_dependency(gsl-lite)
-+find_dependency(gsl-lite CONFIG)
- 
- # add range-v3 dependency only for clang + libc++
- if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+ find_dependency(gsl-lite)

--- a/ports/mp-units/portfile.cmake
+++ b/ports/mp-units/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mpusz/units
     REF "v${VERSION}"
-    SHA512 994922a391ed5c1d0e023545beeb0bbeb8ec067be408f715d553e509d9106cdb5b27cfbaa69f0ca1a27cdf9532edacaff7d2cabaafd54b1713f9c8add93bc389
+    SHA512 d23589ba6e5e18e3477a9bab9fe25cffed5e8777862b4811e4335e294f86d129a48c7e001d57cec0739ddd1f0a936e42d06f2b4782b1bd8b8bb15f86f8d32d53
     PATCHES
       config.patch
 )

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mp-units",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "mp-units - A Units Library for C++",
   "homepage": "https://github.com/mpusz/units",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5697,7 +5697,7 @@
       "port-version": 0
     },
     "mp-units": {
-      "baseline": "2.0.0",
+      "baseline": "2.1.0",
       "port-version": 0
     },
     "mp3lame": {

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "618eb4fd9fef1685431c6e45328faed7a01b0702",
+      "version": "2.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f410b971351069e2e9f1b140104a8e836b76c1b8",
       "version": "2.0.0",
       "port-version": 0

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "618eb4fd9fef1685431c6e45328faed7a01b0702",
+      "git-tree": "8ecbe0c671bd440c941d9c88fb326743a5584f00",
       "version": "2.1.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.