### PR TITLE
[imgui] update to 1.90.2

### DIFF
--- a/ports/imgui-node-editor/fix-vec2-math-operators.patch
+++ b/ports/imgui-node-editor/fix-vec2-math-operators.patch
@@ -1,0 +1,35 @@
+diff --git a/imgui_extra_math.h b/imgui_extra_math.h
+index 5c46cc4..18f6dad 100644
+--- a/imgui_extra_math.h
++++ b/imgui_extra_math.h
+@@ -30,8 +30,10 @@ struct ImLine
+ 
+ 
+ //------------------------------------------------------------------------------
++# if IMGUI_VERSION_NUM < 19002
+ inline bool operator==(const ImVec2& lhs, const ImVec2& rhs);
+ inline bool operator!=(const ImVec2& lhs, const ImVec2& rhs);
++#endif
+ inline ImVec2 operator*(const float lhs, const ImVec2& rhs);
+ # if IMGUI_VERSION_NUM < 18955
+ inline ImVec2 operator-(const ImVec2& lhs);
+diff --git a/imgui_extra_math.inl b/imgui_extra_math.inl
+index 8b1b071..acc1254 100644
+--- a/imgui_extra_math.inl
++++ b/imgui_extra_math.inl
+@@ -19,6 +19,7 @@
+ 
+ 
+ //------------------------------------------------------------------------------
++# if IMGUI_VERSION_NUM < 19002
+ inline bool operator==(const ImVec2& lhs, const ImVec2& rhs)
+ {
+     return lhs.x == rhs.x && lhs.y == rhs.y;
+@@ -28,6 +29,7 @@ inline bool operator!=(const ImVec2& lhs, const ImVec2& rhs)
+ {
+     return lhs.x != rhs.x || lhs.y != rhs.y;
+ }
++#endif
+ 
+ inline ImVec2 operator*(const float lhs, const ImVec2& rhs)
+ {

--- a/ports/imgui-node-editor/portfile.cmake
+++ b/ports/imgui-node-editor/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v${VERSION}
     SHA512 83573b6ed776095837373bc95be1c1f5b85e9c5fae2145647f9cb6fdc17d3889edce716ac9e27c1bbde56f00803a66db98ca856910e6e0ce8714d3c5ce3f7c3f
     HEAD_REF master
+    PATCHES
+        fix-vec2-math-operators.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/imgui-node-editor/vcpkg.json
+++ b/ports/imgui-node-editor/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui-node-editor",
   "version": "0.9.3",
+  "port-version": 1,
   "description": "Node Editor built using Dear ImGui",
   "homepage": "https://github.com/thedmd/imgui-node-editor",
   "license": "MIT",

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -5,7 +5,7 @@ if ("docking-experimental" IN_LIST FEATURES)
        OUT_SOURCE_PATH SOURCE_PATH
        REPO ocornut/imgui
        REF "v${VERSION}-docking"
-       SHA512 50953097ff809bca0e1cee55268eaa8dad001cf8fae85ae7623f484752d16bdf8e63c04227786361f27e73f7aeda5a8d1f9b0cee83c2aca108ce2712a21b74d9
+       SHA512 05f352f4c6739eb672396c33d8fb9765c3fbf8f221c4fa9d09644ae669771cb6c86be7ca110c09d8c3e0d1be37da0a7f5667ebd5280ae8e0a6fcc6efaf338fa7
        HEAD_REF docking
        )
 else()
@@ -13,7 +13,7 @@ else()
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
     REF "v${VERSION}"
-    SHA512 f6b33027c7050acc617c728b04b04572a13bf11589d4d2cab566901e94d349a3d91f133f7980049857ee44768d4bad426c9b2e53baf953f2efbf1a7951c3ba8a
+    SHA512 bd7ac28a1ef7b236e8051d83288ba9fe5f4d0321143ca325b7eb8649a24c0bf047b02b854fac828eb45c99517c7f579bb6bad1dabeeed3c323d714a94102a8e6
     HEAD_REF master
     )
 endif()

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.90",
-  "port-version": 4,
+  "version": "1.90.2",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3541,8 +3541,8 @@
       "port-version": 1
     },
     "imgui": {
-      "baseline": "1.90",
-      "port-version": 4
+      "baseline": "1.90.2",
+      "port-version": 0
     },
     "imgui-node-editor": {
       "baseline": "0.9.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3546,7 +3546,7 @@
     },
     "imgui-node-editor": {
       "baseline": "0.9.3",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui-sfml": {
       "baseline": "2.6",

--- a/versions/i-/imgui-node-editor.json
+++ b/versions/i-/imgui-node-editor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "895085c7cb1ad9ebfd27e9a114d222cf063367dd",
+      "version": "0.9.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "b660409ffe6d690ff6a3fae999b249e4521b5583",
       "version": "0.9.3",
       "port-version": 0

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9be79046f87d6b17d50967e3b76f2460e0d1bf3",
+      "version": "1.90.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0c0f46ea7e2a764b13e8dcf7348ce9c29923836c",
       "version": "1.90",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.