### PR TITLE
[libe57format] Update to 3.0.1

### DIFF
--- a/ports/libe57format/portfile.cmake
+++ b/ports/libe57format/portfile.cmake
@@ -2,10 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO asmaloney/libE57Format
     REF "v${VERSION}"
-    SHA512 5458e35b319f41290594daefe5de18476ff1c4ed94712d881ed907b72a9c7a470e4d091d68cc1d6115838843e682ed158fc8c7a9fa68eef6c2cf421cda361f7e
+    SHA512 8a788411a7f02c76c6befe96f09f4ac91c87fc0506a543fb64af4d68330c84d84229560128b1ccb64a0463d2529bc5d486b4af81e534710382e189ef9f1f98cd
     HEAD_REF master
     PATCHES
-        prevent_warning_as_errors.diff # see https://github.com/asmaloney/libE57Format/issues/232
+        prevent_warning_as_errors.diff # see https://github.com/asmaloney/libE57Format/issues/256
 )
 
 vcpkg_cmake_configure(

--- a/ports/libe57format/vcpkg.json
+++ b/ports/libe57format/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libe57format",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A library to provide read & write support for the E57 file format.",
   "homepage": "https://github.com/asmaloney/libE57Format",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4241,7 +4241,7 @@
       "port-version": 4
     },
     "libe57format": {
-      "baseline": "3.0.0",
+      "baseline": "3.0.1",
       "port-version": 0
     },
     "libebur128": {

--- a/versions/l-/libe57format.json
+++ b/versions/l-/libe57format.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "420f72aa03611d2e9c0418eaf2d442d2ae260cfd",
+      "version": "3.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "fc02f3676ee791122d4afca45f363564a293da8a",
       "version": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
Part of a series of PRs that brings the lib57Format back to the latest version. The intermediate versions are intended to allow you to select the intermediate version in manifest mode if for some reason you do not want to use the latest version.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.