### PR TITLE
[gmsh] Update to 4.12.2

### DIFF
--- a/ports/gmsh/portfile.cmake
+++ b/ports/gmsh/portfile.cmake
@@ -1,9 +1,11 @@
+string(REPLACE "." "_" UNDERSCORES_VERSION "${VERSION}")
+
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.onelab.info
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gmsh/gmsh
-    REF gmsh_4_11_1
-    SHA512 4c10a41659ee4f70ba5091f9ae1c4c3ee285ccf217c3de1157a0d6d694e6f1df9a6b1329b2b24029dd52f945dd7605e477302bdb358106a8d97e903eaba425dc
+    REF "${PORT}_${UNDERSCORES_VERSION}"
+    SHA512 65fbfd9bf30f1334c66345edb35e2a1cc9630c8d390d13f17dd0f0329066637d10fef652ff75114fa8d85046fe0871d60395612467c975bcaa10182454c2ad5e
     HEAD_REF master
     PATCHES fix-install.patch
 )

--- a/ports/gmsh/vcpkg.json
+++ b/ports/gmsh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gmsh",
-  "version": "4.11.1",
+  "version": "4.12.2",
   "description": "Gmsh is an open source 3D finite element mesh generator with a built-in CAD engine and post-processor.",
   "homepage": "https://gmsh.info",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3085,7 +3085,7 @@
       "port-version": 21
     },
     "gmsh": {
-      "baseline": "4.11.1",
+      "baseline": "4.12.2",
       "port-version": 0
     },
     "gobject-introspection": {

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d97f6df221dfe46e532d3f9d27c4dbd3bbdac0ea",
+      "version": "4.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4b2ce12dd16815e31348c4dba93b40ec10e815f3",
       "version": "4.11.1",
       "port-version": 0


### PR DESCRIPTION
Fix #36977

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
Port usage and features test pass with following triplets:
* x64-linux
* x64-windows
* x64-windows-static
