### PR TITLE
[liblzf] New port

### DIFF
--- a/ports/liblzf/0001-add-extern-c.patch
+++ b/ports/liblzf/0001-add-extern-c.patch
@@ -1,0 +1,23 @@
+--- a/lzf.h
++++ b/lzf.h
+@@ -48,6 +48,10 @@
+ 
+ #define LZF_VERSION 0x0105 /* 1.5, API version */
+ 
++#ifdef __cplusplus
++extern "C" {
++#endif
++
+ /*
+  * Compress in_len bytes stored at the memory block starting at
+  * in_data and write the result to out_data, up to a maximum length
+@@ -96,5 +100,9 @@ unsigned int
+ lzf_decompress (const void *const in_data,  unsigned int in_len,
+                 void             *out_data, unsigned int out_len);
+ 
++#ifdef __cplusplus
++}
++#endif
++
+ #endif
+ 

--- a/ports/liblzf/0002-fix-macro-expansion-ub.patch
+++ b/ports/liblzf/0002-fix-macro-expansion-ub.patch
@@ -1,0 +1,15 @@
+--- a/lzfP.h
++++ b/lzfP.h
+@@ -79,7 +79,11 @@
+  * Unconditionally aligning does not cost very much, so do it if unsure
+  */
+ #ifndef STRICT_ALIGN
+-# define STRICT_ALIGN !(defined(__i386) || defined (__amd64))
++# if !(defined(__i386) || defined (__amd64))
++#   define STRICT_ALIGN 1
++# else
++#   define STRICT_ALIGN 0
++# endif
+ #endif
+ 
+ /*

--- a/ports/liblzf/CMakeLists.txt
+++ b/ports/liblzf/CMakeLists.txt
@@ -9,19 +9,8 @@ add_library(liblzf
     lzf_d.c
     liblzf.def
 )
-set_target_properties(liblzf PROPERTIES OUTPUT_NAME lzf)
-
-# The original autotools config specified -O3 -funroll-all-loops for GCC
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
-    CMAKE_C_COMPILER_ID STREQUAL "Clang")
-  target_compile_options(liblzf PRIVATE "$<$<CONFIG:Release>:-O3>")
-  target_compile_options(liblzf PRIVATE "$<$<CONFIG:RelWithDebInfo>:-O3>")
-elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options(liblzf PRIVATE "$<$<CONFIG:Release>:/O2>")
-  target_compile_options(liblzf PRIVATE "$<$<CONFIG:RelWithDebInfo>:/O2>")
-endif()
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-  target_compile_options(liblzf PRIVATE "-funroll-all-loops")
+if(NOT WIN32)
+  set_target_properties(liblzf PROPERTIES OUTPUT_NAME lzf)
 endif()
 
 ## Install ##

--- a/ports/liblzf/CMakeLists.txt
+++ b/ports/liblzf/CMakeLists.txt
@@ -30,7 +30,7 @@ set(LIBLZF_SHARE_DIR share/liblzf)
 install(EXPORT unofficial-liblzf-targets
     FILE unofficial-liblzf-targets.cmake
     NAMESPACE unofficial::liblzf::
-    DESTINATION ${LIBLZF_SHARE_DIR})
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/unofficial-liblzf-config-version.cmake"
@@ -39,12 +39,6 @@ write_basic_package_version_file(
 )
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/unofficial-liblzf-config-version.cmake"
-    DESTINATION ${LIBLZF_SHARE_DIR}
-)
-export(EXPORT unofficial-liblzf-targets
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/unofficial-liblzf-targets.cmake"
-    NAMESPACE unofficial::liblzf::)
-install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake/unofficial-liblzf-targets.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/unofficial-liblzf-targets.cmake"
     DESTINATION ${LIBLZF_SHARE_DIR}
 )

--- a/ports/liblzf/CMakeLists.txt
+++ b/ports/liblzf/CMakeLists.txt
@@ -7,6 +7,7 @@ project(liblzf LANGUAGES C VERSION 3.6)
 add_library(liblzf
     lzf_c.c
     lzf_d.c
+    liblzf.def
 )
 set_target_properties(liblzf PROPERTIES OUTPUT_NAME lzf)
 
@@ -22,8 +23,6 @@ endif()
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
   target_compile_options(liblzf PRIVATE "-funroll-all-loops")
 endif()
-
-set_target_properties(liblzf PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 ## Install ##
 

--- a/ports/liblzf/CMakeLists.txt
+++ b/ports/liblzf/CMakeLists.txt
@@ -9,9 +9,7 @@ add_library(liblzf
     lzf_d.c
     liblzf.def
 )
-if(NOT WIN32)
-  set_target_properties(liblzf PROPERTIES OUTPUT_NAME lzf)
-endif()
+set_target_properties(liblzf PROPERTIES OUTPUT_NAME lzf)
 
 ## Install ##
 

--- a/ports/liblzf/CMakeLists.txt
+++ b/ports/liblzf/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Based on http://cvs.schmorp.de/liblzf/Makefile.in?view=markup
+cmake_minimum_required(VERSION 3.15)
+project(liblzf LANGUAGES C VERSION 3.6)
+
+## Build ##
+
+add_library(liblzf
+    lzf_c.c
+    lzf_d.c
+)
+set_target_properties(liblzf PROPERTIES OUTPUT_NAME lzf)
+
+# The original autotools config specified -O3 -funroll-all-loops for GCC
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
+    CMAKE_C_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(liblzf PRIVATE "$<$<CONFIG:Release>:-O3>")
+  target_compile_options(liblzf PRIVATE "$<$<CONFIG:RelWithDebInfo>:-O3>")
+elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+  target_compile_options(liblzf PRIVATE "$<$<CONFIG:Release>:/O2>")
+  target_compile_options(liblzf PRIVATE "$<$<CONFIG:RelWithDebInfo>:/O2>")
+endif()
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(liblzf PRIVATE "-funroll-all-loops")
+endif()
+
+set_target_properties(liblzf PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+## Install ##
+
+include(GNUInstallDirs)
+install(TARGETS liblzf
+    EXPORT unofficial-liblzf-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(FILES lzf.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+## Write config ##
+
+set(LIBLZF_SHARE_DIR share/liblzf)
+install(EXPORT unofficial-liblzf-targets
+    FILE unofficial-liblzf-targets.cmake
+    NAMESPACE unofficial::liblzf::
+    DESTINATION ${LIBLZF_SHARE_DIR})
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/unofficial-liblzf-config-version.cmake"
+    VERSION ${VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/unofficial-liblzf-config-version.cmake"
+    DESTINATION ${LIBLZF_SHARE_DIR}
+)
+export(EXPORT unofficial-liblzf-targets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/unofficial-liblzf-targets.cmake"
+    NAMESPACE unofficial::liblzf::)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/unofficial-liblzf-targets.cmake"
+    DESTINATION ${LIBLZF_SHARE_DIR}
+)

--- a/ports/liblzf/CMakeLists.txt
+++ b/ports/liblzf/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(liblzf
     liblzf.def
 )
 set_target_properties(liblzf PROPERTIES OUTPUT_NAME lzf)
+target_include_directories(liblzf INTERFACE $<INSTALL_INTERFACE:include>)
 
 ## Install ##
 
@@ -24,11 +25,12 @@ install(FILES lzf.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 ## Write config ##
 
-set(LIBLZF_SHARE_DIR share/liblzf)
+set(LIBLZF_SHARE_DIR share/unofficial-liblzf)
 install(EXPORT unofficial-liblzf-targets
-    FILE unofficial-liblzf-targets.cmake
+    FILE unofficial-liblzf-config.cmake
     NAMESPACE unofficial::liblzf::
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    DESTINATION ${LIBLZF_SHARE_DIR}
+)
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/unofficial-liblzf-config-version.cmake"
@@ -37,6 +39,5 @@ write_basic_package_version_file(
 )
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/unofficial-liblzf-config-version.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/unofficial-liblzf-targets.cmake"
     DESTINATION ${LIBLZF_SHARE_DIR}
 )

--- a/ports/liblzf/liblzf.def
+++ b/ports/liblzf/liblzf.def
@@ -1,0 +1,3 @@
+EXPORTS
+    lzf_compress
+    lzf_decompress

--- a/ports/liblzf/portfile.cmake
+++ b/ports/liblzf/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://dist.schmorp.de/liblzf/liblzf-${VERSION}.tar.gz"
+    FILENAME "liblzf-${VERSION}.tar.gz"
+    SHA512 701f70245a11e7cf3412b14ed26bf7b1464512d5b0cf3f913e70ebfdfe20574b8ebbae5a78f4b56ac0034d54830380309cac3057ca00a8028edbde3d091141f5
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        0001-add-extern-c.patch
+        0002-fix-macro-expansion-ub.patch
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/liblzf/portfile.cmake
+++ b/ports/liblzf/portfile.cmake
@@ -20,11 +20,10 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-liblzf")
 
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/liblzf/portfile.cmake
+++ b/ports/liblzf/portfile.cmake
@@ -12,9 +12,10 @@ vcpkg_extract_source_archive(SOURCE_PATH
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/liblzf.def" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
 vcpkg_cmake_install()

--- a/ports/liblzf/usage
+++ b/ports/liblzf/usage
@@ -1,4 +1,0 @@
-liblzf provides CMake targets:
-
-    find_package(unofficial-liblzf REQUIRED)
-    target_link_libraries(main PRIVATE unofficial::liblzf::liblzf)

--- a/ports/liblzf/usage
+++ b/ports/liblzf/usage
@@ -1,6 +1,4 @@
 liblzf provides CMake targets:
 
     find_package(unofficial-liblzf REQUIRED)
-    target_link_libraries(main PRIVATE unofficial::libmagic::libmagic)
-
-The magic.mgc file can be accessed from the unofficial-libmagic_DICTIONARY variable.
+    target_link_libraries(main PRIVATE unofficial::liblzf::liblzf)

--- a/ports/liblzf/usage
+++ b/ports/liblzf/usage
@@ -1,0 +1,6 @@
+liblzf provides CMake targets:
+
+    find_package(unofficial-liblzf REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::libmagic::libmagic)
+
+The magic.mgc file can be accessed from the unofficial-libmagic_DICTIONARY variable.

--- a/ports/liblzf/vcpkg.json
+++ b/ports/liblzf/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "liblzf",
+  "version": "3.6",
+  "description": "LZF is an extremely fast compression algorithm. It is ideal for applications where you want to save some space but not at the cost of speed.",
+  "homepage": "http://software.schmorp.de/pkg/liblzf.html",
+  "license": "BSD-2-Clause OR GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4552,6 +4552,10 @@
       "baseline": "3.3.2",
       "port-version": 0
     },
+    "liblzf": {
+      "baseline": "3.6",
+      "port-version": 0
+    },
     "liblzma": {
       "baseline": "5.4.4",
       "port-version": 0

--- a/versions/l-/liblzf.json
+++ b/versions/l-/liblzf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "370e7e55d776ea4105b19f8b2894a86852eae6d2",
+      "version": "3.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/liblzf.json
+++ b/versions/l-/liblzf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e1d26e4541a7e7ac5611b96e0c0a6999456d08fc",
+      "git-tree": "6cad789091d0c8dcf46ac93dc301112d5c10177e",
       "version": "3.6",
       "port-version": 0
     }

--- a/versions/l-/liblzf.json
+++ b/versions/l-/liblzf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "370e7e55d776ea4105b19f8b2894a86852eae6d2",
+      "git-tree": "e1d26e4541a7e7ac5611b96e0c0a6999456d08fc",
       "version": "3.6",
       "port-version": 0
     }

--- a/versions/l-/liblzf.json
+++ b/versions/l-/liblzf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6cad789091d0c8dcf46ac93dc301112d5c10177e",
+      "git-tree": "ae07234a575d7c2f86990091df5aa34b9405143a",
       "version": "3.6",
       "port-version": 0
     }


### PR DESCRIPTION
Adds liblzf: http://software.schmorp.de/pkg/liblzf.html

[![Packaging status](https://repology.org/badge/tiny-repos/liblzf.svg)](https://repology.org/project/liblzf/versions)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

