### PR TITLE
[Glaze] Update to v1.9.9

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 ffc2c2d007e736c4ef44407c639c89ba82e2e90d9e6ec9d3d507bdf20e197659e6963439d83e0b311efddb1f089552fa36edfc5af6c6b620f9dd3fdc06e5a52d
+    SHA512 ed1f1cccbba3eb46edb3899ac351d4d0f6f838ef96de958f90e6acea655c626d94c14d7b4e78ed379ea8710d99e43e84b166ccbbf5f3015599b88dae254a764a
 )
 
 vcpkg_cmake_configure(

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "1.9.6",
+  "version": "1.9.9",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2981,7 +2981,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "1.9.6",
+      "baseline": "1.9.9",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "292cb129d7afdb63c4cd1881b863581725fa1f29",
+      "version": "1.9.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "90e9524cec84329ef65d58ce265d64567ff861f5",
       "version": "1.9.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.