### PR TITLE
[gul14] Update to version 2.11.0

### DIFF
--- a/ports/gul14/portfile.cmake
+++ b/ports/gul14/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gul-cpp/gul14
-    REF v2.10.0
-    SHA512 497e95a8bbd3a8060f3775de561afe755aac0054bd4279da6aea79b1bd35d111c41f92622a0a7e8ba99f6c5aa2dd3a2b2a10c2534482c36cf8c80d0b8ce3fe8a
+    REF v2.11.0
+    SHA512 d36bac6573f7eaee068df6b94481efb05270d55d2cf5b22bf57ccaaed650cefece61585fc518769da1308194cfde976854bf5ad89647c5a5808b7f8784c9c7f5
     HEAD_REF main
 )
 

--- a/ports/gul14/vcpkg.json
+++ b/ports/gul14/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gul14",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": [
     "General Utility Library for C++14.",
     "GUL14 contains often-used utility functions and types that form the foundation for other libraries and programs.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3229,7 +3229,7 @@
       "port-version": 0
     },
     "gul14": {
-      "baseline": "2.10.0",
+      "baseline": "2.11.0",
       "port-version": 0
     },
     "gumbo": {

--- a/versions/g-/gul14.json
+++ b/versions/g-/gul14.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b664c010bec11a610ed3b751494527c7f9e9636",
+      "version": "2.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4b96d6a06013e4d0d58af377c43728ca2e78e592",
       "version": "2.10.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version. (DOES NOT APPLY)
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. (DOES NOT APPLY)
- [X] Any patches that are no longer applied are deleted from the port's directory. (DOES NOT APPLY)
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.