### PR TITLE
[mongo-c-driver/libbson] Update to 1.26.0

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -1,12 +1,8 @@
-# This port needs to be updated at the same time as mongo-c-driver
-
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 a80e20917edb752ac5eb42534beaa0122a383037f83a554ee00ce37ae690be68521eaa282b4a5802a5440b61038bcd5414356e16a2ce729ba1193d0738a6ce1c
+    SHA512 3ad7ad67284b8900432c8df6b00a96bb8ee265a0d8bdf689d7ab48a0949fd14f69deff30c6db86d39f9a1729e4884d8e91eb2d21dfc5172a3edb3d950df432fd
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.25.4",
+  "version": "1.26.0",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 a80e20917edb752ac5eb42534beaa0122a383037f83a554ee00ce37ae690be68521eaa282b4a5802a5440b61038bcd5414356e16a2ce729ba1193d0738a6ce1c
+    SHA512 3ad7ad67284b8900432c8df6b00a96bb8ee265a0d8bdf689d7ab48a0949fd14f69deff30c6db86d39f9a1729e4884d8e91eb2d21dfc5172a3edb3d950df432fd
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.25.4",
-  "port-version": 1,
+  "version": "1.26.0",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4149,7 +4149,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.25.4",
+      "baseline": "1.26.0",
       "port-version": 0
     },
     "libcaer": {
@@ -5709,8 +5709,8 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.25.4",
-      "port-version": 1
+      "baseline": "1.26.0",
+      "port-version": 0
     },
     "mongo-cxx-driver": {
       "baseline": "3.9.0",

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c96a39671be9a7428731693d6640a4ea568b71e5",
+      "version": "1.26.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d14fb7001fd70dd80e15562bbe90a30060adef40",
       "version": "1.25.4",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1723d95a3ecde5ac6caa99c1cb33aacc760c1c8",
+      "version": "1.26.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7a6dfbb8124275c3987495969f7f79e5a7023b74",
       "version": "1.25.4",
       "port-version": 1


### PR DESCRIPTION
Fixes #36776, update `mongo-c-driver` and `libbson` to 1.26.0.

mongo-c-driver
-
All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```

The usage test passed on `x64-windows` (header files found):
```
mongo-c-driver provides CMake targets:

    find_package(mongoc-1.0 CONFIG REQUIRED)
    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:mongo::mongoc_shared>,mongo::mongoc_shared,mongo::mongoc_static>)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.