### PR TITLE
[libflac] Fix WASM build by disabling stack protector via feature

### DIFF
--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -17,6 +17,7 @@ endif()
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         asm WITH_ASM
+        stack-protector WITH_STACK_PROTECTOR
 )
 
 vcpkg_cmake_configure(

--- a/ports/libflac/vcpkg.json
+++ b/ports/libflac/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libflac",
   "version": "1.4.3",
+  "port-version": 1,
   "description": "Library for manipulating FLAC files",
   "homepage": "https://xiph.org/flac/",
   "license": "BSD-3-Clause",
@@ -19,6 +20,10 @@
     "asm": {
       "description": "Use any assembly optimization routines",
       "supports": "x86"
+    },
+    "stack-protector": {
+      "description": "Build with stack smashing protection",
+      "supports": "!emscripten"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4342,7 +4342,7 @@
     },
     "libflac": {
       "baseline": "1.4.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libfontenc": {
       "baseline": "1.1.4",

--- a/versions/l-/libflac.json
+++ b/versions/l-/libflac.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a05fdac2efaa1a739e13289a2bec7d6d32e84a3",
+      "version": "1.4.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "b03480bcc5f27cdc9a5f51fef012f880f1b0bf8d",
       "version": "1.4.3",
       "port-version": 0


### PR DESCRIPTION
This fixes the `wasm32-emscripten` build of `libflac`, which would previously fail with

<details>

<summary>Linking Errors</summary>

```
[59/61] : && /opt/homebrew/Cellar/emscripten/3.1.54/libexec/emcc -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes -Waggregate-return -Wcast-align -Wnested-externs -Wshadow -Wundef -Wmissing-declarations -Winline  -DNDEBUG -O3 -DNDEBUG  microbench/CMakeFiles/benchmark_residual.dir/benchmark_residual.c.o microbench/CMakeFiles/benchmark_residual.dir/util.c.o -o microbench/benchmark_residual.js  src/libFLAC/libFLAC.a  -lrt  -lm  <path to vcpkg>/installed/wasm32-emscripten-release/lib/libogg.a && :
FAILED: microbench/benchmark_residual.js 
: && /opt/homebrew/Cellar/emscripten/3.1.54/libexec/emcc -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes -Waggregate-return -Wcast-align -Wnested-externs -Wshadow -Wundef -Wmissing-declarations -Winline  -DNDEBUG -O3 -DNDEBUG  microbench/CMakeFiles/benchmark_residual.dir/benchmark_residual.c.o microbench/CMakeFiles/benchmark_residual.dir/util.c.o -o microbench/benchmark_residual.js  src/libFLAC/libFLAC.a  -lrt  -lm  <path to vcpkg>/installed/wasm32-emscripten-release/lib/libogg.a && :
wasm-ld: error: microbench/CMakeFiles/benchmark_residual.dir/benchmark_residual.c.o: undefined symbol: __stack_chk_guard
wasm-ld: error: microbench/CMakeFiles/benchmark_residual.dir/benchmark_residual.c.o: undefined symbol: __stack_chk_guard
wasm-ld: error: microbench/CMakeFiles/benchmark_residual.dir/benchmark_residual.c.o: undefined symbol: __stack_chk_fail
wasm-ld: error: microbench/CMakeFiles/benchmark_residual.dir/benchmark_residual.c.o: undefined symbol: __stack_chk_guard
wasm-ld: error: microbench/CMakeFiles/benchmark_residual.dir/benchmark_residual.c.o: undefined symbol: __stack_chk_guard
wasm-ld: error: microbench/CMakeFiles/benchmark_residual.dir/benchmark_residual.c.o: undefined symbol: __stack_chk_fail
```

</details>

The stack protector flag is [documented here](https://github.com/xiph/flac/blob/66152791d828e06321e6f92611062118562e7db0/CMakeLists.txt#L21) and is [unsupported in Emscripten](https://github.com/emscripten-core/emscripten/issues/17030).

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.