### PR TITLE
[fmt] Update to 10.2.1

### DIFF
--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fmtlib/fmt
     REF "${VERSION}"
-    SHA512 b90f8ab1692fcae9146f8cad5c5c26a2b5ceb6a0460003e01cabe8a75c0aa2fea1c3760dc3214eddaf08984a1695747ea8b1f3124c40c54cbadfd45458fa4b2d
+    SHA512 27df90c681ec37e55625062a79e3b83589b6d7e94eff37a3b412bb8c1473f757a8adb727603acc9185c3490628269216843b7d7bd5a3cb37f0029da5d1495ffa
     HEAD_REF master
     PATCHES
         fix-write-batch.patch

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fmt",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.",
   "homepage": "https://github.com/fmtlib/fmt",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2713,7 +2713,7 @@
       "port-version": 2
     },
     "fmt": {
-      "baseline": "10.2.0",
+      "baseline": "10.2.1",
       "port-version": 0
     },
     "folly": {

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "405156a2b01c91258bf66768ceb3ae75c1caba7f",
+      "version": "10.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f91bb86075f45f6fad0c35ab9e87d8ea43c9d389",
       "version": "10.2.0",
       "port-version": 0


### PR DESCRIPTION
This contains an ABI fix.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
