### PR TITLE
[vamp-sdk] update download url

### DIFF
--- a/ports/vamp-sdk/portfile.cmake
+++ b/ports/vamp-sdk/portfile.cmake
@@ -1,5 +1,5 @@
 vcpkg_from_github(
-    REPO c4dm/vamp-plugin-sdk
+    REPO vamp-plugins/vamp-plugin-sdk
     REF vamp-plugin-sdk-v2.10
     SHA512 67a71e5396eab5ce9503e9111b4cfc16fc9755cf6ae2d8dfc99ed29fd91e75eaf0de9a9c55ce8f7751f04c235eb86430856eff18f02adde54f1850a87c917ef0
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/vamp-sdk/vcpkg.json
+++ b/ports/vamp-sdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vamp-sdk",
   "version": "2.10",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Library for Vamp plugins",
   "homepage": "https://www.vamp-plugins.org/develop.html",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8906,7 +8906,7 @@
     },
     "vamp-sdk": {
       "baseline": "2.10",
-      "port-version": 4
+      "port-version": 5
     },
     "variant-lite": {
       "baseline": "2.0.0",

--- a/versions/v-/vamp-sdk.json
+++ b/versions/v-/vamp-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de8d329f5acd76465cc9ab71f58ddca238f8d263",
+      "version": "2.10",
+      "port-version": 5
+    },
+    {
       "git-tree": "be6c66cbbf45af0e78aa4456832c04bbe301b951",
       "version": "2.10",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fixes https://github.com/microsoft/vcpkg/issues/36859