### PR TITLE
[libdwarf] Update to v0.9.0

### DIFF
--- a/ports/cpptrace/libdwarf-0.9.0.diff
+++ b/ports/cpptrace/libdwarf-0.9.0.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 418afae..4e94083 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -350,7 +350,7 @@ if(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF)
+   if(CPPTRACE_CONAN)
+     target_link_libraries(${target_name} PRIVATE libdwarf::libdwarf)
+   elseif(CPPTRACE_VCPKG)
+-    target_link_libraries(${target_name} PRIVATE $<IF:$<TARGET_EXISTS:libdwarf::dwarf-static>,libdwarf::dwarf-static,libdwarf::dwarf-shared>)
++    target_link_libraries(${target_name} PRIVATE libdwarf::dwarf)
+   else()
+     target_link_libraries(${target_name} PRIVATE libdwarf::dwarf-static)
+   endif()

--- a/ports/cpptrace/portfile.cmake
+++ b/ports/cpptrace/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 732f8f70d9c8f01d10802bbb1da150d75b93c15fa0299bb84ba5be87d0da52ebe3b637e382a044c8d1e4ea283fae84c008113fc1f17ec4224692d5d911ab45d7
     HEAD_REF main
+    PATCHES
+      libdwarf-0.9.0.diff
 )
 
 vcpkg_cmake_configure(

--- a/ports/libdwarf/dependencies.diff
+++ b/ports/libdwarf/dependencies.diff
@@ -8,9 +8,9 @@ index f444af27..d021d919 100644
  
 +find_package(zstd CONFIG REQUIRED)
 +if(TARGET zstd::libzstd_shared)
-+  add_library(ZSTD::ZSTD ALIAS zstd::libzstd_shared)
++  set(ZSTD_LIB zstd::libzstd_shared)
 +else()
-+  add_library(ZSTD::ZSTD ALIAS zstd::libzstd_static)
++  set(ZSTD_LIB zstd::libzstd_static)
 +endif()
 +
  message(STATUS "CMAKE_SIZEOF_VOID_P ... " ${CMAKE_SIZEOF_VOID_P} )

--- a/ports/libdwarf/dependencies.diff
+++ b/ports/libdwarf/dependencies.diff
@@ -1,30 +1,23 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9e9b75f..fd5fbe3 100644
+index f444af27..d021d919 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -195,6 +195,20 @@ check_c_source_compiles([=[
-   }]=] HAVE_STDAFX_H)
- #message(STATUS "Checking have windows stdafx.h... ${HAVE_STDAFX_H}")
+@@ -189,6 +189,13 @@ if (ZLIB_FOUND AND ZSTD_FOUND )
+   set(HAVE_ZSTD_H TRUE)
+ endif()
  
-+find_package(ZLIB REQUIRED)
-+add_library(z ALIAS ZLIB::ZLIB)
-+set(HAVE_ZLIB 1)
-+set(HAVE_ZLIB_H 1)
-+
 +find_package(zstd CONFIG REQUIRED)
 +if(TARGET zstd::libzstd_shared)
-+  add_library(zstd ALIAS zstd::libzstd_shared)
++  add_library(ZSTD::ZSTD ALIAS zstd::libzstd_shared)
 +else()
-+  add_library(zstd ALIAS zstd::libzstd_static)
++  add_library(ZSTD::ZSTD ALIAS zstd::libzstd_static)
 +endif()
-+set(HAVE_ZSTD 1)
-+set(HAVE_ZSTD_H 1)
 +
