### PR TITLE
[libdatachannel] Fix LibJuice's find method

### DIFF
--- a/ports/libdatachannel/fix_dependency.patch
+++ b/ports/libdatachannel/fix_dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e1a23a0..385da66 100644
+index f604628..1610166 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -239,7 +239,7 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
@@ -38,12 +38,3 @@ index e1a23a0..385da66 100644
  
  if(WIN32)
  	target_link_libraries(datachannel PUBLIC ws2_32) # winsock2
-@@ -406,7 +406,7 @@ else()
- 	target_compile_definitions(datachannel PRIVATE USE_NICE=0)
- 	target_compile_definitions(datachannel-static PRIVATE USE_NICE=0)
- 	if(USE_SYSTEM_JUICE)
--		find_package(LibJuice REQUIRED)
-+		find_package(LibJuice CONFIG REQUIRED)
- 		target_compile_definitions(datachannel PRIVATE RTC_SYSTEM_JUICE=1)
- 		target_compile_definitions(datachannel-static PRIVATE RTC_SYSTEM_JUICE=1)
- 		target_link_libraries(datachannel PRIVATE LibJuice::LibJuice)

--- a/ports/libdatachannel/fix_dependency.patch
+++ b/ports/libdatachannel/fix_dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f604628..1610166 100644
+index e1a23a0..385da66 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -239,7 +239,7 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
@@ -38,3 +38,12 @@ index f604628..1610166 100644
  
  if(WIN32)
  	target_link_libraries(datachannel PUBLIC ws2_32) # winsock2
+@@ -406,7 +406,7 @@ else()
+ 	target_compile_definitions(datachannel PRIVATE USE_NICE=0)
+ 	target_compile_definitions(datachannel-static PRIVATE USE_NICE=0)
+ 	if(USE_SYSTEM_JUICE)
+-		find_package(LibJuice REQUIRED)
++		find_package(LibJuice CONFIG REQUIRED)
+ 		target_compile_definitions(datachannel PRIVATE RTC_SYSTEM_JUICE=1)
+ 		target_compile_definitions(datachannel-static PRIVATE RTC_SYSTEM_JUICE=1)
+ 		target_link_libraries(datachannel PRIVATE LibJuice::LibJuice)

--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_from_github(
         ${PATCHES}
         fix_dependency.patch
 )
-
+file(REMOVE "${SOURCE_PATH}/cmake/Modules/FindLibJuice.cmake")
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" DATACHANNEL_STATIC_LINKAGE)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libdatachannel",
   "version-semver": "0.19.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4210,7 +4210,7 @@
     },
     "libdatachannel": {
       "baseline": "0.19.5",
-      "port-version": 1
+      "port-version": 2
     },
     "libdatrie": {
       "baseline": "0.2.13",

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4ea09a2d404844c361502b3df839f07a820598dd",
+      "git-tree": "73a4d8cba18306b14a98b1fb70d35bfa588ce386",
       "version-semver": "0.19.5",
       "port-version": 2
     },

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ea09a2d404844c361502b3df839f07a820598dd",
+      "version-semver": "0.19.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "2b2d69b30260c468757b11bea046e2dabcba0516",
       "version-semver": "0.19.5",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36335

Deleting cmake/modules/FindLibJuice.cmake before building will correctly find the config file.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
x64-windows-static
```
