### PR TITLE
[hello_imgui] New port

### DIFF
--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -1,0 +1,126 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY) # this mirrors ImGui's portfile behavior
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO pthom/hello_imgui
+    REF b9bdca77cb58bd879228f34a9bcf1f1c2e6b96bd
+    SHA512 2044fb34bdd64377335e46802f8546ccc30077e84f122c895b820bef0d692f62e1c5bc175cf8003c518db2bc0f1e07ed94bf1ccdc4a4720b7c0e0812c192bf7f
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    "opengl3-binding" HELLOIMGUI_HAS_OPENGL3
+    "metal-binding" HELLOIMGUI_HAS_METAL
+    "experimental-vulkan-binding" HELLOIMGUI_HAS_VULKAN
+    "experimental-dx11-binding" HELLOIMGUI_HAS_DIRECTX11
+    "experimental-dx12-binding" HELLOIMGUI_HAS_DIRECTX12
+    "glfw-binding" HELLOIMGUI_USE_GLFW3
+    "sdl2-binding" HELLOIMGUI_USE_SDL2
+    "freetype-lunasvg" HELLOIMGUI_USE_FREETYPE # When hello_imgui is built with freetype, it will also build with lunasvg
+)
+
+if (NOT HELLOIMGUI_HAS_OPENGL3
+    AND NOT HELLOIMGUI_HAS_METAL
+    AND NOT HELLOIMGUI_HAS_VULKAN
+    AND NOT HELLOIMGUI_HAS_DIRECTX11
+    AND NOT HELLOIMGUI_HAS_DIRECTX12)
+    set(no_rendering_backend ON)
+endif()
+
+if (NOT HELLOIMGUI_USE_GLFW3 AND NOT HELLOIMGUI_USE_SDL2)
+    set(no_platform_backend ON)
+endif()
+
+
+set(platform_options "")
+if(WIN32)
+    # Standard win32 options (these are the defaults for HelloImGui)
+    # we could add a vcpkg feature for this, but it would have to be platform specific
+    list(APPEND platform_options
+        -DHELLOIMGUI_WIN32_NO_CONSOLE=ON
+        -DHELLOIMGUI_WIN32_AUTO_WINMAIN=ON
+    )
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    # Standard macOS options (these are the defaults for HelloImGui)
+    # we could add a vcpkg feature for this, but it would have to be platform specific
+    list(APPEND platform_options
+        -DHELLOIMGUI_MACOS_NO_BUNDLE=OFF
+    )
+endif()
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DHELLOIMGUI_BUILD_DEMOS=OFF
+        -DHELLOIMGUI_BUILD_DOCS=OFF
+        -DHELLOIMGUI_BUILD_TESTS=OFF
+
+        # vcpkg does not support ImGui Test Engine, so we cannot enable it
+        -DHELLOIMGUI_WITH_TEST_ENGINE=OFF
+
+        -DHELLOIMGUI_USE_IMGUI_CMAKE_PACKAGE=ON
+        -DHELLO_IMGUI_IMGUI_SHARED=OFF
+        -DHELLOIMGUI_BUILD_IMGUI=OFF
+
+        ${platform_options}
+
+        # Rendering backends
+        -DHELLOIMGUI_HAS_OPENGL3=${HELLOIMGUI_HAS_OPENGL3}
+        -DHELLOIMGUI_HAS_METAL=${HELLOIMGUI_HAS_METAL}
+        -DHELLOIMGUI_HAS_VULKAN=${HELLOIMGUI_HAS_VULKAN}
+        -DHELLOIMGUI_HAS_DIRECTX11=${HELLOIMGUI_HAS_DIRECTX11}
+        -DHELLOIMGUI_HAS_DIRECTX12=${HELLOIMGUI_HAS_DIRECTX12}
+
+        # Platform backends
+        -DHELLOIMGUI_USE_GLFW3=${HELLOIMGUI_USE_GLFW3}
+        -DHELLOIMGUI_USE_SDL2=${HELLOIMGUI_USE_SDL2}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/hello_imgui PACKAGE_NAME "hello-imgui")  # should be active once himgui produces a config
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/hello-imgui/hello_imgui_cmake/ios-cmake"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+if (no_rendering_backend OR no_platform_backend)
+    message(STATUS "
+    ########################################################################
+       !!!!                    WARNING                              !!!!!
+       !!!!   Installed hello-imgui without a viable backend        !!!!!
+    ########################################################################
+
+    When installing hello-imgui, you should specify:
+
+     - At least one (or more) rendering backend (OpenGL3, Metal, Vulkan, DirectX11, DirectX12)
+       Make your choice according to your needs and your target platforms, between:
+          opengl3-binding              # This is the recommended choice, especially for beginners
+          metal-binding                # Apple only, advanced users only
+          experimental-vulkan-binding  # Advanced users only
+          experimental-dx11-binding    # Windows only, still experimental
+          experimental-dx12-binding    # Windows only, advanced users only, still experimental
+
+     - At least one (or more) platform backend (SDL2, Glfw3):
+      Make your choice according to your needs and your target platforms, between:
+          glfw-binding
+          sdl-binding
+
+    For example, you could use:
+        vcpkg install \"hello-imgui[opengl3-binding,glfw-binding]\"
+
+    ########################################################################
+       !!!!                    WARNING                              !!!!!
+       !!!!   Installed hello-imgui without a viable backend        !!!!!
+    ########################################################################
+    ")
+endif()

--- a/ports/hello-imgui/usage
+++ b/ports/hello-imgui/usage
@@ -1,0 +1,17 @@
+hello_imgui provides CMake targets and hello_imgui_add_app:
+
+Usage with `hello_imgui_add_app` (recommended)
+    set(CMAKE_CXX_STANDARD 17)
+    find_package(hello-imgui CONFIG REQUIRED)
+    hello_imgui_add_app(test test.cpp)      # see example below
+
+Usage with `target_link_libraries`
+    set(CMAKE_CXX_STANDARD 17)
+    find_package(hello-imgui CONFIG REQUIRED)
+    # Note the subtle difference between the package name and the target name: hello-imgui vs hello_imgui!
+    target_link_libraries(main PRIVATE hello-imgui::hello_imgui)
+    # this mode will ignore all of hello_imgui cmake tooling, and will not deploy the assets
+
+Example test.cpp:
+    #include "hello_imgui/hello_imgui.h"
+    int main() { HelloImGui::Run([](){ ImGui::Text("Hello, world!"); ImGui::ShowDemoWindow(); }); }

--- a/ports/hello-imgui/vcpkg.json
+++ b/ports/hello-imgui/vcpkg.json
@@ -1,0 +1,121 @@
+{
+  "name": "hello-imgui",
+  "version": "1.4.2",
+  "description": "Hello ImGui: unleash your creativity in app development and prototyping",
+  "homepage": "https://pthom.github.io/hello_imgui/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "imgui",
+      "features": [
+        "docking-experimental"
+      ]
+    },
+    "stb",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "experimental-dx11-binding": {
+      "description": "Use DirectX11 renderer backend (Windows only, experimental)",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "dx11-binding"
+          ]
+        }
+      ]
+    },
+    "experimental-dx12-binding": {
+      "description": "Use DirectX12 renderer backend (Windows only, experimental)",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "dx12-binding"
+          ]
+        }
+      ]
+    },
+    "experimental-vulkan-binding": {
+      "description": "Use Vulkan renderer backend (Windows/Linux/macOS, experimental)",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "vulkan-binding"
+          ]
+        }
+      ]
+    },
+    "freetype-lunasvg": {
+      "description": "Improve font rendering and use colored fonts with freetype and lunasvg",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "freetype",
+            "freetype-lunasvg"
+          ]
+        }
+      ]
+    },
+    "glfw-binding": {
+      "description": "Use GLFW platform backend (default)",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "glfw-binding"
+          ]
+        }
+      ]
+    },
+    "metal-binding": {
+      "description": "Use Metal renderer backend (macOS/iOS only)",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "metal-binding"
+          ]
+        }
+      ]
+    },
+    "opengl3-binding": {
+      "description": "Use OpenGL3/ES2 renderer backend (default)",
+      "dependencies": [
+        {
+          "name": "glad",
+          "features": [
+            "gl-api-43"
+          ]
+        },
+        {
+          "name": "imgui",
+          "features": [
+            "opengl3-binding"
+          ]
+        }
+      ]
+    },
+    "sdl2-binding": {
+      "description": "Use SDL2 platform backend",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "sdl2-binding"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3332,6 +3332,10 @@
       "baseline": "15",
       "port-version": 0
     },
