### PR TITLE
[minizip-ng] Update to 4.0.4

### DIFF
--- a/ports/minizip-ng/fix_find_zstd.patch
+++ b/ports/minizip-ng/fix_find_zstd.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6f6c6bc..1856944 100644
+index 0902052..f301b43 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -334,12 +334,8 @@ endif()
+@@ -340,20 +340,8 @@ endif()
  if(MZ_ZSTD)
      # Check if zstd is present
      if(NOT MZ_FORCE_FETCH_LIBS)
@@ -10,9 +10,18 @@ index 6f6c6bc..1856944 100644
 -        if(PKGCONFIG_FOUND)
 -            pkg_check_modules(ZSTD libzstd)
 -        endif()
-         if(NOT ZSTD_FOUND)
+-        if(NOT ZSTD_FOUND)
 -            find_package(ZSTD QUIET)
-+            find_package(ZSTD NAMES zstd REQUIRED)
-             if(ZSTD_FOUND)
-                 if(TARGET zstd::libzstd_static)
-                     list(APPEND ZSTD_LIBRARIES zstd::libzstd_static)
+-            if(ZSTD_FOUND)
+-                if(TARGET zstd::libzstd_static)
+-                    list(APPEND ZSTD_LIBRARIES zstd::libzstd_static)
+-                else()
+-                    list(APPEND ZSTD_LIBRARIES zstd::libzstd_shared)
+-                endif()
+-            endif()
+-        endif()
++        find_package(ZSTD NAMES zstd REQUIRED)
++        list(APPEND ZSTD_LIBRARIES $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
+     endif()
+ 
+     if(ZSTD_FOUND AND NOT MZ_FORCE_FETCH_LIBS)

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/minizip-ng
     REF "${VERSION}"
-    SHA512 4e626a312c35e5f003e4f365261ef3e1bf33488f8698ec31b1b33d32f6a34ed0b54f0e3ffdae658e5b441532dde3cee45c3822532f52e68ea588e809e8f4081c
+    SHA512 2662ddf90666babe73474f6fc48f5a64f276d555b7a0f04f790b9edef570cb958356e900632c3795fb2053f4813c449240ff101d32b063eca4ad869bef0546fd
     HEAD_REF master
     PATCHES
         fix_find_zstd.patch

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "minizip-ng",
-  "version": "4.0.2",
+  "version": "4.0.4",
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5665,7 +5665,7 @@
       "port-version": 1
     },
     "minizip-ng": {
-      "baseline": "4.0.2",
+      "baseline": "4.0.4",
       "port-version": 0
     },
     "mio": {

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cfab4e259bccd7d7f1a0470b32c7b7bf912609f4",
+      "version": "4.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "33b696b13c4de3a5319c042daab76baa51945f8f",
       "version": "4.0.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:
END OF PORT UPDATE CHECKLIST (delete this line) -->

This PR updates the minizip-ng port to version 4.0.4.
Here are the release notes: https://github.com/zlib-ng/minizip-ng/releases/tag/4.0.4
The zstd-patch has been adapted to use the updated `usage` hints of the zstd port, since I had a configuration error on x64-linux before.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
