### PR TITLE
[brpc] support arm architecture

### DIFF
--- a/ports/braft/fix-dependency.patch
+++ b/ports/braft/fix-dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 53ddaed..a851c00 100644
+index 53ddaed..3d75dd5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -47,8 +47,9 @@ if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
@@ -14,3 +14,18 @@ index 53ddaed..a851c00 100644
  if ((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIB))
      message(FATAL_ERROR "Fail to find gflags")
  endif()
+@@ -77,13 +78,7 @@ if (NOT PROTOBUF_PROTOC_EXECUTABLE)
+     set (PROTOBUF_PROTOC_EXECUTABLE "${PROTO_LIB_DIR}/../bin/protoc")
+ endif()
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+-    set(OPENSSL_ROOT_DIR
+-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
+-        )
+-endif()
+-
+-include(FindOpenSSL)
++find_package(OpenSSL REQUIRED)
+ 
+ include_directories(
+         ${GFLAGS_INCLUDE_PATH}

--- a/ports/braft/vcpkg.json
+++ b/ports/braft/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "braft",
   "version-date": "2021-26-04",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Consensus algorithm library",
   "homepage": "https://github.com/baidu/braft",
   "license": "Apache-2.0",

--- a/ports/brpc/vcpkg.json
+++ b/ports/brpc/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "brpc",
   "version": "1.6.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Industrial-grade RPC framework used throughout Baidu, with 1,000,000+ instances and thousands kinds of services, called \"baidu-rpc\" inside Baidu.",
   "homepage": "https://github.com/apache/incubator-brpc",
   "license": "Apache-2.0",
-  "supports": "!windows & !arm",
+  "supports": "!windows & !(arm & android)",
   "dependencies": [
     "gflags",
     "glog",

--- a/versions/b-/braft.json
+++ b/versions/b-/braft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b376168dcf6ec1336dd980ae419f8dcd626bc41b",
+      "version-date": "2021-26-04",
+      "port-version": 4
+    },
+    {
       "git-tree": "af9ff158d1a8f1284b9cc78d4ec816b0a37c7a3d",
       "version-date": "2021-26-04",
       "port-version": 3

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fd0bfb30a96852a7a92e0526c411ef9f95bed83",
+      "version": "1.6.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "5460a635b3cfa64a9857a378a798ded7f60abc74",
       "version": "1.6.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1334,7 +1334,7 @@
     },
     "braft": {
       "baseline": "2021-26-04",
-      "port-version": 3
+      "port-version": 4
     },
     "breakpad": {
       "baseline": "2023-01-27",
@@ -1350,7 +1350,7 @@
     },
     "brpc": {
       "baseline": "1.6.1",
-      "port-version": 1
+      "port-version": 2
     },
     "brunocodutra-metal": {
       "baseline": "2.1.4",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
