### PR TITLE
[Openmpi] configuration error

### DIFF
--- a/ports/openmpi/portfile.cmake
+++ b/ports/openmpi/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_make(
         OPTIONS
             --with-hwloc=internal
             --with-libevent=internal
+            --with-pmix=internal
             --disable-mpi-fortran
         OPTIONS_DEBUG
             --enable-debug

--- a/ports/openmpi/vcpkg.json
+++ b/ports/openmpi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openmpi",
   "version": "4.1.6",
+  "port-version": 1,
   "description": "The Open MPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.",
   "homepage": "https://www.open-mpi.org/",
   "supports": "!(windows | uwp)"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6314,7 +6314,7 @@
     },
     "openmpi": {
       "baseline": "4.1.6",
-      "port-version": 0
+      "port-version": 1
     },
     "openmvg": {
       "baseline": "2.0",

--- a/versions/o-/openmpi.json
+++ b/versions/o-/openmpi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a63c7aeb8e42d6ebdac726767ec7a0ba46ddf86f",
+      "version": "4.1.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "a35bc145d32795f1a71cbe596de040805c3af780",
       "version": "4.1.6",
       "port-version": 0


### PR DESCRIPTION
Fixes #35705

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.