### PR TITLE
[lua] fix download urls

### DIFF
--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -51,4 +51,4 @@ endif()
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake.in"  "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -1,5 +1,5 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.lua.org/ftp/lua-${VERSION}.tar.gz"
+    URLS "https://lua.org/ftp/lua-${VERSION}.tar.gz"
     FILENAME "lua-${VERSION}.tar.gz"
     SHA512 d90c6903355ee1309cb0d92a8a024522ff049091a117ea21efb585b5de35776191cd67d17a65b18c2f9d374795b7c944f047576f0e3fe818d094b26f0e4845c5
 )

--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -51,4 +51,4 @@ endif()
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake.in"  "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")
+vcpkg_install_copyright(FILE_LIST "${CMAKE_CURRENT_LIST_DIR}/COPYRIGHT")

--- a/ports/lua/vcpkg.json
+++ b/ports/lua/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lua",
   "version": "5.4.6",
+  "port-version": 1,
   "description": "A powerful, fast, lightweight, embeddable scripting language",
   "homepage": "https://www.lua.org",
   "license": null,

--- a/ports/lua/vcpkg.json
+++ b/ports/lua/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "5.4.6",
   "port-version": 1,
   "description": "A powerful, fast, lightweight, embeddable scripting language",
-  "homepage": "https://www.lua.org",
+  "homepage": "https://lua.org",
   "license": null,
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5310,7 +5310,7 @@
     },
     "lua": {
       "baseline": "5.4.6",
-      "port-version": 0
+      "port-version": 1
     },
     "lua-compat53": {
       "baseline": "0.10",

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0757dfdda074a9d2b8f292b7008c5e616dbd5a4b",
+      "git-tree": "85ab916105c7ecb26a346b5be951bb7f9228b56c",
       "version": "5.4.6",
       "port-version": 1
     },

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0757dfdda074a9d2b8f292b7008c5e616dbd5a4b",
+      "version": "5.4.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "a25521a101ee330fd29139a6d4f377be3d814326",
       "version": "5.4.6",
       "port-version": 0

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2e6956cd07839a4fafb5bdb5a4afb1a7c5d73389",
+      "git-tree": "60647faeb0c64f5cd2a33abda7c64a99d6c7029c",
       "version": "5.4.6",
       "port-version": 1
     },

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "85ab916105c7ecb26a346b5be951bb7f9228b56c",
+      "git-tree": "2e6956cd07839a4fafb5bdb5a4afb1a7c5d73389",
       "version": "5.4.6",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes port `lua` download error:
````
warning: Download failed -- retrying after 4000ms
error: Failed to download from mirror set
error: https://www.lua.org/ftp/lua-5.4.6.tar.gz: WinHttpSendRequest failed with exit code 12175
error: https://www.lua.org/ftp/lua-5.4.6.tar.gz: WinHttpSendRequest failed with exit code 12175
error: https://www.lua.org/ftp/lua-5.4.6.tar.gz: WinHttpSendRequest failed with exit code 12175
error: https://www.lua.org/ftp/lua-5.4.6.tar.gz: WinHttpSendRequest failed with exit code 12175
[DEBUG] D:\a\_work\1\s\src\vcpkg\base\downloads.cpp(1048):
[DEBUG] Time in subprocesses: 0us
[DEBUG] Time in parsing JSON: 3us
[DEBUG] Time in JSON reader: 0us
[DEBUG] Time in filesystem: 1625us
[DEBUG] Time in loading ports: 0us
[DEBUG] Exiting after 9.1 s (9060934us)

CMake Error at scripts/cmake/vcpkg_download_distfile.cmake:32 (message):

      Failed to download file with error: 1
      If you are using a proxy, please check your proxy setting. Possible causes are:

````
The upstream download address has changed, I modified the URLS.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.