### PR TITLE
[ceres] Add feature schur

### DIFF
--- a/ports/ceres/portfile.cmake
+++ b/ports/ceres/portfile.cmake
@@ -28,6 +28,7 @@ file(REMOVE "${SOURCE_PATH}/cmake/FindMETIS.cmake")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        "schur"             SCHUR_SPECIALIZATIONS
         "suitesparse"       SUITESPARSE
         "cxsparse"          CXSPARSE
         "lapack"            LAPACK

--- a/ports/ceres/vcpkg.json
+++ b/ports/ceres/vcpkg.json
@@ -20,9 +20,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "schur"
-  ],
   "features": {
     "cuda": {
       "description": "Support for CUDA based dense solvers",

--- a/ports/ceres/vcpkg.json
+++ b/ports/ceres/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ceres",
   "version": "2.1.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "non-linear optimization package",
   "homepage": "https://github.com/ceres-solver/ceres-solver",
   "license": "Apache-2.0",
@@ -19,6 +19,9 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
+  ],
+  "default-features": [
+    "schur"
   ],
   "features": {
     "cuda": {
@@ -47,6 +50,9 @@
       "dependencies": [
         "lapack"
       ]
+    },
+    "schur": {
+      "description": "Enable fixed-size Schur specializations in Ceres"
     },
     "suitesparse": {
       "description": "SuiteSparse support for Ceres",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1526,7 +1526,7 @@
     },
     "ceres": {
       "baseline": "2.1.0",
-      "port-version": 4
+      "port-version": 5
     },
     "cfitsio": {
       "baseline": "3.49",

--- a/versions/c-/ceres.json
+++ b/versions/c-/ceres.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "818578370b424f61c96222471d6490ddf5c8e040",
+      "git-tree": "213619bf4451443bd69f784f9a7fa32fc2436e07",
       "version": "2.1.0",
       "port-version": 5
     },

--- a/versions/c-/ceres.json
+++ b/versions/c-/ceres.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "818578370b424f61c96222471d6490ddf5c8e040",
+      "version": "2.1.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "b2ebeb85c8833b2631210c4b790204151e402981",
       "version": "2.1.0",
       "port-version": 4


### PR DESCRIPTION
This small PR adds a default feature `schur` to control the `SCHUR_SPECIALIZATIONS` option in Ceres. It remains on by default.

As described briefly in the [documentation](http://ceres-solver.org/installation.html#options-controlling-ceres-configuration), `SCHUR_SPECIALIZATIONS` enables some template specializations which improve runtime performance of the `SPARSE_SCHUR` solver, but it requires a large number of explicit instantiations and generates large object files—large enough to require `/bigobj` in MSVC. This can cause issues with some compilers particularly in constrained environments.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.