### PR TITLE
Updating the information on CLion integration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,16 +226,8 @@ add the path to the vcpkg toolchain file:
 
 ### Vcpkg with CLion
 
-Open the Toolchains settings
-(File > Settings on Windows and Linux, CLion > Preferences on macOS),
-and go to the CMake settings (Build, Execution, Deployment > CMake).
-Finally, in `CMake options`, add the following line:
-
-```
--DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake
-```
-
-You must add this line to each profile.
+Vcpkg is integrated in the CLion IDE. 
+For details, see the [official documentation](https://www.jetbrains.com/help/clion/package-management.html).
 
 ### Vcpkg as a Submodule with CMake
 


### PR DESCRIPTION
Hello,

Please consider updating the 'Vcpkg with CLion' section in README.
Starting from the version 2023.2, CLion integrates with vcpkg and there is no need for additional CMake option as before. I also added a link to the web help where users can find out more.

Thank you!