### PR TITLE
[exiv2] fix target in usage description

### DIFF
--- a/ports/exiv2/usage
+++ b/ports/exiv2/usage
@@ -1,4 +1,4 @@
 exiv2 provides CMake targets:
 
     find_package(exiv2 CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE exiv2lib)
+    target_link_libraries(main PRIVATE Exiv2::exiv2lib)

--- a/ports/exiv2/vcpkg.json
+++ b/ports/exiv2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "exiv2",
   "version": "0.28.1",
+  "port-version": 1,
   "description": "Image metadata library and tools",
   "homepage": "https://exiv2.org",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2490,7 +2490,7 @@
     },
     "exiv2": {
       "baseline": "0.28.1",
-      "port-version": 0
+      "port-version": 1
     },
     "expat": {
       "baseline": "2.5.0",

--- a/versions/e-/exiv2.json
+++ b/versions/e-/exiv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c718e83fc18023db2be57de6fb8873555aabdccb",
+      "version": "0.28.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "0c1020def33eb27e28b1cb0bd2cfd53dfe5fbae5",
       "version": "0.28.1",
       "port-version": 0


### PR DESCRIPTION
The `usage` description did not fully qualify the exported target.