### PR TITLE
[qt5 ports] Fix DLL ownership in tools/qt5/bin

### DIFF
--- a/ports/qt5-base/cmake/qt_download_submodule.cmake
+++ b/ports/qt5-base/cmake/qt_download_submodule.cmake
@@ -4,7 +4,7 @@ function(qt_get_submodule_name OUT_NAME)
 endfunction()
 
 function(qt_download_submodule)
-    cmake_parse_arguments(_csc "" "OUT_SOURCE_PATH" "PATCHES;BUILD_OPTIONS;BUILD_OPTIONS_RELEASE;BUILD_OPTIONS_DEBUG" ${ARGN})
+    cmake_parse_arguments(_csc "" "OUT_SOURCE_PATH" "PATCHES;BUILD_OPTIONS;BUILD_OPTIONS_RELEASE;BUILD_OPTIONS_DEBUG;RUNTIME_FOR_TOOLS" ${ARGN})
 
     if(NOT DEFINED _csc_OUT_SOURCE_PATH)
         message(FATAL_ERROR "qt_download_module requires parameter OUT_SOURCE_PATH to be set! Please correct the portfile!")

--- a/ports/qt5-base/cmake/qt_install_runtime_for_tools.cmake
+++ b/ports/qt5-base/cmake/qt_install_runtime_for_tools.cmake
@@ -1,0 +1,97 @@
+# Copy additional runtime libraries to the shared tools/qt5/bin location
+#
+# To ensure predictable ownership regardless of installation order,
+# each port must install its own DLLs, qml libs and plugins
+# if they are needed (in terms of qtdeploy.ps1) by downstream ports.
+function(qt_install_runtime_for_tools)
+    if(NOT VCPKG_BUILD_TYPE)
+        z_qt_install_runtime_for_tools(debug "/debug" "d" ${ARGV})
+    endif()
+    z_qt_install_runtime_for_tools(release "" "" ${ARGV})
+endfunction()
+
+function(z_qt_install_runtime_for_tools config path_suffix dll_suffix)
+    set(arg_LIBRARIES "${ARGN}")
+
+    # Temporarily clone qtdeploy.ps1 --- applocal.ps1 loads it from <search_dir>/../plugins.
+    if(VCPKG_TARGET_IS_WINDOWS)
+        file(COPY "${CURRENT_INSTALLED_DIR}/plugins/qtdeploy.ps1" DESTINATION "${CURRENT_PACKAGES_DIR}${path_suffix}/plugins")
+    endif()
+
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin")
+        set(qt_conf "${CURRENT_INSTALLED_DIR}/tools/qt5/qt_${config}.conf")
+        if(PORT STREQUAL "qt5-base")
+            set(qt_conf "${CURRENT_PACKAGES_DIR}/tools/qt5/qt_${config}.conf")
+        endif()
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin/qt.conf")
+        set(CURRENT_INSTALLED_DIR_BACKUP "${CURRENT_INSTALLED_DIR}")
+        string(REPLACE "/debug" "/.." CURRENT_INSTALLED_DIR "./../../..${path_suffix}") # Making the qt.conf relative and not absolute
+        configure_file("${qt_conf}" "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin/qt.conf") # This makes the tools at least useable for release
+        set(CURRENT_INSTALLED_DIR "${CURRENT_INSTALLED_DIR_BACKUP}")
+
+        vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin")
+        file(COPY "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}${path_suffix}")
+    endif()
+
+    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        # qtdeploy.ps1 is tuned for user projects (one run), not ports (two runs). Fill gaps.
+        if(EXISTS "${CURRENT_PACKAGES_DIR}${path_suffix}/qml")
+            if(EXISTS "${CURRENT_PACKAGES_DIR}/tools/${PORT}${path_suffix}/bin/Qt5Qml${dll_suffix}.dll")
+                # qml libs from CURRENT_INSTALLED_DIR already copied by vcpkg_copy_tool_dependencies.
+                file(COPY "${CURRENT_PACKAGES_DIR}${path_suffix}/qml" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}${path_suffix}/bin")
+                file(COPY "${CURRENT_PACKAGES_DIR}${path_suffix}/qml" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin")
+            elseif("Qt5Qml" IN_LIST arg_LIBRARIES)
+                # qml libs as runtime for tools
+                file(COPY "${CURRENT_INSTALLED_DIR}${path_suffix}/qml" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin")
+            endif()
+        endif()
+        set(rerun_copy_tool_dependencies FALSE)
+        foreach(lib IN LISTS arg_LIBRARIES)
+            string(APPEND lib "${dll_suffix}")
+            if(EXISTS "${CURRENT_PACKAGES_DIR}${path_suffix}/bin/${lib}.dll") # subject to features
+                file(COPY "${CURRENT_PACKAGES_DIR}${path_suffix}/bin/${lib}.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin")
+                set(rerun_copy_tool_dependencies TRUE)
+            elseif(EXISTS "${CURRENT_INSTALLED_DIR}${path_suffix}/bin/${lib}.dll") # subject to features
+                # trigger for plugin deployment
+                file(COPY "${CURRENT_INSTALLED_DIR}${path_suffix}/bin/${lib}.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin")
+                set(rerun_copy_tool_dependencies TRUE)
+            else()
+                # probably a disabled feature
+                message(STATUS "No such lib: ${lib}")
+            endif()
+        endforeach()
+        if(rerun_copy_tool_dependencies)
+            vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin")
+        endif()
+    endif()
+
+    # Remove temporary clones and runtime files which are already owned by other ports
+    file(GLOB files RELATIVE "${CURRENT_PACKAGES_DIR}"
+        "${CURRENT_PACKAGES_DIR}${path_suffix}/plugins/qtdeploy.ps1"
+        "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin/qt.conf"
+        "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin/*.dll"
+        "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin/plugins/*/*.dll"
+        "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin/qml/*" # files and dirs
+    )
+    foreach(file IN LISTS files)
+        if(EXISTS "${CURRENT_INSTALLED_DIR}/${file}")
+            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/${file}")
+        endif()
+    endforeach()
+
+    # Prune empty runtime dirs
+    file(GLOB plugin_dirs "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin/plugins/*")
+    set(base_dirs
+        "${CURRENT_PACKAGES_DIR}${path_suffix}/bin"
+        "${CURRENT_PACKAGES_DIR}${path_suffix}/lib"
+        "${CURRENT_PACKAGES_DIR}${path_suffix}/plugins"
+        "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin/plugins"
+        "${CURRENT_PACKAGES_DIR}/tools/qt5${path_suffix}/bin/qml"
+    )
+    foreach(dir IN LISTS plugin_dirs base_dirs)
+        file(GLOB plugins "${dir}/*")
+        if("${plugins}" STREQUAL "")
+            file(REMOVE_RECURSE "${dir}")
+        endif()
+    endforeach()
+endfunction()

--- a/ports/qt5-base/cmake/qt_port_functions.cmake
+++ b/ports/qt5-base/cmake/qt_port_functions.cmake
@@ -10,5 +10,6 @@ include(qt_fix_prl)
 include(qt_download_submodule)
 include(qt_build_submodule)
 include(qt_install_copyright)
+include(qt_install_runtime_for_tools)
 
 include(qt_submodule_installation)

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -411,12 +411,10 @@ else()
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         qt_fix_prl("${CURRENT_INSTALLED_DIR}" "${PRL_FILES}")
-        file(COPY ${CMAKE_CURRENT_LIST_DIR}/qtdeploy.ps1 DESTINATION ${CURRENT_PACKAGES_DIR}/plugins)
     endif()
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         qt_fix_prl("${CURRENT_INSTALLED_DIR}/debug" "${PRL_FILES}")
-        file(COPY ${CMAKE_CURRENT_LIST_DIR}/qtdeploy.ps1 DESTINATION ${CURRENT_PACKAGES_DIR}/debug/plugins)
     endif()
 
     file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
@@ -473,24 +471,17 @@ else()
     endif()
     file(WRITE "${cmakefile}" "${_contents}")
 
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/tools/qt5/bin)
-        file(COPY ${CURRENT_PACKAGES_DIR}/tools/qt5/bin DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT})
-        vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin)
-        vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/qt5/bin)
-    endif()
-    # This should be removed if possible! (Currently debug build of qt5-translations requires it.)
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/tools/qt5/bin)
-        file(COPY ${CURRENT_PACKAGES_DIR}/tools/qt5/bin DESTINATION ${CURRENT_PACKAGES_DIR}/tools/qt5/debug)
-        vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/qt5/debug/bin)
-    endif()
-
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/tools/qt5/bin/qt.conf)
-        file(REMOVE "${CURRENT_PACKAGES_DIR}/tools/qt5/bin/qt.conf")
-    endif()
-    set(CURRENT_INSTALLED_DIR_BACKUP "${CURRENT_INSTALLED_DIR}")
-    set(CURRENT_INSTALLED_DIR "./../../.." ) # Making the qt.conf relative and not absolute
-    configure_file(${CURRENT_PACKAGES_DIR}/tools/qt5/qt_release.conf ${CURRENT_PACKAGES_DIR}/tools/qt5/bin/qt.conf) # This makes the tools at least useable for release
-    set(CURRENT_INSTALLED_DIR "${CURRENT_INSTALLED_DIR_BACKUP}")
+    qt_install_runtime_for_tools(
+        Qt5Core             # for qt5-base
+        Qt5DBus             # for qt5-base
+        Qt5Gui              # for qt5-declarative
+        Qt5Network          # for qt5-declarative
+        Qt5PrintSupport     # for qt5-tools
+        Qt5Sql              # for qt5-tools
+        Qt5Test             # for qt5-declarative
+        Qt5Widgets          # for qt5-declarative
+        Qt5Xml              # for qt5-tools
+    )
 
     qt_install_copyright(${SOURCE_PATH})
 endif()
