### PR TITLE
[openimageio] Fix linking of giflib

### DIFF
--- a/ports/openimageio/fix-dependencies.patch
+++ b/ports/openimageio/fix-dependencies.patch
@@ -1,11 +1,14 @@
 diff -u -r a/src/cmake/Config.cmake.in b/src/cmake/Config.cmake.in
 --- a/src/cmake/Config.cmake.in
 +++ b/src/cmake/Config.cmake.in
-@@ -6,6 +6,23 @@
+@@ -6,6 +6,26 @@
  
  include(CMakeFindDependencyMacro)
  
-+if (@USE_LIBHEIF@)
++if(@USE_GIF@)
++    find_dependency(GIF)
++endif()
++if(@USE_LIBHEIF@)
 +    find_dependency(libheif CONFIG)
 +endif()
 +find_dependency(PNG)

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openimageio",
   "version": "2.5.8.0",
+  "port-version": 1,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6398,7 +6398,7 @@
     },
     "openimageio": {
       "baseline": "2.5.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openjpeg": {
       "baseline": "2.5.0",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "16578d434e24f9e9bc2e4f47eb81314b503777c9",
+      "version": "2.5.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c5dd8fe433ee655c7368c063d01eac043f9d0553",
       "version": "2.5.8.0",
       "port-version": 0


### PR DESCRIPTION
OpenImageIO 2.5 uses now GIF targets (see
https://github.com/AcademySoftwareFoundation/OpenImageIO/commit/004cbb02382f415b57aee57fe12398cefb42e0ad).

Adapt our patch accordingly (missing in #36638).
