### PR TITLE
[imageinfo] Bump to 2023-12-25

### DIFF
--- a/ports/imageinfo/portfile.cmake
+++ b/ports/imageinfo/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiaozhuai/imageinfo
-    REF 724301f7ef5e29410e78cd900ae25f9fa2e3080a # committed on 2023-01-31
-    SHA512 b9ba5d2ec5698b9eee4eb07e0dbb50d0f361e730b6d468ac6e4c90b29375f6468f45214573673de5f9388d532794f922a556153d34cba5d6ccec854c20d34506
+    REF eb2f4a0727d425ecfe2debd3475bea1f570b1a8d # committed on 2023-12-25
+    SHA512 1f03ff2dbe49d27e757b66c57c28e8a53ddbe372b20bb3f5891d1644dd885a851f55fb40c42637ca3528023b37e1b980b11cbe64fa5484f12a2c462052ae247a
     HEAD_REF master
 )
 
@@ -16,9 +16,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/imageinfo)
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/imageinfo/vcpkg.json
+++ b/ports/imageinfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imageinfo",
-  "version-date": "2023-01-31",
+  "version-date": "2023-12-25",
   "description": "Cross platform super fast single header c++ library to get image size and format without loading/decoding. Support avif, bmp, cur, dds, gif, hdr (pic), heic (heif), icns, ico, jp2, jpeg (jpg), jpx, ktx, png, psd, qoi, tga, tiff (tif), webp ...",
   "homepage": "https://github.com/xiaozhuai/imageinfo",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3501,7 +3501,7 @@
       "port-version": 0
     },
     "imageinfo": {
-      "baseline": "2023-01-31",
+      "baseline": "2023-12-25",
       "port-version": 0
     },
     "imath": {

--- a/versions/i-/imageinfo.json
+++ b/versions/i-/imageinfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0061c49ae5be9cb32e197fd56a0a71e793d49f42",
+      "version-date": "2023-12-25",
+      "port-version": 0
+    },
+    {
       "git-tree": "66f45650934f8561d3779ca4a29d808b8d1cea98",
       "version-date": "2023-01-31",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

