### PR TITLE
[easyloggingpp] Fix pkgconfig and add usage

### DIFF
--- a/ports/easyloggingpp/0003_fix_pkgconfig.patch
+++ b/ports/easyloggingpp/0003_fix_pkgconfig.patch
@@ -1,0 +1,10 @@
+diff --git a/cmake/easyloggingpp.pc.cmakein b/cmake/easyloggingpp.pc.cmakein
+index 61000ce..f7f8d0c 100644
+--- a/cmake/easyloggingpp.pc.cmakein
++++ b/cmake/easyloggingpp.pc.cmakein
+@@ -4,3 +4,5 @@ Version: @ELPP_VERSION_STRING@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ includedir=@ELPP_INCLUDE_INSTALL_DIR@
+ Cflags: -I${includedir}
++libdir=${prefix}/lib
++Libs: -L${libdir} -leasyloggingpp

--- a/ports/easyloggingpp/portfile.cmake
+++ b/ports/easyloggingpp/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         0001_add_cmake_options.patch
         0002_fix_build_uwp.patch
+        0003_fix_pkgconfig.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -26,12 +27,17 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -Dbuild_static_lib=ON
         -Dis_uwp=${TARGET_IS_UWP}
+    OPTIONS_DEBUG
+        -DELPP_PKGCONFIG_INSTALL_DIR="${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig"
+    OPTIONS_RELEASE
+        -DELPP_PKGCONFIG_INSTALL_DIR="${CURRENT_PACKAGES_DIR}/lib/pkgconfig"
 )
 vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
+configure_file("${CURRENT_PORT_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/easyloggingpp/usage
+++ b/ports/easyloggingpp/usage
@@ -1,0 +1,6 @@
+easyloggingpp can be imported via CMake FindPkgConfig module:
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(easyloggingpp easyloggingpp REQUIRED IMPORTED_TARGET)
+
+    target_link_libraries(main PRIVATE PkgConfig::easyloggingpp)

--- a/ports/easyloggingpp/vcpkg.json
+++ b/ports/easyloggingpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "easyloggingpp",
   "version": "9.97.1",
+  "port-version": 1,
   "description": "Easylogging++ is a single header efficient logging library for C++ applications.",
   "homepage": "https://github.com/abumq/easyloggingpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2390,7 +2390,7 @@
     },
     "easyloggingpp": {
       "baseline": "9.97.1",
-      "port-version": 0
+      "port-version": 1
     },
     "eathread": {
       "baseline": "1.32.09",

--- a/versions/e-/easyloggingpp.json
+++ b/versions/e-/easyloggingpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1be9186d989f3f743ee399926293e49afa6a6175",
+      "version": "9.97.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "38a4e115b196ff65465edaf05ce8a89a2640128a",
       "version": "9.97.1",
       "port-version": 0


### PR DESCRIPTION
Fix #36726 

### Changes
* Patch `easyloggingpp/CMakeLists.txt` to change `ELPP_PKGCONFIG_INSTALL_DIR` from `share/pkgconfig` to `lib/pkgconfig`.
* Patch `easyloggingpp/cmake/easyloggingpp.pc.cmakein` to add `libdir` and `Libs`
* Add `usage` about `FindPkgConfig` module

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:
```
x86-windows
x64-linux
x64-windows
x64-windows-static
```