### PR TITLE
[glib] Update to 2.78.4 (microsoft/vcpkg#36330)

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -2,7 +2,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIB_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIB_ARCHIVE
     URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${VERSION}.tar.xz"
     FILENAME "glib-${VERSION}.tar.xz"
-    SHA512 aa9ed9195951b00ac8221e958ea337fbda82621a862ef8f29dc2ea396a6253ce51c2a0a498dfa4e12642f1836f85f9564f09991979ae85c5ed4368355d857376
+    SHA512 6f3a06e10e7373a2dbf0688512de4126472fb73cbec488b7983b5ffecff09c64d7e1ca462f892e8f215d3d277d103ca802bad7ef0bd0f91edf26fc6ce67187b6
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glib",
-  "version": "2.78.1",
+  "version": "2.78.4",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3025,7 +3025,7 @@
       "port-version": 2
     },
     "glib": {
-      "baseline": "2.78.1",
+      "baseline": "2.78.4",
       "port-version": 0
     },
     "glibmm": {

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d67b03e0a09ec580d051b79321b03182c0030c5f",
+      "version": "2.78.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "6c91a4d4382d4d271d13397214c536389fd4a122",
       "version": "2.78.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #36330.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.