### PR TITLE
[matplotplusplus] update to 1.2.1

### DIFF
--- a/ports/matplotplusplus/fix-dependencies.patch
+++ b/ports/matplotplusplus/fix-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/Matplot++Config.cmake.in b/Matplot++Config.cmake.in
-index fc9ceca..1601015 100644
+index 5c402ad..1601015 100644
 --- a/Matplot++Config.cmake.in
 +++ b/Matplot++Config.cmake.in
 @@ -1,4 +1,5 @@
@@ -8,7 +8,7 @@ index fc9ceca..1601015 100644
  
  # How this Matplot++ installation was built
  set(MATPLOT_BUILT_SHARED "@MATPLOTPP_BUILD_SHARED_LIBS@")
-@@ -10,12 +11,44 @@ if (NOT CMAKE_CXX_COMPILER_ID STREQUAL MATPLOT_BUILT_CXX_COMPILER_ID)
+@@ -10,16 +11,44 @@ if (NOT CMAKE_CXX_COMPILER_ID STREQUAL MATPLOT_BUILT_CXX_COMPILER_ID)
      message(WARNING "This installation of Matplot++ was built with ${MATPLOT_BUILT_CXX_COMPILER_ID}.")
  endif()
  
@@ -51,12 +51,16 @@ index fc9ceca..1601015 100644
 -    include(CMakeFindDependencyMacro)
      list(APPEND CMAKE_MODULE_PATH ${MATPLOT_CONFIG_INSTALL_DIR})
      list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
--    find_dependency(Filesystem COMPONENTS Experimental Final)
+-    # OpenGL backend
+-    if (@MATPLOTPP_BUILD_EXPERIMENTAL_OPENGL_BACKEND@)
+-        find_dependency(glad)
+-        find_dependency(glfw3)
+-    endif()
      list(POP_BACK CMAKE_MODULE_PATH)
  endif()
  
 diff --git a/source/3rd_party/CMakeLists.txt b/source/3rd_party/CMakeLists.txt
-index b5656e1..7ff4046 100644
+index b5656e1..7c2d1f3 100644
 --- a/source/3rd_party/CMakeLists.txt
 +++ b/source/3rd_party/CMakeLists.txt
 @@ -1,6 +1,7 @@
@@ -67,166 +71,121 @@ index b5656e1..7ff4046 100644
  if(WITH_SYSTEM_NODESOUP)
    find_path(NODESOUP_INCLUDE_DIR nodesoup.hpp REQUIRED)
    find_library(NODESOUP_LIB nodesoup REQUIRED)
-@@ -47,6 +48,7 @@ if(MASTER_PROJECT AND NOT BUILD_SHARED_LIBS)
+@@ -46,7 +47,7 @@ if(MASTER_PROJECT AND NOT BUILD_SHARED_LIBS)
+       EXPORT Matplot++Targets
        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/Matplot++)
  endif()
- 
+-
 +endif()
  
  #######################################################
  ### CImg                                            ###
-@@ -69,57 +71,69 @@ find_package(PkgConfig)
+@@ -69,57 +70,52 @@ find_package(PkgConfig)
  #            Lots of optional packages are not a good idea in general.
  #            It makes the library much less "packagable" (https://youtu.be/sBP17HQAQjk)
  #            and much more difficult to make sure it works on multiple OSs
 -find_package(JPEG)
 -if(JPEG_FOUND)
-+
-+if (WITH_JPEG)
-+find_package(JPEG REQUIRED)
-+if(1)
++if(WITH_JPEG)
++  find_package(JPEG REQUIRED)
    target_compile_definitions(cimg INTERFACE cimg_use_jpeg)
    target_link_libraries(cimg INTERFACE ${JPEG_LIBRARIES})
    target_include_directories(cimg INTERFACE ${JPEG_INCLUDE_DIRS})
  endif()
-+endif()
  
 -find_package(TIFF)
 -if(TIFF_FOUND)
-+if (WITH_TIFF)
-+find_package(TIFF REQUIRED)
-+if(1)
++if(WITH_TIFF)
++  find_package(TIFF REQUIRED)
    target_compile_definitions(cimg INTERFACE cimg_use_tiff)
    target_link_libraries(cimg INTERFACE ${TIFF_LIBRARIES})
    target_include_directories(cimg INTERFACE ${TIFF_INCLUDE_DIRS})
  endif()
-+endif()
  
 -find_package(ZLIB)
 -if(ZLIB_FOUND)
 -  find_package(PNG)
 -  if (PNG_FOUND)
