### PR TITLE
[gettext-libintl] Avoid conftest triggering debugger window

### DIFF
--- a/ports/gettext-libintl/portfile.cmake
+++ b/ports/gettext-libintl/portfile.cmake
@@ -54,9 +54,12 @@ if(VCPKG_TARGET_IS_WINDOWS)
     list(APPEND OPTIONS
         # Avoid unnecessary tests.
         am_cv_func_iconv_works=yes
-        ## This is required. For some reason these do not get correctly identified for release builds.
+        # This is required. For some reason these do not get correctly identified for release builds.
         ac_cv_func_wcslen=yes
         ac_cv_func_memmove=yes
+        # May trigger debugger window in debug builds, even in unattended builds.
+        # Cf. https://github.com/microsoft/vcpkg/issues/35974
+        gl_cv_func_printf_directive_n=no
     )
     if(NOT VCPKG_TARGET_IS_MINGW)
         list(APPEND OPTIONS

--- a/ports/gettext-libintl/vcpkg.json
+++ b/ports/gettext-libintl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gettext-libintl",
   "version": "0.22.4",
+  "port-version": 1,
   "description": "The libintl C library from GNU gettext-runtime.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2938,7 +2938,7 @@
     },
     "gettext-libintl": {
       "baseline": "0.22.4",
-      "port-version": 0
+      "port-version": 1
     },
     "gettimeofday": {
       "baseline": "2017-10-14",

--- a/versions/g-/gettext-libintl.json
+++ b/versions/g-/gettext-libintl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b81c3757a4f5b2eb78c45e29d51803e5a3418fdb",
+      "version": "0.22.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "003232270da6a899ac59d4e61d7fead638584deb",
       "version": "0.22.4",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/35974.