### PR TITLE
[harfbuzz] Add `directwrite` feature on Windows.

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -23,6 +23,11 @@ if("coretext" IN_LIST FEATURES)
 else()
     list(APPEND FEATURE_OPTIONS -Dcoretext=disabled)
 endif()
+if("directwrite" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS -Ddirectwrite=enabled) # Enable DirectWrite support on Windows
+else()
+    list(APPEND FEATURE_OPTIONS -Ddirectwrite=disabled)
+endif()
 if("glib" IN_LIST FEATURES)
     list(APPEND FEATURE_OPTIONS -Dglib=enabled) # Enable GLib unicode functions
     list(APPEND FEATURE_OPTIONS -Dgobject=enabled) #Enable GObject bindings

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "harfbuzz",
   "version": "8.3.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",
@@ -35,6 +35,10 @@
     "coretext": {
       "description": "Enable CoreText shaper backend on macOS",
       "supports": "osx"
+    },
+    "directwrite": {
+      "description": "Enable DirectWrite support on Windows",
+      "supports": "windows"
     },
     "freetype": {
       "description": "Enable FreeType support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3274,7 +3274,7 @@
     },
     "harfbuzz": {
       "baseline": "8.3.0",
-      "port-version": 2
+      "port-version": 3
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f22f35a345a42b356292d5c480208c6c395ed5a0",
+      "version": "8.3.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "ff776c837e28a47a91cad45946d7ab6b51dc3c67",
       "version": "8.3.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
