### PR TITLE
[xerces-c] Update to 3.2.5

### DIFF
--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/xerces-c
     REF "v${VERSION}"
-    SHA512 0da61e000e871c045fb6e546cabba244eb6470a7a972c1d1b817ba5ce91c0d1d12dfb3ff1479d8b57ab06c49deefd1c16c36dc2541055e41a1cdb15dbd769fcf
+    SHA512 55bf16456408af7c5aa420a55b27555889fc102a24e86aecb918c165acc80bbc344420687061e020fe223ea04dd78bef929ceedc4b3e24727787f12b8d79b610
     HEAD_REF master
     PATCHES
         dependencies.patch

--- a/ports/xerces-c/vcpkg.json
+++ b/ports/xerces-c/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xerces-c",
-  "version": "3.2.4",
-  "port-version": 3,
+  "version-semver": "3.2.5",
   "description": "Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.",
   "homepage": "https://github.com/apache/xerces-c",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9241,8 +9241,8 @@
       "port-version": 1
     },
     "xerces-c": {
-      "baseline": "3.2.4",
-      "port-version": 3
+      "baseline": "3.2.5",
+      "port-version": 0
     },
     "xeus": {
       "baseline": "0.24.3",

--- a/versions/x-/xerces-c.json
+++ b/versions/x-/xerces-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a127df4687908c60c7d7c7a37342a7ab6c509cf",
+      "version-semver": "3.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "4026f062e68881d5a72ecd5d900c70a46f92a8d9",
       "version": "3.2.4",
       "port-version": 3


### PR DESCRIPTION
Update include fix of CVE-2018-1311.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.