### PR TITLE
Updated bext-ut to v2.0.1

### DIFF
--- a/ports/bext-ut/portfile.cmake
+++ b/ports/bext-ut/portfile.cmake
@@ -1,26 +1,37 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO boost-ext/ut
-    REF bf8388f61103571dee3061a4ef23292a320d9dbf #committed on 2023-07-09
-    SHA512 e7f95c71fb094170e0f431af115845f66c53f05748829a547612ae480839339b7794d4a3d8c2ae44ad2536654228f00d9d6b058b3b55c4af3432936efc2f6c2d
-    HEAD_REF master
-)
+  OUT_SOURCE_PATH
+  SOURCE_PATH
+  REPO
+  boost-ext/ut
+  REF
+  "v${VERSION}"
+  SHA512
+  6894767ddae9d3ddd7aac2f77565f653e5051d213d39129a149405c6441a5f20a2878a5f548ad8d4ca37f70e44c6360c447f12df9c870149f9ed57a281214c24
+  HEAD_REF
+  master)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DBOOST_UT_ALLOW_CPM_USE=OFF
-        -DBOOST_UT_BUILD_BENCHMARKS=OFF
-        -DBOOST_UT_BUILD_EXAMPLES=OFF
-        -DBOOST_UT_BUILD_TESTS=OFF
-        -DINCLUDE_INSTALL_DIR=include
-)
+  SOURCE_PATH
+  "${SOURCE_PATH}"
+  OPTIONS
+  -DBOOST_UT_ALLOW_CPM_USE=OFF
+  -DBOOST_UT_BUILD_BENCHMARKS=OFF
+  -DBOOST_UT_BUILD_EXAMPLES=OFF
+  -DBOOST_UT_BUILD_TESTS=OFF
+  -DBOOST_UT_DISABLE_MODULE=ON
+  -DINCLUDE_INSTALL_DIR=include)
+
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+
 vcpkg_cmake_config_fixup(PACKAGE_NAME ut CONFIG_PATH lib/cmake/ut-${VERSION})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug"
-                    "${CURRENT_PACKAGES_DIR}/lib"
-)
+     "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage"
+               "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/bext-ut/usage
+++ b/ports/bext-ut/usage
@@ -1,0 +1,4 @@
+bext-ut provides CMake targets:
+
+find_package(ut CONFIG REQUIRED)
+target_link_libraries(main PRIVATE Boost::ut)

--- a/ports/bext-ut/vcpkg.json
+++ b/ports/bext-ut/vcpkg.json
@@ -1,17 +1,17 @@
 {
-    "name": "bext-ut",
-    "version": "2.0.1",
-    "homepage": "https://github.com/boost-ext/ut",
-    "description": "C++ single header/single module, macro-free μ(micro)/Unit Testing Framework.",
-    "license": "BSL-1.0",
-    "dependencies": [
-        {
-            "name": "vcpkg-cmake",
-            "host": true
-        },
-        {
-            "name": "vcpkg-cmake-config",
-            "host": true
-        }
-    ]
+  "name": "bext-ut",
+  "version": "2.0.1",
+  "description": "C++ single header/single module, macro-free μ(micro)/Unit Testing Framework.",
+  "homepage": "https://github.com/boost-ext/ut",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/bext-ut/vcpkg.json
+++ b/ports/bext-ut/vcpkg.json
@@ -1,18 +1,17 @@
 {
-  "name": "bext-ut",
-  "version": "1.1.9",
-  "port-version": 2,
-  "description": "UT: C++20 μ(micro)/Unit Testing Framework",
-  "homepage": "https://boost-ext.github.io/ut/",
-  "license": "BSL-1.0",
-  "dependencies": [
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    }
-  ]
+    "name": "bext-ut",
+    "version": "2.0.1",
+    "homepage": "https://github.com/boost-ext/ut",
+    "description": "C++ single header/single module, macro-free μ(micro)/Unit Testing Framework.",
+    "license": "BSL-1.0",
+    "dependencies": [
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        },
+        {
+            "name": "vcpkg-cmake-config",
+            "host": true
+        }
+    ]
 }

--- a/versions/b-/bext-ut.json
+++ b/versions/b-/bext-ut.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6921fbfe90dd06757365041189e26786a5fa056b",
+      "version": "2.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a778eac38758ba4adaedb0098ee069c90ead7faa",
       "version": "1.1.9",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -597,8 +597,8 @@
       "port-version": 0
     },
     "bext-ut": {
-      "baseline": "1.1.9",
-      "port-version": 2
+      "baseline": "2.0.1",
+      "port-version": 0
     },
     "bext-wintls": {
       "baseline": "0.9.7",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.