### PR TITLE
[atkmm] Update to 2.36.3

### DIFF
--- a/ports/atkmm/portfile.cmake
+++ b/ports/atkmm/portfile.cmake
@@ -2,13 +2,12 @@ if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
-set(ATKMM_VERSION 2.36.1)
-
 # Keep distfile, don't use GitLab!
+string(REGEX MATCH "^([0-9]*[.][0-9]*)" ATKMM_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnome.org/pub/GNOME/sources/atkmm/2.36/atkmm-${ATKMM_VERSION}.tar.xz"
-    FILENAME "atkmm-${ATKMM_VERSION}.tar.xz"
-    SHA512 23c831afac6bb9a0f9f2e622f8f9ffea29445a33b1cd650e0c07ee77e60b28ae5ee978c029e8e0f9b94e9ff4679d69ebde833f15e0a5403d97914cc7ccf98a6a
+    URLS "https://ftp.gnome.org/pub/GNOME/sources/atkmm/${ATKMM_MAJOR_MINOR}/atkmm-${VERSION}.tar.xz"
+    FILENAME "atkmm-${VERSION}.tar.xz"
+    SHA512 2c2513b5c5fd7a5c9392727325c7551c766d4d51b8089fbea7e8043cde97d07c9b1f98a4a693f30835e4366e9236e28e092c2480a78415d77c5cb72e9432344f
 )
 
 vcpkg_extract_source_archive(
@@ -29,3 +28,5 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME readme.txt)
+file(INSTALL "${SOURCE_PATH}/README.win32.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/atkmm/vcpkg.json
+++ b/ports/atkmm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "atkmm",
-  "version": "2.36.1",
-  "port-version": 2,
+  "version": "2.36.3",
   "description": "atkmm is the official C++ interface for the ATK accessibility toolkit library. It may be used, for instance, by user interfaces implemented with gtkmm.",
   "homepage": "https://www.gtkmm.org",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/atkmm.json
+++ b/versions/a-/atkmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b42bc112850ef59493e65d67cf5bbfb40011fac",
+      "version": "2.36.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "98ad8f81a31186ba590b553c5e99d4ea5415eb64",
       "version": "2.36.1",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -305,8 +305,8 @@
       "port-version": 8
     },
     "atkmm": {
-      "baseline": "2.36.1",
-      "port-version": 2
+      "baseline": "2.36.3",
+      "port-version": 0
     },
     "atl": {
       "baseline": "0",


### PR DESCRIPTION
Fixes #36683.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.