### PR TITLE
[directxmath] Update port for February 2024 3.19 release

### DIFF
--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMath
-    REF dec2023
-    SHA512 ddb5fdb4ef2d524990b0eba254e8395e0c3278a49c37889eef97c977b9d72c4983305c7e2a5b732e05ee54819e0d4aea134a1419f713dda4da386d1bad2d3580
+    REF feb2024
+    SHA512 01bd31dcf22d6800b9c0d6a102fd87a22ed2e113525775c95b56b0c8dc7268627b8c1386cf7296224951e8d96231b1feb3e3471f8c35a169a672b1134acf39fa
     HEAD_REF main
 )
 
@@ -20,9 +20,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/directxmath)
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_download_distfile(
         SAL_HEADER
-        URLS "https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h"
+        URLS "https://raw.githubusercontent.com/dotnet/runtime/v8.0.1/src/coreclr/pal/inc/rt/sal.h"
         FILENAME "sal.h"
-        SHA512 1643571673195d9eb892d2f2ac76eac7113ef7aa0ca116d79f3e4d3dc9df8a31600a9668b7e7678dfbe5a76906f9e0734ef8d6db0903ccc68fc742dd8238d8b0
+        SHA512 0f5a80b97564217db2ba3e4624cc9eb308e19cc9911dae21d983c4ab37003f4756473297ba81b386c498514cedc1ef5a3553d7002edc09aeb6a1335df973095f
     )
 
     file(INSTALL

--- a/ports/directxmath/vcpkg.json
+++ b/ports/directxmath/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmath",
-  "version-date": "2023-12-31",
+  "version-date": "2024-02-14",
   "description": "DirectXMath SIMD C++ math library",
   "homepage": "https://github.com/Microsoft/DirectXMath",
   "documentation": "https://docs.microsoft.com/windows/win32/dxmath/directxmath-portal",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2209,7 +2209,7 @@
       "port-version": 0
     },
     "directxmath": {
-      "baseline": "2023-12-31",
+      "baseline": "2024-02-14",
       "port-version": 0
     },
     "directxmesh": {

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a81c3f765820ce7b53f4ffbf4f0e4bfba0e4a29",
+      "version-date": "2024-02-14",
+      "port-version": 0
+    },
+    {
       "git-tree": "a7b031efa3bb41535fde116ad3cec2674a2764cd",
       "version-date": "2023-12-31",
       "port-version": 0


### PR DESCRIPTION
Updates **directxmath** port for the February 2024 release (version 3.19).