### PR TITLE
[asio-grpc] Update to 2.9.2

### DIFF
--- a/ports/asio-grpc/portfile.cmake
+++ b/ports/asio-grpc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tradias/asio-grpc
     REF "v${VERSION}"
-    SHA512 1dfd6254967dc24185cc17770fb18460289b4d1ff0952b8b3bad5d4222ee1fd640ef56ef437589d88b789ca9e374362f1a780b3fbf7d46dbd1ed6628b6b6ceca
+    SHA512 bb5358c6d64e1e7afaa644dda76a22a0a8b724ecfb9e2ac26a5fb2d4d506df10f09f8866d71713daf79ea0cd808eacecc027a3e925376ed1c1ca544f95656a8a
     HEAD_REF master
 )
 

--- a/ports/asio-grpc/vcpkg.json
+++ b/ports/asio-grpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "asio-grpc",
-  "version": "2.9.0",
+  "version": "2.9.2",
   "description": "Asynchronous gRPC with Asio/unified executors",
   "homepage": "https://github.com/Tradias/asio-grpc",
   "license": "Apache-2.0",

--- a/versions/a-/asio-grpc.json
+++ b/versions/a-/asio-grpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9442924978688fdb467c605e2944a6b1c6749981",
+      "version": "2.9.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4f03cf73ec5ddb5be5e21f4ce6c7f442ac53a769",
       "version": "2.9.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -253,7 +253,7 @@
       "port-version": 0
     },
     "asio-grpc": {
-      "baseline": "2.9.0",
+      "baseline": "2.9.2",
       "port-version": 0
     },
     "asiosdk": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
