### PR TITLE
[imgui] Fix usage of feature allegro5

### DIFF
--- a/ports/imgui/imgui-config.cmake.in
+++ b/ports/imgui/imgui-config.cmake.in
@@ -31,7 +31,7 @@ if (@IMGUI_FREETYPE_LUNASVG@)
 endif()
 
 if (@IMGUI_BUILD_ALLEGRO5_BINDING@)
-    find_dependency(unofficial-allegro5 CONFIG)
+    find_dependency(Allegro CONFIG)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/imgui-targets.cmake")

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "imgui",
   "version": "1.90",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3510,7 +3510,7 @@
     },
     "imgui": {
       "baseline": "1.90",
-      "port-version": 1
+      "port-version": 2
     },
     "imgui-node-editor": {
       "baseline": "0.9.3",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9fd7997ab3813f71b87171213ea8fbd4e70b863",
+      "version": "1.90",
+      "port-version": 2
+    },
+    {
       "git-tree": "027b657658f9b4dd643fd35895496c685d300021",
       "version": "1.90",
       "port-version": 1


### PR DESCRIPTION
Fixes #35766, fix usage of feature `allegro5`. After #35495, `allegro5` officially exports config files.

 Supplement to #35729, resolve the following errors:
```
CMake Error at G:/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package):
  Could not find a package configuration file provided by
  "unofficial-allegro5" with any of the following names:

    unofficial-allegro5Config.cmake
    unofficial-allegro5-config.cmake

  Add the installation prefix of "unofficial-allegro5" to CMAKE_PREFIX_PATH
  or set "unofficial-allegro5_DIR" to a directory containing one of the above
  files.  If "unofficial-allegro5" provides a separate development package or
  SDK, be sure it has been installed.
Call Stack (most recent call first):
  G:/vcpkg/downloads/tools/cmake-3.27.1-windows/cmake-3.27.1-windows-i386/share/cmake-3.27/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  G:/vcpkg/installed/x64-windows/share/imgui/imgui-config.cmake:58 (find_dependency)
  G:/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  CMakeLists.txt:74 (find_package)
```


Feature `imgui[allegro5-binding]` passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

