### PR TITLE
[guile] update to 3.0.9

### DIFF
--- a/ports/guile/portfile.cmake
+++ b/ports/guile/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(GUILE_ARCHIVE 
-      URLS https://ftp.gnu.org/gnu/guile/guile-3.0.8.tar.gz
-      FILENAME guile-3.0.8.tar.gz
-      SHA512 7b2728e849a3ee482fe9a167dd76cc4835e911cc94ca0724dd51e8a813a240c6b5d2de84de16b46469ab24305b5b153a3c812fec942e007d3310bba4d1cf947d
+      URLS https://ftp.gnu.org/gnu/guile/guile-${VERSION}.tar.gz
+      FILENAME guile-${VERSION}.tar.gz
+      SHA512 6fd14f0860c7f5b7a9b53c43a60c6a7ca53072684ddc818cd10c720af2c5761ef110b29af466b89ded884fb66d66060894b14e615eaebee8844c397932d05fa2
   )
 
 vcpkg_extract_source_archive(GUILE_SOURCES ARCHIVE ${GUILE_ARCHIVE})

--- a/ports/guile/portfile.cmake
+++ b/ports/guile/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_download_distfile(GUILE_ARCHIVE
 
 vcpkg_extract_source_archive(GUILE_SOURCES ARCHIVE ${GUILE_ARCHIVE})
 
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gperf")
+
 vcpkg_configure_make(
     SOURCE_PATH "${GUILE_SOURCES}"
     ADD_BIN_TO_PATH

--- a/ports/guile/vcpkg.json
+++ b/ports/guile/vcpkg.json
@@ -16,6 +16,10 @@
       ]
     },
     "gmp",
+    {
+      "name": "gperf",
+      "host": true
+    },
     "libffi",
     "libunistring"
   ]

--- a/ports/guile/vcpkg.json
+++ b/ports/guile/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "guile",
-  "version": "3.0.8",
-  "port-version": 1,
+  "version": "3.0.9",
   "description": "GNU's programming and extension language",
   "homepage": "https://www.gnu.org/software/guile/",
   "documentation": "https://www.gnu.org/software/guile/manual/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3221,8 +3221,8 @@
       "port-version": 2
     },
     "guile": {
-      "baseline": "3.0.8",
-      "port-version": 1
+      "baseline": "3.0.9",
+      "port-version": 0
     },
     "guilite": {
       "baseline": "2022-05-05",

--- a/versions/g-/guile.json
+++ b/versions/g-/guile.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7add05a61610be0bed328ab1825ada7f9f124c1b",
+      "git-tree": "110d7a6bda8678341e931b4b8456e9926dc34e92",
       "version": "3.0.9",
       "port-version": 0
     },

--- a/versions/g-/guile.json
+++ b/versions/g-/guile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7add05a61610be0bed328ab1825ada7f9f124c1b",
+      "version": "3.0.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "ccaa1b9bc0ba4c7397a8f5a05cf99df4c47897d9",
       "version": "3.0.8",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