- set(CMAKE_REQUIRED_LIBRARIES z)
- check_c_source_compiles( [=[
-   #include "zlib.h"
+ message(STATUS "CMAKE_SIZEOF_VOID_P ... " ${CMAKE_SIZEOF_VOID_P} )
+ 
+ #  DW_FWALLXX are gnu C++ options.
 diff --git a/src/lib/libdwarf/cmake/libdwarf-config.cmake b/src/lib/libdwarf/cmake/libdwarf-config.cmake
-index 604c563..5362360 100644
+index 604c563c..53623603 100644
 --- a/src/lib/libdwarf/cmake/libdwarf-config.cmake
 +++ b/src/lib/libdwarf/cmake/libdwarf-config.cmake
 @@ -1,3 +1,6 @@
@@ -35,12 +28,12 @@ index 604c563..5362360 100644
      include(${CMAKE_CURRENT_LIST_DIR}/libdwarf-targets.cmake)
  endif()
 diff --git a/src/lib/libdwarf/libdwarf.pc.cmake b/src/lib/libdwarf/libdwarf.pc.cmake
-index 6b18c77..5c97ce9 100644
+index 6b18c77c..8862d5b4 100644
 --- a/src/lib/libdwarf/libdwarf.pc.cmake
 +++ b/src/lib/libdwarf/libdwarf.pc.cmake
-@@ -9,4 +9,5 @@ Description: DWARF debug symbols library
+@@ -9,4 +9,4 @@ Description: DWARF debug symbols library
  Version: @PACKAGE_VERSION@
  Libs: -L${libdir} -ldwarf
  Cflags: -I${includedir}
+-
 +Requires.private: zlib libzstd
- 

--- a/ports/libdwarf/dependencies.diff
+++ b/ports/libdwarf/dependencies.diff
@@ -16,6 +16,20 @@ index f444af27..d021d919 100644
  message(STATUS "CMAKE_SIZEOF_VOID_P ... " ${CMAKE_SIZEOF_VOID_P} )
  
  #  DW_FWALLXX are gnu C++ options.
+diff --git a/src/lib/libdwarf/CMakeLists.txt b/src/lib/libdwarf/CMakeLists.txt
+index 4ad5c4fb..ccc1c312 100644
+--- a/src/lib/libdwarf/CMakeLists.txt
++++ b/src/lib/libdwarf/CMakeLists.txt
+@@ -108,7 +108,7 @@ target_include_directories(dwarf PUBLIC
+     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+   )
+ if(ZLIB_FOUND AND ZSTD_FOUND)
+-  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ZSTD::ZSTD ) 
++  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ${ZSTD_LIB} ) 
+ endif()
+ 
+ set(SUFFIX $<$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>:64>)
+
 diff --git a/src/lib/libdwarf/cmake/libdwarf-config.cmake b/src/lib/libdwarf/cmake/libdwarf-config.cmake
 index 604c563c..53623603 100644
 --- a/src/lib/libdwarf/cmake/libdwarf-config.cmake

--- a/ports/libdwarf/no-suffix.diff
+++ b/ports/libdwarf/no-suffix.diff
@@ -12,15 +12,11 @@ index 6d2c328b..bc105813 100644
  endif()
  set(LIBDIR lib${SUFFIX})
 diff --git a/src/lib/libdwarf/CMakeLists.txt b/src/lib/libdwarf/CMakeLists.txt
-index 4ad5c4fb..a3d3f429 100644
+index ccc1c312..98ab2879 100644
 --- a/src/lib/libdwarf/CMakeLists.txt
 +++ b/src/lib/libdwarf/CMakeLists.txt
-@@ -108,10 +108,9 @@ target_include_directories(dwarf PUBLIC
-     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-   )
- if(ZLIB_FOUND AND ZSTD_FOUND)
--  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ZSTD::ZSTD ) 
-+  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ${ZSTD_LIB} ) 
+@@ -111,7 +111,6 @@ if(ZLIB_FOUND AND ZSTD_FOUND)
+   target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ${ZSTD_LIB} ) 
  endif()
  
 -set(SUFFIX $<$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>:64>)

--- a/ports/libdwarf/no-suffix.diff
+++ b/ports/libdwarf/no-suffix.diff
@@ -15,8 +15,12 @@ diff --git a/src/lib/libdwarf/CMakeLists.txt b/src/lib/libdwarf/CMakeLists.txt
 index 4ad5c4fb..a3d3f429 100644
 --- a/src/lib/libdwarf/CMakeLists.txt
 +++ b/src/lib/libdwarf/CMakeLists.txt
-@@ -111,7 +111,6 @@ if(ZLIB_FOUND AND ZSTD_FOUND)
-   target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ZSTD::ZSTD ) 
+@@ -108,10 +108,9 @@ target_include_directories(dwarf PUBLIC
+     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+   )
+ if(ZLIB_FOUND AND ZSTD_FOUND)
+-  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ZSTD::ZSTD ) 
++  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ${ZSTD_LIB} ) 
  endif()
  
 -set(SUFFIX $<$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>:64>)

--- a/ports/libdwarf/no-suffix.diff
+++ b/ports/libdwarf/no-suffix.diff
@@ -1,24 +1,25 @@
 diff --git a/src/bin/dwarfdump/CMakeLists.txt b/src/bin/dwarfdump/CMakeLists.txt
-index 1b8aa3a..c77d2f0 100644
+index 6d2c328b..bc105813 100644
 --- a/src/bin/dwarfdump/CMakeLists.txt
 +++ b/src/bin/dwarfdump/CMakeLists.txt
-@@ -66,7 +66,6 @@ target_compile_options(dwarfdump PRIVATE ${DW_FWALL})
- target_link_libraries(dwarfdump PRIVATE ${dwarf-target} ${DW_FZLIB} ${DW_FZSTD} ) 
+@@ -68,7 +68,7 @@ target_compile_options(dwarfdump PRIVATE ${DW_FWALL})
  
