### PR TITLE
[pcre2] Disable JIT when targeting iOS

### DIFF
--- a/ports/pcre2/vcpkg.json
+++ b/ports/pcre2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pcre2",
   "version": "10.42",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Regular Expression pattern matching using the same syntax and semantics as Perl 5.",
   "homepage": "https://github.com/PCRE2Project/pcre2",
   "license": "BSD-3-Clause",
@@ -21,7 +21,7 @@
   "features": {
     "jit": {
       "description": "Enable support for Just-In-Time compiling regex matchers",
-      "supports": "!emscripten"
+      "supports": "!emscripten & !ios"
     },
     "platform-default-features": {
       "description": "Enable default features",
@@ -31,7 +31,7 @@
           "features": [
             "jit"
           ],
-          "platform": "!emscripten"
+          "platform": "!emscripten & !ios"
         }
       ]
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6634,7 +6634,7 @@
     },
     "pcre2": {
       "baseline": "10.42",
-      "port-version": 1
+      "port-version": 2
     },
     "pdal": {
       "baseline": "2.5.3",

--- a/versions/p-/pcre2.json
+++ b/versions/p-/pcre2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20b801575053f62e43a5ab22a8812e3f01302e88",
+      "version": "10.42",
+      "port-version": 2
+    },
+    {
       "git-tree": "678c2336c4102c5a8868570c60140fdc2a8d1dcf",
       "version": "10.42",
       "port-version": 1


### PR DESCRIPTION
PCRE2 JIT compilation is unsupported on iOS as per https://codereview.qt-project.org/c/qt/qtbase/+/204514

Since our Qt port uses the separately built `pcre2` port (instead of the bundled version):

https://github.com/microsoft/vcpkg/blob/3f966cf6a8654a0bc067738bcb95d489e197ad68/ports/qtbase/portfile.cmake#L315

...the linked Qt fix doesn't apply to us, so we'll have to disable it explicitly.

### Background

I ran into this today while debugging a crash of a Qt app built for the iOS simulator (using vcpkg-built libraries):

<details>

<summary>Crash Log</summary>

```
Exception Type:  EXC_BAD_ACCESS (SIGBUS)
Exception Subtype: KERN_PROTECTION_FAILURE at 0x000000010dbb8008
Exception Codes: 0x0000000000000002, 0x000000010dbb8008
VM Region Info: 0x10dbb8008 is in 0x10dbb8000-0x10dbc8000;  bytes after start: 8  bytes before end: 65527
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      ColorSync                   10dbb0000-10dbb8000    [   32K] r--/r-- SM=PRV  
--->  VM_ALLOCATE                 10dbb8000-10dbc8000    [   64K] rwx/rwx SM=PRV  
      GAP OF 0x38000 BYTES
      MALLOC_TINY                 10dc00000-10dd00000    [ 1024K] rw-/rwx SM=PRV  
Termination Reason: SIGNAL 10 Bus error: 10
Terminating Process: exc handler [98229]

Triggered by Thread:  0

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   Mixxx                         	       0x107b8ec24 sljit_malloc_exec + 236
1   Mixxx                         	       0x107b8ea80 pcre2_jit_compile_16 + 160
2   Mixxx                         	       0x104ec52d4 QRegularExpressionPrivate::compilePattern() + 252
3   Mixxx                         	       0x104ec6058 QRegularExpression::isValid() const + 24
4   Mixxx                         	       0x104e30194 QtPrivate::contains(QStringView, QString const*, QRegularExpression const&, QRegularExpressionMatch*) + 52
5   Mixxx                         	       0x10599a8ec QIOSScreen::QIOSScreen(UIScreen*) + 1060
6   Mixxx                         	       0x105998850 QIOSIntegration::initialize() + 272
7   Mixxx                         	       0x104d8165c QCoreApplicationPrivate::init() + 1640
8   Mixxx                         	       0x1076c80e0 QGuiApplicationPrivate::init() + 60
9   Mixxx                         	       0x105d9d20c QApplicationPrivate::init() + 24
10  Mixxx                         	       0x105d9d1e0 QApplication::QApplication(int&, char**, int) + 140
```

</details>

This fixes the problem.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download (not applicable).
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file (not applicable).
- [x] Any patches that are no longer applied are deleted from the port's directory (not applicable).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.