### PR TITLE
[poco] update to 1.13.2

### DIFF
--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
-    REF "poco-1.13.2-release"
+    REF "poco-${VERSION}-release"
     SHA512 7d8454d2f29316fb15d5771f20d2348f426666620aad50c45d63539f0fe33535f0b6954bfa11b66953ea2a2762c1b43bf97ce79987e9d865c2eee4924b3b4f08
     HEAD_REF devel
     PATCHES

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
-    REF "poco-1.13.0-release"
-    SHA512 5e557b4c93dd5eacd7c43af9c89646c49e65217db9d9e0fc016b3f643aca993d70e58a85ec7e63743221eb2b29d36ce9f8a3bfbf4db489d8ff24e20127f450ea
+    REF "poco-1.13.2-release"
+    SHA512 7d8454d2f29316fb15d5771f20d2348f426666620aad50c45d63539f0fe33535f0b6954bfa11b66953ea2a2762c1b43bf97ce79987e9d865c2eee4924b3b4f08
     HEAD_REF devel
     PATCHES
         # Fix embedded copy of pcre in static linking mode

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -110,19 +110,6 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/include/Poco/SQL/SQLite")
     file(COPY "${SOURCE_PATH}/Data/SQLite/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
 endif()
 
-# Copy include files of sql-parser
-file(GLOB HEADERS "${SOURCE_PATH}/Data/src/sql-parser/src/*.h")
-file(COPY ${HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include/Poco/Data/sql-parser/src")
-
-file(GLOB HEADERS "${SOURCE_PATH}/Data/src/sql-parser/src/parser/*.h")
-file(COPY ${HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include/Poco/Data/sql-parser/src/parser")
-
-file(GLOB HEADERS "${SOURCE_PATH}/Data/src/sql-parser/src/sql/*.h")
-file(COPY ${HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include/Poco/Data/sql-parser/src/sql")
-
-file(GLOB HEADERS "${SOURCE_PATH}/Data/src/sql-parser/src/util/*.h")
-file(COPY ${HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include/Poco/Data/sql-parser/src/util")
-
 if(VCPKG_TARGET_IS_WINDOWS)
   vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 else()

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "poco",
-  "version": "1.13.0",
+  "version": "1.13.2",
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6793,7 +6793,7 @@
       "port-version": 0
     },
     "poco": {
-      "baseline": "1.13.0",
+      "baseline": "1.13.2",
       "port-version": 0
     },
     "podofo": {

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "472b4dad6e5b6c2202889e4818d5198d69cd484d",
+      "version": "1.13.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "659229d449f9bbbdf29ab52068c22fcfc5990bc7",
       "version": "1.13.0",
       "port-version": 0

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "472b4dad6e5b6c2202889e4818d5198d69cd484d",
+      "git-tree": "f11911b11eb0bc93f3c2d07420d88255158b7b81",
       "version": "1.13.2",
       "port-version": 0
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f11911b11eb0bc93f3c2d07420d88255158b7b81",
+      "git-tree": "16034dbe3ca8ceae1aed4b5f0a97b07c32942cd9",
       "version": "1.13.2",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #37012

Update `poco` to the latest version 1.13.2


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
