### PR TITLE
[vcpkg baseline][lensfun] Fix and cleanup

### DIFF
--- a/ports/lensfun/portfile.cmake
+++ b/ports/lensfun/portfile.cmake
@@ -12,8 +12,23 @@ vcpkg_from_github(
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LENSFUN_STATIC_LIB)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" LENSFUN_STATIC_CRT)
 
-
 set(LENSFUN_EXTRA_OPTS "")
+if("python" IN_LIST FEATURES)
+    find_file(INITIAL_PYTHON3
+        NAMES "python3${VCPKG_HOST_EXECUTABLE_SUFFIX}" "python${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+        PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/python3"
+        NO_DEFAULT_PATH
+        REQUIRED
+    )
+    x_vcpkg_get_python_packages(OUT_PYTHON_VAR PYTHON3
+        PYTHON_EXECUTABLE "${INITIAL_PYTHON3}"
+        PYTHON_VERSION "3"
+        PACKAGES setuptools
+    )
+else()
+    set(PYTHON3 "false")
+endif()
+
 if (VCPKG_TARGET_IS_WINDOWS)
     list(APPEND LENSFUN_EXTRA_OPTS -DPLATFORM_WINDOWS=ON)
 endif()
@@ -26,11 +41,11 @@ vcpkg_cmake_configure(
         -DBUILD_WITH_MSVC_STATIC_RUNTIME=${LENSFUN_STATIC_CRT}
         -DBUILD_TESTS=OFF
         -DBUILD_DOC=OFF
-        -DINSTALL_PYTHON_MODULE=ON
         -DINSTALL_HELPER_SCRIPTS=OFF
         -DBUILD_LENSTOOL=OFF
         -DBUILD_FOR_SSE=OFF
         -DBUILD_FOR_SSE2=OFF
+        "-DPYTHON=${PYTHON3}"
 )
 
 vcpkg_cmake_install()

--- a/ports/lensfun/portfile.cmake
+++ b/ports/lensfun/portfile.cmake
@@ -1,5 +1,3 @@
-#vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lensfun/lensfun
@@ -29,8 +27,12 @@ else()
     set(PYTHON3 "false")
 endif()
 
-if (VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_WINDOWS)
     list(APPEND LENSFUN_EXTRA_OPTS -DPLATFORM_WINDOWS=ON)
+endif()
+
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    list(APPEND LENSFUN_EXTRA_OPTS -DBUILD_FOR_SSE=OFF -DBUILD_FOR_SSE2=OFF)
 endif()
 
 vcpkg_cmake_configure(
@@ -41,25 +43,24 @@ vcpkg_cmake_configure(
         -DBUILD_WITH_MSVC_STATIC_RUNTIME=${LENSFUN_STATIC_CRT}
         -DBUILD_TESTS=OFF
         -DBUILD_DOC=OFF
-        -DINSTALL_HELPER_SCRIPTS=OFF
         -DBUILD_LENSTOOL=OFF
-        -DBUILD_FOR_SSE=OFF
-        -DBUILD_FOR_SSE2=OFF
+        -DINSTALL_HELPER_SCRIPTS=OFF
         "-DPYTHON=${PYTHON3}"
 )
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-
 vcpkg_fixup_pkgconfig()
-
-if (LENSFUN_STATIC_LIB)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/docs/gpl-3.0.txt" "${SOURCE_PATH}/docs/lgpl-3.0.txt")
+file(READ "${SOURCE_PATH}/README.md" license_comment)
+string(REGEX REPLACE "^.*\n(LICENSE\n)---+\n(.*)" "\\1\\2" license_comment "${license_comment}")
+string(REGEX REPLACE "[^\n]+\n---+.*\$" "" license_comment "${license_comment}")
+vcpkg_install_copyright(
+    COMMENT "${license_comment}"
+    FILE_LIST "${SOURCE_PATH}/docs/gpl-3.0.txt" "${SOURCE_PATH}/docs/lgpl-3.0.txt"
+)

--- a/ports/lensfun/vcpkg.json
+++ b/ports/lensfun/vcpkg.json
@@ -17,16 +17,10 @@
       "host": true
     }
   ],
-  "default-features": [
-    {
-      "name": "python",
-      "platform": "native"
-    }
-  ],
   "features": {
     "python": {
       "description": "Build python module",
-      "supports": "native",
+      "supports": "native & !windows",
       "dependencies": [
         "python3",
         "vcpkg-get-python-packages"

--- a/ports/lensfun/vcpkg.json
+++ b/ports/lensfun/vcpkg.json
@@ -16,5 +16,21 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    {
+      "name": "python",
+      "platform": "native"
+    }
+  ],
+  "features": {
+    "python": {
+      "description": "Build python module",
+      "supports": "native",
+      "dependencies": [
+        "python3",
+        "vcpkg-get-python-packages"
+      ]
+    }
+  }
 }

--- a/ports/lensfun/vcpkg.json
+++ b/ports/lensfun/vcpkg.json
@@ -3,8 +3,8 @@
   "version": "0.3.4",
   "port-version": 1,
   "description": "Provide a open source database of photographic lenses and their characteristics",
-  "homepage": "https://scnlib.dev/",
-  "license": "LGPL-3.0 OR GPL-3.0",
+  "homepage": "https://lensfun.github.io/",
+  "license": null,
   "supports": "!arm",
   "dependencies": [
     "glib",

--- a/ports/lensfun/vcpkg.json
+++ b/ports/lensfun/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lensfun",
   "version": "0.3.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Provide a open source database of photographic lenses and their characteristics",
   "homepage": "https://lensfun.github.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4046,7 +4046,7 @@
     },
     "lensfun": {
       "baseline": "0.3.4",
-      "port-version": 1
+      "port-version": 2
     },
     "leptonica": {
       "baseline": "1.83.1",

--- a/versions/l-/lensfun.json
+++ b/versions/l-/lensfun.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fd1b9bb62e9a630cc4ca8781767c97021a52c073",
+      "git-tree": "84eb6a4d2a0d8d670e0f54ec70bb4ad36cb004df",
       "version": "0.3.4",
       "port-version": 2
     },

--- a/versions/l-/lensfun.json
+++ b/versions/l-/lensfun.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd1b9bb62e9a630cc4ca8781767c97021a52c073",
+      "version": "0.3.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "a085269b70f184d8dbf07c595e37ce336bd79906",
       "version": "0.3.4",
       "port-version": 1


### PR DESCRIPTION
Fix x64-linux baseline regression dependent on installation order.
Enable x64 optimizations.
Update license information.
Cleanup.
Remove the python module from the default features.