### PR TITLE
[vcpkg baseline][clipper2] fix ci error

### DIFF
--- a/ports/clipper2/portfile.cmake
+++ b/ports/clipper2/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/CPP"
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DCLIPPER2_EXAMPLES=OFF
         -DCLIPPER2_TESTS=OFF

--- a/ports/clipper2/vcpkg.json
+++ b/ports/clipper2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "clipper2",
   "version": "1.3.0",
+  "port-version": 1,
   "description": "Polygon Clipping and Offsetting",
   "homepage": "http://www.angusj.com/clipper2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1662,7 +1662,7 @@
     },
     "clipper2": {
       "baseline": "1.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "clockutils": {
       "baseline": "1.1.1",

--- a/versions/c-/clipper2.json
+++ b/versions/c-/clipper2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "666b9d81d31d70d3d691e2286d951168c5d9d970",
+      "version": "1.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "649bee1fd1497da0ee3120c985ab6f465f2ad3c2",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
Fixes REGRESSION:
````
REGRESSION: clipper2:x64-windows failed with BUILD_FAILED
````
````
CMake Error at CMakeLists.txt:28 (configure_file):
  No error


-- Configuring incomplete, errors occurred!
````
Add DISABLE_PARALLEL_CONFIGURE to disables running the CMake configure step in parallel.

- [ ] ~~Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).~~
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.