### PR TITLE
[libofx] Fix opensp link method

### DIFF
--- a/ports/libofx/fix_link_opensp.patch
+++ b/ports/libofx/fix_link_opensp.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cd97e84..294279d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,7 +59,8 @@ endif (NOT CMAKE_BUILD_TYPE)
+ include(CTest)
+ 
+ # locate required dependencies
+-find_package(OpenSP)
++find_package(PkgConfig)
++pkg_check_modules(OpenSP REQUIRED IMPORTED_TARGET opensp)
+ set_package_properties(OpenSP PROPERTIES TYPE REQUIRED PURPOSE "The underlying library that the LibOFX builds upon, we cannot build without it!")
+ 
+ # locate optional dependencies
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 856aa11..5106ded 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -47,7 +47,7 @@ set_target_properties(libofx PROPERTIES SOVERSION ${LIBOFX_LIBRARY_SONAME})
+ set_target_properties(libofx PROPERTIES VERSION ${LIBOFX_LIBRARY_VERSION})
+ set_target_properties(libofx PROPERTIES PREFIX "")
+ 
+-target_link_libraries(libofx OpenSP::OpenSP)
++target_link_libraries(libofx PkgConfig::OpenSP)
+ target_include_directories(libofx BEFORE
+         PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/inc> $<INSTALL_INTERFACE:include>
+         PRIVATE ${CMAKE_BINARY_DIR}

--- a/ports/libofx/portfile.cmake
+++ b/ports/libofx/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 0.10.9
     SHA512 be7b77f77a012fe04121c615b88f674bba11f79b5353b3c4594de395f9f787c3a9b6910693f5ba701421387fc13c13e7977ab73893e18c6a0b6e1292b7d1cfe2
     HEAD_REF master
+    PATCHES
+        fix_link_opensp.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libofx/portfile.cmake
+++ b/ports/libofx/portfile.cmake
@@ -17,22 +17,14 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 vcpkg_find_acquire_program(PKGCONFIG)
 
-if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    set(path_suffix "/debug")
-endif()
-if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-    set(path_suffix "")
-endif()
-vcpkg_backup_env_variables(VARS PKG_CONFIG_PATH)
-vcpkg_host_path_list(PREPEND ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}${path_suffix}/lib/pkgconfig")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DENABLE_OFXCONNECT=OFF # depends on libxml++ ABI 2.6, while vcpkg ships ABI 4.0. See https://libxmlplusplus.github.io/libxmlplusplus/#abi-versions
         ${FEATURE_OPTIONS}
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
 )
-vcpkg_restore_env_variables(VARS PKG_CONFIG_PATH)
 
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()

--- a/ports/libofx/portfile.cmake
+++ b/ports/libofx/portfile.cmake
@@ -27,6 +27,13 @@ vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(PACKAGE_NAME LibOFX CONFIG_PATH lib/cmake/libofx)
 vcpkg_copy_pdbs()
 
+vcpkg_replace_string(
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/LibOFXTargets.cmake"
+    [[# Create imported target libofx::libofx]]
+    [[# Create imported target libofx::libofx 
+find_package(PkgConfig) 
+pkg_check_modules(OpenSP REQUIRED IMPORTED_TARGET opensp)]])
+
 list(REMOVE_ITEM FEATURES core iconv)
 if(FEATURES)
     vcpkg_copy_tools(TOOL_NAMES ${FEATURES} AUTO_CLEAN)

--- a/ports/libofx/portfile.cmake
+++ b/ports/libofx/portfile.cmake
@@ -35,8 +35,7 @@ vcpkg_replace_string(
     "${CURRENT_PACKAGES_DIR}/share/LibOFX/LibOFXTargets.cmake"
     [[# Create imported target libofx::libofx]]
     [[# Create imported target libofx::libofx 
-find_package(PkgConfig) 
-pkg_check_modules(OpenSP REQUIRED IMPORTED_TARGET opensp)]])
+include(${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/libofx/FindOpenSP.cmake)]])
 
 list(REMOVE_ITEM FEATURES core iconv)
 if(FEATURES)

--- a/ports/libofx/portfile.cmake
+++ b/ports/libofx/portfile.cmake
@@ -15,12 +15,24 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "ofx2qif"     ENABLE_OFX2QIF
 )
 
+vcpkg_find_acquire_program(PKGCONFIG)
+
+if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    set(path_suffix "/debug")
+endif()
+if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    set(path_suffix "")
+endif()
+vcpkg_backup_env_variables(VARS PKG_CONFIG_PATH)
+vcpkg_host_path_list(PREPEND ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}${path_suffix}/lib/pkgconfig")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DENABLE_OFXCONNECT=OFF # depends on libxml++ ABI 2.6, while vcpkg ships ABI 4.0. See https://libxmlplusplus.github.io/libxmlplusplus/#abi-versions
         ${FEATURE_OPTIONS}
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
 )
