### PR TITLE
[wxwidgets] Update to 3.2.4

### DIFF
--- a/ports/wxwidgets/fix-glegl.patch
+++ b/ports/wxwidgets/fix-glegl.patch
@@ -1,0 +1,20 @@
+diff --git a/src/unix/glegl.cpp b/src/unix/glegl.cpp
+index 9e1b6b7..5e971a4 100644
+--- a/src/unix/glegl.cpp
++++ b/src/unix/glegl.cpp
+@@ -801,6 +801,7 @@ void wxGLCanvasEGL::FreeDefaultConfig()
+ 
+ bool wxGLCanvasEGL::SwapBuffers()
+ {
++#ifdef GDK_WINDOWING_WAYLAND
+     // Before doing anything else, ensure that eglSwapBuffers() doesn't block:
+     // under Wayland we don't want it to because we use the surface callback to
+     // know when we should draw anyhow and with X11 it blocks for up to a
+@@ -827,6 +828,7 @@ bool wxGLCanvasEGL::SwapBuffers()
+                        this, eglGetError());
+         }
+     }
++#endif // GDK_WINDOWING_WAYLAND
+ 
+     GdkWindow* const window = GTKGetDrawingWindow();
+ #ifdef GDK_WINDOWING_X11

--- a/ports/wxwidgets/fix-glegl.patch
+++ b/ports/wxwidgets/fix-glegl.patch
@@ -1,20 +1,36 @@
 diff --git a/src/unix/glegl.cpp b/src/unix/glegl.cpp
-index 9e1b6b7..5e971a4 100644
+index 9e1b6b7..7407a9f 100644
 --- a/src/unix/glegl.cpp
 +++ b/src/unix/glegl.cpp
-@@ -801,6 +801,7 @@ void wxGLCanvasEGL::FreeDefaultConfig()
+@@ -43,8 +43,9 @@
  
- bool wxGLCanvasEGL::SwapBuffers()
- {
-+#ifdef GDK_WINDOWING_WAYLAND
-     // Before doing anything else, ensure that eglSwapBuffers() doesn't block:
-     // under Wayland we don't want it to because we use the surface callback to
-     // know when we should draw anyhow and with X11 it blocks for up to a
-@@ -827,6 +828,7 @@ bool wxGLCanvasEGL::SwapBuffers()
-                        this, eglGetError());
-         }
-     }
-+#endif // GDK_WINDOWING_WAYLAND
+ static const char* TRACE_EGL = "glegl";
  
-     GdkWindow* const window = GTKGetDrawingWindow();
- #ifdef GDK_WINDOWING_X11
+-#ifdef GDK_WINDOWING_WAYLAND
+-
++// We can't add a member variable to wxGLCanvasEGL in 3.2 branch, so emulate it
++// by encoding the corresponding boolean value via the presence of "this"
++// pointer in the given hash set.
+ #include "wx/hashset.h"
+ 
+ namespace
+@@ -58,8 +59,6 @@ wxGLCanvasSet gs_alreadySetSwapInterval;
+ 
+ } // anonymous namespace
+ 
+-#endif // GDK_WINDOWING_WAYLAND
+-
+ // ----------------------------------------------------------------------------
+ // wxGLContextAttrs: OpenGL rendering context attributes
+ // ----------------------------------------------------------------------------
+@@ -633,9 +632,9 @@ wxGLCanvasEGL::~wxGLCanvasEGL()
+     DestroyWaylandSubsurface();
+     g_clear_pointer(&m_wlEGLWindow, wl_egl_window_destroy);
+     g_clear_pointer(&m_wlSurface, wl_surface_destroy);
++#endif
+ 
+     gs_alreadySetSwapInterval.erase(this);
+-#endif
+ }
+ 
+ void wxGLCanvasEGL::CreateWaylandSubsurface()

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
     REF "v${VERSION}"
-    SHA512 d9cfad429c5c160944cd9c23c3a32ca72740e2d25d7392a06c22374bcbdd099affee5f541d59ac4a9983fb3d82f90bda7eaf92a93a1e8b5ace2c5bf29962ed53
+    SHA512 f1ba875e6dfa3970e6f03741573f96ac224a8d0bace5a4c44dcf95dd4e861031fe086e2dc4429c1c6bcb22d40656fc2c6c287abe0b4678eb9af9698691eda3d9
     HEAD_REF master
     PATCHES
         install-layout.patch

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         fix-pcre2.patch
         gtk3-link-libraries.patch
         sdl2.patch
