### PR TITLE
[azure-*-cpp] Append note to manifest files

### DIFF
--- a/ports/azure-core-tracing-opentelemetry-cpp/portfile.cmake
+++ b/ports/azure-core-tracing-opentelemetry-cpp/portfile.cmake
@@ -1,3 +1,6 @@
+# NOTE: All changes made to this file will get overwritten by the next port release.
+# Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
@@ -19,6 +22,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
+        -DBUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/azure-core-tracing-opentelemetry-cpp/vcpkg.json
+++ b/ports/azure-core-tracing-opentelemetry-cpp/vcpkg.json
@@ -1,7 +1,11 @@
 {
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-core-tracing-opentelemetry-cpp",
   "version-semver": "1.0.0-beta.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Microsoft Azure Core Tracing OpenTelemetry SDK for C++",
     "This library provides support for modern Azure SDK client libraries written in C++ to leverage OpenTelemetry APIs."

--- a/ports/azure-messaging-eventhubs-checkpointstore-blob-cpp/portfile.cmake
+++ b/ports/azure-messaging-eventhubs-checkpointstore-blob-cpp/portfile.cmake
@@ -1,3 +1,6 @@
+# NOTE: All changes made to this file will get overwritten by the next port release.
+# Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp

--- a/ports/azure-messaging-eventhubs-checkpointstore-blob-cpp/vcpkg.json
+++ b/ports/azure-messaging-eventhubs-checkpointstore-blob-cpp/vcpkg.json
@@ -1,6 +1,11 @@
 {
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-messaging-eventhubs-checkpointstore-blob-cpp",
   "version-semver": "1.0.0-beta.1",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Messaging Event Hubs Blob Checkpoint Store SDK for C++",
     "This library provides an Azure-Storage-Blobs based implementation of an Azure Messaging Event Hubs SDK Checkpoint Store."

--- a/ports/azure-security-attestation-cpp/portfile.cmake
+++ b/ports/azure-security-attestation-cpp/portfile.cmake
@@ -1,3 +1,6 @@
+# NOTE: All changes made to this file will get overwritten by the next port release.
+# Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
@@ -19,6 +22,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
+        -DBUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/azure-security-attestation-cpp/vcpkg.json
+++ b/ports/azure-security-attestation-cpp/vcpkg.json
@@ -1,7 +1,11 @@
 {
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-security-attestation-cpp",
   "version-semver": "1.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Microsoft Azure Attestation Service SDK for C++",
     "This library provides API access to the Microsoft Azure Attestation service."

--- a/versions/a-/azure-core-tracing-opentelemetry-cpp.json
+++ b/versions/a-/azure-core-tracing-opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0fb3475fbd40be762b7bb9a1a85fef10eb4af9a3",
+      "version-semver": "1.0.0-beta.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "001d1fc3f1ecbaa77894355634624bc5a7c7d7f2",
       "version-semver": "1.0.0-beta.4",
       "port-version": 1

--- a/versions/a-/azure-messaging-eventhubs-checkpointstore-blob-cpp.json
+++ b/versions/a-/azure-messaging-eventhubs-checkpointstore-blob-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44c7021f43e5786d7be87b935868e4c283d72755",
+      "version-semver": "1.0.0-beta.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "9289b19329d8fc1b12ef5a71d1cf2d743a32cc2a",
       "version-semver": "1.0.0-beta.1",
       "port-version": 0

--- a/versions/a-/azure-security-attestation-cpp.json
+++ b/versions/a-/azure-security-attestation-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ece7b864d0d0ab18ba081e5695efea98c5aa2bdf",
+      "version-semver": "1.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "812294d664f9765544343cfc8b5265edfb88d061",
       "version-semver": "1.1.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -426,7 +426,7 @@
     },
     "azure-core-tracing-opentelemetry-cpp": {
       "baseline": "1.0.0-beta.4",
-      "port-version": 1
+      "port-version": 2
     },
     "azure-identity-cpp": {
       "baseline": "1.6.0",
@@ -446,7 +446,7 @@
     },
     "azure-messaging-eventhubs-checkpointstore-blob-cpp": {
       "baseline": "1.0.0-beta.1",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-messaging-eventhubs-cpp": {
       "baseline": "1.0.0-beta.5",
@@ -454,7 +454,7 @@
     },
     "azure-security-attestation-cpp": {
       "baseline": "1.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "azure-security-keyvault-administration-cpp": {
       "baseline": "4.0.0-beta.3",


### PR DESCRIPTION
This PR adds a note to the Azure SDK ports for the packages that have not been released recently.
All our other port files do already have this note.

This PR also adds a `-DBUILD_TESTING=OFF` which all our ports also have.