### PR TITLE
[imgui] Add support for feature android-binding

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -36,6 +36,10 @@ if(IMGUI_BUILD_ALLEGRO5_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_allegro5.cpp)
 endif()
 
+if(IMGUI_BUILD_ANDROID_BINDING)
+    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_android.cpp)
+endif()
+
 if(IMGUI_BUILD_DX9_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx9.cpp)
 endif()
@@ -156,6 +160,10 @@ if(NOT IMGUI_SKIP_HEADERS)
 
     if(IMGUI_BUILD_ALLEGRO5_BINDING)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_allegro5.h DESTINATION include)
+    endif()
+
+    if (IMGUI_BUILD_ANDROID_BINDING)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_android.h DESTINATION include)
     endif()
 
     if(IMGUI_BUILD_DX9_BINDING)

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -24,6 +24,7 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES 
     allegro5-binding            IMGUI_BUILD_ALLEGRO5_BINDING
+    android-binding             IMGUI_BUILD_ANDROID_BINDING
     dx9-binding                 IMGUI_BUILD_DX9_BINDING
     dx10-binding                IMGUI_BUILD_DX10_BINDING
     dx11-binding                IMGUI_BUILD_DX11_BINDING

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "imgui",
   "version": "1.90",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",
@@ -21,6 +21,10 @@
       "dependencies": [
         "allegro5"
       ]
+    },
+    "android-binding": {
+      "description": "Make available Android native app support",
+      "supports": "android"
     },
     "docking-experimental": {
       "description": "Build with docking support"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3510,7 +3510,7 @@
     },
     "imgui": {
       "baseline": "1.90",
-      "port-version": 2
+      "port-version": 3
     },
     "imgui-node-editor": {
       "baseline": "0.9.3",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12ab98a00e6c2eda3393c25bda6458194d0cc42c",
+      "version": "1.90",
+      "port-version": 3
+    },
+    {
       "git-tree": "a9fd7997ab3813f71b87171213ea8fbd4e70b863",
       "version": "1.90",
       "port-version": 2


### PR DESCRIPTION
Hello! The feature adds support for imgui initialization for Android ANativeWindow (NDK)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature imgui[android-binding] passed with following triplets:
```
arm64-android
arm-neon-android
x64-android
x86-android
```

Now imgui can be initialized for Android NDK in the same way as for other platforms such as win32 or osx:
```
IMGUI_CHECKVERSION();
ImGui::CreateContext();

ImGui_ImplAndroid_Init(_app->window); // <-- initialize for ANativeWindow 
ImGui_ImplOpenGL3_Init("#version 300 es");
...
```