### PR TITLE
[libnick] Update to 2024.2.0

### DIFF
--- a/ports/libnick/portfile.cmake
+++ b/ports/libnick/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NickvisionApps/libnick
     REF "${VERSION}"
-    SHA512 1f345afd0c17b719b41a5a3f364e849c42c371014bad2681af0ff35e8b727da2485350f248746928f9a5da321c7eb3a8a2c810a3d722af7c2049876a4bab2778
+    SHA512 e3bf73cd61440d5bed001ae0ec6c6b9214f160da3e2808ea63def22e7ac0aa7bea0c6db5143d51f55be2cf3e4ede3f08fe468bf02e19e0f624a823a1d32c5ad3
     HEAD_REF main
 )
 
@@ -21,6 +21,7 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libnick)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_copy_pdbs()
 

--- a/ports/libnick/vcpkg.json
+++ b/ports/libnick/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libnick",
-  "version": "2024.1.6",
+  "version": "2024.2.0",
   "maintainers": "Nicholas Logozzo nlogozzo225@gmail.com",
   "description": "A cross-platform base for native Nickvision applications.",
   "homepage": "https://github.com/NickvisionApps/libnick",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4613,7 +4613,7 @@
       "port-version": 3
     },
     "libnick": {
-      "baseline": "2024.1.6",
+      "baseline": "2024.2.0",
       "port-version": 0
     },
     "libnoise": {

--- a/versions/l-/libnick.json
+++ b/versions/l-/libnick.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e57df1f6c0ed8e765854d4caf3f9b5d354f77d6f",
+      "version": "2024.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e500915440f276fc2e525223ead70aea6ad40374",
       "version": "2024.1.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.