### PR TITLE
[libpq] Delete gendef.pl related patches

### DIFF
--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpq",
   "version": "16.2",
+  "port-version": 1,
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "license": "PostgreSQL",

--- a/ports/libpq/windows/msbuild.patch
+++ b/ports/libpq/windows/msbuild.patch
@@ -396,16 +396,3 @@ index b6d31c3..27d89fc 100644
  	}
  	if ($self->{options}->{uuid})
  	{
-diff --git a/src/tools/msvc/gendef.pl b/src/tools/msvc/gendef.pl
-index cf83d7d..2d9a4ec 100644
---- a/src/tools/msvc/gendef.pl
-+++ b/src/tools/msvc/gendef.pl
-@@ -122,7 +122,7 @@ sub writedef
- 
- 		# Strip the leading underscore for win32, but not x64
- 		$f =~ s/^_//
--		  unless ($arch eq "x86_64");
-+		  if ($arch eq "Win32");
- 
- 		# Emit just the name if it's a function symbol, or emit the name
- 		# decorated with the DATA option for variables.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4750,7 +4750,7 @@
     },
     "libpq": {
       "baseline": "16.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libpqxx": {
       "baseline": "7.8.1",

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aac67118e4bd1ee29001f206697fb8461e47a590",
+      "version": "16.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "97c817b2d307e12dfec28d56e87ae08faff70a1b",
       "version": "16.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36693

Delete the patch of gendef.pl in `vcpkg\ports\libpq\windows\msbuild.patch`. Because starting with PostgreSQL 16, the "Win32" patch is no longer valid, the command line arguments to gendef.pl were changed from Win32 to x86.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
```