### PR TITLE
[shiftmedia-libgpg-error] Fix include path

### DIFF
--- a/ports/shiftmedia-libgpg-error/portfile.cmake
+++ b/ports/shiftmedia-libgpg-error/portfile.cmake
@@ -51,7 +51,7 @@ vcpkg_install_msbuild(
 )
 
 get_filename_component(SOURCE_PATH_SUFFIX "${SOURCE_PATH}" NAME)
-file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${SOURCE_PATH_SUFFIX}/msvc/include" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${SOURCE_PATH_SUFFIX}/msvc/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
 
 set(exec_prefix "\${prefix}")
 set(libdir "\${prefix}/lib")

--- a/ports/shiftmedia-libgpg-error/portfile.cmake
+++ b/ports/shiftmedia-libgpg-error/portfile.cmake
@@ -52,6 +52,7 @@ vcpkg_install_msbuild(
 
 get_filename_component(SOURCE_PATH_SUFFIX "${SOURCE_PATH}" NAME)
 file(RENAME "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${SOURCE_PATH_SUFFIX}/msvc/include" "${CURRENT_PACKAGES_DIR}/include")
+file(COPY ${INCLUDE_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 set(exec_prefix "\${prefix}")
 set(libdir "\${prefix}/lib")

--- a/ports/shiftmedia-libgpg-error/portfile.cmake
+++ b/ports/shiftmedia-libgpg-error/portfile.cmake
@@ -51,8 +51,7 @@ vcpkg_install_msbuild(
 )
 
 get_filename_component(SOURCE_PATH_SUFFIX "${SOURCE_PATH}" NAME)
-file(RENAME "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${SOURCE_PATH_SUFFIX}/msvc/include" "${CURRENT_PACKAGES_DIR}/include")
-file(COPY ${INCLUDE_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${SOURCE_PATH_SUFFIX}/msvc/include" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 set(exec_prefix "\${prefix}")
 set(libdir "\${prefix}/lib")

--- a/ports/shiftmedia-libgpg-error/vcpkg.json
+++ b/ports/shiftmedia-libgpg-error/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "shiftmedia-libgpg-error",
   "version": "1.45",
+  "port-version": 1,
   "description": "An unofficial libgpg-error with added native Visual Studio project system",
   "homepage": "https://github.com/ShiftMediaProject/libgpg-error",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7930,7 +7930,7 @@
     },
     "shiftmedia-libgpg-error": {
       "baseline": "1.45",
-      "port-version": 0
+      "port-version": 1
     },
     "shiva": {
       "baseline": "1.0",

--- a/versions/s-/shiftmedia-libgpg-error.json
+++ b/versions/s-/shiftmedia-libgpg-error.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e573df510581802b326bb246fc0ab2ee0de91ae5",
+      "git-tree": "980fe2b368e256297c645b1a326b460d7ffef016",
       "version": "1.45",
       "port-version": 1
     },

--- a/versions/s-/shiftmedia-libgpg-error.json
+++ b/versions/s-/shiftmedia-libgpg-error.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0dadcc0447c00db313377772239330dab767c65",
+      "version": "1.45",
+      "port-version": 1
+    },
+    {
       "git-tree": "194526ea5431d93f00f3e48d1ab2d0aad0e86c48",
       "version": "1.45",
       "port-version": 0

--- a/versions/s-/shiftmedia-libgpg-error.json
+++ b/versions/s-/shiftmedia-libgpg-error.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e0dadcc0447c00db313377772239330dab767c65",
+      "git-tree": "e573df510581802b326bb246fc0ab2ee0de91ae5",
       "version": "1.45",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36490

Fixed the compilation error when the source specified in the --x-buildtrees-root command is not on the same disk.
```
CMake Error at ports/shiftmedia-libgpg-error/portfile.cmake:54 (file):
  file RENAME failed to rename

    F:/vcpkg/shiftmedia-libgpg-error/x64-windows-rel/error-1.45-995040f7c8.clean/msvc/include

  to

    D:/vcpkg/packages/shiftmedia-libgpg-error_x64-windows/include

  because: The system cannot move the file to a different disk drive.
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
```
