### PR TITLE
[g3log] update to 2.4

### DIFF
--- a/ports/g3log/portfile.cmake
+++ b/ports/g3log/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KjellKod/g3log
     REF "${VERSION}"
-    SHA512 cf88bd604a82dd4cd2d2677bbda6f495f4357157d693125cd0df45f84b1976fc6b9dba9eddb5e9ae105e4fc15665ae37c86e9c02aba93d4bb7ba668c88bfddb9
+    SHA512 f48c5bb30d734fc218a5bfb19a406101c89deaee4a2f76b21c7105215a29f558efc2759ee1c1664f62cb37e2d8ae0666f99fdce9b863221e4a9efc9814cdf30c
     HEAD_REF master
 )
 

--- a/ports/g3log/vcpkg.json
+++ b/ports/g3log/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "g3log",
-  "version": "2.3",
-  "port-version": 1,
+  "version": "2.4",
   "description": "Asynchronous logger with Dynamic Sinks",
   "homepage": "https://github.com/KjellKod/g3log",
   "license": "Unlicense",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2873,8 +2873,8 @@
       "port-version": 4
     },
     "g3log": {
-      "baseline": "2.3",
-      "port-version": 1
+      "baseline": "2.4",
+      "port-version": 0
     },
     "gainput": {
       "baseline": "1.0.0",

--- a/versions/g-/g3log.json
+++ b/versions/g-/g3log.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5cee1161ef602cb402b3c902a4d084b04d6388ae",
+      "version": "2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "09cefbb1c15c19b4d15983286f70f39a819703d3",
       "version": "2.3",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