@@ -504,6 +495,7 @@ file(COPY
     ${CMAKE_CURRENT_LIST_DIR}/cmake/qt_download_submodule.cmake
     ${CMAKE_CURRENT_LIST_DIR}/cmake/qt_build_submodule.cmake
     ${CMAKE_CURRENT_LIST_DIR}/cmake/qt_install_copyright.cmake
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/qt_install_runtime_for_tools.cmake
     ${CMAKE_CURRENT_LIST_DIR}/cmake/qt_submodule_installation.cmake
     DESTINATION
         ${CURRENT_PACKAGES_DIR}/share/qt5

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.13",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Base provides the basic non-GUI functionality required by all Qt applications.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -16,7 +16,7 @@ parameters:
   - name: tripletPattern
     displayName: 'Enable triplets which contain this substring'
     type: string
-    default: '-'
+    default: 'x64-windows$'
 
 jobs:
 - job: mintsas

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1354,3 +1354,5 @@ vcpkg-ci-wxwidgets:x64-windows-static-md=pass
 vcpkg-ci-wxwidgets:x64-windows-static=pass
 vcpkg-ci-wxwidgets:x64-windows=pass
 vcpkg-ci-wxwidgets:x86-windows=pass
+
+llvm:x64-windows=skip


### PR DESCRIPTION
Ports must not own other port's DLLs in a shared location.
To make this work, `qtdeploy.ps1` must already be available while building qt5-base, in order to deploy this port's plugins.

To fix the flaky baseline regression as in https://dev.azure.com/vcpkg/public/_build/results?buildId=98121&view=results:
~~~
Installing 454/605 qt5-activeqt:x64-windows@5.15.12...
error: The following files are already installed in D:/installed/x64-windows and are in conflict with qt5-activeqt:x64-windows
Installed by qt5-declarative:x64-windows  
tools/qt5/bin/Qt5Gui.dll
    tools/qt5/bin/Qt5Svg.dll
    tools/qt5/bin/Qt5Widgets.dll
    tools/qt5/bin/brotlicommon.dll
    tools/qt5/bin/brotlidec.dll
    tools/qt5/bin/bz2.dll
    tools/qt5/bin/freetype.dll
    tools/qt5/bin/glib-2.0-0.dll
    tools/qt5/bin/harfbuzz.dll
    tools/qt5/bin/iconv-2.dll
    tools/qt5/bin/intl-8.dll
    tools/qt5/bin/jpeg62.dll
    tools/qt5/bin/libpng16.dll
    tools/qt5/bin/pcre2-8.dll
    tools/qt5/bin/plugins/iconengines/qsvgicon.dll
    tools/qt5/bin/plugins/imageformats/qgif.dll
    tools/qt5/bin/plugins/imageformats/qico.dll
    tools/qt5/bin/plugins/imageformats/qjpeg.dll
    tools/qt5/bin/plugins/imageformats/qsvg.dll
    tools/qt5/bin/plugins/platforms/qwindows.dll
    tools/qt5/bin/plugins/styles/qwindowsvistastyle.dll

Elapsed time to handle qt5-activeqt:x64-windows: 138 ms
~~~