### PR TITLE
[qt5-webengine] Work around mixed protobuf issue

### DIFF
--- a/ports/qt5-webengine/portfile.cmake
+++ b/ports/qt5-webengine/portfile.cmake
@@ -52,6 +52,7 @@ set(PATCHES common.pri.patch
             workaround-msvc2022-missing-include-in-chromium-ui-accessability.patch
             0001-Fix-building-with-ICU-68.patch
             0001-Support-ICU-74-in-LazyTextBreakIterator.patch
+            workaround-protobuf-issue.patch
             )
 
 set(OPTIONS)

--- a/ports/qt5-webengine/vcpkg.json
+++ b/ports/qt5-webengine/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-webengine",
   "version": "5.15.12",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt5 webengine Module;",
   "license": null,
   "supports": "!static",

--- a/ports/qt5-webengine/workaround-protobuf-issue.patch
+++ b/ports/qt5-webengine/workaround-protobuf-issue.patch
@@ -1,0 +1,17 @@
+diff --git a/src/core/core_chromium.pri b/src/core/core_chromium.pri
+index a846f2fbc..102ec9ace 100644
+--- a/src/core/core_chromium.pri
++++ b/src/core/core_chromium.pri
+@@ -32,6 +32,12 @@ isUniversal() {
+ # whenever we are cross compiling.
+ qtConfig(webengine-embedded-build): DEFINES += QTWEBENGINE_EMBEDDED_SWITCHES
+ 
++# Prepend Chromium's protobuf include directory to the include paths
++# to ensure we see same protobuf version as chromium.
++# See https://github.com/microsoft/vcpkg/issues/12150
++CHROMIUM_SRC_DIR = $$QTWEBENGINE_ROOT/$$getChromiumSrcDir()
++INCLUDEPATH = $$CHROMIUM_SRC_DIR/third_party/protobuf/src $$INCLUDEPATH
++
+ INCLUDEPATH += $$PWD $$PWD/api
+ 
+ clang_cl {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7178,7 +7178,7 @@
     },
     "qt5-webengine": {
       "baseline": "5.15.12",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-webglplugin": {
       "baseline": "5.15.12",

--- a/versions/q-/qt5-webengine.json
+++ b/versions/q-/qt5-webengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1dbb523d79f59b6fc3f6136650ab1a9973efcfb6",
+      "version": "5.15.12",
+      "port-version": 2
+    },
+    {
       "git-tree": "18cd1806979e5cdbcd9ea3fabf6722ad57f16d66",
       "version": "5.15.12",
       "port-version": 1


### PR DESCRIPTION
On MS Windows qt5-webengine fails to build in a context where protobuf from vcpkg is also used because it includes the vcpkg supplied version of protobuf headers when building the Qt part of the code in qt5-webengine, against the internal copy of Chromium which has used its older copy of protobuf to generate the headers. The build failure seen is this:

    FAILED: obj/QtWebEngineCore/browser_message_filter_qt.obj
    ...
    ...
    C:\vcpkgroot\qt5-webengine\x64-windows-dbg\src\core\debug\gen\net/third_party/quiche/src/quic/core/proto/cached_network_parameters.pb.h(17): fatal error C1189: #error:  This file was generated by an older version of protoc which is

To work around this issue we ensure that the path to the chromium provided version of protobuf is included before the path to the vcpkg provided includes residing in:

    C:/vcpkgroot/qt5-webengine/x64-windows-dbg/include

Fixes #12150
Fixes #27932
Fixes #34452

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
