### PR TITLE
[libexif] Fix dependency errors

### DIFF
--- a/ports/libexif/portfile.cmake
+++ b/ports/libexif/portfile.cmake
@@ -9,19 +9,10 @@ vcpkg_from_github(
         fix-ssize.patch
 )
 
-vcpkg_list(SET options)
-if("nls" IN_LIST FEATURES)
-    vcpkg_list(APPEND options "--enable-nls")
-else()
-    set(ENV{AUTOPOINT} true) # true, the program
-    vcpkg_list(APPEND options "--disable-nls")
-endif()
-
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     OPTIONS
-        ${options}
         --enable-internal-docs=no
         --enable-ship-binaries=no
 )

--- a/ports/libexif/vcpkg.json
+++ b/ports/libexif/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libexif",
   "version": "0.6.24",
-  "port-version": 1,
+  "port-version": 2,
   "description": "a library for parsing, editing, and saving EXIF data",
   "homepage": "https://libexif.github.io/",
   "license": "LGPL-2.1-or-later",
@@ -10,24 +10,10 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+        "name": "gettext",
+        "host": true
     }
-  ],
-  "default-features": [
-    "nls"
-  ],
-  "features": {
-    "nls": {
-      "description": "Enable native language support.",
-      "dependencies": [
-        {
-          "name": "gettext",
-          "host": true,
-          "features": [
-            "tools"
-          ]
-        },
-        "gettext-libintl"
-      ]
-    }
-  }
+  ]
 }

--- a/ports/libexif/vcpkg.json
+++ b/ports/libexif/vcpkg.json
@@ -8,12 +8,12 @@
   "supports": "!uwp",
   "dependencies": [
     {
-      "name": "vcpkg-cmake",
+      "name": "gettext",
       "host": true
     },
     {
-        "name": "gettext",
-        "host": true
+      "name": "vcpkg-cmake",
+      "host": true
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4270,7 +4270,7 @@
     },
     "libexif": {
       "baseline": "0.6.24",
-      "port-version": 1
+      "port-version": 2
     },
     "libfabric": {
       "baseline": "1.13.2",

--- a/versions/l-/libexif.json
+++ b/versions/l-/libexif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a2305d4d5b3048bdb5aa1285e3cb326224fc2b66",
+      "version": "0.6.24",
+      "port-version": 2
+    },
+    {
       "git-tree": "40f7058e18a937bab35b7213595fc4eef5de7dec",
       "version": "0.6.24",
       "port-version": 1

--- a/versions/l-/libexif.json
+++ b/versions/l-/libexif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a2305d4d5b3048bdb5aa1285e3cb326224fc2b66",
+      "git-tree": "995fd896fe80baaf0faa8e72e59fdae414751544",
       "version": "0.6.24",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/35610

`Can't exec "autopoint": No such file or directory at /usr/share/autoconf-2.71/Autom4te/FileUtils.pm line 293.`
Fix `libexif[core]` compilation error and add dependency on `gettext`.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
