### PR TITLE
[libxdiff] fix the imported target error

### DIFF
--- a/ports/libxdiff/fix-usage-error.patch
+++ b/ports/libxdiff/fix-usage-error.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 33c34c2..11c0125 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -87,7 +87,7 @@ INSTALL (
+     EXPORT XDiffTargets
+     ARCHIVE DESTINATION lib
+     LIBRARY DESTINATION lib
+-    RUNTIME DESTINATION lib
++    RUNTIME DESTINATION bin
+ )
+ 
+ WRITE_BASIC_PACKAGE_VERSION_FILE (

--- a/ports/libxdiff/fix-usage-error.patch
+++ b/ports/libxdiff/fix-usage-error.patch
@@ -1,13 +1,15 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 33c34c2..11c0125 100644
+index 33c34c2..1d93cde 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -87,7 +87,7 @@ INSTALL (
+@@ -87,8 +87,9 @@ INSTALL (
      EXPORT XDiffTargets
      ARCHIVE DESTINATION lib
      LIBRARY DESTINATION lib
 -    RUNTIME DESTINATION lib
 +    RUNTIME DESTINATION bin
  )
++target_include_directories(xdiff INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "$<INSTALL_INTERFACE:include>") 
  
  WRITE_BASIC_PACKAGE_VERSION_FILE (
+     "${CMAKE_CURRENT_BINARY_DIR}/XDiff/XDiffConfigVersion.cmake"

--- a/ports/libxdiff/portfile.cmake
+++ b/ports/libxdiff/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
     REF ${LIBXDIFF_REF}
     SHA512 ${LIBXDIFF_SHA512}
     HEAD_REF master
+    PATCHES
+        fix-usage-error.patch
 )
 
 vcpkg_cmake_configure(
@@ -35,7 +37,7 @@ if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL release)
     endif()
 endif()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_copy_pdbs()
 

--- a/ports/libxdiff/vcpkg.json
+++ b/ports/libxdiff/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libxdiff",
   "version": "0.23",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The LibXDiff library implements basic and yet complete functionalities to create file differences/patches to both binary and text files. The library uses memory files as file abstraction to achieve both performance and portability.",
   "homepage": "https://github.com/Drako/libxdiff",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5066,7 +5066,7 @@
     },
     "libxdiff": {
       "baseline": "0.23",
-      "port-version": 3
+      "port-version": 4
     },
     "libxdmcp": {
       "baseline": "1.1.3",

--- a/versions/l-/libxdiff.json
+++ b/versions/l-/libxdiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c40afb4c2d7a30f53c58d8a4e85fe7c5b4a637b0",
+      "version": "0.23",
+      "port-version": 4
+    },
+    {
       "git-tree": "ce9f54a13c2317e8249e154d852fa5d7ee0940c3",
       "version": "0.23",
       "port-version": 3

--- a/versions/l-/libxdiff.json
+++ b/versions/l-/libxdiff.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c40afb4c2d7a30f53c58d8a4e85fe7c5b4a637b0",
+      "git-tree": "3c416f4eaabd3ca0697fcf4e004e99975d23bd00",
       "version": "0.23",
       "port-version": 4
     },


### PR DESCRIPTION
Fixes #35904

Fix error:
````
[proc] 执行命令: D:\Install\BuildTools\CMake\bin\cmake.EXE --build d:/workbench/sources/cpp/xdiff_test/build --config Debug --target all --
[build] CMake Error at D:/Install/BuildTools/vcpkg/installed/x64-windows/share/XDiff/XDiffTargets.cmake:79 (message):
[build] The imported target "xdiff" references the file
[build]
[build] "D:/Install/BuildTools/vcpkg/installed/x64-windows/debug/lib/xdiff.dll"
[build]
[build] but this file does not exist. Possible reasons include:
[build]
[build] * The file was deleted, renamed, or moved to another location.
[build]
[build] * An install or uninstall procedure did not complete successfully.
[build]
[build] * The installation package was faulty and contained
[build]
[build] "D:/Install/BuildTools/vcpkg/installed/x64-windows/share/XDiff/XDiffTargets.cmake"
[build]
[build] but not all the files it references.
````
Tested usage successfully by `libxdiff:x64-windows`:
````
libxdiff provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(XDiff CONFIG REQUIRED)
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

