### PR TITLE
[libjpeg-turbo] Update to 3.0.2

### DIFF
--- a/ports/libjpeg-turbo/add-options-for-exes-docs-headers.patch
+++ b/ports/libjpeg-turbo/add-options-for-exes-docs-headers.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index efd101a..9c1c69f 100644
+index adb0ca45..e66928bf 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -222,6 +222,12 @@ option(ENABLE_SHARED "Build shared libraries" TRUE)
@@ -15,7 +15,7 @@ index efd101a..9c1c69f 100644
  option(REQUIRE_SIMD "Generate a fatal error if SIMD extensions are not available for this platform (default is to fall back to a non-SIMD build)" FALSE)
  boolean_number(REQUIRE_SIMD)
  option(WITH_ARITH_DEC "Include arithmetic decoding support when emulating the libjpeg v6b API/ABI" TRUE)
-@@ -690,6 +696,7 @@ if(WITH_TURBOJPEG)
+@@ -699,6 +705,7 @@ if(WITH_TURBOJPEG)
          LINK_FLAGS "${TJMAPFLAG}${TJMAPFILE}")
      endif()
  
@@ -23,15 +23,20 @@ index efd101a..9c1c69f 100644
      add_executable(tjunittest tjunittest.c tjutil.c md5/md5.c md5/md5hl.c)
      target_link_libraries(tjunittest turbojpeg)
  
-@@ -701,6 +708,7 @@ if(WITH_TURBOJPEG)
+@@ -710,9 +717,11 @@ if(WITH_TURBOJPEG)
  
      add_executable(tjexample tjexample.c)
      target_link_libraries(tjexample turbojpeg)
