### PR TITLE
[cgal] Fix feature qt missing dependency boost-format

### DIFF
--- a/ports/cgal/vcpkg.json
+++ b/ports/cgal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cgal",
   "version": "5.6",
+  "port-version": 1,
   "description": "The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.",
   "homepage": "https://github.com/CGAL/cgal",
   "license": "GPL-3.0-or-later AND LGPL-3.0-or-later AND BSL-1.0",
@@ -64,6 +65,7 @@
     "qt": {
       "description": "Qt GUI support for CGAL",
       "dependencies": [
+        "boost-format",
         "eigen3",
         "qt5-3d",
         {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1530,7 +1530,7 @@
     },
     "cgal": {
       "baseline": "5.6",
-      "port-version": 0
+      "port-version": 1
     },
     "cgicc": {
       "baseline": "3.2.19",

--- a/versions/c-/cgal.json
+++ b/versions/c-/cgal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "daf7cc06ce0247101d1f713013a1a12416da5111",
+      "version": "5.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "313da2aa8d1221c449a211a4d04a0d5976ae8930",
       "version": "5.6",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36409

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


Usage test pass with following triplets:

```
arm64-osx
```