### PR TITLE
[sdl2-mixer] Fix feature libmodplug build failure

### DIFF
--- a/ports/sdl2-mixer/portfile.cmake
+++ b/ports/sdl2-mixer/portfile.cmake
@@ -28,6 +28,8 @@ if("fluidsynth" IN_LIST FEATURES)
     list(APPEND EXTRA_OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
 endif()
 
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -43,6 +45,7 @@ vcpkg_cmake_configure(
         -DSDL2MIXER_MIDI_NATIVE=OFF
         -DSDL2MIXER_MIDI_TIMIDITY=OFF
         -DSDL2MIXER_MP3_DRMP3=OFF
+        -DSDL2MIXER_MOD_XMP_SHARED=${BUILD_SHARED}
 )
 
 vcpkg_cmake_install()

--- a/ports/sdl2-mixer/vcpkg.json
+++ b/ports/sdl2-mixer/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2-mixer",
   "version": "2.8.0",
+  "port-version": 1,
   "description": "Multi-channel audio mixer library for SDL.",
   "homepage": "https://github.com/libsdl-org/SDL_mixer",
   "license": "Zlib",
@@ -36,7 +37,8 @@
     "libmodplug": {
       "description": "Use libmodplug to play MOD audio format.",
       "dependencies": [
-        "libmodplug"
+        "libmodplug",
+        "libxmp"
       ]
     },
     "mpg123": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7834,7 +7834,7 @@
     },
     "sdl2-mixer": {
       "baseline": "2.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-mixer-ext": {
       "baseline": "2.6.0",

--- a/versions/s-/sdl2-mixer.json
+++ b/versions/s-/sdl2-mixer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b28cae64adf73bec946de9f037724763eb2ef1b2",
+      "version": "2.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "21406093a22cbd3a55befe2ff61f81011d055036",
       "version": "2.8.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #36662.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature `libmodplug` passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
