### PR TITLE
[cpptrace] Add 0.4.1

### DIFF
--- a/ports/cpptrace/portfile.cmake
+++ b/ports/cpptrace/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jeremy-rifkin/cpptrace
     REF "v${VERSION}"
-    SHA512 0d3cfa3f5b12034a111791dad772d4362f2a0071f16beff000edccf022bdce167926c0cb95a40aaffb9820f01bcea6559ceacf183525a85b9018e93e7f6e58b2
+    SHA512 f36f2aa6f94570eac5e01faafdf1fed98f7e308558726ed2499bcf58cb2e9e838fa928b3d32eaca93173976340f72534d340d662491c51ee75ed633b026c14bc
     HEAD_REF main
 )
 

--- a/ports/cpptrace/vcpkg.json
+++ b/ports/cpptrace/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpptrace",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Simple, portable, and self-contained stacktrace library for C++11 and newer",
   "homepage": "https://github.com/jeremy-rifkin/cpptrace",
   "license": "MIT",

--- a/ports/libassert/cpptrace-0.4.1.patch
+++ b/ports/libassert/cpptrace-0.4.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/assert.cpp b/src/assert.cpp
+index 8d4bd24..bd4bc58 100644
+--- a/src/assert.cpp
++++ b/src/assert.cpp
+@@ -1655,7 +1655,7 @@ namespace libassert::detail {
+             const size_t max_frame_width = n_digits(end - start);
+             // do the actual trace
+             for(size_t i = start; i <= end; i++) {
+-                const auto& [address, line, col, source_path, signature, is_inline] = trace.frames[i];
++                const auto& [raw_address, obj_address, line, col, source_path, signature, is_inline] = trace.frames[i];
+                 const std::string line_number = line.has_value() ? std::to_string(line.value()) : "?";
+                 // look for repeats, i.e. recursion we can fold
+                 size_t recursion_folded = 0;

--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         runtime_destination.patch
         magic-enum.patch
         include-dir.patch
+        cpptrace-0.4.1.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)

--- a/ports/libassert/vcpkg.json
+++ b/ports/libassert/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libassert",
   "version": "1.2.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The most over-engineered and overpowered C++ assertion library.",
   "homepage": "https://github.com/jeremy-rifkin/libassert",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1925,7 +1925,7 @@
       "port-version": 4
     },
     "cpptrace": {
-      "baseline": "0.4.0",
+      "baseline": "0.4.1",
       "port-version": 0
     },
     "cppunit": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4138,7 +4138,7 @@
     },
     "libassert": {
       "baseline": "1.2.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libassuan": {
       "baseline": "2.5.6",

--- a/versions/c-/cpptrace.json
+++ b/versions/c-/cpptrace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "366e041c6686ceaee1053bacaacc3343ac716fab",
+      "version": "0.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "714d5c3633b16c2b9b0fa45f224cbe2427f45f02",
       "version": "0.4.0",
       "port-version": 0

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -6,7 +6,7 @@
       "port-version": 2
     },
     {
-      "git-tree": "2a61fee57552e78af5115508d74a0bfeded0de5d",
+      "git-tree": "dfa096c003c1f98dbcdac5a67d924643bc12f994",
       "version": "1.2.2",
       "port-version": 1
     },

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dfa096c003c1f98dbcdac5a67d924643bc12f994",
+      "git-tree": "2a61fee57552e78af5115508d74a0bfeded0de5d",
       "version": "1.2.2",
       "port-version": 1
     },

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9cdcc4bae068fc3645319ee08faba34d533dfec8",
+      "version": "1.2.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "2a61fee57552e78af5115508d74a0bfeded0de5d",
       "version": "1.2.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
