### PR TITLE
[nng] update to 1.6.0

### DIFF
--- a/ports/nng/portfile.cmake
+++ b/ports/nng/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nanomsg/nng
-    REF v1.5.2
-    SHA512 33cda9e0422c6e8cb56e48bd812f381bf07a92a0aa2fbadddbca7cfde585c66299142186a3a76a97163e5570042452a62c1e53180ebfbf016a44eee998b16286
+    REF "v${VERSION}"
+    SHA512 b4f2c812e65f0a5cb57827d80e632912679902b50f06eb10805d5fe86ab30fc97c4441b0b4d1d8c15dbf09ac7628f4c863d699121fa14bbad0a7782c40a1e4bf
     HEAD_REF master
 )
 
@@ -50,6 +50,6 @@ if ("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES nngcat AUTO_CLEAN)
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
 
 vcpkg_copy_pdbs()

--- a/ports/nng/vcpkg.json
+++ b/ports/nng/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nng",
-  "version-semver": "1.5.2",
-  "port-version": 1,
+  "version-semver": "1.6.0",
   "description": "nanomsg-next-gen, lightweight messaging library",
   "homepage": "https://nng.nanomsg.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5993,8 +5993,8 @@
       "port-version": 1
     },
     "nng": {
-      "baseline": "1.5.2",
-      "port-version": 1
+      "baseline": "1.6.0",
+      "port-version": 0
     },
     "nngpp": {
       "baseline": "1.3.0",

--- a/versions/n-/nng.json
+++ b/versions/n-/nng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ac0d0be55aed606e5db8e253d9bf5cc8586e7c2",
+      "version-semver": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "83ce54077bc3c44805db7725549b28e7bc90d536",
       "version-semver": "1.5.2",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/35703
All feature tested on the following triplets:

- x64-windows
- x64-windows-static
- x86-windows

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
