### PR TITLE
[libmodplug] Fix WASM build by pinning C++ standard to 11

### DIFF
--- a/ports/libmodplug/portfile.cmake
+++ b/ports/libmodplug/portfile.cmake
@@ -17,7 +17,16 @@ vcpkg_from_github(
         005-fix-install-paths.patch # https://github.com/Konstanty/libmodplug/pull/61
 )
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+set(EXTRA_OPTIONS)
+
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    list(APPEND EXTRA_OPTIONS "-DCMAKE_CXX_STANDARD=11")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${EXTRA_OPTIONS}
+)
 
 vcpkg_cmake_install()
 

--- a/ports/libmodplug/vcpkg.json
+++ b/ports/libmodplug/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmodplug",
   "version": "0.8.9.0",
-  "port-version": 10,
+  "port-version": 11,
   "description": "The ModPlug mod file playing library.",
   "homepage": "https://github.com/Konstanty/libmodplug",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4606,7 +4606,7 @@
     },
     "libmodplug": {
       "baseline": "0.8.9.0",
-      "port-version": 10
+      "port-version": 11
     },
     "libmorton": {
       "baseline": "0.2.12",

--- a/versions/l-/libmodplug.json
+++ b/versions/l-/libmodplug.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9af89d39aa5f14bf7314ebc51bc74df26ff2a3b",
+      "version": "0.8.9.0",
+      "port-version": 11
+    },
+    {
       "git-tree": "605d260810f9d1a489af7fb484d509581b39763d",
       "version": "0.8.9.0",
       "port-version": 10


### PR DESCRIPTION
Fixes #37089 

The port uses the register storage class specifier which was removed in C++17, pinning the standard to C++11 solves this.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.