### PR TITLE
[libgcrypt] Remove supports

### DIFF
--- a/ports/libgcrypt/vcpkg.json
+++ b/ports/libgcrypt/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "libgcrypt",
   "version": "1.10.2",
+  "port-version": 1,
   "description": "A general purpose cryptographic library",
   "homepage": "https://gnupg.org/software/libgcrypt/index.html",
   "license": null,
-  "supports": "!windows | mingw",
   "dependencies": [
     {
       "name": "libgcrypt",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4314,7 +4314,7 @@
     },
     "libgcrypt": {
       "baseline": "1.10.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libgd": {
       "baseline": "2.3.3",

--- a/versions/l-/libgcrypt.json
+++ b/versions/l-/libgcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "24d8e957179f5645cf2809b560f6dca697025ba1",
+      "version": "1.10.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "fb85f5dab3e4cacb5da45cf352ca23a25d7c4d18",
       "version": "1.10.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #24786.
The following message from upstream https://gnupg.org/software/libgcrypt/index.html, this port could install on windows.
> Libgcrypt works on most POSIX systems and many pre-POSIX systems. It can also be built using a cross-compiler system for Microsoft Windows.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
