### PR TITLE
[libsrtp] Added openssl feature flag for enabling OpenSSL support

### DIFF
--- a/ports/libsrtp/portfile.cmake
+++ b/ports/libsrtp/portfile.cmake
@@ -20,7 +20,6 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
 )
 
-
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libSRTP)

--- a/ports/libsrtp/portfile.cmake
+++ b/ports/libsrtp/portfile.cmake
@@ -7,10 +7,16 @@ vcpkg_from_github(
         fix-runtime-destination.patch
 )
 
+set(ENABLE_OPENSSL OFF)
+if ("openssl" IN_LIST FEATURES)
+    set(ENABLE_OPENSSL ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DCMAKE_PROJECT_INCLUDE=${CMAKE_CURRENT_LIST_DIR}/cmake-project-include.cmake"
+        -DENABLE_OPENSSL=${ENABLE_OPENSSL}
         -DTEST_APPS=OFF
 )
 

--- a/ports/libsrtp/portfile.cmake
+++ b/ports/libsrtp/portfile.cmake
@@ -7,18 +7,19 @@ vcpkg_from_github(
         fix-runtime-destination.patch
 )
 
-set(ENABLE_OPENSSL OFF)
-if ("openssl" IN_LIST FEATURES)
-    set(ENABLE_OPENSSL ON)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        openssl ENABLE_OPENSSL
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DCMAKE_PROJECT_INCLUDE=${CMAKE_CURRENT_LIST_DIR}/cmake-project-include.cmake"
-        -DENABLE_OPENSSL=${ENABLE_OPENSSL}
         -DTEST_APPS=OFF
+        ${FEATURE_OPTIONS}
 )
+
 
 vcpkg_cmake_install()
 

--- a/ports/libsrtp/vcpkg.json
+++ b/ports/libsrtp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libsrtp",
   "version": "2.5.0",
+  "port-version": 1,
   "description": "This package provides an implementation of the Secure Real-time Transport Protocol (SRTP), the Universal Security Transform (UST), and a supporting cryptographic kernel.",
   "homepage": "https://github.com/cisco/libsrtp/",
   "license": "BSD-3-Clause",

--- a/ports/libsrtp/vcpkg.json
+++ b/ports/libsrtp/vcpkg.json
@@ -12,9 +12,9 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-   "features": {
-    "openssl": { "description": "Enable OpenSSL support", "dependencies": ["openssl"]}
-   }
-  ]
+    }
+  ],
+  "features": {
+    "openssl": { "description": "Enable OpenSSL support", "dependencies": ["openssl"] }
+  }
 }

--- a/ports/libsrtp/vcpkg.json
+++ b/ports/libsrtp/vcpkg.json
@@ -15,6 +15,11 @@
     }
   ],
   "features": {
-    "openssl": { "description": "Enable OpenSSL support", "dependencies": ["openssl"] }
+    "openssl": {
+      "description": "Enable OpenSSL support",
+      "dependencies": [
+        "openssl"
+      ]
+    }
   }
 }

--- a/ports/libsrtp/vcpkg.json
+++ b/ports/libsrtp/vcpkg.json
@@ -12,6 +12,9 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+   "features": {
+    "openssl": { "description": "Enable OpenSSL support", "dependencies": ["openssl"]}
+   }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4822,7 +4822,7 @@
     },
     "libsrtp": {
       "baseline": "2.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libssh": {
       "baseline": "0.10.5",

--- a/versions/l-/libsrtp.json
+++ b/versions/l-/libsrtp.json
@@ -6,7 +6,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "0f0b21bc9987edfc4a76c49ecdcaa04d67c7d34c",
+      "git-tree": "27c325c9851b5c07e172e74e312e8070af7b9d0b",
       "version": "2.5.0",
       "port-version": 0
     },

--- a/versions/l-/libsrtp.json
+++ b/versions/l-/libsrtp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15577c99d2d078770d2e07d2bc8cce770797adb8",
+      "version": "2.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0f0b21bc9987edfc4a76c49ecdcaa04d67c7d34c",
       "version": "2.5.0",
       "port-version": 0

--- a/versions/l-/libsrtp.json
+++ b/versions/l-/libsrtp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "27c325c9851b5c07e172e74e312e8070af7b9d0b",
+      "git-tree": "665d570a2ecd7295f1a6c368e8bbe128e12fe953",
       "version": "2.5.0",
       "port-version": 0
     },

--- a/versions/l-/libsrtp.json
+++ b/versions/l-/libsrtp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "665d570a2ecd7295f1a6c368e8bbe128e12fe953",
+      "git-tree": "0f0b21bc9987edfc4a76c49ecdcaa04d67c7d34c",
       "version": "2.5.0",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

This pull request adds a feature flag for the existing libsrtp port, to allow it to be built with OpenSSL support. OpenSSL support is necessary in order for libsrtp to support the AES GCM modes, which you won't realize until you've debugged it. 🙃 

The changes are minimal and hopefully correct, but please let me know if any modifications are needed!

To use the feature flag, you can add "openssl" to the list of features on the dependency (as per the vcpkg docs, same way as any other feature):

```
Your vcpkg.json:
....
  "dependencies": [
    ...
    {"name": "libsrtp", "features": ["openssl"]},
    "openssl",
...
```
