### PR TITLE
[benchmark] Allow shared library creation, disable docs installation

### DIFF
--- a/ports/benchmark/portfile.cmake
+++ b/ports/benchmark/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/benchmark
@@ -14,6 +12,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBENCHMARK_ENABLE_TESTING=OFF
+        -DBENCHMARK_INSTALL_DOCS=OFF
         -Werror=old-style-cast
 )
 

--- a/ports/benchmark/vcpkg.json
+++ b/ports/benchmark/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "https://github.com/google/benchmark/issues/661 describes the missing UWP support upstream",
   "name": "benchmark",
   "version-semver": "1.8.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library to support the benchmarking of functions, similar to unit-tests.",
   "homepage": "https://github.com/google/benchmark",
   "license": "Apache-2.0",

--- a/versions/b-/benchmark.json
+++ b/versions/b-/benchmark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44a03f2c85841f8e1e434e6a7f0a4ae73f7b2310",
+      "version-semver": "1.8.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "5e8efca95a7d5d9c74f8a2c5c2ee05bbd2271451",
       "version-semver": "1.8.3",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -562,7 +562,7 @@
     },
     "benchmark": {
       "baseline": "1.8.3",
-      "port-version": 1
+      "port-version": 2
     },
     "bento4": {
       "baseline": "1.6.0-640",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