- if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
--	set(SUFFIX 64)
+ target_link_libraries(dwarfdump PRIVATE dwarf) 
+ 
+-if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
++if(0)
+ 	set(SUFFIX 64)
  endif()
  set(LIBDIR lib${SUFFIX})
- set(BINDIR bin${SUFFIX})
 diff --git a/src/lib/libdwarf/CMakeLists.txt b/src/lib/libdwarf/CMakeLists.txt
-index 09908bb..91a1447 100644
+index 4ad5c4fb..a3d3f429 100644
 --- a/src/lib/libdwarf/CMakeLists.txt
 +++ b/src/lib/libdwarf/CMakeLists.txt
-@@ -109,7 +109,6 @@ foreach(i RANGE ${targetCount})
- 	
- 	set_target_properties(${target} PROPERTIES OUTPUT_NAME dwarf)
+@@ -111,7 +111,6 @@ if(ZLIB_FOUND AND ZSTD_FOUND)
+   target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ZSTD::ZSTD ) 
+ endif()
  
--	set(SUFFIX $<$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>:64>)
- 	set(LIBDIR lib${SUFFIX})
- 	set(BINDIR bin${SUFFIX})
+-set(SUFFIX $<$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>:64>)
+ set(LIBDIR lib${SUFFIX})
+ set(BINDIR bin${SUFFIX})
  

--- a/ports/libdwarf/portfile.cmake
+++ b/ports/libdwarf/portfile.cmake
@@ -33,5 +33,4 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libdwarf/portfile.cmake
+++ b/ports/libdwarf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO davea42/libdwarf-code
     REF "v${VERSION}"
-    SHA512 3117c69cc77d5a1189aeb1ea7e74d917dedfb84e9e9e98e3df7fec930f8183d12f55bb12e4871ed3746cdb19a29aba924bc73d6334b23bbb6413a1f4be67d499
+    SHA512 757ac42f76d5e9a90e6fab33f3af0ed53497264e2802b838df485d34ada480e5a6c5cec7d974e34b4404a2e49dbb86a979403d0ff28a5227d6550a1ced6b343b
     HEAD_REF main
     PATCHES
         dependencies.diff

--- a/ports/libdwarf/usage
+++ b/ports/libdwarf/usage
@@ -1,4 +1,0 @@
-libdwarf provides CMake targets:
-
-  find_package(libdwarf CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:libdwarf::dwarf-static>,libdwarf::dwarf-static,libdwarf::dwarf-shared>)

--- a/ports/libdwarf/vcpkg.json
+++ b/ports/libdwarf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdwarf",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A library for reading DWARF2 and later DWARF.",
   "homepage": "https://github.com/davea42/libdwarf-code",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1922,7 +1922,7 @@
     },
     "cpptrace": {
       "baseline": "0.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "cppunit": {
       "baseline": "1.15.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4261,7 +4261,7 @@
       "port-version": 3
     },
     "libdwarf": {
-      "baseline": "0.8.0",
+      "baseline": "0.9.0",
       "port-version": 0
     },
     "libe57": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1922,7 +1922,7 @@
     },
     "cpptrace": {
       "baseline": "0.3.1",
-      "port-version": 1
+      "port-version": 0
     },
     "cppunit": {
       "baseline": "1.15.1",

--- a/versions/c-/cpptrace.json
+++ b/versions/c-/cpptrace.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "a9dc1989a430b531df437790e61d09b411342ec3",
+      "git-tree": "0c8ce6d1bfc9c8c519e96079e11fd380752266dd",
       "version": "0.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "620e293efe2a80f6abdf9499855b09718cd8a051",

--- a/versions/c-/cpptrace.json
+++ b/versions/c-/cpptrace.json
@@ -3,7 +3,7 @@
     {
       "git-tree": "0c8ce6d1bfc9c8c519e96079e11fd380752266dd",
       "version": "0.3.1",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "620e293efe2a80f6abdf9499855b09718cd8a051",

--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8aa61f875f55fe903c05d51dc9ce4d0301e4ddbf",
+      "git-tree": "f7bae774c135a266fb960e497e4ba209a4d6d0c1",
       "version": "0.9.0",
       "port-version": 0
     }

--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f7bae774c135a266fb960e497e4ba209a4d6d0c1",
+      "git-tree": "d0d782a289fcbb19cfcd79ebb3b845fcd8ef8503",
       "version": "0.9.0",
       "port-version": 0
     }

--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "8aa61f875f55fe903c05d51dc9ce4d0301e4ddbf",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "port-version": 0
     }
   ]

--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d0d782a289fcbb19cfcd79ebb3b845fcd8ef8503",
+      "git-tree": "ba5b0c70c549798d2d769e5ff72735381d39f5af",
       "version": "0.9.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
