### PR TITLE
[pixman] Update to 0.43.2

### DIFF
--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -46,8 +46,8 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     GITLAB_URL https://gitlab.freedesktop.org
     REPO pixman/pixman
-    REF  37216a32839f59e8dcaa4c3951b3fcfc3f07852c # 0.42.2
-    SHA512 b010b2c698ebc95f8a8566c915ccfb81a82c08f0ccda8b11ddff4818eae4b51b103021d5bae9f3d3bd20bf494433f5fcc6b76188226fe336919b0b347cdcb828
+    REF  91b8526c1eeb2b45c21f091e890cb74cf6989ff6 # 0.43.2
+    SHA512 cd4ea905a2287ae1ec25720ac90a72b2812dfeb6a5a82e3bbfcfeba91461229cde61b8bc6a5dfe5711f6b2937b3d3d4ade2b0c9a0290880c7d0cc4859344b542
     PATCHES
         no-host-cpu-checks.patch
         fix_clang-cl.patch
@@ -58,6 +58,8 @@ vcpkg_from_gitlab(
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${OPTIONS}
+        -Ddemos=disabled
+        -Dgtk=disabled
         -Dlibpng=enabled
         -Dtests=disabled
 )
@@ -69,3 +71,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # # Handle copyright
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/README" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME readme.txt)

--- a/ports/pixman/vcpkg.json
+++ b/ports/pixman/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pixman",
-  "version": "0.42.2",
-  "port-version": 2,
+  "version": "0.43.2",
   "description": "Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.",
   "homepage": "https://www.cairographics.org/releases",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6681,8 +6681,8 @@
       "port-version": 1
     },
     "pixman": {
-      "baseline": "0.42.2",
-      "port-version": 2
+      "baseline": "0.43.2",
+      "port-version": 0
     },
     "pkgconf": {
       "baseline": "2.1.0",

--- a/versions/p-/pixman.json
+++ b/versions/p-/pixman.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2818a78546de0d60e38b89011073ff7ae398796e",
+      "version": "0.43.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a51c895edc5dd8067f51b600d631a5e8b32a65e8",
       "version": "0.42.2",
       "port-version": 2


### PR DESCRIPTION
Fixes #36685.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
