### PR TITLE
[qtbase] enable egl for android

### DIFF
--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.6.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -157,7 +157,7 @@
     },
     "egl": {
       "description": "EGL",
-      "supports": "linux",
+      "supports": "linux | android",
       "dependencies": [
         "egl"
       ]

--- a/scripts/azure-pipelines/android/Dockerfile
+++ b/scripts/azure-pipelines/android/Dockerfile
@@ -32,6 +32,9 @@ ENV APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \
   libxcb-render-util0-dev libxcb-xinerama0-dev libxcb-xkb-dev libxcb-xinput-dev \
   libxcb-cursor-dev libxkbcommon-x11-dev"
 
+# qtwayland
+ENV APT_PACKAGES="$APT_PACKAGES libwayland-dev"
+
 ## PowerShell
 ENV APT_PACKAGES="$APT_PACKAGES powershell"
 

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -933,6 +933,10 @@ qt5-canvas3d:x64-windows=skip
 qt5-canvas3d:x64-windows-static=skip
 qt5-canvas3d:x64-windows-static-md=skip
 qt5-canvas3d:x86-windows=skip
+# Missing Android SDK in Docker image, see https://github.com/microsoft/vcpkg/pull/35845
+qtbase:arm64-android=fail
+qtbase:arm-neon-android=fail
+qtbase:x64-android=fail
 # Missing system libraries
 qtwayland:x64-osx=fail
 qtwayland:arm64-osx=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -940,6 +940,7 @@ qtbase:x64-android=fail
 # Missing system libraries
 qtwayland:x64-osx=fail
 qtwayland:arm64-osx=fail
+qtwayland:x64-linux=fail
 # Missing prerequisites for CI success
 # Fail due to outdated protoc headers.
 # D:\buildtrees\qt5-webengine\x64-windows-dbg\src\core\debug\gen\net/third_party/quiche/src/quic/core/proto/cached_network_parameters.pb.h(17):

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -940,7 +940,8 @@ qtbase:x64-android=fail
 # Missing system libraries
 qtwayland:x64-osx=fail
 qtwayland:arm64-osx=fail
-qtwayland:x64-linux=fail
+# Missing system libraries when pulled in as dependency for android
+qtwayland:x64-linux=skip
 # Missing prerequisites for CI success
 # Fail due to outdated protoc headers.
 # D:\buildtrees\qt5-webengine\x64-windows-dbg\src\core\debug\gen\net/third_party/quiche/src/quic/core/proto/cached_network_parameters.pb.h(17):

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7110,7 +7110,7 @@
     },
     "qtbase": {
       "baseline": "6.6.1",
-      "port-version": 3
+      "port-version": 4
     },
     "qtcharts": {
       "baseline": "6.6.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c5339512fed40e50903ff09dcb0079799274b3b7",
+      "version": "6.6.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "b85d2c16c027edb173f51037d9c5a3e05746efa0",
       "version": "6.6.1",
       "port-version": 3


### PR DESCRIPTION
Enable support for feature `egl` for `android` for `qtbase`.
Specifying it as default-feature for android but at the same time specifying the feature as not supported is inconsistent.

This actively expects `qtbase:*-android` to fail in CI, so far they were ignored because of the above-mentioned inconsistency.

Branched off https://github.com/microsoft/vcpkg/pull/35845 which is more complicated because it requests changes to the ci infrastructure.