### PR TITLE
[vcpkg baseline][libdwarf] Fix file conflict

### DIFF
--- a/ports/libdwarf/dependencies.diff
+++ b/ports/libdwarf/dependencies.diff
@@ -23,7 +23,7 @@ index 7500c9f4..faf1bd7a 100644
 --- a/src/lib/libdwarf/CMakeLists.txt
 +++ b/src/lib/libdwarf/CMakeLists.txt
 @@ -105,7 +105,7 @@ target_include_directories(dwarf PUBLIC
-     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libdwarf>
    )
  if(ZLIB_FOUND AND ZSTD_FOUND)
 -  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ZSTD::ZSTD ) 

--- a/ports/libdwarf/dependencies.diff
+++ b/ports/libdwarf/dependencies.diff
@@ -1,24 +1,25 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 70839abd..04b0f86f 100644
+index 70839abd..cb3b5d8f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -196,6 +196,12 @@ if (ENABLE_DECOMPRESSION)
-     set(HAVE_ZSTD TRUE)
-     set(HAVE_ZSTD_H TRUE)
-   endif()
+@@ -184,12 +184,9 @@ endif()
+ 
+ if (ENABLE_DECOMPRESSION)
+   # Zlib and ZSTD need to be found otherwise disable it
+-  if(NOT TARGET ZLIB::ZLIB)
+-    find_package(ZLIB)
+-  endif()
+-  if(NOT TARGET ZSTD::ZSTD)
+-    find_package(ZSTD)
+-  endif()
++  find_package(ZLIB REQUIRED)
 +  find_package(zstd CONFIG REQUIRED)
-+  if(TARGET zstd::libzstd_shared)
-+    set(ZSTD_LIB zstd::libzstd_shared)
-+  else()
-+    set(ZSTD_LIB zstd::libzstd_static)
-+  endif()
- endif ()
- 
- message(STATUS "CMAKE_SIZEOF_VOID_P ... " ${CMAKE_SIZEOF_VOID_P} )
- 
- #  DW_FWALLXX are gnu C++ options.
++  set(ZSTD_FOUND TRUE)
+   if (ZLIB_FOUND AND ZSTD_FOUND )
+     set(HAVE_ZLIB TRUE)
+     set(HAVE_ZLIB_H TRUE)
 diff --git a/src/lib/libdwarf/CMakeLists.txt b/src/lib/libdwarf/CMakeLists.txt
-index 7500c9f4..ae367cc1 100644
+index 7500c9f4..faf1bd7a 100644
 --- a/src/lib/libdwarf/CMakeLists.txt
 +++ b/src/lib/libdwarf/CMakeLists.txt
 @@ -105,7 +105,7 @@ target_include_directories(dwarf PUBLIC
@@ -26,7 +27,7 @@ index 7500c9f4..ae367cc1 100644
    )
  if(ZLIB_FOUND AND ZSTD_FOUND)
 -  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ZSTD::ZSTD ) 
-+  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ${ZSTD_LIB} ) 
++  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static> ) 
  endif()
  set_target_properties(dwarf PROPERTIES PUBLIC_HEADER "libdwarf.h;dwarf.h")
  

--- a/ports/libdwarf/include-dir.diff
+++ b/ports/libdwarf/include-dir.diff
@@ -1,0 +1,31 @@
+diff --git a/src/lib/libdwarf/CMakeLists.txt b/src/lib/libdwarf/CMakeLists.txt
+index 7500c9f4..78bb1a1a 100644
+--- a/src/lib/libdwarf/CMakeLists.txt
++++ b/src/lib/libdwarf/CMakeLists.txt
+@@ -102,7 +102,7 @@ msvc_posix(dwarf)
+ target_compile_definitions(dwarf PUBLIC ${DEFS})
+ target_include_directories(dwarf PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libdwarf>
+   )
+ if(ZLIB_FOUND AND ZSTD_FOUND)
+   target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ZSTD::ZSTD ) 
+@@ -113,7 +113,7 @@ install(TARGETS dwarf
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libdwarf"
+         )
+ 
+ configure_file(libdwarf.pc.cmake libdwarf.pc @ONLY)
+@@ -125,7 +125,7 @@ configure_file(libdwarf.pc.cmake libdwarf.pc @ONLY)
+ install(TARGETS dwarf EXPORT libdwarfTargets
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libdwarf")
+ install(EXPORT libdwarfTargets
+         FILE libdwarf-targets.cmake
+         NAMESPACE libdwarf::

--- a/ports/libdwarf/portfile.cmake
+++ b/ports/libdwarf/portfile.cmake
@@ -18,12 +18,14 @@ vcpkg_cmake_configure(
     OPTIONS
         -DBUILD_NON_SHARED=${BUILD_NON_SHARED}
         -DBUILD_SHARED=${BUILD_SHARED}
+    OPTIONS_DEBUG
+        -DBUILD_DWARFDUMP=OFF
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libdwarf")
 vcpkg_fixup_pkgconfig()
-
+vcpkg_copy_pdbs()
 vcpkg_copy_tools(TOOL_NAMES dwarfdump AUTO_CLEAN)
 
 if(BUILD_SHARED)

--- a/ports/libdwarf/portfile.cmake
+++ b/ports/libdwarf/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 8e1addaf2b970db792c4488fa416b712c7b48dfe501bbfd5c40a7eaf71f07377abaa70f682982d11de9cf9573d8fd8dc5fd16c020eb9b68b5be558139a0799a1
     HEAD_REF main
     PATCHES
+        include-dir.diff
         dependencies.diff
         msvc-runtime.diff
         off_t.diff
@@ -29,7 +30,7 @@ vcpkg_copy_pdbs()
 vcpkg_copy_tools(TOOL_NAMES dwarfdump AUTO_CLEAN)
 
 if(BUILD_SHARED)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libdwarf.h" "ifndef LIBDWARF_STATIC" "if 1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libdwarf/libdwarf.h" "ifndef LIBDWARF_STATIC" "if 1")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libdwarf/vcpkg.json
+++ b/ports/libdwarf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdwarf",
   "version": "0.9.1",
+  "port-version": 1,
   "description": "A library for reading DWARF2 and later DWARF.",
   "homepage": "https://github.com/davea42/libdwarf-code",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4270,7 +4270,7 @@
     },
     "libdwarf": {
       "baseline": "0.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libe57": {
       "baseline": "1.1.332",

--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bfbcf7685efaeee06337457737598aa6002aaf1c",
+      "version": "0.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6159822bb45daaf469ba049ac34ab10bc78bc843",
       "version": "0.9.1",
       "port-version": 0

--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bfbcf7685efaeee06337457737598aa6002aaf1c",
+      "git-tree": "cf87101e4a1ebc4b0111154a856e7f28b1333189",
       "version": "0.9.1",
       "port-version": 1
     },


### PR DESCRIPTION
Don't build debug tool
Copy pdbs
Fix `find_package()` calls
Fix file conflict with elfutils on Linux

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.