### PR TITLE
[glaze] update to 2.0.0

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 ed1f1cccbba3eb46edb3899ac351d4d0f6f838ef96de958f90e6acea655c626d94c14d7b4e78ed379ea8710d99e43e84b166ccbbf5f3015599b88dae254a764a
+    SHA512 8b8cdf4ce09374f67759c70cf60f1ebc401d89ceba5d94d41ea1085b9f330d9bf6413ad252f469d7e88881281a5bde767022a8cf3eff2401d36203a16140370f
 )
 
 vcpkg_cmake_configure(

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "1.9.9",
+  "version": "2.0.0",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2993,7 +2993,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "1.9.9",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "glbinding": {
@@ -9012,13 +9012,13 @@
       "baseline": "1.0.9",
       "port-version": 0
     },
-    "vsgxchange": {
-      "baseline": "1.0.5",
-      "port-version": 1
-    },
     "vsgimgui": {
       "baseline": "0.1.0",
       "port-version": 0
+    },
+    "vsgxchange": {
+      "baseline": "1.0.5",
+      "port-version": 1
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0eec0f3dc54bd24ecb320dc13258b193992ce11",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "292cb129d7afdb63c4cd1881b863581725fa1f29",
       "version": "1.9.9",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

