### PR TITLE
[directxmath, directxmesh, directxtex, directxtk, uvatlas] Update for Dec2023

### DIFF
--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMath
-    REF dec2022
-    SHA512 61da5464e4a6b0e405307496b0b925fc52e3f7acd3841527c5f8e86d5188865767dd44d4277f034c46b0088d1ee52da72f747c5965cd37411600418b605d4702
+    REF dec2023
+    SHA512 ddb5fdb4ef2d524990b0eba254e8395e0c3278a49c37889eef97c977b9d72c4983305c7e2a5b732e05ee54819e0d4aea134a1419f713dda4da386d1bad2d3580
     HEAD_REF main
 )
 
@@ -11,6 +11,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+
+file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/DirectXMath.pc" DESTINATION "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
+
+vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/directxmath)
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
@@ -28,4 +32,5 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/directxmath/usage
+++ b/ports/directxmath/usage
@@ -1,0 +1,4 @@
+The DirectXMath package provides CMake targets:
+
+    find_package(directxmath CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Microsoft::DirectXMath)

--- a/ports/directxmath/vcpkg.json
+++ b/ports/directxmath/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmath",
-  "version-date": "2022-12-12",
+  "version-date": "2023-12-31",
   "description": "DirectXMath SIMD C++ math library",
   "homepage": "https://github.com/Microsoft/DirectXMath",
   "documentation": "https://docs.microsoft.com/windows/win32/dxmath/directxmath-portal",

--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXMESH_TAG oct2023)
+set(DIRECTXMESH_TAG dec2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMesh
     REF ${DIRECTXMESH_TAG}
-    SHA512 e02471cc0d3a1f2f5c6effe23cea0909a6096b97011885af4b6436e070a11d5f5d5033f0df2c9103cef182b9666c7d17274c519e4f35099cb602a317a9e3bed5
+    SHA512 25442ec60040f2f232079b4a62a4460c8de11a881e36f5bdaeadbe98678d360141e8eca8162169941c03884cc2a05c3e20cf7fd2aef6518f6a647b7382d6d271
     HEAD_REF main
 )
 
@@ -18,16 +18,19 @@ vcpkg_check_features(
         tools BUILD_TOOLS
 )
 
+set(EXTRA_OPTIONS -DBUILD_TESTING=OFF)
+
 if (VCPKG_HOST_IS_LINUX)
     message(WARNING "Build ${PORT} requires GCC version 9 or later")
 endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS} -DBUILD_TESTING=OFF
+    OPTIONS ${FEATURE_OPTIONS} ${EXTRA_OPTIONS}
 )
 
 vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/directxmesh)
 
 if("tools" IN_LIST FEATURES)
@@ -40,7 +43,7 @@ if("tools" IN_LIST FEATURES)
       MESHCONVERT_EXE
       URLS "https://github.com/Microsoft/DirectXMesh/releases/download/${DIRECTXMESH_TAG}/meshconvert.exe"
       FILENAME "meshconvert-${DIRECTXMESH_TAG}.exe"
