### PR TITLE
[cwapi3d] Add CwAPI3D port

### DIFF
--- a/ports/cwapi3d/portfile.cmake
+++ b/ports/cwapi3d/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cwapi3d/cwapi3dcpp
+    REF 2a0608bb0a9b281c0f25aeb011ce61cb11ec07f6
+    SHA512 b6a600d044c71a4e952bca8af52c333c4944f2e1fbce6b70a3756d7c3d7090794bf09a8bc29ca5a84952a2ecc8042f393febca03403a8dd996736ada8231c687
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/CwAPI3D)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cwapi3d/usage
+++ b/ports/cwapi3d/usage
@@ -1,0 +1,4 @@
+The package cwapi3d provides CMake targets:
+
+    find_package(CwAPI3D CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CwAPI3D::CwAPI3D)

--- a/ports/cwapi3d/vcpkg.json
+++ b/ports/cwapi3d/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "cwapi3d",
+  "version": "30.10.1",
+  "description": "CwAPI3D is the Cadwork 3D plugin architecture in C++.",
+  "homepage": "https://github.com/cwapi3d/cwapi3dcpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2080,6 +2080,10 @@
       "baseline": "1.2.9",
       "port-version": 0
     },
+    "cwapi3d": {
+      "baseline": "30.10.1",
+      "port-version": 0
+    },
     "cxxgraph": {
       "baseline": "2.0.0",
       "port-version": 0

--- a/versions/c-/cwapi3d.json
+++ b/versions/c-/cwapi3d.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5345b145ba7d08c63a1783750a8ca24a4886cd5f",
+      "version": "30.10.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.