### PR TITLE
[libobjc2] new port

### DIFF
--- a/ports/libobjc2/portfile.cmake
+++ b/ports/libobjc2/portfile.cmake
@@ -1,0 +1,46 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gnustep/libobjc2
+    REF "v${VERSION}"
+    SHA512 4e49dc00be5a9282678b7cd4793ef1c4202e4a7f26dba2a170f0ff77b0f311c0f44eb72093a01367be34f12156ffd07fec40067162b9c0e4f561ec0784ab0643
+    HEAD_REF master
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_cmake_get_vars(cmake_vars_file)
+    include("${cmake_vars_file}")
+
+    if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+        vcpkg_find_acquire_program(CLANG)
+        cmake_path(GET CLANG PARENT_PATH CLANG_PARENT_PATH)
+        set(CLANG_CL "${CLANG_PARENT_PATH}/clang-cl.exe")
+
+        list(APPEND OPTIONS -DCMAKE_C_COMPILER=${CLANG_CL})
+        list(APPEND OPTIONS -DCMAKE_CXX_COMPILER=${CLANG_CL})
+        list(APPEND OPTIONS "-DCMAKE_OBJC_FLAGS=-Xclang -fobjc-exceptions")
+    endif()
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+
+# Temporary workaround; this will be fixed in a future version, see https://github.com/gnustep/libobjc2/pull/275
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/lib/objc.dll" "${CURRENT_PACKAGES_DIR}/bin/objc.dll")
+    
+    if(NOT VCPKG_BUILD_TYPE)
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/objc.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/objc.dll")
+    endif()
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libobjc2/portfile.cmake
+++ b/ports/libobjc2/portfile.cmake
@@ -43,4 +43,4 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libobjc2/vcpkg.json
+++ b/ports/libobjc2/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "libobjc2",
+  "version": "2.2",
+  "description": "Objective-C runtime library intended for use with Clang.",
+  "homepage": "https://github.com/gnustep/libobjc2",
+  "license": "MIT",
+  "supports": "!static & !arm & !x86 & !uwp",
+  "dependencies": [
+    {
+      "name": "robin-map",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4644,6 +4644,10 @@
       "baseline": "2023-03-23",
       "port-version": 0
     },
+    "libobjc2": {
+      "baseline": "2.2",
+      "port-version": 0
+    },
     "libodb": {
       "baseline": "2.4.0",
       "port-version": 10

--- a/versions/l-/libobjc2.json
+++ b/versions/l-/libobjc2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f47a0d5b16660eb131a7b212ec2d25d3499c3f22",
+      "version": "2.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libobjc2.json
+++ b/versions/l-/libobjc2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f47a0d5b16660eb131a7b212ec2d25d3499c3f22",
+      "git-tree": "797fd53e974e28780d3dab31cfa80ae11990ef34",
       "version": "2.2",
       "port-version": 0
     }


### PR DESCRIPTION

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines. -- see https://repology.org/projects/?search=libobjc2
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.