### PR TITLE
[google-cloud-cpp] update to the latest release (v2.21.0)

### DIFF
--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.20.0",
-  "port-version": 1,
+  "version": "2.21.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -1195,6 +1194,18 @@
     },
     "servicedirectory": {
       "description": "Service Directory API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "servicehealth": {
+      "description": "Personalized Service Health API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3081,8 +3081,8 @@
       "port-version": 7
     },
     "google-cloud-cpp": {
-      "baseline": "2.20.0",
-      "port-version": 1
+      "baseline": "2.21.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f952e2d4eb29bc583991988cc4fe3ba17522669",
+      "git-tree": "a7c7a0afd0c2b29a456d53069d6083c4bb2f6e7d",
       "version": "2.21.0",
       "port-version": 0
     },

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f952e2d4eb29bc583991988cc4fe3ba17522669",
+      "version": "2.21.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "363eb6725f35aaefdbd1da17ab0a3d1bd93e90cd",
       "version": "2.20.0",
       "port-version": 1

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7c7a0afd0c2b29a456d53069d6083c4bb2f6e7d",
+      "git-tree": "d8f3be8b308c4858ec0226b7aebe1e55a21298f4",
       "version": "2.21.0",
       "port-version": 0
     },


### PR DESCRIPTION
Updates google-cloud-cpp to the latest release (v2.21.0).

---

Refactor to reduce duplication. Also install mock libraries for features that have them. e.g.
```
google-cloud-cpp provides CMake targets:

  find_package(google_cloud_cpp_dialogflow_es_mocks CONFIG REQUIRED)
  target_link_libraries(main PRIVATE google-cloud-cpp::dialogflow_es_mocks)

google-cloud-cpp provides pkg-config modules:

    # Mocks for the Dialogflow API C++ Client Library
    google_cloud_cpp_dialogflow_es_mocks
```

---

Tested locally (on x64-linux) with:

```sh
for feature in "servicehealth" "dialogflow-cx" "dialogflow-es"; do ./vcpkg remove google-cloud-cpp; ./vcpkg install "google-cloud-cpp[core,${feature}]" || break; done
```
and
```sh
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'
```

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
