### PR TITLE
[gpgme] update to 1.23.2

### DIFF
--- a/ports/gpgme/portfile.cmake
+++ b/ports/gpgme/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/gpgme/gpgme-${VERSION}.tar.bz2"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gpgme/gpgme-${VERSION}.tar.bz2"
     FILENAME "gpgme-${VERSION}.tar.bz2"
-    SHA512 17053053fa885f01416433e43072ac716b5d5db0c3edf45b2d6e90e6384d127626e6ae3ce421abba8f449f5ca7e8963f3d62f3565d295847170bc998d1ec1a70
+    SHA512 6cfcd07e81a93de240582de5a46545420cee93d1f27fe20ea2c983780fdd3036b69fdba073cf549d68a20791e189bf4b3cdde14a43f912d2ab9ef3414c83ac75
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/gpgme/vcpkg.json
+++ b/ports/gpgme/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gpgme",
-  "version": "1.22.0",
+  "version": "1.23.2",
   "description": "A library designed to make access to GnuPG easier for applications",
   "homepage": "https://gnupg.org/software/gpgme/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3121,7 +3121,7 @@
       "port-version": 1
     },
     "gpgme": {
-      "baseline": "1.22.0",
+      "baseline": "1.23.2",
       "port-version": 0
     },
     "gpgmm": {

--- a/versions/g-/gpgme.json
+++ b/versions/g-/gpgme.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f922d800f46fe46ea028b127ea5e6f77647cca1",
+      "version": "1.23.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "71d1688aa684def46e7303068d31cbac5a90c010",
       "version": "1.22.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

