### PR TITLE
[libdatachannel] fix #37058

### DIFF
--- a/ports/libdatachannel/fix_srtp.patch
+++ b/ports/libdatachannel/fix_srtp.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ca0f12e5..8e0e665f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -326,7 +326,7 @@ else()
+ 	target_compile_definitions(datachannel PUBLIC RTC_ENABLE_MEDIA=1)
+ 	target_compile_definitions(datachannel-static PUBLIC RTC_ENABLE_MEDIA=1)
+ 	if(USE_SYSTEM_SRTP)
+-		find_package(libSRTP REQUIRED)
++		find_package(libSRTP CONFIG REQUIRED)
+ 		if(NOT TARGET libSRTP::srtp2)
+ 			add_library(libSRTP::srtp2 UNKNOWN IMPORTED)
+ 			set_target_properties(libSRTP::srtp2 PROPERTIES

--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -40,6 +40,10 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME LibDataChannel CONFIG_PATH lib/cmake/LibDataChannel)
 vcpkg_fixup_pkgconfig()
 
+if(srtp IN_LIST FEATURES)
+    set(FIND_DEP_SRTP "find_dependency(libSRTP CONFIG)")
+endif()
+
 file(READ "${CURRENT_PACKAGES_DIR}/share/LibDataChannel/LibDataChannelConfig.cmake" DATACHANNEL_CONFIG)
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/LibDataChannel/LibDataChannelConfig.cmake" "
 include(CMakeFindDependencyMacro)
@@ -48,7 +52,9 @@ find_dependency(OpenSSL)
 find_dependency(LibJuice)
 find_dependency(plog CONFIG)
 find_dependency(unofficial-usrsctp CONFIG)
+${FIND_DEP_SRTP}
 ${DATACHANNEL_CONFIG}")
+
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdatachannel",
   "version-semver": "0.20.1",
+  "port-version": 1,
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4242,7 +4242,7 @@
     },
     "libdatachannel": {
       "baseline": "0.20.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libdatrie": {
       "baseline": "0.2.13",

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74a0be59e4e852bb220e6e86cfa0dde836f0b449",
+      "version-semver": "0.20.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "b829fa3c4fbd6031bef6399df8747a9b51245cb6",
       "version-semver": "0.20.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
fix #37058
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
