### PR TITLE
[libpng] Search libm in implicit link dirs

### DIFF
--- a/ports/libpng/libm.patch
+++ b/ports/libpng/libm.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 958b1d6..21c8941 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,6 +84,12 @@ endif()
+ 
+ if(UNIX AND NOT APPLE AND NOT BEOS AND NOT HAIKU AND NOT EMSCRIPTEN)
+   find_library(M_LIBRARY m)
++  if(NOT M_LIBRARY)
++    find_library(M_LIBRARY m PATHS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES} NO_DEFAULT_PATH)
++    if(M_LIBRARY)
++      set(M_LIBRARY m)
++    endif()
++  endif()
+   if(NOT M_LIBRARY)
+     set(M_LIBRARY "")
+   endif()

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -38,6 +38,7 @@ vcpkg_from_github(
         "${LIBPNG_APNG_PATCH_PATH}"
         cmake.patch
         fix-export-targets.patch
+        libm.patch
         pkgconfig.patch
         fix-msa-support-for-mips.patch
 )

--- a/ports/libpng/vcpkg.json
+++ b/ports/libpng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpng",
   "version": "1.6.40",
+  "port-version": 1,
   "description": "libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files",
   "homepage": "https://github.com/glennrp/libpng",
   "license": "libpng-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4686,7 +4686,7 @@
     },
     "libpng": {
       "baseline": "1.6.40",
-      "port-version": 0
+      "port-version": 1
     },
     "libpopt": {
       "baseline": "1.16",

--- a/versions/l-/libpng.json
+++ b/versions/l-/libpng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8b6d2c1150541a94c0ca5b2f060eb21eed4a40b2",
+      "version": "1.6.40",
+      "port-version": 1
+    },
+    {
       "git-tree": "1a2a7f489e57c9e55e049b7c5f0a28c8ff4464ed",
       "version": "1.6.40",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/35463.

Similar patches do already exist, e.g. in libtiff.
For context and alternatives, cf. https://github.com/microsoft/vcpkg/issues/35463#issuecomment-1871948712 f.