### PR TITLE
[libtorch] build failure

### DIFF
--- a/ports/libtorch/missing_include.patch
+++ b/ports/libtorch/missing_include.patch
@@ -1,0 +1,57 @@
+diff --git a/aten/src/ATen/core/dynamic_type.h b/aten/src/ATen/core/dynamic_type.h
+index a84644ddde0..b1b6b2c9ecc 100644
+--- a/aten/src/ATen/core/dynamic_type.h
++++ b/aten/src/ATen/core/dynamic_type.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <cstdint>
+ #include <memory>
+ #include <type_traits>
+ 
+diff --git a/c10/util/BFloat16.h b/c10/util/BFloat16.h
+index 1ada02bba1c..f6f9fc65e0e 100644
+--- a/c10/util/BFloat16.h
++++ b/c10/util/BFloat16.h
+@@ -3,6 +3,7 @@
+ // Defines the bloat16 type (brain floating-point). This representation uses
+ // 1 bit for the sign, 8 bits for the exponent and 7 bits for the mantissa.
+ 
++#include <cstdint>
+ #include <c10/macros/Macros.h>
+ #include <cmath>
+ #include <cstring>
+diff --git a/torch/csrc/jit/passes/quantization/quantization_type.h b/torch/csrc/jit/passes/quantization/quantization_type.h
+index ea5ca10b15a..c704f9c3037 100644
+--- a/torch/csrc/jit/passes/quantization/quantization_type.h
++++ b/torch/csrc/jit/passes/quantization/quantization_type.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ #include <ostream>
++#include <cstdint>
+ 
+ namespace torch {
+ namespace jit {
+diff --git a/torch/csrc/jit/runtime/logging.cpp b/torch/csrc/jit/runtime/logging.cpp
+index 66712990368..b326f587bc8 100644
+--- a/torch/csrc/jit/runtime/logging.cpp
++++ b/torch/csrc/jit/runtime/logging.cpp
+@@ -1,6 +1,7 @@
+ #include <torch/csrc/jit/runtime/logging.h>
+ 
+ #include <atomic>
++#include <stdexcept>
+ #include <mutex>
+ #include <unordered_map>
+ 
+diff --git a/torch/csrc/lazy/core/multi_wait.cpp b/torch/csrc/lazy/core/multi_wait.cpp
+index 6b9933518e0..db0742b32a3 100644
+--- a/torch/csrc/lazy/core/multi_wait.cpp
++++ b/torch/csrc/lazy/core/multi_wait.cpp
+@@ -1,5 +1,6 @@
+ #include <torch/csrc/lazy/core/multi_wait.h>
+ 
++#include <stdexcept>
+ #include <chrono>
+ #include <exception>
+ 

--- a/ports/libtorch/portfile.cmake
+++ b/ports/libtorch/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     SHA512 afeb551904ebd9b5901ae623a98eadbb3045115247cedf8006a940742cfad04e5ce24cfaf363336a9ed88d7ce6a4ac53dbb6a5c690aef6efdf20477c3a22c7ca
     HEAD_REF master
     PATCHES
+        missing_include.patch
         pytorch-pr-85958.patch # https://github.com/pytorch/pytorch/pull/85958
         fix-cmake.patch
         fix-fbgemm-include.patch

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "1.12.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4918,7 +4918,7 @@
     },
     "libtorch": {
       "baseline": "1.12.1",
-      "port-version": 4
+      "port-version": 5
     },
     "libtorrent": {
       "baseline": "2.0.9",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20a2f323fb33dab29315fd18217e263ade2a9bd6",
+      "version": "1.12.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "de2d4bfd4a26268b29c3be02790c16d23ecd3d5e",
       "version": "1.12.1",
       "port-version": 4


### PR DESCRIPTION
Fixes #35707

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.