### PR TITLE
[cgicc] update to 3.2.20

### DIFF
--- a/ports/cgicc/portfile.cmake
+++ b/ports/cgicc/portfile.cmake
@@ -1,11 +1,10 @@
-set(CGICC_VERSION 3.2.19)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnu.org/gnu/cgicc/cgicc-${CGICC_VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/cgicc/cgicc-${CGICC_VERSION}.tar.gz"
-    FILENAME "cgicc-${CGICC_VERSION}.tar.gz"
-    SHA512 c361923cf3ac876bc3fc94dffd040d2be7cd44751d8534f4cfa3545e9f58a8ec35ebcd902a8ce6a19da0efe52db67506d8b02e5cc868188d187ce3092519abdf
+    URLS "https://ftp.gnu.org/gnu/cgicc/cgicc-${VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/cgicc/cgicc-${VERSION}.tar.gz"
+    FILENAME "cgicc-${VERSION}.tar.gz"
+    SHA512 e57b8f30b26b29008bcf1ffc3b2d272bdbd77848fb02e24912b6182ae90923d5933b9d204c556ac922a389f73ced465065b6e2202fc0c3d008e0e6038e7c8052
 )
 
 vcpkg_extract_source_archive(

--- a/ports/cgicc/vcpkg.json
+++ b/ports/cgicc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cgicc",
-  "version": "3.2.19",
-  "port-version": 7,
+  "version": "3.2.20",
   "description": "GNU Cgicc is an ANSI C++ compliant class library that greatly simplifies the creation of CGI applications for the World Wide Web",
   "homepage": "https://www.gnu.org/software/cgicc/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1537,8 +1537,8 @@
       "port-version": 1
     },
     "cgicc": {
-      "baseline": "3.2.19",
-      "port-version": 7
+      "baseline": "3.2.20",
+      "port-version": 0
     },
     "cglm": {
       "baseline": "0.9.2",

--- a/versions/c-/cgicc.json
+++ b/versions/c-/cgicc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3532e691224cc3ac6c144d0ba4cc82fc81077996",
+      "git-tree": "f9e35a8d1360fc1eb4f323ef22e461d0e5926a90",
       "version": "3.2.20",
       "port-version": 0
     },

--- a/versions/c-/cgicc.json
+++ b/versions/c-/cgicc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3532e691224cc3ac6c144d0ba4cc82fc81077996",
+      "version": "3.2.20",
+      "port-version": 0
+    },
+    {
       "git-tree": "60fd4672dd6d913e3af2560314dd31bed192a205",
       "version": "3.2.19",
       "port-version": 7


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

