### PR TITLE
[recastnavigation] Make detail mesh edge detection more robust

### DIFF
--- a/ports/recastnavigation/fix-detail-mesh-edge-detection.patch
+++ b/ports/recastnavigation/fix-detail-mesh-edge-detection.patch
@@ -1,0 +1,103 @@
+diff --git a/Recast/Source/RecastMeshDetail.cpp b/Recast/Source/RecastMeshDetail.cpp
+index 40f5b8c..d83bf1c 100644
+--- a/Recast/Source/RecastMeshDetail.cpp
++++ b/Recast/Source/RecastMeshDetail.cpp
+@@ -634,6 +634,40 @@ inline float getJitterY(const int i)
+ 	return (((i * 0xd8163841) & 0xffff) / 65535.0f * 2.0f) - 1.0f;
+ }
+ 
++static bool onHull(int a, int b, int nhull, int* hull)
++{
++	// All internal sampled points come after the hull so we can early out for those.
++	if (a >= nhull || b >= nhull)
++		return false;
++
++	for (int j = nhull - 1, i = 0; i < nhull; j = i++)
++	{
++		if (a == hull[j] && b == hull[i])
++			return true;
++	}
++
++	return false;
++}
++
++// Find edges that lie on hull and mark them as such.
++static void setTriFlags(rcIntArray& tris, int nhull, int* hull)
++{
++	// Matches DT_DETAIL_EDGE_BOUNDARY
++	const int DETAIL_EDGE_BOUNDARY = 0x1;
++
++	for (int i = 0; i < tris.size(); i += 4)
++	{
++		int a = tris[i + 0];
++		int b = tris[i + 1];
++		int c = tris[i + 2];
++		unsigned short flags = 0;
++		flags |= (onHull(a, b, nhull, hull) ? DETAIL_EDGE_BOUNDARY : 0) << 0;
++		flags |= (onHull(b, c, nhull, hull) ? DETAIL_EDGE_BOUNDARY : 0) << 2;
++		flags |= (onHull(c, a, nhull, hull) ? DETAIL_EDGE_BOUNDARY : 0) << 4;
++		tris[i + 3] = (int)flags;
++	}
++}
++
+ static bool buildPolyDetail(rcContext* ctx, const float* in, const int nin,
+ 							const float sampleDist, const float sampleMaxError,
+ 							const int heightSearchRadius, const rcCompactHeightfield& chf,
+@@ -771,6 +805,7 @@ static bool buildPolyDetail(rcContext* ctx, const float* in, const int nin,
+ 	if (minExtent < sampleDist*2)
+ 	{
+ 		triangulateHull(nverts, verts, nhull, hull, nin, tris);
++		setTriFlags(tris, nhull, hull);
+ 		return true;
+ 	}
+ 	
+@@ -875,7 +910,8 @@ static bool buildPolyDetail(rcContext* ctx, const float* in, const int nin,
+ 		tris.resize(MAX_TRIS*4);
+ 		ctx->log(RC_LOG_ERROR, "rcBuildPolyMeshDetail: Shrinking triangle count from %d to max %d.", ntris, MAX_TRIS);
+ 	}
+-	
++
++	setTriFlags(tris, nhull, hull);	
+ 	return true;
+ }
+ 
+@@ -1137,30 +1173,6 @@ static void getHeightData(rcContext* ctx, const rcCompactHeightfield& chf,
+ 	}
+ }
+ 
+-static unsigned char getEdgeFlags(const float* va, const float* vb,
+-								  const float* vpoly, const int npoly)
+-{
+-	// The flag returned by this function matches dtDetailTriEdgeFlags in Detour.
+-	// Figure out if edge (va,vb) is part of the polygon boundary.
+-	static const float thrSqr = rcSqr(0.001f);
+-	for (int i = 0, j = npoly-1; i < npoly; j=i++)
+-	{
+-		if (distancePtSeg2d(va, &vpoly[j*3], &vpoly[i*3]) < thrSqr &&
+-			distancePtSeg2d(vb, &vpoly[j*3], &vpoly[i*3]) < thrSqr)
+-			return 1;
+-	}
+-	return 0;
+-}
+-
+-static unsigned char getTriFlags(const float* va, const float* vb, const float* vc,
+-								 const float* vpoly, const int npoly)
+-{
+-	unsigned char flags = 0;
+-	flags |= getEdgeFlags(va,vb,vpoly,npoly) << 0;
+-	flags |= getEdgeFlags(vb,vc,vpoly,npoly) << 2;
+-	flags |= getEdgeFlags(vc,va,vpoly,npoly) << 4;
+-	return flags;
+-}
+ 
+ /// @par
+ ///
+@@ -1377,7 +1389,7 @@ bool rcBuildPolyMeshDetail(rcContext* ctx, const rcPolyMesh& mesh, const rcCompa
+ 			dmesh.tris[dmesh.ntris*4+0] = (unsigned char)t[0];
+ 			dmesh.tris[dmesh.ntris*4+1] = (unsigned char)t[1];
+ 			dmesh.tris[dmesh.ntris*4+2] = (unsigned char)t[2];
+-			dmesh.tris[dmesh.ntris*4+3] = getTriFlags(&verts[t[0]*3], &verts[t[1]*3], &verts[t[2]*3], poly, npoly);
++			dmesh.tris[dmesh.ntris*4+3] = (unsigned char)t[3];
+ 			dmesh.ntris++;
+ 		}
+ 	}

--- a/ports/recastnavigation/portfile.cmake
+++ b/ports/recastnavigation/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v${VERSION}
     SHA512 7567aaa78219cc490a6f76210fba1f130f0c17aeaa06432ab1207e0fd03404abe31042e8b03971aa0d04ad65d39469f13575fe0072fb920c38581d39568b70fb
     HEAD_REF master
+    PATCHES
+        fix-detail-mesh-edge-detection.patch #Upstream fix https://github.com/recastnavigation/recastnavigation/pull/657
 )
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -25,4 +27,4 @@ vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")

--- a/ports/recastnavigation/vcpkg.json
+++ b/ports/recastnavigation/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "recastnavigation",
   "version": "1.6.0",
+  "port-version": 1,
   "description": "Navigation-mesh Toolset for Games",
   "homepage": "https://github.com/recastnavigation/recastnavigation",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7438,7 +7438,7 @@
     },
     "recastnavigation": {
       "baseline": "1.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "recycle": {
       "baseline": "6.0.0",

--- a/versions/r-/recastnavigation.json
+++ b/versions/r-/recastnavigation.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "806d9850ce88d7190649eb90863455084516d519",
+      "version": "1.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d08244dcfe4974f58b9dd481f1e3e34414a46207",
       "version": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/35844.
Add patch to include important nullptr dereference fixed
https://github.com/recastnavigation/recastnavigation/commit/c393777d26d2ff6519ac23612abf8af42678c9dd

It will be deleted in the next version update.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
