### PR TITLE
[7zip]  Switch download source to github

### DIFF
--- a/ports/7zip/portfile.cmake
+++ b/ports/7zip/portfile.cmake
@@ -1,14 +1,9 @@
-set(7ZIP_VERSION "2301")
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.7-zip.org/a/7z${7ZIP_VERSION}-src.7z"
-    FILENAME "7z${7ZIP_VERSION}-src.7z"
-    SHA512 45038fc49b0be8e7435939a79ad9f46f360b43b651148a8cde74fafdb8536f51a4be3b1ea91e06203267e5121267f6601f8ae6678feaf18e4b7a4f79a16730e7
-)
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
-    NO_REMOVE_ONE_LEVEL
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ip7z/7zip
+    REF "${VERSION}"
+    SHA512 7c2fb18261ce9185d29b690ccb7694d7926abe3af0619dbe42b7ab43b400ee71c1eb79c31f892aea2fbdb55036225f31ee393287cce91afd17f20cff8f6cb949
+    HEAD_REF main
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -23,10 +18,6 @@ vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup()
 
-file(
-    INSTALL "${SOURCE_PATH}/DOC/License.txt"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-    RENAME copyright
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/DOC/License.txt")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "7zip",
   "version-string": "23.01",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library for archiving file with a high compression ratio.",
   "homepage": "https://www.7-zip.org",
   "license": "LGPL-2.1-or-later",

--- a/scripts/cmake/vcpkg_find_acquire_program(7Z).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(7Z).cmake
@@ -3,7 +3,7 @@ if(CMAKE_HOST_WIN32)
     set(tool_subdirectory "23.01")
     set(paths_to_search "${DOWNLOADS}/tools/7zip_msi-${tool_subdirectory}-windows/Files/7-Zip") # vcpkg fetch 7zip_msi path
     list(APPEND paths_to_search "${DOWNLOADS}/tools/7z/${tool_subdirectory}/Files/7-Zip")
-    set(download_urls "https://7-zip.org/a/7z2301.msi")
+    set(download_urls "https://github.com/ip7z/7zip/releases/download/23.01/7z2301.msi")
     set(download_filename "7z2301.msi")
     set(download_sha512 002c8ab30be802fa5fa90896d2bdf710bfbd89e39487af25af9d63821986e6d11c42b1c4f4acc79d325719b10193cd31c38f648403ef16f0580609afa8da9596)
 endif()

--- a/scripts/cmake/vcpkg_find_acquire_program(7Z).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(7Z).cmake
@@ -3,7 +3,7 @@ if(CMAKE_HOST_WIN32)
     set(tool_subdirectory "23.01")
     set(paths_to_search "${DOWNLOADS}/tools/7zip_msi-${tool_subdirectory}-windows/Files/7-Zip") # vcpkg fetch 7zip_msi path
     list(APPEND paths_to_search "${DOWNLOADS}/tools/7z/${tool_subdirectory}/Files/7-Zip")
-    set(download_urls "https://github.com/ip7z/7zip/releases/download/23.01/7z2301.msi")
+    set(download_urls "https://github.com/ip7z/7zip/releases/download/23.01/7z2301.msi" "https://7-zip.org/a/7z2301.msi")
     set(download_filename "7z2301.msi")
     set(download_sha512 002c8ab30be802fa5fa90896d2bdf710bfbd89e39487af25af9d63821986e6d11c42b1c4f4acc79d325719b10193cd31c38f648403ef16f0580609afa8da9596)
 endif()

--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -133,14 +133,14 @@
     <tool name="7zip_msi" os="windows">
         <version>23.01</version>
         <exeRelativePath>Files\7-Zip\7z.exe</exeRelativePath>
-        <url>https://www.7-zip.org/a/7z2301-x64.msi</url>
+        <url>https://github.com/ip7z/7zip/releases/download/23.01/7z2301-x64.msi</url>
         <sha512>09e3ce970ea8383e8c736a51ebb61e3036e655c81d59bc64c5eecb041abdad2cbce2f400fcf4478e22f56fe40f8d912c639f550a5f990e24abfd4e86cdd3755c</sha512>
         <archiveName>7z2301-x64.msi</archiveName>
     </tool>
     <tool name="7zip" os="windows">
         <version>23.01</version>
         <exeRelativePath>7za.exe</exeRelativePath>
-        <url>https://www.7-zip.org/a/7z2301-extra.7z</url>
+        <url>https://github.com/ip7z/7zip/releases/download/23.01/7z2301-extra.7z</url>
         <sha512>c849c2cb489cf5b6eeb92bfbc27dcb37d0349c36971e1bc7ef32c7cde1b659e19e8b46d734ba90f47affe07fdfd5b4774cbfa0fdf4b681e9f60bb46bba1f7f9b</sha512>
         <archiveName>7z2301-extra.7z</archiveName>
      </tool>

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23256cddd31991c2df4d96a07fc016fd446c2d2d",
+      "version-string": "23.01",
+      "port-version": 2
+    },
+    {
       "git-tree": "2f1fa323db9a88dd410e7d46ad651f7fe5cb620c",
       "version-string": "23.01",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6,7 +6,7 @@
     },
     "7zip": {
       "baseline": "23.01",
-      "port-version": 1
+      "port-version": 2
     },
     "ableton": {
       "baseline": "3.0.6",


### PR DESCRIPTION
Fixes #36214, #26844.

As requested by some users, I switched the download source from `https://www.7-zip.org` to `https://github.com/ip7z/7zip`.  This is the official github website of 7zip:

![image](https://github.com/microsoft/vcpkg/assets/110024546/ecf2d64e-2516-4aec-a319-b782bdf74830)


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


The usage test passed on `x64-windows` (header files found):
```
7zip provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(7zip CONFIG REQUIRED)
  target_link_libraries(main PRIVATE 7zip::7zip)
```