### PR TITLE
[rmlui] Add option for LuaJIT bindings

### DIFF
--- a/ports/rmlui/add-luajit-option.patch
+++ b/ports/rmlui/add-luajit-option.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9a18c4de..0d1f1da9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -156,11 +156,17 @@ if(NOT IOS)
+ endif(NOT IOS)
+ 
+ option(BUILD_LUA_BINDINGS "Build Lua bindings" OFF)
++option(BUILD_LUAJIT_BINDINGS "Build Lua(JIT) bindings" OFF)
+ 
+ if (BUILD_LUA_BINDINGS)
+ 	option(BUILD_LUA_BINDINGS_FOR_LUAJIT "Build Lua bindings using luajit" OFF)
+ endif()
+ 
++if (BUILD_LUAJIT_BINDINGS)
++	set(BUILD_LUA_BINDINGS ON CACHE BOOL "Build Lua bindings")
++	set(BUILD_LUA_BINDINGS_FOR_LUAJIT ON CACHE BOOL "Build Lua bindings using luajit")
++endif ()
++
+ if(APPLE)
+ 	option(BUILD_FRAMEWORK "Build Framework bundle for OSX" OFF)
+ endif()

--- a/ports/rmlui/portfile.cmake
+++ b/ports/rmlui/portfile.cmake
@@ -6,13 +6,13 @@ vcpkg_from_github(
 	HEAD_REF master
 	PATCHES
 		add-robin-hood.patch
+		add-luajit-option.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 	FEATURES 
 		lua             BUILD_LUA_BINDINGS
-		luajit          BUILD_LUA_BINDINGS
-		luajit          BUILD_LUA_BINDINGS_FOR_LUAJIT
+		luajit          BUILD_LUAJIT_BINDINGS
 	INVERTED_FEATURES
 		freetype        NO_FONT_INTERFACE_DEFAULT
 )

--- a/ports/rmlui/portfile.cmake
+++ b/ports/rmlui/portfile.cmake
@@ -11,6 +11,8 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 	FEATURES 
 		lua             BUILD_LUA_BINDINGS
+		luajit          BUILD_LUA_BINDINGS
+		luajit          BUILD_LUA_BINDINGS_FOR_LUAJIT
 	INVERTED_FEATURES
 		freetype        NO_FONT_INTERFACE_DEFAULT
 )

--- a/ports/rmlui/vcpkg.json
+++ b/ports/rmlui/vcpkg.json
@@ -35,6 +35,12 @@
       "dependencies": [
         "lua"
       ]
+    },
+    "luajit": {
+      "description": "Build Lua(JIT) bindings",
+      "dependencies": [
+        "luajit"
+      ]
     }
   }
 }

--- a/ports/rmlui/vcpkg.json
+++ b/ports/rmlui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rmlui",
-  "version": "5.1.0",
+  "version": "5.1-0",
   "maintainers": "Michael R. P. Ragazzon <mikke89@users.noreply.github.com>",
   "description": "RmlUi is the C++ user interface library based on the HTML and CSS standards, designed as a complete solution for any project's interface needs.",
   "homepage": "https://github.com/mikke89/RmlUi",

--- a/ports/rmlui/vcpkg.json
+++ b/ports/rmlui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rmlui",
-  "version": "5.1-0",
+  "version": "5.1",
+  "port-version": 1,
   "maintainers": "Michael R. P. Ragazzon <mikke89@users.noreply.github.com>",
   "description": "RmlUi is the C++ user interface library based on the HTML and CSS standards, designed as a complete solution for any project's interface needs.",
   "homepage": "https://github.com/mikke89/RmlUi",

--- a/ports/rmlui/vcpkg.json
+++ b/ports/rmlui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rmlui",
-  "version": "5.1",
+  "version": "5.1.0",
   "maintainers": "Michael R. P. Ragazzon <mikke89@users.noreply.github.com>",
   "description": "RmlUi is the C++ user interface library based on the HTML and CSS standards, designed as a complete solution for any project's interface needs.",
   "homepage": "https://github.com/mikke89/RmlUi",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7629,8 +7629,8 @@
       "port-version": 0
     },
     "rmlui": {
-      "baseline": "5.1-0",
-      "port-version": 0
+      "baseline": "5.1",
+      "port-version": 1
     },
     "rmqcpp": {
       "baseline": "1.0.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7629,7 +7629,7 @@
       "port-version": 0
     },
     "rmlui": {
-      "baseline": "5.1.0",
+      "baseline": "5.1-0",
       "port-version": 0
     },
     "rmqcpp": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7629,7 +7629,7 @@
       "port-version": 0
     },
     "rmlui": {
-      "baseline": "5.1",
+      "baseline": "5.1.0",
       "port-version": 0
     },
     "rmqcpp": {

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eba9634946979bfc92ea5630e5f053766d40daa9",
+      "git-tree": "504260bcb2390b251995af10b4082ead7a9aac9b",
       "version": "5.1",
       "port-version": 1
     },

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "551ed11d52a253a0a0165fa3397f0136ef95061d",
+      "version": "5.1-0",
+      "port-version": 0
+    },
+    {
       "git-tree": "55710b58dd314006584812eafab1d89fc35815be",
       "version": "5.1.0",
       "port-version": 0

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -3,17 +3,7 @@
     {
       "git-tree": "94de4eab8f339dd3c8887bbb728809685681245b",
       "version": "5.1",
-      "port-version": 2
-    },
-    {
-      "git-tree": "551ed11d52a253a0a0165fa3397f0136ef95061d",
-      "version": "5.1-0",
-      "port-version": 0
-    },
-    {
-      "git-tree": "55710b58dd314006584812eafab1d89fc35815be",
-      "version": "5.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "eef365a991fcf66a1848ed65bb9af75e767ffce6",

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "94de4eab8f339dd3c8887bbb728809685681245b",
+      "git-tree": "eba9634946979bfc92ea5630e5f053766d40daa9",
       "version": "5.1",
       "port-version": 1
     },

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55710b58dd314006584812eafab1d89fc35815be",
+      "version": "5.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "eef365a991fcf66a1848ed65bb9af75e767ffce6",
       "version": "5.1",
       "port-version": 0

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "94de4eab8f339dd3c8887bbb728809685681245b",
+      "version": "5.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "551ed11d52a253a0a0165fa3397f0136ef95061d",
       "version": "5.1-0",
       "port-version": 0


### PR DESCRIPTION
Add option for LuaJIT bindings

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
