### PR TITLE
[libtracepoint] update to v1.3.2

### DIFF
--- a/ports/libeventheader-tracepoint/portfile.cmake
+++ b/ports/libeventheader-tracepoint/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 6b22ecded7029dfb9d9fba4fb76a8c25a28fbb3a6295b8ff6f66cea83d5b7645a85244126f52896065eccb9d08cbafa89dd1a23971c38842c4f752a274e5a72d
+    SHA512 d2126bb8e89c952630e22d66f0c9f2be7e46debd8f8dbc27f3a886af77cf4c1d9c3efcf3b7cae886feacfb9fe142355b26a3fb468c9b3582d65eb16f4dc6c288
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libeventheader-tracepoint/vcpkg.json
+++ b/ports/libeventheader-tracepoint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libeventheader-tracepoint",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "C/C++ interface for generating EventHeader-encoded Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "libtracepoint",
-      "version>=": "1.3.0"
+      "version>=": "1.3.2"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libtracepoint-control/portfile.cmake
+++ b/ports/libtracepoint-control/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 6b22ecded7029dfb9d9fba4fb76a8c25a28fbb3a6295b8ff6f66cea83d5b7645a85244126f52896065eccb9d08cbafa89dd1a23971c38842c4f752a274e5a72d
+    SHA512 d2126bb8e89c952630e22d66f0c9f2be7e46debd8f8dbc27f3a886af77cf4c1d9c3efcf3b7cae886feacfb9fe142355b26a3fb468c9b3582d65eb16f4dc6c288
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint-control/vcpkg.json
+++ b/ports/libtracepoint-control/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtracepoint-control",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "C++ classes for collecting Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",

--- a/ports/libtracepoint/portfile.cmake
+++ b/ports/libtracepoint/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 6b22ecded7029dfb9d9fba4fb76a8c25a28fbb3a6295b8ff6f66cea83d5b7645a85244126f52896065eccb9d08cbafa89dd1a23971c38842c4f752a274e5a72d
+    SHA512 d2126bb8e89c952630e22d66f0c9f2be7e46debd8f8dbc27f3a886af77cf4c1d9c3efcf3b7cae886feacfb9fe142355b26a3fb468c9b3582d65eb16f4dc6c288
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint/vcpkg.json
+++ b/ports/libtracepoint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtracepoint",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "C/C++ interface for generating Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4313,7 +4313,7 @@
       "port-version": 0
     },
     "libeventheader-tracepoint": {
-      "baseline": "1.3.0",
+      "baseline": "1.3.2",
       "port-version": 0
     },
     "libevhtp": {
@@ -4985,11 +4985,11 @@
       "port-version": 0
     },
     "libtracepoint": {
-      "baseline": "1.3.0",
+      "baseline": "1.3.2",
       "port-version": 0
     },
     "libtracepoint-control": {
-      "baseline": "1.3.0",
+      "baseline": "1.3.2",
       "port-version": 0
     },
     "libtracepoint-decode": {

--- a/versions/l-/libeventheader-tracepoint.json
+++ b/versions/l-/libeventheader-tracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "385d9d3fa27d1ff3d6f97b696d4463245ce630dc",
+      "version": "1.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "32f98983357ea758d5d4e9a7fd6ccd119fa5d598",
       "version": "1.3.0",
       "port-version": 0

--- a/versions/l-/libtracepoint-control.json
+++ b/versions/l-/libtracepoint-control.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b05ff61de046e0087a9afc28e4c1dad8cdab354",
+      "version": "1.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "26f974a4e3a3dbbdea53a0111f0e854875df4f62",
       "version": "1.3.0",
       "port-version": 0

--- a/versions/l-/libtracepoint.json
+++ b/versions/l-/libtracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0d01d006dcaa8c61e29447694069bf652141d11",
+      "version": "1.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "701e69ab507fc9cd97aaf936d5b82dfebe17c046",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
- [ X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ X] SHA512s are updated for each updated download.
- [ X] The "supports" clause reflects platforms that may be fixed by this new version.
- [ X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ X] Any patches that are no longer applied are deleted from the port's directory.
- [ X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ X] Only one version is added to each modified port's versions file.
