### PR TITLE
[sail] Update to 0.9.1

### DIFF
--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -2,14 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HappySeaFox/sail
     REF "v${VERSION}"
-    SHA512 9d2e783a597bea5923db4eb822985488a24c5337376384f69bedeb2952d23e84005639c0e1aa243b81b40e87e428da470895ce30418fc31e0f1b60bc71b17d09
+    SHA512 c8cface60031c5e84b99eaedb216f9e3af0354d24f5db7d6d0ec1f97d593ae46cb13c86bc244b6b8673cddfecf829a8b7738fdde8620472c12e95a5b61495133
     HEAD_REF master
 )
 
 # Enable selected codecs
 set(ONLY_CODECS "")
 
-foreach(CODEC avif bmp gif ico jpeg jpeg2000 jpegxl pcx png psd qoi tga tiff wal webp xbm)
+foreach(CODEC avif bmp gif ico jpeg jpeg2000 jpegxl pcx png psd qoi svg tga tiff wal webp xbm)
     if (${CODEC} IN_LIST FEATURES)
         list(APPEND ONLY_CODECS ${CODEC})
     endif()
@@ -17,11 +17,17 @@ endforeach()
 
 list(JOIN ONLY_CODECS "\;" ONLY_CODECS_ESCAPED)
 
+# Enable OpenMP
+if ("openmp" IN_LIST FEATURES)
+    set(SAIL_ENABLE_OPENMP ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
         -DSAIL_COMBINE_CODECS=ON
+        -DSAIL_ENABLE_OPENMP=${SAIL_ENABLE_OPENMP}
         -DSAIL_ONLY_CODECS=${ONLY_CODECS_ESCAPED}
         -DSAIL_BUILD_APPS=OFF
         -DSAIL_BUILD_EXAMPLES=OFF

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sail",
-  "version-semver": "0.9.0",
+  "version-semver": "0.9.1",
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",
@@ -16,7 +16,7 @@
     }
   ],
   "default-features": [
-    "highest-priority"
+    "highest-priority-codecs"
   ],
   "features": {
     "all": {
@@ -25,11 +25,11 @@
         {
           "name": "sail",
           "features": [
-            "high-priority",
-            "highest-priority",
-            "low-priority",
-            "lowest-priority",
-            "medium-priority"
+            "high-priority-codecs",
+            "highest-priority-codecs",
+            "low-priority-codecs",
+            "lowest-priority-codecs",
+            "medium-priority-codecs"
           ]
         }
       ]
@@ -49,18 +49,19 @@
         "giflib"
       ]
     },
-    "high-priority": {
+    "high-priority-codecs": {
       "description": "Enable high priority codecs such as BMP",
       "dependencies": [
         {
           "name": "sail",
           "features": [
-            "bmp"
+            "bmp",
+            "svg"
           ]
         }
       ]
     },
-    "highest-priority": {
+    "highest-priority-codecs": {
       "description": "Enable highest priority codecs such as JPEG or PNG",
       "dependencies": [
         {
@@ -95,7 +96,7 @@
         "libjxl"
       ]
     },
-    "low-priority": {
+    "low-priority-codecs": {
       "description": "Enable low priority codecs such as TGA",
       "dependencies": [
         {
@@ -110,7 +111,7 @@
         }
       ]
     },
-    "lowest-priority": {
+    "lowest-priority-codecs": {
       "description": "Enable lowest priority codecs such as XBM",
       "dependencies": [
         {
@@ -122,7 +123,7 @@
         }
       ]
     },
-    "medium-priority": {
+    "medium-priority-codecs": {
       "description": "Enable medium priority codecs such as AVIF",
       "dependencies": [
         {
@@ -135,6 +136,9 @@
           ]
         }
       ]
+    },
+    "openmp": {
+      "description": "Enable OpenMP support"
     },
     "pcx": {
       "description": "Enable PCX codec"
@@ -150,6 +154,12 @@
     },
     "qoi": {
       "description": "Enable QOI codec"
+    },
+    "svg": {
+      "description": "Enable SVG codec",
+      "dependencies": [
+        "nanosvg"
+      ]
     },
     "tga": {
       "description": "Enable TGA codec"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7661,7 +7661,7 @@
       "port-version": 0
     },
     "sail": {
-      "baseline": "0.9.0",
+      "baseline": "0.9.1",
       "port-version": 0
     },
     "sajson": {

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e673bf75a449ebb5474953cb8eaa69333fc08b4",
+      "version-semver": "0.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "63143e644f5e386b1b8aae22194e8b157bcdca5e",
       "version-semver": "0.9.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
