### PR TITLE
[sentry-native] Fix cmake function spelling error

### DIFF
--- a/ports/sentry-native/fix-config-cmake.patch
+++ b/ports/sentry-native/fix-config-cmake.patch
@@ -15,7 +15,7 @@ index 70ce7d3..796d428 100644
  	include("${CMAKE_CURRENT_LIST_DIR}/sentry_crashpad-targets.cmake")
  	if(NOT MSVC AND NOT SENTRY_BUILD_SHARED_LIBS)
 -		find_package(ZLIB REQUIRED)
-+		find_depenency(ZLIB)
++		find_dependency(ZLIB)
  	endif()
  endif()
 

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sentry-native",
   "version": "0.7.0",
+  "port-version": 1,
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2294,7 +2294,7 @@
     },
     "drogon": {
       "baseline": "1.9.2",
-      "port-version": 0 
+      "port-version": 0
     },
     "dstorage": {
       "baseline": "1.2.2",
@@ -7854,7 +7854,7 @@
     },
     "sentry-native": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "septag-dmon": {
       "baseline": "2022-02-08",

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b95acbd27868522d2e27abe48d9f108d439f523",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5b7467839d13128952c0f944197f8d2fcbc7a763",
       "version": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36132

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```
