### PR TITLE
[zeromq] fix warning

### DIFF
--- a/ports/zeromq/portfile.cmake
+++ b/ports/zeromq/portfile.cmake
@@ -13,19 +13,16 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        sodium          WITH_LIBSODIUM
-        draft           ENABLE_DRAFTS
-        websockets      ENABLE_WS
+        sodium            WITH_LIBSODIUM
+        draft             ENABLE_DRAFTS
+        websockets        ENABLE_WS
         websockets-secure WITH_TLS
-        curve           ENABLE_CURVE
+        curve             ENABLE_CURVE
 )
 
 set(PLATFORM_OPTIONS "")
 if(VCPKG_TARGET_IS_MINGW)
     list(APPEND PLATFORM_OPTIONS "-DCMAKE_SYSTEM_VERSION=6.0" "-DZMQ_HAVE_IPC=0")
-endif()
-if(BUILD_SHARED)
-    list(APPEND PLATFORM_OPTIONS "-DWITH_PERF_TOOL=OFF")
 endif()
 
 vcpkg_cmake_configure(
@@ -34,6 +31,7 @@ vcpkg_cmake_configure(
         -DZMQ_BUILD_TESTS=OFF
         -DBUILD_STATIC=${BUILD_STATIC}
         -DBUILD_SHARED=${BUILD_SHARED}
+        -DWITH_PERF_TOOL=OFF
         -DWITH_DOCS=OFF
         -DWITH_NSS=OFF
         -DWITH_LIBBSD=OFF
@@ -44,9 +42,9 @@ vcpkg_cmake_configure(
     OPTIONS_DEBUG
         "-DCMAKE_PDB_OUTPUT_DIRECTORY=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
     MAYBE_UNUSED_VARIABLES
-        USE_PERF_TOOLS
         CMAKE_REQUIRE_FIND_PACKAGE_GnuTLS
         WITH_LIBBSD
+        WITH_PERF_TOOL
         WITH_TLS
 )
 

--- a/ports/zeromq/portfile.cmake
+++ b/ports/zeromq/portfile.cmake
@@ -22,7 +22,10 @@ vcpkg_check_features(
 
 set(PLATFORM_OPTIONS "")
 if(VCPKG_TARGET_IS_MINGW)
-    set(PLATFORM_OPTIONS -DCMAKE_SYSTEM_VERSION=6.0 -DZMQ_HAVE_IPC=0)
+    list(APPEND PLATFORM_OPTIONS "-DCMAKE_SYSTEM_VERSION=6.0" "-DZMQ_HAVE_IPC=0")
+endif()
+if(BUILD_SHARED)
+    list(APPEND PLATFORM_OPTIONS "-DWITH_PERF_TOOL=OFF")
 endif()
 
 vcpkg_cmake_configure(
@@ -31,7 +34,6 @@ vcpkg_cmake_configure(
         -DZMQ_BUILD_TESTS=OFF
         -DBUILD_STATIC=${BUILD_STATIC}
         -DBUILD_SHARED=${BUILD_SHARED}
-        -DWITH_PERF_TOOL=OFF
         -DWITH_DOCS=OFF
         -DWITH_NSS=OFF
         -DWITH_LIBBSD=OFF

--- a/ports/zeromq/vcpkg.json
+++ b/ports/zeromq/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zeromq",
   "version": "4.3.5",
+  "port-version": 1,
   "description": "The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products",
   "homepage": "https://github.com/zeromq/libzmq",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9410,7 +9410,7 @@
     },
     "zeromq": {
       "baseline": "4.3.5",
-      "port-version": 0
+      "port-version": 1
     },
     "zfp": {
       "baseline": "1.0.0",

--- a/versions/z-/zeromq.json
+++ b/versions/z-/zeromq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b29c6d49b57e312a9b59cc0303d76907dcea8ab8",
+      "version": "4.3.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "7c31f33a815e20807d89d684435dcab872c37d2a",
       "version": "4.3.5",
       "port-version": 0

--- a/versions/z-/zeromq.json
+++ b/versions/z-/zeromq.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b29c6d49b57e312a9b59cc0303d76907dcea8ab8",
+      "git-tree": "3ac6a3ee94fb7235dc37fc7042e8270060c685c1",
       "version": "4.3.5",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix build warning "The following variables are not used in CMakeLists.txt: WITH_PERF_TOOL"
The WITH_PERF_TOOL options is set in upstream CMake only for shared builds.