### PR TITLE
[chipmunk] Export targets for usage

### DIFF
--- a/ports/chipmunk/export-targets.patch
+++ b/ports/chipmunk/export-targets.patch
@@ -3,8 +3,8 @@ index 34882d1..d47c303 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -31,7 +31,9 @@ if(BUILD_SHARED)
-          # need to explicitly link to the math library because the CMake/Android toolchains may not do it automatically
-          target_link_libraries(chipmunk m)
+ 	  # need to explicitly link to the math library because the CMake/Android toolchains may not do it automatically
+ 	  target_link_libraries(chipmunk m)
    endif(ANDROID OR UNIX)
 -  install(TARGETS chipmunk RUNTIME DESTINATION ${BIN_INSTALL_DIR}
 +  target_include_directories(chipmunk INTERFACE $<INSTALL_INTERFACE:include>)
@@ -27,7 +27,7 @@ index 34882d1..d47c303 100644
 +                                    ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
    endif(INSTALL_STATIC)
  endif(BUILD_STATIC)
-
+ 
 @@ -57,3 +62,9 @@ if(BUILD_SHARED OR INSTALL_STATIC)
    install(FILES ${chipmunk_public_header} DESTINATION include/chipmunk)
    install(FILES ${chipmunk_constraint_header} DESTINATION include/chipmunk/constraints)

--- a/ports/chipmunk/export-targets.patch
+++ b/ports/chipmunk/export-targets.patch
@@ -1,10 +1,10 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 2ffde35..030321d 100644
+index 34882d1..d47c303 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -31,7 +31,9 @@ if(BUILD_SHARED)
- 	  # need to explicitly link to the math library because the CMake/Android toolchains may not do it automatically
- 	  target_link_libraries(chipmunk m)
+          # need to explicitly link to the math library because the CMake/Android toolchains may not do it automatically
+          target_link_libraries(chipmunk m)
    endif(ANDROID OR UNIX)
 -  install(TARGETS chipmunk RUNTIME DESTINATION ${BIN_INSTALL_DIR}
 +  target_include_directories(chipmunk INTERFACE $<INSTALL_INTERFACE:include>)
@@ -13,10 +13,12 @@ index 2ffde35..030321d 100644
                             LIBRARY DESTINATION ${LIB_INSTALL_DIR}
                             ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
  endif(BUILD_SHARED)
-@@ -47,8 +49,11 @@ if(BUILD_STATIC)
+@@ -46,9 +48,12 @@ if(BUILD_STATIC)
+     set_target_properties(chipmunk_static PROPERTIES LINKER_LANGUAGE CXX)
    endif(MSVC)
    # Sets chipmunk_static to output "libchipmunk.a" not "libchipmunk_static.a"
-   set_target_properties(chipmunk_static PROPERTIES OUTPUT_NAME chipmunk)
+-  set_target_properties(chipmunk_static PROPERTIES OUTPUT_NAME chipmunk)
++  set_target_properties(chipmunk_static PROPERTIES OUTPUT_NAME chipmunk EXPORT_NAME chipmunk)
 +  target_include_directories(chipmunk_static INTERFACE $<INSTALL_INTERFACE:include>)
    if(INSTALL_STATIC)
 -    install(TARGETS chipmunk_static ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
@@ -25,8 +27,8 @@ index 2ffde35..030321d 100644
 +                                    ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
    endif(INSTALL_STATIC)
  endif(BUILD_STATIC)
- 
-@@ -57,3 +57,9 @@ if(BUILD_SHARED OR INSTALL_STATIC)
+
+@@ -57,3 +62,9 @@ if(BUILD_SHARED OR INSTALL_STATIC)
    install(FILES ${chipmunk_public_header} DESTINATION include/chipmunk)
    install(FILES ${chipmunk_constraint_header} DESTINATION include/chipmunk/constraints)
  endif(BUILD_SHARED OR INSTALL_STATIC)

--- a/ports/chipmunk/export-targets.patch
+++ b/ports/chipmunk/export-targets.patch
@@ -1,0 +1,38 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 2ffde35..030321d 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -31,7 +31,9 @@ if(BUILD_SHARED)
+ 	  # need to explicitly link to the math library because the CMake/Android toolchains may not do it automatically
+ 	  target_link_libraries(chipmunk m)
+   endif(ANDROID OR UNIX)
+-  install(TARGETS chipmunk RUNTIME DESTINATION ${BIN_INSTALL_DIR}
++  target_include_directories(chipmunk INTERFACE $<INSTALL_INTERFACE:include>)
++  install(TARGETS chipmunk EXPORT unofficial-chipmunk-config
++                           RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+                            LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+                            ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
+ endif(BUILD_SHARED)
+@@ -47,8 +49,11 @@ if(BUILD_STATIC)
+   endif(MSVC)
+   # Sets chipmunk_static to output "libchipmunk.a" not "libchipmunk_static.a"
+   set_target_properties(chipmunk_static PROPERTIES OUTPUT_NAME chipmunk)
++  target_include_directories(chipmunk_static INTERFACE $<INSTALL_INTERFACE:include>)
+   if(INSTALL_STATIC)
+-    install(TARGETS chipmunk_static ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
++    install(TARGETS chipmunk_static EXPORT unofficial-chipmunk-config
++                                    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
++                                    ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
+   endif(INSTALL_STATIC)
+ endif(BUILD_STATIC)
+ 
+@@ -57,3 +57,9 @@ if(BUILD_SHARED OR INSTALL_STATIC)
+   install(FILES ${chipmunk_public_header} DESTINATION include/chipmunk)
+   install(FILES ${chipmunk_constraint_header} DESTINATION include/chipmunk/constraints)
+ endif(BUILD_SHARED OR INSTALL_STATIC)
++
++install(EXPORT unofficial-chipmunk-config
++        FILE unofficial-chipmunk-config.cmake
++        NAMESPACE unofficial::chipmunk::
++        DESTINATION share/unofficial-chipmunk
++)

--- a/ports/chipmunk/portfile.cmake
+++ b/ports/chipmunk/portfile.cmake
@@ -8,11 +8,12 @@ vcpkg_download_distfile(
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO slembcke/Chipmunk2D
-    REF 87340c216bf97554dc552371bbdecf283f7c540e
-    SHA512 9094017755e9c140aa5bf8a1b5502077ae4fb2b0a3e12f1114e86d8591a6188f89822ecc578a2b5e95f61c555018f1b3273fe50e833fe2daf30e94b180a3d07c
+    REF "Chipmunk-${VERSION}"
+    SHA512 edd16544a572c8f7654c99d6420aefe2f73ce2630f3e2e969f17b4980a8ea4044b5738f4a3cefbe0edd7bb4cd039a70748773b48cd59df12a09123eca9f451e4
     HEAD_REF master
     PATCHES
         "${SYSCTL_REMOVED_PATCH}"
+        export-targets.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" KEYSTONE_BUILD_STATIC)
@@ -33,15 +34,6 @@ if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL debug)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 endif()
 
-file(GLOB DLLS "${CURRENT_PACKAGES_DIR}/lib/*.dll")
-if(DLLS)
-    file(COPY ${DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-    file(REMOVE ${DLLS})
-endif()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-chipmunk)
 
-file(INSTALL
-    "${SOURCE_PATH}/include/chipmunk"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
-)
-
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/chipmunk/portfile.cmake
+++ b/ports/chipmunk/portfile.cmake
@@ -36,4 +36,5 @@ endif()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-chipmunk)
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/chipmunk/portfile.cmake
+++ b/ports/chipmunk/portfile.cmake
@@ -36,5 +36,4 @@ endif()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-chipmunk)
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/chipmunk/usage
+++ b/ports/chipmunk/usage
@@ -1,4 +1,0 @@
-The package chipmunk provides CMake targets:
-
-  find_package(unofficial-chipmunk CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:unofficial::chipmunk::chipmunk>,unofficial::chipmunk::chipmunk,unofficial::chipmunk::chipmunk_static>)

--- a/ports/chipmunk/usage
+++ b/ports/chipmunk/usage
@@ -1,0 +1,4 @@
+The package chipmunk provides CMake targets:
+
+  find_package(unofficial-chipmunk CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:unofficial::chipmunk::chipmunk>,unofficial::chipmunk::chipmunk,unofficial::chipmunk::chipmunk_static>)

--- a/ports/chipmunk/vcpkg.json
+++ b/ports/chipmunk/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "chipmunk",
   "version": "7.0.3",
-  "port-version": 6,
+  "port-version": 7,
   "description": "A fast and lightweight 2D game physics library.",
   "homepage": "https://github.com/slembcke/Chipmunk2D",
+  "license": "MIT",
   "supports": "!(arm & !arm64 & android)",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1570,7 +1570,7 @@
     },
     "chipmunk": {
       "baseline": "7.0.3",
-      "port-version": 6
+      "port-version": 7
     },
     "chmlib": {
       "baseline": "0.40",

--- a/versions/c-/chipmunk.json
+++ b/versions/c-/chipmunk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "956bb3dfb25e55e2815d68c18d2aa82cf96723ef",
+      "version": "7.0.3",
+      "port-version": 7
+    },
+    {
       "git-tree": "daaeebb368f5c367d7005bb828913f8e158648c1",
       "version": "7.0.3",
       "port-version": 6

--- a/versions/c-/chipmunk.json
+++ b/versions/c-/chipmunk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "571a4002e886e55b0f5cb08340b355fafd7015be",
+      "git-tree": "860e99dc5300cd7f253d6f69ae01437cfed119a9",
       "version": "7.0.3",
       "port-version": 7
     },

--- a/versions/c-/chipmunk.json
+++ b/versions/c-/chipmunk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "32048c150c42701ba4ecd09abe8bedf34359e662",
+      "git-tree": "571a4002e886e55b0f5cb08340b355fafd7015be",
       "version": "7.0.3",
       "port-version": 7
     },

--- a/versions/c-/chipmunk.json
+++ b/versions/c-/chipmunk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "956bb3dfb25e55e2815d68c18d2aa82cf96723ef",
+      "git-tree": "32048c150c42701ba4ecd09abe8bedf34359e662",
       "version": "7.0.3",
       "port-version": 7
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/36162

Export the targets for usage.
Usage test passed with following triplets:
```
x86-windows 
x64-windows 
x64-windows-static 
```
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
