### PR TITLE
[libde265] Update to 1.0.15

### DIFF
--- a/ports/libde265/portfile.cmake
+++ b/ports/libde265/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO strukturag/libde265
     REF "v${VERSION}"
-    SHA512 670482a5304635847d338eb49af18732a71bcc72eb52d77ca558f1f60e1fc6caabd293a02a700badc211cac7b5e14715d6c7810d766fa1f132dd0b4dfc22059a
+    SHA512 df380f1ea6345e20ed1f907df3c7cdaaac44358a6746e29e16699005783ce96524d30fec7bba457c9f9773a6373250aaaf0b9cd41224057b269798117964b8b5
     HEAD_REF master
     PATCHES
         fix-interface-include.patch

--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libde265",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4225,7 +4225,7 @@
       "port-version": 1
     },
     "libde265": {
-      "baseline": "1.0.14",
+      "baseline": "1.0.15",
       "port-version": 0
     },
     "libdeflate": {

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "386663192fc988e45cc4c16378b3a5a0549a7366",
+      "version": "1.0.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "f66d0188266eee664296198145c0380a1557915d",
       "version": "1.0.14",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36421

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```