### PR TITLE
[capstone] Add missing arch features

### DIFF
--- a/ports/capstone/portfile.cmake
+++ b/ports/capstone/portfile.cmake
@@ -24,12 +24,18 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "tms320c64x"  CAPSTONE_TMS320C64X_SUPPORT
         "x86"         CAPSTONE_X86_SUPPORT
         "xcore"       CAPSTONE_XCORE_SUPPORT
+        "mos65xx"     CAPSTONE_MOS65XX_SUPPORT
+        "tricore"     CAPSTONE_TRICORE_SUPPORT
+        "wasm"        CAPSTONE_WASM_SUPPORT
+        "bpf"         CAPSTONE_BPF_SUPPORT
+        "riscv"       CAPSTONE_RISCV_SUPPORT
         "diet"        CAPSTONE_BUILD_DIET
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DCAPSTONE_ARCHITECTURE_DEFAULT=OFF
         -DCAPSTONE_BUILD_TESTS=OFF
         -DCAPSTONE_BUILD_CSTOOL=OFF
         -DCAPSTONE_BUILD_STATIC_RUNTIME=${STATIC_CRT}

--- a/ports/capstone/vcpkg.json
+++ b/ports/capstone/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "capstone",
   "version": "5.0.1",
+  "port-version": 1,
   "description": "Multi-architecture disassembly framework",
   "homepage": "https://github.com/capstone-engine/capstone",
   "dependencies": [
@@ -20,6 +21,9 @@
     "arm64": {
       "description": "Capstone disassembly support for ARM64"
     },
+    "bpf": {
+      "description": "Capstone disassembly support for BPF"
+    },
     "diet": {
       "description": "Build Capstone in diet mode (reduced features for smaller size)"
     },
@@ -35,8 +39,14 @@
     "mips": {
       "description": "Capstone disassembly support for MIPS"
     },
+    "mos65xx": {
+      "description": "Capstone disassembly support for MOS65XX"
+    },
     "ppc": {
       "description": "Capstone disassembly support for PowerPC"
+    },
+    "riscv": {
+      "description": "Capstone disassembly support for RISC-V"
     },
     "sparc": {
       "description": "Capstone disassembly support for SPARC"
@@ -46,6 +56,12 @@
     },
     "tms320c64x": {
       "description": "Capstone disassembly support for TMS320C64X"
+    },
+    "tricore": {
+      "description": "Capstone disassembly support for TriCore"
+    },
+    "wasm": {
+      "description": "Capstone disassembly support for WebAssembly"
     },
     "x86": {
       "description": "Capstone disassembly support for x86"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1438,7 +1438,7 @@
     },
     "capstone": {
       "baseline": "5.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "cargs": {
       "baseline": "1.0.3",

--- a/versions/c-/capstone.json
+++ b/versions/c-/capstone.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2879a914b5c261ad9fb1b48b921a4d53a486eb0",
+      "version": "5.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "4c89ad8669fdc6aa946d13cfe053a64fa50f75a7",
       "version": "5.0.1",
       "port-version": 0


### PR DESCRIPTION
The capstone port was missing features for some optional disassembler architectures. Since we did not previously set `CAPSTONE_ARCHITECTURE_DEFAULT=OFF`, this resulted in these relatively obscure architectures being included by default, unlike all of the other architectures which required an explicit opt-in.

Address this by adding missing features and by setting `CAPSTONE_ARCHITECTURE_DEFAULT=OFF` so any additional architecture added in the future by upstream will require an explicit opt-in in due course.
