### PR TITLE
[opentelemetry-cpp] Pick up fix for Geneva feature

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -48,9 +48,9 @@ if(WITH_GENEVA)
     vcpkg_from_github(
         OUT_SOURCE_PATH CONTRIB_SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF 3f1b0ef547a304635aa1357af5990b4291c9f074
+        REF 15483a6e77f246dadb85e67fe78cdb5c4003d2f1
         HEAD_REF main
-        SHA512 00887a901663b1917f49eb0ddd59135a1c9904b420c982e958a52c9fdea0f389a80dde8500218aa4ce19666c3d0c1293f76a4493c0b1b7d473554dad10a67330
+        SHA512 f5dfb8a6efd22bdf22e6b6a4c8b2ebc29021d33fd045c6362a71140bc46a4b57ca86905a6bd82bbc9f60a551aeeec19cd02431e58669d2dca31ce417f6a37cdb
     )
 
     set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${CONTRIB_SOURCE_PATH}/exporters/geneva")

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.14.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6446,7 +6446,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.14.0",
-      "port-version": 1
+      "port-version": 2
     },
     "opentelemetry-fluentd": {
       "baseline": "2.0.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0615b7500e8e0997acc13d53b8a0f8ebf370dd3b",
+      "version-semver": "1.14.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "f3b824a861450db24c3cd2ed97564917eeb6acdc",
       "version-semver": "1.14.0",
       "port-version": 1


### PR DESCRIPTION
Pick up a fix for Geneva feature from [opentelemtry-cpp-contrib](https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main). The contrib repo is not versioned independently than the main repo [opentelemetry-cpp](https://github.com/open-telemetry/opentelemetry-cpp), thus the version number will remain the current one.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.