### PR TITLE
[fakeit] Fix fakeit build

### DIFF
--- a/ports/fakeit/fix-include_dir.patch
+++ b/ports/fakeit/fix-include_dir.patch
@@ -1,0 +1,22 @@
+diff --git a/single_header/CMakeLists.txt b/single_header/CMakeLists.txt
+index 1d2e280..460e6c7 100644
+--- a/single_header/CMakeLists.txt
++++ b/single_header/CMakeLists.txt
+@@ -10,7 +10,7 @@ function(add_configuration config_name)
+     # If we use FakeIt from install-tree then we use INSTALL_INTERFACE wrapper.
+     target_include_directories(FakeIt-${config_name} SYSTEM INTERFACE
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${config_name}>
+-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${config_name}>
++        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/fakeit/single_header/${config_name}>
+     )
+ 
+     # Add alias for the library with namespace.
+@@ -20,7 +20,7 @@ function(add_configuration config_name)
+     # "${config_name}" instead of "${config_name}/" string means that the header will be
+     # installed at ${CMAKE_INSTALL_PREFIX}/include/${config_name}/fakeit.hpp
+     # instead of ${CMAKE_INSTALL_PREFIX}/include/fakeit.hpp.
+-    install(DIRECTORY ${config_name} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    install(DIRECTORY ${config_name} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fakeit/single_header)
+ 
+     # Add the new config target to the FakeItConfig.cmake file which will be used to find FakeIt from outside.
+     install(TARGETS FakeIt-${config_name} EXPORT FakeItConfig)

--- a/ports/fakeit/portfile.cmake
+++ b/ports/fakeit/portfile.cmake
@@ -4,8 +4,17 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 3575dc2247a97ea6d3c584e9b933e32cc0d1936fec480b19caf8305e8ba39bb11b4437930a5343b343df66347354ef5aaa8d2811e0ff3119bfc619629a0c2b8b
     HEAD_REF master
+    PATCHES fix-include_dir.patch
 )
 
-file(COPY "${SOURCE_PATH}/single_header/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}" FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h")
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fakeit/portfile.cmake
+++ b/ports/fakeit/portfile.cmake
@@ -9,12 +9,18 @@ vcpkg_from_github(
 
 set(VCPKG_BUILD_TYPE release) # header-only port
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DENABLE_TESTING=OFF
+)
 
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fakeit/usage
+++ b/ports/fakeit/usage
@@ -1,6 +1,4 @@
 fakeit provides CMake targets:
 
-  # this is heuristically generated, and may not be correct
   find_package(FakeIt CONFIG REQUIRED)
-  # note: 7 additional targets are not displayed.
   target_link_libraries(main PRIVATE FakeIt::FakeIt-boost FakeIt::FakeIt-catch FakeIt::FakeIt-cute FakeIt::FakeIt-doctest FakeIt::FakeIt-gtest FakeIt::FakeIt-mettle FakeIt::FakeIt-mstest FakeIt::FakeIt-nunit FakeIt::FakeIt-qtest FakeIt::FakeIt-standalone FakeIt::FakeIt-tpunit)

--- a/ports/fakeit/usage
+++ b/ports/fakeit/usage
@@ -1,4 +1,9 @@
-fakeit provides CMake targets:
+The package FakeIt provides CMake targets:
 
-  find_package(FakeIt CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE FakeIt::FakeIt-boost FakeIt::FakeIt-catch FakeIt::FakeIt-cute FakeIt::FakeIt-doctest FakeIt::FakeIt-gtest FakeIt::FakeIt-mettle FakeIt::FakeIt-mstest FakeIt::FakeIt-nunit FakeIt::FakeIt-qtest FakeIt::FakeIt-standalone FakeIt::FakeIt-tpunit)
+    # Usage for specific framework tests (e.g. boost, catch, gtest, etc.)
+    find_package(FakeIt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE FakeIt::FakeIt-<framework>)
+
+    # Only specific test framework configuration files are provided upstream.
+    # It does not install its own source header files.
+    # So only the usage of the test framework is provided here.

--- a/ports/fakeit/usage
+++ b/ports/fakeit/usage
@@ -1,0 +1,6 @@
+fakeit provides CMake targets:
+
+  # this is heuristically generated, and may not be correct
+  find_package(FakeIt CONFIG REQUIRED)
+  # note: 7 additional targets are not displayed.
+  target_link_libraries(main PRIVATE FakeIt::FakeIt-boost FakeIt::FakeIt-catch FakeIt::FakeIt-cute FakeIt::FakeIt-doctest FakeIt::FakeIt-gtest FakeIt::FakeIt-mettle FakeIt::FakeIt-mstest FakeIt::FakeIt-nunit FakeIt::FakeIt-qtest FakeIt::FakeIt-standalone FakeIt::FakeIt-tpunit)

--- a/ports/fakeit/vcpkg.json
+++ b/ports/fakeit/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "fakeit",
   "version": "2.4.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "FakeIt is a simple mocking framework for C++. It supports GCC, Clang and MS Visual C++.",
   "homepage": "https://github.com/eranpeer/FakeIt",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2526,7 +2526,7 @@
     },
     "fakeit": {
       "baseline": "2.4.0",
-      "port-version": 1
+      "port-version": 2
     },
     "fameta-counter": {
       "baseline": "2021-02-13",

--- a/versions/f-/fakeit.json
+++ b/versions/f-/fakeit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a75ea060efce507d50d75148d413b9b794aa90ba",
+      "git-tree": "58270401b83064dae32cc600e418b34f6323553e",
       "version": "2.4.0",
       "port-version": 2
     },

--- a/versions/f-/fakeit.json
+++ b/versions/f-/fakeit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "58270401b83064dae32cc600e418b34f6323553e",
+      "git-tree": "0d6b693f9bf5b9acd2573754924d7483576d6096",
       "version": "2.4.0",
       "port-version": 2
     },

--- a/versions/f-/fakeit.json
+++ b/versions/f-/fakeit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0d6b693f9bf5b9acd2573754924d7483576d6096",
+      "git-tree": "808389303a7bd3b6a4d3b9614c8b7e582f4dc6d5",
       "version": "2.4.0",
       "port-version": 2
     },

--- a/versions/f-/fakeit.json
+++ b/versions/f-/fakeit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a75ea060efce507d50d75148d413b9b794aa90ba",
+      "version": "2.4.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "4975f837bbd496c621a2b6cd11fc6745357c61c5",
       "version": "2.4.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #36180. 

Use `vcpkg_cmake_configure()` to build `fakeit` and install the `config*.cmake` files.

Add `fix-include_dir.patch` to modify the header file installation path to avoid mixing header files with other ports (for example: boost, gtest).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
