### PR TITLE
[open62541] Update to 1.3.9

### DIFF
--- a/ports/open62541/disable-docs.patch
+++ b/ports/open62541/disable-docs.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7a051f12f..a751b6d83 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1529,7 +1529,6 @@ target_link_libraries(open62541 ${open62541_LIBRARIES})
+ ##########################
+ 
+ # always include, builds with make doc
+-add_subdirectory(doc)
+ 
+ if(UA_BUILD_EXAMPLES)
+     if(UA_ENABLE_AMALGAMATION)
+@@ -1565,7 +1564,6 @@ endif()
+ ########################
+ # Linting as target    #
+ ########################
+-include(linting_target)
+ 
+ ##########################
+ # Installation           #

--- a/ports/open62541/portfile.cmake
+++ b/ports/open62541/portfile.cmake
@@ -2,8 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open62541/open62541
     REF "v${VERSION}"
-    SHA512 48ae61fd096c3a45f57ecc70bec9bb4223d046eed017532937c99883e4e92f79d7425b4db02c1a7e451764b787313efd76b2ae3cd3011d575154199d5350a790
+    SHA512 8771a70d1f38f2a02f21281200d98fdd8d41d842cc82704155793529a1768beeb2583382f7547e6aaefdab4a17c3130779af792b2a59487889a3cdea4a2fa776
     HEAD_REF master
+    PATCHES
+        disable-docs.patch
 )
 
 vcpkg_check_features(
@@ -35,12 +37,11 @@ vcpkg_cmake_configure(
         ${OPEN62541_ENCRYPTION_OPTIONS}
         "-DOPEN62541_VERSION=v${VERSION}"
         -DUA_MSVC_FORCE_STATIC_CRT=OFF
-    OPTIONS_DEBUG
-        -DCMAKE_DEBUG_POSTFIX=d
+        -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/open62541")
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 

--- a/ports/open62541/vcpkg.json
+++ b/ports/open62541/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "open62541",
-  "version": "1.3.8",
-  "port-version": 2,
+  "version": "1.3.9",
   "description": "open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.",
   "homepage": "https://open62541.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6265,8 +6265,8 @@
       "port-version": 0
     },
     "open62541": {
-      "baseline": "1.3.8",
-      "port-version": 2
+      "baseline": "1.3.9",
+      "port-version": 0
     },
     "open62541pp": {
       "baseline": "0.11.0",

--- a/versions/o-/open62541.json
+++ b/versions/o-/open62541.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2cab251773b17791187e59d83a27ec09d344a49c",
+      "version": "1.3.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "6bfbedbf2007596294583ab894f5481d754991f2",
       "version": "1.3.8",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
