### PR TITLE
[libunifex] update to 0.4.0

### DIFF
--- a/ports/libunifex/portfile.cmake
+++ b/ports/libunifex/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookexperimental/libunifex
     REF "v${VERSION}"
-    SHA512 91a02d50e45c0458e25bd51c50fb6e98a668298733a3e66e8eb5353b0a5ea78a3656fe83b873e0ea50b26c6a7de572a663160b458c0fb1272ffa8bfd7715d1cc
+    SHA512 9625a248b9ed43f7ac8e3da054020e7c5c71d3da253cfa587ee62eb8a1d4cfee794758b7d28896e4038c1924b204c92be7230c20cf525684e2c304ceaa4a6321
     HEAD_REF main
     PATCHES
         fix-compile-error.patch

--- a/ports/libunifex/vcpkg.json
+++ b/ports/libunifex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libunifex",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Unified Executors",
   "homepage": "https://github.com/facebookexperimental/libunifex",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4989,7 +4989,7 @@
       "port-version": 0
     },
     "libunifex": {
-      "baseline": "0.3.0",
+      "baseline": "0.4.0",
       "port-version": 0
     },
     "libunistring": {

--- a/versions/l-/libunifex.json
+++ b/versions/l-/libunifex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7524481edfefbd5145b3a1d5a4caad55601e714",
+      "version": "0.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c60e3416d322f4e80f25e565190f679c99967931",
       "version": "0.3.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

