### PR TITLE
[c-ares] update to 1.26.0

### DIFF
--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -36,7 +36,7 @@ vcpkg_fixup_pkgconfig()
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string(
         "${CURRENT_PACKAGES_DIR}/include/ares.h"
-        "#ifdef CARES_STATICLIB" "#if 1"
+        "#  ifdef CARES_STATICLIB" "#if 1"
     )
 endif()
 

--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
     REF "cares-${_c_ares_version_major}_${_c_ares_version_minor}_${_c_ares_version_patch}"
-    SHA512 a99ca6066490ef31b37f6be12f9fa1d7599c3736c04c8df50a4a0d2e489c99c1c776028fcfec4e6029c8aa5845f3bede364cceb39cd95b2689305d23277bdd8d
+    SHA512 1ff8d35cc0e022a0478149ca80a0a1f80b2c8d04e108b6cb9912ecc8c391017b6443129b9b52c2cf82b21ef338de0c80d89c92c6d7f95fe1f9c42575ed1a3919
     HEAD_REF main
     PATCHES
         avoid-docs.patch

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c-ares",
-  "version-semver": "1.25.0",
+  "version-semver": "1.26.0",
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1401,7 +1401,7 @@
       "port-version": 5
     },
     "c-ares": {
-      "baseline": "1.25.0",
+      "baseline": "1.26.0",
       "port-version": 0
     },
     "c-dbg-macro": {

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a21650de4e9497d95283072377d734e2a6362382",
+      "git-tree": "2c98426c40efeeefe1eadb00c943dc80f72e9f99",
       "version-semver": "1.26.0",
       "port-version": 0
     },

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a21650de4e9497d95283072377d734e2a6362382",
+      "version-semver": "1.26.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "79f168b5491191bf701a2683c2352c67d664e99a",
       "version-semver": "1.25.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

