### PR TITLE
[etl] Fix cmake usage

### DIFF
--- a/ports/etl/portfile.cmake
+++ b/ports/etl/portfile.cmake
@@ -6,6 +6,9 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# header-only
+set(VCPKG_BUILD_TYPE "release")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -13,7 +16,12 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup()
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+vcpkg_cmake_config_fixup(CONFIG_PATH share/etl/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/etl/.vscode")
+# remove templates used for generating headers
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/etl/generators")
+file(GLOB_RECURSE PNG_FILES "${CURRENT_PACKAGES_DIR}/include/etl/*.png")
+file(REMOVE ${PNG_FILES})
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/etl/vcpkg.json
+++ b/ports/etl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "etl",
   "version": "20.38.10",
+  "port-version": 1,
   "description": "A C++ template library for embedded applications",
   "homepage": "https://www.etlcpp.com",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2502,7 +2502,7 @@
     },
     "etl": {
       "baseline": "20.38.10",
-      "port-version": 0
+      "port-version": 1
     },
     "eve": {
       "baseline": "2023.2.15",

--- a/versions/e-/etl.json
+++ b/versions/e-/etl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04525d7e18f604bc4b4a7e1317c919ef691907af",
+      "version": "20.38.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "079f0debc933d6e50b2a2e2cda340343f6bf6a6d",
       "version": "20.38.10",
       "port-version": 0


### PR DESCRIPTION
Installed cmake targets were unusable.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
