### PR TITLE
[Freetype] burn in linkage

### DIFF
--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -74,6 +74,14 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
+if(VCPKG_TARGET_IS_WINDOWS)
+  set(dll_linkage 1)
+  if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(dll_linkage 0)
+  endif()
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/freetype/config/public-macros.h" "#elif defined( DLL_IMPORT )" "#elif ${dll_linkage}")
+endif()
+
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
     "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/freetype/vcpkg.json
+++ b/ports/freetype/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "freetype",
   "version": "2.12.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A library to render fonts.",
   "homepage": "https://www.freetype.org/",
   "license": "FTL OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2782,7 +2782,7 @@
     },
     "freetype": {
       "baseline": "2.12.1",
-      "port-version": 4
+      "port-version": 5
     },
     "freetype-gl": {
       "baseline": "2022-01-17",

--- a/versions/f-/freetype.json
+++ b/versions/f-/freetype.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5480587e6a2faf047bc6d8520e48c12fc57604a",
+      "version": "2.12.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "4e52babe5d382c3f9cdb1b8037874d78eceb3512",
       "version": "2.12.1",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

