### PR TITLE
[bot] automatically handle too short issues and internal compiler errors 

### DIFF
--- a/.github/workflows/check_issues.yml
+++ b/.github/workflows/check_issues.yml
@@ -20,46 +20,53 @@ jobs:
               repo: context.repo.repo
             };
             let issue = await github.rest.issues.get(issue_query)
+            let commentLabelClose = async (comment, label) => {
+              await github.rest.issues.removeAllLabels(issue_query);
+              await github.rest.issues.setLabels({...issue_query, labels: [label]});
+              await github.rest.issues.createComment({...issue_query, body: comment});
+              await github.rest.issues.update({...issue_query, state: "closed"});
+            }
 
             // missing-windows-sdk-issue
             let reg = /RC Pass 1: command "rc .*" failed \(exit code 0\) with the following output:/;
             if (reg.test(issue.data.body)){
-              await github.rest.issues.removeAllLabels(issue_query);
-              await github.rest.issues.setLabels({...issue_query, labels: ["category:question"]});
               let body = "Thanks for posting this issue. Please make sure you have the following installed.\n" +
                          "- Visual Studio Desktop development with C++.\n" +
                          "- Windows 10 SDK or Windows 11 SDK.";
-              await github.rest.issues.createComment({...issue_query, body}); 
-              // Close the issue? 
+              return await commentLabelClose(body, "category:question");
             }
 
             // msys2 download fails => old vcpkg version
             reg = /error: https:\/\/repo\.msys2\.org\/.*: failed: status code 404/;
             if (reg.test(issue.data.body)){
-              await github.rest.issues.removeAllLabels(issue_query);
-              await github.rest.issues.setLabels({...issue_query, labels: ["category:question"]});
               let body = "Try updating your vcpkg version via `git pull` to resolve this issue. MSYS2 downloads are removed from the upstream servers from time to time, so using an up-to-date vcpkg version is necessary."
-              await github.rest.issues.createComment({...issue_query, body}); 
-              // Close the issue? 
+              return await commentLabelClose(body, "category:question");
             }
 
             // Issue text is: Copy issue body from .../issue_body.md
             reg = /^Copy issue body from .*issue_body.md$/;
             if (reg.test(issue.data.body)){
-              await github.rest.issues.removeAllLabels(issue_query);
-              await github.rest.issues.setLabels({...issue_query, labels: ["requires:more-information"]});
               let body = "Please see #30604 for how to report a build failure."
-              await github.rest.issues.createComment({...issue_query, body});
-              await github.rest.issues.update({...issue_query, state: "closed"});
+              return await commentLabelClose(body, "requires:more-information");
+            }
+
+            // Issue to short like #36592 or #36668
+            reg = /^error: building.* BUILD_FAILED\r\nElapsed time.*\r\nPlease ensure.*(\r\nThen check .*\r\n.*)?$/;
+            if (reg.test(issue.data.body)){
+              let body = "Please see #30604 for how to report a build failure."
+              return await commentLabelClose(body, "requires:more-information");
             }
 
             // pkg-config/ not found issues like #36011
             reg = /CMake Error at scripts\/cmake\/vcpkg_find_acquire_program.*\r\n(.*Please install it via your package manager:[\s\S]+)Call Stack/;
             match = issue.data.body.match(reg)
             if (match){
-              await github.rest.issues.removeAllLabels(issue_query);
-              await github.rest.issues.setLabels({...issue_query, labels: ["category:question"]});
               let body = "From the log:\n```\n" + match[1] + "```\n"
-              await github.rest.issues.createComment({...issue_query, body});
-              await github.rest.issues.update({...issue_query, state: "closed"});
+              return await commentLabelClose(body, "category:question");
+            }
+
+            // MSVC internal compiler error like #36628
+            if (issue.data.body.indexOf("fatal error C1001: Internal compiler error") !== -1){
+              let body = "The build failed due to an internal compiler error. Please update your compiler or revert to an old version."
+              return await commentLabelClose(body, "category:question");
             }


### PR DESCRIPTION
Handles issues that are to short or reports an internal compiler error. Examples:
https://github.com/autoantwort/vcpkg/issues/37
https://github.com/autoantwort/vcpkg/issues/38
https://github.com/autoantwort/vcpkg/issues/39
