### PR TITLE
Remove password from Osx Readme for azure pipelines

### DIFF
--- a/scripts/azure-pipelines/osx/README.md
+++ b/scripts/azure-pipelines/osx/README.md
@@ -47,7 +47,7 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
 - [ ] Install MacOS like you would on real hardware.
     * Apple ID: 'Set Up Later' / Skip
     * Account name: vcpkg
-    * As password set a password of your choice
+    * A very similar password :)
 - [ ] Install Parallels Tools
 - [ ] Restart the VM
 - [ ] Change the desktop background to a solid color
@@ -109,7 +109,7 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
 - [ ] Follow prompts as you would on real hardware.
     * Apple ID: 'Set Up Later' / Skip
     * Account name: vcpkg
-    * As password set a password of your choice
+    * A very similar password
     * No location services
     * Yes send crash reports
 - [ ] Set the desktop wallpaper to a fixed color from Settings -> Wallpaper . (This makes the KVM a lot easier to use :) )

--- a/scripts/azure-pipelines/osx/README.md
+++ b/scripts/azure-pipelines/osx/README.md
@@ -47,7 +47,7 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
 - [ ] Install MacOS like you would on real hardware.
     * Apple ID: 'Set Up Later' / Skip
     * Account name: vcpkg
-    * Account password: vcpkg
+    * As password set a password of your choice
 - [ ] Install Parallels Tools
 - [ ] Restart the VM
 - [ ] Change the desktop background to a solid color
@@ -109,7 +109,7 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
 - [ ] Follow prompts as you would on real hardware.
     * Apple ID: 'Set Up Later' / Skip
     * Account name: vcpkg
-    * Account password: vcpkg
+    * As password set a password of your choice
     * No location services
     * Yes send crash reports
 - [ ] Set the desktop wallpaper to a fixed color from Settings -> Wallpaper . (This makes the KVM a lot easier to use :) )


### PR DESCRIPTION
This PR removes the password from the OsX azure pipeline readme.md file. This password triggers credential scan errors which would have to be suppressed in projects using it within Azure, thus it is easier to remove it directly in vcpkg.