### PR TITLE
[libunwind] Update to 1.8.0

### DIFF
--- a/ports/libunwind/portfile.cmake
+++ b/ports/libunwind/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "libunwind/libunwind"
     REF "v${VERSION}"
-    HEAD_REF "v1.7-stable"
-    SHA512 b560f45cfa8ca3a60b41779afbcd862860c0f7af4014298c0b22eaec8b39740349c2077a940fb0d235c8f7d6a567e00c5cb0a04c251053f90c51320616784fd2
+    HEAD_REF "v1.8-stable"
+    SHA512 105bd4ff0f23f98046a4ed2cb58664083eba35154c92334a1f905ef13e1e92abbf87acb82556c9242c4209626f065d2519f3260e69d2146234a285b4ddd64470
 )
 
 vcpkg_configure_make(

--- a/ports/libunwind/vcpkg.json
+++ b/ports/libunwind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libunwind",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Unix libray for portable stack unwinding",
   "homepage": "https://www.nongnu.org/libunwind",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5017,7 +5017,7 @@
       "port-version": 3
     },
     "libunwind": {
-      "baseline": "1.7.2",
+      "baseline": "1.8.0",
       "port-version": 0
     },
     "liburing": {

--- a/versions/l-/libunwind.json
+++ b/versions/l-/libunwind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e1ae4e9ac079e529efa51416aef23cb20246e3d",
+      "version": "1.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "294a42641c25a25372ce73673ad0ec151ed50fac",
       "version": "1.7.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36797

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-linux
```
