### PR TITLE
[azure-messaging-eventhubs-cpp] Update to 1.0.0-beta.6

### DIFF
--- a/ports/azure-messaging-eventhubs-cpp/portfile.cmake
+++ b/ports/azure-messaging-eventhubs-cpp/portfile.cmake
@@ -4,8 +4,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-messaging-eventhubs_1.0.0-beta.5
-    SHA512 1c8200a0ae2618ef7c4fbf82770a45fcd922cdc76618022711f9cb934355cc13ccc49c61ca48f70235d799e217cc813c27d57cdb4bd74ddc1916e9dfbb768367
+    REF azure-messaging-eventhubs_1.0.0-beta.6
+    SHA512 bb3cd12637c487e779ebc64c12b3f68fb83a2d0b4aba7db35fc62c7f39b2f499b07f5f3fcdbd3992cc10f8b97c3c5f0710ccc156b9a97a07617ef1bf5d42088c
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs")

--- a/ports/azure-messaging-eventhubs-cpp/vcpkg.json
+++ b/ports/azure-messaging-eventhubs-cpp/vcpkg.json
@@ -4,7 +4,7 @@
     "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
   ],
   "name": "azure-messaging-eventhubs-cpp",
-  "version-semver": "1.0.0-beta.5",
+  "version-semver": "1.0.0-beta.6",
   "description": [
     "Microsoft Azure Messaging Event Hubs SDK for C++",
     "This library provides Azure Messaging Event Hubs SDK."

--- a/ports/azure-messaging-eventhubs-cpp/vcpkg.json
+++ b/ports/azure-messaging-eventhubs-cpp/vcpkg.json
@@ -15,7 +15,7 @@
     {
       "name": "azure-core-amqp-cpp",
       "default-features": false,
-      "version>=": "1.0.0-beta.5"
+      "version>=": "1.0.0-beta.7"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/a-/azure-messaging-eventhubs-cpp.json
+++ b/versions/a-/azure-messaging-eventhubs-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "84820bf0368e7bb36812dcb9eea440664d5165f4",
+      "version-semver": "1.0.0-beta.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "b863a91f0ee55df12d178fb00837d37d640e6f80",
       "version-semver": "1.0.0-beta.5",
       "port-version": 0

--- a/versions/a-/azure-messaging-eventhubs-cpp.json
+++ b/versions/a-/azure-messaging-eventhubs-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "84820bf0368e7bb36812dcb9eea440664d5165f4",
+      "git-tree": "2823cc22f2097df4705b1ab925822f6ba19e40f9",
       "version-semver": "1.0.0-beta.6",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -465,7 +465,7 @@
       "port-version": 1
     },
     "azure-messaging-eventhubs-cpp": {
-      "baseline": "1.0.0-beta.5",
+      "baseline": "1.0.0-beta.6",
       "port-version": 0
     },
     "azure-security-attestation-cpp": {


### PR DESCRIPTION
cc @LarryOsterman

## azure-messaging-eventhubs-cpp 1.0.0-beta.6 (2024-02-06)

### Breaking Changes

- `PartitionClient::Close` now takes an optional `Azure::Core::Context` parameter to reflect that it now waits until the `Close` verb has fully completed. This should not affect existing clients.
- `ProcessorPartitionClient::Close` now takes an optional `Azure::Core::Context` parameter to reflect that it now waits until the `Close` verb has fully completed. This should not affect existing clients.
