### PR TITLE
[cpprestsdk] Add winpplx feature

### DIFF
--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -18,6 +18,11 @@ if(NOT VCPKG_TARGET_IS_UWP)
         -DWEBSOCKETPP_CONFIG_VERSION=${WEBSOCKETPP_PATH})
 endif()
 
+if ("winpplx" IN_LIST FEATURES)
+    list(APPEND OPTIONS
+        -DCPPREST_PPLX_IMPL="winpplx")
+endif()
+
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     INVERTED_FEATURES

--- a/ports/cpprestsdk/vcpkg.json
+++ b/ports/cpprestsdk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cpprestsdk",
   "version": "2.10.19",
+  "port-version": 1,
   "description": [
     "C++11 JSON, REST, and OAuth library",
     "The C++ REST SDK is a Microsoft project for cloud-based client-server communication in native code using a modern asynchronous C++ API design. This project aims to help C++ developers connect to and interact with services."

--- a/ports/cpprestsdk/vcpkg.json
+++ b/ports/cpprestsdk/vcpkg.json
@@ -111,6 +111,9 @@
           "platform": "!uwp"
         }
       ]
+    },
+    "winpplx": {
+      "description": "Usage of Winpplx for CPPREST_PPLX_IMPL"
     }
   }
 }

--- a/ports/cpprestsdk/vcpkg.json
+++ b/ports/cpprestsdk/vcpkg.json
@@ -114,7 +114,8 @@
       ]
     },
     "winpplx": {
-      "description": "Usage of Winpplx for CPPREST_PPLX_IMPL"
+      "description": "Usage of Winpplx for CPPREST_PPLX_IMPL",
+      "supports": "windows"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1890,7 +1890,7 @@
     },
     "cpprestsdk": {
       "baseline": "2.10.19",
-      "port-version": 0
+      "port-version": 1
     },
     "cppslippi": {
       "baseline": "1.3.3.14",

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eee3e86a0ebed0c5890b544ab7fc42b72396b375",
+      "version": "2.10.19",
+      "port-version": 1
+    },
+    {
       "git-tree": "110c2c2a08e520877aa3fa9231ab69e0a76f388d",
       "version": "2.10.19",
       "port-version": 0

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eee3e86a0ebed0c5890b544ab7fc42b72396b375",
+      "git-tree": "b5e1b644a3eb5339bb83847cebd79122be854b4e",
       "version": "2.10.19",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


