### PR TITLE
[bde] update to 3.124.0.0

### DIFF
--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -23,7 +23,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "bloomberg/bde"
     REF "${VERSION}"
-    SHA512 27e204e22883065e3ae9ab92d2c87d8e26a2871a36ede01367ee0e4d4a0e0de4f7b9452a0c219066dbb37a6f06ec3acabd6be029b8fdaab6c6ea4094300371d0    
+    SHA512 27e204e22883065e3ae9ab92d2c87d8e26a2871a36ede01367ee0e4d4a0e0de4f7b9452a0c219066dbb37a6f06ec3acabd6be029b8fdaab6c6ea4094300371d0
     HEAD_REF main
 )
 

--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -1,6 +1,5 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(BDE_TOOLS_VERSION "${VERSION}")
 
 # Acquire Python and add it to PATH
 vcpkg_find_acquire_program(PYTHON3)
@@ -10,9 +9,9 @@ get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
 vcpkg_from_github(
     OUT_SOURCE_PATH TOOLS_PATH
     REPO "bloomberg/bde-tools"
-    REF "${BDE_TOOLS_VERSION}"
-    SHA512 e59560810acfe562d85a13585d908decce17ec76c89bd61f43dac56cddfdf6c56269566da75730f8eda14b5fc046d2ebce959b24110a428e8eac0e358d2597c2
-    HEAD_REF 3.123.0.0
+    REF "${VERSION}"
+    SHA512 3aa64215c473ccecbd213234826b0c8cffd9491e7bf358e5947c80103e0723ef56da8ec7cc9cf51c6b7a887e5b0b52e80f3201d933accf7f6d5cc95fc1cb35dc
+    HEAD_REF main
 )
 
 message(STATUS "Configure bde-tools-v${BDE_TOOLS_VERSION}")
@@ -24,8 +23,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "bloomberg/bde"
     REF "${VERSION}"
-    SHA512 f1c3c5ddec7ff1d301ca6f8ab00e6be42ab6a5fa3c889639e7797df74f68425d57d8b71978098331c9247820c7c831edeaf4427ae64c890d81f704343b1bb112
-    HEAD_REF 3.123.0.0
+    SHA512 27e204e22883065e3ae9ab92d2c87d8e26a2871a36ede01367ee0e4d4a0e0de4f7b9452a0c219066dbb37a6f06ec3acabd6be029b8fdaab6c6ea4094300371d0    
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bde",
-  "version": "3.123.0.0",
+  "version": "3.124.0.0",
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
   "supports": "!windows & !arm & !android & !osx",
   "dependencies": [

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f8c8bc5beb99b215e68af4269bc1bac20957d485",
+      "version": "3.124.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "71df70f3716434e8069b394593ba8859b6556959",
       "version": "3.123.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -545,7 +545,7 @@
       "port-version": 0
     },
     "bde": {
-      "baseline": "3.123.0.0",
+      "baseline": "3.124.0.0",
       "port-version": 0
     },
     "bdwgc": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

