### PR TITLE
[gloo] Add array header file

### DIFF
--- a/ports/gloo/fix-array.patch
+++ b/ports/gloo/fix-array.patch
@@ -1,0 +1,24 @@
+diff --git a/gloo/transport/tcp/device.cc b/gloo/transport/tcp/device.cc
+index cda44c8..2df6167 100644
+--- a/gloo/transport/tcp/device.cc
++++ b/gloo/transport/tcp/device.cc
+@@ -12,6 +12,7 @@
+ #include <netdb.h>
+ #include <netinet/in.h>
+ #include <string.h>
++#include <array>
+ 
+ #include "gloo/common/linux.h"
+ #include "gloo/common/logging.h"
+diff --git a/gloo/transport/tcp/tls/pair.cc b/gloo/transport/tcp/tls/pair.cc
+index e8f95f7..b0277aa 100644
+--- a/gloo/transport/tcp/tls/pair.cc
++++ b/gloo/transport/tcp/tls/pair.cc
+@@ -17,6 +17,7 @@
+ 
+ #include <cstring>
+ #include <poll.h>
++#include <array>
+ 
+ namespace gloo {
+ namespace transport {

--- a/ports/gloo/portfile.cmake
+++ b/ports/gloo/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
   REF 1da21174054eaabbbd189b7f657ea24842d821e2
   SHA512 ebd8369e413aee739a3928f8e6738c15708f009e0cd5a3763b8cadbe6f6d0a9d758585a7a2b0f7dd6d39a12882ff2f9497ab2d4edcebd4eb2a7237ab857f317e
   HEAD_REF master
+  PATCHES
+      fix-array.patch #https://github.com/facebookincubator/gloo/issues/332
   )
 
 # Determine which backend to build via specified feature

--- a/ports/gloo/vcpkg.json
+++ b/ports/gloo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gloo",
   "version": "20201203",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Collective communications library with various primitives for multi-machine training.",
   "homepage": "https://github.com/facebookincubator/gloo",
   "supports": "x64 & linux",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3058,7 +3058,7 @@
     },
     "gloo": {
       "baseline": "20201203",
-      "port-version": 2
+      "port-version": 3
     },
     "glpk": {
       "baseline": "5.0",

--- a/versions/g-/gloo.json
+++ b/versions/g-/gloo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc506cd5c27f23c9b2f3fb1d3cfe5774c05e0364",
+      "version": "20201203",
+      "port-version": 3
+    },
+    {
       "git-tree": "a48ea12e9618f830268147a2c05fc65769182f0d",
       "version": "20201203",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36833
```
/mnt/vcpkg/buildtrees/gloo/src/4842d821e2-089f9c85b8.clean/gloo/transport/tcp/device.cc:151:39: error: aggregate ‘std::array<char, 64> hostname’ has incomplete type and cannot be defined
  151 |       std::array<char, HOST_NAME_MAX> hostname;
      |                                       ^~~~~~~~
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-linux
```
