### PR TITLE
[libid3tag] Add version 0.16.3

### DIFF
--- a/ports/libid3tag/portfile.cmake
+++ b/ports/libid3tag/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_download_distfile(
+    ARCHIVE URLS "https://codeberg.org/tenacityteam/libid3tag/archive/${VERSION}.tar.gz"
+    FILENAME "${VERSION}.tar.gz"
+    SHA512 d49bc637899e4251ed66b5b56aa4c910dcdecd6b03ed197866d74175fc4eadff40f40f336606b23e2505b0e11834c4212a1314feeeaa2c0e9713051fdb56cb45
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME id3tag CONFIG_PATH lib/cmake/id3tag)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libid3tag/vcpkg.json
+++ b/ports/libid3tag/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libid3tag",
+  "version": "0.16.3",
+  "description": "ID3 tag manipulation library",
+  "homepage": "https://codeberg.org/tenacityteam/libid3tag",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4456,6 +4456,10 @@
       "baseline": "1.6.6",
       "port-version": 0
     },
+    "libid3tag": {
+      "baseline": "0.16.3",
+      "port-version": 0
+    },
     "libideviceactivation": {
       "baseline": "2023-05-01",
       "port-version": 1

--- a/versions/l-/libid3tag.json
+++ b/versions/l-/libid3tag.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a30c7af82d01be2c3bd973012681915cf394d464",
+      "version": "0.16.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add's Tenacity's libid3tag (originally by @Be-ing) port with some modifications, including a hashable source, correct usage text, and using `vcpkg_install_copyright()`.

This is similar #15991, but this port is smaller, does not feature any patches, and uses 0.16.3.

Note: the usage text may be wrong, which is why this is a draft PR at the moment. Once I can confirm the usage text is correct, I'll mark this as ready.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.