### PR TITLE
Update version of type-safe

### DIFF
--- a/ports/type-safe/portfile.cmake
+++ b/ports/type-safe/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO foonathan/type_safe
-    REF v0.2.2
-    SHA512 5dbc9e906e066cfc5eb8fd9a308e952e33c7463b5d2abaadd4303ebe8c38a1d8e79865076ad6422f4c56ffa23113b291e3c11d6dd28e73ec3d6fe2e3e7a233a3
+    REF v0.2.3
+    SHA512 2064995421c5b6bad1b336adf71af9ad1dd3d2245411be1f531d3b72db782a9a959f20597c18a1bd8a71fd3e9e87e396b4fe5595a5e99a32e2d814d6a7c6222b
     HEAD_REF main
 )
 

--- a/ports/type-safe/vcpkg.json
+++ b/ports/type-safe/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "type-safe",
-  "version": "0.2.2",
-  "port-version": 1,
+  "version": "0.2.3",
+  "port-version": 0,
   "description": "Zero overhead abstractions that use the C++ type system to prevent bugs.",
   "homepage": "https://github.com/foonathan/type_safe",
   "dependencies": [

--- a/ports/type-safe/vcpkg.json
+++ b/ports/type-safe/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "type-safe",
   "version": "0.2.3",
-  "port-version": 0,
   "description": "Zero overhead abstractions that use the C++ type system to prevent bugs.",
   "homepage": "https://github.com/foonathan/type_safe",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8649,8 +8649,8 @@
       "port-version": 3
     },
     "type-safe": {
-      "baseline": "0.2.2",
-      "port-version": 1
+      "baseline": "0.2.3",
+      "port-version": 0
     },
     "uchardet": {
       "baseline": "0.0.8",

--- a/versions/t-/type-safe.json
+++ b/versions/t-/type-safe.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "803fe8770512e68321e60560d9a303e4782c266e",
+      "version": "0.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "63cdf2cb69a2a7f3de1a5bf82d63e556b742e909",
       "version": "0.2.2",
       "port-version": 1


### PR DESCRIPTION
Updates the version of foonathan/type-safe to the latest tagged release, as the previous one was almost two years old

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ X] SHA512s are updated for each updated download
- [ X] The "supports" clause reflects platforms that may be fixed by this new version
- [ X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ X] Any patches that are no longer applied are deleted from the port's directory.
- [ X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ X] Only one version is added to each modified port's versions file.
