### PR TITLE
[jwt-cpp] Update to 0.7.0

### DIFF
--- a/ports/jwt-cpp/portfile.cmake
+++ b/ports/jwt-cpp/portfile.cmake
@@ -1,12 +1,13 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Thalhammer/jwt-cpp
-    REF 4a537e969891dde542ad8b1a4a214955a83be29f # v0.6.0
-    SHA512 eeeb6adb7f94b699a020b5622b9dbb6c677d92779b57bfb2298b331a5cf69d9112d0b123f0c2ca235ecd96df6d32fcf44e85e144fa414aeff8fd67e3b87576d2
+    REF "v${VERSION}"
+    SHA512 b6fdb93e3f2f065a2eb45fe16cb076a932b8d4bfad2251bd66d2be40d8afaf5c27a9cf17aaea61d8bfa3f5ff9ed3b45f90962dc14d72704ac5b9d717c12cc79f
     HEAD_REF master
 )
 
 # Copy the header files
 file(GLOB HEADER_FILES ${SOURCE_PATH}/include/jwt-cpp/*)
 file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/jwt-cpp)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/jwt-cpp/vcpkg.json
+++ b/ports/jwt-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-cpp",
-  "version-semver": "0.6.0",
+  "version-semver": "0.7.0",
   "description": "A header only library for creating and validating json web tokens in c++",
   "homepage": "https://github.com/Thalhammer/jwt-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3757,7 +3757,7 @@
       "port-version": 0
     },
     "jwt-cpp": {
-      "baseline": "0.6.0",
+      "baseline": "0.7.0",
       "port-version": 0
     },
     "jxrlib": {

--- a/versions/j-/jwt-cpp.json
+++ b/versions/j-/jwt-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5302b22e1086039ecf4c3a04a2e8be2218e40305",
+      "version-semver": "0.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d1a0be50079d7774b6807b914518a3028477096",
       "version-semver": "0.6.0",
       "port-version": 0


### PR DESCRIPTION
Fix #36905 

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Tests
Test pass with following triplets:
```plain
x64-windows
x64-windows-static
x86-windows
```