### PR TITLE
[capnproto] update to 1.0.2

### DIFF
--- a/ports/capnproto/portfile.cmake
+++ b/ports/capnproto/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO capnproto/capnproto
-    REF v1.0.1
-    SHA512 189d8c483bded3889e903e3998d32d022b5a7bf45d519dc551dc9b2d7909a45a8816a09f4a817aa0fbb14c86c32b838a0c26457c2e89c33ec0eb93bbb93391c0
+    REF "v${VERSION}"
+    SHA512 56551ecad52cf06e5dd52401e6d848eae41126c6ba2bb31a9ec1c82e1b47e0e6171d69db923c118c614aec0d396ddf35724081cccef3a605c39d0b5379a2c03e
     HEAD_REF master
     PATCHES
         disable-C-20-co-routines.patch

--- a/ports/capnproto/vcpkg.json
+++ b/ports/capnproto/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "capnproto",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Data interchange format and capability-based RPC system",
   "homepage": "https://capnproto.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1453,7 +1453,7 @@
       "port-version": 0
     },
     "capnproto": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.2",
       "port-version": 0
     },
     "capstone": {

--- a/versions/c-/capnproto.json
+++ b/versions/c-/capnproto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52f73df5478fbcdb34b8dd5dd8d488672031cc32",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a615543c6406b84fc52a931335d7fdb70037627",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

