### PR TITLE
[community triplet] Add `arm64-ios-simulator-release` triplet

### DIFF
--- a/triplets/community/arm64-ios-simulator-release.cmake
+++ b/triplets/community/arm64-ios-simulator-release.cmake
@@ -1,0 +1,7 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME iOS)
+set(VCPKG_OSX_SYSROOT iphonesimulator)
+
+set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
The release variant of #37054, targeting the iOS simulator in release mode (in analogy to #36373).