### PR TITLE
[libqglviewer] Fix error C2039 when build port with VS2019

### DIFF
--- a/ports/libqglviewer/Fix-error-c2039.patch
+++ b/ports/libqglviewer/Fix-error-c2039.patch
@@ -1,0 +1,52 @@
+diff --git a/QGLViewer/VRender/NVector3.h b/QGLViewer/VRender/NVector3.h
+index 40b7f98..f2d8305 100644
+--- a/QGLViewer/VRender/NVector3.h
++++ b/QGLViewer/VRender/NVector3.h
+@@ -7,6 +7,8 @@
+ namespace vrender
+ {
+   class Vector3;
++  class NVector3;
++  std::ostream& operator<<(std::ostream &out,const NVector3 &u);
+ 
+   class NVector3
+   {
+diff --git a/QGLViewer/VRender/Primitive.h b/QGLViewer/VRender/Primitive.h
+index 88ab11d..d38470d 100644
+--- a/QGLViewer/VRender/Primitive.h
++++ b/QGLViewer/VRender/Primitive.h
+@@ -21,6 +21,7 @@ namespace vrender
+ {
+ 	class Feedback3DColor ;
+ 	class Primitive ;
++    std::ostream& operator<<(std::ostream&, const Feedback3DColor&) ;
+ 
+ #define EPS_SMOOTH_LINE_FACTOR 0.06  /* Lower for better smooth lines. */
+ 
+diff --git a/QGLViewer/VRender/Vector2.h b/QGLViewer/VRender/Vector2.h
+index f6aaaf3..7b9b82a 100644
+--- a/QGLViewer/VRender/Vector2.h
++++ b/QGLViewer/VRender/Vector2.h
+@@ -6,7 +6,9 @@
+ 
+ namespace vrender
+ {
++  class Vector2;
+   class Vector3;
++  std::ostream& operator<< (std::ostream&,const Vector2&);
+ 
+   class Vector2
+ 	{
+diff --git a/QGLViewer/VRender/Vector3.h b/QGLViewer/VRender/Vector3.h
+index 32597e8..f6d5099 100644
+--- a/QGLViewer/VRender/Vector3.h
++++ b/QGLViewer/VRender/Vector3.h
+@@ -10,6 +10,8 @@
+ namespace vrender
+ {
+   class NVector3;
++  class Vector3;
++  std::ostream& operator<< (std::ostream&, const Vector3&);
+ 
+ 	class Vector3
+ 	{

--- a/ports/libqglviewer/portfile.cmake
+++ b/ports/libqglviewer/portfile.cmake
@@ -1,10 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GillesDebunne/libQGLViewer
-    REF v2.9.1
+    REF "v${VERSION}"
     SHA512 09bfc5c0f07e51625a9af0094b83f40f84ead55a67c6e492c9702521f58c6b461bc840382fb73b64d16ad71a0a2a75d04aa12a77a78ced0a19e0e784e8d36bd7
     PATCHES
         Add-compile-definitions.patch
+        Fix-error-c2039.patch #https://github.com/GillesDebunne/libQGLViewer/pull/80
 )
 
 vcpkg_cmake_configure(
@@ -17,4 +18,4 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/LICENCE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libqglviewer RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENCE")

--- a/ports/libqglviewer/vcpkg.json
+++ b/ports/libqglviewer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libqglviewer",
   "version": "2.9.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libQGLViewer is an open source C++ library based on Qt that eases the creation of OpenGL 3D viewers.",
   "homepage": "http://libqglviewer.com/",
   "license": "GPL-2.0-or-later",
@@ -13,10 +13,6 @@
     },
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4742,7 +4742,7 @@
     },
     "libqglviewer": {
       "baseline": "2.9.1",
-      "port-version": 1
+      "port-version": 2
     },
     "libqrencode": {
       "baseline": "4.1.1",

--- a/versions/l-/libqglviewer.json
+++ b/versions/l-/libqglviewer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bfaae9deb95ec0d71a5d9ba8342fd3c83c8871fa",
+      "version": "2.9.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "fb8cb610ce82055671ffb7e84836da4a02cc3127",
       "version": "2.9.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/36465

This issue is a known issue of upstream https://github.com/GillesDebunne/libQGLViewer/issues/67

No feature need to be tested.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
