### PR TITLE
[hexl] update to 1.2.5

### DIFF
--- a/ports/hexl/portfile.cmake
+++ b/ports/hexl/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/hexl
-    REF b4589b6149a46dd287bcc0c81c746f72bcf6b37d # 1.2.4
-    SHA512 79eaec45cf5b83459e41cd26c58118a1d0fa4bc1f07ebb00ebd646c90effb0d1dc26f3c33d28f3f1d3cd1cdff8fd23053790156b1c1a736525681bb6fa1fe027
+    REF "v${VERSION}"
+    SHA512 1a5e42fdeac877f3b4ef87ab75ffa8280697e941d7a8f0f6dc8c5066f2dd405470530dfabdf12d846362bd3e7e6cd30fd1f11d8dd99bee5086d09371ba1da196
     HEAD_REF development
 )
 
@@ -22,7 +22,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "HEXL" CONFIG_PATH "lib/cmake/hexl-1.2.4")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "HEXL" CONFIG_PATH "lib/cmake/hexl-${VERSION}")
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/hexl/vcpkg.json
+++ b/ports/hexl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hexl",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Intel® HEXL is an open-source library which provides efficient implementations of integer arithmetic on Galois fields.",
   "homepage": "https://github.com/intel/hexl",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3349,7 +3349,7 @@
       "port-version": 0
     },
     "hexl": {
-      "baseline": "1.2.4",
+      "baseline": "1.2.5",
       "port-version": 0
     },
     "hffix": {

--- a/versions/h-/hexl.json
+++ b/versions/h-/hexl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "507c302772e728f454519b1c7eb2740414b11386",
+      "version": "1.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d048751f3f15d5536e3e26d096e5efe3d8713ac",
       "version": "1.2.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

