### PR TITLE
[libosmium] Fix and cleanup

### DIFF
--- a/ports/libosmium/portfile.cmake
+++ b/ports/libosmium/portfile.cmake
@@ -1,22 +1,23 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO osmcode/libosmium
     REF "v${VERSION}"
     SHA512 72e881e221dc3e62d7459b5cd84bf65de4fc0149bed66fe0534107d0d4dc30e5d474df685b44af07e6065a690dd7b31b877b5b040b8e0b4b0b971738175c34a3
 )
-set(BOOST_ROOT "${CURRENT_INSTALLED_DIR}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
         -DBUILD_EXAMPLES=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_GDAL=ON
+        # for transitive dependencies via pkgconf 
+        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=1
+        -DVCPKG_HOST_TRIPLET=${HOST_TRIPLET}
 )
-
 vcpkg_cmake_install()
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libosmium/usage
+++ b/ports/libosmium/usage
@@ -1,0 +1,4 @@
+libosmium is header-only and can be used from CMake via:
+
+    find_path(OSMIUM_INCLUDE_DIRS "osmium/version.hpp")
+    target_include_directories(main PRIVATE ${OSMIUM_INCLUDE_DIRS})

--- a/ports/libosmium/vcpkg.json
+++ b/ports/libosmium/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libosmium",
   "version-semver": "2.20.0",
+  "port-version": 1,
   "description": "A fast and flexible C++ library for working with OpenStreetMap data",
   "homepage": "https://osmcode.org/libosmium/",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4646,7 +4646,7 @@
     },
     "libosmium": {
       "baseline": "2.20.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libosmscout": {
       "baseline": "1.1.1",

--- a/versions/l-/libosmium.json
+++ b/versions/l-/libosmium.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e43abda3d2ab79b2d813717eef1b330b390557f",
+      "version-semver": "2.20.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b77d6ee3568b3a3fedb7b00984ae085253e46506",
       "version-semver": "2.20.0",
       "port-version": 0


### PR DESCRIPTION
- Fix installation order dependency on gdal. gdal is not used to install this port.
- Skip debug build
- Install existing usage.

Fixes CI baseline regression.