### PR TITLE
[openmesh] Update to 10.0 and apply more love

### DIFF
--- a/ports/openmesh/fix-library-install-path.patch
+++ b/ports/openmesh/fix-library-install-path.patch
@@ -37,7 +37,7 @@ index 7a5269c..e3f87ff 100644
      FILE(GLOB files_install_libs "${CMAKE_BINARY_DIR}/Build/lib/*.lib" )
      FILE(GLOB files_install_dlls "${CMAKE_BINARY_DIR}/Build/*.dll" )
      INSTALL(FILES ${files_install_libs} DESTINATION lib )
-@@ -240,7 +240,7 @@ target_include_directories(OpenMeshCore PUBLIC
+@@ -240,7 +240,8 @@ target_include_directories(OpenMeshCore PUBLIC
  endif ()
  
  install(TARGETS OpenMeshCore EXPORT OpenMeshConfig
@@ -47,6 +47,7 @@ index 7a5269c..e3f87ff 100644
 +  ARCHIVE DESTINATION lib
 +  LIBRARY DESTINATION lib
 +  RUNTIME DESTINATION bin)
++  target_compile_features(OpenMeshCore PUBLIC cxx_std_11)
  
 diff --git a/src/OpenMesh/Tools/CMakeLists.txt b/src/OpenMesh/Tools/CMakeLists.txt
 index 0170e2b..e40dfa1 100644

--- a/ports/openmesh/fix-library-install-path.patch
+++ b/ports/openmesh/fix-library-install-path.patch
@@ -1,9 +1,44 @@
-diff --git a/src/OpenMesh/Core/CMakeLists.txt b/src/OpenMesh/Core/CMakeLists.txt
+diff --git a/cmake-library/VCI/VCICommon.cmake b/cmake-library/VCI/VCICommon.cmake
+index 7a5269c..e3f87ff 100644
+--- a/cmake-library/VCI/VCICommon.cmake
++++ b/cmake-library/VCI/VCICommon.cmake
+@@ -242,7 +242,8 @@
+     set (_and_static 0)
+   endif ()
+ 
+-  add_library (${_target} ${_type} ${ARGN} )
++  set(_and_static 0)
++  add_library (${_target} ${ARGN} )
+ 
+   # set common target properties defined in common.cmake
+   vci_set_target_props (${_target})
 index 7a5269c..e3f87ff 100644
 --- a/src/OpenMesh/Core/CMakeLists.txt
 +++ b/src/OpenMesh/Core/CMakeLists.txt
-@@ -146,7 +146,7 @@ target_include_directories(OpenMeshCore PUBLIC
-   $<INSTALL_INTERFACE:include>)
+@@ -156,9 +156,9 @@
+                                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+                                           $<INSTALL_INTERFACE:include>)
+ 
+-  target_include_directories(OpenMeshCoreStatic PUBLIC
+-                                          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+-                                          $<INSTALL_INTERFACE:include>)
++  #target_include_directories(OpenMeshCoreStatic PUBLIC
++  #                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
++  #                                        $<INSTALL_INTERFACE:include>)
+ 
+   set_target_properties (OpenMeshCore PROPERTIES VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+                                                SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} )
+@@ -180,7 +180,7 @@ endif()
+ 
+ # if we build debug and release in the same dir, we want to install both!
+ if ( ${CMAKE_PROJECT_NAME} MATCHES "OpenMesh")
+-  if ( WIN32 )
++  if ( 0 )
+     FILE(GLOB files_install_libs "${CMAKE_BINARY_DIR}/Build/lib/*.lib" )
+     FILE(GLOB files_install_dlls "${CMAKE_BINARY_DIR}/Build/*.dll" )
+     INSTALL(FILES ${files_install_libs} DESTINATION lib )
+@@ -240,7 +240,7 @@ target_include_directories(OpenMeshCore PUBLIC
+ endif ()
  
  install(TARGETS OpenMeshCore EXPORT OpenMeshConfig
 -  ARCHIVE DESTINATION ${VCI_PROJECT_LIBDIR}
@@ -17,8 +52,30 @@ diff --git a/src/OpenMesh/Tools/CMakeLists.txt b/src/OpenMesh/Tools/CMakeLists.t
 index 0170e2b..e40dfa1 100644
 --- a/src/OpenMesh/Tools/CMakeLists.txt
 +++ b/src/OpenMesh/Tools/CMakeLists.txt
+@@ -122,9 +122,9 @@
+                                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+                                           $<INSTALL_INTERFACE:include>)
+ 
+-  target_include_directories(OpenMeshToolsStatic PUBLIC
+-                                          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+-                                          $<INSTALL_INTERFACE:include>)
++  #target_include_directories(OpenMeshToolsStatic PUBLIC
++  #                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
++  #                                        $<INSTALL_INTERFACE:include>)
+ 
+   set_target_properties (OpenMeshTools PROPERTIES VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+                                                 SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} )
+@@ -132,7 +132,7 @@
+ 
+ target_link_libraries (OpenMeshTools OpenMeshCore)
+ 
+-IF( NOT WIN32 )
++IF( 0 )
+   target_link_libraries (OpenMeshToolsStatic OpenMeshCoreStatic)
+ ENDIF(NOT WIN32)
+ 
 @@ -126,7 +126,8 @@ target_include_directories(OpenMeshTools PUBLIC
-   $<INSTALL_INTERFACE:include>)
+ endif ()
  
  install(TARGETS OpenMeshTools EXPORT OpenMeshConfig
 -  ARCHIVE DESTINATION ${VCI_PROJECT_LIBDIR}

--- a/ports/openmesh/fix-pkgconfig.patch
+++ b/ports/openmesh/fix-pkgconfig.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7a5269c..e3f87ff 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -188,12 +188,15 @@
+ 
+ # Generate openmesh.pc file
+ 
++if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
++  set(_debug_postfix "${CMAKE_DEBUG_POSTFIX}")
++endif()
+ set(DEST_DIR "${CMAKE_INSTALL_PREFIX}")
+-set(PRIVATE_LIBS "-lOpenMeshCore -lOpenMeshTools")
++set(PRIVATE_LIBS "-lOpenMeshCore${_debug_postfix} -lOpenMeshTools${_debug_postfix}")
+ 
+ configure_file("openmesh.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/openmesh.pc" @ONLY)
+ 
+-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openmesh.pc DESTINATION libdata/pkgconfig)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openmesh.pc DESTINATION lib/pkgconfig)
+ 
+ # generate target file
+ 

