### PR TITLE
[folly,fizz,wangle,mvfst,proxygen,fbthrift] update to 2024.02.19.00

### DIFF
--- a/ports/fbthrift/vcpkg.json
+++ b/ports/fbthrift/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fbthrift",
-  "version-string": "2024.01.01.00",
+  "version-string": "2024.02.19.00",
   "description": "Facebook's branch of Apache Thrift, including a new C++ server.",
   "homepage": "https://github.com/facebook/fbthrift",
   "license": "Apache-2.0",

--- a/ports/fizz/vcpkg.json
+++ b/ports/fizz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fizz",
-  "version-string": "2024.01.01.00",
+  "version-string": "2024.02.19.00",
   "description": "a TLS 1.3 implementation by Facebook",
   "homepage": "https://github.com/facebookincubator/fizz",
   "license": "BSD-3-Clause",

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "folly",
-  "version-string": "2024.01.01.00",
+  "version-string": "2024.02.19.00",
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/ports/mvfst/vcpkg.json
+++ b/ports/mvfst/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mvfst",
-  "version-string": "2024.01.01.00",
+  "version-string": "2024.02.19.00",
   "description": "mvfst (Pronounced move fast) is a client and server implementation of IETF QUIC protocol in C++ by Facebook.",
   "homepage": "https://github.com/facebook/mvfst",
   "license": "MIT",

--- a/ports/proxygen/vcpkg.json
+++ b/ports/proxygen/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "proxygen",
-  "version-string": "2024.01.01.00",
+  "version-string": "2024.02.19.00",
   "description": "It comprises the core C++ HTTP abstractions used at Facebook.",
   "homepage": "https://github.com/facebook/proxygen",
   "license": "BSD-3-Clause",

--- a/ports/wangle/vcpkg.json
+++ b/ports/wangle/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wangle",
-  "version-string": "2024.01.01.00",
+  "version-string": "2024.02.19.00",
   "description": "Wangle is a framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.",
   "homepage": "https://github.com/facebook/wangle",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2625,7 +2625,7 @@
       "port-version": 0
     },
     "fbthrift": {
-      "baseline": "2024.01.01.00",
+      "baseline": "2024.02.19.00",
       "port-version": 0
     },
     "fcl": {
@@ -2669,7 +2669,7 @@
       "port-version": 0
     },
     "fizz": {
-      "baseline": "2024.01.01.00",
+      "baseline": "2024.02.19.00",
       "port-version": 0
     },
     "flagpp": {
@@ -2753,7 +2753,7 @@
       "port-version": 0
     },
     "folly": {
-      "baseline": "2024.01.01.00",
+      "baseline": "2024.02.19.00",
       "port-version": 0
     },
     "font-chef": {
@@ -5897,7 +5897,7 @@
       "port-version": 7
     },
     "mvfst": {
-      "baseline": "2024.01.01.00",
+      "baseline": "2024.02.19.00",
       "port-version": 0
     },
     "mygui": {
@@ -6901,7 +6901,7 @@
       "port-version": 0
     },
     "proxygen": {
-      "baseline": "2024.01.01.00",
+      "baseline": "2024.02.19.00",
       "port-version": 0
     },
     "psimd": {
@@ -9129,7 +9129,7 @@
       "port-version": 5
     },
     "wangle": {
-      "baseline": "2024.01.01.00",
+      "baseline": "2024.02.19.00",
       "port-version": 0
     },
     "wasmedge": {

--- a/versions/f-/fbthrift.json
+++ b/versions/f-/fbthrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e063a462e94693273f2bd1f4eae5a3a8830e1998",
+      "version-string": "2024.02.19.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "824b246c1bf15c6d96a4ca1126d3e9a279663585",
       "version-string": "2024.01.01.00",
       "port-version": 0

--- a/versions/f-/fizz.json
+++ b/versions/f-/fizz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b291b2be577c70dbefe8f2f4ada3f930114abf0",
+      "version-string": "2024.02.19.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "b3a03c5a987e674153efbc6e8a9ab1ed9655b0b0",
       "version-string": "2024.01.01.00",
       "port-version": 0

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95beaef3b4221a98f01a91aa2db9038ebc780448",
+      "version-string": "2024.02.19.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "14d0ea48901f854308ce005f8de818b0a0bb06b2",
       "version-string": "2024.01.01.00",
       "port-version": 0

--- a/versions/m-/mvfst.json
+++ b/versions/m-/mvfst.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9cb37eb3e943c5c5b425bfc1bb12b08e1e5471d7",
+      "version-string": "2024.02.19.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "c0b5b25444aee23d293543cb07f671e422d131a1",
       "version-string": "2024.01.01.00",
       "port-version": 0

--- a/versions/p-/proxygen.json
+++ b/versions/p-/proxygen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "87da878ff43aed5f8ccdfc87c89d5c4cb7c2d5f0",
+      "version-string": "2024.02.19.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "dd720dffa16fc78103cb6e6fc9aae13e94d33fb3",
       "version-string": "2024.01.01.00",
       "port-version": 0

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5740a5829bff9ee1df45c0cc408c7126679db2f",
+      "version-string": "2024.02.19.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "efa950ad690a3f10060fe5c09cfea6a55201736a",
       "version-string": "2024.01.01.00",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
