### PR TITLE
[qtopcua] Feature ns0idgenerator doesn't support cross-building

### DIFF
--- a/ports/qtopcua/portfile.cmake
+++ b/ports/qtopcua/portfile.cmake
@@ -27,10 +27,6 @@ if("uacpp" IN_LIST FEATURES)
     message(WARNING "\nPlease note that you have to install the Unified Automation C++ SDK yourself.\n")
 endif()
 
-if (VCPKG_CROSSCOMPILING AND "ns0idgenerator" IN_LIST FEATURES)
-    message(FATAL_ERROR "Tools qtopcua-defaultnodeidsgenerator does not support cross-building.")
-endif()
-
 qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
                      CONFIGURE_OPTIONS
                         ${FEATURE_OPTIONS}

--- a/ports/qtopcua/portfile.cmake
+++ b/ports/qtopcua/portfile.cmake
@@ -27,6 +27,10 @@ if("uacpp" IN_LIST FEATURES)
     message(WARNING "\nPlease note that you have to install the Unified Automation C++ SDK yourself.\n")
 endif()
 
+if (VCPKG_CROSSCOMPILING AND "ns0idgenerator" IN_LIST FEATURES)
+    message(FATAL_ERROR "Tools qtopcua-defaultnodeidsgenerator does not support cross-building.")
+endif()
+
 qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
                      CONFIGURE_OPTIONS
                         ${FEATURE_OPTIONS}

--- a/ports/qtopcua/vcpkg.json
+++ b/ports/qtopcua/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtopcua",
   "version": "6.6.1",
+  "port-version": 1,
   "description": "Qt wrapper for existing OPC UA stacks",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtopcua/vcpkg.json
+++ b/ports/qtopcua/vcpkg.json
@@ -28,7 +28,8 @@
       "description": "Support for global discovery server"
     },
     "ns0idgenerator": {
-      "description": "Namespace 0 NodeIds generator from the NodeIds.csv file."
+      "description": "Namespace 0 NodeIds generator from the NodeIds.csv file.",
+      "supports": "native"
     },
     "ns0idnames": {
       "description": "Support for namespace 0 NodeId names"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7198,7 +7198,7 @@
     },
     "qtopcua": {
       "baseline": "6.6.1",
-      "port-version": 0
+      "port-version": 1
     },
     "qtpositioning": {
       "baseline": "6.6.1",

--- a/versions/q-/qtopcua.json
+++ b/versions/q-/qtopcua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8bcb7d7bc36f95d6def097138a77da2e2f8fe8c2",
+      "version": "6.6.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "bbd569723a9e84b190ba938c4f040d0cc83af21d",
       "version": "6.6.1",
       "port-version": 0

--- a/versions/q-/qtopcua.json
+++ b/versions/q-/qtopcua.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8bcb7d7bc36f95d6def097138a77da2e2f8fe8c2",
+      "git-tree": "158f8110a6d3d504c64bf24e2ec68552b8e34097",
       "version": "6.6.1",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #35633. Feature `ns0idgenerator` will to install tools `qtopcua-defaultnodeidsgenerator`, it doesn't support cross-building, and this feature has been removed in latest version of upstream.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
