### PR TITLE
[qtinterfaceframework] Update python requirements versions

### DIFF
--- a/ports/qtinterfaceframework/requirements_minimal.txt
+++ b/ports/qtinterfaceframework/requirements_minimal.txt
@@ -3,8 +3,8 @@ argh==0.26.2
 click==6.7
 coloredlogs==10.0
 humanfriendly==4.15.1
-Jinja2==2.11.3
-MarkupSafe==1.1
+Jinja2==3.1.3
+MarkupSafe==2.1.3
 path.py==11.0.1
 pathtools==0.1.2
 PyYAML==6.0.1

--- a/ports/qtinterfaceframework/vcpkg.json
+++ b/ports/qtinterfaceframework/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtinterfaceframework",
   "version": "6.6.1",
+  "port-version": 1,
   "description": "Qt Interface Framework",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7194,7 +7194,7 @@
     },
     "qtinterfaceframework": {
       "baseline": "6.6.1",
-      "port-version": 0
+      "port-version": 1
     },
     "qtkeychain": {
       "baseline": "0.14.1",

--- a/versions/q-/qtinterfaceframework.json
+++ b/versions/q-/qtinterfaceframework.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e6b9a3607cbd6f63dd80e8d5207cca2bd452013",
+      "version": "6.6.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "1bcb4f2fd5111908f77a8b70692b935ec23c2d27",
       "version": "6.6.1",
       "port-version": 0


### PR DESCRIPTION
Thanks to dependentabot for notifying us to update the python packages: #36133.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~SHA512s are updated for each updated download~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
