### PR TITLE
[velodyne-decoder] New port

### DIFF
--- a/ports/velodyne-decoder/0001-fix-msvc-flags.patch
+++ b/ports/velodyne-decoder/0001-fix-msvc-flags.patch
@@ -1,0 +1,17 @@
+Backport of https://github.com/valgur/velodyne_decoder/commit/22809df3a4d550c3746b17aaca1d6c20692730c4
+
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -17,7 +17,11 @@
+ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ 
+ if(MSVC)
+-  add_compile_options(/W4 /O2)
++  add_compile_options(
++      "$<$<CONFIG:RelWithDebInfo>:/O2>"
++      "$<$<CONFIG:Release>:/O2>"
++      /W4
++  )
+ else()
+   add_compile_options(
+     "$<$<CONFIG:Debug>:-ggdb3;-Og>"

--- a/ports/velodyne-decoder/portfile.cmake
+++ b/ports/velodyne-decoder/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO valgur/velodyne_decoder
+    REF "v${VERSION}"
+    SHA512 f09dd173cdea6b651a023d799bed7047ee2ac8518446d57e289a6eed9a92ff1ec2644ec49b78bd29ecfebb2046cb89455910bcb476db852a14e42e106b9881ce
+    HEAD_REF develop
+    PATCHES
+        0001-fix-msvc-flags.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DINSTALL_THIRD_PARTY=FALSE
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "velodyne_decoder"
+    CONFIG_PATH lib/cmake/velodyne_decoder
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/velodyne-decoder/usage
+++ b/ports/velodyne-decoder/usage
@@ -1,0 +1,4 @@
+velodyne-decoder provides CMake targets:
+
+find_package(velodyne_decoder CONFIG REQUIRED)
+target_link_libraries(main PRIVATE velodyne_decoder::velodyne_decoder)

--- a/ports/velodyne-decoder/vcpkg.json
+++ b/ports/velodyne-decoder/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "velodyne-decoder",
+  "version": "3.0.0",
+  "description": "A decoder library for raw Velodyne data and telemetry info",
+  "homepage": "https://github.com/valgur/velodyne_decoder",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "ms-gsl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "yaml-cpp",
+      "version>=": "0.7"
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9004,6 +9004,10 @@
       "baseline": "1.0",
       "port-version": 0
     },
+    "velodyne-decoder": {
+      "baseline": "3.0.0",
+      "port-version": 0
+    },
     "verdict": {
       "baseline": "1.4.0",
       "port-version": 0

--- a/versions/v-/velodyne-decoder.json
+++ b/versions/v-/velodyne-decoder.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "14057817c4d38c4c315e12a837213035d5f8eed0",
+      "version": "3.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a port for `velodyne-decoder`: https://github.com/valgur/velodyne_decoder

[![Packaging status](https://repology.org/badge/tiny-repos/velodyne-decoder.svg)](https://repology.org/project/velodyne-decoder/versions)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
