### PR TITLE
[glibmm] Update to 2.78.1

### DIFF
--- a/ports/glibmm/portfile.cmake
+++ b/ports/glibmm/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIBMM_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIBMM_ARCHIVE
     URLS "https://ftp.gnome.org/pub/GNOME/sources/glibmm/${GLIBMM_MAJOR_MINOR}/glibmm-${VERSION}.tar.xz"
     FILENAME "glibmm-${VERSION}.tar.xz"
-    SHA512 be49599f5eb8eb5a1cef015cdb37af2564fcd1ea845aa4344804ca5f0f61468949711e25cefebb93219e1be37128ebfdd2a816324e752ac4395b4b87c072fc78
+    SHA512 5ace15c492be553e2c6abd8d0699197239261feaa2b45ff77181f59bb98b584dc822bdd46dbdee35691cc5a955a3b88e03f58532459236fd780823354c35d0a6
 )
 
 vcpkg_extract_source_archive(
@@ -32,5 +32,4 @@ vcpkg_fixup_pkgconfig()
 # Handle copyright and readmes
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME readme.txt)
-file(INSTALL "${SOURCE_PATH}/README.SUN" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/README.win32" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/README.win32.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/glibmm/vcpkg.json
+++ b/ports/glibmm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glibmm",
-  "version": "2.76.0",
-  "port-version": 1,
+  "version": "2.78.1",
   "description": "This is glibmm, a C++ API for parts of glib that are useful for C++.",
   "homepage": "https://www.gtkmm.org.",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3029,8 +3029,8 @@
       "port-version": 0
     },
     "glibmm": {
-      "baseline": "2.76.0",
-      "port-version": 1
+      "baseline": "2.78.1",
+      "port-version": 0
     },
     "glm": {
       "baseline": "1.0.0",

--- a/versions/g-/glibmm.json
+++ b/versions/g-/glibmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05b0a2d69b2ddb67eef2f6922dfb06c47c3b33d1",
+      "version": "2.78.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d8a2235a74e6c215246a3ade8ad3248b7e04e439",
       "version": "2.76.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #36681

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.