### PR TITLE
[calceph] update to version 3.5.5

### DIFF
--- a/ports/calceph/portfile.cmake
+++ b/ports/calceph/portfile.cmake
@@ -1,4 +1,4 @@
-set(CALCEPH_HASH 387a96a1007c8182ae5867415ccbfb1f65f10e11980efa69ffa06ba29dddb18e2bd208a52b3a3f7d8f23ccd2878bb6ccddd86a0e021a10ee32ee7a93e0e15c95)
+set(CALCEPH_HASH bbb60179b36f3ea9f05daa43e7950494d058137cf5a92e6c7b9742048dc0767490b7b42d2d2db7329f5ca96ffc4f2f32443abacb1073e29af78e58935b8b3edc)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-${VERSION}.tar.gz"
@@ -13,7 +13,6 @@ vcpkg_extract_source_archive(
 
 if (VCPKG_TARGET_IS_WINDOWS)
 
-    file(COPY "${SOURCE_PATH}/pythonapi/src/calcephpy.pyx.in" DESTINATION "${SOURCE_PATH}/pythonapi/src/calcephpy.pyx.vc")
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
         OPTIONS

--- a/ports/calceph/vcpkg.json
+++ b/ports/calceph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "calceph",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "description": "C library to access the binary planetary ephemeris files.",
   "homepage": "https://www.imcce.fr/inpop/calceph/",
   "documentation": "https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/html/c/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1441,7 +1441,7 @@
       "port-version": 1
     },
     "calceph": {
-      "baseline": "3.5.4",
+      "baseline": "3.5.5",
       "port-version": 0
     },
     "camport3": {

--- a/versions/c-/calceph.json
+++ b/versions/c-/calceph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "068e74605df6b8a253d6f659db2e2114d1764588",
+      "version": "3.5.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "3602c8d1030d2f0260d5de2104b5111fd4f7f253",
       "version": "3.5.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

