### PR TITLE
[libsrt] update to 1.5.3

### DIFF
--- a/ports/libsrt/fix-dependency-install.patch
+++ b/ports/libsrt/fix-dependency-install.patch
@@ -1,38 +1,39 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1492306..3f08b6a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1008,6 +1008,7 @@ set (INSTALL_SHARED_DIR ${CMAKE_INSTALL_LIBDIR})
+@@ -1133,6 +1133,7 @@ set (INSTALL_SHARED_DIR ${CMAKE_INSTALL_LIBDIR})
  if (CYGWIN)
  	set (INSTALL_SHARED_DIR ${CMAKE_INSTALL_BINDIR})
  endif()
 +set(CMAKE_INSTALL_INCLUDEDIR include)
  
  message(STATUS "INSTALL DIRS: bin=${CMAKE_INSTALL_BINDIR} lib=${CMAKE_INSTALL_LIBDIR} shlib=${INSTALL_SHARED_DIR} include=${CMAKE_INSTALL_INCLUDEDIR}")
- 
-@@ -1085,7 +1085,7 @@
- 
- macro(srt_add_program name)
- 	srt_add_program_dont_install(${name} ${ARGN})
--	install(TARGETS ${name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-+	install(TARGETS ${name} RUNTIME DESTINATION tools)
- endmacro()
- 
- macro(srt_make_application name)
-@@ -1124,7 +1124,7 @@ endmacro()
- macro(srt_add_application name) # ARGN=sources...
- 	srt_add_program(${name} apps/${name}.cpp ${ARGN})
- 	srt_make_application(${name})
--	install(TARGETS ${name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-+	install(TARGETS ${name} RUNTIME DESTINATION tools)
- endmacro()
- 
- ## FIXME: transmitmedia.cpp does not build on OpenBSD
-@@ -1324,7 +1324,7 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
+ if (NEED_DESTINATION)
+@@ -1228,7 +1229,7 @@ macro(srt_add_program name)
+ 	if(NOT NEED_DESTINATION)
+ 		install(TARGETS ${name} RUNTIME)
+ 	elseif (DEFINED CMAKE_INSTALL_BINDIR)
+-		install(TARGETS ${name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++		install(TARGETS ${name} RUNTIME DESTINATION tools)
+ 	else()
+ 		message(WARNING "No location to install program ${name}")
+ 	endif()
+@@ -1273,7 +1274,7 @@ macro(srt_add_application name) # ARGN=sources...
+ 	if(NOT NEED_DESTINATION)
+ 		install(TARGETS ${name} RUNTIME)
+ 	elseif (DEFINED CMAKE_INSTALL_BINDIR)
+-		install(TARGETS ${name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++		install(TARGETS ${name} RUNTIME DESTINATION tools)
+ 	else()
+ 		message(WARNING "No location to install program ${name}")
+ 	endif()
+@@ -1483,7 +1484,7 @@ endif()
+ if(NOT NEED_DESTINATION)
+ 	install(PROGRAMS scripts/srt-ffplay TYPE BIN)
+ elseif (DEFINED CMAKE_INSTALL_BINDIR)
+-	install(PROGRAMS scripts/srt-ffplay DESTINATION ${CMAKE_INSTALL_BINDIR})
++	install(PROGRAMS scripts/srt-ffplay DESTINATION tools)
+ else()
+ 	message(WARNING "No location to install scripts/srt-ffplay")
  endif()
- 
- 
--install(PROGRAMS scripts/srt-ffplay DESTINATION ${CMAKE_INSTALL_BINDIR})
-+install(PROGRAMS scripts/srt-ffplay DESTINATION tools)
- 
- 
- if (DEFINED SRT_EXTRA_APPS_INC)

--- a/ports/libsrt/fix-static.patch
+++ b/ports/libsrt/fix-static.patch
@@ -1,12 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9931589..e5a588e 100644
+index 3f08b6a..dc7dfb9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -931,20 +931,7 @@ endif()
- 
+@@ -1027,20 +1027,7 @@ endif()
  if (srt_libspec_static)
  	add_library(${TARGET_srt}_static STATIC ${OBJECT_LIB_SUPPORT} ${VIRTUAL_srt})
--
+ 
 -	# For Windows, leave the name to be "srt_static.lib".
 -	# Windows generates two different library files:
 -	# - a usual static library for static linkage
@@ -20,7 +19,8 @@ index 9931589..e5a588e 100644
 -	else()
 -		set_property(TARGET ${TARGET_srt}_static PROPERTY OUTPUT_NAME ${TARGET_srt})
 -	endif()
+-
 +	set_property(TARGET ${TARGET_srt}_static PROPERTY OUTPUT_NAME ${TARGET_srt})
- 
  	list (APPEND INSTALL_TARGETS ${TARGET_srt}_static)
  	if (ENABLE_ENCRYPTION)
+ 		target_link_libraries(${TARGET_srt}_static PRIVATE ${SSL_LIBRARIES})

--- a/ports/libsrt/portfile.cmake
+++ b/ports/libsrt/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Haivision/srt
-    REF v1.5.0
-    SHA512 68ab5fe316cfbbbba31b5b2354f657e23c90e14674f8dac01df2bf98c4776a7fafcd690a4dfad3a340e6be577a22360ca04ef2397c8a0dd507adebdd54dc22fb
+    REF v1.5.3
+    SHA512 5b576d6fd325515e05074e4568e3b65d1ae265e3e971db6e6242e5138243fc1594df1e3a7d90962385dac38abc34c4c4b0a567439050f8c0ff818b3b3d497efc
     HEAD_REF master
     PATCHES
         fix-dependency-install.patch

--- a/ports/libsrt/vcpkg.json
+++ b/ports/libsrt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libsrt",
-  "version": "1.5.0",
-  "port-version": 3,
+  "version": "1.5.3",
   "description": "Secure Reliable Transport (SRT) is an open source transport technology that optimizes streaming performance across unpredictable networks, such as the Internet.",
   "homepage": "https://github.com/Haivision/srt",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4909,8 +4909,8 @@
       "port-version": 13
     },
     "libsrt": {
-      "baseline": "1.5.0",
-      "port-version": 3
+      "baseline": "1.5.3",
+      "port-version": 0
     },
     "libsrtp": {
       "baseline": "2.5.0",

--- a/versions/l-/libsrt.json
+++ b/versions/l-/libsrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59dffbc2b1d1253746ad5ecad399a358535663b0",
+      "version": "1.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "96864197a0d35ea5a746ac1076b625c0372c37ae",
       "version": "1.5.0",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

Title says it all, pretty straightforward update. 

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
