### PR TITLE
[dcmtk] Add prefix to vendored libjpeg symbols

### DIFF
--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -11,6 +11,14 @@ vcpkg_from_github(
         fix_link_tiff.patch
 )
 
+# Prefix all exported API symbols of vendored libjpeg with "dcmtk_"
+file(GLOB src_files "${SOURCE_PATH}/dcmjpeg/libijg*/*.c" "${SOURCE_PATH}/dcmjpeg/libijg*/*.h")
+foreach(file_path ${src_files})
+    file(READ "${file_path}" file_string)
+    string(REGEX REPLACE "(#define[ \t\r\n]+[A-Za-z0-9_]*[ \t\r\n]+)(j[a-z]+[0-9]+_)" "\\1dcmtk_\\2" file_string "${file_string}")
+    file(WRITE "${file_path}" "${file_string}")
+endforeach()
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         "iconv"   DCMTK_WITH_ICONV

--- a/ports/dcmtk/vcpkg.json
+++ b/ports/dcmtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dcmtk",
   "version": "3.6.8",
-  "port-version": 2,
+  "port-version": 3,
   "description": "This DICOM ToolKit (DCMTK) package consists of source code, documentation and installation instructions for a set of software libraries and applications implementing part of the DICOM/MEDICOM Standard.",
   "homepage": "https://github.com/DCMTK/dcmtk",
   "license": "BSD-3-Clause OR BSD-2-Clause OR libtiff OR MIT OR Zlib OR Libpng",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2174,7 +2174,7 @@
     },
     "dcmtk": {
       "baseline": "3.6.8",
-      "port-version": 2
+      "port-version": 3
     },
     "debug-assert": {
       "baseline": "1.3.3",

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43cc4b7f4cafcf246412bd814cc0e3cd6f60db6f",
+      "version": "3.6.8",
+      "port-version": 3
+    },
+    {
       "git-tree": "86607f6cdca69d2aca997eead93dfa2b767679a1",
       "version": "3.6.8",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:END OF PORT UPDATE CHECKLIST (delete this line) -->
Fixes #33512.

DCMTK comes with a vendored version of libjpeg that has custom adjustments (e. g. a special lossless mode ).
The vendored version of libjpeg has conflicting symbols with the libjpeg-turbo>=3.0.0 library that is built and linked in by vcpkg via transitive dependencies, e.g. when linking in `tiff` support, where libtiff has been built with `jpeg` support. 

This PR implements a search and replace operation that prefixes the exported symbols of the vendored libjpeg version with `dcmtk_`, thus enabling us to link against both the vendored and the vcpkg version of libjpeg at the same time without conflicting symbols.

The generated static library files have been checked with `nm -g libijg{8,12,16}.a | grep -v dcmtk_` to see if there are any exported symbols without `dcmtk_` remaining. There are none except for `0000000000000000 B jaritab` which is not defined in `libjpeg.a`.

The PR has been tested with x64-linux and arm64-osx triplets and builds `dcmtk[tools,tiff,zlib]` cleanly.

In order to fix #33512, we have to work around that vendored version of libjpeg one way or another.

- Changes do not fully comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md). Avoiding the vendored dependency would imply creating a dcmtk-jpeg package from the vendored one, that is exclusively used for dcmtk and needs to be kept in sync with dcmtk.
- ~~SHA512s are updated for each updated download.~~
- ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [_] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
