### PR TITLE
[llgi] Update to 2023-12-19

### DIFF
--- a/ports/llgi/portfile.cmake
+++ b/ports/llgi/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO altseed/LLGI
-    REF 1b6b59b9f5bc9f81b4c2af2333d69f6e23670b3e
-    SHA512 c9011dee560897caf5ae53d8fa58869b774bd3bc7ce2e0cc4696ac034fc89a36adf3f5285e82cffe6430ca61f6509fd7fbadf5c77aef896c74e8d70e70ff4312
+    REF 8f8510e2dffa1d747ff6ebb0da341198e75291ec
+    SHA512 d521b47f293b90faed28f9648facdfae327c6122ea6391683a08e48558fdf62ce0d3977f78aef3bc276d77ab19fc40ab3cc4d27311dd5a292e0884635fe7c9d3
     HEAD_REF master
     PATCHES
         fix-cmake-use-vcpkg.patch

--- a/ports/llgi/vcpkg.json
+++ b/ports/llgi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "llgi",
-  "version-date": "2023-11-04",
+  "version-date": "2023-12-19",
   "homepage": "https://github.com/altseed/LLGI",
   "license": null,
   "supports": "!(uwp | android)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5233,7 +5233,7 @@
       "port-version": 0
     },
     "llgi": {
-      "baseline": "2023-11-04",
+      "baseline": "2023-12-19",
       "port-version": 0
     },
     "llgl": {

--- a/versions/l-/llgi.json
+++ b/versions/l-/llgi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70bc60ef323833846200e1ffe0937de2cfaaf77e",
+      "version-date": "2023-12-19",
+      "port-version": 0
+    },
+    {
       "git-tree": "a0f885d3531458ac1a7748ce8af641b30a80a166",
       "version-date": "2023-11-04",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/35730

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x64-windows
x64-osx
```