### PR TITLE
[ogre-next] vulkan no osx

### DIFF
--- a/ports/ogre-next/vcpkg.json
+++ b/ports/ogre-next/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ogre-next",
   "version": "2.3.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Ogre Next - scene-oriented, flexible 3D engine written in C++",
   "homepage": "https://github.com/OGRECave/ogre-next",
   "license": "MIT",
@@ -61,6 +61,7 @@
     },
     "vulkan": {
       "description": "Vulkan render system",
+      "supports": "!osx",
       "dependencies": [
         "glslang",
         "vulkan"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6166,7 +6166,7 @@
     },
     "ogre-next": {
       "baseline": "2.3.3",
-      "port-version": 1
+      "port-version": 2
     },
     "ois": {
       "baseline": "1.5.1",

--- a/versions/o-/ogre-next.json
+++ b/versions/o-/ogre-next.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1563ee76136a49e438bd5229b68635ce8fdc347a",
+      "version": "2.3.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "92372bf7078f6e5f955072f35696788f09849b71",
       "version": "2.3.3",
       "port-version": 1


### PR DESCRIPTION
It requires `xcb`/X11 on osx

```
/Users/leanderSchulten/git_projekte/vcpkg2/buildtrees/ogre-next/src/v2.3.3-d8d38bba95.clean/RenderSystems/Vulkan/src/Windowing/X11/OgreVulkanXcbSupport.cpp:34:10: fatal error: 'xcb/randr.h' file not found
```