### PR TITLE
[skia] Fixes build error on x64-linux

### DIFF
--- a/ports/skia/add-cstdlib.patch
+++ b/ports/skia/add-cstdlib.patch
@@ -1,0 +1,12 @@
+diff --git a/src/dawn/common/Mutex.cpp b/src/dawn/common/Mutex.cpp
+index b8b891f..84c47af 100644
+--- a/src/dawn/common/Mutex.cpp
++++ b/src/dawn/common/Mutex.cpp
+@@ -13,6 +13,7 @@
+ // limitations under the License.
+ 
+ #include "dawn/common/Mutex.h"
++#include <cstdlib>
+ 
+ namespace dawn {
+ Mutex::~Mutex() = default;

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -30,6 +30,7 @@ declare_external_from_git(dawn
     LICENSE_FILE LICENSE
     PATCHES
         dawn-dedup-native-proc-gen.patch
+        add-cstdlib.patch
 )
 declare_external_from_git(dng_sdk
     URL "https://android.googlesource.com/platform/external/dng_sdk.git"

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "skia",
   "version": "0.38.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7978,7 +7978,7 @@
     },
     "skia": {
       "baseline": "0.38.2",
-      "port-version": 3
+      "port-version": 4
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b33b637ea6bf1d04acc4aac659b0238f9d16a0c1",
+      "version": "0.38.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "35eec017ed472e7061cc38768bb4aa9168464332",
       "version": "0.38.2",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/36060

`skia[dawn]:x64-linux` install failed with below error in release build:
```
../src/it_-0.38.2-72617eb022/third_party/externals/dawn/src/dawn/common/Mutex.cpp:46:5: error: ‘abort’ was not declared in this scope
   46 |     abort();
      |     ^~~~~
../src/it_-0.38.2-72617eb022/third_party/externals/dawn/src/dawn/common/Mutex.cpp:16:1: note: ‘abort’ is defined in header ‘<cstdlib>’; did you forget to ‘#include <cstdlib>’?
   15 | #include "dawn/common/Mutex.h"
  +++ |+#include <cstdlib>
   16 | 
../src/it_-0.38.2-72617eb022/third_party/externals/dawn/src/dawn/common/Mutex.cpp:48:1: warning: no return statement in function returning non-void [-Wreturn-type]
   48 | }
      | ^
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
