### PR TITLE
[gettext] Fix osx

### DIFF
--- a/ports/gettext/assume-modern-darwin.patch
+++ b/ports/gettext/assume-modern-darwin.patch
@@ -1,0 +1,26 @@
+diff --git a/gettext-runtime/configure b/gettext-runtime/configure
+index a984774..f436a19 100755
+--- a/gettext-runtime/configure
++++ b/gettext-runtime/configure
+@@ -35448,7 +35448,7 @@ fi
+       haiku*) use_elf_origin_trick=yes ;;
+       # On Mac OS X 10.4 or newer, use Mac OS X tools. See
+       # <https://wincent.com/wiki/@executable_path,_@load_path_and_@rpath>.
+-      darwin | darwin[1-7].*) ;;
++      darwin[1-7].*) ;;
+       darwin*) use_macos_tools=yes ;;
+     esac
+     if test $is_noop = yes; then
+diff --git a/gettext-tools/configure b/gettext-tools/configure
+index ee64b69..2dde1f5 100755
+--- a/gettext-tools/configure
++++ b/gettext-tools/configure
+@@ -48606,7 +48606,7 @@ fi
+       haiku*) use_elf_origin_trick=yes ;;
+       # On Mac OS X 10.4 or newer, use Mac OS X tools. See
+       # <https://wincent.com/wiki/@executable_path,_@load_path_and_@rpath>.
+-      darwin | darwin[1-7].*) ;;
++      darwin[1-7].*) ;;
+       darwin*) use_macos_tools=yes ;;
+     esac
+     if test $is_noop = yes; then

--- a/ports/gettext/config-step-order.patch
+++ b/ports/gettext/config-step-order.patch
@@ -1,5 +1,5 @@
 diff --git a/gettext-runtime/configure b/gettext-runtime/configure
-index ed6cb37..780cc84 100644
+index 2a376c6..a984774 100755
 --- a/gettext-runtime/configure
 +++ b/gettext-runtime/configure
 @@ -22346,6 +22346,12 @@ printf "%s\n" "$acl_cv_libdirstems" >&6; }
@@ -8,23 +8,23 @@ index ed6cb37..780cc84 100644
  
 +### Configuration step reordering
 +### Similar to AM_GNU_GETTEXT(external,...), cf. gettext-runtime/m4/gettext.m4
-+### Pull iconv lookup before actual GNU gettext lookup.
-+for configuration_step in gettext-iconv gettext-main; do
++### Pull (include_next and) iconv lookup before actual GNU gettext lookup.
++for configuration_step in gettext-independent gettext-main ; do
 +case "$configuration_step" in
 +gettext-main)
      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for CFPreferencesCopyAppValue" >&5
  printf %s "checking for CFPreferencesCopyAppValue... " >&6; }
  if test ${gt_cv_func_CFPreferencesCopyAppValue+y}
-@@ -29535,6 +29541,9 @@ printf "%s\n" "#define HAVE_WEAK_SYMBOLS 1" >>confdefs.h
+@@ -23288,6 +23294,9 @@ printf "%s\n" "#define HAVE_DCGETTEXT 1" >>confdefs.h
  
  
  
 +### Configuration step reordering
 +;;
-+gettext-iconv)
-     use_additional=yes
- 
-   acl_save_prefix="$prefix"
++gettext-independent)
+                         # Check whether --enable-cross-guesses was given.
+ if test ${enable_cross_guesses+y}
+ then :
 @@ -30464,6 +30473,10 @@ printf "%s\n" "$gl_cv_next_iconv_h" >&6; }
         gl_next_as_first_directive=$gl_cv_next_iconv_h
       fi
@@ -37,7 +37,7 @@ index ed6cb37..780cc84 100644
  
  
 diff --git a/gettext-tools/configure b/gettext-tools/configure
-index b4a4f93..17b05c8 100644
+index 5ce6cf1..ee64b69 100755
 --- a/gettext-tools/configure
 +++ b/gettext-tools/configure
 @@ -25735,6 +25735,12 @@ printf "%s\n" "$acl_cv_libdirstems" >&6; }
@@ -46,23 +46,23 @@ index b4a4f93..17b05c8 100644
  
 +### Configuration step reordering
 +### Similar to AM_GNU_GETTEXT(external,...), cf. gettext-runtime/m4/gettext.m4
-+### Pull iconv lookup before actual GNU gettext lookup.
-+for configuration_step in gettext-iconv gettext-main; do
++### Pull (include_next and) iconv lookup before actual GNU gettext lookup.
++for configuration_step in gettext-independent gettext-main; do
 +case "$configuration_step" in
 +gettext-main)
      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for CFPreferencesCopyAppValue" >&5
  printf %s "checking for CFPreferencesCopyAppValue... " >&6; }
  if test ${gt_cv_func_CFPreferencesCopyAppValue+y}
-@@ -37529,6 +37535,9 @@ printf "%s\n" "#define HAVE_WEAK_SYMBOLS 1" >>confdefs.h
+@@ -27588,6 +27594,9 @@ fi
  
  
  
 +### Configuration step reordering
 +;;
-+gettext-iconv)
-     use_additional=yes
- 
-   acl_save_prefix="$prefix"
++gettext-independent)
+                         # Check whether --enable-cross-guesses was given.
+ if test ${enable_cross_guesses+y}
+ then :
 @@ -38458,6 +38467,10 @@ printf "%s\n" "$gl_cv_next_iconv_h" >&6; }
         gl_next_as_first_directive=$gl_cv_next_iconv_h
       fi

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
+        assume-modern-darwin.patch
         uwp.patch
         rel_path.patch
         subdirs.patch

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gettext",
   "version": "0.22.4",
+  "port-version": 1,
   "description": "A GNU framework to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2934,7 +2934,7 @@
     },
     "gettext": {
       "baseline": "0.22.4",
-      "port-version": 0
+      "port-version": 1
     },
     "gettext-libintl": {
       "baseline": "0.22.4",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd31edd407c0889c864c1e8854be92b602a4e29f",
+      "version": "0.22.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "e30ed5daac31351d72a221b74c1b8c4ecd06b694",
       "version": "0.22.4",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/35778: With the necessary libiconv check before the gettext check, we also need the include_next check before the libiconv check. Instead of pulling the libiconv check in before the gettext check, push the gettext check behind everything up to the libiconv check: I didn't spot any references to GETTEXT or LIBINTL dependencies in the now-early checks.

Fixes failing cross builds for osx targets: There is probably an upstream bug around relocatable installations, but it is only visible when building for ...-darwin auto tools triplets without trailing release number. Vcpkg uses such triplets for cross builds (and it generally doesn't set the osx deployment target for arm64-osx). The patch aligns cross-builds with native builds on osx >= 10.4.