### PR TITLE
[thomasmonkman-filewatch] Fix patch for the latest version of FileWatch

### DIFF
--- a/ports/thomasmonkman-filewatch/fix-unix-listen.patch
+++ b/ports/thomasmonkman-filewatch/fix-unix-listen.patch
@@ -26,11 +26,11 @@ index 4eba08b..2c0ff6d 100644
  								}
 +                               			else if (event->mask & IN_MOVED_FROM)
 +                               			{
-+                               			    parsed_information.emplace_back(T{ changed_file }, Event::renamed_old);
++                               			    parsed_information.emplace_back(StringType{ changed_file }, Event::renamed_old);
 +                               			}
 +                               			else if (event->mask & IN_MOVED_TO)
 +                               			{
-+                               			    parsed_information.emplace_back(T{ changed_file }, Event::renamed_new);
++                               			    parsed_information.emplace_back(StringType{ changed_file }, Event::renamed_new);
 +                               			}
  							}
  						}

--- a/ports/thomasmonkman-filewatch/vcpkg.json
+++ b/ports/thomasmonkman-filewatch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "thomasmonkman-filewatch",
   "version-date": "2023-01-16",
-  "port-version": 1,
+  "port-version": 2,
   "description": "File watcher in C++.",
   "homepage": "https://github.com/ThomasMonkman/filewatch",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8414,7 +8414,7 @@
     },
     "thomasmonkman-filewatch": {
       "baseline": "2023-01-16",
-      "port-version": 1
+      "port-version": 2
     },
     "thor": {
       "baseline": "2022-04-16",

--- a/versions/t-/thomasmonkman-filewatch.json
+++ b/versions/t-/thomasmonkman-filewatch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3f6f9e4f5a7ac943e3f0ec0c81bcdc3db371705",
+      "version-date": "2023-01-16",
+      "port-version": 2
+    },
+    {
       "git-tree": "6dede6ba1ac505ea4bd64c60bf97edfe7b8d5647",
       "version-date": "2023-01-16",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.