### PR TITLE
[google-cloud-cpp] update to the latest release (v2.20.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 a392da19ac353409ecbf30e390803b2e34670552fd54466a08ee554a77c893d447289b30d5841c7f79b2a23244a269d8ecac8f7fbd8a34dda45ce2d8b1d46817
+    SHA512 f017252b3fbccd5b91088a00c98a610606c5e98b920bf6c0889b6bf0f33f923c38a6116df7d9784381fd6b81ff4c303f55a609fde2e7182958a3c9cbab1f9f47
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.19.0",
-  "port-version": 1,
+  "version": "2.20.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -286,6 +285,18 @@
     },
     "cloudbuild": {
       "description": "Cloud Build API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "cloudquotas": {
+      "description": "Cloud Quotas API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3057,8 +3057,8 @@
       "port-version": 6
     },
     "google-cloud-cpp": {
-      "baseline": "2.19.0",
-      "port-version": 1
+      "baseline": "2.20.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b6b859d3c9db3328c9cb34949d5d618f4999090",
+      "version": "2.20.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "815f9e2c25c4aa47b16ec69ac6c41e2d52655d89",
       "version": "2.19.0",
       "port-version": 1


### PR DESCRIPTION
Updates google-cloud-cpp to the latest release (v2.20.0)

Tested locally (on x64-linux) with:

```
for feature in cloudquotas; do ./vcpkg remove google-cloud-cpp; ./vcpkg install "google-cloud-cpp[core,${feature}]" || break; done
```

and

```
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

