### PR TITLE
[liberasurecode] add new port

### DIFF
--- a/ports/liberasurecode/fix-build.patch
+++ b/ports/liberasurecode/fix-build.patch
@@ -1,0 +1,23 @@
+diff --git a/Makefile.am b/Makefile.am
+index 6135f2a..e00f58a 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,5 +1,5 @@
+ # Top-level liberasurecode automake configuration
+-SUBDIRS = src test doc
++SUBDIRS = src
+ 
+ EXTRA_DIST = autogen.sh get_flags_from_cpuid.c
+ 
+diff --git a/erasurecode.pc.in b/erasurecode.pc.in
+index 148c382..403ab30 100644
+--- a/erasurecode.pc.in
++++ b/erasurecode.pc.in
+@@ -11,5 +11,6 @@ Version: @LIBERASURECODE_VERSION@
+ Requires:
+ Conflicts:
+ Libs: -L${libdir} -lerasurecode -ldl
+-Libs.private: @ERASURECODE_STATIC_LIBS@ -lz
++Libs.private: -lXorcode -lnullcode -lerasurecode_rs_vand
++Requires: zlib
+ Cflags: -I${includedir}/ -I${includedir}/liberasurecode

--- a/ports/liberasurecode/fix-build.patch
+++ b/ports/liberasurecode/fix-build.patch
@@ -1,16 +1,18 @@
 diff --git a/Makefile.am b/Makefile.am
-index 6135f2a..e00f58a 100644
+index 6135f2a..e68974f 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -1,5 +1,5 @@
- # Top-level liberasurecode automake configuration
--SUBDIRS = src test doc
-+SUBDIRS = src
+@@ -8,7 +8,7 @@ INCLUDE = -I$(abs_top_builddir)/include \
+ 		  -I$(abs_top_builddir)/include/xor_codes
  
- EXTRA_DIST = autogen.sh get_flags_from_cpuid.c
+ AM_CPPFLAGS = $(CPPFLAGS) $(INCLUDE)
+-AM_CPPFLAGS += -Werror -Wall
++AM_CPPFLAGS += -Wall
+ 
+ AM_CFLAGS = -fPIC $(AM_CPPFLAGS) @GCOV_FLAGS@ -L/usr/local/lib
  
 diff --git a/erasurecode.pc.in b/erasurecode.pc.in
-index 148c382..403ab30 100644
+index 148c382..5a8578f 100644
 --- a/erasurecode.pc.in
 +++ b/erasurecode.pc.in
 @@ -11,5 +11,6 @@ Version: @LIBERASURECODE_VERSION@
@@ -19,5 +21,18 @@ index 148c382..403ab30 100644
  Libs: -L${libdir} -lerasurecode -ldl
 -Libs.private: @ERASURECODE_STATIC_LIBS@ -lz
 +Libs.private: -lXorcode -lnullcode -lerasurecode_rs_vand
-+Requires: zlib
++Requires.private: zlib
  Cflags: -I${includedir}/ -I${includedir}/liberasurecode
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 693809e..097954d 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -32,7 +32,7 @@ liberasurecode_la_SOURCES = \
+ 		backends/shss/shss.c \
+ 		backends/phazrio/libphazr.c
+ 
+-liberasurecode_la_CPPFLAGS = -Werror @GCOV_FLAGS@
++liberasurecode_la_CPPFLAGS = @GCOV_FLAGS@
+ liberasurecode_la_LIBADD = \
+ 		builtin/null_code/libnullcode.la \
+ 		builtin/xor_codes/libXorcode.la \

--- a/ports/liberasurecode/portfile.cmake
+++ b/ports/liberasurecode/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO openstack/liberasurecode
+    REF "${VERSION}"
+    SHA512 d5daa962324ef19fd195cfa842ec375d9dd5e62e3391b4a1cbf49a850b852b18cfc9be929ab18786d6b839139f6260d5cb4c88a0ba440c06b0e54e04ffb1bee1
+    HEAD_REF master
+    PATCHES
+        fix-build.patch
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/liberasurecode/portfile.cmake
+++ b/ports/liberasurecode/portfile.cmake
@@ -10,6 +10,9 @@ vcpkg_from_github(
 
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS
+        "--disable-werror"
 )
 
 vcpkg_install_make()

--- a/ports/liberasurecode/vcpkg.json
+++ b/ports/liberasurecode/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "liberasurecode",
+  "version": "1.6.3",
+  "description": "Erasure Code API library written in C with pluggable Erasure Code backends. Mirror of code maintained at opendev.org.",
+  "homepage": "https://github.com/openstack/liberasurecode",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    "zlib"
+  ]
+}

--- a/ports/liberasurecode/vcpkg.json
+++ b/ports/liberasurecode/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Erasure Code API library written in C with pluggable Erasure Code backends. Mirror of code maintained at opendev.org.",
   "homepage": "https://github.com/openstack/liberasurecode",
   "license": "BSD-2-Clause",
+  "supports": "!android & !windows",
   "dependencies": [
     "zlib"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4304,6 +4304,10 @@
       "baseline": "1.5.10",
       "port-version": 2
     },
+    "liberasurecode": {
+      "baseline": "1.6.3",
+      "port-version": 0
+    },
     "libev": {
       "baseline": "4.33",
       "port-version": 2

--- a/versions/l-/liberasurecode.json
+++ b/versions/l-/liberasurecode.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cc93bdf145faf85b76f06031c368ca6f7effa5b3",
+      "git-tree": "a300fd3432428d6cf55f4034e2572bc9e34550d4",
       "version": "1.6.3"
     }
   ]

--- a/versions/l-/liberasurecode.json
+++ b/versions/l-/liberasurecode.json
@@ -1,0 +1,8 @@
+{
+  "versions": [
+    {
+      "git-tree": "cc93bdf145faf85b76f06031c368ca6f7effa5b3",
+      "version": "1.6.3"
+    }
+  ]
+}

--- a/versions/l-/liberasurecode.json
+++ b/versions/l-/liberasurecode.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e0d9f43e4ead7f35a6708db47ba2b9774e8c8bd",
+      "git-tree": "f5e09c1c29fa6e2cd2fc023031001372f27b635b",
       "version": "1.6.3"
     }
   ]

--- a/versions/l-/liberasurecode.json
+++ b/versions/l-/liberasurecode.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a300fd3432428d6cf55f4034e2572bc9e34550d4",
+      "git-tree": "5e0d9f43e4ead7f35a6708db47ba2b9774e8c8bd",
       "version": "1.6.3"
     }
   ]


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
