### PR TITLE
[dcmtk] Enable toggling external dictionary as a feature

### DIFF
--- a/ports/dcmtk/dictionary_paths.patch
+++ b/ports/dcmtk/dictionary_paths.patch
@@ -1,0 +1,26 @@
+diff --git a/CMake/GenerateDCMTKConfigure.cmake b/CMake/GenerateDCMTKConfigure.cmake
+index 8a59d44fa..8d3b4fc60 100644
+--- a/CMake/GenerateDCMTKConfigure.cmake
++++ b/CMake/GenerateDCMTKConfigure.cmake
+@@ -173,19 +173,11 @@ if(WIN32 AND NOT CYGWIN)
+ 
+   # Set dictionary path to the data dir inside install main dir (prefix)
+   if(DCMTK_DEFAULT_DICT STREQUAL "external")
+-    if(DCMTK_USE_WIN32_PROGRAMDATA)
+-      set(DCM_DICT_DEFAULT_PATH "${CMAKE_INSTALL_FULL_DATADIR}\\\\dicom.dic")
+-    else()
+-      set(DCM_DICT_DEFAULT_PATH "${DCMTK_PREFIX}\\\\${CMAKE_INSTALL_DATADIR}\\\\dcmtk\\\\dicom.dic")
+-    endif()
++    set(DCM_DICT_DEFAULT_PATH "${CMAKE_INSTALL_FULL_DATADIR}\\\\dicom.dic")
+ 
+     # If private dictionary should be utilized, add it to default dictionary path.
+     if(ENABLE_PRIVATE_TAGS)
+-      if(DCMTK_USE_WIN32_PROGRAMDATA)
+-        set(DCM_DICT_DEFAULT_PATH "${DCM_DICT_DEFAULT_PATH};${CMAKE_INSTALL_FULL_DATADIR}\\\\private.dic")
+-      else()
+-        set(DCM_DICT_DEFAULT_PATH "${DCM_DICT_DEFAULT_PATH};${DCMTK_PREFIX}\\\\${CMAKE_INSTALL_DATADIR}\\\\dcmtk\\\\private.dic")
+-      endif()
++      set(DCM_DICT_DEFAULT_PATH "${DCM_DICT_DEFAULT_PATH};${CMAKE_INSTALL_FULL_DATADIR}\\\\private.dic")
+     endif()
+ 
+      # Again, for Windows strip all / from path and replace it with \\.

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         dcmtk.patch
         fix_link_xml2.patch
+        dictionary_paths.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -21,10 +22,17 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "tools"   BUILD_APPS
 )
 
+if("external-dict" IN_LIST FEATURES)
+    set(DCMTK_DEFAULT_DICT "external")
+else()
+    set(DCMTK_DEFAULT_DICT "builtin")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        "-DDCMTK_DEFAULT_DICT=${DCMTK_DEFAULT_DICT}" 
         -DDCMTK_WITH_DOXYGEN=OFF
         -DDCMTK_FORCE_FPIC_ON_UNIX=ON
         -DDCMTK_OVERWRITE_WIN32_COMPILER_FLAGS=OFF

--- a/ports/dcmtk/vcpkg.json
+++ b/ports/dcmtk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dcmtk",
   "version": "3.6.8",
+  "port-version": 1,
   "description": "This DICOM ToolKit (DCMTK) package consists of source code, documentation and installation instructions for a set of software libraries and applications implementing part of the DICOM/MEDICOM Standard.",
   "homepage": "https://github.com/DCMTK/dcmtk",
   "license": "BSD-3-Clause OR BSD-2-Clause OR libtiff OR MIT OR Zlib OR Libpng",
@@ -16,6 +17,9 @@
     }
   ],
   "features": {
+    "external-dict": {
+      "description": "Enable external dictionary"
+    },
     "iconv": {
       "description": "Enable Iconv support",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2146,7 +2146,7 @@
     },
     "dcmtk": {
       "baseline": "3.6.8",
-      "port-version": 0
+      "port-version": 1
     },
     "debug-assert": {
       "baseline": "1.3.3",

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bec215b4880ee37ff46a69fdbc6bd3888901c52a",
+      "version": "3.6.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "04c152f7113c88dcfb84b3f4963cadd60c254a74",
       "version": "3.6.8",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #36134
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
