### PR TITLE
[fplus] update to 0.2.23

### DIFF
--- a/ports/fplus/portfile.cmake
+++ b/ports/fplus/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/FunctionalPlus
     REF "v${VERSION}"
-    SHA512 399ff3012efd49e8617a0ae275e72bf13e87380e830f6ceb56f85fcda948d4ef252c5aa48f48f0a4a015874015d6e8ff442ac9395d523b4c946a01c17f2bd1b9
+    SHA512 025216c9b054b581d2be2c6bf3a9ebf906cce436875d3f7246fdd85f06fe0f29ece9b4dbe3f25228cd329cce36e95aa73fc406fb1bbdd0ee1a6bc30bf95ecf76
     HEAD_REF master
 )
 

--- a/ports/fplus/vcpkg.json
+++ b/ports/fplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fplus",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Functional Programming Library for C++. Write concise and readable C++ code",
   "homepage": "https://github.com/Dobiasd/FunctionalPlus",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2789,7 +2789,7 @@
       "port-version": 2
     },
     "fplus": {
-      "baseline": "0.2.22",
+      "baseline": "0.2.23",
       "port-version": 0
     },
     "freealut": {

--- a/versions/f-/fplus.json
+++ b/versions/f-/fplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "402c97c95b5a67356eb96cfbf9cdb748cb8f497e",
+      "version": "0.2.23",
+      "port-version": 0
+    },
+    {
       "git-tree": "754768124cbee8d04ff59b7401e071dec918a487",
       "version": "0.2.22",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

