### PR TITLE
[gettext] Workaround bash substitution failure

### DIFF
--- a/ports/gettext/subdirs.patch
+++ b/ports/gettext/subdirs.patch
@@ -7,7 +7,7 @@ index 904bdf5..e751ffc 100755
  
  
 -subdirs="$subdirs gettext-runtime libtextstyle gettext-tools"
-+subdirs="$subdirs gettext-runtime ${VCPKG_GETTEXT_SUBDIRS/gettext-runtime/}"
++subdirs="$subdirs gettext-runtime $(echo ${VCPKG_GETTEXT_SUBDIRS} | sed 's/gettext-runtime//')"
  
  
  

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext",
   "version": "0.22.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A GNU framework to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2934,7 +2934,7 @@
     },
     "gettext": {
       "baseline": "0.22.4",
-      "port-version": 1
+      "port-version": 2
     },
     "gettext-libintl": {
       "baseline": "0.22.4",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9cc9b8256d9653fe2d484ecf268f7368666d942",
+      "version": "0.22.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "bd31edd407c0889c864c1e8854be92b602a4e29f",
       "version": "0.22.4",
       "port-version": 1


### PR DESCRIPTION
Fixes #36201

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
