### PR TITLE
[realsense2] Add support !arm

### DIFF
--- a/ports/realsense2/vcpkg.json
+++ b/ports/realsense2/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "realsense2",
   "version": "2.54.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).",
   "homepage": "https://github.com/IntelRealSense/librealsense",
   "license": "Apache-2.0",
-  "supports": "!uwp",
+  "supports": "!uwp & !arm",
   "dependencies": [
     {
       "name": "libusb",

--- a/ports/realsense2/vcpkg.json
+++ b/ports/realsense2/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).",
   "homepage": "https://github.com/IntelRealSense/librealsense",
   "license": "Apache-2.0",
-  "supports": "!uwp & !arm",
+  "supports": "!uwp & !(windows & arm)",
   "dependencies": [
     {
       "name": "libusb",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -990,7 +990,6 @@ rbdl-orb:x64-osx=skip
 rbdl:arm-neon-android=fail
 rbdl:arm64-android=fail
 rbdl:x64-android=fail
-realsense2:arm64-windows=fail
 replxx:arm-neon-android=fail
 replxx:arm64-android=fail
 replxx:x64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7430,7 +7430,7 @@
     },
     "realsense2": {
       "baseline": "2.54.2",
-      "port-version": 1
+      "port-version": 2
     },
     "recast": {
       "baseline": "deprecated",

--- a/versions/r-/realsense2.json
+++ b/versions/r-/realsense2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5179ab41135dff03e38531bc532d0fe5c4bcdc20",
+      "git-tree": "b15354f0a205d2288e63564e2789e317442bd999",
       "version": "2.54.2",
       "port-version": 2
     },

--- a/versions/r-/realsense2.json
+++ b/versions/r-/realsense2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5179ab41135dff03e38531bc532d0fe5c4bcdc20",
+      "version": "2.54.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "17434b2bd3e05364a70afea06d2d7ccb9db544c6",
       "version": "2.54.2",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/35628
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
