### PR TITLE
[alsa] update to 1.2.11

### DIFF
--- a/ports/alsa/portfile.cmake
+++ b/ports/alsa/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alsa-project/alsa-lib
     REF "v${VERSION}"
-    SHA512 923cd9f19afa77cf46bb15b4fefdaa2db75054052af0f11b6d18e1703a0d3d05fecca235606ea06bca380a4306c134f88b71be73839eca3f4ce077dbdcb13c6a
+    SHA512 da9277007dd3b197fcafb748ced4ace89fdb1ab5eafae7596e91935ee9fb410be54fa76aabe86cdd83227e48cd073a7df319e90bdf06fa2da7c97470c085645d
     HEAD_REF master
     PATCHES
         "fix-plugin-dir.patch"

--- a/ports/alsa/vcpkg.json
+++ b/ports/alsa/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "alsa",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "The Advanced Linux Sound Architecture (ALSA) - library",
   "homepage": "https://www.alsa-project.org/",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/alsa.json
+++ b/versions/a-/alsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ea8f5d1e2f27c55e80e1bcce24aacc37849074e",
+      "version": "1.2.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "d3fa8b1fd27e767f429d0736b6636df796e2c335",
       "version": "1.2.10",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -93,7 +93,7 @@
       "port-version": 0
     },
     "alsa": {
-      "baseline": "1.2.10",
+      "baseline": "1.2.11",
       "port-version": 0
     },
     "amd-adl-sdk": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

