### PR TITLE
[libjuice] update to 1.3.4

### DIFF
--- a/ports/libjuice/portfile.cmake
+++ b/ports/libjuice/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO paullouisageneau/libjuice
     REF "v${VERSION}"
-    SHA512 187901d6d8e1210210667b0bca274ce9507d46cc5f3fe81e812fb7c16dc2739359a5d331ce03a9a3958252c4ea942a75ca29a624f486abb23c19dd10c71127bc
+    SHA512 0c690940fab9c29c52955ee96c254c086f4170c8e59a26b767b9ffc288db9ecc7195136f958b9773903201e2719279bca63c7f64b6bb89bf8a41b6dd1da4eb63
     HEAD_REF master
     PATCHES
         fix-for-vcpkg.patch

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libjuice",
-  "version": "1.3.1",
+  "version": "1.3.4",
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4473,7 +4473,7 @@
       "port-version": 0
     },
     "libjuice": {
-      "baseline": "1.3.1",
+      "baseline": "1.3.4",
       "port-version": 0
     },
     "libjxl": {

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "124bb0aff578c4ef748087f00e23f0b0e038c91d",
+      "version": "1.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ace25316c085db75ac26220e854bd83baa86294",
       "version": "1.3.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

