### PR TITLE
[ezc3d] update to 1.5.7

### DIFF
--- a/ports/ezc3d/portfile.cmake
+++ b/ports/ezc3d/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pyomeca/ezc3d
     REF "Release_${VERSION}"
-    SHA512 19f2602be04ea4b0d65d7c26cc6b5c687f65ef5bceae104d7bcddec1e8db05cc65db2cb37ac8133b7bbda99cd097ead08fd7dcdaf470f710f5cc68cd73edb150
+    SHA512 8e3a03c2d588ac1f8ed3d0988b90f7560f2c0b36c05f5bf9b6f029a5f4c6e4ab49d7153ef7a9bbbdb018c719a92d1da08a6af259ba95972bf8fd60766d4a480e
     HEAD_REF dev
 )
 

--- a/ports/ezc3d/vcpkg.json
+++ b/ports/ezc3d/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ezc3d",
-  "version": "1.5.0",
+  "version": "1.5.7",
   "description": "C3D reader/writer",
   "homepage": "https://github.com/pyomeca/ezc3d",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2521,7 +2521,7 @@
       "port-version": 2
     },
     "ezc3d": {
-      "baseline": "1.5.0",
+      "baseline": "1.5.7",
       "port-version": 0
     },
     "ezfoundation": {

--- a/versions/e-/ezc3d.json
+++ b/versions/e-/ezc3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1331eec1377ca1e720afdd9c3cf2660c49b58084",
+      "version": "1.5.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "f41d466838bd526b6e8717bf3c962b29a7bb47c5",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

