### PR TITLE
[miniaudio] update to 0.11.21

### DIFF
--- a/ports/miniaudio/portfile.cmake
+++ b/ports/miniaudio/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO mackron/miniaudio
   REF "${VERSION}"
-  SHA512 b16fd9af65af050ddb0597498fc10aec1d277c9e6ebac968c0c2a0d8688181eb2a221f50b9d8101d454ede305ce50ab4c0729beaa1a6ffef71ab2402a7013994
+  SHA512 0c67ff7d9112409fea5af7756c1bc14bca4acfa45a97896ea339cdab228ac3dcc843c492e6da9dc75d4cd6f6b795ee80fe3ad9c4c746d7db691b1216f86e456d
   HEAD_REF master
 )
 

--- a/ports/miniaudio/vcpkg.json
+++ b/ports/miniaudio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "miniaudio",
-  "version": "0.11.19",
+  "version": "0.11.21",
   "description": "Audio playback and capture library written in C, in a single source file",
   "homepage": "https://github.com/mackron/miniaudio",
   "license": "Unlicense OR MIT-0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5625,7 +5625,7 @@
       "port-version": 4
     },
     "miniaudio": {
-      "baseline": "0.11.19",
+      "baseline": "0.11.21",
       "port-version": 0
     },
     "minifb": {

--- a/versions/m-/miniaudio.json
+++ b/versions/m-/miniaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "980dc0e20ab6855dfe916b881f580cd9f371f991",
+      "version": "0.11.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "62c26f2cd7ae5eb016e30a1555ff384f045047d5",
       "version": "0.11.19",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
