### PR TITLE
[cctz] Fix compilation error when vs version is greater than 17.7

### DIFF
--- a/ports/cctz/fix_vs177.patch
+++ b/ports/cctz/fix_vs177.patch
@@ -1,0 +1,18 @@
+diff --git a/include/cctz/civil_time_detail.h b/include/cctz/civil_time_detail.h
+index decc5f2..26c5aef 100644
+--- a/include/cctz/civil_time_detail.h
++++ b/include/cctz/civil_time_detail.h
+@@ -353,11 +353,11 @@ class civil_time {
+       : civil_time(ct.f_) {}
+ 
+   // Factories for the maximum/minimum representable civil_time.
+-  static CONSTEXPR_F civil_time (max)() {
++  static CONSTEXPR_F auto (max)() -> civil_time {
+     const auto max_year = (std::numeric_limits<std::int_least64_t>::max)();
+     return civil_time(max_year, 12, 31, 23, 59, 59);
+   }
+-  static CONSTEXPR_F civil_time (min)() {
++  static CONSTEXPR_F auto (min)() -> civil_time {
+     const auto min_year = (std::numeric_limits<std::int_least64_t>::min)();
+     return civil_time(min_year, 1, 1, 0, 0, 0);
+   }

--- a/ports/cctz/portfile.cmake
+++ b/ports/cctz/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v2.3
     SHA512 e688ddac1bff108e8315bf94cb61483b72b0d16f601e4e1eeb0fd5c064aefe5a573eee66e8903401aa4c2be71ea9f10dd6c9a9cdf8379f5bb6073248a21a83ff
     HEAD_REF master
+    PATCHES
+        fix_vs177.patch #https://github.com/google/cctz/pull/273
 )
 
 vcpkg_cmake_configure(

--- a/ports/cctz/vcpkg.json
+++ b/ports/cctz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cctz",
   "version": "2.3",
-  "port-version": 6,
+  "port-version": 7,
   "description": "two libraries that cooperate with <chrono> to give C++ programmers all the necessary tools for computing with dates, times, and time zones in a simple and correct manner.",
   "homepage": "https://github.com/google/cctz",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1482,7 +1482,7 @@
     },
     "cctz": {
       "baseline": "2.3",
-      "port-version": 6
+      "port-version": 7
     },
     "cdt": {
       "baseline": "1.3.0",

--- a/versions/c-/cctz.json
+++ b/versions/c-/cctz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "527442456bc48c0fd960541f6489dd0ac2add02c",
+      "version": "2.3",
+      "port-version": 7
+    },
+    {
       "git-tree": "02114f18edd1088204f039ab6bc662e23d2e4fcc",
       "version": "2.3",
       "port-version": 6


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36089

There is an https://github.com/google/or-tools/discussions/3922 in the current cctz version when using Visual Studio >17.7, which prevents it from being compiled and used inside other projects (like abseil).
Generate a patch to fix the issue using the fix [PR](https://github.com/google/cctz/pull/273) submitted upstream.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```