+-
++    endif()
++    if(INSTALL_DOCS)
+     add_custom_target(tjdoc COMMAND doxygen -s doxygen.config
+       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 +    endif()
    endif()
  
    if(ENABLE_STATIC)
-@@ -721,6 +729,7 @@ if(WITH_TURBOJPEG)
+@@ -733,6 +742,7 @@ if(WITH_TURBOJPEG)
        set_target_properties(turbojpeg-static PROPERTIES OUTPUT_NAME turbojpeg)
      endif()
  
@@ -39,7 +44,7 @@ index efd101a..9c1c69f 100644
      add_executable(tjunittest-static tjunittest.c tjutil.c md5/md5.c
        md5/md5hl.c)
      target_link_libraries(tjunittest-static turbojpeg-static)
-@@ -730,6 +739,7 @@ if(WITH_TURBOJPEG)
+@@ -742,6 +752,7 @@ if(WITH_TURBOJPEG)
      if(UNIX)
        target_link_libraries(tjbench-static m)
      endif()
@@ -47,7 +52,7 @@ index efd101a..9c1c69f 100644
    endif()
  endif()
  
-@@ -748,13 +758,15 @@ if(ENABLE_STATIC)
+@@ -760,13 +771,15 @@ if(ENABLE_STATIC)
    add_library(cjpeg16-static OBJECT rdgif.c rdppm.c)
    set_property(TARGET cjpeg16-static PROPERTY COMPILE_FLAGS
      "-DBITS_IN_JSAMPLE=16 -DGIF_SUPPORTED -DPPM_SUPPORTED")
@@ -64,7 +69,7 @@ index efd101a..9c1c69f 100644
    # Compile a separate version of these source files with 12-bit and 16-bit
    # data precision.
    add_library(djpeg12-static OBJECT rdcolmap.c wrgif.c wrppm.c)
-@@ -763,6 +775,7 @@ if(ENABLE_STATIC)
+@@ -775,6 +788,7 @@ if(ENABLE_STATIC)
    add_library(djpeg16-static OBJECT wrppm.c)
    set_property(TARGET djpeg16-static PROPERTY COMPILE_FLAGS
      "-DBITS_IN_JSAMPLE=16 -DPPM_SUPPORTED")
@@ -72,7 +77,7 @@ index efd101a..9c1c69f 100644
    add_executable(djpeg-static djpeg.c cdjpeg.c rdcolmap.c rdswitch.c wrbmp.c
      wrgif.c wrppm.c wrtarga.c $<TARGET_OBJECTS:djpeg12-static>
      $<TARGET_OBJECTS:djpeg16-static>)
-@@ -776,11 +789,14 @@ if(ENABLE_STATIC)
+@@ -788,11 +802,14 @@ if(ENABLE_STATIC)
  
    add_executable(example-static example.c)
    target_link_libraries(example-static jpeg-static)
@@ -87,7 +92,7 @@ index efd101a..9c1c69f 100644
  
  
  ###############################################################################
-@@ -1687,8 +1703,10 @@ if(WITH_TURBOJPEG)
+@@ -1721,8 +1738,10 @@ if(WITH_TURBOJPEG)
        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -98,7 +103,7 @@ index efd101a..9c1c69f 100644
      if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC AND
        CMAKE_C_LINKER_SUPPORTS_PDB)
        install(FILES "$<TARGET_PDB_FILE:turbojpeg>"
-@@ -1699,7 +1717,7 @@ if(WITH_TURBOJPEG)
+@@ -1733,7 +1752,7 @@ if(WITH_TURBOJPEG)
      install(TARGETS turbojpeg-static EXPORT ${CMAKE_PROJECT_NAME}Targets
        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -107,7 +112,7 @@ index efd101a..9c1c69f 100644
        if(GENERATOR_IS_MULTI_CONFIG)
          set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
        else()
-@@ -1709,15 +1727,17 @@ if(WITH_TURBOJPEG)
+@@ -1743,15 +1762,17 @@ if(WITH_TURBOJPEG)
          DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME tjbench${EXE})
      endif()
    endif()
@@ -126,7 +131,7 @@ index efd101a..9c1c69f 100644
      if(GENERATOR_IS_MULTI_CONFIG)
        set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
      else()
-@@ -1732,8 +1752,11 @@ if(ENABLE_STATIC)
+@@ -1766,8 +1787,11 @@ if(ENABLE_STATIC)
    endif()
  endif()
  
@@ -138,7 +143,7 @@ index efd101a..9c1c69f 100644
  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.ijg
    ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_SOURCE_DIR}/example.c
    ${CMAKE_CURRENT_SOURCE_DIR}/tjexample.c
-@@ -1745,8 +1768,9 @@ if(WITH_JAVA)
+@@ -1779,8 +1803,9 @@ if(WITH_JAVA)
    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/java/TJExample.java
      DESTINATION ${CMAKE_INSTALL_DOCDIR})
  endif()
@@ -149,7 +154,7 @@ index efd101a..9c1c69f 100644
    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cjpeg.1
      ${CMAKE_CURRENT_SOURCE_DIR}/djpeg.1 ${CMAKE_CURRENT_SOURCE_DIR}/jpegtran.1
      ${CMAKE_CURRENT_SOURCE_DIR}/rdjpgcom.1
-@@ -1767,11 +1791,12 @@ install(EXPORT ${CMAKE_PROJECT_NAME}Targets
+@@ -1801,11 +1826,12 @@ install(EXPORT ${CMAKE_PROJECT_NAME}Targets
    NAMESPACE ${CMAKE_PROJECT_NAME}::
    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME})
  
@@ -164,10 +169,10 @@ index efd101a..9c1c69f 100644
  
  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmakescripts/cmake_uninstall.cmake.in"
 diff --git a/sharedlib/CMakeLists.txt b/sharedlib/CMakeLists.txt
-index 8e94256..8a16497 100644
+index 8e942569..6f3454a9 100644
 --- a/sharedlib/CMakeLists.txt
 +++ b/sharedlib/CMakeLists.txt
