### PR TITLE
[xtensor] update to 0.25.0

### DIFF
--- a/ports/xtensor/portfile.cmake
+++ b/ports/xtensor/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtensor
     REF "${VERSION}"
-    SHA512 1b2683225a400e2ed06679eedc13c001be80163afb8b42918091670995c04f26ef03ffa9ef72ec7fe6c9d4c1aa88df9ad17698abe5ccd8b19a057ebc10956594
+    SHA512 d8ff5bdb2af66db5ba84cceb2e5138728b7e689b81d5aab904c4f5dfbebdcde67b8ecf38e69750edb85e30a6f45ce70ff618ca3d1a76f38a2b4013a6a6320de6
     HEAD_REF master
     PATCHES
         fix-find-tbb-and-install-destination.patch

--- a/ports/xtensor/vcpkg.json
+++ b/ports/xtensor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xtensor",
-  "version": "0.24.7",
+  "version": "0.25.0",
   "description": "C++ tensors with broadcasting and lazy computing",
   "homepage": "https://github.com/xtensor-stack/xtensor",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9365,7 +9365,7 @@
       "port-version": 0
     },
     "xtensor": {
-      "baseline": "0.24.7",
+      "baseline": "0.25.0",
       "port-version": 0
     },
     "xtensor-blas": {

--- a/versions/x-/xtensor.json
+++ b/versions/x-/xtensor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f8e8bf52ae7f55b38fabb98423beafc361cff28",
+      "version": "0.25.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f097c22efd106eadd130143bbe0ea4ce0355959",
       "version": "0.24.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.