-      SHA512 24385c74fa4b32c41bb2d6713ffe2fc78ef899d4f9f55bdb1a9d0a362858c019e6f59b932c03a7c66298362aed09b845f409dcd659dc79c05cb6e00c04db52ae
+      SHA512 db2d32ec44993547881e2f14ee3403aa6133758d250ffc54b7cec9c1f15be46e5a5d847eb1cff60081bdfeaaa1e6be129475f40502c0a8c5ba2d58e5baa71691
     )
 
     file(INSTALL
@@ -55,7 +58,7 @@ if("tools" IN_LIST FEATURES)
       MESHCONVERT_EXE
       URLS "https://github.com/Microsoft/DirectXMesh/releases/download/${DIRECTXMESH_TAG}/meshconvert_arm64.exe"
       FILENAME "meshconvert-${DIRECTXMESH_TAG}-arm64.exe"
-      SHA512 32b64534f7dc7bbf41c5d7ad154d401dbfec2442ebb62969b2acef94595fe4f07e092e1e201aebb7596b47216904ee9e7647911c2a52efdc588d9abc1d691785
+      SHA512 deaa61a1f24bf1ffff817a7b72b125d2402b97ca15713411eb3a5b0af0b5f2b25407be87d2fd60fb4670744656230d221183510167a1696685d2def9fa9c1532
     )
 
     file(INSTALL

--- a/ports/directxmesh/usage
+++ b/ports/directxmesh/usage
@@ -1,4 +1,4 @@
-The package DirectXMesh is compatible with built-in CMake targets:
+The DirectXMesh package provides CMake targets:
 
     find_package(directxmesh CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::DirectXMesh)

--- a/ports/directxmesh/vcpkg.json
+++ b/ports/directxmesh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmesh",
-  "version-date": "2023-10-28",
+  "version-date": "2023-12-31",
   "description": "DirectXMesh geometry processing library",
   "homepage": "https://github.com/Microsoft/DirectXMesh",
   "documentation": "https://github.com/microsoft/DirectXMesh/wiki",

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTEX_TAG oct2023)
+set(DIRECTXTEX_TAG dec2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
     REF ${DIRECTXTEX_TAG}
-    SHA512 4521d716bc903e9373c8d2929ff4fec04b3ae276a3005a06a744d5ee7044520faec6aa06e166b9c3bcc18f68c8e7553f23b21c227154eb3ef994a1c68b57da1a
+    SHA512 c4d9c5f0ce275bb612ee5055c7fcbe4dbfdfd8a1a6eda78e25761f1e70b9883bf620812de2f27b5ac950ca5416f5dcdd08c364d0d2afe13150746bba4c36e3dd
     HEAD_REF main
     )
 
@@ -40,6 +40,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtex)
 
 if("tools" IN_LIST FEATURES)
@@ -52,21 +53,21 @@ if("tools" IN_LIST FEATURES)
       TEXASSEMBLE_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texassemble.exe"
       FILENAME "texassemble-${DIRECTXTEX_TAG}.exe"
