### PR TITLE
[blake3] fixes preprocessor with clang-cl

### DIFF
--- a/ports/blake3/fix-windows-arm-build-error.patch
+++ b/ports/blake3/fix-windows-arm-build-error.patch
@@ -7,7 +7,7 @@ index af6c3da..dce85b4 100644
  #define ATOMIC_LOAD(x) x
  #define ATOMIC_STORE(x, y) x = y
 -#elif defined(_MSC_VER)
-+#elif defined(IS_X86) and defined(_MSC_VER)
++#elif defined(IS_X86) && defined(_MSC_VER)
  #define ATOMIC_INT LONG
  #define ATOMIC_LOAD(x) InterlockedOr(&x, 0)
  #define ATOMIC_STORE(x, y) InterlockedExchange(&x, y)

--- a/ports/blake3/vcpkg.json
+++ b/ports/blake3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "blake3",
   "version": "1.5.0",
+  "port-version": 1,
   "description": "BLAKE3 cryptographic hash function.",
   "homepage": "https://github.com/BLAKE3-team/BLAKE3",
   "license": "CC0-1.0 OR Apache-2.0",

--- a/versions/b-/blake3.json
+++ b/versions/b-/blake3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "62d312f1abb1e3acf086050e4e14d650973f5568",
+      "version": "1.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3d62ef88b0bacbb197e9bb921b8b7d0fea336f1d",
       "version": "1.5.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -654,7 +654,7 @@
     },
     "blake3": {
       "baseline": "1.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "blas": {
       "baseline": "2023-03-25",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fixes https://github.com/BLAKE3-team/BLAKE3/issues/385