### PR TITLE
[c-ares] Update to 1.27.0

### DIFF
--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
     REF "cares-${_c_ares_version_major}_${_c_ares_version_minor}_${_c_ares_version_patch}"
-    SHA512 1ff8d35cc0e022a0478149ca80a0a1f80b2c8d04e108b6cb9912ecc8c391017b6443129b9b52c2cf82b21ef338de0c80d89c92c6d7f95fe1f9c42575ed1a3919
+    SHA512 6060897a4b26afe135e9676002e6de22834aabe3c7d0aaceb64f178591329d6a30394884e8e3971b30992cf3624986aef7e6e4c941d93b0288a21483963827af
     HEAD_REF main
     PATCHES
         avoid-docs.patch

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c-ares",
-  "version-semver": "1.26.0",
+  "version-semver": "1.27.0",
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1405,7 +1405,7 @@
       "port-version": 5
     },
     "c-ares": {
-      "baseline": "1.26.0",
+      "baseline": "1.27.0",
       "port-version": 0
     },
     "c-dbg-macro": {

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a79f37c205d30ea300e9d20c9bb504655e34336",
+      "version-semver": "1.27.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c98426c40efeeefe1eadb00c943dc80f72e9f99",
       "version-semver": "1.26.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
