### PR TITLE
[baresip-libre] update to version 3.9.0

### DIFF
--- a/ports/baresip-libre/fix-static-library-build.patch
+++ b/ports/baresip-libre/fix-static-library-build.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 03c82fb..cce8694 100644
+index 84a507f..d400e3b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -99,7 +99,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -20,46 +20,7 @@ index 03c82fb..cce8694 100644
    target_include_directories(re PUBLIC
      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
    )
-@@ -656,6 +656,9 @@ if(LIBRE_BUILD_STATIC)
- 
-   if(MSVC)
-     set_target_properties(re PROPERTIES OUTPUT_NAME "re-static")
-+    if(NOT LIBRE_BUILD_SHARED)
-+      set(PC_LIBNAME "re-static")
-+    endif()
-   endif()
- endif()
- 
-@@ -668,6 +671,28 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-   add_subdirectory(packaging)
- endif()
- 
-+if(NOT PC_LIBNAME)
-+  set(PC_LIBNAME "re")
-+endif()
-+set(PC_REQUIRES "")
-+set(PC_LINKLIBS "")
-+foreach(item IN LISTS LINKLIBS)
-+  if(item STREQUAL "Threads::Threads")
-+    list(APPEND PC_LINKLIBS ${CMAKE_THREADS_LIBS_INIT})
-+  elseif(item STREQUAL "OpenSSL::Crypto")
-+    list(APPEND PC_REQUIRES "libcrypto")
-+  elseif(item STREQUAL "OpenSSL::SSL")
-+    list(APPEND PC_REQUIRES "libssl")
-+  elseif(item STREQUAL "ZLIB::ZLIB")
-+    list(APPEND PC_REQUIRES "zlib")
-+  elseif(item MATCHES "^-|/")
-+    list(APPEND PC_LINKLIBS "${item}")
-+  else()
-+    list(APPEND PC_LINKLIBS "-l${item}")
-+  endif()
-+endforeach()
-+list(JOIN PC_LINKLIBS " " PC_LINKLIBS)
-+list(JOIN PC_REQUIRES " " PC_REQUIRES)
- configure_file(packaging/libre.pc.in libre.pc @ONLY)
- 
- 
-@@ -679,6 +704,9 @@ configure_file(packaging/libre.pc.in libre.pc @ONLY)
+@@ -704,6 +704,9 @@ configure_file(packaging/libre.pc.in libre.pc @ONLY)
  
  install(TARGETS ${RE_INSTALL_TARGETS}
    EXPORT libre
@@ -69,7 +30,7 @@ index 03c82fb..cce8694 100644
    LIBRARY
      DESTINATION ${CMAKE_INSTALL_LIBDIR}
      COMPONENT Libraries
-@@ -697,7 +725,9 @@ install(FILES ${HEADERS}
+@@ -722,7 +725,9 @@ install(FILES ${HEADERS}
  
  install(EXPORT libre
    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libre
@@ -79,7 +40,7 @@ index 03c82fb..cce8694 100644
  )
  
  if(LIBRE_BUILD_SHARED)
-@@ -709,12 +739,8 @@ if(LIBRE_BUILD_SHARED)
+@@ -734,12 +739,8 @@ if(LIBRE_BUILD_SHARED)
    )
  endif()
  
@@ -123,17 +84,3 @@ index 0965b84..e8548a0 100644
 +        set_target_properties(libre::libre PROPERTIES INTERFACE_LINK_LIBRARIES libre::re)
 +    endif()
 +endif()
-diff --git a/packaging/libre.pc.in b/packaging/libre.pc.in
-index 5817066..2df8f6c 100644
---- a/packaging/libre.pc.in
-+++ b/packaging/libre.pc.in
-@@ -7,6 +7,7 @@ Name: libre
- Description: @CMAKE_PROJECT_DESCRIPTION@
- Version: @PROJECT_VERSION@
- URL: @CMAKE_PROJECT_HOMEPAGE_URL@
--Libs: -L${libdir} -lre
--Libs.private: -L${libdir} -lre -ldl -lssl -lcrypto -lz -lpthread
-+Libs: -L${libdir} -l@PC_LIBNAME@
-+Libs.private: @PC_LINKLIBS@
-+Requires.private: @PC_REQUIRES@
- Cflags: -I${includedir}

--- a/ports/baresip-libre/portfile.cmake
+++ b/ports/baresip-libre/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO baresip/re
     REF "v${VERSION}"
-    SHA512 7c03502aae0424bb05e03320c2497de0ec534d872334fe16ec0a688efbc1cc493ad1774e9802e0dc58bb396b4b8a065f3e338deeff4dd1ddd87cb76793e82306
+    SHA512 d19fc5c48399ad4942c27d86c47350f579f8ebeaf8dc04b13a930b930c13a20e5e7dd5f0fe05d11b6b365667d8306f2499f5cb925850f4484049ba853d36b0b1
     HEAD_REF main
     PATCHES
         fix-static-library-build.patch

--- a/ports/baresip-libre/vcpkg.json
+++ b/ports/baresip-libre/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "baresip-libre",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Generic library for real-time communications with async IO support",
   "homepage": "https://github.com/baresip/re",
   "license": "BSD-3-Clause",

--- a/versions/b-/baresip-libre.json
+++ b/versions/b-/baresip-libre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b7cfa061bebae8f9628f0d56ca21de4ec1c68fa",
+      "version": "3.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "eac42649337bc140a827e4ae83eb7ec1ccac3917",
       "version": "3.8.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -525,7 +525,7 @@
       "port-version": 0
     },
     "baresip-libre": {
-      "baseline": "3.8.0",
+      "baseline": "3.9.0",
       "port-version": 0
     },
     "basisu": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
