### PR TITLE
[minizip] update to 1.3.1

### DIFF
--- a/ports/minizip/minizip-win32.def
+++ b/ports/minizip/minizip-win32.def
@@ -3,18 +3,18 @@ EXPORTS
      fill_win32_filefunc64
      fill_win32_filefunc64A
      fill_win32_filefunc64W
-     win32_open_file_func
-     win32_read_file_func
-     win32_write_file_func
-     win32_tell64_file_func
-     win32_seek64_file_func
-     win32_close_file_func
-     win32_error_file_func
      win32_open64_file_func
      win32_open64_file_funcA
      win32_open64_file_funcW
+     win32_open_file_func
+     win32_read_file_func
+     win32_write_file_func
      win32_tell_file_func
+     win32_tell64_file_func
      win32_seek_file_func
+     win32_seek64_file_func
+     win32_close_file_func
+     win32_error_file_func
      unzRepair
      zip_copyright
      zipOpen

--- a/ports/minizip/portfile.cmake
+++ b/ports/minizip/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO madler/zlib
     REF "v${VERSION}"
-    SHA512 78eecf335b14af1f7188c039a4d5297b74464d61156e4f12a485c74beec7d62c4159584ad482a07ec57ae2616d58873e45b09cb8ea822bb5b17e43d163df84e9
+    SHA512 8c9642495bafd6fad4ab9fb67f09b268c69ff9af0f4f20cf15dfc18852ff1f312bd8ca41de761b3f8d8e90e77d79f2ccacd3d4c5b19e475ecf09d021fdfe9088
     HEAD_REF master
     PATCHES
         0001-remove-ifndef-NOUNCRYPT.patch

--- a/ports/minizip/vcpkg.json
+++ b/ports/minizip/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "minizip",
-  "version": "1.3",
-  "port-version": 1,
+  "version": "1.3.1",
   "description": "Minizip zip file manipulation library",
   "homepage": "https://github.com/madler/zlib",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5669,8 +5669,8 @@
       "port-version": 0
     },
     "minizip": {
-      "baseline": "1.3",
-      "port-version": 1
+      "baseline": "1.3.1",
+      "port-version": 0
     },
     "minizip-ng": {
       "baseline": "4.0.4",

--- a/versions/m-/minizip.json
+++ b/versions/m-/minizip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a421d5b61058bace21296039e5f5bcbe9c9010a",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "91fe1aaa8a5d696bda657a3d2b687fecfa92a7c3",
       "version": "1.3",
       "port-version": 1


### PR DESCRIPTION
Fixes #36558.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The update was executed as follows:
1. update port version number and checksums as usual. 
2. activate `GENERATE_SYMBOLS` in the portfile.
3. install the port which fails due to mismatching symbols.
4. copy the generated symbols from the file `minizip-x64.def.log` in the buildtree to the file `minizip-win32.def` in the port directory.
5. deactivate `GENERATE_SYMBOLS` in the portfile.
6. install the port which now succeeds. 
