### PR TITLE
[inih] update to 58

### DIFF
--- a/ports/inih/portfile.cmake
+++ b/ports/inih/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO benhoyt/inih
-    REF r57
-    SHA512 9f758df876df54ed7e228fd82044f184eefbe47e806cd1e6d62e1b0ea28e2c08e67fa743042d73b4baef0b882480e6afe2e72878b175822eb2bdbb6d89c0e411
+    REF "r${VERSION}"
+    SHA512 d69f488299c1896e87ddd3dd20cd9db5848da7afa4c6159b8a99ba9a5d33f35cadfdb9f65d6f2fe31decdbadb8b43bf610ff2699df475e1f9ff045e343ac26ae
     HEAD_REF master
 )
 

--- a/ports/inih/vcpkg.json
+++ b/ports/inih/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "inih",
-  "version": "57",
+  "version": "58",
   "description": "Simple .INI file parser",
   "homepage": "https://github.com/benhoyt/inih",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3593,7 +3593,7 @@
       "port-version": 0
     },
     "inih": {
-      "baseline": "57",
+      "baseline": "58",
       "port-version": 0
     },
     "iniparser": {

--- a/versions/i-/inih.json
+++ b/versions/i-/inih.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f86a866280aff2071eb313ff85cc1c5c7cabaeff",
+      "version": "58",
+      "port-version": 0
+    },
+    {
       "git-tree": "c5a05cc38f61274fdbef602c91505397b7cd43e8",
       "version": "57",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

