### PR TITLE
[imath] update to 3.1.11

### DIFF
--- a/ports/imath/portfile.cmake
+++ b/ports/imath/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/Imath
-    REF v3.1.9
-    SHA512 ad96b2ac306fc13c01e8ea3256f885499c3f545be327feaba0f5e093b70b544bcca6f8b353fa7e35107aae515c19caced44331a95d0414f367ead4691ec73564
+    REF "v${VERSION}"
+    SHA512 0bc86bea3a2aca89d02b501b4fba3c13ca861e914cec558e820fe9e4c43ab14cac34e31ff278b8c35b5fe76f7bea32f2c8105c0d33eb92224eb23d42d7a402e9
     HEAD_REF master
 )
 

--- a/ports/imath/vcpkg.json
+++ b/ports/imath/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "imath",
-  "version": "3.1.9",
-  "port-version": 1,
+  "version": "3.1.11",
   "description": "Imath is a C++ and Python library of 2D and 3D vector, matrix, and math operations for computer graphics.",
   "homepage": "https://github.com/AcademySoftwareFoundation/Imath",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3549,8 +3549,8 @@
       "port-version": 0
     },
     "imath": {
-      "baseline": "3.1.9",
-      "port-version": 1
+      "baseline": "3.1.11",
+      "port-version": 0
     },
     "imgui": {
       "baseline": "1.90.2",

--- a/versions/i-/imath.json
+++ b/versions/i-/imath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "656b29a2ec31b311e86110926a1f33348a38d15d",
+      "version": "3.1.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "47c02f0c550c3639178d554a27475f376c2fdcbc",
       "version": "3.1.9",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

