### PR TITLE
[neargye-semver] use find-package support in vcpkg port

### DIFF
--- a/ports/neargye-semver/portfile.cmake
+++ b/ports/neargye-semver/portfile.cmake
@@ -1,3 +1,5 @@
+set(VCPKG_BUILD_TYPE release) # header-only port
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/semver
@@ -5,8 +7,6 @@ vcpkg_from_github(
     SHA512 b620a27d31ca2361e243e4def890ddfc4dfb65a507187c918fabc332d48c420fb10b0e6fb38c83c4c3998a047201e81b70a164c66675351cf4ff9475defc6287
     HEAD_REF master
 )
-
-set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -18,4 +18,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME semver CONFIG_PATH "lib/cmake/semver")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib") # empty; rm for vcpkg validity checks
 

--- a/ports/neargye-semver/portfile.cmake
+++ b/ports/neargye-semver/portfile.cmake
@@ -1,13 +1,21 @@
-# header-only library
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/semver
-    REF v0.3.0
+    REF v${VERSION}
     SHA512 b620a27d31ca2361e243e4def890ddfc4dfb65a507187c918fabc332d48c420fb10b0e6fb38c83c4c3998a047201e81b70a164c66675351cf4ff9475defc6287
     HEAD_REF master
 )
 
-file(COPY "${SOURCE_PATH}/include/semver.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/neargye")
+set(VCPKG_BUILD_TYPE release) # header-only port
 
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      -DSEMVER_OPT_INSTALL=ON
+      -DSEMVER_OPT_BUILD_EXAMPLES=OFF
+      -DSEMVER_OPT_BUILD_TESTS=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME semver CONFIG_PATH "lib/cmake/semver")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+

--- a/ports/neargye-semver/vcpkg.json
+++ b/ports/neargye-semver/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "neargye-semver",
   "version": "0.3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++17 header-only dependency-free versioning library complying with Semantic Versioning 2.0.0",
   "homepage": "https://github.com/Neargye/semver",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5990,7 +5990,7 @@
     },
     "neargye-semver": {
       "baseline": "0.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "ned14-internal-quickcpplib": {
       "baseline": "2023-11-22",

--- a/versions/n-/neargye-semver.json
+++ b/versions/n-/neargye-semver.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "608416b55c95a2375668d7c35d9554edebafb90f",
+      "git-tree": "8a0361995070a733294c3533d5401a074be6f366",
       "version": "0.3.0",
       "port-version": 2
     },

--- a/versions/n-/neargye-semver.json
+++ b/versions/n-/neargye-semver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "608416b55c95a2375668d7c35d9554edebafb90f",
+      "version": "0.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "f3d1444f15582cd16f398589648054bfa9b03ba7",
       "version": "0.3.0",
       "port-version": 1


### PR DESCRIPTION
Originally, this port copied the single header provided by the upstream into the install destination. This required consumers to use the package via `find_path(semver.hpp)`, which is less robust, is inconsistent, and doesn't use targets.

These changes update the vcpkg port to leverage the config-file package offered by [neargye/semver](https://github.com/Neargye/semver). With this, consumers use the package through `find_package(neargye-semver CONFIG), and the target `semver::semver`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- ~[ ] SHA512s are updated for each updated download.~
- ~[ ] The "supports" clause reflects platforms that may be fixed by this new version.~
- ~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- ~[ ] Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

