### PR TITLE
[gmmlib] update to 22.3.17

### DIFF
--- a/ports/gmmlib/portfile.cmake
+++ b/ports/gmmlib/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/gmmlib
     REF "intel-gmmlib-${VERSION}"
-    SHA512 afe64aaaddac9b72ff12aa41faeb668141999e1b9c644fa21ced8fd851cf698ec57bac1080c87c0fae5c464b47ea5b94e6290c0e4c0c24ec010071f535c60e42
+    SHA512 073cb2e9ec025ae32e2f33f51547083cd8425b0c7297e361b037c71b55a8d2322cd36ac7cabbf8c7a325f80f1cc97947c0aa8aa833dc5fbae5abe28e9c04451a
     HEAD_REF master
 )
 

--- a/ports/gmmlib/vcpkg.json
+++ b/ports/gmmlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gmmlib",
-  "version": "22.3.12",
+  "version": "22.3.17",
   "description": "Intel(R) Graphics Memory Management Library",
   "homepage": "https://github.com/intel/gmmlib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3061,7 +3061,7 @@
       "port-version": 6
     },
     "gmmlib": {
-      "baseline": "22.3.12",
+      "baseline": "22.3.17",
       "port-version": 0
     },
     "gmp": {

--- a/versions/g-/gmmlib.json
+++ b/versions/g-/gmmlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f7e953649b6c9b189ade0aa39fb4ac5689322c3",
+      "version": "22.3.17",
+      "port-version": 0
+    },
+    {
       "git-tree": "04bd253bdd2f2e7e02b69feb0d72854fd663d3fb",
       "version": "22.3.12",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

