### PR TITLE
[opentelemetry-cpp] remove otlp feature which doesn't exist

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 # opentelemetry-proto is a third party submodule and opentelemetry-cpp release did not pack it.
-if(WITH_OTLP_GRPC)
+if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
     set(OTEL_PROTO_VERSION "1.0.0")
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/open-telemetry/opentelemetry-proto/archive/v${OTEL_PROTO_VERSION}.tar.gz"
@@ -69,7 +69,6 @@ vcpkg_cmake_configure(
         -DOPENTELEMETRY_EXTERNAL_COMPONENT_PATH="${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}"
         ${FEATURE_OPTIONS}
     MAYBE_UNUSED_VARIABLES
-        WITH_OTLP_GRPC
         WITH_GENEVA
 )
 

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.13.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."
@@ -33,19 +33,6 @@
     "geneva": {
       "description": "Whether to include the Geneva Exporter from the opentelemetry-cpp-contrib repository"
     },
-    "otlp": {
-      "description": "Whether to include the OpenTelemetry Protocol in the SDK",
-      "dependencies": [
-        {
-          "name": "opentelemetry-cpp",
-          "default-features": false,
-          "features": [
-            "otlp-grpc",
-            "otlp-http"
-          ]
-        }
-      ]
-    },
     "otlp-grpc": {
       "description": "Whether to include the OTLP gRPC exporter in the SDK",
       "dependencies": [
@@ -53,27 +40,13 @@
         {
           "name": "grpc",
           "host": true
-        },
-        {
-          "name": "opentelemetry-cpp",
-          "default-features": false,
-          "features": [
-            "otlp"
-          ]
         }
       ]
     },
     "otlp-http": {
       "description": "Whether to include the OpenTelemetry Protocol over HTTP in the SDK",
       "dependencies": [
-        "curl",
-        {
-          "name": "opentelemetry-cpp",
-          "default-features": false,
-          "features": [
-            "otlp"
-          ]
-        }
+        "curl"
       ]
     },
     "prometheus": {

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -46,7 +46,8 @@
     "otlp-http": {
       "description": "Whether to include the OpenTelemetry Protocol over HTTP in the SDK",
       "dependencies": [
-        "curl"
+        "curl",
+        "protobuf"
       ]
     },
     "prometheus": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6418,7 +6418,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.13.0",
-      "port-version": 2
+      "port-version": 3
     },
     "opentelemetry-fluentd": {
       "baseline": "2.0.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2afbd4d8a236e1ba427c839bfe3399c85f6bab3c",
+      "git-tree": "f732f422f031bbc6b126743a388bcf50280acb0e",
       "version-semver": "1.13.0",
       "port-version": 3
     },

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2afbd4d8a236e1ba427c839bfe3399c85f6bab3c",
+      "version-semver": "1.13.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "34b7683811362c31ff5e3742dd47ee8a721817f0",
       "version-semver": "1.13.0",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

The OTLP is not a separate feature and is deprecated in the upstream repo. The feature is either otlp-grpc or otlp-http.

https://github.com/open-telemetry/opentelemetry-cpp/blob/main/CMakeLists.txt#L197

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
