### PR TITLE
Add period for some descriptions in the new PR and new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-report-package-build-failure.yml
+++ b/.github/ISSUE_TEMPLATE/00-report-package-build-failure.yml
@@ -35,7 +35,7 @@ body:
     id: logs
     attributes:
       label: Failure logs
-      description: The console output and all the logs metioned in the output
+      description: The console output and all the logs metioned in the output.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/00-report-package-build-failure.yml
+++ b/.github/ISSUE_TEMPLATE/00-report-package-build-failure.yml
@@ -35,7 +35,7 @@ body:
     id: logs
     attributes:
       label: Failure logs
-      description: The console output and all the logs metioned in the output.
+      description: The console output and all the logs mentioned in the output.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/01-request-a-new-port.yml
+++ b/.github/ISSUE_TEMPLATE/01-request-a-new-port.yml
@@ -1,5 +1,5 @@
 name: Request a new port
-description: Request a new port/library that vcpkg should support
+description: Request a new port/library that vcpkg should support.
 title: "[New Port Request] <library name here>"
 labels: ["category:new-port", "info:good-first-issue"]
 

--- a/.github/ISSUE_TEMPLATE/03-request-a-feature-or-improvement-to-a-port.yml
+++ b/.github/ISSUE_TEMPLATE/03-request-a-feature-or-improvement-to-a-port.yml
@@ -1,5 +1,5 @@
 name: Request a feature or improvement to a port
-description: Suggest an improvement to one the the ports/libraries in vcpkg
+description: Suggest an improvement to one the the ports/libraries in vcpkg.
 title: "[<portname>] <short description of feature>"
 labels: ["category:port-feature"]
 body:

--- a/.github/ISSUE_TEMPLATE/04-request-a-feature-or-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/04-request-a-feature-or-improvement.yml
@@ -1,5 +1,5 @@
 name: Request a feature or improvement
-description: Suggest an improvement to vcpkg
+description: Suggest an improvement to vcpkg.
 title: ''
 labels: ["category:vcpkg-feature"]
 body:

--- a/.github/ISSUE_TEMPLATE/05-other-type-of-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/05-other-type-of-bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Other type of bug report
-about: Let us know about an issues that does not fit into any of the other issues
+about: Let us know about an issues that does not fit into any of the other issues.
   types
 title: ''
 labels: ''

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 <!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
 
-<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->
+<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->
 
 <!-- If this PR updates an existing port, please uncomment and fill out this checklist:
 
-- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
-- [ ] SHA512s are updated for each updated download
-- [ ] The "supports" clause reflects platforms that may be fixed by this new version
+- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
+- [ ] SHA512s are updated for each updated download.
+- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
 - [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
 - [ ] Any patches that are no longer applied are deleted from the port's directory.
 - [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
@@ -16,9 +16,9 @@ END OF PORT UPDATE CHECKLIST (delete this line) -->
 
 <!-- If this PR adds a new port, please uncomment and fill out this checklist:
 
-- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
+- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
 - [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
-- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
+- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
 - [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
 - [ ] The license declaration in `vcpkg.json` matches what upstream says.
 - [ ] The installed as the "copyright" file matches what upstream says.


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Some descriptions in the new PR and new issue templates missing period, add period for them.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
