### PR TITLE
[poppler] update to 24.02.0

### DIFF
--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO poppler/poppler
     REF "poppler-${POPPLER_VERSION}"
-    SHA512 23fe0f5445896e3a0731a0f3eae6aac84dc8f4b0718e947ae3ee3492295720408738f0c706eb2e5cbaa41e854dafc70e5c59c9c70e7d78ab33c318b2e8d7e4ff
+    SHA512 964a7e535b14a6860b1ba70bda82177bc804442e8d99e43dfd3dbed50381b7b1114d66ec6c32194ef86ee83fd8dbf07d82f5bec4ec97e082269acfd22f9af252
     HEAD_REF master
     PATCHES
         export-unofficial-poppler.patch
@@ -106,6 +106,6 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO poppler/poppler
     REF "poppler-${POPPLER_VERSION}"
-    SHA512 964a7e535b14a6860b1ba70bda82177bc804442e8d99e43dfd3dbed50381b7b1114d66ec6c32194ef86ee83fd8dbf07d82f5bec4ec97e082269acfd22f9af252
+    SHA512 3f1cb23f9f89cae24c05618c31e0d6414cfe48cffa6b59fc2a0b0fbe79df2715584e170785d2fdd1e5592af7bda4b3a9e3070e8452a17db86d484dcd6b00138d
     HEAD_REF master
     PATCHES
         export-unofficial-poppler.patch

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "poppler",
-  "version": "24.1.0",
+  "version": "24.2.0",
   "description": "A PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "license": "GPL-2.0-or-later",
@@ -63,13 +63,6 @@
           ],
           "platform": "!windows & !android"
         }
-      ]
-    },
-    "fontconfig": {
-      "description": "Use fontconfig",
-      "supports": "!windows, mingw",
-      "dependencies": [
-        "fontconfig"
       ]
     },
     "glib": {

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -65,6 +65,13 @@
         }
       ]
     },
+    "fontconfig": {
+      "description": "Use fontconfig",
+      "supports": "!windows, mingw",
+      "dependencies": [
+        "fontconfig"
+      ]
+    },
     "glib": {
       "description": "glib for poppler",
       "dependencies": [

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "poppler",
-  "version": "23.11.0",
+  "version": "24.1.0",
   "description": "A PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6781,7 +6781,7 @@
       "port-version": 5
     },
     "poppler": {
-      "baseline": "23.11.0",
+      "baseline": "24.2.0",
       "port-version": 0
     },
     "popsift": {

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43f075658198e146ddae3f04f3c3fbc9efb9eca9",
+      "version": "24.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "59fe9d32b68bf9d4bc186eea35c45ceaddac1848",
       "version": "23.11.0",
       "port-version": 0

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "43f075658198e146ddae3f04f3c3fbc9efb9eca9",
+      "git-tree": "4035b8dd08a68fca8ad6cfbcc4c4a4ec0eb4e04f",
       "version": "24.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #36396, update `poppler` to 24.2.0.

Feature `fontconfig` is tested successfully in the following triplet:
```
x64-linux
```

Except `fontconfig`, all features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```

The usage test passed on `x64-windows` (header files found):
```
The package poppler can be imported via CMake FindPkgConfig module:

    find_package(PkgConfig)
    pkg_check_modules(POPPLER_CPP REQUIRED IMPORTED_TARGET poppler-cpp)

    target_link_libraries(main PRIVATE PkgConfig::POPPLER_CPP)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.