### PR TITLE
[string-theory] Update to 3.8

### DIFF
--- a/ports/string-theory/portfile.cmake
+++ b/ports/string-theory/portfile.cmake
@@ -1,13 +1,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zrax/string_theory
-    REF 3.6
-    SHA512 2bbd8e6c5c2501cc9616ee6a77b60a7cac5e7c9fa58d6616f6ba39cfdee33dc1b072c5d1b34bd2f88726fb4d65d32032595be7a67854a2e894eb3d81d4a8eea9
+    REF "${VERSION}"
+    SHA512 5071fb091dd5b5279776c2949b2bff7033c6bce336b1b4916e04957228884104b07e64ff3aa248b6498889fd50947c1fa7807e5d07a74c60203ffd1aade4a5a4
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DST_BUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()
@@ -16,4 +18,4 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME string_theory CONFIG_PATH lib/cmake/string
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/string-theory/vcpkg.json
+++ b/ports/string-theory/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "string-theory",
-  "version": "3.6",
+  "version": "3.8",
   "description": "Flexible modern C++ string library with type-safe formatting.",
   "homepage": "https://github.com/zrax/string_theory",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8233,7 +8233,7 @@
       "port-version": 2
     },
     "string-theory": {
-      "baseline": "3.6",
+      "baseline": "3.8",
       "port-version": 0
     },
     "string-view-lite": {

--- a/versions/s-/string-theory.json
+++ b/versions/s-/string-theory.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca2ab2f3286c4b1f945ea10f070bfb0845755018",
+      "version": "3.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "e3c6df91d194be6ca56d8f4044cf0137041d4f04",
       "version": "3.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
