### PR TITLE
[blaze] Add lapack and openmp features

### DIFF
--- a/ports/blaze/portfile.cmake
+++ b/ports/blaze/portfile.cmake
@@ -6,9 +6,16 @@ vcpkg_from_bitbucket(
     HEAD_REF master
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        lapack   USE_LAPACK
+        openmp   BLAZE_SHARED_MEMORY_PARALLELIZATION
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBLAZE_SMP_THREADS=OpenMP
 )
 

--- a/ports/blaze/vcpkg.json
+++ b/ports/blaze/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "name": "blaze",
   "version": "3.8.2",
+  "port-version": 1,
   "description": "Blaze is an open-source, high-performance C++ math library for dense and sparse arithmetic.",
   "homepage": "https://bitbucket.org/blaze-lib/blaze",
   "license": "BSD-3-Clause",
   "dependencies": [
     "boost-exception",
-    "lapack",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -15,5 +15,20 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "lapack",
+    "openmp"
+  ],
+  "features": {
+    "lapack": {
+      "description": "LAPACK support",
+      "dependencies": [
+        "lapack"
+      ]
+    },
+    "openmp": {
+      "description": "OpenMP support"
+    }
+  }
 }

--- a/versions/b-/blaze.json
+++ b/versions/b-/blaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "408eb24a2dfa52911481429dbf59d384ee80464d",
+      "version": "3.8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "9f237bb789d83a4004b263f9544ed3d6668f160f",
       "version": "3.8.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -662,7 +662,7 @@
     },
     "blaze": {
       "baseline": "3.8.2",
-      "port-version": 0
+      "port-version": 1
     },
     "blend2d": {
       "baseline": "2023-06-16",


### PR DESCRIPTION
Hi, this PR adds two feature flags to Blaze to allow for a minimal 'core' installation:

1. `lapack`: LAPACK/BLAS is currently a default dependency, but its only required for certain matrix operations and `BLAZE_BLAS_MODE` which is off by default. See [CMakeLists.txt#L65-L75](https://bitbucket.org/blaze-lib/blaze/src/3156507a4b7a6a9cd413ef87df0a0aa2b1c697d9/CMakeLists.txt#lines-65:75). 
2. `openmp`: The absence of this flag actually disables SMP support entirely, so it might be better to just use `smp` instead. Thoughts? I used `openmp` for consistency with the existing port which explicitly sets the threading library via `BLAZE_SMP_THREADS=OpenMP`. In any case, Blaze defaults to OpenMP and removes `BLAZE_SMP_THREADS` from cache when `BLAZE_SHARED_MEMORY_PARALLELIZATION` is turned off. See [CMakeLists.txt#L297-L304](https://bitbucket.org/blaze-lib/blaze/src/3156507a4b7a6a9cd413ef87df0a0aa2b1c697d9/CMakeLists.txt#lines-297:304).

Both of these are still set as default features to ensure compatibility, though I think the default LAPACK REQUIRED as a reminder to package maintainers might be a bit excessive! If you're using LAPACK, you probably aren't relying on Blaze to import it for you. That's probably more of a discussion for upstream in any case.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
