### PR TITLE
[qtkeychain-qt6] Fix compilation on android and ios

### DIFF
--- a/ports/qtkeychain-qt6/vcpkg.json
+++ b/ports/qtkeychain-qt6/vcpkg.json
@@ -1,16 +1,22 @@
 {
   "name": "qtkeychain-qt6",
   "version": "0.14.1",
+  "port-version": 1,
   "description": "(Unaffiliated with Qt) Platform-independent Qt6 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "libsecret",
-      "platform": "!(windows | uwp | osx)"
+      "platform": "linux"
+    },
+    {
+      "name": "qtbase",
+      "default-features": false
     },
     {
       "name": "qttools",
+      "host": true,
       "features": [
         "linguist"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7250,7 +7250,7 @@
     },
     "qtkeychain-qt6": {
       "baseline": "0.14.1",
-      "port-version": 0
+      "port-version": 1
     },
     "qtlanguageserver": {
       "baseline": "6.6.1",

--- a/versions/q-/qtkeychain-qt6.json
+++ b/versions/q-/qtkeychain-qt6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43422edc152951a565a24a097c3c52a1b1ac1e4f",
+      "version": "0.14.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "dcb9fb0fa722410c03a4d6fbfdb3608af68de9d5",
       "version": "0.14.1",
       "port-version": 0


### PR DESCRIPTION
This PR fixes compilation of qtkeychain-qt6 on Android and iOS. 