### PR TITLE
[fmt] Fix visibility

### DIFF
--- a/ports/fmt/fix-visibility.patch
+++ b/ports/fmt/fix-visibility.patch
@@ -1,0 +1,12 @@
+diff --git a/include/fmt/core.h b/include/fmt/core.h
+index b51c1406..bb139509 100644
+--- a/include/fmt/core.h
++++ b/include/fmt/core.h
+@@ -2306,6 +2306,7 @@ enum class state { start, align, sign, hash, zero, width, precision, locale };
+ 
+ // Parses standard format specifiers.
+ template <typename Char>
++FMT_VISIBILITY("hidden") // Suppress an ld warning on macOS (#3769).
+ FMT_CONSTEXPR FMT_INLINE auto parse_format_specs(
+     const Char* begin, const Char* end, dynamic_format_specs<Char>& specs,
+     basic_format_parse_context<Char>& ctx, type arg_type) -> const Char* {

--- a/ports/fmt/fix-write-batch.patch
+++ b/ports/fmt/fix-write-batch.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f21cf45..691a632 100644
+index 88c12148..967b53dd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -157,7 +157,7 @@ if (MASTER_PROJECT AND CMAKE_GENERATOR MATCHES "Visual Studio")
+@@ -260,7 +260,7 @@ if (FMT_MASTER_PROJECT AND CMAKE_GENERATOR MATCHES "Visual Studio")
    join(netfxpath
         "C:\\Program Files\\Reference Assemblies\\Microsoft\\Framework\\"
         ".NETFramework\\v4.0")
 -  file(WRITE run-msbuild.bat "
-+  file(WRITE ${CMAKE_BINARY_DIR}/run-msbuild.bat "
++  file(WRITE "${CMAKE_BINARY_DIR}/run-msbuild.bat" "
      ${MSBUILD_SETUP}
      ${CMAKE_MAKE_PROGRAM} -p:FrameworkPathOverride=\"${netfxpath}\" %*")
  endif ()

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 27df90c681ec37e55625062a79e3b83589b6d7e94eff37a3b412bb8c1473f757a8adb727603acc9185c3490628269216843b7d7bd5a3cb37f0029da5d1495ffa
     HEAD_REF master
     PATCHES
+        fix-visibility.patch
         fix-write-batch.patch
 )
 

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fmt",
   "version": "10.2.1",
+  "port-version": 1,
   "description": "Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.",
   "homepage": "https://github.com/fmtlib/fmt",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2750,7 +2750,7 @@
     },
     "fmt": {
       "baseline": "10.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "folly": {
       "baseline": "2024.01.01.00",

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74cfe848ded3d9610b11e442aa6b2341cfa65b1b",
+      "version": "10.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "405156a2b01c91258bf66768ceb3ae75c1caba7f",
       "version": "10.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

```
ld: warning: direct access in function 'fmt::v10::detail::format_error_code(fmt::v10::detail::buffer<char>&, int, fmt::v10::basic_string_view<char>)' from file '/usr/local/vcpkg/installed/x64-osx/lib/libfmt.a(format.cc.o)' to global weak symbol 'decltype(fp.begin()) fmt::v10::detail::parse_format_specs<int, fmt::v10::detail::compile_parse_context<char> >(fmt::v10::detail::compile_parse_context<char>&)' from file '/usr/local/vcpkg/installed/x64-osx/lib/libspdlog.a(spdlog.cpp.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```

When link with `spdlog`, it shows this warning.

This problem was once reported in #29280 by @marcovc

And this pr fix it.