### PR TITLE
[ms-ifc-sdk] Add new port

### DIFF
--- a/ports/ms-ifc-sdk/portfile.cmake
+++ b/ports/ms-ifc-sdk/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/ifc
+    REF 0.43.1
+    SHA512 c7ce8570d776f875c1a1fed929734ebc73b2cf25106e2a5e80625269f4f91d8106d19da34525cc4d7a694d750788d124e8e1ef082c54a13c9b34fe3da7f9e82d
+    HEAD_REF main
+)
+
+set(config_path share/cmake/Microsoft.IFC)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DIFC_INSTALL_CMAKEDIR:PATH=${config_path}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME Microsoft.IFC
+    CONFIG_PATH "${config_path}"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ms-ifc-sdk/usage
+++ b/ports/ms-ifc-sdk/usage
@@ -1,0 +1,8 @@
+The package Microsoft.IFC provides CMake targets:
+
+    find_package(Microsoft.IFC CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Microsoft.IFC::SDK)
+
+    # Or use the individual components of Microsoft.IFC::SDK for advanced use
+    find_package(Microsoft.IFC CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Microsoft.IFC::Core Microsoft.IFC::DOM)

--- a/ports/ms-ifc-sdk/vcpkg.json
+++ b/ports/ms-ifc-sdk/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "ms-ifc-sdk",
+  "version": "0.43.1",
+  "description": "SDK for the IFC specification at https://github.com/microsoft/ifc-spec",
+  "homepage": "https://github.com/microsoft/ifc",
+  "license": "Apache-2.0 WITH LLVM-exception",
+  "dependencies": [
+    "ms-gsl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -728,13 +728,17 @@ mp3lame:arm-neon-android=fail
 mp3lame:arm64-android=fail
 mp3lame:x64-android=fail
 mpir:x64-android=fail
-# these ports require the Microsoft GDK with Xbox Extensions which is not installed on the CI pipeline machines
+# ms-gltf and ms-quic require the Microsoft GDK with Xbox Extensions which is not installed on the CI pipeline machines
 ms-gdkx:x64-windows=fail
 ms-gdkx:x64-windows-static=fail
 ms-gdkx:x64-windows-static-md=fail
 ms-gltf:arm-neon-android=fail
 ms-gltf:arm64-android=fail
 ms-gltf:x64-android=fail
+# ms-ifc-sdk requires a very recent compiler (C++23)
+ms-ifc-sdk:arm-neon-android=fail
+ms-ifc-sdk:arm64-android=fail
+ms-ifc-sdk:x64-android=fail
 ms-quic:arm64-uwp=fail
 ms-quic:arm64-windows=fail
 ms-quic:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5764,6 +5764,10 @@
       "baseline": "4.0.0",
       "port-version": 1
     },
+    "ms-ifc-sdk": {
+      "baseline": "0.43.1",
+      "port-version": 0
+    },
     "ms-quic": {
       "baseline": "1.2.0",
       "port-version": 0

--- a/versions/m-/ms-ifc-sdk.json
+++ b/versions/m-/ms-ifc-sdk.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1c24ff4ae05b7f1b10e071e516d4fb07cedfee16",
+      "version": "0.43.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Issue: https://github.com/microsoft/ifc/issues/45

cc @GabrielDosReis @cdacamar

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
