### PR TITLE
[libdatachannel] Update to 0.20.1

### DIFF
--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO paullouisageneau/libdatachannel
     REF "v${VERSION}"
-    SHA512 63551a9f2ce8de7f7aba13b2114418d3d705a6c190d91eac7cf6deba93ccbe9bda053000feb7ac109d538646c77da62b31686a58f83d752f191cac3a015f2d69
+    SHA512 28ef96773b5c0b470ad9c52dafc1c7b8c88e54414a59bf0363ce3ca3f099f81a3e8005f57d4e4d93c8be9bdd72855d8af5438266e75fdabb23882df6d6f0b550
     HEAD_REF master
     PATCHES 
         ${PATCHES}

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libdatachannel",
-  "version-semver": "0.19.5",
-  "port-version": 2,
+  "version-semver": "0.20.1",
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4237,8 +4237,8 @@
       "port-version": 0
     },
     "libdatachannel": {
-      "baseline": "0.19.5",
-      "port-version": 2
+      "baseline": "0.20.1",
+      "port-version": 0
     },
     "libdatrie": {
       "baseline": "0.2.13",

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b829fa3c4fbd6031bef6399df8747a9b51245cb6",
+      "version-semver": "0.20.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "73a4d8cba18306b14a98b1fb70d35bfa588ce386",
       "version-semver": "0.19.5",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
