### PR TITLE
[jasper] update to 4.2.1

### DIFF
--- a/ports/jasper/portfile.cmake
+++ b/ports/jasper/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jasper-software/jasper
     REF "version-${VERSION}"
-    SHA512 31da8f49cec3ba2a3bb9ba40fa54fe64c97d1e564631c980619f0b3ffca36814adc6c2cb8dc1ead774a15546f308e7a33990821538d1e7b6c885b14ed4e1f711
+    SHA512 2da4b72e7566fb3f1240fe8e058f2801642d2a2a8bed6e89f1a32209d22d715bff811a99102ba2cfe0eb566f0fb2292bbefffe75a17011995e35ab8f6bc8a417
     HEAD_REF master
     PATCHES
         no_stdc_check.patch

--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jasper",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/jasper-software/jasper",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3673,7 +3673,7 @@
       "port-version": 1
     },
     "jasper": {
-      "baseline": "4.2.0",
+      "baseline": "4.2.1",
       "port-version": 0
     },
     "jbig2dec": {

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c3bc011eb133f1203cd2c41da885725e7cc99e0",
+      "version": "4.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e7c4fac8db3b39fcce348be5b8d1140a753197ed",
       "version": "4.2.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.