### PR TITLE
[libpqxx] fix linking errors by enabling c++20

### DIFF
--- a/ports/libpqxx/portfile.cmake
+++ b/ports/libpqxx/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSKIP_BUILD_TEST=ON
+        -DCMAKE_CXX_STANDARD=20
 )
 
 vcpkg_cmake_install()

--- a/ports/libpqxx/vcpkg.json
+++ b/ports/libpqxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpqxx",
   "version": "7.8.1",
+  "port-version": 1,
   "description": "The official C++ client API for PostgreSQL",
   "homepage": "https://www.postgresql.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4706,7 +4706,7 @@
     },
     "libpqxx": {
       "baseline": "7.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libprotobuf-mutator": {
       "baseline": "1.1",

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8083e94ed4ded4546cbad5263a7efb4b9b154b73",
+      "git-tree": "3cc64cbe1d90f8ed44bfd8528522b18fc3c346b2",
       "version": "7.8.1",
       "port-version": 1
     },

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -3,6 +3,11 @@
     {
       "git-tree": "8083e94ed4ded4546cbad5263a7efb4b9b154b73",
       "version": "7.8.1",
+      "port-version": 1
+    },
+    {
+      "git-tree": "8083e94ed4ded4546cbad5263a7efb4b9b154b73",
+      "version": "7.8.1",
       "port-version": 0
     },
     {


### PR DESCRIPTION
people suffer from this upstream issue https://github.com/jtv/libpqxx/issues/732

while upstream issue is non-windows, we're able to reproduce this. on x64-windows-static as well

![image](https://github.com/microsoft/vcpkg/assets/37947786/df6d0ad8-e773-4dbe-a03b-a1ec6e7e11ac)

adding cxx standard as upstream issue comments suggest fixes the error