### PR TITLE
[json-dto] Update to 0.3.3

### DIFF
--- a/ports/json-dto/portfile.cmake
+++ b/ports/json-dto/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stiffstream/json_dto
     REF "v.${VERSION}"
-    SHA512 476091f78f0c3b2dd0da2a83964fbf280259c163f058b2578eb17055fce0a2162e14bbea12e3bbdef93afda1f1c9f48a91e570f8f5e0f53a58a4f7188ebd437e
+    SHA512 18e135c5a45c4421e6ae17955e042056890270717963008c4e0cba94f6dfe240fa7ea84991319ff88359abf0688ca32ed7c9783e575eca4a20b5694558a49c3d
 )
 
 vcpkg_cmake_configure(

--- a/ports/json-dto/vcpkg.json
+++ b/ports/json-dto/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "json-dto",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A small header-only library for converting data between json representation and c++ structs.",
   "homepage": "https://github.com/Stiffstream/json_dto",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3689,7 +3689,7 @@
       "port-version": 3
     },
     "json-dto": {
-      "baseline": "0.3.2",
+      "baseline": "0.3.3",
       "port-version": 0
     },
     "json-rpc-cxx": {

--- a/versions/j-/json-dto.json
+++ b/versions/j-/json-dto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f087895b63b47221f3f3bca7c2b300c05817f0be",
+      "version": "0.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "217034e6dfd4139a952dea7e21091522367f8189",
       "version": "0.3.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- ~~[ ] The "supports" clause reflects platforms that may be fixed by this new version~~.
- ~~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file~~.
- ~~[ ] Any patches that are no longer applied are deleted from the port's directory~~.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
