### PR TITLE
[hwloc] update to 2.10.0

### DIFF
--- a/ports/hwloc/portfile.cmake
+++ b/ports/hwloc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-mpi/hwloc
     REF "hwloc-${VERSION}"
-    SHA512 958f385d846ed1b6ab60725b7966374213eff3e304a77c5bc8a26f1900c04eb082119d5147f98b2c7f931f566e2d1b05a2a4e89bda220f45258e497b68735929
+    SHA512 e49ccb8ccaf7ce29cf46a99b1fc725dfcb2ac7e5f35ffd8d9bc7f085dae3de73840427efa9fdd38555e389dd948e7cd613481309fbb6e9dac6dc52db5c5da24c
     PATCHES
         fix_shared_win_build.patch
         stdout_fileno.patch

--- a/ports/hwloc/vcpkg.json
+++ b/ports/hwloc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hwloc",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "maintainers": "bgoglin<Brice.Goglin@inria.fr>",
   "description": [
     "Portable Hardware Locality (hwloc)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3385,7 +3385,7 @@
       "port-version": 0
     },
     "hwloc": {
-      "baseline": "2.9.3",
+      "baseline": "2.10.0",
       "port-version": 0
     },
     "hyperscan": {

--- a/versions/h-/hwloc.json
+++ b/versions/h-/hwloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f21a1b350aea6164f80b41c45980189c6d561ffa",
+      "version": "2.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8c536aed23026d6f8a30f1815e47f30652112c22",
       "version": "2.9.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

