### PR TITLE
[skia] add feature rtti

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -189,6 +189,10 @@ if("metal" IN_LIST FEATURES)
     string(APPEND OPTIONS " skia_use_metal=true")
 endif()
 
+if("rtti" IN_LIST FEATURES)
+    string(APPEND EXTRA_CXX_FLAGS " -frtti")
+endif()
+
 if("vulkan" IN_LIST FEATURES)
     list(APPEND required_externals
         vulkan_headers
@@ -276,12 +280,12 @@ else()
 endif()
 
 string_to_gn_list(SKIA_C_FLAGS_DBG "${VCPKG_COMBINED_C_FLAGS_DEBUG}")
-string_to_gn_list(SKIA_CXX_FLAGS_DBG "${VCPKG_COMBINED_CXX_FLAGS_DEBUG}")
+string_to_gn_list(SKIA_CXX_FLAGS_DBG "${VCPKG_COMBINED_CXX_FLAGS_DEBUG}${EXTRA_CXX_FLAGS}")
 string(APPEND OPTIONS_DBG " \
     extra_cflags_c=${SKIA_C_FLAGS_DBG} \
     extra_cflags_cc=${SKIA_CXX_FLAGS_DBG}")
 string_to_gn_list(SKIA_C_FLAGS_REL "${VCPKG_COMBINED_C_FLAGS_RELEASE}")
-string_to_gn_list(SKIA_CXX_FLAGS_REL "${VCPKG_COMBINED_CXX_FLAGS_RELEASE}")
+string_to_gn_list(SKIA_CXX_FLAGS_REL "${VCPKG_COMBINED_CXX_FLAGS_RELEASE}${EXTRA_CXX_FLAGS}")
 string(APPEND OPTIONS_REL " \
     extra_cflags_c=${SKIA_C_FLAGS_REL} \
     extra_cflags_cc=${SKIA_CXX_FLAGS_REL}")

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "skia",
   "version": "0.38.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",
@@ -128,6 +128,9 @@
     "metal": {
       "description": "Metal support for skia",
       "supports": "ios, osx"
+    },
+    "rtti": {
+      "description": "Build with dynamic typeinfo"
     },
     "vulkan": {
       "description": "Vulkan support for skia",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8034,7 +8034,7 @@
     },
     "skia": {
       "baseline": "0.38.2",
-      "port-version": 4
+      "port-version": 5
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76c369b0c6578a6bd72f9b5456f242af3742eb68",
+      "version": "0.38.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "b33b637ea6bf1d04acc4aac659b0238f9d16a0c1",
       "version": "0.38.2",
       "port-version": 4


### PR DESCRIPTION
This is necessary on UNIX platforms when using the skia library in an application built with rtti itself.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.