+        fix-glegl.patch
 )
 
 vcpkg_check_features(

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wxwidgets",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9165,7 +9165,7 @@
       "port-version": 0
     },
     "wxwidgets": {
-      "baseline": "3.2.3",
+      "baseline": "3.2.4",
       "port-version": 0
     },
     "wyhash": {

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea1e14e3f7e09e6bb23baec9ac1194eec01cd8e7",
+      "version": "3.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "8dfaace5786af8de744ecf9e02622b7b3e39087a",
       "version": "3.2.3",
       "port-version": 0

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "29f317e089f113d8940dc41a3eb13f58e7655962",
+      "git-tree": "b76c48ce396ff7c6e49ec508b7c5bd749fb94fbb",
       "version": "3.2.4",
       "port-version": 0
     },

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ea1e14e3f7e09e6bb23baec9ac1194eec01cd8e7",
+      "git-tree": "29f317e089f113d8940dc41a3eb13f58e7655962",
       "version": "3.2.4",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #35938, update `wxwidgets` to 3.2.4.

Add the patch `fix-glegl.patch` to fix the following issues, related issue in the upstream: https://github.com/wxWidgets/wxWidgets/issues/24076.
```
FAILED: libs/gl/CMakeFiles/wxgl.dir/__/__/__/__/src/unix/glegl.cpp.o 
/usr/bin/c++ -DWXBUILDING -DWX_PRECOMP -D_FILE_OFFSET_BITS=64 -D_UNICODE -D__WXGTK3__ -D__WXGTK__ -DwxUSE_BASE=0 -DwxUSE_GUI=1 -I/mnt/vcpkg-ci/b/wxwidgets/x64-linux-dbg/lib/wx/include/gtk3-unicode-static-3.2 -I/mnt/vcpkg-ci/b/wxwidgets/src/v3.2.4-9b80bee8c3.clean/include -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/gtk-3.0 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/pango-1.0 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/cairo -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/gdk-pixbuf-2.0 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/at-spi2-atk/2.0 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/at-spi-2.0 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/dbus-1.0 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../lib/dbus-1.0/include -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/atk-1.0 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/fribidi -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/harfbuzz -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/libpng16 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/pixman-1 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/gio-unix-2.0 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/glib-2.0 -I/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../lib/glib-2.0/include -I/mnt/vcpkg-ci/installed/x64-linux/include/gtk-3.0/unix-print -I/usr/include/xkbcommon -isystem /mnt/vcpkg-ci/installed/x64-linux/include -isystem /mnt/vcpkg-ci/installed/x64-linux/include/SDL2 -fPIC -g -fPIC -Wall -Wundef -Wunused-parameter -Wno-deprecated-declarations -Wno-ctor-dtor-privacy -Woverloaded-virtual -pthread -Winvalid-pch -include /mnt/vcpkg-ci/b/wxwidgets/x64-linux-dbg/libs/gl/CMakeFiles/wxgl.dir/cmake_pch.hxx -MD -MT libs/gl/CMakeFiles/wxgl.dir/__/__/__/__/src/unix/glegl.cpp.o -MF libs/gl/CMakeFiles/wxgl.dir/__/__/__/__/src/unix/glegl.cpp.o.d -o libs/gl/CMakeFiles/wxgl.dir/__/__/__/__/src/unix/glegl.cpp.o -c /mnt/vcpkg-ci/b/wxwidgets/src/v3.2.4-9b80bee8c3.clean/src/unix/glegl.cpp
/mnt/vcpkg-ci/b/wxwidgets/src/v3.2.4-9b80bee8c3.clean/src/unix/glegl.cpp: In member function ‘virtual bool wxGLCanvasEGL::SwapBuffers()’:
/mnt/vcpkg-ci/b/wxwidgets/src/v3.2.4-9b80bee8c3.clean/src/unix/glegl.cpp:813:11: error: ‘gs_alreadySetSwapInterval’ was not declared in this scope
  813 |     if ( !gs_alreadySetSwapInterval.count(this) )
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~
```


All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```

The usage test passed on `x64-windows` (header files found):
```
The package wxwidgets provides CMake targets:

    find_package(wxWidgets CONFIG REQUIRED)
    target_link_libraries(main PRIVATE wx::core wx::base)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.