### PR TITLE
[flint] update to 3.0.1

### DIFF
--- a/ports/flint/fix-cmakelists.patch
+++ b/ports/flint/fix-cmakelists.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2616d06..4be28ac 100644
+index 54f6aa9..da159f7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -34,10 +34,11 @@ find_package(MPFR REQUIRED)
+@@ -55,10 +55,11 @@ find_package(MPFR REQUIRED)
  if (WITH_NTL)
      find_package(NTL REQUIRED)
  endif()
--find_package(PythonInterp REQUIRED)
+-find_package(Python REQUIRED)
  
 +if(WITH_CBLAS)
  find_package(CBLAS)
@@ -15,7 +15,7 @@ index 2616d06..4be28ac 100644
  
  if(CMAKE_BUILD_TYPE STREQUAL Debug)
    set(FLINT_WANT_ASSERT ON)
-@@ -47,6 +48,8 @@ endif()
+@@ -68,6 +69,8 @@ endif()
  
  if(MSVC)
      find_package(PThreads REQUIRED)

--- a/ports/flint/portfile.cmake
+++ b/ports/flint/portfile.cmake
@@ -1,18 +1,14 @@
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.flintlib.org/flint-${VERSION}.zip"
-    FILENAME "flint-${VERSION}.zip"
-    SHA512 3dd9a4e79e08ab6bc434a786c8d4398eba6cb04e57bcb8d01677f4912cddf20ed3a971160a3e2d533d9a07b728678b0733cc8315bcb39a3f13475b6efa240062
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO flintlib/flint
+    REF "v${VERSION}"
+    SHA512 4b5b432b962135cd708a0ce4242343f3226f0fdf73c3f541728ed4540e7ef6cb7812a48b6b46e65a8fcc1f5cae93d8bb59838d24728024cd9aa0f7b8e5c6f98f
+    HEAD_REF main
+    PATCHES fix-cmakelists.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    PATCHES
-        fix-cmakelists.patch
-)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/flint/vcpkg.json
+++ b/ports/flint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flint",
-  "version-semver": "2.9.0",
+  "version-semver": "3.0.1",
   "description": "Fast Library for Number Theory",
   "homepage": "https://www.flintlib.org/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2697,7 +2697,7 @@
       "port-version": 0
     },
     "flint": {
-      "baseline": "2.9.0",
+      "baseline": "3.0.1",
       "port-version": 0
     },
     "fltk": {

--- a/versions/f-/flint.json
+++ b/versions/f-/flint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7808f3c7654e8bf9eb85a1f574a927c9ce7bbe79",
+      "version-semver": "3.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "282413c373b7f2f2d2d38783fc9c9d8c4492de16",
       "version-semver": "2.9.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

