### PR TITLE
[libavif] update to 1.0.3

### DIFF
--- a/ports/libavif/portfile.cmake
+++ b/ports/libavif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AOMediaCodec/libavif
     REF "v${VERSION}"
-    SHA512 f7c35e40f9214314afeae69d5da6ab345e6dbd025e737a920ea4270452cdf7ff7010d7af5cc18d27e93b217114eb6b613cd349703d0e1bb7814dbeb84a9fd70f
+    SHA512 b713f35fd3e54e105e16f46012becdada86f522b4ed8ab7097a93fd437524b4f2c997c42d6f06828f93b53253b1d90302417afdb0bd8e09d176f64f19c7a0faa
     HEAD_REF master
     PATCHES
         disable-source-utf8.patch

--- a/ports/libavif/vcpkg.json
+++ b/ports/libavif/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libavif",
-  "version-semver": "1.0.1",
+  "version-semver": "1.0.3",
   "description": "Library for encoding and decoding AVIF files",
   "homepage": "https://github.com/AOMediaCodec/libavif",
   "license": "BSD-2-Clause AND Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4125,7 +4125,7 @@
       "port-version": 0
     },
     "libavif": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.3",
       "port-version": 0
     },
     "libb2": {

--- a/versions/l-/libavif.json
+++ b/versions/l-/libavif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4532b7082f91c3b906444106b2fed0023178fad1",
+      "version-semver": "1.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "204b6c51e6d23a77e275b5ec370e15e1c9fccaf1",
       "version-semver": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

