### PR TITLE
[vxl] Fix missing header files

### DIFF
--- a/ports/vxl/fix_limits.patch
+++ b/ports/vxl/fix_limits.patch
@@ -1,0 +1,12 @@
+diff --git a/core/vnl/vnl_bignum.cxx b/core/vnl/vnl_bignum.cxx
+index b615a9b..741bd43 100644
+--- a/core/vnl/vnl_bignum.cxx
++++ b/core/vnl/vnl_bignum.cxx
+@@ -6,6 +6,7 @@
+ #include <algorithm>
+ #include <vector>
+ #include <iostream>
++#include <limits>
+ #include "vnl_bignum.h"
+ //:
+ // \file

--- a/ports/vxl/portfile.cmake
+++ b/ports/vxl/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
     PATCHES
         fix_dependency.patch
         testlib.patch
+        fix_limits.patch
 )
 
 set(USE_WIN_WCHAR_T OFF)
@@ -43,6 +44,9 @@ vcpkg_cmake_configure(
         -DVXL_USE_DCMTK=OFF # TODO : need fix dcmtk support to turn on
         -DVXL_USE_GEOTIFF=ON
         -DVXL_USE_WIN_WCHAR_T=${USE_WIN_WCHAR_T}
+    MAYBE_UNUSED_VARIABLES
+        VXL_USE_DCMTK
+        VXL_USING_NATIVE_BZLIB2
 )
 
 vcpkg_cmake_install()

--- a/ports/vxl/vcpkg.json
+++ b/ports/vxl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vxl",
   "version": "2.0.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding.",
   "dependencies": [
     "bzip2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9006,7 +9006,7 @@
     },
     "vxl": {
       "baseline": "2.0.2",
-      "port-version": 4
+      "port-version": 5
     },
     "wampcc": {
       "baseline": "2019-09-04",

--- a/versions/v-/vxl.json
+++ b/versions/v-/vxl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63c0db04d12a2dbe25a0ec754983ca25415e3b38",
+      "version": "2.0.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "7a84f7e74335e755ba16066fa148e3d30a9d5af5",
       "version": "2.0.2",
       "port-version": 4


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/32397
```
/mnt/vcpkg/buildtrees/vxl/src/4a7bd1d8ee-ec810ed456/core/vnl/vnl_bignum.cxx: In member function ‘vnl_bignum::operator float() const’:
/mnt/vcpkg/buildtrees/vxl/src/4a7bd1d8ee-ec810ed456/core/vnl/vnl_bignum.cxx:716:37: error: ‘numeric_limits’ is not a member of ‘std’
  716 |   if (this->is_infinity()) f = std::numeric_limits<float>::infinity();
```
The function cannot be found due to the lack of header files. Add the corresponding header files.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Compile test pass with following triplets:
```
x64-linux
```