### PR TITLE
[OpenFX] Add new port

### DIFF
--- a/ports/openfx/CONTROL
+++ b/ports/openfx/CONTROL
@@ -1,5 +1,0 @@
-Source: openfx
-Version: 1.4.0
-Description: OpenFX - An open-source plugin API for visual effects
-Maintainer: Behnam Binesh Behnambih@gmail.com
-Homepage: https://github.com/ofxa/openfx

--- a/ports/openfx/CONTROL
+++ b/ports/openfx/CONTROL
@@ -1,0 +1,5 @@
+Source: openfx
+Version: 1.4.0
+Description: OpenFX - An open-source plugin API for visual effects
+Maintainer: Behnam Binesh Behnambih@gmail.com
+Homepage: https://github.com/ofxa/openfx

--- a/ports/openfx/portfile.cmake
+++ b/ports/openfx/portfile.cmake
@@ -1,0 +1,16 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO AcademySoftwareFoundation/openfx
+    TAG OFX_Release_1_4_TAG
+    REF a355991
+    SHA512 cda67fd3aa30fb01a580e8c42cd06284f83e5ae06e95c4fda7adb09f4130853aedb3d908b6c465025415973b45b72b17711c646b5b6faeff988b60ad80b0a4c2
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()

--- a/ports/openfx/portfile.cmake
+++ b/ports/openfx/portfile.cmake
@@ -14,3 +14,4 @@ vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
+

--- a/ports/openfx/portfile.cmake
+++ b/ports/openfx/portfile.cmake
@@ -1,7 +1,3 @@
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/openfx
@@ -9,9 +5,49 @@ vcpkg_from_github(
     REF a355991
     SHA512 cda67fd3aa30fb01a580e8c42cd06284f83e5ae06e95c4fda7adb09f4130853aedb3d908b6c465025415973b45b72b17711c646b5b6faeff988b60ad80b0a4c2
 )
+message("OpenFX Path:")
+message(${SOURCE_PATH})
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
-vcpkg_cmake_install()
-vcpkg_copy_pdbs()
-vcpkg_fixup_pkgconfig()
+# Read the original solution file
+#file(READ ${SOURCE_PATH}/HostSupport/HostSupport.sln HOSTSUPPORT_SOLUTION_CONTENT)
+
+# Update the solution file format to Visual Studio 2017
+#string(REPLACE "# Visual Studio 2005" "# Visual Studio 15" HOSTSUPPORT_SOLUTION_CONTENT ${HOSTSUPPORT_SOLUTION_CONTENT})
+#string(REPLACE "Microsoft Visual Studio Solution File, Format Version 9.00" "Microsoft Visual Studio Solution File, Format Version 12.00" HOSTSUPPORT_SOLUTION_CONTENT ${HOSTSUPPORT_SOLUTION_CONTENT})
+# Append a new string to the solution file content
+#string(APPEND HOSTSUPPORT_SOLUTION_CONTENT "\n VisualStudioVersion = 15.0.28307.852 \n")
+#string(APPEND HOSTSUPPORT_SOLUTION_CONTENT "\n MinimumVisualStudioVersion = 10.0.40219.1 \n")
+
+# Write the updated solution file
+#file(WRITE ${SOURCE_PATH}/HostSupport/HostSupport.sln ${HOSTSUPPORT_SOLUTION_CONTENT})
+#set(devenv_cmd
+#    devenv /upgrade HostSupport.sln
+#)
+#execute_process(
+#    COMMAND ${devenv_cmd}
+#    WORKING_DIRECTORY ${SOURCE_PATH}/HostSupport
+#)
+
+#if (MSVC)
+    # Define the build command for HostSupport project
+    set(build_cmd
+        msbuild HostSupport.sln /p:Configuration=Release /p:Platform=x64 /p:OutputPath=$(SolutionDir)$(Configuration)
+    )
+
+    # Add custom build step to build HostSupport
+    execute_process(
+        COMMAND ${build_cmd}
+        WORKING_DIRECTORY ${SOURCE_PATH}/HostSupport/
+        RESULT_VARIABLE build_result
+    )
+
+    if (NOT build_result EQUAL 0)
+        message(FATAL_ERROR "Failed to build HostSupport project")
+    endif()
+#endif()
+
+#vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+#vcpkg_cmake_install()
+#vcpkg_copy_pdbs()
+#vcpkg_fixup_pkgconfig()
 

--- a/ports/openfx/vcpkg.json
+++ b/ports/openfx/vcpkg.json
@@ -4,15 +4,5 @@
   "maintainers": "Behnam Binesh BehnamBih@gmail.com",
   "description": "OpenFX - An open-source plugin API for visual effects",
   "homepage": "https://github.com/AcademySoftwareFoundation/openfx",
-  "license": "MIT",
-  "dependencies": [
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    }
-  ]
+  "license": "MIT"
 }

--- a/ports/openfx/vcpkg.json
+++ b/ports/openfx/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "openfx",
+  "version-string": "1.4.0",
+  "maintainers": "Behnam Binesh BehnamBih@gmail.com",
+  "description": "OpenFX - An open-source plugin API for visual effects",
+  "homepage": "https://github.com/AcademySoftwareFoundation/openfx",
+  "license": "MIT"
+}

--- a/ports/openfx/vcpkg.json
+++ b/ports/openfx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openfx",
-  "version-string": "1.4.0",
+  "version": "1.4.0",
   "maintainers": "Behnam Binesh BehnamBih@gmail.com",
   "description": "OpenFX - An open-source plugin API for visual effects",
   "homepage": "https://github.com/AcademySoftwareFoundation/openfx",

--- a/ports/openfx/vcpkg.json
+++ b/ports/openfx/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "openfx",
-  "version": "1.4.0",
+  "version-date": "2015-10-01",
   "maintainers": "Behnam Binesh BehnamBih@gmail.com",
   "description": "OpenFX - An open-source plugin API for visual effects",
   "homepage": "https://github.com/AcademySoftwareFoundation/openfx",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6365,7 +6365,7 @@
       "port-version": 0
     },
     "openfx": {
-      "baseline": "1.4.0",
+      "baseline": "2015-10-01",
       "port-version": 0
     },
     "opengl": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6364,6 +6364,10 @@
       "baseline": "2022-07-18",
       "port-version": 0
     },
+    "openfx": {
+      "baseline": "1.4.0",
+      "port-version": 0
+    },
     "opengl": {
       "baseline": "2022-12-04",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
