### PR TITLE
[opencv3/opencv4] Check whether TARGET libprotobuf is defined

### DIFF
--- a/ports/opencv3/portfile.cmake
+++ b/ports/opencv3/portfile.cmake
@@ -420,8 +420,8 @@ endif()
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(READ "${CURRENT_PACKAGES_DIR}/share/opencv3/OpenCVModules.cmake" OPENCV_MODULES)
   set(DEPS_STRING "include(CMakeFindDependencyMacro)
-if(${BUILD_opencv_flann})
-  find_dependency(Protobuf CONFIG REQUIRED)
+if(${BUILD_opencv_flann} AND NOT TARGET libprotobuf) #Check if the CMake target libprotobuf is already defined
+  find_dependency(Protobuf CONFIG REQUIRED) 
   if(TARGET protobuf::libprotobuf)
     add_library (libprotobuf INTERFACE IMPORTED)
     set_target_properties(libprotobuf PROPERTIES
@@ -538,4 +538,4 @@ endif()
 
 configure_file("${CURRENT_PORT_DIR}/usage.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/opencv3/portfile.cmake
+++ b/ports/opencv3/portfile.cmake
@@ -421,7 +421,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(READ "${CURRENT_PACKAGES_DIR}/share/opencv3/OpenCVModules.cmake" OPENCV_MODULES)
   set(DEPS_STRING "include(CMakeFindDependencyMacro)
 if(${BUILD_opencv_flann} AND NOT TARGET libprotobuf) #Check if the CMake target libprotobuf is already defined
-  find_dependency(Protobuf CONFIG REQUIRED) 
+  find_dependency(Protobuf CONFIG REQUIRED)
   if(TARGET protobuf::libprotobuf)
     add_library (libprotobuf INTERFACE IMPORTED)
     set_target_properties(libprotobuf PROPERTIES

--- a/ports/opencv3/vcpkg.json
+++ b/ports/opencv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv3",
   "version": "3.4.18",
-  "port-version": 12,
+  "port-version": 13,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -490,7 +490,7 @@ endif()
 
   file(READ "${CURRENT_PACKAGES_DIR}/share/opencv4/OpenCVModules.cmake" OPENCV_MODULES)
   set(DEPS_STRING "include(CMakeFindDependencyMacro)
-if(${BUILD_opencv_dnn})
+if(${BUILD_opencv_dnn}  AND NOT TARGET libprotobuf)
   find_dependency(Protobuf CONFIG REQUIRED)
   if(TARGET protobuf::libprotobuf)
     add_library (libprotobuf INTERFACE IMPORTED)

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -490,7 +490,7 @@ endif()
 
   file(READ "${CURRENT_PACKAGES_DIR}/share/opencv4/OpenCVModules.cmake" OPENCV_MODULES)
   set(DEPS_STRING "include(CMakeFindDependencyMacro)
-if(${BUILD_opencv_dnn} AND NOT TARGET libprotobuf)
+if(${BUILD_opencv_dnn} AND NOT TARGET libprotobuf)  #Check if the CMake target libprotobuf is already defined
   find_dependency(Protobuf CONFIG REQUIRED)
   if(TARGET protobuf::libprotobuf)
     add_library (libprotobuf INTERFACE IMPORTED)

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -490,7 +490,7 @@ endif()
 
   file(READ "${CURRENT_PACKAGES_DIR}/share/opencv4/OpenCVModules.cmake" OPENCV_MODULES)
   set(DEPS_STRING "include(CMakeFindDependencyMacro)
-if(${BUILD_opencv_dnn}  AND NOT TARGET libprotobuf)
+if(${BUILD_opencv_dnn} AND NOT TARGET libprotobuf)
   find_dependency(Protobuf CONFIG REQUIRED)
   if(TARGET protobuf::libprotobuf)
     add_library (libprotobuf INTERFACE IMPORTED)

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
-  "port-version": 14,
+  "port-version": 15,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6278,7 +6278,7 @@
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 14
+      "port-version": 15
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6274,7 +6274,7 @@
     },
     "opencv3": {
       "baseline": "3.4.18",
-      "port-version": 12
+      "port-version": 13
     },
     "opencv4": {
       "baseline": "4.8.0",

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "737a177bb2f267938b95cc36650fb8ef844d71cf",
+      "git-tree": "577dd8933e58290664f4290476069978692ed4f2",
       "version": "3.4.18",
       "port-version": 13
     },

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "737a177bb2f267938b95cc36650fb8ef844d71cf",
+      "version": "3.4.18",
+      "port-version": 13
+    },
+    {
       "git-tree": "f5ee69ffa1b6c98a28fc805afffaeb799b4d22a8",
       "version": "3.4.18",
       "port-version": 12

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68598dc3107a004df321e1605865a8a2e3e437b4",
+      "version": "4.8.0",
+      "port-version": 15
+    },
+    {
       "git-tree": "852583d8f7a5bb15998efad9c0305a8ce686e59b",
       "version": "4.8.0",
       "port-version": 14

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "68598dc3107a004df321e1605865a8a2e3e437b4",
+      "git-tree": "ec4e040d476cee60b2fc21a1f847d30905ac9726",
       "version": "4.8.0",
       "port-version": 15
     },


### PR DESCRIPTION
Fixes #36093, check if `TARGET libprotobuf` is defined before `add_library (libprotobuf ...)`: 
```
CMake Error at /opt/vcpkg/scripts/buildsystems/vcpkg.cmake:639 (_add_library):
  _add_library cannot create imported target "libprotobuf" because another
  target with the same name already exists.
Call Stack (most recent call first):
  /opt/vcpkg/vcpkg_installed/x64-linux/share/opencv3/OpenCVModules.cmake:22 (add_library)
  /opt/vcpkg/vcpkg_installed/x64-linux/share/opencv3/OpenCVConfig.cmake:133 (include)
  /opt/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  cmake/extra_modules.cmake:39 (find_package)
  cmake/extra_modules.cmake:162 (ov_generate_dev_package_config)
  CMakeLists.txt:142 (include)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
