### PR TITLE
[apriltag] New port added

### DIFF
--- a/ports/apriltag/fix-config.patch
+++ b/ports/apriltag/fix-config.patch
@@ -1,0 +1,62 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 72c3ad6..607d024 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
+ project(apriltag VERSION 3.2.0 LANGUAGES C CXX)
+ 
+ if(POLICY CMP0077)
+@@ -39,6 +39,9 @@ endif()
+ aux_source_directory(common COMMON_SRC)
+ set(APRILTAG_SRCS apriltag.c apriltag_pose.c apriltag_quad_thresh.c)
+ 
++if (MSVC)
++  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
++endif()
+ # Library
+ file(GLOB TAG_FILES ${PROJECT_SOURCE_DIR}/tag*.c)
+ add_library(${PROJECT_NAME} ${APRILTAG_SRCS} ${COMMON_SRC} ${TAG_FILES})
+@@ -46,8 +49,8 @@ add_library(${PROJECT_NAME} ${APRILTAG_SRCS} ${COMMON_SRC} ${TAG_FILES})
+ if (MSVC)
+     # FindThreads will not find pthread.h with MSVC
+     # winmm is necessary for __imp_timeGetTime
+-    find_library(PTHREAD_LIBRARIES NAMES pthreads)
+-    target_link_libraries(${PROJECT_NAME} ${PTHREAD_LIBRARIES} winmm)
++    find_package(PThreads4W REQUIRED)
++    target_link_libraries(${PROJECT_NAME} PThreads4W::PThreads4W winmm)
+ else()
+     find_package(Threads REQUIRED)
+     target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads m)
+@@ -101,6 +104,7 @@ write_basic_package_version_file("${version_config}" COMPATIBILITY SameMajorVers
+ install(TARGETS ${PROJECT_NAME} EXPORT ${targets_export_name}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         )
+ 
+ install(EXPORT ${targets_export_name}
+@@ -123,7 +127,7 @@ install(FILES "${PROJECT_BINARY_DIR}/apriltag.pc" DESTINATION "${CMAKE_INSTALL_L
+ 
+ # Python wrapper
+ include(CMakeDependentOption)
+-cmake_dependent_option(BUILD_PYTHON_WRAPPER "Builds Python wrapper" ON BUILD_SHARED_LIBS OFF)
++option(BUILD_PYTHON_WRAPPER "Builds Python wrapper" OFF)
+ 
+ if(BUILD_PYTHON_WRAPPER)
+     SET(Python_ADDITIONAL_VERSIONS 3)
+@@ -160,7 +164,7 @@ string(STRIP ${PY_DEST} PY_DEST)
+ install(FILES ${PROJECT_BINARY_DIR}/apriltag${PY_EXT_SUFFIX} DESTINATION ${PY_DEST})
+ endif (NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND AND BUILD_PYTHON_WRAPPER)
+ 
+-
++if(0)
+ # Examples
+ # apriltag_demo
+ add_executable(apriltag_demo example/apriltag_demo.c)
+@@ -179,3 +183,4 @@ endif(OpenCV_FOUND)
+ 
+ # install example programs
+ install(TARGETS apriltag_demo RUNTIME DESTINATION bin)
++endif()

--- a/ports/apriltag/portfile.cmake
+++ b/ports/apriltag/portfile.cmake
@@ -1,0 +1,38 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO AprilRobotics/apriltag
+    REF v${VERSION}
+    SHA512 0b09b530ed03dce0bdc3c4e08b17d98f1303ab1d45870843354bf1a5bdf6c7efc6089e2bdf40a370d17a8191b7ce2c46fefa2dd2d49a959591351e00e186f33e
+    HEAD_REF master
+    PATCHES
+        fix-config.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_cmake_config_fixup(CONFIG_PATH share/${PORT}/cmake)
+vcpkg_fixup_pkgconfig()
+
+if (VCPKG_TARGET_IS_WINDOWS)
+    file(READ "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}Config.cmake" FIXED_CONFIG)
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}Config.cmake" "
+    include(CMakeFindDependencyMacro)
+    find_dependency(PThreads4W)
+    ${FIXED_CONFIG}
+    ")
+endif()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/apriltag/usage
+++ b/ports/apriltag/usage
@@ -1,0 +1,4 @@
+The package apriltag is compatible with built-in CMake targets:
+
+    find_package(apriltag REQUIRED)
+    target_link_libraries(main PRIVATE apriltag::apriltag)

--- a/ports/apriltag/vcpkg.json
+++ b/ports/apriltag/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "apriltag",
+  "version": "3.2.0",
+  "description": "AprilTag is a visual fiducial system popular for robotics research.",
+  "homepage": "https://april.eecs.umich.edu/software/apriltag",
+  "license": "BSD-2-Clause",
+  "supports": "!uwp",
+  "dependencies": [
+    "pthreads",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/apriltag.json
+++ b/versions/a-/apriltag.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3523f2ad6198164afda1782327470188dc3f7221",
+      "version": "3.2.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -172,6 +172,10 @@
       "baseline": "1.6.3",
       "port-version": 0
     },
+    "apriltag": {
+      "baseline": "3.2.0",
+      "port-version": 0
+    },
     "apsi": {
       "baseline": "0.11.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

