### PR TITLE
[nvlabs-flip] Add NVlabs/flip

### DIFF
--- a/ports/nvlabs-flip/001-vcpkg-dependencies.patch
+++ b/ports/nvlabs-flip/001-vcpkg-dependencies.patch
@@ -1,0 +1,27 @@
+diff --git a/cpp/CPP/CMakeLists.txt b/cpp/CPP/CMakeLists.txt
+index f3868bf..ab8e1b0 100644
+--- a/cpp/CPP/CMakeLists.txt
++++ b/cpp/CPP/CMakeLists.txt
+@@ -30,6 +30,9 @@
+ # SPDX-License-Identifier: BSD-3-Clause
+ #################################################################################
+ 
++find_package(Stb REQUIRED)
++find_package(tinyexr CONFIG REQUIRED)
++
+ if (FLIP_LIBRARY)
+   add_library(${PROJECT_NAME} ../common/FLIP.cpp)
+ else()
+@@ -41,4 +44,12 @@ PRIVATE
+   ${CMAKE_CURRENT_LIST_DIR}
+   ${CMAKE_CURRENT_LIST_DIR}/../common
+ )
++target_include_directories(${PROJECT_NAME}
++  PUBLIC
++    ${Stb_INCLUDE_DIR}
++)
++target_link_libraries(${PROJECT_NAME}
++  PUBLIC
++    unofficial::tinyexr::tinyexr
++)
+ install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/ports/nvlabs-flip/002-fix-installation-rules.patch
+++ b/ports/nvlabs-flip/002-fix-installation-rules.patch
@@ -1,0 +1,75 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bffe127..12faf51 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -53,3 +53,33 @@ add_subdirectory(cpp/CPP)
+ if (FLIP_ENABLE_CUDA)
+   add_subdirectory(cpp/CUDA)
+ endif()
++
++include(CMakePackageConfigHelpers)
++
++file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-flip-config.cmake.in" [=[@PACKAGE_INIT@
++    include(CMakeFindDependencyMacro)
++
++    find_dependency(tinyexr CONFIG REQUIRED)
++
++    include("${CMAKE_CURRENT_LIST_DIR}/unofficial-flip-targets.cmake")
++    check_required_components("@PROJECT_NAME@")
++]=])
++
++configure_package_config_file(
++    "${CMAKE_CURRENT_BINARY_DIR}/unofficial-flip-config.cmake.in"
++    "${CMAKE_CURRENT_BINARY_DIR}/unofficial-flip-config.cmake"
++    INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/unofficial-flip
++)
++
++install(
++    EXPORT      unofficial-flip-targets
++    NAMESPACE   "unofficial::flip::"
++    DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-flip"
++)
++
++install(
++    FILES
++        "${CMAKE_CURRENT_BINARY_DIR}/unofficial-flip-config.cmake"
++    DESTINATION
++        "${CMAKE_INSTALL_DATADIR}/unofficial-flip"
++)
+\ No newline at end of file
+diff --git a/cpp/CPP/CMakeLists.txt b/cpp/CPP/CMakeLists.txt
+index ab8e1b0..bddeeb7 100644
+--- a/cpp/CPP/CMakeLists.txt
++++ b/cpp/CPP/CMakeLists.txt
+@@ -46,10 +46,29 @@ PRIVATE
+ )
+ target_include_directories(${PROJECT_NAME}
+   PUBLIC
+-    ${Stb_INCLUDE_DIR}
++    $<BUILD_INTERFACE:${Stb_INCLUDE_DIR}>
++    $<INSTALL_INTERFACE:include>
+ )
+ target_link_libraries(${PROJECT_NAME}
+   PUBLIC
+     unofficial::tinyexr::tinyexr
+ )
+-install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++install(TARGETS ${PROJECT_NAME} EXPORT unofficial-flip-targets)
++install(FILES
++    "../common/commandline.h"
++    "../common/filename.h"
++    "../common/mapMagma.h"
++    "../common/mapViridis.h"
++    "../common/pooling.h"
++    "../common/sharedflip.h"
++  DESTINATION
++    "${CMAKE_INSTALL_INCLUDEDIR}/flip/common"
++)
++install(FILES
++    "color.h"
++    "FLIP.h"
++    "image.h"
++    "tensor.h"
++  DESTINATION
++    "${CMAKE_INSTALL_INCLUDEDIR}/flip/CPP"
++)

