### PR TITLE
[libmad] Add `aso` to default features

### DIFF
--- a/ports/libmad/vcpkg.json
+++ b/ports/libmad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmad",
   "version": "0.16.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "high-quality MPEG audio decoder",
   "homepage": "http://codeberg.org/tenacityteam/libmad",
   "dependencies": [
@@ -12,6 +12,12 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "aso",
+      "platform": "x86 | x64 | arm"
     }
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4578,7 +4578,7 @@
     },
     "libmad": {
       "baseline": "0.16.4",
-      "port-version": 2
+      "port-version": 3
     },
     "libmagic": {
       "baseline": "5.45",

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69c818a7eba6f5da1e09077064ee37a12887ecf0",
+      "version": "0.16.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "204aa1729bb363c40a79cbcdb3beab84fa4bd03e",
       "version": "0.16.4",
       "port-version": 2


### PR DESCRIPTION
A small follow-up to #37088, which unintentionally disabled asm optimizations on non-WASM platforms.

This PR adds `aso` to the set of default features, which should fix this.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.