### PR TITLE
[libmad] Fix hash

### DIFF
--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS "https://codeberg.org/tenacityteam/libmad/archive/${VERSION}.tar.gz"
     FILENAME "tenacityteam-libmad-${VERSION}.tar.gz"
-    SHA512 6752c199096f999ed478dea712eb669913eec182eec8a56bf4871e77e6c38798d13146febf646007427f43f86aea8d40b9ec2b72928ac3132066ebddcaa0cfde
+    SHA512 e56b84e112e3a95cd4fde7be1ce94c4a277275da3cc69ca051113162a84158ac9a1fe9c3f2de186202de5eca5c112aacb87533206288a084cf5ba048e6d95c22
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")

--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -2,11 +2,14 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-vcpkg_from_git(
-    OUT_SOURCE_PATH SOURCE_PATH
-    URL "https://codeberg.org/tenacityteam/libmad/"
-    REF ee7c3cdd4361b7f7c7da52fa3ba9f76cc35230a9
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS "https://codeberg.org/tenacityteam/libmad/releases/download/${VERSION}/libmad-${VERSION}.tar.gz"
+    FILENAME "tenacityteam-libmad-${VERSION}.tar.gz"
+    SHA512 5b0a826408395e8b6b8a33953401355d6c2f1b33ec5085530b4ac8a538c39ffa903ce2e6845e9dcad73936933078959960b2f3fbba11ae091fda5bc5ee310df5
 )
+
+vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -2,14 +2,11 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-vcpkg_download_distfile(
-    ARCHIVE
-    URLS "https://codeberg.org/tenacityteam/libmad/archive/${VERSION}.tar.gz"
-    FILENAME "tenacityteam-libmad-${VERSION}.tar.gz"
-    SHA512 e56b84e112e3a95cd4fde7be1ce94c4a277275da3cc69ca051113162a84158ac9a1fe9c3f2de186202de5eca5c112aacb87533206288a084cf5ba048e6d95c22
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL "https://codeberg.org/tenacityteam/libmad/"
+    REF ee7c3cdd4361b7f7c7da52fa3ba9f76cc35230a9
 )
-
-vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libmad/vcpkg.json
+++ b/ports/libmad/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmad",
   "version": "0.16.4",
+  "port-version": 1,
   "description": "high-quality MPEG audio decoder",
   "homepage": "http://codeberg.org/tenacityteam/libmad",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4526,7 +4526,7 @@
     },
     "libmad": {
       "baseline": "0.16.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libmagic": {
       "baseline": "5.45",
@@ -9016,13 +9016,13 @@
       "baseline": "1.0.9",
       "port-version": 0
     },
-    "vsgxchange": {
-      "baseline": "1.0.5",
-      "port-version": 1
-    },
     "vsgimgui": {
       "baseline": "0.1.0",
       "port-version": 0
+    },
+    "vsgxchange": {
+      "baseline": "1.0.5",
+      "port-version": 1
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9fb81037e132bbcbb8dd5c239e347e9450ae888a",
+      "version": "0.16.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "ca6bd50225347461a9d72269c1b7d082a691f31d",
       "version": "0.16.4",
       "port-version": 0

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d6f89685c79a9aae3feb24e19895cc855c06253f",
+      "git-tree": "7016c2c6c5e65a6420a176aa97696897bb134c40",
       "version": "0.16.4",
       "port-version": 1
     },

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9fb81037e132bbcbb8dd5c239e347e9450ae888a",
+      "git-tree": "d6f89685c79a9aae3feb24e19895cc855c06253f",
       "version": "0.16.4",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #36362, use `vcpkg_from_git` instead of `vcpkg_download_distfile`.

- [ ] ~Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).~
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
