### PR TITLE
[firebirdsql] new port

### DIFF
--- a/ports/firebird/firebird-config.cmake
+++ b/ports/firebird/firebird-config.cmake
@@ -1,0 +1,40 @@
+if(TARGET firebird)
+    return()
+endif()
+
+include(CMakeFindDependencyMacro)
+
+add_library(firebird SHARED IMPORTED)
+
+find_library(firebird_LIBRARY_RELEASE
+    NAMES firebird
+    PATH_SUFFIXES lib
+    PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}"
+    NO_DEFAULT_PATH
+)
+
+find_library(firebird_LIBRARY_DEBUG
+    NAMES firebird
+    PATH_SUFFIXES lib
+    PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug"
+    NO_DEFAULT_PATH
+)
+
+set_target_properties(firebird PROPERTIES
+    IMPORTED_CONFIGURATIONS "DEBUG;RELEASE"
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../include/"
+)
+
+if(LINUX)
+    set_target_properties(firebird PROPERTIES
+        IMPORTED_LOCATION_RELEASE "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/libfbclient.so"
+        IMPORTED_LOCATION_DEBUG "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib/libfbclient.so"
+    )
+endif()
+
+if(WIN32)
+    set_target_properties(firebird PROPERTIES
+        IMPORTED_IMPLIB_RELEASE "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/fbclient_ms.lib"
+        IMPORTED_IMPLIB_DEBUG "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib/fbclient_ms.lib"
+    )
+endif()

