### PR TITLE
[units] Fix cmake usage

### DIFF
--- a/ports/units/portfile.cmake
+++ b/ports/units/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_github(
     SHA512 40d803e6bb17f4bb46a0136c7753ae25a0d3ce352dbff3843b0c231e94eb8bade1de65d5b988589607fb12b11e4bfa762708a68839f2d7dccb45440672d09031
 )
 
+set(VCPKG_BUILD_TYPE "release")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -12,11 +14,6 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/units/cmake)
 
-# Handle copyright/readme/package files
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
-# Remove unneeded directories
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/units/vcpkg.json
+++ b/ports/units/vcpkg.json
@@ -1,12 +1,17 @@
 {
   "name": "units",
   "version": "2.3.3",
+  "port-version": 1,
   "description": "A compile-time, header-only, dimensional analysis and unit conversion library built on c++14 with no dependencies.",
   "homepage": "https://github.com/nholthaus/units",
   "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8782,7 +8782,7 @@
     },
     "units": {
       "baseline": "2.3.3",
-      "port-version": 0
+      "port-version": 1
     },
     "unittest-cpp": {
       "baseline": "2.0.0",

--- a/versions/u-/units.json
+++ b/versions/u-/units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb579beb1fc4d50b1b6bd4aa3d04449d41195d89",
+      "version": "2.3.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "d33e796f2c898b89720bf55e28d836f5cab1db75",
       "version": "2.3.3",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
