### PR TITLE
[coin] Add a warning message for installing libgl and libglu

### DIFF
--- a/ports/coin/portfile.cmake
+++ b/ports/coin/portfile.cmake
@@ -1,7 +1,22 @@
+if(NOT VCPKG_HOST_IS_WINDOWS)
+    message(WARNING "${PORT} currently requires the following programs from the system package manager:
+    libgl libglu
+On Debian and Ubuntu derivatives:
+    sudo apt-get install libgl-dev libglu1-mesa-dev
+On CentOS and recent Red Hat derivatives:
+    yum install mesa-libGL-devel mesa-libGLU-devel
+On Fedora derivatives:
+    sudo dnf install mesa-libGL-devel mesa-libGLU-devel
+On Arch Linux and derivatives:
+    sudo pacman -S gl glu
+On Alpine:
+    apk add gl glu\n")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Coin3D/coin
-    REF v${VERSION}
+    REF "v${VERSION}"
     SHA512 f913f1b1ec5819d72e054dc94702effe9ee2a28547fc9bebc2f6b2e55d8a67c6cfa05e43239461e806cbead0a7548f82b31d5b86181eed4ffc5c801d3b94aa67
     HEAD_REF master
     PATCHES
@@ -33,7 +48,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Coin-${VERSION})
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/coin/vcpkg.json
+++ b/ports/coin/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "coin",
   "version": "4.0.2",
+  "port-version": 1,
   "description": "A high-level 3D visualization library with Open Inventor 2.1 API",
   "homepage": "https://github.com/coin3d/coin",
+  "license": "BSD-3-Clause",
   "supports": "!(arm | arm64 | uwp)",
   "dependencies": [
     "boost-assert",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1694,7 +1694,7 @@
     },
     "coin": {
       "baseline": "4.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "coin-or-buildtools": {
       "baseline": "2023-02-02",

--- a/versions/c-/coin.json
+++ b/versions/c-/coin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f679393fe0adfac4fbc6aa8235ce8a35e106cd7a",
+      "version": "4.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "1f151412ad103c9cafd511a97783d60b85aae246",
       "version": "4.0.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #24925, Add a warning to prevent issues similar to #24925.
The related log:
```
CMake Error at /mnt/lily/vcpkg/downloads/tools/cmake-3.27.1-linux/cmake-3.27.1-linux-x86_64/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_INCLUDE_DIR)

CMake Error at /mnt/lily/vcpkg/buildtrees/coin/x64-linux-dbg/CMakeFiles/CMakeScratch/TryCompile-4WBMZa/CMakeLists.txt:24 (target_link_libraries):
  Target "cmTC_ace06" links to:

    OpenGL::GLU
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