-      SHA512 e53548f8715f9ecfe7bd9904eec5fd2fe77d09e8fae78fa95a056a882d8856fe9311d01a703da47ef530e3878fdee8bc4a288617a81ffb61043d6b48acef5df0
+      SHA512 ce1e136eb68a3c5f8da6c99e95a066a567c9127346bdafa7218886a766d747ea1407c62d1c8630c76b315e1b17ffd6cd5e3b3a04badb390d468abb56d595360d
     )
 
     vcpkg_download_distfile(
       TEXCONV_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texconv.exe"
       FILENAME "texconv-${DIRECTXTEX_TAG}.exe"
-      SHA512 ca1772650f7368917ea719d853eade2040ed189c45acb8cbaa1dec57e61ca429e041b411271a53e9ca9a11f7a5fc84df1e25c0d019886647b8208bdde93ff258
+      SHA512 0da10ad66c6ac71127c1f8b14b9c3410dc3c87b27c0788a0cebf54618211978740a27d9664d9314998f8c4d7ecfc8aa621860fd8eef05844bd7257c9fabbdc5e
     )
 
     vcpkg_download_distfile(
       TEXDIAG_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texdiag.exe"
       FILENAME "texdiag-${DIRECTXTEX_TAG}.exe"
-      SHA512 baea51318adec86e7d0808c99c5ed8d529d9196073ce31c7df79fc12c7ff085169ab72d8876a47bc462d4eb6ec02e103af3f8b1ee0fdd762c2662c0453388e74
+      SHA512 0b66e919847c299aa7e6078dea1616e1a69ea94660bd37c1476c4d37b2247589f33fa830cb7dddb3ef2daf7eea13e4c12d1975c442eef5e72e7b1436359d7dfe
     )
 
     file(INSTALL
@@ -85,21 +86,21 @@ if("tools" IN_LIST FEATURES)
       TEXASSEMBLE_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texassemble_arm64.exe"
       FILENAME "texassemble-${DIRECTXTEX_TAG}-arm64.exe"
-      SHA512 d11152bf4193ab83ab8cabae58ef517b05babec049f2fb1317a51b708d14ba4a93806ff4ebeb1004391c0692fc76b9bedd7a43dbea3d74a4d7548fb69c809f8b
+      SHA512 b85b6632027e329c90504e1e5923587301fc8fca2e5600d9b01eceaeb62579004dda410a625c6c9d9d39a6877ffb3df892ca60a8fe54d17825f51fe6baa032cb
     )
 
     vcpkg_download_distfile(
       TEXCONV_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texconv_arm64.exe"
       FILENAME "texconv-${DIRECTXTEX_TAG}-arm64.exe"
-      SHA512 09f3bc8aebac8804644f6673d0f21d4ee21155f13383c5a0da8afcaef6df6a1186c9254679334247b638ec11b9f1080abed285e174716a1e7662fc46c103278d
+      SHA512 82d22d6aca167d2e8a6ef8a92c6b43e38584d773c9ccac3c8746ec4b59cbc795aa41ffeac4b865bda5a8c5350547f25e3aef32529ec5ff06f78dabf398a16b21
     )
 
     vcpkg_download_distfile(
       TEXDIAG_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texdiag_arm64.exe"
       FILENAME "texdiag-${DIRECTXTEX_TAG}-arm64.exe"
-      SHA512 d1ec122e9647d243349678b8d1d267d9b26a84a6a845728c0408f94a486fe6c43488b2f507a96035063fc245bcb670367c0f219626c627ddc31d1713a782a1fd
+      SHA512 5b015b85ff60bd393c7844223575c0dd16b527c9bd65e1c57d2b07892293dae049df175d1f4ef28d32cf536e51aed9925fd79e520f72c892a6979e198fd9fa1f
     )
 
     file(INSTALL

--- a/ports/directxtex/usage
+++ b/ports/directxtex/usage
@@ -1,4 +1,4 @@
-The package DirectXTex is compatible with built-in CMake targets:
+The DirectXTex package provides CMake targets:
 
     find_package(directxtex CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::DirectXTex)

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtex",
-  "version-date": "2023-10-28",
+  "version-date": "2023-12-31",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTK_TAG oct2023)
+set(DIRECTXTK_TAG dec2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
     REF ${DIRECTXTK_TAG}
-    SHA512 3df7f26df2edfbfd8ba8ab2ff8b7f653c1df194145e89fd2bbe7c3f0581d4a11de2845091a6c7d27c2b7800d2b1e8770728fb357e6ab0ce57e714d8fcc0c3453
+    SHA512 952f1455fd91c858b0debb10e0dea17f229a26eee0c3316341de4d2b7101c9023eb20d7b9c5a09eb5a21f3f8ca1d97ecae9e29b7ce5f0eb2a0797db6ff9ae8b9
     HEAD_REF main
 )
 
@@ -32,6 +32,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk)
 
 if("tools" IN_LIST FEATURES)
@@ -40,7 +41,7 @@ if("tools" IN_LIST FEATURES)
     MAKESPRITEFONT_EXE
     URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/MakeSpriteFont.exe"
     FILENAME "makespritefont-${DIRECTXTK_TAG}.exe"
