### PR TITLE
[mpg123] Support system dependency CFLAGS better

### DIFF
--- a/ports/mpg123/fix-modules-cmake-cflags.patch
+++ b/ports/mpg123/fix-modules-cmake-cflags.patch
@@ -1,0 +1,19 @@
+diff --git a/ports/cmake/src/libout123/modules/CMakeLists.txt b/ports/cmake/src/libout123/modules/CMakeLists.txt
+index 21810c6..51c673d 100644
+--- a/ports/cmake/src/libout123/modules/CMakeLists.txt
++++ b/ports/cmake/src/libout123/modules/CMakeLists.txt
+@@ -17,11 +17,11 @@ if(NOT USE_MODULES)
+         $<$<STREQUAL:${DEFAULT_OUTPUT_MODULE},win32>:${WIN32_LIBRARIES}>
+         $<$<STREQUAL:${DEFAULT_OUTPUT_MODULE},win32_wasapi>:${WIN32_WASAPI_LIBRARIES}>)
+     if(DEFAULT_OUTPUT_MODULE STREQUAL "pulse")
+-        target_compile_definitions(defaultmodule PRIVATE ${PULSE_CFLAGS})
++        target_compile_options(defaultmodule PRIVATE ${PULSE_CFLAGS})
+     elseif(DEFAULT_OUTPUT_MODULE STREQUAL "jack")
+-        target_compile_definitions(defaultmodule PRIVATE ${JACK_CFLAGS})
++        target_compile_options(defaultmodule PRIVATE ${JACK_CFLAGS})
+     elseif(DEFAULT_OUTPUT_MODULE STREQUAL "tinyalsa")
+-        target_compile_definitions(defaultmodule PRIVATE ${TINYALSA_CFLAGS})
++        target_compile_options(defaultmodule PRIVATE ${TINYALSA_CFLAGS})
+     endif()
+     if(BUILD_SHARED_LIBS)
+         set_target_properties(defaultmodule PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/ports/mpg123/portfile.cmake
+++ b/ports/mpg123/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_sourceforge(
         fix-checktypesize.patch
         fix-modulejack.patch
         fix-m1-build.patch
+        fix-modules-cmake-cflags.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/mpg123/vcpkg.json
+++ b/ports/mpg123/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpg123",
   "version": "1.31.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "mpg123 is a real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3 (MPEG 1.0 layer 3 also known as MP3).",
   "homepage": "https://sourceforge.net/projects/mpg123/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5734,7 +5734,7 @@
     },
     "mpg123": {
       "baseline": "1.31.3",
-      "port-version": 3
+      "port-version": 4
     },
     "mpi": {
       "baseline": "1",

--- a/versions/m-/mpg123.json
+++ b/versions/m-/mpg123.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "37566a41dbc98698c2fb1236e378f181a965b0d3",
+      "version": "1.31.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "6e990602e7caa6965db94c4ef01e3f1b44fb4f67",
       "version": "1.31.3",
       "port-version": 3


### PR DESCRIPTION
Upstream bug https://sourceforge.net/p/mpg123/bugs/366/

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
