### PR TITLE
[libmagic] Fix for emscripten by only installing libmagic library, not everything else

### DIFF
--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -42,7 +42,7 @@ elseif(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     set(EXTRA_ARGS "ADD_BIN_TO_PATH")
 endif()
 
-vcpkg_install_make(${EXTRA_ARGS})
+vcpkg_install_make(${EXTRA_ARGS} SUBPATH src)
 vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
 vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin")
 vcpkg_fixup_pkgconfig()

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmagic",
   "version": "5.45",
-  "port-version": 1,
+  "port-version": 2,
   "description": "This library can be used to classify files according to magic number tests.",
   "homepage": "https://github.com/file/file",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4510,7 +4510,7 @@
     },
     "libmagic": {
       "baseline": "5.45",
-      "port-version": 1
+      "port-version": 2
     },
     "libmariadb": {
       "baseline": "3.3.1",

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d37fb1faae4fdb45cb5419a13c79b4d785bcabdd",
+      "version": "5.45",
+      "port-version": 2
+    },
+    {
       "git-tree": "65715ba20e3afecd46e0fb81326503257174585f",
       "version": "5.45",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version (I didn't find it)
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. (I didn't find it)
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This PR modify the libmagic port by only building the libmagic library. Else, when trying to build everything, it tries to run the file `src/file`, which is JavaScript code with the emscripten triplet.

Please note that I'm not sure what "everything else" is. I assume it's simply the `file` executable being compiled and executed, which is why I disabled it. (according to the maintainer's guide, it should not be built in the first place)

Example of failure: https://github.com/iTrooz/ImHex/actions/runs/7348235336/job/20005998206#step:5:311
here, `build-wasm32-emscripten-dbg-err.log` contains 
```
cache:INFO: generating system asset: symbol_lists/12d96912f0539cb4ebd234a1fba841bb665d2a3c.json... (this will be cached in "/emsdk/upstream/emscripten/cache/symbol_lists/12d96912f0539cb4ebd234a1fba841bb665d2a3c.json" for subsequent builds)
cache:INFO:  - ok
/bin/bash: line 1: ../src/file: Permission denied
make[2]: *** [Makefile:867: magic.mgc] Error 126
make[1]: *** [Makefile:464: all-recursive] Error 1
make: *** [Makefile:373: all] Error 2
```