### PR TITLE
[devil] Fix error in cpp17

### DIFF
--- a/ports/devil/0007-remove_register_keyword_cpp17.patch
+++ b/ports/devil/0007-remove_register_keyword_cpp17.patch
@@ -1,0 +1,30 @@
+diff --git a/DevIL/src-IL/src/il_manip.cpp b/DevIL/src-IL/src/il_manip.cpp
+index 79acc99..229a692 100644
+--- a/DevIL/src-IL/src/il_manip.cpp
++++ b/DevIL/src-IL/src/il_manip.cpp
+@@ -37,9 +37,9 @@ ILushort ILAPIENTRY ilFloatToHalf(ILuint i) {
+ 	// of float and half (127 versus 15).
+ 	//
+ 
+-	register int s =  (i >> 16) & 0x00008000;
+-	register int e = ((i >> 23) & 0x000000ff) - (127 - 15);
+-	register int m =   i        & 0x007fffff;
++	int s =  (i >> 16) & 0x00008000;
++	int e = ((i >> 23) & 0x000000ff) - (127 - 15);
++	int m =   i        & 0x007fffff;
+ 
+ 	//
+ 	// Now reassemble s, e and m into a half:
+diff --git a/DevIL/src-ILU/src/ilu_scaling.cpp b/DevIL/src-ILU/src/ilu_scaling.cpp
+index c2893a3..ef35c13 100644
+--- a/DevIL/src-ILU/src/ilu_scaling.cpp
++++ b/DevIL/src-ILU/src/ilu_scaling.cpp
+@@ -406,7 +406,7 @@ main(argc, argv)
+ int argc;
+ char *argv[];
+ {
+-	register int c;
++	int c;
+ 	int optind;
+ 	char *optarg;
+ 	int xsize = 0, ysize = 0;

--- a/ports/devil/portfile.cmake
+++ b/ports/devil/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         0005-fix-pkgconfig.patch
         0006-fix-ilut-header.patch
         jasper-4.patch
+        0007-remove_register_keyword_cpp17.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/DevIL/src-IL/cmake/FindOpenEXR.cmake")

--- a/ports/devil/vcpkg.json
+++ b/ports/devil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "devil",
   "version": "1.8.0",
-  "port-version": 11,
+  "port-version": 12,
   "description": "A full featured cross-platform image library",
   "homepage": "https://github.com/DentonW/DevIL",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2194,7 +2194,7 @@
     },
     "devil": {
       "baseline": "1.8.0",
-      "port-version": 11
+      "port-version": 12
     },
     "dimcli": {
       "baseline": "7.1.0",

--- a/versions/d-/devil.json
+++ b/versions/d-/devil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e22a47b75583772a690e6e361fcbb3739838282",
+      "version": "1.8.0",
+      "port-version": 12
+    },
+    {
       "git-tree": "03010167ad1849c5f1a8e5bc044115b3c84478a3",
       "version": "1.8.0",
       "port-version": 11


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/36653
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
