### PR TITLE
[vcpkg baseline][xcb-util-errors] Fix python script failure

### DIFF
--- a/ports/xcb-util-errors/fix_python.patch
+++ b/ports/xcb-util-errors/fix_python.patch
@@ -1,5 +1,5 @@
 diff --git a/src/extensions.py b/src/extensions.py
-index 94d7d57fe..022d4003e 100644
+index 94d7d57..40ce0f9 100644
 --- a/src/extensions.py
 +++ b/src/extensions.py
 @@ -1,5 +1,6 @@
@@ -9,12 +9,17 @@ index 94d7d57fe..022d4003e 100644
  from xml.etree.cElementTree import parse
  
  class Module(object):
-@@ -83,7 +84,7 @@ def parseFile(filename):
+@@ -83,7 +84,12 @@ def parseFile(filename):
  
  # Parse the xml file
  output_file = sys.argv[1]
 -for input_file in sys.argv[2:]:
-+for input_file in glob.glob(sys.argv[2]):
++
++file_list = sys.argv[2]
++if file_list.startswith('/'):
++    file_list = file_list[1:]
++    
++for input_file in glob.glob(file_list):
      parseFile(input_file)
  
  assert xproto != None

--- a/ports/xcb-util-errors/portfile.cmake
+++ b/ports/xcb-util-errors/portfile.cmake
@@ -35,6 +35,6 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()
 

--- a/ports/xcb-util-errors/vcpkg.json
+++ b/ports/xcb-util-errors/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "xcb-util-errors",
   "version": "1.0.1",
+  "port-version": 1,
   "description": "XCB utility library that gives human readable names to error, event, & request codes.",
   "homepage": "https://xcb.freedesktop.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9330,7 +9330,7 @@
     },
     "xcb-util-errors": {
       "baseline": "1.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "xcb-util-m4": {
       "baseline": "2022-01-24",

--- a/versions/x-/xcb-util-errors.json
+++ b/versions/x-/xcb-util-errors.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "725b4698760f7f90ffe69bb2628e2f35d70e4351",
+      "version": "1.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "b4f1619f7e94fe694b69d8021d6864e0d0369ce8",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes below failures since https://dev.azure.com/vcpkg/public/_build/results?buildId=99381&view=results
```
xcb-util-errors:x86-windows
xcb-util-errors:x64-windows
xcb-util-errors:x64-windows-static
xcb-util-errors:x64-windows-static-md
xcb-util-errors:arm64-windows

Traceback (most recent call last):
  File "D:\b\xcb-util-errors\x86-windows-dbg\src\extensions.py", line 90, in <module>
    assert xproto != None
           ^^^^^^^^^^^^^^
AssertionError
make: *** [Makefile:1394: src/extensions.c] Error 1
```

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
