### PR TITLE
[live555] Pass options to fix osx

### DIFF
--- a/ports/live555/CMakeLists.txt
+++ b/ports/live555/CMakeLists.txt
@@ -17,6 +17,14 @@ if (NOT MSVC)
     add_compile_options(-DSOCKLEN_T=socklen_t)
 endif()
 
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+   add_compile_options(-DBSD=1)
+   add_compile_options(-DHAVE_SOCKADDR_LEN=1)
+   add_compile_options(-DTIME_BASE=int)
+   add_compile_options(-DNEED_XLOCALE_H=1)
+endif()
+
+
 file(GLOB BASIC_USAGE_ENVIRONMENT_SRCS BasicUsageEnvironment/*.c BasicUsageEnvironment/*.cpp)
 add_library(BasicUsageEnvironment ${BASIC_USAGE_ENVIRONMENT_SRCS})
 

--- a/ports/live555/CMakeLists.txt
+++ b/ports/live555/CMakeLists.txt
@@ -24,7 +24,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
    add_compile_options(-DNEED_XLOCALE_H=1)
 endif()
 
-
 file(GLOB BASIC_USAGE_ENVIRONMENT_SRCS BasicUsageEnvironment/*.c BasicUsageEnvironment/*.cpp)
 add_library(BasicUsageEnvironment ${BASIC_USAGE_ENVIRONMENT_SRCS})
 

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "live555",
   "version-date": "2023-11-30",
-  "port-version":1,
+  "port-version": 1,
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "live555",
   "version-date": "2023-11-30",
+  "port-version":1,
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5226,7 +5226,7 @@
     },
     "live555": {
       "baseline": "2023-11-30",
-      "port-version": 0
+      "port-version": 1
     },
     "llfio": {
       "baseline": "2023-11-06",

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "38de97378ac2b1d8d9ee977d490ad4bc35319519",
+      "git-tree": "2402cdcc3405afe25f02e4a6d3c44ec1b1c68aaf",
       "version-date": "2023-11-30",
       "port-version": 1
     },

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "38de97378ac2b1d8d9ee977d490ad4bc35319519",
+      "version-date": "2023-11-30",
+      "port-version": 1
+    },
+    {
       "git-tree": "80eb597529bc497ceb274509b6224bf0524930c1",
       "version-date": "2023-11-30",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/36106
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
Pass the correct from upstream triplet files:
```
cat config.macosx-catalina
COMPILE_OPTS =          $(INCLUDES) -I. -I/usr/local/include $(EXTRA_LDFLAGS) -DBSD=1 -O -DSOCKLEN_T=socklen_t -DHAVE_SOCKADDR_LEN=1 -DTIME_BASE=int -DNEED_XLOCALE_H=1
```
<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
