### PR TITLE
[libmad] Fix WASM build by disabling asm-based optimizations

### DIFF
--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -11,9 +11,26 @@ vcpkg_download_distfile(
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        aso ASO
+)
+
+set(EXTRA_OPTIONS)
+
+# Avoid architecture-specific assembly when targeting WASM.  The upstream
+# CMakeLists incorrectly recognizes the CPU as an Intel/64-bit CPU, therefore
+# we have to override these flags:
+# https://codeberg.org/tenacityteam/libmad/src/commit/84ba587793d61caadf6d1f6c0d94c3e165874a50/CMakeLists.txt
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    list(APPEND EXTRA_OPTIONS "-DFPM_64BIT=OFF -DFPM_INTEL=OFF -DFPM_DEFAULT=ON")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
+        ${EXTRA_OPTIONS}
         -DEXAMPLE=OFF
 )
 

--- a/ports/libmad/vcpkg.json
+++ b/ports/libmad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmad",
   "version": "0.16.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "high-quality MPEG audio decoder",
   "homepage": "http://codeberg.org/tenacityteam/libmad",
   "dependencies": [
@@ -13,5 +13,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "aso": {
+      "description": "Enable CPU architecture-specific optimizations (x86, ARM and MIPS only)",
+      "supports": "x86 | x64 | arm"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4562,7 +4562,7 @@
     },
     "libmad": {
       "baseline": "0.16.4",
-      "port-version": 1
+      "port-version": 2
     },
     "libmagic": {
       "baseline": "5.45",

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "204aa1729bb363c40a79cbcdb3beab84fa4bd03e",
+      "version": "0.16.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "7016c2c6c5e65a6420a176aa97696897bb134c40",
       "version": "0.16.4",
       "port-version": 1


### PR DESCRIPTION
Fixes #37087

This disables architecture-specific optimizations when targeting WASM. The root issue is that `libmad`'s CMake configuration seems to detect WASM as an Intel CPU (via `CMAKE_SYSTEM_PROCESSOR`) and then tries to use arch-specific assembly, which results in the build errors from the linked issue.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.