### PR TITLE
[atomic-queue] Update to 1.5

### DIFF
--- a/ports/atomic-queue/portfile.cmake
+++ b/ports/atomic-queue/portfile.cmake
@@ -1,20 +1,20 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO max0x7ba/atomic_queue
-    REF 7619054490efdbfe377bd528bc09b21f5cd38a02
-    SHA512 0d145f461a5c978c4d6f6d8ec1f06f0c61f3d009e65eac12db806c2aa7941461f881b34b9c4dd9aeebd3206a4598e6081f89f983c389b2f5aecefefcbddd94b6
+    REF "v${VERSION}"
+    SHA512 d2b329698412127d23e9ee55472f65869c59b228439e714ebbe6cc66202b654a102f32583e7cc3b5999c22c1dba69a5aa4365870cc4b88b75b1ac0b4d94b979a
     HEAD_REF master
 )
 
 file(
-    COPY 
-        ${SOURCE_PATH}/include/atomic_queue/atomic_queue.h 
-        ${SOURCE_PATH}/include/atomic_queue/atomic_queue_mutex.h 
-        ${SOURCE_PATH}/include/atomic_queue/barrier.h 
-        ${SOURCE_PATH}/include/atomic_queue/defs.h 
-        ${SOURCE_PATH}/include/atomic_queue/spinlock.h 
-    DESTINATION 
-        ${CURRENT_PACKAGES_DIR}/include/atomic_queue
+    COPY
+        "${SOURCE_PATH}/include/atomic_queue/atomic_queue.h"
+        "${SOURCE_PATH}/include/atomic_queue/atomic_queue_mutex.h"
+        "${SOURCE_PATH}/include/atomic_queue/barrier.h"
+        "${SOURCE_PATH}/include/atomic_queue/defs.h"
+        "${SOURCE_PATH}/include/atomic_queue/spinlock.h"
+    DESTINATION
+        "${CURRENT_PACKAGES_DIR}/include/atomic_queue"
 )
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/atomic-queue/vcpkg.json
+++ b/ports/atomic-queue/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "atomic-queue",
-  "version-date": "2021-05-03",
+  "version": "1.5",
   "description": "Minimalistic header-only thread-safe ultra-low-latency multiple-producer-multiple-consumer lockless queues based on circular buffer with std::atomic.",
-  "homepage": "https://github.com/max0x7ba/atomic_queue"
+  "homepage": "https://github.com/max0x7ba/atomic_queue",
+  "license": "MIT"
 }

--- a/versions/a-/atomic-queue.json
+++ b/versions/a-/atomic-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "045962c06085fe2da8633106b2170b29f4febe47",
+      "version": "1.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "a32a426d9c16a0067532134ecb6680ee7928f7f7",
       "version-date": "2021-05-03",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -309,7 +309,7 @@
       "port-version": 3
     },
     "atomic-queue": {
-      "baseline": "2021-05-03",
+      "baseline": "1.5",
       "port-version": 0
     },
     "attr": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
