### PR TITLE
Fix the SAS token generation script

### DIFF
--- a/scripts/azure-pipelines/generate-sas-tokens.ps1
+++ b/scripts/azure-pipelines/generate-sas-tokens.ps1
@@ -26,8 +26,12 @@ function Get-SasToken {
     $ctx = New-AzStorageContext -StorageAccountName $StorageAccountName -StorageAccountKey $key.Value
     $start = Get-Date -AsUTC
     $end = $start.AddDays(90)
-    $token = New-AzStorageContainerSASToken -Name $ContainerName -Permission $Permission -StartTime $start -ExpiryTime $end -Context $ctx
-    return $token.Substring(1)
+    $token = New-AzStorageContainerSASToken -Name $ContainerName -Permission $Permission -StartTime $start -ExpiryTime $end -Context $ctx -Protocol HttpsOnly
+    if ($token.StartsWith('?')) {
+        $token = $token.Substring(1)
+    }
+
+    return $token
 }
 
 # Asset Cache:


### PR DESCRIPTION
to account for breaking change in New-AzStorageContainerSASToken which causes it to no longer start with a question mark.

See https://learn.microsoft.com/en-us/powershell/azure/release-notes-azureps?view=azps-11.3.0#azstorage-600
