### PR TITLE
[json-schema-validator] update to 2.3.0

### DIFF
--- a/ports/json-schema-validator/portfile.cmake
+++ b/ports/json-schema-validator/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pboettch/json-schema-validator
     REF "${VERSION}"
-    SHA512 8d7fe6775774040099aa8d8b10fa18c4ccebe4437ecf9670710a0f64443d3588ca3e1bf1bc32a800518b748aa3acd89ecc61d1568b6dd8bf54273b33c5ab5d5a
+    SHA512 6d207031acdb94c44f96ff6346dccaf98f2c9d3619d71e419ddabff548ea34d50e8eb103622c99ae28ecb7fddedd687b297e5ad934aa0106c58ac59fc4d65ea9
     HEAD_REF master
 )
 

--- a/ports/json-schema-validator/vcpkg.json
+++ b/ports/json-schema-validator/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-validator",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "C++ library for validating JSON documents based on a JSON Schema. This validator is based on the nlohmann-json library.",
   "homepage": "https://github.com/pboettch/json-schema-validator",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3697,7 +3697,7 @@
       "port-version": 0
     },
     "json-schema-validator": {
-      "baseline": "2.2.0",
+      "baseline": "2.3.0",
       "port-version": 0
     },
     "json-spirit": {

--- a/versions/j-/json-schema-validator.json
+++ b/versions/j-/json-schema-validator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4466bee34b5544a3ecfaf5f480464b1f9d45e9b1",
+      "version": "2.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "968aee6b22bf2b1248b38ae25aed43a1760fec0d",
       "version": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

