### PR TITLE
[gts] fix for correctly excluding predicates_init.c file in build

### DIFF
--- a/ports/gts/CMakeLists.txt
+++ b/ports/gts/CMakeLists.txt
@@ -26,7 +26,7 @@ add_definitions(
 )
 
 file(GLOB src src/*.c src/gts.def)
-list(REMOVE_ITEM src src/predicate_init.c)
+list(FILTER src EXCLUDE REGEX ".*predicates_init\\.c$")
 add_library(gts ${src})
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/config.h" "")
 target_include_directories(gts PUBLIC

--- a/ports/gts/vcpkg.json
+++ b/ports/gts/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gts",
   "version": "0.7.6",
-  "port-version": 8,
+  "port-version": 9,
   "description": "3D surfaces meshed with interconnected triangles",
   "homepage": "https://gts.sourceforge.net/",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3202,7 +3202,7 @@
     },
     "gts": {
       "baseline": "0.7.6",
-      "port-version": 8
+      "port-version": 9
     },
     "gtsam": {
       "baseline": "4.2a9",

--- a/versions/g-/gts.json
+++ b/versions/g-/gts.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3daf9b46d06d7c989ebc0b0236d5eb8912d00bb0",
+      "version": "0.7.6",
+      "port-version": 9
+    },
+    {
       "git-tree": "1c12aefc981ca389e3235cf1940883f881dddb4d",
       "version": "0.7.6",
       "port-version": 8


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


Fix for excluding the `predicates_init.c` file from the build:
- fix typo `predicate_init.c` -> `predicates_init.c`
- use regex to filter out the file such that we can use a relative path to filter out the file.
