### PR TITLE
[braft] --triplet=arm64-linux bugs

### DIFF
--- a/ports/braft/export-target.patch
+++ b/ports/braft/export-target.patch
@@ -1,5 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a851c00..d18ecd0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -105,7 +105,7 @@ if(BRPC_WITH_GLOG)
+         ${OPENSSL_LIBRARIES}
+         ${OPENSSL_CRYPTO_LIBRARY}
+         dl
+-        z
++        ZLIB::ZLIB
+         )
+ else()
+     set(DYNAMIC_LIB
+@@ -117,7 +117,7 @@ else()
+         ${OPENSSL_LIBRARIES}
+         ${OPENSSL_CRYPTO_LIBRARY}
+         dl
+-        z
++        ZLIB::ZLIB
+ 	)
+ endif()
+ 
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 78adc56..ff435a2 100644
+index 78adc56..0ab4dce 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -19,8 +19,10 @@ add_library(braft-static STATIC $<TARGET_OBJECTS:OBJ_LIB>)
@@ -13,7 +35,7 @@ index 78adc56..ff435a2 100644
  target_link_libraries(braft-static PUBLIC ${DYNAMIC_LIB})
  endif()
  
-@@ -31,15 +33,30 @@ SET_TARGET_PROPERTIES(braft-shared PROPERTIES OUTPUT_NAME braft CLEAN_DIRECT_OUT
+@@ -31,15 +33,31 @@ SET_TARGET_PROPERTIES(braft-shared PROPERTIES OUTPUT_NAME braft CLEAN_DIRECT_OUT
  endif()
  
  if (NOT BUILD_SHARED_LIBS)
@@ -34,6 +56,7 @@ index 78adc56..ff435a2 100644
 +
 +file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-braft-config.cmake"
 +[[include(CMakeFindDependencyMacro)
++find_dependency(ZLIB)
 +find_dependency(gflags CONFIG)
 +file(GLOB TARGET_FILES "${CMAKE_CURRENT_LIST_DIR}/unofficial-braftTargets.cmake")
 +foreach (TARGET_FILE ${TARGET_FILES})

--- a/ports/braft/vcpkg.json
+++ b/ports/braft/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "braft",
   "version-date": "2021-26-04",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Consensus algorithm library",
   "homepage": "https://github.com/baidu/braft",
   "license": "Apache-2.0",

--- a/versions/b-/braft.json
+++ b/versions/b-/braft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af9ff158d1a8f1284b9cc78d4ec816b0a37c7a3d",
+      "version-date": "2021-26-04",
+      "port-version": 3
+    },
+    {
       "git-tree": "0c776a091a987943aadb4879fdb7434929d4dd3d",
       "version-date": "2021-26-04",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1334,7 +1334,7 @@
     },
     "braft": {
       "baseline": "2021-26-04",
-      "port-version": 2
+      "port-version": 3
     },
     "breakpad": {
       "baseline": "2023-01-27",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
