### PR TITLE
[arrow] Update to 15.0.0

### DIFF
--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE_PATH
     URLS "https://archive.apache.org/dist/arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
     FILENAME apache-arrow-${VERSION}.tar.gz
-    SHA512 dd6cf6cbb817a48ef5275bb409367e5904526a3c16a17a37ea75101085ea19a71ba6bf936a6f099012e7c528811db1728ef2f14dcb16a1056a22088839280ce0
+    SHA512 d5dccaa0907b0e6f2a460e32ae75091942dcb70b51db4aefe2767ee8d99882694607b723a9c06898dda3938d8eb498258d7f9aad11054665b6ea9c2fbaeafa74
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "arrow",
-  "version": "14.0.2",
-  "port-version": 2,
+  "version": "15.0.0",
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d736db2f9ac170765f1e6ac8c90f4d46c94a3552",
+      "version": "15.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "68021accce836c6b394076d1494379df640dcb8c",
       "version": "14.0.2",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -237,8 +237,8 @@
       "port-version": 5
     },
     "arrow": {
-      "baseline": "14.0.2",
-      "port-version": 2
+      "baseline": "15.0.0",
+      "port-version": 0
     },
     "arsenalgear": {
       "baseline": "2.1.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
