### PR TITLE
[daw-header-libraries] update to 2.98.5

### DIFF
--- a/ports/daw-header-libraries/portfile.cmake
+++ b/ports/daw-header-libraries/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/header_libraries
     REF "v${VERSION}"
-    SHA512 8e41be509fc62f1421ec987b409203b48e2041b225a468a8d9bc79e1ac0f8261e4b60009c7f6b205c7a5a0ded4b385fe8b38bb1d3d2b1abc1e5399b26d0aced9
+    SHA512 6d59950b71c47aaba23ea762c2bd37665c00d65d5d7f9ac4c15d78b758f8c2061d04b26ad9ec8f7bf9540644601d47e801a363f85fcbb8d0b1da8c3de136d32e
     HEAD_REF master
 )
 

--- a/ports/daw-header-libraries/vcpkg.json
+++ b/ports/daw-header-libraries/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daw-header-libraries",
-  "version": "2.97.0",
+  "version": "2.98.5",
   "description": "Set of header-only algorithms used in daw-utf8-range and daw-json-link.",
   "homepage": "https://github.com/beached/header_libraries",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2125,7 +2125,7 @@
       "port-version": 1
     },
     "daw-header-libraries": {
-      "baseline": "2.97.0",
+      "baseline": "2.98.5",
       "port-version": 0
     },
     "daw-json-link": {
@@ -2294,7 +2294,7 @@
     },
     "drogon": {
       "baseline": "1.9.2",
-      "port-version": 0 
+      "port-version": 0
     },
     "dstorage": {
       "baseline": "1.2.2",

--- a/versions/d-/daw-header-libraries.json
+++ b/versions/d-/daw-header-libraries.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "30edee4980890f4dbdb9a1c982ddf0b845c1e9cc",
+      "version": "2.98.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "3646a7d51cdffec8d94d24bd71ea60ffeab50cbd",
       "version": "2.97.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