+    "hello-imgui": {
+      "baseline": "1.4.2",
+      "port-version": 0
+    },
     "hexl": {
       "baseline": "1.2.4",
       "port-version": 0

--- a/versions/h-/hello-imgui.json
+++ b/versions/h-/hello-imgui.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5ecf61526918746249b229e66d820f4da98e0c5a",
+      "version": "1.4.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This port adds support for [hello_imgui](https://pthom.github.io/hello_imgui), whose source is found [on github](https://github.com/pthom/hello_imgui)

---

## New port checklist

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md). 
=> See question below about default features

- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
=> See remarks below

- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.

---

### Solved issues

**~~[Default features](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md#default-features-should-enable-behaviors-not-apis)~~**

~~By default, these features are active:    "glfw-binding", "opengl3-binding". They are needed if we want the default install to be functional. They select a render + platform backend combination. Outside of vcpkg, hello_imgui auto-selects this backend combination when no choice is made. Should they be removed, and in this case, should the default install be non functional? The install of hello_imgui would fail if no backend is selected, as it is an app development toolkit, and no app can be developed without a backend.~~

Update: this is solved. No default feature is selected. The default install does not install any feature.


 ~~**[Do not use features to implement alternatives](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md#do-not-use-features-to-implement-alternatives)**~~

~~this poses an issue because hello_imgui cannot handle several concurrent rendering backends (having both opengl3-binding and metal-binding would lead to compilation errors for example). See [this extract](https://github.com/pthom/hello_imgui/blob/63f82f48667911c146a137061c593d008d009286/hello_imgui_cmake/hello_imgui_build_lib.cmake#L717-L743) of hello_imgui cmake tooling.Feedback welcome on this point.~~

Update: this is solved, now all features are compatible between them, since Hello ImGui now accepts any combination of renderer + platform backend.


---
### About the usage text:
The usage file is a bit longer than others, but accurate and to the point. Here is its content:
```
hello_imgui provides CMake targets and hello_imgui_add_app:

Usage with `hello_imgui_add_app` (recommended)
    set(CMAKE_CXX_STANDARD 17)
    find_package(hello-imgui CONFIG REQUIRED)
    hello_imgui_add_app(test test.cpp)      # see example below

Usage with `target_link_libraries`
    set(CMAKE_CXX_STANDARD 17)
    find_package(hello_imgui CONFIG REQUIRED)
    # Note the subtle difference between the package name and the target name: hello-imgui vs hello_imgui!
    target_link_libraries(main PRIVATE hello-imgui::hello_imgui)
    # this mode will ignore all of hello_imgui cmake tooling, and will not deploy the assets

Example test.cpp:
    #include "hello_imgui/hello_imgui.h"
    int main() { HelloImGui::Run([](){ ImGui::Text("Hello, world!"); ImGui::ShowDemoWindow(); }); }
```


---


### Note: some CI is already active in the hello_imgui repo:

(Click on the badges to see the github actions results)

VcpkgDeps checks that hello_imgui can be installed by using dependencies from vcpkg:
[![VcpkgDeps](https://github.com/pthom/hello_imgui/workflows/VcpkgDeps/badge.svg)](https://github.com/pthom/hello_imgui/actions/workflows/VcpkgDeps.yml)


[![VcpkgPackage](https://github.com/pthom/hello_imgui/workflows/VcpkgPackage/badge.svg)](https://github.com/pthom/hello_imgui/actions/workflows/VcpkgPackage.yml)

VcpkgPackage checks that:
 1. the vcpkg package build successfully (using [an overlay](https://github.com/pthom/hello_imgui/tree/master/hello_imgui_cmake/overlay_vcpkg/hello-imgui))
    - on all platforms
    - for all rendering bindings (opengl3-binding, metal-binding, opengl3-binding, vulkan-binding, dx11-binding, dx12-binding)
    - for all window backends (glfw-binding, sdl2-binding)
    - with all optional dependencies (freetype, freetype-lunasvg)
 2. An app can be built with hello_imgui as a vcpkg package
    (with all combinations of rendering bindings, window backends, optional dependencies)
 3. An app can be run
    (only on selected backends and platforms)

---

## Status on all platforms

### macOS

#### Status from automated checks (VcpkgPackage action)
Successful Builds:
build opengl3-binding
build metal-binding

#### Additional status from manual checks
Successful Builds and Runs:
opengl3-binding, glfw and sdl
metal-binding, glfw and sdl
vulkan-binding, glfw


### Linux

#### Status from automated checks (VcpkgPackage action)

Successful Builds:
build opengl3-binding
build vulkan-binding

Successful Runs: 
run test app (Glfw - opengl3-binding)
run test app (SDL - opengl3-binding)

I could not test the vulkan app (using a mac M1 where Vulkan does not work on Parallels)


### Windows

#### Status from automated checks (VcpkgPackage action)

Successful Builds:
build opengl3-binding
build vulkan-binding
build dx11-binding
build dx12-binding

Successful Runs: 
run test app (Glfw - opengl3-binding)
run test app (SDL - opengl3-binding)
run test app (Glfw - dx11-binding)
run test app (SDL - dx11-binding)
run test app (Glfw - dx12-binding)

I could not test the vulkan apps (using a mac M1 where Vulkan does not work on Parallels)