-    SHA512 00a4c94d3f9b6607f652edfbe1ce0cc9c09437f3084e2b252462458e652ff2735bf94f028091739ec66edbf29c1ebeb813af5c9b68644ac02cebf8ab6833d8fa
+    SHA512 f5872c479e537ae02d32039dce9ed4820c834de37795365b02cb5ae0d9241fb2ece58c1555335c57394a7cfbca95202a91ddda4e77d6bdd484c6cf6e7b9d6e0e
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -55,7 +56,7 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/XWBTool.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}.exe"
-      SHA512 2b60b1dedfe8803914d16c760b546aad82a05404eedff9740f56a1ca8e15d9b77bba3743a3b39adb2092d04afc90106c8a3c2dffc87392cf5dfe6686752c4d3d
+      SHA512 e30f786e72e0a9ec84b359e768d3ea024c7e5611ea274b01189ee30faa2ce976579b42307edd4979fa39bdae7f0bc6041463723db3e97399e98575985b15d5da
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -68,7 +69,7 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/XWBTool_arm64.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}-arm64.exe"
-      SHA512 d0ff53fefedeba588ad583f99ab2c2420fe0b30a1efb88e4ce556436f1d5d8d76c69f28be7ca7209660212d017a1a404bcdb43349743a4142a7c3e88937ce1d3
+      SHA512 8b01d120954e29e532ded2a38bd3ba883310e48655eab6af884ddcb9c4516640b59ed0d970d01eec189c7b4d04593b51a79739895761f2514c1e8f0df8504d99
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")

--- a/ports/directxtk/usage
+++ b/ports/directxtk/usage
@@ -1,4 +1,4 @@
-The DirectX Tool Kit for DX11 package is compatible with built-in CMake targets:
+The DirectX Tool Kit for DX11 package provides CMake targets:
 
     find_package(directxtk CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::DirectXTK)

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk",
-  "version-date": "2023-10-28",
+  "version-date": "2023-12-31",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTK_TAG oct2023)
+set(DIRECTXTK_TAG dec2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
     REF ${DIRECTXTK_TAG}
-    SHA512 3a162ce9101ee8585470bb76f7ac13397f215e4c70fca5a9e0ec419ba114bd4d07da9922cf7022b00cfb3cff0e7016df082658fd3f1e32d230fa2fd0140a338f
+    SHA512 7946ccd4ea9199ac981079462d1ff4621a3b10e70359948a9209a1d192ec936f0ea336bd8b6c2adaa63ace04a94950f933b1013242cadb9f7a22cd191c73699e
     HEAD_REF main
 )
 
@@ -31,6 +31,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk12)
 
 if("tools" IN_LIST FEATURES)
@@ -39,7 +40,7 @@ if("tools" IN_LIST FEATURES)
     MAKESPRITEFONT_EXE
     URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/MakeSpriteFont.exe"
     FILENAME "makespritefont-${DIRECTXTK_TAG}.exe"
-    SHA512 00a4c94d3f9b6607f652edfbe1ce0cc9c09437f3084e2b252462458e652ff2735bf94f028091739ec66edbf29c1ebeb813af5c9b68644ac02cebf8ab6833d8fa
+    SHA512 f5872c479e537ae02d32039dce9ed4820c834de37795365b02cb5ae0d9241fb2ece58c1555335c57394a7cfbca95202a91ddda4e77d6bdd484c6cf6e7b9d6e0e
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -54,7 +55,7 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/XWBTool.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}.exe"
-      SHA512 2b60b1dedfe8803914d16c760b546aad82a05404eedff9740f56a1ca8e15d9b77bba3743a3b39adb2092d04afc90106c8a3c2dffc87392cf5dfe6686752c4d3d
+      SHA512 e30f786e72e0a9ec84b359e768d3ea024c7e5611ea274b01189ee30faa2ce976579b42307edd4979fa39bdae7f0bc6041463723db3e97399e98575985b15d5da
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -67,7 +68,7 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/XWBTool_arm64.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}-arm64.exe"
-      SHA512 d0ff53fefedeba588ad583f99ab2c2420fe0b30a1efb88e4ce556436f1d5d8d76c69f28be7ca7209660212d017a1a404bcdb43349743a4142a7c3e88937ce1d3
+      SHA512 8b01d120954e29e532ded2a38bd3ba883310e48655eab6af884ddcb9c4516640b59ed0d970d01eec189c7b4d04593b51a79739895761f2514c1e8f0df8504d99
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")

