### PR TITLE
Fix python include path for non-windows

### DIFF
--- a/ports/python3/0018-fix-sysconfig-include.patch
+++ b/ports/python3/0018-fix-sysconfig-include.patch
@@ -2,18 +2,6 @@ diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
 index ebe371182..e351df7da 100644
 --- a/Lib/sysconfig.py
 +++ b/Lib/sysconfig.py
-@@ -30,9 +30,9 @@
-         'purelib': '{base}/lib/python{py_version_short}/site-packages',
-         'platlib': '{platbase}/{platlibdir}/python{py_version_short}/site-packages',
-         'include':
--            '{installed_base}/include/python{py_version_short}{abiflags}',
-+            '{installed_base}/../../include/python{py_version_short}{abiflags}',
-         'platinclude':
--            '{installed_platbase}/include/python{py_version_short}{abiflags}',
-+            '{installed_platbase}/../../include/python{py_version_short}{abiflags}',
-         'scripts': '{base}/bin',
-         'data': '{base}',
-         },
 @@ -51,8 +51,8 @@
          'platstdlib': '{base}/Lib',
          'purelib': '{base}/Lib/site-packages',

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.11.5",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6954,7 +6954,7 @@
     },
     "python3": {
       "baseline": "3.11.5",
-      "port-version": 4
+      "port-version": 5
     },
     "qca": {
       "baseline": "2.3.7",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "262bbdcf3e67802bfdcb9efe22a34e81defc3fb1",
+      "version": "3.11.5",
+      "port-version": 5
+    },
+    {
       "git-tree": "196d8baf56879fd416fbcfb05a7033ea61febf24",
       "version": "3.11.5",
       "port-version": 4


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36698

On macos/linux a wrong include path is reported by python since https://github.com/microsoft/vcpkg/pull/34888

```
./tools/python3/python3.11 -c "import pprint;import sysconfig; pprint.pprint(sysconfig.get_paths())"                                                                     
{'data': '/home/mkuhn/dev/vcpkg/installed/x64-linux',
 'include': '/home/mkuhn/dev/vcpkg/include/python3.11',
 'platinclude': '/home/mkuhn/dev/vcpkg/include/python3.11',
 'platlib': '/home/mkuhn/dev/vcpkg/installed/x64-linux/lib/python3.11/site-packages',
 'platstdlib': '/home/mkuhn/dev/vcpkg/installed/x64-linux/lib/python3.11',
 'purelib': '/home/mkuhn/dev/vcpkg/installed/x64-linux/lib/python3.11/site-packages',
 'scripts': '/home/mkuhn/dev/vcpkg/installed/x64-linux/bin',
 'stdlib': '/home/mkuhn/dev/vcpkg/installed/x64-linux/lib/python3.11'}
```