### PR TITLE
[bext-di] Add feature to support extensions

### DIFF
--- a/ports/bext-di/portfile.cmake
+++ b/ports/bext-di/portfile.cmake
@@ -8,6 +8,11 @@ vcpkg_from_github(
 
 file(INSTALL ${SOURCE_PATH}/include/boost
     DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+	
+if ("extensions" IN_LIST FEATURES)
+	file(INSTALL ${SOURCE_PATH}/extension/include/boost
+		DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+endif()
 
 vcpkg_download_distfile(LICENSE
     URLS https://www.boost.org/LICENSE_1_0.txt

--- a/ports/bext-di/vcpkg.json
+++ b/ports/bext-di/vcpkg.json
@@ -1,6 +1,12 @@
 {
   "name": "bext-di",
   "version": "1.3.0",
+  "port-version": 1,
   "description": "C++14 Dependency Injection Library.",
-  "homepage": "https://github.com/boost-ext/di"
+  "homepage": "https://github.com/boost-ext/di",
+  "features": {
+    "extensions": {
+      "description": "Build with extensions included"
+    }
+  }
 }

--- a/versions/b-/bext-di.json
+++ b/versions/b-/bext-di.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41c55bfd3aeb579a5233a48257ee125174b0f9b6",
+      "version": "1.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b4882fdad119370cd0496487cd2b2cfc4db087ce",
       "version": "1.3.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -582,7 +582,7 @@
     },
     "bext-di": {
       "baseline": "1.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "bext-mp": {
       "baseline": "2023-03-02",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
