### PR TITLE
[reactiveplusplus] update to 2.0.0

### DIFF
--- a/ports/reactiveplusplus/portfile.cmake
+++ b/ports/reactiveplusplus/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO victimsnino/ReactivePlusPlus
     REF "v${VERSION}"
-    SHA512 24bc81cf6b26ed994f0740140dedcca2fa794f28e1c59cb6ddb876286a65678dcc849ea7e3ce8d71eb12e1d210eaa2f3e913e0f4e6fc7414e3afaa82c3e0b06a
+    SHA512 b19a164bf19f787ca182f88a616317eea122b76fea9ab0b90b2fe05e30ab94a7540b33aef1156003141dd4b0bc30b41bf2dc224a8cbe31707ab111bcfd7a3c5b
     HEAD_REF master
 )
 

--- a/ports/reactiveplusplus/vcpkg.json
+++ b/ports/reactiveplusplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "reactiveplusplus",
-  "version": "0.2.3",
+  "version": "2.0.0",
   "description": "ReactivePlusPlus is reactive programming library for C++ language",
   "homepage": "https://github.com/victimsnino/ReactivePlusPlus",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7469,7 +7469,7 @@
       "port-version": 0
     },
     "reactiveplusplus": {
-      "baseline": "0.2.3",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "readerwriterqueue": {

--- a/versions/r-/reactiveplusplus.json
+++ b/versions/r-/reactiveplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "774134fb825ed931da1baa9285611c9a6c606fb5",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5c5e055740d26b07149cc34e3dc41ef0674844b2",
       "version": "0.2.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