--- a/ports/openmesh/portfile.cmake
+++ b/ports/openmesh/portfile.cmake
@@ -1,8 +1,8 @@
 # Note: upstream GitLab instance at https://graphics.rwth-aachen.de:9000 often goes down
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.openmesh.org/media/Releases/${VERSION}/OpenMesh-${VERSION}.tar.gz"
+    URLS "https://www.openmesh.org/media/Releases/${VERSION}/OpenMesh-${VERSION}.0.tar.gz"
     FILENAME "OpenMesh-${VERSION}.tar.gz"
-    SHA512 d4d1872204595c8ccdf1fd09b2e923b7fc5e71e95958cbee52aeca0c1a3de0e648e4fa4913aca14acee30a000ef54b5abd92a30db8cef310e87bfbfe26726afc
+    SHA512 b895e5eaabdf5d3671625df5314e1f95921ac672e9d9d945a5cf0973e20b4e395aac6517d86269a2e8c103f32bc9c8c2ecf57d811a260bbc69f592043e1307ba
 )
 
 vcpkg_extract_source_archive(
@@ -10,6 +10,7 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE}"
     PATCHES
         fix-library-install-path.patch
+        fix-pkgconfig.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -22,6 +23,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_APPS=OFF
+        -DVCI_COMMON_DO_NOT_COPY_POST_BUILD=ON
+        -DVCI_NO_LIBRARY_INSTALL=ON
         -DOPENMESH_BUILD_SHARED=${OPENMESH_BUILD_SHARED}
 	MAYBE_UNUSED_VARIABLES
 		OPENMESH_BUILD_SHARED
