### PR TITLE
[python3] Fix lld-link and add port config for python site

### DIFF
--- a/ports/python3/0016-undup-ffi-symbols.patch
+++ b/ports/python3/0016-undup-ffi-symbols.patch
@@ -1,0 +1,14 @@
+diff --git a/Modules/_ctypes/malloc_closure.c b/Modules/_ctypes/malloc_closure.c
+index 788bae6a9..3938f79db 100644
+--- a/Modules/_ctypes/malloc_closure.c
++++ b/Modules/_ctypes/malloc_closure.c
+@@ -11,6 +11,9 @@
+ #endif
+ #include "ctypes.h"
+ 
++#undef Py_ffi_closure_alloc
++#undef Py_ffi_closure_free
++
+ /* BLOCKSIZE can be adjusted.  Larger blocksize will take a larger memory
+    overhead, but allocate less blocks from the system.  It may be that some
+    systems have a limit of how many mmap'd blocks can be open.

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -33,6 +33,7 @@ set(PATCHES
     0012-force-disable-modules.patch
     0014-fix-get-python-inc-output.patch
     0015-dont-use-WINDOWS-def.patch
+    0016-undup-ffi-symbols.patch # Required for lld-link.
     0018-fix-sysconfig-include.patch
 )
 
@@ -375,3 +376,12 @@ if (NOT VCPKG_TARGET_IS_WINDOWS)
         replace_dirs_in_config_file("${python_config_file}")
     endif()
 endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/python3/Lib/distutils/command/build_ext.py" "'libs'" "'../../lib'")
+else()
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/python3.${PYTHON_VERSION_MINOR}/distutils/command/build_ext.py" "'libs'" "'../../lib'")
+  file(COPY_FILE "${CURRENT_PACKAGES_DIR}/tools/python3/python3.${PYTHON_VERSION_MINOR}" "${CURRENT_PACKAGES_DIR}/tools/python3/python3")
+endif()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake" "${CURRENT_PACKAGES_DIR}/share/python3/vcpkg-port-config.cmake" @ONLY)

--- a/ports/python3/vcpkg-port-config.cmake
+++ b/ports/python3/vcpkg-port-config.cmake
@@ -1,0 +1,12 @@
+set(PYTHON3_VERSION "@VERSION@")
+set(PYTHON3_VERSION_MAJOR "@PYTHON_VERSION_MAJOR@")
+set(PYTHON3_VERSION_MINOR "@PYTHON_VERSION_MINOR@")
+set(PYTHON3_INCLUDE "include/python${PYTHON3_VERSION_MAJOR}.${PYTHON3_VERSION_MINOR}")
+set(site_base "")
+if(VCPKG_TARGET_IS_WINDOWS)
+  set(site_base "tools/python${PYTHON3_VERSION_MAJOR}/Lib")
+else()
+  set(site_base "lib/python${PYTHON3_VERSION_MAJOR}.${PYTHON3_VERSION_MINOR}")
+endif()
+set(PYTHON3_SITE "${site_base}/site-packages")
+

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.11.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6906,7 +6906,7 @@
     },
     "python3": {
       "baseline": "3.11.5",
-      "port-version": 3
+      "port-version": 4
     },
     "qca": {
       "baseline": "2.3.7",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "196d8baf56879fd416fbcfb05a7033ea61febf24",
+      "version": "3.11.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "e6acf202b9752a04a0b9557d1ea9e4fa2f427e8d",
       "version": "3.11.5",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [-] SHA512s are updated for each updated download
- [-] The "supports" clause reflects platforms that may be fixed by this new version
- [-] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [-] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
