### PR TITLE
[winreg] Update to 6.1.1

### DIFF
--- a/ports/winreg/portfile.cmake
+++ b/ports/winreg/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GiovanniDicanio/WinReg
-    REF ba6b74972038778d0bf5ffa6de705ec6e2768735 #v6.1.0
-    SHA512 1b7ac1ef4322c2e1c80be840d4117424263c4ad02050926f1ebdd3fbb4978a02d12f485ccb0aff46ca4acc4188f48f7522ac4d6d663517d7bad71147224accc7
+    REF "v${VERSION}"
+    SHA512 2117f5f2a869b3623e77d9ff86b95349c37db593ae5c205e85fb6afd430d018befe9cfdb87d1f7fdd8feab37fbb7b1b91ad435cf36115893653e045ecbb42310
     HEAD_REF master
 )
 
@@ -12,4 +12,4 @@ vcpkg_from_github(
 file(COPY "${SOURCE_PATH}/WinReg/WinReg.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/winreg/vcpkg.json
+++ b/ports/winreg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "winreg",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "High-level C++ wrapper around the Windows Registry C API.",
   "homepage": "https://github.com/GiovanniDicanio/WinReg",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9173,7 +9173,7 @@
       "port-version": 0
     },
     "winreg": {
-      "baseline": "6.1.0",
+      "baseline": "6.1.1",
       "port-version": 0
     },
     "winsock2": {

--- a/versions/w-/winreg.json
+++ b/versions/w-/winreg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6acea55c34f2a89b2ed2d2b9a335e4f074dcbb40",
+      "version": "6.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c2ca5ed4ead6f69d105bd677fc3acaeba4be8879",
       "version": "6.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #36762, update `winreg` to 6.1.1.

No featrue needs to be tested, the usage test passed on `x64-windows` (header files found): 
```
winreg is header-only and can be used from CMake via:

    find_path(WINREG_INCLUDE_DIRS "winreg/WinReg.hpp")
    target_include_directories(main PRIVATE ${WINREG_INCLUDE_DIRS})
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.