### PR TITLE
[boinc] update to 7.24.3

### DIFF
--- a/ports/boinc/portfile.cmake
+++ b/ports/boinc/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX REPLACE "^([0-9]*[.][0-9]*)[.].*" "\\1" MAJOR_MINOR "${VERSION}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BOINC/boinc
-    REF client_release/${MAJOR_MINOR}/${VERSION}
+    REF "client_release/${MAJOR_MINOR}/${VERSION}"
     SHA512 d66664df49b83fb71e8f06e6f9ca0aee720ec04b1fb95b08426ee9af365403605624ba6dc1f78f3fba3f966d365b610ed24ceffdc54b071509f4f0bf959e027c
     HEAD_REF master
 )

--- a/ports/boinc/portfile.cmake
+++ b/ports/boinc/portfile.cmake
@@ -1,10 +1,10 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
+string(REGEX REPLACE "^([0-9]*[.][0-9]*)[.].*" "\\1" MAJOR_MINOR "${VERSION}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BOINC/boinc
-    REF client_release/7.24/7.24.1
-    SHA512 7dad36900c13b69a89b5a173fc283130bc4cf15c781ed31ed72ce0b6ba0db4895a12314d0f302c7a91c2762333b7c162f20f32e67ed5e2e7a4099e1f2238c255
+    REF client_release/${MAJOR_MINOR}/${VERSION}
+    SHA512 d66664df49b83fb71e8f06e6f9ca0aee720ec04b1fb95b08426ee9af365403605624ba6dc1f78f3fba3f966d365b610ed24ceffdc54b071509f4f0bf959e027c
     HEAD_REF master
 )
 

--- a/ports/boinc/vcpkg.json
+++ b/ports/boinc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "boinc",
-  "version": "7.24.1",
+  "version": "7.24.3",
   "description": "Open-source software for volunteer computing and grid computing.",
   "homepage": "https://boinc.berkeley.edu/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/boinc.json
+++ b/versions/b-/boinc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6e3416e5c49a6f0e091a8287edea765448003776",
+      "git-tree": "b49e9a16d262cfdde45934d7a3c9a6aebf391225",
       "version": "7.24.3",
       "port-version": 0
     },

--- a/versions/b-/boinc.json
+++ b/versions/b-/boinc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e3416e5c49a6f0e091a8287edea765448003776",
+      "version": "7.24.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "1108b5895433bd23e8a9d6b8695adf85438382c2",
       "version": "7.24.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -685,7 +685,7 @@
       "port-version": 0
     },
     "boinc": {
-      "baseline": "7.24.1",
+      "baseline": "7.24.3",
       "port-version": 0
     },
     "bond": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

