### PR TITLE
[libtracepoint] Upgrade to v1.3.0

### DIFF
--- a/ports/libeventheader-decode/portfile.cmake
+++ b/ports/libeventheader-decode/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
+    SHA512 6b22ecded7029dfb9d9fba4fb76a8c25a28fbb3a6295b8ff6f66cea83d5b7645a85244126f52896065eccb9d08cbafa89dd1a23971c38842c4f752a274e5a72d
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libeventheader-decode/vcpkg.json
+++ b/ports/libeventheader-decode/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libeventheader-decode",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "C++ classes for decoding EventHeader-encoded Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -8,11 +8,11 @@
   "dependencies": [
     {
       "name": "libeventheader-tracepoint",
-      "version>=": "1.2.1"
+      "version>=": "1.3.0"
     },
     {
       "name": "libtracepoint-decode",
-      "version>=": "1.2.1"
+      "version>=": "1.3.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libeventheader-tracepoint/portfile.cmake
+++ b/ports/libeventheader-tracepoint/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
+    SHA512 6b22ecded7029dfb9d9fba4fb76a8c25a28fbb3a6295b8ff6f66cea83d5b7645a85244126f52896065eccb9d08cbafa89dd1a23971c38842c4f752a274e5a72d
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libeventheader-tracepoint/vcpkg.json
+++ b/ports/libeventheader-tracepoint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libeventheader-tracepoint",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "C/C++ interface for generating EventHeader-encoded Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "libtracepoint",
-      "version>=": "1.2.1"
+      "version>=": "1.3.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libtracepoint-control/portfile.cmake
+++ b/ports/libtracepoint-control/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
+    SHA512 6b22ecded7029dfb9d9fba4fb76a8c25a28fbb3a6295b8ff6f66cea83d5b7645a85244126f52896065eccb9d08cbafa89dd1a23971c38842c4f752a274e5a72d
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint-control/vcpkg.json
+++ b/ports/libtracepoint-control/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtracepoint-control",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "C++ classes for collecting Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "libtracepoint-decode",
-      "version>=": "1.2.1"
+      "version>=": "1.3.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libtracepoint-decode/portfile.cmake
+++ b/ports/libtracepoint-decode/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
+    SHA512 6b22ecded7029dfb9d9fba4fb76a8c25a28fbb3a6295b8ff6f66cea83d5b7645a85244126f52896065eccb9d08cbafa89dd1a23971c38842c4f752a274e5a72d
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint-decode/vcpkg.json
+++ b/ports/libtracepoint-decode/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtracepoint-decode",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "C++ classes for decoding Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",

--- a/ports/libtracepoint/portfile.cmake
+++ b/ports/libtracepoint/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 3ef4881b66c8990afe3aab844f4e5b9dcc98b67f954027ffe60f2b868a0501f04d6bb0747021b4ffff2e984987028d641975215b7ab32d0fd710171385f0f030
+    SHA512 6b22ecded7029dfb9d9fba4fb76a8c25a28fbb3a6295b8ff6f66cea83d5b7645a85244126f52896065eccb9d08cbafa89dd1a23971c38842c4f752a274e5a72d
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint/vcpkg.json
+++ b/ports/libtracepoint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtracepoint",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "C/C++ interface for generating Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4265,11 +4265,11 @@
       "port-version": 0
     },
     "libeventheader-decode": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "libeventheader-tracepoint": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "libevhtp": {
@@ -4937,15 +4937,15 @@
       "port-version": 0
     },
     "libtracepoint": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "libtracepoint-control": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "libtracepoint-decode": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "libu2f-server": {

--- a/versions/l-/libeventheader-decode.json
+++ b/versions/l-/libeventheader-decode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "857383da3bf1b1947838e23bb1a9066c31cb00da",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "75e4da728961822b82de47fb036aeae025893fb6",
       "version": "1.2.1",
       "port-version": 0

--- a/versions/l-/libeventheader-tracepoint.json
+++ b/versions/l-/libeventheader-tracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32f98983357ea758d5d4e9a7fd6ccd119fa5d598",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "076106bc342a9e9253ced5bfd4e13ac16b360d20",
       "version": "1.2.1",
       "port-version": 0

--- a/versions/l-/libtracepoint-control.json
+++ b/versions/l-/libtracepoint-control.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26f974a4e3a3dbbdea53a0111f0e854875df4f62",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "410f33d930822507551474d486031021c4fea1dd",
       "version": "1.2.1",
       "port-version": 0

--- a/versions/l-/libtracepoint-decode.json
+++ b/versions/l-/libtracepoint-decode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0783b839d7fd6457a9f26ec6c51d85e51aa7104",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "51ab3448c97daa75b873c3e4b70f2894908fc2f4",
       "version": "1.2.1",
       "port-version": 0

--- a/versions/l-/libtracepoint.json
+++ b/versions/l-/libtracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "701e69ab507fc9cd97aaf936d5b82dfebe17c046",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9f85708521c851b4c64ad10c04ad0261343fef25",
       "version": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
- [X ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X ] SHA512s are updated for each updated download
- [X ] The "supports" clause reflects platforms that may be fixed by this new version
- [X ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X ] Any patches that are no longer applied are deleted from the port's directory.
- [X ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X ] Only one version is added to each modified port's versions file.