--- a/ports/directxtk12/usage
+++ b/ports/directxtk12/usage
@@ -1,4 +1,4 @@
-The DirectX Tool Kit for DX12 package is compatible with built-in CMake targets:
+The DirectX Tool Kit for DX12 package provides CMake targets
 
     find_package(directxtk12 CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::DirectXTK12)

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-date": "2023-10-28",
+  "version-date": "2023-12-31",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",

--- a/ports/openexr/portfile.cmake
+++ b/ports/openexr/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_cmake_configure(
         -DBUILD_TESTING=OFF
         -DOPENEXR_INSTALL_EXAMPLES=OFF
         -DBUILD_DOCS=OFF
+        -DOPENEXR_INSTALL_PKG_CONFIG=ON
     OPTIONS_DEBUG
         -DOPENEXR_BUILD_TOOLS=OFF
         -DOPENEXR_INSTALL_TOOLS=OFF
@@ -28,6 +29,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/OpenEXR)
+
 vcpkg_fixup_pkgconfig()
 
 if(OPENEXR_INSTALL_TOOLS)
@@ -43,4 +45,4 @@ file(REMOVE_RECURSE
 )
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/openexr/vcpkg.json
+++ b/ports/openexr/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openexr",
   "version": "3.1.8",
+  "port-version": 1,
   "description": "OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications",
   "homepage": "https://www.openexr.com/",
   "license": "BSD-3-Clause",

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -1,4 +1,4 @@
-set(UVATLAS_TAG oct2023)
+set(UVATLAS_TAG dec2023)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
     REF ${UVATLAS_TAG}
-    SHA512 2ad831663a0db907c21cc13af766704ff9b037a55032bed0e99e71aae496df367e00a7ee146b4f2223fa1390c4ad3f050a79dd6ffdbc0f16982dbb3592da8912
+    SHA512 44caebdb6c4c2fc42c8dbbe4acbaf7046996dfcd08e36d622c50a024c1ea3968e1174bd4bf35356068d163c76ac88b697bebb4904dcd2c2bdb6e3e2daf9781d3
     HEAD_REF main
     PATCHES openexr.patch
 )
@@ -19,16 +19,19 @@ vcpkg_check_features(
         tools BUILD_TOOLS
 )
 
+set(EXTRA_OPTIONS -DBUILD_TESTING=OFF)
+
 if (VCPKG_HOST_IS_LINUX)
     message(WARNING "Build ${PORT} requires GCC version 9 or later")
 endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS} -DBUILD_TESTING=OFF
+    OPTIONS ${FEATURE_OPTIONS} ${EXTRA_OPTIONS}
 )
 
 vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/uvatlas)
 
 if("tools" IN_LIST FEATURES)
@@ -41,7 +44,7 @@ if("tools" IN_LIST FEATURES)
       UVATLASTOOL_EXE
       URLS "https://github.com/Microsoft/UVAtlas/releases/download/${UVATLAS_TAG}/uvatlastool.exe"
       FILENAME "uvatlastool-${UVATLAS_TAG}.exe"
