### PR TITLE
[fdk-aac] Add restriction feature he-aac does not support Android platform

### DIFF
--- a/ports/fdk-aac/vcpkg.json
+++ b/ports/fdk-aac/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fdk-aac",
   "version-semver": "2.0.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A standalone Third-Party Modified Version of the Fraunhofer FDK AAC Codec Library for Android. Uses a fork without HE-AAC, HE-AACv2, or xHE-AAC support to avoid patent licensing and GPL compatibility issues when built without the he-aac option.",
   "homepage": "https://gitlab.freedesktop.org/wtaymans/fdk-aac-stripped",
   "license": "FDK-AAC",
@@ -17,7 +17,8 @@
   ],
   "features": {
     "he-aac": {
-      "description": "Support patent-encumbered HE-AAC, HE-AACv2, and xHE-AAC codec profiles. Do not distribute binaries with this option without the relevant patent licenses if you are in a jurisdiction that recognizes software patents. Might not be compatible with the GPL depending on legal interpretation. Refer to https://bugzilla.redhat.com/show_bug.cgi?id=1501522#c112"
+      "description": "Support patent-encumbered HE-AAC, HE-AACv2, and xHE-AAC codec profiles. Do not distribute binaries with this option without the relevant patent licenses if you are in a jurisdiction that recognizes software patents. Might not be compatible with the GPL depending on legal interpretation. Refer to https://bugzilla.redhat.com/show_bug.cgi?id=1501522#c112",
+      "supports": "!android"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2630,7 +2630,7 @@
     },
     "fdk-aac": {
       "baseline": "2.0.2",
-      "port-version": 2
+      "port-version": 3
     },
     "fdlibm": {
       "baseline": "5.3",

--- a/versions/f-/fdk-aac.json
+++ b/versions/f-/fdk-aac.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "557cf019e07ef3e1c865204c7509bb7920301a89",
+      "version-semver": "2.0.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "85e6f9518580daf2454d9db89b0e813d0e9d4008",
       "version-semver": "2.0.2",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36868
According to the upstream author's [comment](https://github.com/mstorsjo/fdk-aac/issues/124#:~:text=This%20project%20isn%27t,the%20MediaCodec%20API.), this feature does not support the Android platform.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```