### PR TITLE
[imageinfo] Bump to 2024-01-19

### DIFF
--- a/ports/imageinfo/portfile.cmake
+++ b/ports/imageinfo/portfile.cmake
@@ -1,22 +1,31 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiaozhuai/imageinfo
-    REF eb2f4a0727d425ecfe2debd3475bea1f570b1a8d # committed on 2023-12-25
-    SHA512 1f03ff2dbe49d27e757b66c57c28e8a53ddbe372b20bb3f5891d1644dd885a851f55fb40c42637ca3528023b37e1b980b11cbe64fa5484f12a2c462052ae247a
+    REF 3c24fd6442808471d7d4acf4e2ff50f3f235a481 # committed on 2024-01-19
+    SHA512 269c3872aeeecf30289cc90bb529747c498db36e20266762d2b39065410e12b9e76d3b4fff13b2bbc8f3c56e39dd2318b18357a2529f9074ae7919ef0b622bd6
     HEAD_REF master
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools IMAGEINFO_BUILD_TOOLS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DIMAGEINFO_BUILD_TOOL=OFF
+        -DIMAGEINFO_BUILD_INSTALL=ON
         -DIMAGEINFO_BUILD_TESTS=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES imageinfo AUTO_CLEAN)
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/ports/imageinfo/vcpkg.json
+++ b/ports/imageinfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imageinfo",
-  "version-date": "2023-12-25",
+  "version-date": "2024-01-19",
   "description": "Cross platform super fast single header c++ library to get image size and format without loading/decoding. Support avif, bmp, cur, dds, gif, hdr (pic), heic (heif), icns, ico, jp2, jpeg (jpg), jpx, ktx, png, psd, qoi, tga, tiff (tif), webp ...",
   "homepage": "https://github.com/xiaozhuai/imageinfo",
   "license": "MIT",
@@ -13,5 +13,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "build command line tool",
+      "supports": "!android & !ios & !xbox"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3501,7 +3501,7 @@
       "port-version": 0
     },
     "imageinfo": {
-      "baseline": "2023-12-25",
+      "baseline": "2024-01-19",
       "port-version": 0
     },
     "imath": {

--- a/versions/i-/imageinfo.json
+++ b/versions/i-/imageinfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08efe02a552cf7bce5a61a088fa5768dd4b4d84d",
+      "version-date": "2024-01-19",
+      "port-version": 0
+    },
+    {
       "git-tree": "0061c49ae5be9cb32e197fd56a0a71e793d49f42",
       "version-date": "2023-12-25",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

