### PR TITLE
[libassert] Use magic-enum from vcpkg

### DIFF
--- a/ports/libassert/include-dir.patch
+++ b/ports/libassert/include-dir.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c653d61..c9e599f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -43,7 +43,7 @@ target_include_directories(
+   assert
+   PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/assert/assert>
++  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/assert>
+ )
+ 
+ #set(CMAKE_CXX_FLAGS_REL_WITH_ASSERTS "-O3")
+@@ -119,7 +121,7 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
+   install(
+     FILES
+     include/assert.hpp
+-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/assert/assert
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/assert
+   )
+ 
+   install(

--- a/ports/libassert/magic-enum.patch
+++ b/ports/libassert/magic-enum.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c653d61..a5d9980 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -94,6 +94,8 @@ endif()
+ 
+ if(ASSERT_USE_MAGIC_ENUM)
+   target_compile_definitions(assert PUBLIC ASSERT_USE_MAGIC_ENUM)
++  find_package(magic_enum CONFIG REQUIRED)
++  target_link_libraries(assert PUBLIC magic_enum::magic_enum)
+ endif()
+ 
+ if(NOT "${ASSERT_FAIL}" STREQUAL "")
+diff --git a/include/assert.hpp b/include/assert.hpp
+index b49c633..299a47e 100644
+--- a/include/assert.hpp
++++ b/include/assert.hpp
+@@ -34,7 +34,7 @@
+ #ifdef ASSERT_USE_MAGIC_ENUM
+  // this is a temporary hack to make testing thing in compiler explorer quicker (it disallows simple relative includes)
+  #include \
+- "../third_party/magic_enum.hpp"
++ <magic_enum.hpp>
+ #endif
+ 
+ #define LIBASSERT_IS_CLANG 0

--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         runtime_destination.patch
         magic-enum.patch
+        include-dir.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)

--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_cmake_config_fixup(
     PACKAGE_NAME libassert
     CONFIG_PATH lib/cmake/assert
 )
+vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/assert/third_party")

--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -20,10 +20,13 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME libassert
+    PACKAGE_NAME assert
     CONFIG_PATH lib/cmake/assert
 )
 vcpkg_copy_pdbs()
+
+file(APPEND "${CURRENT_PACKAGES_DIR}/share/assert/assert-config.cmake" "include(CMakeFindDependencyMacro)
+find_dependency(magic_enum REQUIRED)")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/assert/third_party")

--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -26,7 +26,8 @@ vcpkg_cmake_config_fixup(
 vcpkg_copy_pdbs()
 
 file(APPEND "${CURRENT_PACKAGES_DIR}/share/assert/assert-config.cmake" "include(CMakeFindDependencyMacro)
-find_dependency(magic_enum REQUIRED)")
+find_dependency(magic_enum)
+find_dependency(cpptrace)")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/assert/third_party")

--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -5,25 +5,26 @@ vcpkg_from_github(
     SHA512 beba94e033f7e43c84123736a32725a333c915392d5dc57c26a63f832a507564d79f290a151cb136de8bded3d8d343dad3c4bf2efec9977d878df3c9a8677554
     HEAD_REF main
     PATCHES
-      runtime_destination.patch
+        runtime_destination.patch
+        magic-enum.patch
 )
 
-vcpkg_list(SET options -DASSERT_USE_EXTERNAL_CPPTRACE=On)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-  vcpkg_list(APPEND options -DASSERT_STATIC=On)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${options}
+    OPTIONS
+        -DASSERT_USE_EXTERNAL_CPPTRACE=ON
+        -DASSERT_STATIC=${BUILD_STATIC}
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME "libassert"
-    CONFIG_PATH "lib/cmake/assert"
+    PACKAGE_NAME libassert
+    CONFIG_PATH lib/cmake/assert
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/assert/third_party")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libassert/vcpkg.json
+++ b/ports/libassert/vcpkg.json
@@ -1,12 +1,14 @@
 {
   "name": "libassert",
   "version": "1.2.2",
+  "port-version": 1,
   "description": "The most over-engineered and overpowered C++ assertion library.",
   "homepage": "https://github.com/jeremy-rifkin/libassert",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
     "cpptrace",
+    "magic-enum",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4134,7 +4134,7 @@
     },
     "libassert": {
       "baseline": "1.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libassuan": {
       "baseline": "2.5.6",

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5cdcfbf0fe98bb8ead394f382c190e27c6f89e9e",
+      "git-tree": "bc179768d690c63d56361963c08cfd02bac6af97",
       "version": "1.2.2",
       "port-version": 1
     },

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f019fceeefa845b05cfa926f090b451e1a27b86b",
+      "git-tree": "53a7a0a284472c6e8e03d204cadd90dd3fe6cd1d",
       "version": "1.2.2",
       "port-version": 1
     },

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f019fceeefa845b05cfa926f090b451e1a27b86b",
+      "version": "1.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "b67ed1f09482482afcb344d882f99fa6fa53caf4",
       "version": "1.2.2",
       "port-version": 0

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "53a7a0a284472c6e8e03d204cadd90dd3fe6cd1d",
+      "git-tree": "5cdcfbf0fe98bb8ead394f382c190e27c6f89e9e",
       "version": "1.2.2",
       "port-version": 1
     },

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc179768d690c63d56361963c08cfd02bac6af97",
+      "git-tree": "dfa096c003c1f98dbcdac5a67d924643bc12f994",
       "version": "1.2.2",
       "port-version": 1
     },


### PR DESCRIPTION
Copy pdbs
Fix cmake usage (fixes https://github.com/microsoft/vcpkg/pull/35240#issuecomment-1826033720 )
Use magic-enum provided by vcpkg

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
