### PR TITLE
[gobject-introspection] Fixed pkg-config file to follow vcpkg directory layout rule

### DIFF
--- a/ports/gobject-introspection/fix-pkgconfig.patch
+++ b/ports/gobject-introspection/fix-pkgconfig.patch
@@ -1,0 +1,17 @@
+diff --git a/meson.build b/meson.build
+index b253927..312fbdc 100644
+--- a/meson.build
++++ b/meson.build
+@@ -254,9 +254,9 @@ endif
+ pkgconfig_variables = [
+   'datadir=' + '${prefix}' / get_option('datadir'),
+   'bindir=' + '${prefix}' / get_option('bindir'),
+-  'g_ir_scanner=${bindir}/g-ir-scanner',
+-  'g_ir_compiler=${bindir}/g-ir-compiler@0@'.format(exe_ext),
+-  'g_ir_generate=${bindir}/g-ir-generate@0@'.format(exe_ext),
++  'g_ir_scanner=${prefix}/tools/gobject-introspection/g-ir-scanner',
++  'g_ir_compiler=${prefix}/tools/gobject-introspection/g-ir-compiler@0@'.format(exe_ext),
++  'g_ir_generate=${prefix}/tools/gobject-introspection/g-ir-generate@0@'.format(exe_ext),
+   'gidatadir=${datadir}/gobject-introspection-1.0',
+   'girdir=' + gir_dir_pc_prefix / 'gir-1.0',
+   'typelibdir=${libdir}/girepository-1.0',

--- a/ports/gobject-introspection/portfile.cmake
+++ b/ports/gobject-introspection/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_extract_source_archive(
         0002-cross-build.patch
         0003-fix-paths.patch
         python.patch
+        fix-pkgconfig.patch
 )
 
 vcpkg_find_acquire_program(FLEX)

--- a/ports/gobject-introspection/vcpkg.json
+++ b/ports/gobject-introspection/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gobject-introspection",
   "version": "1.72.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "A middleware layer between C libraries (using GObject) and language bindings.",
   "homepage": "https://gi.readthedocs.io/en/latest/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3062,7 +3062,7 @@
     },
     "gobject-introspection": {
       "baseline": "1.72.0",
-      "port-version": 6
+      "port-version": 7
     },
     "google-cloud-cpp": {
       "baseline": "2.20.0",

--- a/versions/g-/gobject-introspection.json
+++ b/versions/g-/gobject-introspection.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d0cfb4e7056136db4c9def1e64b88b7417dc0e8",
+      "version": "1.72.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "aa7163808411a8ff5641022957909a6d681cea69",
       "version": "1.72.0",
       "port-version": 6


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #36275
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