-@@ -76,11 +76,13 @@ set_property(TARGET cjpeg12 PROPERTY COMPILE_FLAGS
+@@ -76,12 +76,13 @@ set_property(TARGET cjpeg12 PROPERTY COMPILE_FLAGS
  add_library(cjpeg16 OBJECT ../rdgif.c ../rdppm.c)
  set_property(TARGET cjpeg16 PROPERTY COMPILE_FLAGS
    "-DBITS_IN_JSAMPLE=16 -DGIF_SUPPORTED -DPPM_SUPPORTED")
@@ -177,11 +182,27 @@ index 8e94256..8a16497 100644
    $<TARGET_OBJECTS:cjpeg16>)
  set_property(TARGET cjpeg PROPERTY COMPILE_FLAGS ${CDJPEG_COMPILE_FLAGS})
  target_link_libraries(cjpeg jpeg)
+-
 +endif()
- 
  # Compile a separate version of these source files with 12-bit and 16-bit data
  # precision.
-@@ -111,8 +113,10 @@ install(TARGETS jpeg EXPORT ${CMAKE_PROJECT_NAME}Targets
+ add_library(djpeg12 OBJECT ../rdcolmap.c ../wrgif.c ../wrppm.c)
+@@ -90,6 +91,7 @@ set_property(TARGET djpeg12 PROPERTY COMPILE_FLAGS
+ add_library(djpeg16 OBJECT ../wrppm.c)
+ set_property(TARGET djpeg16 PROPERTY COMPILE_FLAGS
+   "-DBITS_IN_JSAMPLE=16 -DPPM_SUPPORTED")
++if(ENABLE_EXECUTABLES)
+ add_executable(djpeg ../djpeg.c ../cdjpeg.c ../rdcolmap.c ../rdswitch.c
+   ../wrbmp.c ../wrgif.c ../wrppm.c ../wrtarga.c $<TARGET_OBJECTS:djpeg12>
+   $<TARGET_OBJECTS:djpeg16>)
+@@ -105,14 +107,16 @@ target_link_libraries(example jpeg)
+ 
+ add_executable(jcstest ../jcstest.c)
+ target_link_libraries(jcstest jpeg)
+-
++endif()
+ install(TARGETS jpeg EXPORT ${CMAKE_PROJECT_NAME}Targets
+   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libjpeg-turbo/libjpeg-turbo
     REF "${VERSION}"
-    SHA512 6f9f384bb3bf5476935b313576c03f11d3e22bf727aa135eb840a2c9b994890e6712e23f25996b91ee901e8242b41100fb8c3cb4905ffb72776edf14b2c05a12
+    SHA512 9dddc039d9fd43fe2e2ff6a8b14fab4344f778ff270ec6f38f6496846501701df10b5127e2fe8b778cc236cac38b73889b9cc5bf884f8a43c37c4736097abb25
     HEAD_REF master
     PATCHES
         add-options-for-exes-docs-headers.patch

--- a/ports/libjpeg-turbo/vcpkg.json
+++ b/ports/libjpeg-turbo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libjpeg-turbo",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "libjpeg-turbo is a JPEG image codec that uses SIMD instructions (MMX, SSE2, NEON, AltiVec) to accelerate baseline JPEG compression and decompression on x86, x86-64, ARM, and PowerPC systems.",
   "homepage": "https://github.com/libjpeg-turbo/libjpeg-turbo",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4469,7 +4469,7 @@
       "port-version": 2
     },
     "libjpeg-turbo": {
-      "baseline": "3.0.1",
+      "baseline": "3.0.2",
       "port-version": 0
     },
     "libjuice": {

--- a/versions/l-/libjpeg-turbo.json
+++ b/versions/l-/libjpeg-turbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d061c71a48ca2abff5cf471f77ef14d7222aa52",
+      "version": "3.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "481b08127d4002ba7441f144df259e03271e7592",
       "version": "3.0.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:END OF PORT UPDATE CHECKLIST (delete this line) -->

Release notes are here: https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/3.0.2

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
-  ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
-  ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
