### PR TITLE
[qtbase] Add support for building with OpenGL ES 3.0

### DIFF
--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -169,6 +169,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_GUI_OPTIONS
     "xrender"             FEATURE_xrender # requires FEATURE_xcb_native_painting; otherwise disabled. 
     "xrender"             FEATURE_xcb_native_painting # experimental
     "gles2"               FEATURE_opengles2
+    "gles3"               FEATURE_opengles3
     #Cannot be required since Qt will look in CONFIG mode first but is controlled via CMAKE_DISABLE_FIND_PACKAGE_Vulkan below
     #"vulkan"              CMAKE_REQUIRE_FIND_PACKAGE_WrapVulkanHeaders 
     "egl"                 FEATURE_egl
@@ -187,6 +188,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_GUI_OPTIONS
     "opengl"              CMAKE_DISABLE_FIND_PACKAGE_WrapOpenGL
     "egl"                 CMAKE_DISABLE_FIND_PACKAGE_EGL
     "gles2"               CMAKE_DISABLE_FIND_PACKAGE_GLESv2
+    "gles3"               CMAKE_DISABLE_FIND_PACKAGE_GLESv3
     "fontconfig"          CMAKE_DISABLE_FIND_PACKAGE_Fontconfig
     #"freetype"            CMAKE_DISABLE_FIND_PACKAGE_WrapSystemFreetype # Bug in qt cannot be deactivated
     "harfbuzz"            CMAKE_DISABLE_FIND_PACKAGE_WrapSystemHarfbuzz
@@ -201,7 +203,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_GUI_OPTIONS
     # There are more X features but I am unsure how to safely disable them! Most of them seem to be found automaticall with find_package(X11)
      )
 
-if( "gles2" IN_LIST FEATURES)
+if("gles2" IN_LIST FEATURES)
     list(APPEND FEATURE_GUI_OPTIONS -DINPUT_opengl='es2')
     list(APPEND FEATURE_GUI_OPTIONS -DFEATURE_opengl_desktop=OFF)
 endif()
@@ -223,8 +225,7 @@ else()
     list(APPEND FEATURE_GUI_OPTIONS -DINPUT_xkbcommon=no)
 endif()
 
-# Disable GLES3
-list(APPEND FEATURE_GUI_OPTIONS -DFEATURE_opengles3:BOOL=OFF)
+# Disable OpenGL ES 3.1 and 3.2
 list(APPEND FEATURE_GUI_OPTIONS -DFEATURE_opengles31:BOOL=OFF)
 list(APPEND FEATURE_GUI_OPTIONS -DFEATURE_opengles32:BOOL=OFF)
 

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.6.1",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -207,6 +207,19 @@
           "default-features": false,
           "features": [
             "gui"
+          ]
+        }
+      ]
+    },
+    "gles3": {
+      "description": "OpenGL ES 3.0",
+      "supports": "!windows & !osx",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "gles2"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7178,7 +7178,7 @@
     },
     "qtbase": {
       "baseline": "6.6.1",
-      "port-version": 8
+      "port-version": 9
     },
     "qtcharts": {
       "baseline": "6.6.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99b63c90d57e03fb23c3750b28f70e810c981474",
+      "version": "6.6.1",
+      "port-version": 9
+    },
+    {
       "git-tree": "5e2e2b00fd42bc15c333b7dded4e7db4109ca11f",
       "version": "6.6.1",
       "port-version": 8


### PR DESCRIPTION
This adds support for building Qt with OpenGL ES 3.0, a necessity to build many OpenGL apps for iOS.

## Implementation note

The implementation follows the way the GL ES features are structured in the `configure` script, namely by implying `gles2` and enabling `gles3` only via a feature flag:

- https://github.com/qt/qtbase/blob/1ea51e1f2dfedbea306a16b2a2996ed13c29f7fd/config_help.txt#L262-L265
- https://github.com/qt/qtbase/blob/1ea51e1f2dfedbea306a16b2a2996ed13c29f7fd/cmake/configure-cmake-mapping.md?plain=1#L141-L142

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download (doesn't apply).
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file (doesn't apply).
- [x] Any patches that are no longer applied are deleted from the port's directory (doesn't apply).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.