--- a/ports/firebird/portfile.cmake
+++ b/ports/firebird/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO FirebirdSQL/firebird
+    REF v5.0.0
+    SHA512 8ba88b161df60b2759042a6119c5530dc9b3d9b6e1ec074906f17d13bf01f61c65becba732a75853321c6718b21ea51a3c61889c59e822a2cab6cb657975ca4d
+    HEAD_REF master
+    PATCHES
+        windows-paths.diff
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    include("${CMAKE_CURRENT_LIST_DIR}/windows/portfile.cmake")
+else()
+    include("${CMAKE_CURRENT_LIST_DIR}/posix/portfile.cmake")
+endif()
+
+# Copy common files
+
+file(
+    INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/builds/install/misc/IPLicense.txt"
+        "${SOURCE_PATH}/builds/install/misc/IDPLicense.txt"
+)
+
+file(
+    INSTALL "${CMAKE_CURRENT_LIST_DIR}/${PORT}-config.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)

--- a/ports/firebird/posix/portfile.cmake
+++ b/ports/firebird/posix/portfile.cmake
@@ -1,6 +1,8 @@
 # Firebird libraries are already relocatable and this causes problems with their runpaths.
 set(VCPKG_FIXUP_ELF_RPATH OFF)
 
+vcpkg_find_acquire_program(PATCHELF)
+
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     COPY_SOURCE
@@ -8,10 +10,6 @@ vcpkg_configure_make(
     OPTIONS
         --enable-client-only
         --enable-binreloc
-        --with-builtin-tomcrypt
-        --with-builtin-tommath
-        --with-termlib=:libncurses.a
-        --with-atomiclib=:libatomic.a
         --with-plugins=plugins/${PORT}
         --with-fbmsg=share/${PORT}
         --with-tzdata=share/${PORT}/tzdata
@@ -35,22 +33,18 @@ file(
     INSTALL "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/lib"
     DESTINATION "${CURRENT_PACKAGES_DIR}"
     USE_SOURCE_PERMISSIONS
-    PATTERN "libtom*" EXCLUDE
-)
-
-file(GLOB EXT_LIBS_RELEASE
-    "${SOURCE_COPY_REL_PATH}/extern/libtomcrypt/.libs/libtomcrypt.so*"
-    "${SOURCE_COPY_REL_PATH}/extern/libtommath/.libs/libtommath.so*"
-)
-file(
-    INSTALL ${EXT_LIBS_RELEASE}
-    DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
-    USE_SOURCE_PERMISSIONS
 )
 
 file(GLOB PLUGINS_FILES_RELEASE
     "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/plugins/*"
 )
+
+foreach(plugin ${PLUGINS_FILES_RELEASE})
+    execute_process(
+        COMMAND "${PATCHELF}" --set-rpath "$ORIGIN/../../lib" ${plugin}
+    )
+endforeach()
+
 file(
     INSTALL ${PLUGINS_FILES_RELEASE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/plugins/${PORT}"
@@ -76,22 +70,18 @@ file(
     INSTALL "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/lib"
     DESTINATION "${CURRENT_PACKAGES_DIR}/debug"
     USE_SOURCE_PERMISSIONS
-    PATTERN "libtom*" EXCLUDE
-)
-
-file(GLOB EXT_LIBS_DEBUG
-    "${SOURCE_COPY_DBG_PATH}/extern/libtomcrypt/.libs/libtomcrypt.so*"
-    "${SOURCE_COPY_DBG_PATH}/extern/libtommath/.libs/libtommath.so*"
-)
-file(
-    INSTALL ${EXT_LIBS_DEBUG}
-    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
-    USE_SOURCE_PERMISSIONS
 )
 
 file(GLOB PLUGINS_FILES_DEBUG
     "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/plugins/*"
 )
+
+foreach(plugin ${PLUGINS_FILES_DEBUG})
+    execute_process(
+        COMMAND "${PATCHELF}" --set-rpath "$ORIGIN/../../lib" ${plugin}
+    )
+endforeach()
+
 file(
     INSTALL ${PLUGINS_FILES_DEBUG}
     DESTINATION "${CURRENT_PACKAGES_DIR}/debug/plugins/${PORT}"

--- a/ports/firebird/posix/portfile.cmake
+++ b/ports/firebird/posix/portfile.cmake
@@ -1,0 +1,128 @@
+# Firebird libraries are already relocatable and this causes problems with their runpaths.
+set(VCPKG_FIXUP_ELF_RPATH OFF)
+
+
+# Release build
+
+vcpkg_execute_build_process(
+    COMMAND ./autogen.sh
+        --enable-client-only
+        --enable-binreloc
+        --with-builtin-tomcrypt
+        --with-builtin-tommath
+        --with-termlib=:libncurses.a
+        --with-atomiclib=:libatomic.a
+        --with-plugins=plugins/${PORT}
+        --with-fbmsg=share/${PORT}
+        --with-tzdata=share/${PORT}/tzdata
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME configure-${TARGET_TRIPLET}-rel
+)
+
+vcpkg_execute_build_process(
+    COMMAND make -j ${VCPKG_CONCURRENCY}
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME make-${TARGET_TRIPLET}-rel
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/gen/Release/firebird/include"
+    DESTINATION "${CURRENT_PACKAGES_DIR}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/gen/Release/firebird/lib"
+    DESTINATION "${CURRENT_PACKAGES_DIR}"
+    USE_SOURCE_PERMISSIONS
+    PATTERN "libtom*" EXCLUDE
+)
+
+file(GLOB EXT_LIBS_RELEASE
+    "${SOURCE_PATH}/extern/libtomcrypt/.libs/libtomcrypt.so*"
+    "${SOURCE_PATH}/extern/libtommath/.libs/libtommath.so*"
+)
+file(
+    INSTALL ${EXT_LIBS_RELEASE}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
+    USE_SOURCE_PERMISSIONS
+)
+
+file(GLOB PLUGINS_FILES_RELEASE
+    "${SOURCE_PATH}/gen/Release/firebird/plugins/*"
+)
+file(
+    INSTALL ${PLUGINS_FILES_RELEASE}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/plugins/${PORT}"
+    USE_SOURCE_PERMISSIONS
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/gen/Release/firebird/firebird.msg"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/gen/Release/firebird/tzdata"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+
+# Debug build
+
+vcpkg_execute_build_process(
+    COMMAND ./autogen.sh
+        --enable-developer
+        --enable-client-only
+        --enable-binreloc
+        --with-builtin-tomcrypt
+        --with-builtin-tommath
+        --with-termlib=:libncurses.a
+        --with-atomiclib=:libatomic.a
+        --with-plugins=plugins/${PORT}
+        --with-fbmsg=share/${PORT}
+        --with-tzdata=share/${PORT}/tzdata
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME configure-${TARGET_TRIPLET}-dbg
+)
+
+vcpkg_execute_build_process(
+    COMMAND make -j ${VCPKG_CONCURRENCY}
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME make-${TARGET_TRIPLET}-dbg
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/gen/Debug/firebird/lib"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug"
+    USE_SOURCE_PERMISSIONS
+    PATTERN "libtom*" EXCLUDE
+)
+
+file(GLOB EXT_LIBS_DEBUG
+    "${SOURCE_PATH}/extern/libtomcrypt/.libs/libtomcrypt.so*"
+    "${SOURCE_PATH}/extern/libtommath/.libs/libtommath.so*"
+)
+file(
+    INSTALL ${EXT_LIBS_DEBUG}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
+    USE_SOURCE_PERMISSIONS
+)
+
+file(GLOB PLUGINS_FILES_DEBUG
+    "${SOURCE_PATH}/gen/Debug/firebird/plugins/*"
+)
+file(
+    INSTALL ${PLUGINS_FILES_DEBUG}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/plugins/${PORT}"
+    USE_SOURCE_PERMISSIONS
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/gen/Release/firebird/firebird.msg"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/gen/Release/firebird/tzdata"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+)

--- a/ports/firebird/posix/portfile.cmake
+++ b/ports/firebird/posix/portfile.cmake
@@ -1,11 +1,11 @@
 # Firebird libraries are already relocatable and this causes problems with their runpaths.
 set(VCPKG_FIXUP_ELF_RPATH OFF)
 
-
-# Release build
-
-vcpkg_execute_build_process(
-    COMMAND ./autogen.sh
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    COPY_SOURCE
+    AUTOCONFIG
+    OPTIONS
         --enable-client-only
         --enable-binreloc
         --with-builtin-tomcrypt
@@ -15,31 +15,32 @@ vcpkg_execute_build_process(
         --with-plugins=plugins/${PORT}
         --with-fbmsg=share/${PORT}
         --with-tzdata=share/${PORT}/tzdata
-    WORKING_DIRECTORY "${SOURCE_PATH}"
-    LOGNAME configure-${TARGET_TRIPLET}-rel
+    OPTIONS_DEBUG
+        --enable-developer
 )
 
-vcpkg_execute_build_process(
-    COMMAND make -j ${VCPKG_CONCURRENCY}
-    WORKING_DIRECTORY "${SOURCE_PATH}"
-    LOGNAME make-${TARGET_TRIPLET}-rel
-)
+vcpkg_build_make()
+
+
+# Release build
+
+set(SOURCE_COPY_REL_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
 
 file(
-    INSTALL "${SOURCE_PATH}/gen/Release/firebird/include"
+    INSTALL "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/include"
     DESTINATION "${CURRENT_PACKAGES_DIR}"
 )
 
 file(
-    INSTALL "${SOURCE_PATH}/gen/Release/firebird/lib"
+    INSTALL "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/lib"
     DESTINATION "${CURRENT_PACKAGES_DIR}"
     USE_SOURCE_PERMISSIONS
     PATTERN "libtom*" EXCLUDE
 )
 
 file(GLOB EXT_LIBS_RELEASE
-    "${SOURCE_PATH}/extern/libtomcrypt/.libs/libtomcrypt.so*"
-    "${SOURCE_PATH}/extern/libtommath/.libs/libtommath.so*"
+    "${SOURCE_COPY_REL_PATH}/extern/libtomcrypt/.libs/libtomcrypt.so*"
+    "${SOURCE_COPY_REL_PATH}/extern/libtommath/.libs/libtommath.so*"
 )
 file(
     INSTALL ${EXT_LIBS_RELEASE}
@@ -48,7 +49,7 @@ file(
 )
 
 file(GLOB PLUGINS_FILES_RELEASE
-    "${SOURCE_PATH}/gen/Release/firebird/plugins/*"
+    "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/plugins/*"
 )
 file(
     INSTALL ${PLUGINS_FILES_RELEASE}
@@ -57,50 +58,30 @@ file(
 )
 
 file(
-    INSTALL "${SOURCE_PATH}/gen/Release/firebird/firebird.msg"
+    INSTALL "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/firebird.msg"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
 
 file(
-    INSTALL "${SOURCE_PATH}/gen/Release/firebird/tzdata"
+    INSTALL "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/tzdata"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
 
 
 # Debug build
 
-vcpkg_execute_build_process(
-    COMMAND ./autogen.sh
-        --enable-developer
-        --enable-client-only
-        --enable-binreloc
-        --with-builtin-tomcrypt
-        --with-builtin-tommath
-        --with-termlib=:libncurses.a
-        --with-atomiclib=:libatomic.a
-        --with-plugins=plugins/${PORT}
-        --with-fbmsg=share/${PORT}
-        --with-tzdata=share/${PORT}/tzdata
-    WORKING_DIRECTORY "${SOURCE_PATH}"
-    LOGNAME configure-${TARGET_TRIPLET}-dbg
-)
-
-vcpkg_execute_build_process(
-    COMMAND make -j ${VCPKG_CONCURRENCY}
-    WORKING_DIRECTORY "${SOURCE_PATH}"
-    LOGNAME make-${TARGET_TRIPLET}-dbg
-)
+set(SOURCE_COPY_DBG_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
 
 file(
-    INSTALL "${SOURCE_PATH}/gen/Debug/firebird/lib"
+    INSTALL "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/lib"
     DESTINATION "${CURRENT_PACKAGES_DIR}/debug"
     USE_SOURCE_PERMISSIONS
     PATTERN "libtom*" EXCLUDE
 )
 
 file(GLOB EXT_LIBS_DEBUG
-    "${SOURCE_PATH}/extern/libtomcrypt/.libs/libtomcrypt.so*"
-    "${SOURCE_PATH}/extern/libtommath/.libs/libtommath.so*"
+    "${SOURCE_COPY_DBG_PATH}/extern/libtomcrypt/.libs/libtomcrypt.so*"
+    "${SOURCE_COPY_DBG_PATH}/extern/libtommath/.libs/libtommath.so*"
 )
 file(
     INSTALL ${EXT_LIBS_DEBUG}
@@ -109,7 +90,7 @@ file(
 )
 
 file(GLOB PLUGINS_FILES_DEBUG
-    "${SOURCE_PATH}/gen/Debug/firebird/plugins/*"
+    "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/plugins/*"
 )
 file(
     INSTALL ${PLUGINS_FILES_DEBUG}
@@ -118,11 +99,11 @@ file(
 )
 
 file(
-    INSTALL "${SOURCE_PATH}/gen/Release/firebird/firebird.msg"
+    INSTALL "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/firebird.msg"
     DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
 )
 
 file(
-    INSTALL "${SOURCE_PATH}/gen/Release/firebird/tzdata"
+    INSTALL "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/tzdata"
     DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
 )

--- a/ports/firebird/usage
+++ b/ports/firebird/usage
@@ -1,0 +1,3 @@
+firebird provides CMake targets:
+    find_package(firebird CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE firebird)

--- a/ports/firebird/vcpkg.json
+++ b/ports/firebird/vcpkg.json
@@ -1,5 +1,13 @@
 {
   "name": "firebird",
   "version-string": "5.0.0",
-  "description": "Firebird SQL DBMS"
+  "description": "Firebird SQL DBMS",
+  "dependencies": [
+    "libtomcrypt",
+    "libtommath",
+    {
+      "name": "ncurses",
+      "platform": "!windows"
+    }
+  ]
 }

--- a/ports/firebird/vcpkg.json
+++ b/ports/firebird/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "firebird",
+  "version-string": "5.0.0",
+  "description": "Firebird SQL DBMS"
+}

--- a/ports/firebird/vcpkg.json
+++ b/ports/firebird/vcpkg.json
@@ -9,5 +9,6 @@
       "name": "ncurses",
       "platform": "!windows"
     }
-  ]
+  ],
+  "supports": "!osx"
 }

--- a/ports/firebird/windows-paths.diff
+++ b/ports/firebird/windows-paths.diff
@@ -1,0 +1,95 @@
+diff --git a/src/common/unicode_util.cpp b/src/common/unicode_util.cpp
+index 40871dcfdb..45c1bce046 100644
+--- a/src/common/unicode_util.cpp
++++ b/src/common/unicode_util.cpp
+@@ -239,6 +239,12 @@ void BaseICU::initialize(ModuleLoader::Module* module)
+ 
+ 		pathsToTry.add(Config::getRootDirectory());
+ 
++#ifdef FB_SHAREDIR
++		PathName sharePath;
++		PathUtils::concatPath(sharePath, Config::getRootDirectory(), FB_SHAREDIR);
++		pathsToTry.add(sharePath);
++#endif
++
+ 		file.printf("icudt%u%c.dat", majorVersion,
+ #ifdef WORDS_BIGENDIAN
+ 			'b'
+diff --git a/src/include/gen/autoconfig_msvc.h b/src/include/gen/autoconfig_msvc.h
+index 1e25478c64..7cf81bd668 100644
+--- a/src/include/gen/autoconfig_msvc.h
++++ b/src/include/gen/autoconfig_msvc.h
+@@ -318,6 +318,7 @@
+ 
+ #define FB_PREFIX "c:\\Program Files\\Firebird\\"
+ 
++#define FB_SHAREDIR "share/firebird"
+ #define FB_BINDIR ""
+ #define FB_CONFDIR ""
+ #define FB_DOCDIR ""
+@@ -327,13 +328,13 @@
+ #define FB_LIBDIR ""
+ #define FB_LOGDIR ""
+ #define FB_MISCDIR ""
+-#define FB_MSGDIR ""
+-#define FB_PLUGDIR ""
++#define FB_MSGDIR FB_SHAREDIR
++#define FB_PLUGDIR "plugins/firebird"
+ #define FB_SAMPLEDBDIR ""
+ #define FB_SAMPLEDIR ""
+ #define FB_SBINDIR ""
+ #define FB_SECDBDIR ""
+-#define FB_TZDATADIR ""
++#define FB_TZDATADIR (FB_SHAREDIR "/tzdata")
+ 
+ #define FB_LOGFILENAME "firebird.log"
+ 
+diff --git a/src/yvalve/config/os/win32/config_root.cpp b/src/yvalve/config/os/win32/config_root.cpp
+index 3658ee3d89..bcd6d5b3a0 100644
+--- a/src/yvalve/config/os/win32/config_root.cpp
++++ b/src/yvalve/config/os/win32/config_root.cpp
+@@ -68,40 +68,20 @@ void ConfigRoot::osConfigInstallDir()
+ 	// get the pathname of the running dll / executable
+ 	PathName module_path;
+ 	if (!getPathFromHInstance(module_path))
+-	{
+ 		module_path = fb_utils::get_process_name();
+-	}
+ 
+ 	if (module_path.hasData())
+ 	{
+ 		// get rid of the filename
+-		PathName bin_dir, file_name;
++		PathName bin_dir, file_name, parent_dir;
+ 		PathUtils::splitLastComponent(bin_dir, file_name, module_path);
++		PathUtils::splitLastComponent(parent_dir, file_name, bin_dir);
+ 
+-		// search for the configuration file in the bin directory
+-		PathUtils::concatPath(file_name, bin_dir, Firebird::CONFIG_FILE);
+-		DWORD attributes = GetFileAttributes(file_name.c_str());
+-		if (attributes == INVALID_FILE_ATTRIBUTES || attributes == FILE_ATTRIBUTE_DIRECTORY)
+-		{
+-			// search for the configuration file in the parent directory
+-			PathName parent_dir;
+-			PathUtils::splitLastComponent(parent_dir, file_name, bin_dir);
+-
+-			if (parent_dir.hasData())
+-			{
+-				PathUtils::concatPath(file_name, parent_dir, Firebird::CONFIG_FILE);
+-				attributes = GetFileAttributes(file_name.c_str());
+-				if (attributes != INVALID_FILE_ATTRIBUTES && attributes != FILE_ATTRIBUTE_DIRECTORY)
+-				{
+-					install_dir = parent_dir;
+-				}
+-			}
+-		}
++		if (parent_dir.hasData())
++			install_dir = parent_dir;
+ 
+ 		if (install_dir.isEmpty())
+-		{
+ 			install_dir = bin_dir;
+-		}
+ 	}
+ 
+ 	if (install_dir.isEmpty())

--- a/ports/firebird/windows/portfile.cmake
+++ b/ports/firebird/windows/portfile.cmake
@@ -1,0 +1,126 @@
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(FB_ARCH "Win32")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(FB_ARCH "x64")
+endif()
+
+
+# Release build
+
+vcpkg_execute_build_process(
+    COMMAND run_all.bat
+        JUSTBUILD
+        RELEASE
+        CLIENT_ONLY
+    WORKING_DIRECTORY "${SOURCE_PATH}/builds/win32"
+    LOGNAME configure-${TARGET_TRIPLET}-rel
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_release/include"
+    DESTINATION "${CURRENT_PACKAGES_DIR}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_release/lib"
+    DESTINATION "${CURRENT_PACKAGES_DIR}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_release/fbclient.dll"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/temp/${FB_ARCH}/release/yvalve/fbclient.pdb"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
+)
+
+file(GLOB ICU_FILES_RELEASE
+    "${SOURCE_PATH}/output_${FB_ARCH}_release/icu*.dll"
+)
+file(
+    INSTALL ${ICU_FILES_RELEASE}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
+)
+
+file(GLOB PLUGINS_FILES_RELEASE
+    "${SOURCE_PATH}/output_${FB_ARCH}_release/plugins/*"
+)
+file(
+    INSTALL ${PLUGINS_FILES_RELEASE}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/plugins/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_release/icudt63l.dat"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_release/firebird.msg"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_release/tzdata"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+
+# Debug build
+
+vcpkg_execute_build_process(
+    COMMAND run_all.bat
+        JUSTBUILD
+        DEBUG
+        CLIENT_ONLY
+    WORKING_DIRECTORY "${SOURCE_PATH}/builds/win32"
+    LOGNAME configure-${TARGET_TRIPLET}-dbg
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_debug/lib"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_debug/fbclient.dll"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/temp/${FB_ARCH}/debug/yvalve/fbclient.pdb"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin"
+)
+
+file(GLOB ICU_FILES_DEBUG
+    "${SOURCE_PATH}/output_${FB_ARCH}_debug/icu*.dll"
+)
+file(
+    INSTALL ${ICU_FILES_DEBUG}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin"
+)
+
+file(GLOB PLUGINS_FILES_DEBUG
+    "${SOURCE_PATH}/output_${FB_ARCH}_debug/plugins/*"
+)
+file(
+    INSTALL ${PLUGINS_FILES_DEBUG}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/plugins/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_debug/icudt63l.dat"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_debug/firebird.msg"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH}_debug/tzdata"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2628,6 +2628,10 @@
       "baseline": "2023-07-31",
       "port-version": 0
     },
+    "firebird": {
+      "baseline": "5.0.0",
+      "port-version": 0
+    },
     "fixed-string": {
       "baseline": "0.1.1",
       "port-version": 0

--- a/versions/f-/firebird.json
+++ b/versions/f-/firebird.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d6de44a8ef7aa931b6a22fffdd5d51cf12f92493",
+      "version": "5.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