@@ -31,30 +34,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(PACKAGE_NAME OpenMesh CONFIG_PATH "share/OpenMesh/cmake")
-
-if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/debug/libdata/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
-endif()
-if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/libdata/pkgconfig" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
-endif()
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/libdata" "${CURRENT_PACKAGES_DIR}/libdata")
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/OpenMesh/Tools/VDPM/xpm")
-# Only move dynamic libraries to bin on Windows
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-  if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/OpenMeshCore.dll" "${CURRENT_PACKAGES_DIR}/bin/OpenMeshCore.dll")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/OpenMeshTools.dll" "${CURRENT_PACKAGES_DIR}/bin/OpenMeshTools.dll")
-  endif()
-  if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/OpenMeshCored.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/OpenMeshCored.dll")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/OpenMeshToolsd.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/OpenMeshToolsd.dll")
-  endif()
-endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/openmesh/portfile.cmake
+++ b/ports/openmesh/portfile.cmake
@@ -11,6 +11,11 @@ vcpkg_extract_source_archive(
     PATCHES
         fix-library-install-path.patch
         fix-pkgconfig.patch
+
+        # This patch is a combination of these two:
+        # https://gitlab.vci.rwth-aachen.de:9000/OpenMesh/OpenMesh/-/commit/1d4a866282ace376c8e3ba05c21ce3bcc6643040
+        # https://gitlab.vci.rwth-aachen.de:9000/OpenMesh/OpenMesh/-/commit/a7f30b6f70447932444f5b518840ca26e9461fa9
+        restore-c++11-compatibility.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/openmesh/restore-c++11-compatibility.patch
+++ b/ports/openmesh/restore-c++11-compatibility.patch
@@ -1,0 +1,25 @@
+From 1d4a866282ace376c8e3ba05c21ce3bcc6643040 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20M=C3=B6bius?= <moebius@cs.rwth-aachen.de>
+Date: Tue, 9 Jan 2024 12:59:45 +0100
+Subject: [PATCH] Small patch to keep backward compatibility with c++11
+
+---
+ src/OpenMesh/Core/Utils/Property.hh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/OpenMesh/Core/Utils/Property.hh b/src/OpenMesh/Core/Utils/Property.hh
+index 485d3072..6ba66584 100644
+--- a/src/OpenMesh/Core/Utils/Property.hh
++++ b/src/OpenMesh/Core/Utils/Property.hh
+@@ -250,7 +250,7 @@ public: // inherited from BaseProperty
+   virtual void reserve(size_t _n) override { data_.reserve(_n);    }
+   virtual void resize(size_t _n) override  { data_.resize(_n);     }
+   virtual void clear() override  { data_.clear(); vector_type().swap(data_);    }
+-  virtual void push_back() override        { data_.emplace_back(); }
++  virtual void push_back() override        { data_.push_back(bool()); }
+   virtual void swap(size_t _i0, size_t _i1) override
+   { bool t(data_[_i0]); data_[_i0]=data_[_i1]; data_[_i1]=t; }
+   virtual void copy(size_t _i0, size_t _i1) override
+-- 
+GitLab
+

--- a/ports/openmesh/vcpkg.json
+++ b/ports/openmesh/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openmesh",
-  "version": "9.0",
-  "port-version": 2,
+  "version": "10.0",
   "description": "A generic and efficient polygon mesh data structure",
   "homepage": "https://www.graphics.rwth-aachen.de/media/openmesh_static/Daily-Builds/Doc/index.html",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6377,8 +6377,8 @@
       "port-version": 3
     },
     "openmesh": {
-      "baseline": "9.0",
-      "port-version": 2
+      "baseline": "10.0",
+      "port-version": 0
     },
     "openmpi": {
       "baseline": "4.1.6",

--- a/versions/o-/openmesh.json
+++ b/versions/o-/openmesh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1ce6646b4a23c0923636d2324141292205c54657",
+      "git-tree": "bea5d6796009e8156570bbfae1c9fb60d86d7286",
       "version": "10.0",
       "port-version": 0
     },

--- a/versions/o-/openmesh.json
+++ b/versions/o-/openmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ce6646b4a23c0923636d2324141292205c54657",
+      "version": "10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8228f40bfdd38a2049f284b9a1d0b6e58ce86c57",
       "version": "9.0",
       "port-version": 2


### PR DESCRIPTION
Changelog: https://www.graphics.rwth-aachen.de/media/openmesh_static/Documentations/OpenMesh-Doc-Latest/a06138.html

- Don't copy binaries to packages root (`VCI_COMMON_DO_NOT_COPY_POST_BUILD`)
- Don't install library twice (`VCI_NO_LIBRARY_INSTALL`)
- Fix pkgconfig by adding debug suffix
- Don't build and install static and shared binaries simultaneously on linux (also fixes x64-linux-dynamic)

Note: download URL for some reason contains `10.0.0` instead of `10.0`, but AFAICT version scheme has not been changed.