### PR TITLE
[frugally-deep] update to 0.15.30

### DIFF
--- a/ports/frugally-deep/portfile.cmake
+++ b/ports/frugally-deep/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/frugally-deep
-    REF "v${VERSION}-p0"
-    SHA512 2b9a747420d20a380587ed787f6488c0cab2fadc72fdb25327a8afb95ad251d0fd332b3449b8bc1be8ca8a5eb9cccd4cce8ea92026422d7043f4a0484b734d27
+    REF "v${VERSION}"
+    SHA512 ec31a174a1a13d572d7cfce4a1773964cc185c1acaf91250bc8038cd9eba77f864fe9fd592a39648de8c620f02375142344f70c9663613ab1b406df1c68e6cb1
     HEAD_REF master
 )
 

--- a/ports/frugally-deep/vcpkg.json
+++ b/ports/frugally-deep/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "frugally-deep",
-  "version-semver": "0.15.24",
+  "version-semver": "0.15.30",
   "description": "Header-only library for using Keras models in C++.",
   "homepage": "https://github.com/Dobiasd/frugally-deep",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2817,7 +2817,7 @@
       "port-version": 0
     },
     "frugally-deep": {
-      "baseline": "0.15.24",
+      "baseline": "0.15.30",
       "port-version": 0
     },
     "fruit": {

--- a/versions/f-/frugally-deep.json
+++ b/versions/f-/frugally-deep.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29bccc24fe184c3f063bdfda3b41c333465652c8",
+      "version-semver": "0.15.30",
+      "port-version": 0
+    },
+    {
       "git-tree": "d25ec18e137e21fcdd4e2770377e7a3e9c5434f1",
       "version-semver": "0.15.24",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

