### PR TITLE
[libdatachannel] Fix failure to link usrsctp on linux

### DIFF
--- a/ports/libdatachannel/fix-for-vcpkg.patch
+++ b/ports/libdatachannel/fix-for-vcpkg.patch
@@ -1,9 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a3837943..2c34d7fb 100644
+index a383794..98de58c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -446,11 +446,25 @@ if(WARNINGS_AS_ERRORS)
-        endif()
+@@ -302,7 +302,7 @@ target_include_directories(datachannel-static PUBLIC
+ target_include_directories(datachannel-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/rtc)
+ target_include_directories(datachannel-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+ target_link_libraries(datachannel-static PRIVATE Threads::Threads)
+-target_link_libraries(datachannel-static PRIVATE Usrsctp::Usrsctp plog::plog)
++target_link_libraries(datachannel-static PRIVATE usrsctp plog::plog)
+ 
+ if(WIN32)
+ 	target_link_libraries(datachannel PUBLIC ws2_32) # winsock2
+@@ -446,11 +446,24 @@ if(WARNINGS_AS_ERRORS)
+ 	endif()
  endif()
  
 +if(DATACHANNEL_STATIC_LINKAGE)
@@ -18,13 +27,12 @@ index a3837943..2c34d7fb 100644
 +else()
 +set_target_properties(datachannel PROPERTIES EXCLUDE_FROM_ALL 0)
 +set_target_properties(datachannel-static PROPERTIES EXCLUDE_FROM_ALL 1)
-+
  install(TARGETS datachannel EXPORT LibDataChannelTargets
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
  )
 +endif()
  
  install(FILES ${LIBDATACHANNEL_HEADERS}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rtc
+ 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rtc

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdatachannel",
   "version-semver": "0.19.4",
+  "port-version": 1,
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4186,7 +4186,7 @@
     },
     "libdatachannel": {
       "baseline": "0.19.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libdatrie": {
       "baseline": "0.2.13",

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fae871627d2ca849e528c15cdf1d1d96b4057f67",
+      "version-semver": "0.19.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "3e45715d7c64f9b22c87aff96594979f11e872a7",
       "version-semver": "0.19.4",
       "port-version": 0


### PR DESCRIPTION
Fixes #35863, fix failure to link `usrsctp` on linux:
```
/usr/bin/ld: cannot find -lUsrsctp::Usrsctp
collect2: error: ld returned 1 exit status
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.