### PR TITLE
[rtmfp-cpp] Update to 1.5.1

### DIFF
--- a/ports/rtmfp-cpp/portfile.cmake
+++ b/ports/rtmfp-cpp/portfile.cmake
@@ -2,12 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zenomt/rtmfp-cpp
     REF "v${VERSION}"
-    SHA512 e83df63d01207300f53dcbece150e8c2db8630f19a5b477292285833ad3406a09037c3055181b9f67b6a6a0f528e1c36f72577c86451591161fd3ccd945f5841
+    SHA512 cc8eac88c70b6a00a92a76bee66a3b319857a009fbfd82e9a710fe1c0fc452cf9fdf4128529e3f10931ed33c26eaf69253cab3b3e5a739eca6dd37a13f72800b
     HEAD_REF main
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_REQUIRE_FIND_PACKAGE_OpenSSL=ON
 )
 
 vcpkg_cmake_install()
@@ -15,8 +17,5 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/rtmfp)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-set(LICENSE_FILES "${SOURCE_PATH}/LICENSE")
-# Copyright and license
-vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rtmfp-cpp/vcpkg.json
+++ b/ports/rtmfp-cpp/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "rtmfp-cpp",
-  "version": "1.4.0-20230213.18168ec",
+  "version": "1.5.1",
   "description": "Secure Real-Time Media Flow Protocol Library (RTMFP)",
   "homepage": "https://github.com/zenomt/rtmfp-cpp",
   "license": "MIT",
-  "supports": "x64 & !uwp",
   "dependencies": [
     "openssl",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7681,7 +7681,7 @@
       "port-version": 4
     },
     "rtmfp-cpp": {
-      "baseline": "1.4.0-20230213.18168ec",
+      "baseline": "1.5.1",
       "port-version": 0
     },
     "rtmidi": {

--- a/versions/r-/rtmfp-cpp.json
+++ b/versions/r-/rtmfp-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1636dde21e228a5529dc9195b72b138e7fe1eca0",
+      "version": "1.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f79ae1d45117b5405db38e63128165d5c4a5114a",
       "version": "1.4.0-20230213.18168ec",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