--- a/ports/nvlabs-flip/003-option-build-tools.patch
+++ b/ports/nvlabs-flip/003-option-build-tools.patch
@@ -1,0 +1,56 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 12faf51..5d2f89f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,7 +47,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+ include(GNUInstallDirs)
+ 
+ option(FLIP_ENABLE_CUDA "Include CUDA version of flip" OFF)
+-option(FLIP_LIBRARY OFF)
++option(FLIP_BUILD_TOOLS "Build command-line tools" OFF)
+ 
+ add_subdirectory(cpp/CPP)
+ if (FLIP_ENABLE_CUDA)
+diff --git a/cpp/CPP/CMakeLists.txt b/cpp/CPP/CMakeLists.txt
+index bddeeb7..4101fbf 100644
+--- a/cpp/CPP/CMakeLists.txt
++++ b/cpp/CPP/CMakeLists.txt
+@@ -33,12 +33,7 @@
+ find_package(Stb REQUIRED)
+ find_package(tinyexr CONFIG REQUIRED)
+ 
+-if (FLIP_LIBRARY)
+-  add_library(${PROJECT_NAME} ../common/FLIP.cpp)
+-else()
+-  add_executable(${PROJECT_NAME} ../common/FLIP.cpp)
+-endif()
+-
++add_library(${PROJECT_NAME} ../common/FLIP.cpp)
+ target_include_directories(${PROJECT_NAME}
+ PRIVATE
+   ${CMAKE_CURRENT_LIST_DIR}
+@@ -72,3 +67,23 @@ install(FILES
+   DESTINATION
+     "${CMAKE_INSTALL_INCLUDEDIR}/flip/CPP"
+ )
++
++if(FLIP_BUILD_TOOLS)
++  add_executable(flip_cli ../common/FLIP.cpp)
++  target_include_directories(flip_cli
++    PRIVATE
++      ${CMAKE_CURRENT_LIST_DIR}
++      ${CMAKE_CURRENT_LIST_DIR}/../common
++  )
++  target_include_directories(flip_cli
++    PRIVATE
++      ${Stb_INCLUDE_DIR}
++  )
++  target_link_libraries(flip_cli
++    PRIVATE
++      unofficial::tinyexr::tinyexr
++  )
++  install(TARGETS flip_cli EXPORT unofficial-flip-targets)
++  set_property(TARGET flip_cli PROPERTY EXPORT_NAME "cli")
++  set_property(TARGET flip_cli PROPERTY OUTPUT_NAME "flip")
++endif()
+\ No newline at end of file

--- a/ports/nvlabs-flip/004-remove-cmake-variable-set.patch
+++ b/ports/nvlabs-flip/004-remove-cmake-variable-set.patch
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5d2f89f..58cd9d3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,15 +32,6 @@
+ 
+ cmake_minimum_required(VERSION 3.9)
+ 
+-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+-
+-set(CMAKE_CXX_STANDARD 17)
+-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+-set(CMAKE_CXX_EXTENSIONS OFF)
+-
+-set(CMAKE_BUILD_TYPE_INIT "Release")
+-
+ project(flip LANGUAGES CXX)
+ 
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+--- a/cpp/CPP/CMakeLists.txt
++++ b/cpp/CPP/CMakeLists.txt
+@@ -48,6 +48,10 @@ target_link_libraries(${PROJECT_NAME}
+   PUBLIC
+     unofficial::tinyexr::tinyexr
+ )
++target_compile_features(${PROJECT_NAME}
++  PUBLIC
++    cxx_std_17
++)
+ install(TARGETS ${PROJECT_NAME} EXPORT unofficial-flip-targets)
+ install(FILES
+     "../common/commandline.h"
+@@ -83,6 +87,10 @@ if(FLIP_BUILD_TOOLS)
+     PRIVATE
+       unofficial::tinyexr::tinyexr
+   )
++  target_compile_features(flip_cli
++    PRIVATE
++      cxx_std_17
++  )
+   install(TARGETS flip_cli EXPORT unofficial-flip-targets)
+   set_property(TARGET flip_cli PROPERTY EXPORT_NAME "cli")
+   set_property(TARGET flip_cli PROPERTY OUTPUT_NAME "flip")

--- a/ports/nvlabs-flip/portfile.cmake
+++ b/ports/nvlabs-flip/portfile.cmake
@@ -1,0 +1,53 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVlabs/flip
+    REF 5d8b86c205a6a675976b1ba1a82f578ef944e038 # HEAD as of 20231108
+    SHA512 6ab1acd11b7e817cb031ea86d357a0c523b23a637376653267daf67759e779c0fd166dc7e1100d4dc728e9e7305c61341ae509fed81af5344b9f89689b26bfb1
+    HEAD_REF main
+    PATCHES
+        001-vcpkg-dependencies.patch
+        002-fix-installation-rules.patch
+        003-option-build-tools.patch
+        004-remove-cmake-variable-set.patch
+)
+
+file(REMOVE
+    "${SOURCE_PATH}/cpp/common/stb_image.h"
+    "${SOURCE_PATH}/cpp/common/stb_image_write.h"
+    "${SOURCE_PATH}/cpp/common/tinyexr.h"
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools FLIP_BUILD_TOOLS
+        cuda FLIP_ENABLE_CUDA
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS ${FEATURE_OPTIONS}
+)
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-flip)
+
+if(VCPKG_HOST_IS_WINDOWS)
+    vcpkg_fixup_pkgconfig(SKIP_CHECK)
+else()
+    vcpkg_fixup_pkgconfig()
+endif()
+
+if(FLIP_BUILD_TOOLS)
+    vcpkg_copy_tools(AUTO_CLEAN TOOL_NAMES flip)
+endif()
+
+# Cleanup
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README.md")

--- a/ports/nvlabs-flip/vcpkg.json
+++ b/ports/nvlabs-flip/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "nvlabs-flip",
+  "version-date": "2023-11-08",
+  "port-version": 1,
+  "description": "A tool for visualizing and communicating the errors in rendered images.",
+  "homepage": "https://github.com/NVlabs/flip",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "stb",
+    "tinyexr",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Include CUDA version of flip"
+    },
+    "tools": {
+      "description": "Build flip command-line tool"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6068,6 +6068,10 @@
       "baseline": "5.1.4",
       "port-version": 0
     },
+    "nvlabs-flip": {
+      "baseline": "2023-11-08",
+      "port-version": 1
+    },
     "nvtt": {
       "baseline": "2.1.2",
       "port-version": 8

--- a/versions/n-/nvlabs-flip.json
+++ b/versions/n-/nvlabs-flip.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f110aea2bc45d8dd143e621d356f465325a1a0eb",
+      "version-date": "2023-11-08",
+      "port-version": 1
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.