### PR TITLE
[fast-float] update to 6.0.0

### DIFF
--- a/ports/fast-float/portfile.cmake
+++ b/ports/fast-float/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fastfloat/fast_float
     REF "v${VERSION}"
-    SHA512 c703c7cba3c69775317c66a62ce145646fd7d3d063124501e3d6a7deebb8c62c14a2ccdffed18de2d73d9d3a8ba2061ef1d34cc780ee0b6d607935d5f1b1de81
+    SHA512 37280efebea7aa33cc25c8d8375b6c9456a8025d29d618abb5aac580c025097a6110ec3a913d1504fd9af1df43e434bc5411e07e38dd66c12491f3edc7374fff
     HEAD_REF master
 )
 

--- a/ports/fast-float/vcpkg.json
+++ b/ports/fast-float/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-float",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "Fast and exact implementation of the C++ from_chars functions for float and double types: 4x faster than strtod",
   "homepage": "https://github.com/fastfloat/fast_float",
   "license": "Apache-2.0 OR BSL-1.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2545,7 +2545,7 @@
       "port-version": 2
     },
     "fast-float": {
-      "baseline": "5.2.0",
+      "baseline": "6.0.0",
       "port-version": 0
     },
     "fastcdr": {

--- a/versions/f-/fast-float.json
+++ b/versions/f-/fast-float.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f36d745c12126b63e7f6b1dc5f41f6c644e1367",
+      "version": "6.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b78d9590504b99e64f96cdddac42bf67fed57feb",
       "version": "5.2.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #35842
Update fast-float to the latest version 6.0.0

Note: no feature need to test.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.