### PR TITLE
[libdisasm] add license

### DIFF
--- a/ports/libdisasm/vcpkg.json
+++ b/ports/libdisasm/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libdisasm",
   "version": "0.23",
-  "port-version": 10,
+  "port-version": 11,
   "description": "x86 Disassembler Library.",
   "homepage": "https://sourceforge.net/projects/bastard",
+  "license": "ClArtistic",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4206,7 +4206,7 @@
     },
     "libdisasm": {
       "baseline": "0.23",
-      "port-version": 10
+      "port-version": 11
     },
     "libdivide": {
       "baseline": "5.0",

--- a/versions/l-/libdisasm.json
+++ b/versions/l-/libdisasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d98ead706d535c81198d0b4fd3a1744cd0e0a23e",
+      "version": "0.23",
+      "port-version": 11
+    },
+    {
       "git-tree": "e6870682ac5d76671fbe396235d4667f5edf669b",
       "version": "0.23",
       "port-version": 10


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Full license text is visible here: https://sourceforge.net/p/bastard/code/HEAD/tree/trunk/libdisasm/LICENSE