### PR TITLE
[libusb] Update version to 1.0.27

### DIFF
--- a/ports/libusb/portfile.cmake
+++ b/ports/libusb/portfile.cmake
@@ -5,7 +5,7 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/libusb
-    REF "v${VERSION}" # v1.0.26.11791 2023-03-12
+    REF "v${VERSION}"
     SHA512 36afceae9a03c1543adb9c92fb9a9320b312282bfc8ac8db7b43983c2797c63f13ce94b8ae7aab2afa94ce68d53b6aa7a69efd8ab6b3711c072b89940d4ee734
     HEAD_REF master
 )

--- a/ports/libusb/portfile.cmake
+++ b/ports/libusb/portfile.cmake
@@ -2,12 +2,11 @@ if(VCPKG_TARGET_IS_LINUX)
     message("${PORT} currently requires the following tools and libraries from the system package manager:\n    autoreconf\n    libudev\n\nThese can be installed on Ubuntu systems via apt-get install autoconf libudev-dev")
 endif()
 
-set(VERSION 1.0.26)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/libusb
-    REF fcf0c710ef5911ae37fbbf1b39d48a89f6f14e8a # v1.0.26.11791 2023-03-12
-    SHA512 0aa6439f7988487adf2a3bff473fec80b5c722a47f117a60696d2aa25c87cc3f20fb6aaca7c66e49be25db6a35eb0bb5f71ed7b211d1b8ee064c5d7f1b985c73
+    REF "v${VERSION}" # v1.0.26.11791 2023-03-12
+    SHA512 36afceae9a03c1543adb9c92fb9a9320b312282bfc8ac8db7b43983c2797c63f13ce94b8ae7aab2afa94ce68d53b6aa7a69efd8ab6b3711c072b89940d4ee734
     HEAD_REF master
 )
 

--- a/ports/libusb/vcpkg.json
+++ b/ports/libusb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libusb",
-  "version": "1.0.26.11791",
-  "port-version": 7,
+  "version": "1.0.27",
   "description": "a cross-platform library to access USB devices",
   "homepage": "https://github.com/libusb/libusb",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5033,8 +5033,8 @@
       "port-version": 0
     },
     "libusb": {
-      "baseline": "1.0.26.11791",
-      "port-version": 7
+      "baseline": "1.0.27",
+      "port-version": 0
     },
     "libusb-win32": {
       "baseline": "1.2.6.0",

--- a/versions/l-/libusb.json
+++ b/versions/l-/libusb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "58c3b03e75cc8fefdc3f6b7ac7e5b7e220804afc",
+      "git-tree": "b46d634782590b2e45f3a1202144c4e4235a2a43",
       "version": "1.0.27",
       "port-version": 0
     },

--- a/versions/l-/libusb.json
+++ b/versions/l-/libusb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "58c3b03e75cc8fefdc3f6b7ac7e5b7e220804afc",
+      "version": "1.0.27",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae02e3ed7014fe0c328b2c3ec6ed60cff9c0b956",
       "version": "1.0.26.11791",
       "port-version": 7


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/36614
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
