### PR TITLE
[portmidi] Scope alsa dependency to Linux/Android/{Free,Open}BSD

### DIFF
--- a/ports/portmidi/vcpkg.json
+++ b/ports/portmidi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "portmidi",
   "version": "2.0.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "PortMidi is a cross platform (Windows, macOS, Linux, and BSDs which support alsalib) library for interfacing with operating systems' MIDI I/O APIs.",
   "homepage": "https://github.com/PortMidi/portmidi",
   "license": "MIT",
@@ -9,7 +9,7 @@
   "dependencies": [
     {
       "name": "alsa",
-      "platform": "!(windows | osx)"
+      "platform": "linux | android | freebsd | openbsd"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6810,7 +6810,7 @@
     },
     "portmidi": {
       "baseline": "2.0.4",
-      "port-version": 2
+      "port-version": 3
     },
     "portsmf": {
       "baseline": "239",

--- a/versions/p-/portmidi.json
+++ b/versions/p-/portmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2e836f32941f2eb402cecca7bff1e0ec566c4287",
+      "version": "2.0.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "73cae77fb0424c85894d1165fd2cc162bd4cd98a",
       "version": "2.0.4",
       "port-version": 2


### PR DESCRIPTION
When building for a platform like iOS `portmidi` (erroneously) has a dependency on ALSA. To fix this, this PR updates the platform condition from `!(windows | osx)` to `linux | android | freebsd | openbsd` (as per the description that `portmidi` supports BSDs). Other platforms using alsalib can be added as needed.

An alternative solution would be to exclude iOS, but my gut feeling is that declaring platforms inclusively is a more robust solution here since we avoid regressing on potentially new platforms. Thoughts welcome.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download (not applicable).
- [x] The "supports" clause reflects platforms that may be fixed by this new version (not applicable).
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file (not applicable).
- [x] Any patches that are no longer applied are deleted from the port's directory (not applicable).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.