### PR TITLE
[protobuf] Delete unused backends from sources.

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -33,6 +33,17 @@ if (VCPKG_DOWNLOAD_MODE)
     vcpkg_find_acquire_program(PKGCONFIG)
 endif()
 
+# Delete language backends we aren't targeting to reduce false positives in automated dependency
+# detectors like Dependabot.
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/csharp"
+    "${SOURCE_PATH}/java"
+    "${SOURCE_PATH}/objectivec"
+    "${SOURCE_PATH}/php"
+    "${SOURCE_PATH}/python"
+    "${SOURCE_PATH}/ruby"
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "protobuf",
   "version": "3.21.12",
+  "port-version": 1,
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6846,7 +6846,7 @@
     },
     "protobuf": {
       "baseline": "3.21.12",
-      "port-version": 0
+      "port-version": 1
     },
     "protobuf-c": {
       "baseline": "1.4.1",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d742753b6c35666168a4178f0aae986740ae42c",
+      "version": "3.21.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "3b145508ba614fe26989b23f6317f15bf6467be4",
       "version": "3.21.12",
       "port-version": 0


### PR DESCRIPTION
We have an internal Microsoft report of dependency tracking tools complaining about requirements.txt in the Python backend of protobuf after a build. It's just as likely that similar alerts will be fired for other unused language backends. However, they're unused, so we can delete them.
