### PR TITLE
[draco] update to 1.5.7

### DIFF
--- a/ports/draco/portfile.cmake
+++ b/ports/draco/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/draco
     REF "${VERSION}"
-    SHA512 d4bc48aeac23aba377d1770a46e6676cb01596a436493385fb0c4ef9ba3f0fae42027232131a3d438250909aff4311353e114925753d045cc585af42660be0b1
+    SHA512 8b444744cdf12fb9d276916eb2ff0735cd1a6497b65b88813ec457fe2169db987db62e3db253a7d0f3ae7d45ae6502e8a9f8c0b81abde73e07b3bec69f9dc170
     HEAD_REF master
     PATCHES
         fix-compile-error-uwp.patch

--- a/ports/draco/vcpkg.json
+++ b/ports/draco/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "draco",
-  "version": "1.5.6",
-  "port-version": 1,
+  "version": "1.5.7",
   "description": " A library for compressing and decompressing 3D geometric meshes and point clouds. It is intended to improve the storage and transmission of 3D graphics.",
   "homepage": "https://github.com/google/draco",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2297,8 +2297,8 @@
       "port-version": 0
     },
     "draco": {
-      "baseline": "1.5.6",
-      "port-version": 1
+      "baseline": "1.5.7",
+      "port-version": 0
     },
     "drlibs": {
       "baseline": "2023-08-16",

--- a/versions/d-/draco.json
+++ b/versions/d-/draco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06799add74da6e9e4634e4c7f27b82b1149a8bb6",
+      "version": "1.5.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "7766920ec32ef9da00121a0668edf41bf9d1d76b",
       "version": "1.5.6",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