-+if (WITH_ZLIB)
-+find_package(ZLIB REQUIRED)
-+if(1)
-+  find_package(libpng CONFIG REQUIRED)
-+  if (1)
-     target_compile_definitions(cimg INTERFACE cimg_use_zlib cimg_use_png)
+-    target_compile_definitions(cimg INTERFACE cimg_use_zlib cimg_use_png)
 -    target_include_directories(cimg INTERFACE ${ZLIB_INCLUDE_DIRS} ${PNG_INCLUDE_DIRS})
 -    target_link_libraries(cimg INTERFACE ${ZLIB_LIBRARIES} ${PNG_LIBRARIES})
-+    target_link_libraries(cimg INTERFACE ZLIB::ZLIB png)
-   endif ()
+-  endif ()
++if(WITH_ZLIB)
++  find_package(ZLIB REQUIRED)
++  find_package(libpng CONFIG REQUIRED)
++  target_compile_definitions(cimg INTERFACE cimg_use_zlib cimg_use_png)
++  target_link_libraries(cimg INTERFACE ZLIB::ZLIB png)
  endif()
-+endif()
  
 -find_package(LAPACK)
 -if(LAPACK_FOUND)
-+if (WITH_LAPACK)
-+find_package(LAPACK REQUIRED)
-+if(1)
++if(WITH_LAPACK)
++  find_package(LAPACK REQUIRED)
    target_compile_definitions(cimg INTERFACE cimg_use_lapack)
    target_link_libraries(cimg INTERFACE ${LAPACK_LIBRARIES})
    target_include_directories(cimg INTERFACE ${LAPACK_INCLUDE_DIRS})
  endif()
-+endif()
  
 -find_package(BLAS)
 -if(BLAS_FOUND)
-+if (WITH_BLAS)
-+find_package(BLAS REQUIRED)
-+if(1)
++if(WITH_BLAS)
++  find_package(BLAS REQUIRED)
    target_compile_definitions(cimg INTERFACE cimg_use_blas)
    target_link_libraries(cimg INTERFACE ${BLAS_LIBRARIES})
    target_include_directories(cimg INTERFACE ${BLAS_INCLUDE_DIRS})
  endif()
-+endif()
  
 -find_package(FFTW)
 -if(FFTW_FOUND)
-+if (WITH_FFTW3)
-+find_package(FFTW3 CONFIG REQUIRED)
-+if(1)
++if(WITH_FFTW3)
++  find_package(FFTW3 CONFIG REQUIRED)
    target_compile_definitions(cimg INTERFACE cimg_use_fftw3)
 -  target_link_libraries(cimg INTERFACE ${FFTW_LIBRARIES})
 -  target_include_directories(cimg INTERFACE ${FFTW_INCLUDE_DIRS})
 +  target_link_libraries(cimg INTERFACE FFTW3::fftw3)
-+endif()
  endif()
  
  if (CMAKE_MODULE_PATH)
 -  find_package(OpenCV QUIET)
 -  if (OpenCV_FOUND)
 +  if (WITH_OPENCV)
-+  find_package(OpenCV CONFIG REQUIRED)
-+  if (1)
++    find_package(OpenCV CONFIG REQUIRED)
      target_compile_definitions(cimg INTERFACE cimg_use_opencv)
 -    target_link_libraries(cimg INTERFACE ${OpenCV_LIBRARIES})
 -    target_include_directories(cimg INTERFACE ${OpenCV_INCLUDE_DIRS})
 +    target_link_libraries(cimg INTERFACE opencv_core)
-+  endif()
    endif()
  else()
    message("No CMAKE_MODULE_PATH path for OpenCV configured")
 diff --git a/source/matplot/CMakeLists.txt b/source/matplot/CMakeLists.txt
-index fe9ad53..b06ed7e 100644
+index a0428ac..b6abc8e 100644
 --- a/source/matplot/CMakeLists.txt
 +++ b/source/matplot/CMakeLists.txt
