### PR TITLE
[directxsdk] Add missing d3d9 header and lib

### DIFF
--- a/ports/directxsdk/portfile.cmake
+++ b/ports/directxsdk/portfile.cmake
@@ -33,6 +33,8 @@ set(HEADERS
     ${INC_DIR}/D3DX11async.h
     ${INC_DIR}/D3DX11core.h
     ${INC_DIR}/D3DX11tex.h
+    ${INC_DIR}/d3d9.h
+    ${INC_DIR}/d3d9types.h
     ${INC_DIR}/d3dx9.h
     ${INC_DIR}/d3dx9anim.h
     ${INC_DIR}/d3dx9core.h
@@ -70,6 +72,7 @@ set(RELEASE_LIBS
     ${LIB_DIR}/d3dx9.lib
 )
 set(OTHER_LIBS
+    ${LIB_DIR}/d3d9.lib
     ${LIB_DIR}/d3dxof.lib
     ${LIB_DIR}/DxErr.lib
 )

--- a/ports/directxsdk/vcpkg.json
+++ b/ports/directxsdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "directxsdk",
   "version-string": "jun10",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Legacy DirectX SDK",
   "homepage": "https://docs.microsoft.com/en-us/windows/win32/directx-sdk--august-2009-",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2190,7 +2190,7 @@
     },
     "directxsdk": {
       "baseline": "jun10",
-      "port-version": 7
+      "port-version": 8
     },
     "directxtex": {
       "baseline": "2023-12-31",

--- a/versions/d-/directxsdk.json
+++ b/versions/d-/directxsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c82a75b02160ef435f13eb2fda1f2079013bca68",
+      "version-string": "jun10",
+      "port-version": 8
+    },
+    {
       "git-tree": "10f6ac11c6480f52d70ff2725cf34fd39b942376",
       "version-string": "jun10",
       "port-version": 7


### PR DESCRIPTION
The legacy directxsdk package is in a pretty bad way by the looks of things. On first glance, and for my use case, it didn't even declare `d3d9.h`, `d3d9.lib` or its associated headers/libraries from the archive, making it useless for "low-level" Direct3D work.

This is an incomplete fix-up just to add the extra missing pieces that I need for my use case. It probably needs a much more comprehensive overhaul.

Also... the package search tool declares that this supports arm64! That is obviously not the case.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

