### PR TITLE
[NEW] SFCGAL

### DIFF
--- a/ports/sfcgal/portfile.cmake
+++ b/ports/sfcgal/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_cmake_configure(
 	-DBUILD_TESTING=OFF
 	)
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH bin/sfcgal-config)
 vcpkg_fixup_pkgconfig()

--- a/ports/sfcgal/portfile.cmake
+++ b/ports/sfcgal/portfile.cmake
@@ -1,0 +1,29 @@
+# Header only
+vcpkg_buildpath_length_warning(37)
+
+vcpkg_from_gitlab(
+	GITLAB_URL https://gitlab.com
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO Oslandia/SFCGAL
+	REF v1.5.1
+	SHA512 8d33235512a14997b00b4419f42d1195fd40186b56af63cd4494555031799af2a2fc1d0b3c2cd706ce8f6fc6be844af60be3a57774515326a782494e1de44ec2 
+	HEAD_REF master
+	)
+
+
+vcpkg_cmake_configure(
+	SOURCE_PATH "${SOURCE_PATH}"
+	OPTIONS
+	-DSFCGAL_BUILD_TESTS=OFF
+	-DBUILD_TESTING=OFF
+	)
+
+vcpkg_install_cmake()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH bin/sfcgal-config)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+

--- a/ports/sfcgal/vcpkg.json
+++ b/ports/sfcgal/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "sfcgal",
+  "version": "1.5.1",
+  "description": "sfcgal is a C++ wrapper library around CGAL with the aim of supporting ISO 191007:2013 and OGC Simple Features for 3D operations.",
+  "homepage": "https://gitlab.com/Oslandia/SFCGAL",
+  "license": "LGPL-2.0-or-later",
+  "supports": "!xbox",
+  "dependencies": [
+    "cgal",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/sfcgal/vcpkg.json
+++ b/ports/sfcgal/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "sfcgal is a C++ wrapper library around CGAL with the aim of supporting ISO 191007:2013 and OGC Simple Features for 3D operations.",
   "homepage": "https://gitlab.com/Oslandia/SFCGAL",
   "license": "LGPL-2.0-or-later",
-  "supports": "!xbox",
+  "supports": "!(arm32 | x86 | xbox)",
   "dependencies": [
     "cgal",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7824,6 +7824,10 @@
       "baseline": "0.2.0",
       "port-version": 4
     },
+    "sfcgal": {
+      "baseline": "1.5.1",
+      "port-version": 0
+    },
     "sfgui": {
       "baseline": "0.4.0",
       "port-version": 6

--- a/versions/s-/sfcgal.json
+++ b/versions/s-/sfcgal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b771f2b74411fc0d172f4726f856c966d763b152",
+      "git-tree": "aac87c83280d209e7913346ed128c8eb0d702ca4",
       "version": "1.5.1",
       "port-version": 0
     }

--- a/versions/s-/sfcgal.json
+++ b/versions/s-/sfcgal.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b771f2b74411fc0d172f4726f856c966d763b152",
+      "version": "1.5.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
SFCGAL is a C++ wrapper library around CGAL with the aim of supporting ISO
19107:2013 and OGC Simple Features Access 1.2 for 3D operations.

SFCGAL provides standard compliant geometry types and operations, that can be
accessed from its C or C++ APIs. PostGIS uses the C API, to expose some
SFCGAL's functions in spatial databases

https://gitlab.com/sfcgal/SFCGAL
https://sfcgal.org/

Nota: I am the primary maintainer of SFCGAL. I also handle its packaging on FreeBSD and MSYS2/MinGW. I commit to ensuring its maintenance and further development.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.

