### PR TITLE
[bootstrap-vcpkg.sh] Test for ${CC} rather than gcc on systems using vcpkgUseSystem

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -98,6 +98,12 @@ if [ -e /etc/alpine-release ]; then
     if [ "$ARCH" = "x86_64" ]; then
         vcpkgUseMuslC="ON"
     fi
+    if [ -z ${$CXX+x} ]; then
+        CXX=g++
+    fi
+    if [ -z ${CC+x} ]; then
+        CC=gcc
+    fi
 fi
 
 if [ "$UNAME" = "OpenBSD" ]; then
@@ -115,7 +121,8 @@ if [ "$vcpkgUseSystem" = "ON" ]; then
     vcpkgCheckRepoTool cmake
     vcpkgCheckRepoTool ninja
     vcpkgCheckRepoTool git
-    vcpkgCheckRepoTool gcc
+    vcpkgCheckRepoTool ${CC}
+    vcpkgCheckRepoTool ${CXX}
 fi
 
 vcpkgCheckEqualFileHash()

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -108,8 +108,6 @@ if [ "$vcpkgUseSystem" = "ON" ]; then
     vcpkgCheckRepoTool cmake
     vcpkgCheckRepoTool ninja
     vcpkgCheckRepoTool git
-    vcpkgCheckRepoTool ${CC:-cc}
-    vcpkgCheckRepoTool ${CXX:-c++}
 fi
 
 vcpkgCheckEqualFileHash()

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -103,10 +103,10 @@ fi
 if [ "$UNAME" = "OpenBSD" ]; then
     vcpkgUseSystem="ON"
 
-    if [ -z "$CXX" ]; then
+    if [ -z ${$CXX+x} ]; then
         CXX=/usr/bin/clang++
     fi
-    if [ -z "$CC" ]; then
+    if [ -z ${CC+x} ]; then
         CC=/usr/bin/clang
     fi
 fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -191,27 +191,6 @@ fi
 if [ "$vcpkgDownloadTool" = "ON" ]; then
     vcpkgDownloadFile "https://github.com/microsoft/vcpkg-tool/releases/download/$VCPKG_TOOL_RELEASE_TAG/$vcpkgToolName" "$vcpkgRootDir/vcpkg" $vcpkgToolReleaseSha
 else
-    if [ "x$CXX" = "x" ]; then
-        if which g++-12 >/dev/null 2>&1; then
-            CXX=g++-12
-        elif which g++-11 >/dev/null 2>&1; then
-            CXX=g++-11
-        elif which g++-10 >/dev/null 2>&1; then
-            CXX=g++-10
-        elif which g++-9 >/dev/null 2>&1; then
-            CXX=g++-9
-        elif which g++-8 >/dev/null 2>&1; then
-            CXX=g++-8
-        elif which g++-7 >/dev/null 2>&1; then
-            CXX=g++-7
-        elif which g++-6 >/dev/null 2>&1; then
-            CXX=g++-6
-        elif which g++ >/dev/null 2>&1; then
-            CXX=g++
-        fi
-        # If we can't find g++, allow CMake to do the look-up
-    fi
-
     vcpkgToolReleaseTarball="$VCPKG_TOOL_RELEASE_TAG.tar.gz"
     vcpkgToolUrl="https://github.com/microsoft/vcpkg-tool/archive/$vcpkgToolReleaseTarball"
     baseBuildDir="$vcpkgRootDir/buildtrees/_vcpkg"
@@ -237,7 +216,7 @@ else
         cmakeConfigOptions=" $cmakeConfigOptions '-DCMAKE_JOB_POOL_COMPILE:STRING=compile' '-DCMAKE_JOB_POOL_LINK:STRING=link' '-DCMAKE_JOB_POOLS:STRING=compile=$VCPKG_MAX_CONCURRENCY;link=$VCPKG_MAX_CONCURRENCY' "
     fi
 
-    (cd "$buildDir" && CXX="$CXX" eval cmake "$srcDir" $cmakeConfigOptions) || exit 1
+    (cd "$buildDir" && cmake "$srcDir" $cmakeConfigOptions) || exit 1
     (cd "$buildDir" && cmake --build .) || exit 1
 
     rm -rf "$vcpkgRootDir/vcpkg"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -98,22 +98,18 @@ if [ -e /etc/alpine-release ]; then
     if [ "$ARCH" = "x86_64" ]; then
         vcpkgUseMuslC="ON"
     fi
-    CC=${CC:=gcc}
-    CXX=${CXX:=g++}
 fi
 
 if [ "$UNAME" = "OpenBSD" ]; then
     vcpkgUseSystem="ON"
-    CC=${CC:=clang}
-    CXX=${CXX:=clang++}
 fi
 
 if [ "$vcpkgUseSystem" = "ON" ]; then
     vcpkgCheckRepoTool cmake
     vcpkgCheckRepoTool ninja
     vcpkgCheckRepoTool git
-    vcpkgCheckRepoTool ${CC}
-    vcpkgCheckRepoTool ${CXX}
+    vcpkgCheckRepoTool ${CC:-cc}
+    vcpkgCheckRepoTool ${CXX:-c++}
 fi
 
 vcpkgCheckEqualFileHash()

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -104,10 +104,10 @@ if [ "$UNAME" = "OpenBSD" ]; then
     vcpkgUseSystem="ON"
 
     if [ -z ${$CXX+x} ]; then
-        CXX=/usr/bin/clang++
+        CXX=clang++
     fi
     if [ -z ${CC+x} ]; then
-        CC=/usr/bin/clang
+        CC=clang
     fi
 fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -98,23 +98,14 @@ if [ -e /etc/alpine-release ]; then
     if [ "$ARCH" = "x86_64" ]; then
         vcpkgUseMuslC="ON"
     fi
-    if [ -z ${$CXX+x} ]; then
-        CXX=g++
-    fi
-    if [ -z ${CC+x} ]; then
-        CC=gcc
-    fi
+    CC=${CC:=gcc}
+    CXX=${CXX:=g++}
 fi
 
 if [ "$UNAME" = "OpenBSD" ]; then
     vcpkgUseSystem="ON"
-
-    if [ -z ${$CXX+x} ]; then
-        CXX=clang++
-    fi
-    if [ -z ${CC+x} ]; then
-        CC=clang
-    fi
+    CC=${CC:=clang}
+    CXX=${CXX:=clang++}
 fi
 
 if [ "$vcpkgUseSystem" = "ON" ]; then


### PR DESCRIPTION
Fixes #36807 
