### PR TITLE
[qtbase] Add securetransport feature to build with SSL support on iOS

### DIFF
--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -134,6 +134,7 @@ list(APPEND FEATURE_CORE_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_Slog2:BOOL=ON)
  FEATURES
     "openssl"             FEATURE_openssl
     "brotli"              FEATURE_brotli
+    "securetransport"     FEATURE_securetransport
     #"brotli"              CMAKE_REQUIRE_FIND_PACKAGE_WrapBrotli
     #"openssl"             CMAKE_REQUIRE_FIND_PACKAGE_WrapOpenSSL
  INVERTED_FEATURES

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.6.1",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -66,9 +66,16 @@
       "name": "opengl",
       "platform": "!ios"
     },
-    "openssl",
+    {
+      "name": "openssl",
+      "platform": "!ios"
+    },
     "pcre2",
     "png",
+    {
+      "name": "securetransport",
+      "platform": "ios"
+    },
     "sql",
     "sql-psql",
     "sql-sqlite",
@@ -335,6 +342,10 @@
           ]
         }
       ]
+    },
+    "securetransport": {
+      "description": "Enable Secure Transport",
+      "supports": "ios | osx"
     },
     "sql": {
       "description": "Qt Sql",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7178,7 +7178,7 @@
     },
     "qtbase": {
       "baseline": "6.6.1",
-      "port-version": 7
+      "port-version": 8
     },
     "qtcharts": {
       "baseline": "6.6.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e2e2b00fd42bc15c333b7dded4e7db4109ca11f",
+      "version": "6.6.1",
+      "port-version": 8
+    },
+    {
       "git-tree": "f21d3613038a80d31b8b1aaec2c16a55f45da52e",
       "version": "6.6.1",
       "port-version": 7


### PR DESCRIPTION
This PR adds a secure transport feature to qtbase. The feature is needed when building on iOS to allow for SSL networking.