### PR TITLE
[bddisasm] Update to 2.1.0

### DIFF
--- a/ports/bddisasm/portfile.cmake
+++ b/ports/bddisasm/portfile.cmake
@@ -29,3 +29,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 
 vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/bddisasm/portfile.cmake
+++ b/ports/bddisasm/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bitdefender/bddisasm
-    REF v1.34.10
-    SHA512 441a14c590fa12920bb972ca1d1b255cd03e0444be57eef16565803b446a1d9a49c62642b7947a1dcbf64b650fb7a66ae1796e42872d742cbaa9071a35150527
+    REF v2.1.0
+    SHA512 307a341eeaddf6ba6858ee0f5c4c51d20e82ad5c5e977a9a40bed94266a5d1d05164a0dca0ee9bf3f6a0b4613e6c82a78a1118c09fc623c9b09fe8d0872da6d2
     HEAD_REF master
 )
 

--- a/ports/bddisasm/portfile.cmake
+++ b/ports/bddisasm/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bitdefender/bddisasm
-    REF v2.1.0
+    REF "v${VERSION}"
     SHA512 307a341eeaddf6ba6858ee0f5c4c51d20e82ad5c5e977a9a40bed94266a5d1d05164a0dca0ee9bf3f6a0b4613e6c82a78a1118c09fc623c9b09fe8d0872da6d2
     HEAD_REF master
 )

--- a/ports/bddisasm/usage
+++ b/ports/bddisasm/usage
@@ -1,0 +1,11 @@
+bddisasm provides CMake targets:
+
+  find_package(bddisasm CONFIG REQUIRED)
+  # Decoder library.
+  target_link_libraries(main PRIVATE bddisasm::bddisasm)
+  # Shellcode emulator library.
+  target_link_libraries(main PRIVATE bddisasm::bdshemu)
+
+bddisasm provides pkg-config modules:
+
+    lbddisasm

--- a/ports/bddisasm/vcpkg.json
+++ b/ports/bddisasm/vcpkg.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/bitdefender/bddisasm",
   "documentation": "https://bddisasm.readthedocs.io/en/latest/",
   "license": "Apache-2.0",
+  "supports": "!osx & !android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/bddisasm/vcpkg.json
+++ b/ports/bddisasm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bddisasm",
-  "version": "1.34.10",
+  "version": "2.1.0",
   "maintainers": "Cristi Anichitei <ianichitei@bitdefender.com>",
   "description": "bddisasm is a fast, lightweight, x86/x64 instruction decoder and emulator.",
   "homepage": "https://github.com/bitdefender/bddisasm",

--- a/ports/bddisasm/vcpkg.json
+++ b/ports/bddisasm/vcpkg.json
@@ -6,7 +6,6 @@
   "homepage": "https://github.com/bitdefender/bddisasm",
   "documentation": "https://bddisasm.readthedocs.io/en/latest/",
   "license": "Apache-2.0",
-  "supports": "!arm",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/b-/bddisasm.json
+++ b/versions/b-/bddisasm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b21350132d1ccae8ffd59e85d961fc99d8ece1da",
+      "git-tree": "26b6c5584f03700f47ff9d457df6f16dfdaebdba",
       "version": "2.1.0",
       "port-version": 0
     },

--- a/versions/b-/bddisasm.json
+++ b/versions/b-/bddisasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b21350132d1ccae8ffd59e85d961fc99d8ece1da",
+      "version": "2.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b34f372d51168c9361ccd85f91263792b2c9bd4d",
       "version": "1.34.10",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -545,7 +545,7 @@
       "port-version": 3
     },
     "bddisasm": {
-      "baseline": "1.34.10",
+      "baseline": "2.1.0",
       "port-version": 0
     },
     "bde": {


### PR DESCRIPTION
## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I'm not entirely sure that I did the right thing. Previous versions were having troubles building on arm, so they specified `"supports": "!arm"` in `vcpkg.json`. These issues should be fixed now, although I had minimal access to ARM devices/cross compilation tools to properly test this. Should I add an explicit list of supported platforms instead? 