-      SHA512 66b773c97dc591785c7472557da7f9df0f682dd8b20a4751aa4e3ad97c3a0edc6080ce563ac49d21e3781a12ca0c748e1aa032b20839bcf06f6d21133e5cc8e1
+      SHA512 d8c76c4745e120f45e99330be09498e53d013d64342c7df836a9d3bc6746cfc1d0d351b9d7d8ae76c24206f3032d98a4402a04b8a6450d2ced68594675f9be08
     )
 
     file(INSTALL

--- a/ports/uvatlas/usage
+++ b/ports/uvatlas/usage
@@ -1,4 +1,4 @@
-The package UVAtlas is compatible with built-in CMake targets:
+The UVAtlas package provides CMake targets:
 
     find_package(uvatlas CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::UVAtlas)

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uvatlas",
-  "version-date": "2023-10-31",
+  "version-date": "2023-12-31",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2181,11 +2181,11 @@
       "port-version": 0
     },
     "directxmath": {
-      "baseline": "2022-12-12",
+      "baseline": "2023-12-31",
       "port-version": 0
     },
     "directxmesh": {
-      "baseline": "2023-10-28",
+      "baseline": "2023-12-31",
       "port-version": 0
     },
     "directxsdk": {
@@ -2193,15 +2193,15 @@
       "port-version": 7
     },
     "directxtex": {
-      "baseline": "2023-10-28",
+      "baseline": "2023-12-31",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "2023-10-28",
+      "baseline": "2023-12-31",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2023-10-28",
+      "baseline": "2023-12-31",
       "port-version": 0
     },
     "dirent": {
@@ -6274,7 +6274,7 @@
     },
     "openexr": {
       "baseline": "3.1.8",
-      "port-version": 0
+      "port-version": 1
     },
     "openfbx": {
       "baseline": "2022-07-18",
@@ -8781,7 +8781,7 @@
       "port-version": 2
     },
     "uvatlas": {
-      "baseline": "2023-10-31",
+      "baseline": "2023-12-31",
       "port-version": 0
     },
     "uvw": {

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7b031efa3bb41535fde116ad3cec2674a2764cd",
+      "version-date": "2023-12-31",
+      "port-version": 0
+    },
+    {
       "git-tree": "ecd21e108091a293a27869c9c093ad558ffcdc42",
       "version-date": "2022-12-12",
       "port-version": 0

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e63a47ffc37c894672b093434b97137d86e599f",
+      "version-date": "2023-12-31",
+      "port-version": 0
+    },
+    {
       "git-tree": "174e5777bf0c14a32b9182a55f29a4f6c23c2226",
       "version-date": "2023-10-28",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "badb59a9a275010d4edfa78e2f63d35a91341126",
+      "version-date": "2023-12-31",
+      "port-version": 0
+    },
+    {
       "git-tree": "7721548fe4f3648dae608b765e757f69db31fe02",
       "version-date": "2023-10-28",
       "port-version": 0

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c817d9e4e03e8e1b848d90681b3ae042dbf3f50",
+      "version-date": "2023-12-31",
+      "port-version": 0
+    },
+    {
       "git-tree": "8f18ff4afb77acfd3b6383375fd2016746b192d2",
       "version-date": "2023-10-28",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "812ae3f8a37d56767d5bf058d1c02320a5b10183",
+      "version-date": "2023-12-31",
+      "port-version": 0
+    },
+    {
       "git-tree": "753353fa24f0d2c86cb75b0c6a881b621835a572",
       "version-date": "2023-10-28",
       "port-version": 0

--- a/versions/o-/openexr.json
+++ b/versions/o-/openexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3823a9121b31308e654b79c1be1dd2d3f195f4c",
+      "version": "3.1.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "36064f5fe46f2399a9a532fdb6d7542dae7faede",
       "version": "3.1.8",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e9c34981bb0811581e42a967e3168cf4caae0b1",
+      "version-date": "2023-12-31",
+      "port-version": 0
+    },
+    {
       "git-tree": "b19700b61aeb3ea159f83d6f2184708142ebae73",
       "version-date": "2023-10-31",
       "port-version": 0


### PR DESCRIPTION
This PR updates the DirectXMath, DirectX Tool Kit, DirectXMesh, DirectXTex, and UVAtlas ports for December 2023 releases.

The DirectXTex list adds Xbox extensions when targeting the ``x64-xbox-`` triplets.

The releases also include generating pkg-config files, which required having the **openexr** port also generate a pkg-config.