### PR TITLE
[dlpack] New port

### DIFF
--- a/ports/dlpack/portfile.cmake
+++ b/ports/dlpack/portfile.cmake
@@ -16,9 +16,9 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/dlpack")
 
-# remove debug for header-only library
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/dlpack/portfile.cmake
+++ b/ports/dlpack/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dmlc/dlpack
+    REF "v${VERSION}"
+    SHA512 1669d5145904918499682ed80db7a444d012708c7b8c1d03410ef8fa8bcacd95e56450e95a842b0b4d900f973d04e24bd86e33f54b8afe80dd5dbbb02d04fc13
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      -DBUILD_MOCK=FALSE
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/dlpack")
+
+# remove debug for header-only library
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/dlpack/portfile.cmake
+++ b/ports/dlpack/portfile.cmake
@@ -1,3 +1,5 @@
+set(VCPKG_BUILD_TYPE release) # header-only port
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dmlc/dlpack
@@ -16,7 +18,6 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/dlpack")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/dlpack/usage
+++ b/ports/dlpack/usage
@@ -1,0 +1,4 @@
+dlpack provides CMake targets:
+
+find_package(dlpack CONFIG REQUIRED)
+target_link_libraries(main PRIVATE dlpack::dlpack)

--- a/ports/dlpack/usage
+++ b/ports/dlpack/usage
@@ -1,4 +1,4 @@
 dlpack provides CMake targets:
 
-find_package(dlpack CONFIG REQUIRED)
-target_link_libraries(main PRIVATE dlpack::dlpack)
+    find_package(dlpack CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE dlpack::dlpack)

--- a/ports/dlpack/vcpkg.json
+++ b/ports/dlpack/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "dlpack",
+  "version": "0.8",
+  "description": "DLPack is an open in-memory tensor structure for sharing tensors among frameworks",
+  "homepage": "https://github.com/dmlc/dlpack",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2272,6 +2272,10 @@
       "baseline": "19.24",
       "port-version": 3
     },
+    "dlpack": {
+      "baseline": "0.8",
+      "port-version": 0
+    },
     "dmlc": {
       "baseline": "2022-06-22",
       "port-version": 0

--- a/versions/d-/dlpack.json
+++ b/versions/d-/dlpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "df93e129963651a9188bf7d4f9c3c35d9aee3a4f",
+      "git-tree": "1e72d25c162aca9ea5c40d24ba1eea8f9899ad43",
       "version": "0.8",
       "port-version": 0
     }

--- a/versions/d-/dlpack.json
+++ b/versions/d-/dlpack.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8fb9efbd6c9f9618678a86cc8eb7b0f62cf8e24e",
+      "version": "0.8",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/dlpack.json
+++ b/versions/d-/dlpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1e72d25c162aca9ea5c40d24ba1eea8f9899ad43",
+      "git-tree": "935f86ccd4d13dfc3534e81cc898026736249c06",
       "version": "0.8",
       "port-version": 0
     }

--- a/versions/d-/dlpack.json
+++ b/versions/d-/dlpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8fb9efbd6c9f9618678a86cc8eb7b0f62cf8e24e",
+      "git-tree": "df93e129963651a9188bf7d4f9c3c35d9aee3a4f",
       "version": "0.8",
       "port-version": 0
     }


### PR DESCRIPTION
Adds dlpack: https://github.com/dmlc/dlpack

[![Packaging status](https://repology.org/badge/tiny-repos/dlpack.svg)](https://repology.org/project/dlpack/versions)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
