### PR TITLE
[opengl-registry/egl-registry] update

### DIFF
--- a/ports/egl-registry/copyright
+++ b/ports/egl-registry/copyright
@@ -1,0 +1,28 @@
+## include/KHR/khrplatform.h
+
+Copyright (c) 2008-2018 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+## include/EGL/*
+## share/opengl/egl.xml
+
+Copyright 2013-2020 The Khronos Group Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/ports/egl-registry/portfile.cmake
+++ b/ports/egl-registry/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KhronosGroup/EGL-Registry
-  REF af97e2c27b49a090a335fc6ed5040c780ad9fec8
-  SHA512 89f29608702cb85c5280a7d86ef2cd1c77ed746d4a2577ea143767828ea41ef28cf038d2d86fe1eccc03db08ad27258cb04dadb92233ed9acc10548d93537a80
+  REF 7db3005d4c2cb439f129a0adc931f3274f9019e6
+  SHA512 474d7a4d614efed18151e0ff18840aaa8349ec0b01ec3cc4e6ff3f60fdb918e0b8c68dbb13e09dc5e7b081a9eb637b008b48b1a4be537d360f9a6d247b7b8802
   HEAD_REF master
 )
 
@@ -19,9 +19,4 @@ file(
   DESTINATION "${CURRENT_PACKAGES_DIR}/share/opengl"
 )
 
-file(
-  INSTALL "${SOURCE_PATH}/sdk/docs/man/copyright.xml"
-  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-  RENAME copyright
-)
-
+vcpkg_install_copyright(FILE_LIST "${CURRENT_PORT_DIR}/copyright")

--- a/ports/egl-registry/vcpkg.json
+++ b/ports/egl-registry/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "egl-registry",
-  "version-date": "2022-09-20",
-  "description": "the EGL API and Extension Registry",
+  "version-date": "2024-01-25",
+  "description": "EGL API and Extension Registry",
   "homepage": "https://github.com/KhronosGroup/EGL-Registry"
 }

--- a/ports/opengl-registry/copyright
+++ b/ports/opengl-registry/copyright
@@ -1,0 +1,2 @@
+The files installed by the `opengl-registry` port are using different licenses.
+Each file defines its license in a comment at the top of the file.

--- a/ports/opengl-registry/portfile.cmake
+++ b/ports/opengl-registry/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KhronosGroup/OpenGL-Registry
-  REF 5bae8738b23d06968e7c3a41308568120943ae77
-  SHA512 3f8c58474627ded85d95f8a4d86329ec4f55b179eb2df393983462d42088e9496eef1a5980481f4b085e6ffb749cd5dd3b312a1e2b7b8189d9723a673ec65b0d
+  REF 3530768138c5ba3dfbb2c43c830493f632f7ea33
+  SHA512 1b2260e2baf2f40964ff6677ce2c5f0e970752408e94b251d443de57c2021d8848dda8ba61ba67547692dfd283fd2351fc900da60e3973f14b7b9be8a5ec5145
   HEAD_REF master
 )
 
@@ -19,12 +19,7 @@ file(COPY
   DESTINATION "${CURRENT_PACKAGES_DIR}/share/opengl"
 )
 
-# Using the Makefile because it is the smallest file with a complete copy of the license text
-file(
-  INSTALL "${SOURCE_PATH}/xml/Makefile"
-  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-  RENAME copyright
-)
+vcpkg_install_copyright(FILE_LIST "${CURRENT_PORT_DIR}/copyright")
 
 # pc layout from cygwin (consumed in xserver!)
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/pkgconfig/khronos-opengl-registry.pc" [=[
@@ -33,5 +28,5 @@ datadir=${prefix}/share
 specdir=${datadir}/opengl
 Name: khronos-opengl-registry
 Description: Khronos OpenGL registry
-Version: git4594c03239fb76580bc5d5a13acb2a8f563f0158
+Version: git3530768138c5ba3dfbb2c43c830493f632f7ea33
 ]=])

--- a/ports/opengl-registry/vcpkg.json
+++ b/ports/opengl-registry/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "opengl-registry",
-  "version-date": "2022-09-29",
+  "version-date": "2024-02-10",
   "port-version": 1,
-  "description": "the API and Extension registries for the OpenGL family APIs",
+  "description": "OpenGL, OpenGL ES, and OpenGL ES-SC API and Extension Registry",
   "homepage": "https://github.com/KhronosGroup/OpenGL-Registry",
   "supports": "!xbox",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2445,7 +2445,7 @@
       "port-version": 0
     },
     "egl-registry": {
-      "baseline": "2022-09-20",
+      "baseline": "2024-01-25",
       "port-version": 0
     },
     "eigen3": {
@@ -6365,7 +6365,7 @@
       "port-version": 3
     },
     "opengl-registry": {
-      "baseline": "2022-09-29",
+      "baseline": "2024-02-10",
       "port-version": 1
     },
     "openh264": {

--- a/versions/e-/egl-registry.json
+++ b/versions/e-/egl-registry.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d883db43133dd223c4ffdbef4193943f6784d43a",
+      "version-date": "2024-01-25",
+      "port-version": 0
+    },
+    {
       "git-tree": "e596b6c29ad16da764aab6f2fef830a3a884f14b",
       "version-date": "2022-09-20",
       "port-version": 0

--- a/versions/o-/opengl-registry.json
+++ b/versions/o-/opengl-registry.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22f7aa58ee78c9f0db904b6251e9265f2be26f9d",
+      "version-date": "2024-02-10",
+      "port-version": 1
+    },
+    {
       "git-tree": "367e1502c966f1df0656bdea115989650d01a781",
       "version-date": "2022-09-29",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This PR updates the `opengl-registry` and `egl-registry` ports to the latest version. In addition both ports have broken copyright information as both repositories are using individual licenses for each file. I tried to fix this by including a vendored copyright file for the `egl-registry` port. For `opengl-registry` I have just included a note that all files are individually licensed. A proper fix for this seems to be already worked on in #28644.