### PR TITLE
[taglib] Fix WASM build by patching out `wchar_t` check

### DIFF
--- a/ports/taglib/disable-wchar-t-check-emscripten.patch
+++ b/ports/taglib/disable-wchar-t-check-emscripten.patch
@@ -1,0 +1,30 @@
+From 477e4cee4389b4b692734b7dc1669d9cfae62f61 Mon Sep 17 00:00:00 2001
+Date: Sat, 2 Mar 2024 23:38:50 +0100
+Subject: [PATCH] Disable wchar_t check when targeting Emscripten
+
+---
+ ConfigureChecks.cmake | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/ConfigureChecks.cmake b/ConfigureChecks.cmake
+index 7d2ff95..2dc1891 100644
+--- a/ConfigureChecks.cmake
++++ b/ConfigureChecks.cmake
+@@ -19,9 +19,11 @@ if(NOT ${SIZEOF_LONGLONG} EQUAL 8)
+   message(FATAL_ERROR "TagLib requires that long long is 64-bit wide.")
+ endif()
+ 
+-check_type_size("wchar_t" SIZEOF_WCHAR_T)
+-if(${SIZEOF_WCHAR_T} LESS 2)
+-  message(FATAL_ERROR "TagLib requires that wchar_t is sufficient to store a UTF-16 char.")
++if(NOT EMSCRIPTEN)
++  check_type_size("wchar_t" SIZEOF_WCHAR_T)
++  if(${SIZEOF_WCHAR_T} LESS 2)
++    message(FATAL_ERROR "TagLib requires that wchar_t is sufficient to store a UTF-16 char.")
++  endif()
+ endif()
+ 
+ check_type_size("float" SIZEOF_FLOAT)
+-- 
+2.43.0
+

--- a/ports/taglib/portfile.cmake
+++ b/ports/taglib/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 099d02b2eab033f5702a8cb03e70752d7523c6f8c2f3eebdd0bcd939eafbdca3f2a6c82452983904b5822cfa45f2707ed866c3419508df9d43bf5c0b3a476f6c
     HEAD_REF master
+    PATCHES
+        disable-wchar-t-check-emscripten.patch
 )
 
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")

--- a/ports/taglib/vcpkg.json
+++ b/ports/taglib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "taglib",
   "version": "2.0",
+  "port-version": 1,
   "description": "TagLib Audio Meta-Data Library",
   "homepage": "https://taglib.org/",
   "license": "LGPL-2.1-only OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8426,7 +8426,7 @@
     },
     "taglib": {
       "baseline": "2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "talib": {
       "baseline": "0.4.0",

--- a/versions/t-/taglib.json
+++ b/versions/t-/taglib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d75dc6293826199b1b4717ca732780aafa381ec2",
+      "version": "2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7d2acd4bdd0e356aa93ff858c10b967c6355ea51",
       "version": "2.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #37104 

This fixes the WASM build by patching out the `wchar_t` size check when targeting WASM/Emscripten. From what I have read, `wchar_t` defaults to 32-bit when targeting Emscripten and uses 16-bit even when `-fshort-wchar` is set, both of which should be enough for a UTF-16 code unit, which is presumably what this check verifies.

Feel free to suggest better solutions, since this feels a bit hacky, even if it works.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.