### PR TITLE
[netcdf-c] Fix static linkage of libm

### DIFF
--- a/ports/netcdf-c/fix-dependency-libmath.patch
+++ b/ports/netcdf-c/fix-dependency-libmath.patch
@@ -2,12 +2,19 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index c36908b..390ac0a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -944,7 +944,7 @@ OPTION(ENABLE_BYTERANGE "Enable byte-range access to remote datasets.." OFF)
+@@ -944,6 +944,15 @@ OPTION(ENABLE_BYTERANGE "Enable byte-range access to remote datasets.." OFF)
  
  # Check for the math library so it can be explicitly linked.
  IF(NOT WIN32)
--  FIND_LIBRARY(HAVE_LIBM NAMES math m libm)
-+  FIND_LIBRARY(HAVE_LIBM NAMES m libm math)
++  block(SCOPE_FOR VARIABLES)
++    if(VCPKG_CRT_LINKAGE STREQUAL "static")
++      list(PREPEND CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_STATIC_LIBRARY_SUFFIX}")
++    endif()
++    find_library(HAVE_LIBM_PATH m PATHS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
++    if(HAVE_LIBM_PATH)
++      set(HAVE_LIBM m CACHE STRING "Math link library")
++    endif()
++  endblock()
+   FIND_LIBRARY(HAVE_LIBM NAMES math m libm)
    MESSAGE(STATUS "Found Math library: ${HAVE_LIBM}")
    IF(NOT HAVE_LIBM)
-     MESSAGE(FATAL_ERROR "Unable to find the math library.")

--- a/ports/netcdf-c/vcpkg.json
+++ b/ports/netcdf-c/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "netcdf-c",
   "version": "4.8.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.",
   "homepage": "https://github.com/Unidata/netcdf-c",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6006,7 +6006,7 @@
     },
     "netcdf-c": {
       "baseline": "4.8.1",
-      "port-version": 4
+      "port-version": 5
     },
     "netcdf-cxx4": {
       "baseline": "4.3.1",

--- a/versions/n-/netcdf-c.json
+++ b/versions/n-/netcdf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e93ab8e5b418fbc359d4e1dcb888e2e050c83f49",
+      "version": "4.8.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "12002458bc69dbcd92c6792a3edd1f5e3931ae95",
       "version": "4.8.1",
       "port-version": 4


### PR DESCRIPTION
Ensure that static CRT linkage actually prefers `libm.a`.