### PR TITLE
[freerdp] remove deprecated client-mac

### DIFF
--- a/ports/freerdp/portfile.cmake
+++ b/ports/freerdp/portfile.cmake
@@ -20,7 +20,6 @@ endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        client-mac  WITH_CLIENT_MAC
         ffmpeg      WITH_FFMPEG
         ffmpeg      WITH_SWSCALE
         server      WITH_SERVER
@@ -52,6 +51,7 @@ vcpkg_cmake_configure(
         -DWITH_OPENSSL=ON
         -DWITH_SAMPLE=OFF
         -DWITH_UNICODE_BUILTIN=ON
+        -DWITH_CLIENT=OFF
         "-DMSVC_RUNTIME=${VCPKG_CRT_LINKAGE}"
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
         -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
@@ -83,26 +83,13 @@ vcpkg_fixup_pkgconfig()
 
 vcpkg_list(SET tools)
 if(VCPKG_TARGET_IS_WINDOWS)
-    list(APPEND tools wfreerdp)
     if("server" IN_LIST FEATURES)
         list(APPEND tools wfreerdp-server)
     endif()
 elseif(VCPKG_TARGET_IS_OSX)
-    if("client-mac" IN_LIST FEATURES)
-        file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/client/Mac/cli/MacFreeRDP.app"
-            DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
-        )
-        list(APPEND tools MacFreeRDP)
-    endif()
     if("server" IN_LIST FEATURES)
         list(APPEND tools mfreerdp-server)
     endif()
-endif()
-if("wayland" IN_LIST FEATURES)
-    list(APPEND tools wlfreerdp)
-endif()
-if("x11" IN_LIST FEATURES)
-    list(APPEND tools xfreerdp)
 endif()
 if("winpr-tools" IN_LIST FEATURES)
     list(APPEND tools winpr-hash winpr-makecert)

--- a/ports/freerdp/vcpkg.json
+++ b/ports/freerdp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "freerdp",
   "version": "3.0.0",
+  "port-version": 1,
   "description": "A free implementation of the Remote Desktop Protocol (RDP)",
   "homepage": "https://github.com/FreeRDP/FreeRDP",
   "license": "Apache-2.0",
@@ -23,10 +24,6 @@
     "zlib"
   ],
   "features": {
-    "client-mac": {
-      "description": "Build native mac client. Requires XCode.",
-      "supports": "osx"
-    },
     "ffmpeg": {
       "description": "Enable image scaling, video and audio with ffmpeg",
       "supports": "!windows",
@@ -74,7 +71,7 @@
     },
     "x11": {
       "description": "Enable X11 support",
-      "supports": "!android & !ios & !windows",
+      "supports": "!android & !ios & !windows & !osx",
       "dependencies": [
         "xcb"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2774,7 +2774,7 @@
     },
     "freerdp": {
       "baseline": "3.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "freetds": {
       "baseline": "1.3.10",

--- a/versions/f-/freerdp.json
+++ b/versions/f-/freerdp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "58d88811f61ec9063eb70b837f23c6ceeceb0198",
+      "version": "3.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "dfb634ed4a717897d4cb646a34dc9c663dcfceb8",
       "version": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
Failed to build with
```
CMake Error at ports/freerdp/portfile.cmake:92 (file):
  file COPY cannot find
  "/Users/leanderSchulten/git_projekte/vcpkg2/buildtrees/freerdp/arm64-osx-rel/client/Mac/cli/MacFreeRDP.app":
  No such file or directory.
Call Stack (most recent call first):
  scripts/ports.cmake:170 (include)
error: building freerdp:arm64-osx failed with: BUILD_FAILED
```
which could be fixed, but since the feature is deprecated i decided to remove it:
```
[21:54:19:644] [77226:df7a2100] [WARN][com.freerdp.client.common.cmdline] - [freerdp_client_warn_deprecated]: [deprecated] /Users/leanderSchulten/git_projekte/vcpkg2/buildtrees/freerdp/arm64-osx-rel/client/Mac/cli/MacFreeRDP client has been deprecated
[21:54:19:644] [77226:df7a2100] [WARN][com.freerdp.client.common.cmdline] - [freerdp_client_warn_deprecated]: As replacement there is a SDL based client available.
```
