### PR TITLE
[libatomic-ops] Update to v7.8.2

### DIFF
--- a/ports/libatomic-ops/portfile.cmake
+++ b/ports/libatomic-ops/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ivmai/libatomic_ops
     REF "v${VERSION}"
-    SHA512 2b33aaaef0b4ed995044ba818b6acfedf1a70efea419338eece90b3cb453d7dba6ca55cd7fb36dce6143ede511284e75b6e17cd773d8da8f32d7888cb029dfd1
+    SHA512 6b0ab1c01600346413184f66eaff1f707d1bc46fad9fd52ac855f2c66a55097dfad620c68b898459527142c1eb7ba50fde34498f962f24cec83268500c5bcccb
     HEAD_REF master
 )
 

--- a/ports/libatomic-ops/vcpkg.json
+++ b/ports/libatomic-ops/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libatomic-ops",
-  "version": "7.8.0",
+  "version": "7.8.2",
   "description": "The atomic_ops project (Atomic memory update operations portable implementation)",
   "homepage": "https://github.com/ivmai/libatomic_ops",
   "license": "MIT OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4093,7 +4093,7 @@
       "port-version": 0
     },
     "libatomic-ops": {
-      "baseline": "7.8.0",
+      "baseline": "7.8.2",
       "port-version": 0
     },
     "libavif": {

--- a/versions/l-/libatomic-ops.json
+++ b/versions/l-/libatomic-ops.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46231da262a01373e326ad31eeb8ac03cecbbeb3",
+      "version": "7.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c4a1f1354f550bce6ae190b82bf984c3827937a3",
       "version": "7.8.0",
       "port-version": 0


### PR DESCRIPTION
Update to latest upstream, major change is: allocator fix in atomic_ops_malloc.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
