### PR TITLE
[freetype-gl] GLEW as default feature

### DIFF
--- a/ports/freetype-gl/portfile.cmake
+++ b/ports/freetype-gl/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        "glew" freetype-gl_WITH_GLEW
         "glad" freetype-gl_WITH_GLAD
 )
 

--- a/ports/freetype-gl/vcpkg.json
+++ b/ports/freetype-gl/vcpkg.json
@@ -6,7 +6,6 @@
   "homepage": "https://github.com/rougier/freetype-gl",
   "dependencies": [
     "freetype",
-    "glew",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -16,7 +15,18 @@
       "host": true
     }
   ],
+  "default-features": [
+    {
+      "name": "glew"
+    }
+  ],
   "features": {
+    "glew": {
+      "description": "Use the GLEW gl loader",
+      "dependencies": [
+        "glew"
+      ]
+    },
     "glad": {
       "description": "Use the GLAD gl loader",
       "dependencies": [

--- a/ports/freetype-gl/vcpkg.json
+++ b/ports/freetype-gl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "freetype-gl",
   "version-date": "2022-01-17",
-  "port-version": 2,
+  "port-version": 3,
   "description": "OpenGL text using one vertex buffer, one texture and FreeType",
   "homepage": "https://github.com/rougier/freetype-gl",
   "dependencies": [
@@ -16,21 +16,19 @@
     }
   ],
   "default-features": [
-    {
-      "name": "glew"
-    }
+    "glew"
   ],
   "features": {
-    "glew": {
-      "description": "Use the GLEW gl loader",
-      "dependencies": [
-        "glew"
-      ]
-    },
     "glad": {
       "description": "Use the GLAD gl loader",
       "dependencies": [
         "glad"
+      ]
+    },
+    "glew": {
+      "description": "Use the GLEW gl loader",
+      "dependencies": [
+        "glew"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2786,7 +2786,7 @@
     },
     "freetype-gl": {
       "baseline": "2022-01-17",
-      "port-version": 2
+      "port-version": 3
     },
     "freexl": {
       "baseline": "2.0.0",

--- a/versions/f-/freetype-gl.json
+++ b/versions/f-/freetype-gl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7cf37536a9cecde0557197e4d7c61073dbe947d2",
+      "version-date": "2022-01-17",
+      "port-version": 3
+    },
+    {
       "git-tree": "a356f56c15dd0a66094c00cc35670791c545027e",
       "version-date": "2022-01-17",
       "port-version": 2

--- a/versions/f-/freetype-gl.json
+++ b/versions/f-/freetype-gl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7cf37536a9cecde0557197e4d7c61073dbe947d2",
+      "git-tree": "e61e27b5a7928879435242d50ac2470fe79cb3e3",
       "version-date": "2022-01-17",
       "port-version": 3
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

Add GLEW as default feature instead of dependency to avoid unnecessary installation of GLEW when using other GL loader (GLAD)