### PR TITLE
[libmount] Update and fix

### DIFF
--- a/ports/libmount/portfile.cmake
+++ b/ports/libmount/portfile.cmake
@@ -12,26 +12,39 @@ vcpkg_extract_source_archive(
 
 set(ENV{GTKDOCIZE} true)
 
+vcpkg_list(SET options)
+if("nls" IN_LIST FEATURES)
+    vcpkg_list(APPEND options "--enable-nls")
+else()
+    set(ENV{AUTOPOINT} true) # true, the program
+    vcpkg_list(APPEND options "--disable-nls")
+endif()
+
 vcpkg_configure_make(
     AUTOCONFIG
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${options}
         --disable-asciidoc
         --disable-all-programs
+        --disable-dependency-tracking
         --enable-libmount
         --enable-libblkid
+        "--mandir=${CURRENT_PACKAGES_DIR}/share/man"
 )
 
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/sbin" "${CURRENT_PACKAGES_DIR}/debug/sbin")
-endif()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools") # empty folder
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/bin"
+    "${CURRENT_PACKAGES_DIR}/debug/sbin"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/bin"
+    "${CURRENT_PACKAGES_DIR}/sbin"
+    "${CURRENT_PACKAGES_DIR}/share"
+    "${CURRENT_PACKAGES_DIR}/tools"
+)
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README.licensing" "${SOURCE_PATH}/COPYING")

--- a/ports/libmount/portfile.cmake
+++ b/ports/libmount/portfile.cmake
@@ -1,11 +1,7 @@
-set(VERSION_MAJOR 2)
-set(VERSION_MINOR 38)
-set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR})
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${VERSION_MAJOR}.${VERSION_MINOR}/util-linux-${VERSION}.tar.xz"
+    URLS "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${VERSION}/util-linux-${VERSION}.tar.xz"
     FILENAME "util-linux-${VERSION}.tar.xz"
-    SHA512 d0f7888f457592067938e216695871ce6475a45d83a092cc3fd72b8cf8fca145ca5f3a99122f1744ef60b4f773055cf4e178dc6c59cd30837172aee0b5597e8c
+    SHA512 3d59a0f114c06be19ef7f86fca37ba5b9073823d011b3fc37997ddb00124b4505ea32903b78798a64dffbccf0ba645a692678ee845cc65a5b321824448a82a94
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libmount/vcpkg.json
+++ b/ports/libmount/vcpkg.json
@@ -3,6 +3,21 @@
   "version": "2.39",
   "description": "Block device identification library from util-linux",
   "homepage": "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/about/",
-  "license": "GPL-2.0-only",
-  "supports": "linux"
+  "license": null,
+  "supports": "linux",
+  "features": {
+    "nls": {
+      "description": "Enable native language support",
+      "dependencies": [
+        {
+          "name": "gettext",
+          "host": true,
+          "features": [
+            "tools"
+          ]
+        },
+        "gettext-libintl"
+      ]
+    }
+  }
 }

--- a/ports/libmount/vcpkg.json
+++ b/ports/libmount/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmount",
-  "version": "2.38",
-  "port-version": 2,
+  "version": "2.39",
   "description": "Block device identification library from util-linux",
   "homepage": "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/about/",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4553,8 +4553,8 @@
       "port-version": 0
     },
     "libmount": {
-      "baseline": "2.38",
-      "port-version": 2
+      "baseline": "2.39",
+      "port-version": 0
     },
     "libmpeg2": {
       "baseline": "0.5.1",

--- a/versions/l-/libmount.json
+++ b/versions/l-/libmount.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fbc2733330a3bac410e90c460db96f54e39e0a5",
+      "version": "2.39",
+      "port-version": 0
+    },
+    {
       "git-tree": "747604a5c97736ced9e0ef3b2963c2c949bdc655",
       "version": "2.38",
       "port-version": 2


### PR DESCRIPTION
Resolves https://github.com/microsoft/vcpkg/issues/35539.

Licensing:  
I guess the binary artifacts are actually LGPL-2.1-or-later, but I'm unable to check all source files now. Some are public domain, some use other licenses.