### PR TITLE
[opentelemetry-cpp] update port to v1.4.2

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-telemetry/opentelemetry-cpp
     REF "v${VERSION}"
-    SHA512 db8394d8e0a6fe0d8dd0dd32c64c7b697a6bae57ca4d0334604c41edfe49ee23b203ac40c93f9a736e42305d30ce614f2a5092dce988c1630186b82f4fa4db78
+    SHA512 97635bbaf6dd567c201451dfaf7815b2052fe50d9bccc97aade86cfa4a92651374d167296a5453031b2681dc302806a289bca011a9e79ddc381a17d6118971d7
     HEAD_REF main
     PATCHES
         # Missing find_dependency for Abseil
@@ -48,9 +48,9 @@ if(WITH_GENEVA)
     vcpkg_from_github(
         OUT_SOURCE_PATH CONTRIB_SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF 15483a6e77f246dadb85e67fe78cdb5c4003d2f1
+        REF 68885bee3b160ee7a032872c8fa6ecf68a7f4edc
         HEAD_REF main
-        SHA512 f5dfb8a6efd22bdf22e6b6a4c8b2ebc29021d33fd045c6362a71140bc46a4b57ca86905a6bd82bbc9f60a551aeeec19cd02431e58669d2dca31ce417f6a37cdb
+        SHA512 5e7de7820e47327448f5f2cbfd5f21c1c66342579c369587ba2401497c55b7e8ebb1aec1e5e0eb1291b64a31bdd725fb6554436b7b95c0dbe777c669ff058ab6
     )
 
     set(OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS "${CONTRIB_SOURCE_PATH}/exporters/geneva")

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
-  "version-semver": "1.14.0",
-  "port-version": 2,
+  "version-semver": "1.14.2",
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6449,8 +6449,8 @@
       "port-version": 1
     },
     "opentelemetry-cpp": {
-      "baseline": "1.14.0",
-      "port-version": 2
+      "baseline": "1.14.2",
+      "port-version": 0
     },
     "opentelemetry-fluentd": {
       "baseline": "2.0.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f00f6d33fda736b79735a241864efb13c9c030d",
+      "version-semver": "1.14.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0615b7500e8e0997acc13d53b8a0f8ebf370dd3b",
       "version-semver": "1.14.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
