### PR TITLE
[opencascade] Fix feature freeimage build failure

### DIFF
--- a/ports/opencascade/fix-link-freeimage.patch
+++ b/ports/opencascade/fix-link-freeimage.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d3252b3..33d50b8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -634,6 +634,9 @@ if (CAN_USE_FREEIMAGE)
+     add_definitions (-DHAVE_FREEIMAGE)
+     find_package(freeimage CONFIG REQUIRED)
+     set(CSF_FreeImagePlus freeimage::FreeImagePlus)
++    if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
++        add_definitions (-DDEBUG_FREEIMAGE_LIB)
++    endif()
+   else()
+     OCCT_CHECK_AND_UNSET_GROUP ("3RDPARTY_FREEIMAGE")
+     OCCT_CHECK_AND_UNSET ("INSTALL_FREEIMAGE")
+diff --git a/src/Image/Image_AlienPixMap.cxx b/src/Image/Image_AlienPixMap.cxx
+index f869e8f..f12e17a 100644
+--- a/src/Image/Image_AlienPixMap.cxx
++++ b/src/Image/Image_AlienPixMap.cxx
+@@ -21,7 +21,11 @@
+   #include <FreeImage.h>
+ 
+   #ifdef _MSC_VER
+-    #pragma comment( lib, "FreeImage.lib" )
++    #ifdef DEBUG_FREEIMAGE_LIB
++        #pragma comment( lib, "FreeImaged.lib" )
++    #else
++        #pragma comment( lib, "FreeImage.lib" )
++    #endif
+   #endif
+ #elif defined(HAVE_WINCODEC)
+   #include <wincodec.h>

--- a/ports/opencascade/portfile.cmake
+++ b/ports/opencascade/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         fix-pdb-find.patch
         fix-install-prefix-path.patch
         install-include-dir.patch
+        fix-link-freeimage.patch
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/opencascade/vcpkg.json
+++ b/ports/opencascade/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencascade",
   "version": "7.7.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Open CASCADE Technology (OCCT) is an open-source software development platform for 3D CAD, CAM, CAE.",
   "homepage": "https://github.com/Open-Cascade-SAS/OCCT",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6230,7 +6230,7 @@
     },
     "opencascade": {
       "baseline": "7.7.2",
-      "port-version": 2
+      "port-version": 3
     },
     "opencc": {
       "baseline": "1.1.6",

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cff97ecb51449af3dc81c849ba7ceb36eedd4917",
+      "version": "7.7.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "2b1d21c510a4aa414a64ac5e2e46fa0767ff76b1",
       "version": "7.7.2",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #35476, fix the build failure of feature `opencascade[freeimage]`:
```
[2316/5599] C:\PROGRA~1\MICROS~2\2022\Enterprise\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\cl.exe   /TP -DHAVE_FREEIMAGE -DHAVE_FREETYPE -DHAVE_OPENGL -DHAVE_OPENGL_EXT -DHAVE_RAPIDJSON -DHAVE_TBB -DTBB_USE_DEBUG -DTKV3d_EXPORTS -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_UNICODE -IC:\vcpkg\buildtrees\opencascade\x64-windows-dbg\include\opencascade -external:IC:\vcpkg\installed\x64-windows\include -external:W0 /nologo   /W4 /utf-8 /GR /EHa /MP  /fp:precise /fp:precise /wd"26812" /MP /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1  -D__V3d_DLL -D__Select3D_DLL -D__Prs3d_DLL -D__StdPrs_DLL -D__SelectBasics_DLL -D__SelectMgr_DLL -D__PrsMgr_DLL -D__AIS_DLL -D__StdSelect_DLL -D__DsgPrs_DLL -D__PrsDim_DLL /showIncludes /Fosrc\TKV3d\CMakeFiles\TKV3d.dir\__\V3d\V3d_Plane.cxx.obj /Fdsrc\TKV3d\CMakeFiles\TKV3d.dir\ /FS -c C:\vcpkg\buildtrees\opencascade\src\V7_7_2-5faf513493.clean\src\V3d\V3d_Plane.cxx
[2317/5599] cmd.exe /C "cd . && C:\vcpkg\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E vs_link_dll --intdir=src\TKService\CMakeFiles\TKService.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\10.0.22621.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\10.0.22621.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\Enterprise\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\link.exe  @CMakeFiles\TKService.rsp  /out:win64\vc14\bind\TKService.dll /implib:win64\vc14\libd\TKService.lib /pdb:win64\vc14\bin\TKService.pdb /dll /version:7.7 /machine:x64 /nologo    /debug /INCREMENTAL  && cd ."
FAILED: win64/vc14/bind/TKService.dll win64/vc14/libd/TKService.lib 
cmd.exe /C "cd . && C:\vcpkg\downloads\tools\cmake-3.27.1-windows\cmake-3.27.1-windows-i386\bin\cmake.exe -E vs_link_dll --intdir=src\TKService\CMakeFiles\TKService.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\10.0.22621.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\10.0.22621.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\Enterprise\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\link.exe  @CMakeFiles\TKService.rsp  /out:win64\vc14\bind\TKService.dll /implib:win64\vc14\libd\TKService.lib /pdb:win64\vc14\bin\TKService.pdb /dll /version:7.7 /machine:x64 /nologo    /debug /INCREMENTAL  && cd ."
LINK Pass 1: command "C:\PROGRA~1\MICROS~2\2022\Enterprise\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\link.exe @CMakeFiles\TKService.rsp /out:win64\vc14\bind\TKService.dll /implib:win64\vc14\libd\TKService.lib /pdb:win64\vc14\bin\TKService.pdb /dll /version:7.7 /machine:x64 /nologo /debug /INCREMENTAL /MANIFEST /MANIFESTFILE:src\TKService\CMakeFiles\TKService.dir/intermediate.manifest src\TKService\CMakeFiles\TKService.dir/manifest.res" failed (exit code 1104) with the following output:
LINK : fatal error LNK1104: cannot open file 'FreeImage.lib'
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature `opencascade[freeimage,core]` passed with following triplets:
```
x64-windows
x64-windows-static
```

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
