### PR TITLE
[mongo-c-driver] update to 1.25.4

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 77569b9816eb9bfcc6fe2f3cfab69845410aa2e7c6a5db987957eef74cff5cfd51006373bbc8539ecf385adf8c9c067df5a151bdf9b5f7ee71cdf5c9c64040a8
+    SHA512 a80e20917edb752ac5eb42534beaa0122a383037f83a554ee00ce37ae690be68521eaa282b4a5802a5440b61038bcd5414356e16a2ce729ba1193d0738a6ce1c
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.25.2",
+  "version": "1.25.4",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/disable-dynamic-when-static.patch
+++ b/ports/mongo-c-driver/disable-dynamic-when-static.patch
@@ -1,55 +1,34 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 61cae9c..5f553c5 100644
+index c36dff1..525e065 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -812,6 +812,7 @@ if (MONGOC_ENABLE_STATIC_BUILD)
+@@ -812,7 +812,7 @@ if (MONGOC_ENABLE_STATIC_BUILD)
     set_target_properties (mcd_rpc PROPERTIES OUTPUT_NAME "mcd-rpc")
  endif ()
  
+-if (ENABLE_SHARED)
 +if (NOT MONGOC_ENABLE_STATIC_BUILD)
- add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
- if(WIN32)
-    # Add resource-definition script for Windows shared library (.dll).
-@@ -865,7 +866,7 @@ set_target_properties (mongoc_shared PROPERTIES
-    )
- mongo_generate_pkg_config(mongoc_shared INSTALL RENAME libmongoc-${MONGOC_API_VERSION}.pc)
- 
--if (MONGOC_ENABLE_STATIC_BUILD)
-+else()
-    add_library (mongoc_static STATIC ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
-    target_link_libraries (mongoc_static PUBLIC ${STATIC_LIBRARIES} ${BSON_STATIC_LIBRARIES} mongo::detail::c_dependencies)
-    if (NOT WIN32 AND ENABLE_PIC)
-@@ -934,7 +935,11 @@ if (ENABLE_APPLE_FRAMEWORK)
+    add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
+    if(WIN32)
+       # Add resource-definition script for Windows shared library (.dll).
+@@ -1253,7 +1253,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
+    list (APPEND TARGETS_TO_INSTALL mongoc_static)
  endif ()
  
- add_executable (mongoc-stat ${PROJECT_SOURCE_DIR}/../../src/tools/mongoc-stat.c)
--target_link_libraries (mongoc-stat mongoc_shared ${LIBRARIES})
+-if (ENABLE_SHARED)
 +if (NOT MONGOC_ENABLE_STATIC_BUILD)
-+ target_link_libraries (mongoc-stat mongoc_shared ${LIBRARIES})
-+else()
-+ target_link_libraries (mongoc-stat mongoc_static ${LIBRARIES})
-+endif()
- 
- # mongoc-stat works if shared memory performance counters are enabled.
- if (ENABLE_SHM_COUNTERS)
-@@ -1244,7 +1249,7 @@ file (COPY ${PROJECT_SOURCE_DIR}/tests/x509gen DESTINATION ${PROJECT_BINARY_DIR}
- file (COPY ${PROJECT_SOURCE_DIR}/tests/release_files DESTINATION ${PROJECT_BINARY_DIR}/tests)
- 
- if (MONGOC_ENABLE_STATIC_INSTALL)
--   set (TARGETS_TO_INSTALL mongoc_shared mongoc_static)
-+   set (TARGETS_TO_INSTALL mongoc_static)
- else ()
-    set (TARGETS_TO_INSTALL mongoc_shared)
+    list (APPEND TARGETS_TO_INSTALL mongoc_shared)
  endif ()
-@@ -1299,6 +1304,7 @@ endif()
- # Relative include-path will be given the install prefix:
+ 
+@@ -1308,6 +1308,7 @@ endif()
  set_property(TARGET ${TARGETS_TO_INSTALL} APPEND PROPERTY pkg_config_INCLUDE_DIRECTORIES "${MONGOC_HEADER_INSTALL_DIR}")
  
-+if(NOT MONGOC_ENABLE_STATIC_INSTALL)
  # Deprecated alias for libmongoc-1.0.pc, see CDRIVER-2086.
++if(NOT MONGOC_ENABLE_STATIC_INSTALL)
  if (MONGOC_ENABLE_SSL)
     configure_file (
-@@ -1310,6 +1316,7 @@ if (MONGOC_ENABLE_SSL)
+       ${CMAKE_CURRENT_SOURCE_DIR}/src/libmongoc-ssl-1.0.pc.in
+@@ -1318,6 +1319,7 @@ if (MONGOC_ENABLE_SSL)
        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     )
  endif ()

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -6,10 +6,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 77569b9816eb9bfcc6fe2f3cfab69845410aa2e7c6a5db987957eef74cff5cfd51006373bbc8539ecf385adf8c9c067df5a151bdf9b5f7ee71cdf5c9c64040a8
+    SHA512 a80e20917edb752ac5eb42534beaa0122a383037f83a554ee00ce37ae690be68521eaa282b4a5802a5440b61038bcd5414356e16a2ce729ba1193d0738a6ce1c
     HEAD_REF master
     PATCHES
-        disable-dynamic-when-static.patch
+        #disable-dynamic-when-static.patch
         fix-dependencies.patch
         fix-include-directory.patch
         fix-mingw.patch

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     SHA512 a80e20917edb752ac5eb42534beaa0122a383037f83a554ee00ce37ae690be68521eaa282b4a5802a5440b61038bcd5414356e16a2ce729ba1193d0738a6ce1c
     HEAD_REF master
     PATCHES
-        #disable-dynamic-when-static.patch
+        disable-dynamic-when-static.patch
         fix-dependencies.patch
         fix-include-directory.patch
         fix-mingw.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.25.2",
+  "version": "1.25.4",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4113,7 +4113,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.25.2",
+      "baseline": "1.25.4",
       "port-version": 0
     },
     "libcaer": {
@@ -5661,7 +5661,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.25.2",
+      "baseline": "1.25.4",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d14fb7001fd70dd80e15562bbe90a30060adef40",
+      "version": "1.25.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "0c4c352f8b6c44b8cb678e906b8f8431b54d2d27",
       "version": "1.25.2",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2e277fb00940c1caadb124b8a91a0aa80e862b4d",
+      "version": "1.25.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "654476156359ba012d49880fbf0acf549c6eaa35",
       "version": "1.25.2",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2e277fb00940c1caadb124b8a91a0aa80e862b4d",
+      "git-tree": "219d51be972af0596a2c538b530fc379d136fcb2",
       "version": "1.25.4",
       "port-version": 0
     },


### PR DESCRIPTION
Fixed based on [comments](https://github.com/microsoft/vcpkg/issues/35506#:~:text=mongo%2Dc%2Ddriver%201.25.4%20has%20been%20released%3A%20https%3A//github.com/mongodb/mongo%2Dc%2Ddriver/releases/tag/1.25.4).

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
x64-windows-static
```
All features passed with following triplets:

```
x64-windows
x64-windows-static
```