### PR TITLE
[aom] update to 3.8.1

### DIFF
--- a/ports/aom/portfile.cmake
+++ b/ports/aom/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_add_to_path(${PERL_PATH})
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL "https://aomedia.googlesource.com/aom"
-    REF 6054fae218eda6e53e1e3b4f7ef0fff4877c7bf1 # v3.7.0
+    REF bb6430482199eaefbeaaa396600935082bc43f66
     PATCHES
         aom-rename-static.diff
         aom-uninitialized-pointer.diff

--- a/ports/aom/vcpkg.json
+++ b/ports/aom/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aom",
-  "version-semver": "3.7.0",
+  "version-semver": "3.8.1",
   "description": "AV1 codec library",
   "homepage": "https://aomedia.googlesource.com/aom",
   "license": "BSD-2-Clause",

--- a/versions/a-/aom.json
+++ b/versions/a-/aom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ec15ea1e8e0e6c1401fc91f2dd167eba6122b20",
+      "version-semver": "3.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "71fe99b6007b153a98a5058a2d2212117af8031a",
       "version-semver": "3.7.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -153,7 +153,7 @@
       "port-version": 2
     },
     "aom": {
-      "baseline": "3.7.0",
+      "baseline": "3.8.1",
       "port-version": 0
     },
     "apache-datasketches": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

