### PR TITLE
[libvpx] Avoid using GNU specific diff option

### DIFF
--- a/ports/libvpx/0006-fix-diff-detection.patch
+++ b/ports/libvpx/0006-fix-diff-detection.patch
@@ -1,0 +1,11 @@
+--- configure.old	2024-01-17 06:40:18.170468000 +0900
++++ configure	2024-01-17 06:42:52.441297000 +0900
+@@ -191,7 +191,7 @@
+     [ -f "${source_path}/${t}.mk" ] && enable_feature ${t}
+ done
+ 
+-if ! diff --version >/dev/null; then
++if ! hash diff 2>/dev/null; then
+   die "diff missing: Try installing diffutils via your package manager."
+ fi
+ 

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         0003-add-uwp-v142-and-v143-support.patch
         0004-remove-library-suffixes.patch
         0005-fix-arm64-build.patch # Upstream commit: https://github.com/webmproject/libvpx/commit/858a8c611f4c965078485860a6820e2135e6611b
+        0006-fix-diff-detection.patch #From https://github.com/freebsd/freebsd-ports/blob/c6c496b829623bb3f93647d953dde6a6a7142979/multimedia/libvpx/files/patch-configure
 )
 
 if(CMAKE_HOST_WIN32)

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libvpx",
   "version": "1.13.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5022,7 +5022,7 @@
     },
     "libvpx": {
       "baseline": "1.13.1",
-      "port-version": 2
+      "port-version": 3
     },
     "libwandio": {
       "baseline": "4.2.1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "62d1db76101eaccd92ace0ab03e2256505b55ebe",
+      "version": "1.13.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "66ea767e9ce55da152694d49a74ad2125ca4d937",
       "version": "1.13.1",
       "port-version": 2


### PR DESCRIPTION
Import patch from FreeBSD ports' multimedia/libvpx to circumvent a dependency on GNU diff.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.