### PR TITLE
[vcpkg-tool-meson] Fix installation

### DIFF
--- a/ports/vcpkg-tool-meson/install.cmake
+++ b/ports/vcpkg-tool-meson/install.cmake
@@ -1,0 +1,5 @@
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/meson")
+file(INSTALL "${SOURCE_PATH}/meson.py"
+             "${SOURCE_PATH}/mesonbuild"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/meson"
+)

--- a/ports/vcpkg-tool-meson/portfile.cmake
+++ b/ports/vcpkg-tool-meson/portfile.cmake
@@ -38,12 +38,16 @@ vcpkg_from_github(
         remove-freebsd-pcfile-specialization.patch
 )
 
-file(INSTALL "${SOURCE_PATH}"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/tools"
-    RENAME "meson"
+vcpkg_execute_required_process(
+    COMMAND "${CMAKE_COMMAND}"
+        "-DSOURCE_PATH=${SOURCE_PATH}"
+        "-DCURRENT_PACKAGES_DIR=${CURRENT_PACKAGES_DIR}"
+        -P "${CURRENT_PORT_DIR}/install.cmake"
+    WORKING_DIRECTORY "${VCPKG_ROOT_DIR}"
+    LOGNAME install
 )
 
-configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-port-config.cmake" @ONLY)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 z_vcpkg_find_acquire_program_find_internal("${program}"
     INTERPRETER "${interpreter}"

--- a/ports/vcpkg-tool-meson/vcpkg.json
+++ b/ports/vcpkg-tool-meson/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vcpkg-tool-meson",
   "version": "0.63",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8878,7 +8878,7 @@
     },
     "vcpkg-tool-meson": {
       "baseline": "0.63",
-      "port-version": 1
+      "port-version": 2
     },
     "vcpkg-tool-mozbuild": {
       "baseline": "4.0.2",

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f6f5419cfc743a85e4f1fb1b582d4728b79c1e2",
+      "version": "0.63",
+      "port-version": 2
+    },
+    {
       "git-tree": "d4234634624fc778e5d80db63cf53bac8587ebb9",
       "version": "0.63",
       "port-version": 1


### PR DESCRIPTION
Fixes #35795.
- Install only necessary files, no symlinks.  
  Fixes binary caching.
- Redirect install output to log file.