### PR TITLE
[opentelemetry-cpp] add ETW as dependence of Geneva feature

### DIFF
--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -34,7 +34,9 @@
       "dependencies": [
         {
           "name": "opentelemetry-cpp",
-          "features": ["etw"],
+          "features": [
+            "etw"
+          ],
           "platform": "windows"
         }
       ]

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.14.0",
+  "port-version": 1,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."
@@ -29,7 +30,14 @@
       "supports": "windows"
     },
     "geneva": {
-      "description": "Whether to include the Geneva Exporter from the opentelemetry-cpp-contrib repository"
+      "description": "Whether to include the Geneva Exporter from the opentelemetry-cpp-contrib repository",
+      "dependencies": [
+        {
+          "name": "opentelemetry-cpp",
+          "features": ["etw"],
+          "platform": "windows"
+        }
+      ]
     },
     "otlp-grpc": {
       "description": "Whether to include the OTLP gRPC exporter in the SDK",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6442,7 +6442,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.14.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opentelemetry-fluentd": {
       "baseline": "2.0.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b4e7d1eb3fdf9b46da915bc798cc18584c0a9c2",
+      "version-semver": "1.14.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7ccef9777cd5eb8b6a8a68074eb9fc2d2a00fd18",
       "version-semver": "1.14.0",
       "port-version": 0

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4b4e7d1eb3fdf9b46da915bc798cc18584c0a9c2",
+      "git-tree": "f3b824a861450db24c3cd2ed97564917eeb6acdc",
       "version-semver": "1.14.0",
       "port-version": 1
     },


### PR DESCRIPTION
opentelemetry-cpp[geneva] depends on opentelemetry-cpp[etw] on Windows, as the Geneva exporter applies header files on top of ETW exporter header files. Without declaration this dependency in vcpkg, the user would need to install both features manually to make it work, like opentelemetry[etw,geneva].

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
