### PR TITLE
[clickhouse-cpp] update to 2.5.1

### DIFF
--- a/ports/clickhouse-cpp/portfile.cmake
+++ b/ports/clickhouse-cpp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ClickHouse/clickhouse-cpp
     REF "v${VERSION}"
-    SHA512 2719c034a2dc2de7e992aa17859ea437551bfe89395e6a708a4549ed274f366aee0c0f0bcd90a690c15f5361a8f8198bb4f1d7d986da98c1d632489bcfb8bdd0
+    SHA512 6e6632084906699d3702bbe4c59d8db0c81934b60d2bb6bb427b25004fa36f4e2955a0d4a6cd45a48721f992a3d162d6569fb4c0a3d6787a98356e5d5319d9d4
     HEAD_REF master
     PATCHES
         fix-deps-and-build-type.patch
@@ -25,6 +25,7 @@ vcpkg_cmake_configure(
         -DWITH_SYSTEM_ABSEIL=ON
         -DWITH_SYSTEM_LZ4=ON
         -DWITH_SYSTEM_CITYHASH=ON
+        -DDEBUG_DEPENDENCIES=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/clickhouse-cpp/vcpkg.json
+++ b/ports/clickhouse-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-cpp",
-  "version": "2.4.0",
+  "version": "2.5.1",
   "description": "C++ client for Yandex ClickHouse",
   "homepage": "https://github.com/ClickHouse/clickhouse-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1633,7 +1633,7 @@
       "port-version": 0
     },
     "clickhouse-cpp": {
-      "baseline": "2.4.0",
+      "baseline": "2.5.1",
       "port-version": 0
     },
     "clipboardxx": {

--- a/versions/c-/clickhouse-cpp.json
+++ b/versions/c-/clickhouse-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "91e161642e06b5e3f6f86a16714a4b58453a36b5",
+      "version": "2.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d665e3d36b571b68596140563d1934e8b416aa23",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

