### PR TITLE
[soundtouch] Update SHA512 (again)

### DIFF
--- a/ports/soundtouch/portfile.cmake
+++ b/ports/soundtouch/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     GITHUB_HOST https://codeberg.org
     REPO soundtouch/soundtouch
     REF ${VERSION}
-    SHA512 3d4d6314d6fccb3cb899aee36b90799bb9bf7cf1aad9ff2fff6b18c73e68be7e0e00a3f4e31d5dd340c979236f5474b7ef95d51ddb813f353dde920bdef4cb51
+    SHA512 93f757b2c1abe16be589e0d191e6c0416c5980843bd416cd5cb820b65a705d98081c0fc7ca0d9880af54b5343318262c77ba39a096bb240ceec084e93ceef964
     HEAD_REF master
 )
 

--- a/ports/soundtouch/vcpkg.json
+++ b/ports/soundtouch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "soundtouch",
   "version": "2.3.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "SoundTouch is an open-source audio processing library for changing the Tempo, Pitch and Playback Rates of audio streams or audio files.",
   "homepage": "https://www.surina.net/soundtouch",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8146,7 +8146,7 @@
     },
     "soundtouch": {
       "baseline": "2.3.2",
-      "port-version": 1
+      "port-version": 2
     },
     "soxr": {
       "baseline": "0.1.3",

--- a/versions/s-/soundtouch.json
+++ b/versions/s-/soundtouch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac2649a7dd79e3a99721c357c744f81b94643a3c",
+      "version": "2.3.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "a2f43b08cb75d26f5756e611a64f5708dcbfb0a1",
       "version": "2.3.2",
       "port-version": 1


### PR DESCRIPTION
Funnily enough this effectively seems to revert #35269.

The changing checksums seem to be a Codeberg issue: https://codeberg.org/Codeberg/Community/issues/1366

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.