### PR TITLE
[tinyutf8] Fix cmake usage

### DIFF
--- a/ports/tinyutf8/portfile.cmake
+++ b/ports/tinyutf8/portfile.cmake
@@ -1,27 +1,22 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO DuffsDevice/tinyutf8
-    REF 84d9878051cd89eb930ebfc2b686d2edfdb9db10    #version 4.4.3
-    SHA512 dee248c3269c54a9bb616a08868236a049cdc629a1b668f39af59a69c672751067ce01a7f81df28ac41b500749019e543721ceae903ae9c11ea5282f2d308da4
+    REPO DuffsDevice/tiny-utf8
+    REF "v${VERSION}"
+    SHA512 e87368614671c8e160e9fd7c529bba08f6b3d6bdd0b178c68a4f25a54a6428afe01c3099f80d4976a1b2ce9f2e19b877da54a5dbf024ad25c7a5d5e47cb57bb0
     HEAD_REF master
 )
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" TINYUTF8_BUILD_STATIC)
+# header-only
+set(VCPKG_BUILD_TYPE "release")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS 
-        -DTINYUTF8_BUILD_STATIC=${TINYUTF8_BUILD_STATIC}
+    OPTIONS
         -DTINYUTF8_BUILD_TESTING=OFF
+        -DTINYUTF8_BUILD_DOC=OFF
 )
 
 vcpkg_cmake_install()
-vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/tinyutf8/cmake)
 
-# Handle copyright
-configure_file("${SOURCE_PATH}/LICENCE" "${CURRENT_PACKAGES_DIR}/share/tinyutf8/copyright" COPYONLY)
-
-# remove unneeded files
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENCE")

--- a/ports/tinyutf8/vcpkg.json
+++ b/ports/tinyutf8/vcpkg.json
@@ -1,11 +1,17 @@
 {
   "name": "tinyutf8",
   "version": "4.4.3",
+  "port-version": 1,
   "description": "TINYUTF8 is a library for extremely easy integration of Unicode into an arbitrary C++11 project.",
+  "homepage": "https://github.com/DuffsDevice/tiny-utf8/",
   "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8614,7 +8614,7 @@
     },
     "tinyutf8": {
       "baseline": "4.4.3",
-      "port-version": 0
+      "port-version": 1
     },
     "tinyxml": {
       "baseline": "2.6.2",

--- a/versions/t-/tinyutf8.json
+++ b/versions/t-/tinyutf8.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82748b59bb1ff3c389a8e16cf806c9cb6e9bf4d8",
+      "version": "4.4.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "68f68a99c01bfa1afbb04e680667e665330028ce",
       "version": "4.4.3",
       "port-version": 0


### PR DESCRIPTION
Installed cmake targets were unusable.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
