### PR TITLE
[libphonenumber] update to 8.13.29

### DIFF
--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/libphonenumber
     REF "v${VERSION}"
-    SHA512 d7a576e64fd3f3ce9d4f79750d8c785c56efd97d90f37d0062fb2634124ed6b181c74e772b4d9e72daf8897cc9cae4d4e525dd8b5113739c8c7ac7279315cd66
+    SHA512 bdfc51a8e2ecf59b092a74a7d5b99594194c21e62bc9e956e7263f98d8a6cdd85a9b04f2e5aa01e501319335ddf77feec66e74967e3b1b186f899543ebadb8ca
     HEAD_REF master
     PATCHES 
         fix-re2-identifiers.patch

--- a/ports/libphonenumber/vcpkg.json
+++ b/ports/libphonenumber/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libphonenumber",
-  "version": "8.13.23",
+  "version": "8.13.29",
   "description": "Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.",
   "license": "Apache-2.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4701,7 +4701,7 @@
       "port-version": 2
     },
     "libphonenumber": {
-      "baseline": "8.13.23",
+      "baseline": "8.13.29",
       "port-version": 0
     },
     "libplist": {

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6968832284b2011625dfc11d47cd2cf0c92d2a1",
+      "version": "8.13.29",
+      "port-version": 0
+    },
+    {
       "git-tree": "9df18bd6b1bab30de04c91942cf6724b6ff26f0c",
       "version": "8.13.23",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

