### PR TITLE
[sqlite3] Update to 3.45.0, add windows version info

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -7,7 +7,7 @@ option(SQLITE3_SKIP_TOOLS "Disable build sqlite3 executable" OFF)
 
 set(PKGCONFIG_LIBS_PRIVATE "")
 
-add_library(sqlite3 sqlite3.c)
+add_library(sqlite3 sqlite3.c sqlite3.rc)
 
 target_include_directories(sqlite3 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>)
 
@@ -17,6 +17,7 @@ target_compile_definitions(
         $<$<CONFIG:Debug>:SQLITE_DEBUG=1>
         $<$<CONFIG:Debug>:SQLITE_ENABLE_SELECTTRACE>
         $<$<CONFIG:Debug>:SQLITE_ENABLE_WHERETRACE>
+        $<$<COMPILE_LANGUAGE:RC>:RC_VERONLY>
 )
 
 if (BUILD_SHARED_LIBS)

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -2,9 +2,9 @@ string(REGEX REPLACE "^([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]([0-9]+)" "\\1,0\\2,0\\3
 string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "\\1\\2\\3\\4" SQLITE_VERSION "${SQLITE_VERSION}")
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://sqlite.org/2023/sqlite-amalgamation-${SQLITE_VERSION}.zip"
-    FILENAME "sqlite-amalgamation-${SQLITE_VERSION}.zip"
-    SHA512 5ef0e65ee92a088187376fa82ccb182dffa35391dd4dbcb3fafeb0a6f1602ced1e212753837079a9cad007d73d3f5b8a67ca1a6596eba6cf0c695052fa307392
+    URLS "https://sqlite.org/2024/sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
+    FILENAME "sqlite-autoconf-${SQLITE_VERSION}.zip"
+    SHA512 40ae9ba1dea234aacfecf44a6b1c0713c24348d8d475503c11f1d92ed2fffb54a765bbd0669f39aa09d20f42cbcfac4dedcf7e64f4421b8762eebfc66399aa9a
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.43.2",
-  "port-version": 1,
+  "version": "3.45.0",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8201,8 +8201,8 @@
       "port-version": 1
     },
     "sqlite3": {
-      "baseline": "3.43.2",
-      "port-version": 1
+      "baseline": "3.45.0",
+      "port-version": 0
     },
     "sqlitecpp": {
       "baseline": "3.3.1",

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "537fe5086cb7cad8b2c24f4182b0777b81d7c175",
+      "version": "3.45.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "73056e20fb351b2c6978b351c74112223791eb25",
       "version": "3.43.2",
       "port-version": 1


### PR DESCRIPTION
Makes it more similar to official binary packages.
![image](https://github.com/microsoft/vcpkg/assets/8740768/a8f15354-7464-48f9-942e-8c0f19343f95)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.