### PR TITLE
[restinio] Update to 0.7.1

### DIFF
--- a/ports/restinio/portfile.cmake
+++ b/ports/restinio/portfile.cmake
@@ -2,8 +2,21 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stiffstream/restinio
     REF "v.${VERSION}"
-    SHA512 de9929d9ed6acf9574482ffa3f865a550e319716c9cfc5a9e2e9f604169206df022d55e0e55174c66f0edc04a4491c028755272067e55ae646ecfccc1573f78f
+    SHA512 b5932a08687ef2d3ae02d0b0b1384b3462706ce207f16126efa8cd3dcea130d823863169dd5088b12b8c69761ccd044b447c2fe04f31ee10d26ff33d088606ee
 )
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "standalone-asio" USE_STANDALONE_ASIO
+        "boost-asio" USE_BOOST_ASIO)
+
+if(USE_STANDALONE_ASIO)
+    set(ASIO_PROPS "-DRESTINIO_ASIO_SOURCE=standalone" "-DRESTINIO_DEP_STANDALONE_ASIO=find")
+endif()
+
+if(USE_BOOST_ASIO)
+    set(ASIO_PROPS "-DRESTINIO_ASIO_SOURCE=boost" "-DRESTINIO_DEP_BOOST_ASIO=find")
+endif()
 
 set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_cmake_configure(
@@ -14,8 +27,7 @@ vcpkg_cmake_configure(
         -DRESTINIO_SAMPLE=OFF
         -DRESTINIO_BENCHMARK=OFF
         -DRESTINIO_WITH_SOBJECTIZER=OFF
-        -DRESTINIO_ASIO_SOURCE=standalone
-        -DRESTINIO_DEP_STANDALONE_ASIO=find
+        ${ASIO_PROPS}
         -DRESTINIO_DEP_LLHTTP=find
         -DRESTINIO_DEP_FMT=find
         -DRESTINIO_DEP_EXPECTED_LITE=find

--- a/ports/restinio/portfile.cmake
+++ b/ports/restinio/portfile.cmake
@@ -5,19 +5,6 @@ vcpkg_from_github(
     SHA512 b5932a08687ef2d3ae02d0b0b1384b3462706ce207f16126efa8cd3dcea130d823863169dd5088b12b8c69761ccd044b447c2fe04f31ee10d26ff33d088606ee
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        "standalone-asio" USE_STANDALONE_ASIO
-        "boost-asio" USE_BOOST_ASIO)
-
-if(USE_STANDALONE_ASIO)
-    set(ASIO_PROPS "-DRESTINIO_ASIO_SOURCE=standalone" "-DRESTINIO_DEP_STANDALONE_ASIO=find")
-endif()
-
-if(USE_BOOST_ASIO)
-    set(ASIO_PROPS "-DRESTINIO_ASIO_SOURCE=boost" "-DRESTINIO_DEP_BOOST_ASIO=find")
-endif()
-
 set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/dev"
@@ -27,7 +14,8 @@ vcpkg_cmake_configure(
         -DRESTINIO_SAMPLE=OFF
         -DRESTINIO_BENCHMARK=OFF
         -DRESTINIO_WITH_SOBJECTIZER=OFF
-        ${ASIO_PROPS}
+        -DRESTINIO_ASIO_SOURCE=standalone
+        -DRESTINIO_DEP_STANDALONE_ASIO=find
         -DRESTINIO_DEP_LLHTTP=find
         -DRESTINIO_DEP_FMT=find
         -DRESTINIO_DEP_EXPECTED_LITE=find

--- a/ports/restinio/vcpkg.json
+++ b/ports/restinio/vcpkg.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/Stiffstream/restinio",
   "license": "BSD-3-Clause",
   "dependencies": [
+    "asio",
     "expected-lite",
     "fmt",
     "llhttp",
@@ -16,22 +17,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "default-features": [
-    "standalone-asio"
-  ],
-  "features": {
-    "boost-asio": {
-      "description": "Use of Boost.Asio",
-      "dependencies": [
-        "boost-asio"
-      ]
-    },
-    "standalone-asio": {
-      "description": "Use of standalone version of Asio",
-      "dependencies": [
-        "asio"
-      ]
-    }
-  }
+  ]
 }

--- a/ports/restinio/vcpkg.json
+++ b/ports/restinio/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "restinio",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A header-only C++14 library that gives you an embedded HTTP/Websocket server targeted primarily for asynchronous processing of HTTP-requests.",
   "homepage": "https://github.com/Stiffstream/restinio",
   "license": "BSD-3-Clause",
   "dependencies": [
-    "asio",
     "expected-lite",
     "fmt",
     "llhttp",
@@ -17,5 +16,18 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "standalone-asio"
+  ],
+  "features" : {
+    "standalone-asio": {
+      "description": "Use of standalone version of Asio",
+      "dependencies": [ "asio" ]
+    },
+    "boost-asio": {
+      "description": "Use of Boost.Asio",
+      "dependencies": [ "boost-asio" ]
+    }
+  }
 }

--- a/ports/restinio/vcpkg.json
+++ b/ports/restinio/vcpkg.json
@@ -20,14 +20,18 @@
   "default-features": [
     "standalone-asio"
   ],
-  "features" : {
-    "standalone-asio": {
-      "description": "Use of standalone version of Asio",
-      "dependencies": [ "asio" ]
-    },
+  "features": {
     "boost-asio": {
       "description": "Use of Boost.Asio",
-      "dependencies": [ "boost-asio" ]
+      "dependencies": [
+        "boost-asio"
+      ]
+    },
+    "standalone-asio": {
+      "description": "Use of standalone version of Asio",
+      "dependencies": [
+        "asio"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7485,7 +7485,7 @@
       "port-version": 0
     },
     "restinio": {
-      "baseline": "0.7.0",
+      "baseline": "0.7.1",
       "port-version": 0
     },
     "rexo": {

--- a/versions/r-/restinio.json
+++ b/versions/r-/restinio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9fa02c4d7f6cc2e5c700702b1dc40d211f387131",
+      "version": "0.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "06ab98765576c8b3d11f5a9a1d4125e0176c482a",
       "version": "0.7.0",
       "port-version": 0

--- a/versions/r-/restinio.json
+++ b/versions/r-/restinio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9fa02c4d7f6cc2e5c700702b1dc40d211f387131",
+      "git-tree": "b59b3fc1e00b5abdfbbedaeb495e2816aeee1b44",
       "version": "0.7.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- ~~[ ] The "supports" clause reflects platforms that may be fixed by this new version~~
- ~~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- ~~[ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
