### PR TITLE
[ktx] Updating to 4.3.1 (and fixing iOS port problem with missing headers)

### DIFF
--- a/ports/ktx/0006-fix-ios-install.patch
+++ b/ports/ktx/0006-fix-ios-install.patch
@@ -1,17 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ccf4af61..4b232a50 100644
+index ccf4af61..2f6e404f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -485,9 +485,9 @@ macro(common_libktx_settings target enable_write library_type)
+@@ -484,7 +484,7 @@ macro(common_libktx_settings target enable_write library_type)
+         CXX_STANDARD_REQUIRED YES
  
      )
-     if(IOS)
--        set_target_properties(${target} PROPERTIES
--            FRAMEWORK TRUE
--        )
-+        #set_target_properties(${target} PROPERTIES
-+        #    FRAMEWORK TRUE
-+        #)
-     endif()
- 
-     if( NOT ${library_type} STREQUAL STATIC )
+-    if(IOS)
++    if(0)
+         set_target_properties(${target} PROPERTIES
+             FRAMEWORK TRUE
+         )

--- a/ports/ktx/0006-fix-ios-install.patch
+++ b/ports/ktx/0006-fix-ios-install.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ccf4af61..4b232a50 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -485,9 +485,9 @@ macro(common_libktx_settings target enable_write library_type)
+ 
+     )
+     if(IOS)
+-        set_target_properties(${target} PROPERTIES
+-            FRAMEWORK TRUE
+-        )
++        #set_target_properties(${target} PROPERTIES
++        #    FRAMEWORK TRUE
++        #)
+     endif()
+ 
+     if( NOT ${library_type} STREQUAL STATIC )

--- a/ports/ktx/portfile.cmake
+++ b/ports/ktx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/KTX-Software
     REF "v${VERSION}"
-    SHA512 5a89f8986464705ec36ac1becaddd0ff335e4c3c235468aaef0e963fcfeda4c0d669a086b91e61c16a3ae9e1fa5bf456dccf12cc65720e1a22e7cc0f30552541
+    SHA512 8ecb10d188b42c2104ae1ad1df8ba01a86af8b9ff673d74a767f742d2b5aa7effdc4765c2c280df43d717af3a14765189421d6b162f39515972dc439bd624619
     HEAD_REF master
     PATCHES
         0001-Use-vcpkg-zstd.patch

--- a/ports/ktx/portfile.cmake
+++ b/ports/ktx/portfile.cmake
@@ -78,3 +78,8 @@ endif()
 file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
 file(COPY ${LICENSE_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSES")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+
+if(VCPKG_TARGET_IS_IOS)
+    file(COPY "${CURRENT_PACKAGES_DIR}/lib/ktx.framework/Headers"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+endif()

--- a/ports/ktx/portfile.cmake
+++ b/ports/ktx/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         0003-mkversion.patch
         0004-quirks.patch
         0005-no-vendored-libs.patch
+        0006-fix-ios-install.patch
 )
 file(REMOVE "${SOURCE_PATH}/other_include/zstd_errors.h")
 
@@ -78,9 +79,3 @@ endif()
 file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
 file(COPY ${LICENSE_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSES")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
-
-if(VCPKG_TARGET_IS_IOS)
-    file(COPY "${CURRENT_PACKAGES_DIR}/lib/ktx.framework/Headers"
-         DESTINATION "${CURRENT_PACKAGES_DIR}")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/Headers" "${CURRENT_PACKAGES_DIR}/include")
-endif()

--- a/ports/ktx/portfile.cmake
+++ b/ports/ktx/portfile.cmake
@@ -47,8 +47,6 @@ vcpkg_cmake_configure(
         -DKTX_FEATURE_STATIC_LIBRARY=${ENABLE_STATIC}
         ${FEATURE_OPTIONS}
         ${OPTIONS}
-        # Do not regenerate headers (needs more dependencies)
-        -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=1
     DISABLE_PARALLEL_CONFIGURE
 )
 

--- a/ports/ktx/portfile.cmake
+++ b/ports/ktx/portfile.cmake
@@ -81,5 +81,6 @@ vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
 
 if(VCPKG_TARGET_IS_IOS)
     file(COPY "${CURRENT_PACKAGES_DIR}/lib/ktx.framework/Headers"
-         DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+         DESTINATION "${CURRENT_PACKAGES_DIR}")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/Headers" "${CURRENT_PACKAGES_DIR}/include")
 endif()

--- a/ports/ktx/vcpkg.json
+++ b/ports/ktx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ktx",
-  "version-semver": "4.3.0-beta1",
-  "port-version": 1,
+  "version-semver": "4.3.1",
   "description": [
     "The Khronos KTX library and tools.",
     "Functions for writing and reading KTX files, and instantiating OpenGL®, OpenGL ES™️ and Vulkan® textures from them."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3997,8 +3997,8 @@
       "port-version": 0
     },
     "ktx": {
-      "baseline": "4.3.0-beta1",
-      "port-version": 1
+      "baseline": "4.3.1",
+      "port-version": 0
     },
     "kubazip": {
       "baseline": "0.2.6",

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "71b9b120eb8de423b806b1e0132e77535280e557",
+      "git-tree": "f76ec7207a21b3964ce0fbfd83960e9894e82eae",
       "version-semver": "4.3.1",
       "port-version": 0
     },

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "71b9b120eb8de423b806b1e0132e77535280e557",
+      "version-semver": "4.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7db3fff00913b362bd7ac3c0a3611209f5d038df",
       "version-semver": "4.3.0-beta1",
       "port-version": 1

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f76ec7207a21b3964ce0fbfd83960e9894e82eae",
+      "git-tree": "431742044c29b87bf97157f68f0748b3ab91d1c0",
       "version-semver": "4.3.1",
       "port-version": 0
     },

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "431742044c29b87bf97157f68f0748b3ab91d1c0",
+      "git-tree": "1649737a0a12801c81fce5489406d57d8fb5d101",
       "version-semver": "4.3.1",
       "port-version": 0
     },

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6da74a851afd72a260f3cedb3e6713cb9e2b25e1",
+      "git-tree": "61e81d296c64a64fb9c8d217d763fd61bd012b2a",
       "version-semver": "4.3.1",
       "port-version": 0
     },

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1649737a0a12801c81fce5489406d57d8fb5d101",
+      "git-tree": "6da74a851afd72a260f3cedb3e6713cb9e2b25e1",
       "version-semver": "4.3.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Updating the port to 4.3.1 was pretty painless. Adding the fix for the iOS port seems a bit crass but I tried linking against the port without issue. Sadly I can't test at runtime at the moment.