### PR TITLE
[liborigin] new port

### DIFF
--- a/ports/liborigin/portfile.cmake
+++ b/ports/liborigin/portfile.cmake
@@ -1,0 +1,38 @@
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO liborigin
+    REF liborigin/3.0
+    FILENAME liborigin-${VERSION}.tar.gz
+    SHA512 9fb5ae6d8aa8fb54e659482f8f5dc581b8d0ace2ebca7bb9f092b7ec753049d497491eb47ad89b12c8ddf7e19dc47f76e76c51ace789366370bd056d99e091ee
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+  set(LIB_OPTION "-DBUILD_STATIC_LIBS=OFF")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${LIB_OPTION}
+)
+
+vcpkg_cmake_build()
+
+vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+  file(COPY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/origin.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
+  file(COPY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/origin.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+else()
+  file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*.exe" "${CURRENT_PACKAGES_DIR}/debug/bin/*.exe")
+  file(REMOVE_RECURSE ${EXES})
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/liborigin/vcpkg.json
+++ b/ports/liborigin/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "liborigin",
+  "version": "3.0.2",
+  "description": "A library for reading OriginLab OPJ project files.",
+  "homepage": "https://sourceforge.net/projects/liborigin/",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4720,6 +4720,10 @@
       "baseline": "0.2.1",
       "port-version": 3
     },
+    "liborigin": {
+      "baseline": "3.0.2",
+      "port-version": 0
+    },
     "libosip2": {
       "baseline": "5.3.1",
       "port-version": 0

--- a/versions/l-/liborigin.json
+++ b/versions/l-/liborigin.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4ad9ef1e0eddb7bc93dbf08548d7daead3c5d73d",
+      "version": "3.0.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