-@@ -1,5 +1,4 @@
- if(NOT MINGW)
--find_package(Filesystem REQUIRED COMPONENTS Experimental Final)
- endif()
- 
- #######################################################
-@@ -102,12 +101,13 @@ target_include_directories(matplot
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+@@ -112,7 +112,8 @@ target_include_directories(matplot
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/matplot/detail/exports.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/matplot/detail)
  
  # Dependencies
+-target_link_libraries_system(matplot PRIVATE cimg nodesoup)
 +find_package(nodesoup CONFIG REQUIRED)
- if(NOT MINGW)
--target_link_libraries_system(matplot
--  PRIVATE cimg nodesoup std::filesystem)
-+target_link_libraries(matplot
-+  PRIVATE cimg nodesoup::nodesoup)
- else()
--target_link_libraries_system(matplot
--  PRIVATE cimg nodesoup)
-+target_link_libraries(matplot
-+  PRIVATE cimg nodesoup::nodesoup)
- endif()
++target_link_libraries_system(matplot PRIVATE cimg nodesoup::nodesoup)
  
  # Required compiler features required
-@@ -134,7 +134,6 @@ maybe_target_pedantic_warnings(matplot)
- # Use experimental filesystem if std::filesystem is not available yet
- if(NOT MINGW)
-     if (CXX_FILESYSTEM_IS_EXPERIMENTAL)
--      target_compile_definitions(matplot PRIVATE CXX_FILESYSTEM_IS_EXPERIMENTAL)
-     endif()
- endif()
- # Some hack to not depend on FILE* internals
-@@ -217,7 +216,7 @@ if (MATPLOTPP_BUILD_EXPERIMENTAL_OPENGL_BACKEND)
-     find_package(OpenGL REQUIRED)
+ # https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
+@@ -215,7 +216,7 @@ if (MATPLOTPP_BUILD_EXPERIMENTAL_OPENGL_BACKEND)
+     find_package(OpenGL)
  
      # https://github.com/Dav1dde/glad
--    find_package(GLAD QUIET)
+-    find_package(glad CONFIG)
 +    find_package(GLAD NAMES glad CONFIG REQUIRED)
-     if (NOT GLAD_FOUND AND NOT TARGET glad)
-         # Use CPM only if not found, to avoid ODR violations
-         # find_package(GLAD REQUIRE) would suffice if it worked well
-@@ -233,7 +232,7 @@ if (MATPLOTPP_BUILD_EXPERIMENTAL_OPENGL_BACKEND)
-     endif ()
+     if (NOT glad_FOUND)
+         find_package(GLAD QUIET)
+     endif()
+@@ -238,7 +239,7 @@ if (MATPLOTPP_BUILD_EXPERIMENTAL_OPENGL_BACKEND)
+     endif()
  
      # https://github.com/glfw/glfw
 -    find_package(glfw3 QUIET)
 +    find_package(GLFW3 NAMES glfw3 CONFIG REQUIRED)
-     if (NOT GLFW3_FOUND AND NOT TARGET glfw)
+     if ((NOT glfw3_FOUND AND NOT GLFW3_FOUND) OR NOT TARGET glfw)
          # Use CPM only if not found, to avoid ODR violations
          # find_package(glfw3 REQUIRE) would suffice if it worked well
-@@ -247,7 +246,7 @@ if (MATPLOTPP_BUILD_EXPERIMENTAL_OPENGL_BACKEND)
-             backend/opengl.h
-             backend/opengl.cpp
-             )
--    target_link_libraries(matplot_opengl PUBLIC matplot glad glfw ${CMAKE_DL_LIBS})
-+    target_link_libraries(matplot_opengl PUBLIC matplot glad::glad glfw ${CMAKE_DL_LIBS})
- 
-     list(APPEND TARGETS matplot_opengl)
- endif()

--- a/ports/matplotplusplus/portfile.cmake
+++ b/ports/matplotplusplus/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alandefreitas/matplotplusplus
     REF "v${VERSION}"
-    SHA512 9193381fd9d4925259f28a03da33231b3da1273237e7510b93da1ca076610455746feb4ea0d8aa9a4a9e46a5f5f344fc1322f7ffc57963837dbe8b0be0b811ac
+    SHA512 8ecb13fa206ff6762dec74c4de0778bf275e1ebf11ec1b48e8c0e544cf2990220e1be2b3bc9c658f06cb6714c9cc103fa81f10c079a32128218ebdaf265514d5
     HEAD_REF master
     PATCHES
                 fix-dependencies.patch

--- a/ports/matplotplusplus/vcpkg.json
+++ b/ports/matplotplusplus/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "matplotplusplus",
-  "version": "1.2.0",
-  "port-version": 1,
+  "version": "1.2.1",
   "description": "A C++ graphics library for data visualization",
   "homepage": "https://alandefreitas.github.io/matplotplusplus/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5545,8 +5545,8 @@
       "port-version": 2
     },
     "matplotplusplus": {
-      "baseline": "1.2.0",
-      "port-version": 1
+      "baseline": "1.2.1",
+      "port-version": 0
     },
     "matroska": {
       "baseline": "1.7.1",

--- a/versions/m-/matplotplusplus.json
+++ b/versions/m-/matplotplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51c46b79b51c246c051a496bbdfa057aec3860ca",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "99828f36e20657952b4574a84c4281f684a0afeb",
       "version": "1.2.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.