### PR TITLE
[soundtouch] Fix WASM build by using -O3 instead of -Ofast

### DIFF
--- a/ports/soundtouch/portfile.cmake
+++ b/ports/soundtouch/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_github(
     REF ${VERSION}
     SHA512 93f757b2c1abe16be589e0d191e6c0416c5980843bd416cd5cb820b65a705d98081c0fc7ca0d9880af54b5343318262c77ba39a096bb240ceec084e93ceef964
     HEAD_REF master
+    PATCHES
+        use-o3-emscripten.patch # Upstream PR: https://codeberg.org/soundtouch/soundtouch/pulls/29
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/soundtouch/use-o3-emscripten.patch
+++ b/ports/soundtouch/use-o3-emscripten.patch
@@ -1,0 +1,34 @@
+From 405c4586d4556982fd5bbddf1c70bc4815465c51 Mon Sep 17 00:00:00 2001
+Date: Sat, 2 Mar 2024 23:02:06 +0100
+Subject: [PATCH] Use -O3 instead of -Ofast when targeting Emscripten (WASM)
+
+---
+ CMakeLists.txt | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 14f23e8..dabcb9c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,11 +3,16 @@ project(SoundTouch VERSION 2.3.2 LANGUAGES CXX)
+ 
+ include(GNUInstallDirs)
+ 
++set(COMPILE_OPTIONS)
++
+ if(MSVC)
+   set(COMPILE_DEFINITIONS /O2 /fp:fast)
+-  set(COMPILE_OPTIONS )
+ else()
+-  set(COMPILE_OPTIONS -Ofast)
++  if(EMSCRIPTEN)
++    list(APPEND COMPILE_OPTIONS -O3)
++  else()
++    list(APPEND COMPILE_OPTIONS -Ofast)
++  endif()
+ endif()
+ 
+ #####################
+-- 
+2.43.0
+

--- a/ports/soundtouch/vcpkg.json
+++ b/ports/soundtouch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "soundtouch",
   "version": "2.3.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "SoundTouch is an open-source audio processing library for changing the Tempo, Pitch and Playback Rates of audio streams or audio files.",
   "homepage": "https://www.surina.net/soundtouch",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8166,7 +8166,7 @@
     },
     "soundtouch": {
       "baseline": "2.3.2",
-      "port-version": 2
+      "port-version": 3
     },
     "soxr": {
       "baseline": "0.1.3",

--- a/versions/s-/soundtouch.json
+++ b/versions/s-/soundtouch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a30af1c2b397ee59f6c0048c5453ebbdf4626415",
+      "version": "2.3.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "ac2649a7dd79e3a99721c357c744f81b94643a3c",
       "version": "2.3.2",
       "port-version": 2


### PR DESCRIPTION
Fixes #37102 

The `-Ofast` option is unfortunately not supported by Emscripten yet (as per https://github.com/emscripten-core/emscripten/pull/11884), therefore we have to patch around this for now.

Once the upstream PR is merged and released, we can remove this: https://codeberg.org/soundtouch/soundtouch/pulls/29

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.