### PR TITLE
[vcpkg-tool-swig] Add new tool port

### DIFF
--- a/ports/vcpkg-tool-swig/portfile.cmake
+++ b/ports/vcpkg-tool-swig/portfile.cmake
@@ -1,0 +1,30 @@
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO swig/swig 
+    REF "v${VERSION}"
+    SHA512 5d653333f73356d4d5ba8b615882e49f33f188bc68d8204352116bc4aca7946ec01ce2e02524c5ce805b98c2219ed05e664120485bf18095c5c0785436487074
+    HEAD_REF master
+)
+
+vcpkg_find_acquire_program(BISON)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DBISON_EXECUTABLE=${BISON}"
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_tools(
+    TOOL_NAMES swig
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/swig"
+)
+
+file(COPY "${CURRENT_PACKAGES_DIR}/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/swig")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/vcpkg-tool-swig/vcpkg.json
+++ b/ports/vcpkg-tool-swig/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "vcpkg-tool-swig",
+  "version": "4.2.1",
+  "description": "A software development tool that connects programs written in C and C++ with a variety of high-level programming languages.",
+  "homepage": "https://www.swig.org/",
+  "license": "GPL-3.0-only",
+  "supports": "!uwp",
+  "dependencies": [
+    "pcre2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9352,6 +9352,10 @@
       "baseline": "2.7.18",
       "port-version": 1
     },
+    "vcpkg-tool-swig": {
+      "baseline": "4.2.1",
+      "port-version": 0
+    },
     "vectorclass": {
       "baseline": "2.02.00",
       "port-version": 0

--- a/versions/v-/vcpkg-tool-swig.json
+++ b/versions/v-/vcpkg-tool-swig.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b4301e6eae04738e7b64c1fbabc4e2d2ba2418a5",
+      "version": "4.2.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

