### PR TITLE
[audiofile] update to 1.1.1

### DIFF
--- a/ports/audiofile/portfile.cmake
+++ b/ports/audiofile/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO adamstark/AudioFile
-    REF 004065d01e9b7338580390d4fdbfbaa46adede4e # 1.1.0
-    SHA512 99d31035fc82ca8da3c555c30b6b40ea99e15e1f82002c7f04c567ab7aee1de71deddf6930564c56f3a2e83eea1b5f5e9ca631673ed4a943579732b8d62e9603
+    REF "${VERSION}"
+    SHA512 0
     HEAD_REF master
     PATCHES
         fix-cmakeLists.patch

--- a/ports/audiofile/portfile.cmake
+++ b/ports/audiofile/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO adamstark/AudioFile
     REF "${VERSION}"
-    SHA512 0
+    SHA512 b0612e6d6c440e52a168f27410d6ac14f7fcef2ba183e8a80e03f924e6fc778c01e4f46b40cab10dd73c48f8f10dc4112c58f602728fdeec0bc3e143852fc95e
     HEAD_REF master
     PATCHES
         fix-cmakeLists.patch

--- a/ports/audiofile/vcpkg.json
+++ b/ports/audiofile/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "audiofile",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A simple header-only C++ library for reading and writing audio files.",
   "homepage": "https://github.com/adamstark/AudioFile",
   "license": "MIT",

--- a/versions/a-/audiofile.json
+++ b/versions/a-/audiofile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1119c0807f33e882435fd4bc66a62a79f147bd0",
+      "version": "1.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "fa276b1ad374c2ae6034445b6655518d8f9a23de",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/a-/audiofile.json
+++ b/versions/a-/audiofile.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b1119c0807f33e882435fd4bc66a62a79f147bd0",
+      "git-tree": "6f06a6467594b612bfd24dc86f696d07e1c4b500",
       "version": "1.1.1",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -329,7 +329,7 @@
       "port-version": 1
     },
     "audiofile": {
-      "baseline": "1.1.0",
+      "baseline": "1.1.1",
       "port-version": 0
     },
     "aurora": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

