### PR TITLE
[aklomp-base64] Fix TOOLS_PATH

### DIFF
--- a/ports/aklomp-base64/portfile.cmake
+++ b/ports/aklomp-base64/portfile.cmake
@@ -19,4 +19,9 @@ vcpkg_cmake_config_fixup(
 	CONFIG_PATH "lib/cmake/base64"
 )
 
+vcpkg_copy_tools(
+	TOOL_NAMES base64
+	AUTO_CLEAN
+)
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/aklomp-base64/vcpkg.json
+++ b/ports/aklomp-base64/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "aklomp-base64",
   "version": "0.5.1",
+  "port-version": 1,
   "description": "Implementation of a base64 stream encoding/decoding library in C99 with SIMD (AVX2, AVX512, NEON, AArch64/NEON, SSSE3, SSE4.1, SSE4.2, AVX) and OpenMP acceleration",
   "homepage": "https://github.com/aklomp/base64",
   "license": "BSD-2-Clause",

--- a/versions/a-/aklomp-base64.json
+++ b/versions/a-/aklomp-base64.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5926b07ccceb403b943d7766c6fc03c7a2fb8a44",
+      "version": "0.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "ed49981a592ca849cbb3274159c8ed21392e73df",
       "version": "0.5.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -62,7 +62,7 @@
     },
     "aklomp-base64": {
       "baseline": "0.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "alac": {
       "baseline": "2017-11-03-c38887c5",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.


trying to install using `manifest` mode, got this error:
```CMake Error at build_uni/vcpkg_installed/osx-uni/share/base64/base64-targets.cmake:83 (message):
  The imported target "aklomp::base64-bin" references the file

     ".../build_uni/vcpkg_installed/osx-uni/tools/aklomp-base64/base64"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     ".../build_uni/vcpkg_installed/osx-uni/share/base64/base64-targets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  build_uni/vcpkg_installed/osx-uni/share/base64/base64-config.cmake:27 (include)
  .../vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  CMakeLists.txt:47 (find_package)
```

current change fixes the error