### PR TITLE
[ffmpeg] OpenSSL feature requires LGPL v3, not non-free license

### DIFF
--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "6.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -510,7 +510,7 @@
           "name": "ffmpeg",
           "default-features": false,
           "features": [
-            "nonfree"
+            "version3"
           ]
         },
         "openssl"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2642,7 +2642,7 @@
     },
     "ffmpeg": {
       "baseline": "6.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "ffnvcodec": {
       "baseline": "11.1.5.3",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b85222da88d04c67c9b83d24a278c5821f5f0b0",
+      "version": "6.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "830c58775efe5c5e501bad472af97b064b3446bc",
       "version": "6.1.1",
       "port-version": 1


### PR DESCRIPTION
OpenSSL has moved to Apache 2 license, which is clearly compatible with LGPL v3 (but not v2.1, which is ffmpeg's default). Note that FFmpeg devs believe that the previous license is also compatible with LGPL (any version), but not GPL.

See https://github.com/FFmpeg/FFmpeg/blob/37702e20663dc8111534229af551763c2a954e73/LICENSE.md#incompatible-libraries for more details.

Note that the upstream also believes that Fraunhofer FDK AAC is also compatible with LGPL, but IANAL and fdk-aac uses its own custom license.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] ~~SHA512s are updated for each updated download.~~
- [x] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [x] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
