### PR TITLE
[cglm] Enable for uwp

### DIFF
--- a/ports/cglm/vcpkg.json
+++ b/ports/cglm/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "cglm",
   "version-semver": "0.9.2",
+  "port-version": 1,
   "description": "Highly Optimized Graphics Math (glm) for C",
   "homepage": "https://github.com/recp/cglm",
   "license": "MIT",
-  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1542,7 +1542,7 @@
     },
     "cglm": {
       "baseline": "0.9.2",
-      "port-version": 0
+      "port-version": 1
     },
     "cgltf": {
       "baseline": "1.13",

--- a/versions/c-/cglm.json
+++ b/versions/c-/cglm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89b93a34ee7896b76bd78e8584deddbf96d203d9",
+      "version-semver": "0.9.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "307a5dca27758987b25ae8f1868c50f3c332d3d6",
       "version-semver": "0.9.2",
       "port-version": 0


### PR DESCRIPTION
Upstream CI was updated recently and seems to work for WindowsStore, so trying it out here.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
