### PR TITLE
Change Android docker hosts to CBL-Mariner

### DIFF
--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -43,7 +43,6 @@ jobs:
   steps:
     # Note: /mnt is the Azure machines' temporary disk.
   - bash: |
-      curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       az login --identity
       az acr login --name vcpkgandroidwus3
     displayName: 'Set up managed identity'
@@ -56,6 +55,15 @@ jobs:
       sudo mkdir ${{ variables.VCPKG_DOWNLOADS }} -m=777
       exit 0
     displayName: 'Create working directories'
+  - bash: |
+      CONTAINERS=$(docker ps -a -q)
+      if [ -n "$CONTAINERS" ]; then
+        docker rm -f $CONTAINERS
+      fi
+    displayName: 'Stop and remove all docker containers'
+  - bash: |
+      docker pull ${{ parameters.dockerImage }}
+    displayName: 'Pull Docker Container'
   - bash: |
       docker run --rm \
       --mount type=bind,source=$(Build.Repository.LocalPath),target=/vcpkg \
@@ -70,15 +78,6 @@ jobs:
       ./scripts/azure-pipelines/bootstrap-from-source.sh ${{ parameters.vcpkgToolSha }}
     displayName: "Build vcpkg with CMake"
     condition: ne('use default', '${{ parameters.vcpkgToolSha }}')
-  - bash: |
-      CONTAINERS=$(docker ps -a -q)
-      if [ -n "$CONTAINERS" ]; then
-        docker rm -f $CONTAINERS
-      fi
-    displayName: 'Stop and remove all docker containers'
-  - bash: |
-      docker pull ${{ parameters.dockerImage }}
-    displayName: 'Pull Docker Container'
   - task: Bash@3
     inputs:
       targetType: inline

--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -25,7 +25,6 @@ jobs:
     name: 'PrAnd-1ES-Pool'
     demands:
     - ImageOverride -equals vcpkg-mariner-docker-gen1
-    - ImageVersionOverride -equals 3.0.0
   workspace:
     clean: resources
   timeoutInMinutes: 1440 # 1 day

--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -11,8 +11,6 @@ parameters:
     type: string
   - name: jobName
     type: string
-  - name: poolName
-    type: string
   - name: dockerImage
     type: string
   - name: tripletPattern
@@ -24,7 +22,8 @@ jobs:
 - job: ${{ parameters.jobName }}
   condition: and(succeeded(), contains('^${{ parameters.triplet }}$', '${{ parameters.tripletPattern }}'))
   pool:
-    name: ${{ parameters.poolName }}
+    name: 'PrAnd-1ES-Pool'
+    image: 'vcpkg-mariner-docker-gen1'
   workspace:
     clean: resources
   timeoutInMinutes: 1440 # 1 day

--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -23,7 +23,9 @@ jobs:
   condition: and(succeeded(), contains('^${{ parameters.triplet }}$', '${{ parameters.tripletPattern }}'))
   pool:
     name: 'PrAnd-1ES-Pool'
-    demands: ImageOverride -equals vcpkg-mariner-docker-gen1
+    demands:
+    - ImageOverride -equals vcpkg-mariner-docker-gen1
+    - ImageVersionOverride -equals 3.0.0
   workspace:
     clean: resources
   timeoutInMinutes: 1440 # 1 day

--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
   condition: and(succeeded(), contains('^${{ parameters.triplet }}$', '${{ parameters.tripletPattern }}'))
   pool:
     name: 'PrAnd-1ES-Pool'
-    image: 'vcpkg-mariner-docker-gen1'
+    demands: ImageOverride -equals vcpkg-mariner-docker-gen1
   workspace:
     clean: resources
   timeoutInMinutes: 1440 # 1 day

--- a/scripts/azure-pipelines/android/example-ubuntu-provision.sh
+++ b/scripts/azure-pipelines/android/example-ubuntu-provision.sh
@@ -4,6 +4,10 @@
 #
 # This script is to set up the machine for the Docker host.
 
+# This script is no longer used by official vcpkg testing due to an internal compliance effort
+# requiring use of CBL-Mariner. It's still intended to be more or less identical to how the lab
+# actually works though; everything meaningful is inside the Docker image; see Dockerfile
+
 export DEBIAN_FRONTEND=noninteractive
 
 ## Docker

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 #
 variables:
-  android-pool: 'PrAnd-1ES-Pool'
   linux-pool: 'PrLin-1ES-Pool'
   windows-pool: 'PrWin-2024-02-16'
   osx-pool: 'PrOsx-2024-01-18'
@@ -102,7 +101,6 @@ jobs:
   parameters:
     triplet: arm-neon-android
     jobName: arm_neon_android
-    poolName: $(android-pool)
     dockerImage: $(linux-docker-image)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
     tripletPattern: ${{ parameters.tripletPattern }}
@@ -111,7 +109,6 @@ jobs:
   parameters:
     triplet: x64-android
     jobName: x64_android
-    poolName: $(android-pool)
     dockerImage: $(linux-docker-image)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
     tripletPattern: ${{ parameters.tripletPattern }}
@@ -120,7 +117,6 @@ jobs:
   parameters:
     triplet: arm64-android
     jobName: arm64_android
-    poolName: $(android-pool)
     dockerImage: $(linux-docker-image)
     vcpkgToolSha: ${{ parameters.vcpkgToolSha }}
     tripletPattern: ${{ parameters.tripletPattern }}


### PR DESCRIPTION
CBL-Mariner ( https://github.com/micro…soft/azurelinux )

This resolves a Service360 alert caused by Ubuntu refusing to make a security patch publicly available for Ubuntu 22.04 LTS, see https://ubuntu.com/security/notices/USN-6472-1 .

It seems likely that we will need to reconsider Ubuntu being our 'default' test environment following this type of behavior, since it's likely vcpkg customers will be similarly affected.