### PR TITLE
[launch-darkly-server] Fix dependence clib symbol Duplicate with openssl

### DIFF
--- a/ports/launch-darkly-server/fix-confilct-with-openssl.patch
+++ b/ports/launch-darkly-server/fix-confilct-with-openssl.patch
@@ -1,0 +1,26 @@
+diff --git a/sha1.c b/sha1.c
+index fe8da83..53ad2c4 100644
+--- a/sha1.c
++++ b/sha1.c
+@@ -279,7 +279,7 @@ void SHA1Final(
+     memset(&finalcount, '\0', sizeof(finalcount));
+ }
+ 
+-void SHA1(
++void SHA1_CLIBS(
+     char *hash_out,
+     const char *str,
+     int len)
+diff --git a/sha1.h b/sha1.h
+index 96bb008..53c4b01 100644
+--- a/sha1.h
++++ b/sha1.h
+@@ -36,7 +36,7 @@ void SHA1Final(
+     SHA1_CTX * context
+     );
+ 
+-void SHA1(
++void SHA1_CLIBS(
+     char *hash_out,
+     const char *str,
+     int len);

--- a/ports/launch-darkly-server/fix-depend-clib.patch
+++ b/ports/launch-darkly-server/fix-depend-clib.patch
@@ -1,0 +1,13 @@
+diff --git a/src/evaluate.c b/src/evaluate.c
+index f702419..e80fa6c 100644
+--- a/src/evaluate.c
++++ b/src/evaluate.c
+@@ -1246,7 +1246,7 @@ LDi_bucketUser(
+             char        digest[21], encoded[17];
+             const float longScale = 1152921504606846975.0;
+ 
+-            SHA1(digest, raw, strlen(raw));
++            SHA1_CLIBS(digest, raw, strlen(raw));
+ 
+             /* encodes to hex, and shortens, 16 characters in hex 8 bytes */
+             status = hexify(

--- a/ports/launch-darkly-server/portfile.cmake
+++ b/ports/launch-darkly-server/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         findPCRE.patch
         FixStrictPrototypes.patch # required with clang-15
         removeWarningAsError.patch
+        fix-depend-clib.patch
 )
 
 
@@ -37,6 +38,8 @@ vcpkg_from_github(
     REF fa1d96ec293d2968791603548125e3274bd6b472
     SHA512 fd7dfbed4ac10e2c482da1cd460dabf0a53965e6fa17fab97156becb8214e435ee3605b2748705141380e254de7c32ab42da5e42cd6e4494f7ecaafb3b9e19f0
     HEAD_REF master
+    PATCHES
+        fix-confilct-with-openssl.patch
 )
 
 vcpkg_from_github(

--- a/ports/launch-darkly-server/vcpkg.json
+++ b/ports/launch-darkly-server/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "launch-darkly-server",
   "version": "2.8.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "LaunchDarkly server-side SDK for C/C++",
   "homepage": "https://github.com/launchdarkly/c-server-sdk",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3994,7 +3994,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.8.6",
-      "port-version": 1
+      "port-version": 2
     },
     "lazy-importer": {
       "baseline": "2023-08-03",

--- a/versions/l-/launch-darkly-server.json
+++ b/versions/l-/launch-darkly-server.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf4d27e890d7becddd87f89a3a0622199892ebd2",
+      "version": "2.8.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "d2e41e5748cc5b77167205b83be64003e979e637",
       "version": "2.8.6",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/35449
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
