### PR TITLE
[rocksdb] Update to 8.10.0

### DIFF
--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb
   REF "v${VERSION}"
-  SHA512 a93720ef2ecafe2e3d51594b8a8bf6b5d36b0dfeae571cec650ee9d7b3d0c166bd6d9fbe2acb6e57cf34e73b58a2277a6465cce56a5274dd68b03bc9009e0323
+  SHA512 524e3e70ed2b1d2e6c61a7b401946e50473cc95684ce4efc6250062f5bc945e443e96f7907fcc3ee1ab98c71179a8b56a654383cf2c0bbe1bb20907ab1ac7523
   HEAD_REF main
   PATCHES
     0001-fix-dependencies.patch

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rocksdb",
-  "version": "8.9.1",
+  "version": "8.10.0",
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7569,7 +7569,7 @@
       "port-version": 0
     },
     "rocksdb": {
-      "baseline": "8.9.1",
+      "baseline": "8.10.0",
       "port-version": 0
     },
     "rpclib": {

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00b3130e81114b517e3a4324c9a0408e1b9ac3d7",
+      "version": "8.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0262aa76211da9eacdd5e70f88bf172eaef286bd",
       "version": "8.9.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
