### PR TITLE
[zeromq] Updated to the released 4.3.5 version.

### DIFF
--- a/ports/zeromq/portfile.cmake
+++ b/ports/zeromq/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeromq/libzmq
-    REF ecc63d0d3b0e1a62c90b58b1ccdb5ac16cb2400a
-    SHA512 4e8f709691d8f3f64d41cc0f0fd70fe0a676247dc88b1283fa90f41b838f5b83100ccabd18714e5638cfa66c5cec0ac67943a3559d535357ff3499de62e47069
+    REF v4.3.5
+    SHA512 108d9c5fa761c111585c30f9c651ed92942dda0ac661155bca52cc7b6dbeb3d27b0dd994abde206eacfc3bc88d19ed24e45b291050c38469e34dca5f8c9a037d
     PATCHES 
         fix-arm.patch
 )

--- a/ports/zeromq/portfile.cmake
+++ b/ports/zeromq/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeromq/libzmq
-    REF v4.3.5
+    REF "v${VERSION}"
     SHA512 108d9c5fa761c111585c30f9c651ed92942dda0ac661155bca52cc7b6dbeb3d27b0dd994abde206eacfc3bc88d19ed24e45b291050c38469e34dca5f8c9a037d
     PATCHES 
         fix-arm.patch

--- a/ports/zeromq/vcpkg.json
+++ b/ports/zeromq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zeromq",
-  "version-date": "2023-06-20",
-  "port-version": 1,
+  "version": "4.3.5",
+  "port-version": 2,
   "description": "The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products",
   "homepage": "https://github.com/zeromq/libzmq",
   "license": "MPL-2.0",

--- a/ports/zeromq/vcpkg.json
+++ b/ports/zeromq/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zeromq",
   "version": "4.3.5",
-  "port-version": 0,
   "description": "The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products",
   "homepage": "https://github.com/zeromq/libzmq",
   "license": "MPL-2.0",

--- a/ports/zeromq/vcpkg.json
+++ b/ports/zeromq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zeromq",
   "version": "4.3.5",
-  "port-version": 2,
+  "port-version": 0,
   "description": "The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products",
   "homepage": "https://github.com/zeromq/libzmq",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9405,8 +9405,8 @@
       "port-version": 4
     },
     "zeromq": {
-      "baseline": "2023-06-20",
-      "port-version": 1
+      "baseline": "4.3.5",
+      "port-version": 0
     },
     "zfp": {
       "baseline": "1.0.0",

--- a/versions/z-/zeromq.json
+++ b/versions/z-/zeromq.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cd720f1a5654946d3b2387f77644b44fbcf8d71e",
+      "git-tree": "5970da937ebf1ba63808ec2028c1839a8971b054",
       "version": "4.3.5",
       "port-version": 0
     },

--- a/versions/z-/zeromq.json
+++ b/versions/z-/zeromq.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5970da937ebf1ba63808ec2028c1839a8971b054",
+      "git-tree": "7c31f33a815e20807d89d684435dcab872c37d2a",
       "version": "4.3.5",
       "port-version": 0
     },

--- a/versions/z-/zeromq.json
+++ b/versions/z-/zeromq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cd720f1a5654946d3b2387f77644b44fbcf8d71e",
+      "version": "4.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "6f361429d0511b651b4f7b98f0dc47adf2601843",
       "version-date": "2023-06-20",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

This PR updates the ZeroMQ port to point to the released 4.3.5 version. 
The current port for ZeroMQ (libzmq) points to a non-release commit that still reports to have version 4.3.5. It seems the version of libzmq was already incremented to 4.3.5, although it was not the final version for that release. Therefore, it is deceiving for the package consumers because calling `find_package()` in CMake will set `${ZeroMQ_VERSION}` to 4.3.5, while the installed version will differ from the one released under the tag 4.3.5, see https://github.com/zeromq/libzmq/releases/tag/v4.3.5. 
 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

