### PR TITLE
[datraw] Add new port

### DIFF
--- a/ports/datraw/portfile.cmake
+++ b/ports/datraw/portfile.cmake
@@ -1,0 +1,14 @@
+# header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO UniStuttgart-VISUS/datraw
+    REF "v${VERSION}"
+    SHA512 f38401e0e878f8df8e1b7b9750f4e7fec6920495bfb914a694aab166a0ffbda6dec189693a0d5b9aadb760789706e255f49a382d4e902002aef7120033dce016
+    HEAD_REF master
+)
+
+file(COPY "${SOURCE_PATH}/datraw/datraw.h" "${SOURCE_PATH}/datraw/datraw"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENCE.md")

--- a/ports/datraw/portfile.cmake
+++ b/ports/datraw/portfile.cmake
@@ -1,4 +1,4 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only library
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/datraw/vcpkg.json
+++ b/ports/datraw/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "datraw",
+  "version": "1.0.9",
+  "description": "C++ reimplementation of VIS's datraw library.",
+  "homepage": "https://github.com/UniStuttgart-VISUS/datraw",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2104,6 +2104,10 @@
       "baseline": "3.0.1",
       "port-version": 5
     },
+    "datraw": {
+      "baseline": "1.0.9",
+      "port-version": 0
+    },
     "dav1d": {
       "baseline": "1.3.0",
       "port-version": 1

--- a/versions/d-/datraw.json
+++ b/versions/d-/datraw.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cabfe22cc3f3a53db944b793def6df83aa259078",
+      "git-tree": "b125e43a3f58c35a31755006e118216a94c72036",
       "version": "1.0.9",
       "port-version": 0
     }

--- a/versions/d-/datraw.json
+++ b/versions/d-/datraw.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "cabfe22cc3f3a53db944b793def6df83aa259078",
+      "version": "1.0.9",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

About choosing the port name:
Repology has no entry for `datraw`. First search result on Google and Bing for `datraw` is the GitHub repo of this library (at least when searching from my location). There is an official NuGet Package of this library also using the name `datraw` (https://nuget.info/packages/datraw).
The name "dat/raw", ".dat .raw file pairs", or similar is sometimes used in scientific literature to refer to a volume data file format. This library is a reader of that format.