### PR TITLE
[lcm] update to 1.5.0

### DIFF
--- a/ports/lcm/disable-docs.patch
+++ b/ports/lcm/disable-docs.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6d3a4c2..90833e3 100644
+index 926ffac..6903617 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -39,7 +39,6 @@ if(LCM_ENABLE_EXAMPLES)
+@@ -45,7 +45,6 @@ if(LCM_ENABLE_PYTHON)
  endif()
  
  # Documentation (Main, C/C++, .NET)

--- a/ports/lcm/fix-build-error.patch
+++ b/ports/lcm/fix-build-error.patch
@@ -1,22 +1,23 @@
 diff --git a/lcm/windows/WinPorting.cpp b/lcm/windows/WinPorting.cpp
-index e22acd6..b9c7e69 100644
+index 46a685b..8ea523c 100644
 --- a/lcm/windows/WinPorting.cpp
 +++ b/lcm/windows/WinPorting.cpp
-@@ -1,8 +1,8 @@
- 
+@@ -2,9 +2,9 @@
  #define _WIN32_WINNT 0x0501
+ #include "WinPorting.h"
+ 
 -#include <Mswsock.h>
  #include <stdio.h>
  #include <winsock2.h>
 +#include <Mswsock.h>
  
- #include "WinPorting.h"
+ #include <cstdint>
  
 diff --git a/lcmgen/emit_go.c b/lcmgen/emit_go.c
-index c520044..b5be56a 100644
+index 6cd0890..2ce2a05 100644
 --- a/lcmgen/emit_go.c
 +++ b/lcmgen/emit_go.c
-@@ -6,8 +6,13 @@
+@@ -6,7 +6,11 @@
  #include <stdio.h>
  #include <stdlib.h>
  #include <string.h>
@@ -26,7 +27,5 @@ index c520044..b5be56a 100644
  #include <unistd.h>
 +#endif
  #ifdef WIN32
-+#define F_OK 0
+ #define F_OK 0                /* Test for existence.  */
  #define __STDC_FORMAT_MACROS  // Enable integer types
- #endif
- 

--- a/ports/lcm/glib.link.patch
+++ b/ports/lcm/glib.link.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/FindGLib2.cmake b/cmake/FindGLib2.cmake
-index 2f1a8be45..db823b953 100644
+index 1b4c5ae..400229e 100644
 --- a/cmake/FindGLib2.cmake
 +++ b/cmake/FindGLib2.cmake
-@@ -14,7 +14,7 @@ function(_glib2_find_include VAR HEADER)
+@@ -18,7 +18,7 @@ function(_glib2_find_include VAR HEADER)
  
    find_path(GLIB2_${VAR}_INCLUDE_DIR ${HEADER}
      PATHS ${_paths}
@@ -11,7 +11,7 @@ index 2f1a8be45..db823b953 100644
    )
    mark_as_advanced(GLIB2_${VAR}_INCLUDE_DIR)
  endfunction()
-@@ -108,6 +108,16 @@ foreach(_glib2_component ${GLib2_FIND_COMPONENTS})
+@@ -115,6 +115,16 @@ foreach(_glib2_component ${GLib2_FIND_COMPONENTS})
  
  endforeach()
  

--- a/ports/lcm/portfile.cmake
+++ b/ports/lcm/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lcm-proj/lcm
-    REF v1.4.0
-    SHA512 ca036aa2c31911e0bfaeab9665188c97726201267314693a1c333c4efe13ea598b39a55a19bc1d48e65462ac9d1716adfda5af86c645d59c3247192631247cc6
+    REF "v${VERSION}"
+    SHA512 a19800c1ac79b7725f26fd1e2e5abedcfcbe1b197a8a48860dd50a7b3e3af658286fe7dd3a1e3c69920eccf2a73185c90bf1cd6cf0f05a405abfa9d8f33eae4c
     HEAD_REF master
     PATCHES 
         only-install-one-flavor.patch

--- a/ports/lcm/vcpkg.json
+++ b/ports/lcm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "lcm",
-  "version": "1.4.0",
-  "port-version": 6,
+  "version": "1.5.0",
   "description": [
     "Lightweight Communications and Marshalling (LCM)",
     "LCM is a set of libraries and tools for message passing and data marshalling, targeted at real-time systems where high-bandwidth and low latency are critical. It provides a publish/subscribe message passing model and automatic marshalling/unmarshalling code generation with bindings for applications in a variety of programming languages."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4057,8 +4057,8 @@
       "port-version": 0
     },
     "lcm": {
-      "baseline": "1.4.0",
-      "port-version": 6
+      "baseline": "1.5.0",
+      "port-version": 0
     },
     "lcms": {
       "baseline": "2.14",

--- a/versions/l-/lcm.json
+++ b/versions/l-/lcm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4217e8c284f3b8d90983f1b3820ec8daf0faf15b",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b282016c7e5f1aacff821854e8fab52d64b4c970",
       "version": "1.4.0",
       "port-version": 6


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

