### PR TITLE
[llvm] Add mlir-tblgen to package if mlir feature requested

### DIFF
--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -168,8 +168,7 @@
             "mlir"
           ]
         },
-        "pybind11",
-        "python3"
+        "pybind11"
       ]
     },
     "enable-rtti": {
@@ -294,7 +293,8 @@
           "name": "llvm",
           "default-features": false,
           "features": [
-            "tools"
+            "tools",
+            "utils"
           ]
         }
       ]

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "17.0.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -168,7 +168,8 @@
             "mlir"
           ]
         },
-        "pybind11"
+        "pybind11",
+        "python3"
       ]
     },
     "enable-rtti": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5278,7 +5278,7 @@
     },
     "llvm": {
       "baseline": "17.0.2",
-      "port-version": 2
+      "port-version": 3
     },
     "lmdb": {
       "baseline": "0.9.31",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce44a7977e6376d53613ed81224eb992a0b82a98",
+      "version": "17.0.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "af2e23c1205568f576321133141a51439ef1059f",
       "version": "17.0.2",
       "port-version": 2


### PR DESCRIPTION
Fixes #36497

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
