### PR TITLE
[cuda-api-wrappers] Update to 0.6.7

### DIFF
--- a/ports/cuda-api-wrappers/portfile.cmake
+++ b/ports/cuda-api-wrappers/portfile.cmake
@@ -23,5 +23,3 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-
-vcpkg_fixup_pkgconfig()

--- a/ports/cuda-api-wrappers/portfile.cmake
+++ b/ports/cuda-api-wrappers/portfile.cmake
@@ -2,28 +2,17 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eyalroz/cuda-api-wrappers
     REF "v${VERSION}"
-    SHA512 4bc095513ed1a40f7239810abf7f6edcfde5471a89de8cf27a76038f6a54f6234542693bb606cc5e389403f3d12cb186b5a9cfb31c2bf3e437c112d215fb872d
+    SHA512 71170b59a116a886c319f6409204d610636a16148754a9811a8c608912b14c09f5f9037b9366c2d0a012c3fd88b5c90d289ce3da692663f1a86f3c3f2bbd7b02
     HEAD_REF master
 )
 
 # head only library
 set(VCPKG_BUILD_TYPE release)
 
-# cuda toolkit check
-vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT)
-message(STATUS "CUDA_TOOLKIT_ROOT ${CUDA_TOOLKIT_ROOT}")
-
-# nvcc compiler path
-set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT}/bin/nvcc${VCPKG_HOST_EXECUTABLE_SUFFIX}")
-
-set(CUDA_ARCHITECTURES "native")
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCAW_BUILD_EXAMPLES=OFF
-        "-DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}"
-        "-DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}"
 )
 
 vcpkg_cmake_install()

--- a/ports/cuda-api-wrappers/vcpkg.json
+++ b/ports/cuda-api-wrappers/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "cuda-api-wrappers",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "header-only library of integrated wrappers around the core parts of NVIDIA's CUDA execution ecosystem",
+  "homepage": "https://github.com/eyalroz/cuda-api-wrappers",
   "license": "BSD-3-Clause",
   "dependencies": [
     "cuda",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2025,7 +2025,7 @@
       "port-version": 13
     },
     "cuda-api-wrappers": {
-      "baseline": "0.6.6",
+      "baseline": "0.6.7",
       "port-version": 0
     },
     "cudnn": {

--- a/versions/c-/cuda-api-wrappers.json
+++ b/versions/c-/cuda-api-wrappers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d6ba5522fce5db6a2ee5e4798e48ea825a042cc2",
+      "git-tree": "7a504ca0e13729c26c4df96ba5b7a321069219be",
       "version": "0.6.7",
       "port-version": 0
     },

--- a/versions/c-/cuda-api-wrappers.json
+++ b/versions/c-/cuda-api-wrappers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6ba5522fce5db6a2ee5e4798e48ea825a042cc2",
+      "version": "0.6.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "f31ca06768d00b72f8387dce98f3a8d2d867cfcb",
       "version": "0.6.6",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix `cuda-api-wrappers:x64-windows` failed in an internal version of Visual Studio 2022 which the `_MSC_VER` is 1940:
```
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.1\include\crt/host_config.h(153): fatal error C1189: #error: -- unsupported Microsoft Visual Studio version! Only the versions between 2017 and 2022 (inclusive) are supported! The nvcc flag '-allow-unsupported-compiler' can be used to override this version check; however, using an unsupported host compiler may cause compilation failure or incorrect run time execution.  Use at your own risk.
```
```
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.1\include\crt/host_config.h
#if defined(_WIN32)
#if _MSC_VER < 1910 || _MSC_VER >= 1940
#error -- unsupported Microsoft Visual Studio version! Only the versions between 2017 and 2022 (inclusive) are supported! The nvcc flag '-allow-unsupported-compiler' can be used to override this version check; however, using an unsupported host compiler may cause compilation failure or incorrect run time execution. Use at your own risk.
```
This error occurred because the CMakeLists.txt file for version 0.6.6 of this port specified `cuda` as the language when configuring this project, triggering the CUDA detection:
```
PROJECT(cuda-api-wrappers
	VERSION 0.6.6
	DESCRIPTION "Thin C++-flavored wrappers for the CUDA Runtime API"
	HOMEPAGE_URL https://github.com/eyalroz/cuda-api-wrappers
	LANGUAGES CUDA CXX)
```
The upstream has already removed this setting in 0.6.7, and since this port is head-only and doesn't require building, I am updating this port to fix the issue.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