+vcpkg_restore_env_variables(VARS PKG_CONFIG_PATH)
 
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
@@ -28,7 +40,7 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME LibOFX CONFIG_PATH lib/cmake/libofx)
 vcpkg_copy_pdbs()
 
 vcpkg_replace_string(
-    "${CURRENT_PACKAGES_DIR}/share/${PORT}/LibOFXTargets.cmake"
+    "${CURRENT_PACKAGES_DIR}/share/LibOFX/LibOFXTargets.cmake"
     [[# Create imported target libofx::libofx]]
     [[# Create imported target libofx::libofx 
 find_package(PkgConfig) 

--- a/ports/libofx/vcpkg.json
+++ b/ports/libofx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libofx",
   "version": "0.10.9",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OFX banking protocol abstraction library",
   "homepage": "https://github.com/libofx/libofx",
   "license": "GPL-2.0-only",

--- a/ports/libofx/vcpkg.json
+++ b/ports/libofx/vcpkg.json
@@ -8,13 +8,16 @@
   "supports": "!uwp & !xbox",
   "dependencies": [
     "libopensp",
-    "pkgconf",
     {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "pkgconf",
       "host": true
     }
   ],

--- a/ports/libofx/vcpkg.json
+++ b/ports/libofx/vcpkg.json
@@ -9,15 +9,15 @@
   "dependencies": [
     "libopensp",
     {
+      "name": "pkgconf",
+      "host": true
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
-      "host": true
-    },
-    {
-      "name": "pkgconf",
       "host": true
     }
   ],

--- a/ports/libofx/vcpkg.json
+++ b/ports/libofx/vcpkg.json
@@ -8,6 +8,7 @@
   "supports": "!uwp & !xbox",
   "dependencies": [
     "libopensp",
+    "pkgconf",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4618,7 +4618,7 @@
     },
     "libofx": {
       "baseline": "0.10.9",
-      "port-version": 1
+      "port-version": 2
     },
     "libogg": {
       "baseline": "1.3.5",

--- a/versions/l-/libofx.json
+++ b/versions/l-/libofx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "788b582f72860398d92b411ec68f0cd0f43c8aa0",
+      "git-tree": "6418209a028f5523c6f505434d7f9f4f4b48b42f",
       "version": "0.10.9",
       "port-version": 2
     },

--- a/versions/l-/libofx.json
+++ b/versions/l-/libofx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9d9bfd471fb2bad16c8ef2d0f381c954a6795e30",
+      "git-tree": "b87a96c448b1f51bf82855759110c0fcd63fbce1",
       "version": "0.10.9",
       "port-version": 2
     },

--- a/versions/l-/libofx.json
+++ b/versions/l-/libofx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2bae5c9f44b186a39c6f01f4c2faa51f6d66f302",
+      "git-tree": "61f87f7414dc3b70bd46277da27d5693d1f87bc0",
       "version": "0.10.9",
       "port-version": 2
     },

--- a/versions/l-/libofx.json
+++ b/versions/l-/libofx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f2060ed1632311dc2dd135cdf18065f608f80a2c",
+      "git-tree": "9d9bfd471fb2bad16c8ef2d0f381c954a6795e30",
       "version": "0.10.9",
       "port-version": 2
     },

--- a/versions/l-/libofx.json
+++ b/versions/l-/libofx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2bae5c9f44b186a39c6f01f4c2faa51f6d66f302",
+      "version": "0.10.9",
+      "port-version": 2
+    },
+    {
       "git-tree": "2b01272b9801e2885f990f376956f8058851b9fe",
       "version": "0.10.9",
       "port-version": 1

--- a/versions/l-/libofx.json
+++ b/versions/l-/libofx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "61f87f7414dc3b70bd46277da27d5693d1f87bc0",
+      "git-tree": "788b582f72860398d92b411ec68f0cd0f43c8aa0",
       "version": "0.10.9",
       "port-version": 2
     },

--- a/versions/l-/libofx.json
+++ b/versions/l-/libofx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f48a9cfe2abbbae5e78aa64dc98dff01a39ac1f1",
+      "git-tree": "f2060ed1632311dc2dd135cdf18065f608f80a2c",
       "version": "0.10.9",
       "port-version": 2
     },

--- a/versions/l-/libofx.json
+++ b/versions/l-/libofx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6418209a028f5523c6f505434d7f9f4f4b48b42f",
+      "git-tree": "f48a9cfe2abbbae5e78aa64dc98dff01a39ac1f1",
       "version": "0.10.9",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/33043
```
Undefined symbols for architecture arm64:
  "_bindtextdomain", referenced from:
      OpenSP::GettextMessageTable::registerMessageDomain(OpenSP::MessageModule&, char*, char*) const in libosp.a(MessageTable.o)
  "_dgettext", referenced from:
      OpenSP::GettextMessageTable::getText(OpenSP::MessageFragment const&, OpenSP::String<char>&) const in libosp.a(MessageTable.o)
```
The method of searching for the `opensp` library is wrong, resulting in failure to link.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
x64-osx
```