### PR TITLE
[libraw] Disable default features of jasper

### DIFF
--- a/ports/libraw/vcpkg.json
+++ b/ports/libraw/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libraw",
   "version": "0.21.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "raw image decoder library",
   "homepage": "https://www.libraw.org",
   "license": "LGPL-2.1-only OR CDDL-1.0",

--- a/ports/libraw/vcpkg.json
+++ b/ports/libraw/vcpkg.json
@@ -7,7 +7,10 @@
   "license": "LGPL-2.1-only OR CDDL-1.0",
   "supports": "!uwp & !xbox",
   "dependencies": [
-    "jasper",
+    {
+      "name": "jasper",
+      "default-features": false
+    },
     "lcms",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4730,7 +4730,7 @@
     },
     "libraw": {
       "baseline": "0.21.1",
-      "port-version": 2
+      "port-version": 3
     },
     "librdkafka": {
       "baseline": "2.3.0",

--- a/versions/l-/libraw.json
+++ b/versions/l-/libraw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3a10e9f3c0a023e53a82eb8408365f50e6825e80",
+      "version": "0.21.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "ca8608b21d32cbd238b21eafc1ceb19ab91729b5",
       "version": "0.21.1",
       "port-version": 2


### PR DESCRIPTION
Jasper's default features pull OpenGL, which is not needed by libraw.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.