### PR TITLE
[libflac] Add `stack-protector` to default features

### DIFF
--- a/ports/libflac/vcpkg.json
+++ b/ports/libflac/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libflac",
   "version": "1.4.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library for manipulating FLAC files",
   "homepage": "https://xiph.org/flac/",
   "license": "BSD-3-Clause",
@@ -14,6 +14,12 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "stack-protector",
+      "platform": "!emscripten"
     }
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4350,7 +4350,7 @@
     },
     "libflac": {
       "baseline": "1.4.3",
-      "port-version": 1
+      "port-version": 2
     },
     "libfontenc": {
       "baseline": "1.1.4",

--- a/versions/l-/libflac.json
+++ b/versions/l-/libflac.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a92a3397dfb70e6eec94fab7b3665a1288d9f7bd",
+      "version": "1.4.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "8a05fdac2efaa1a739e13289a2bec7d6d32e84a3",
       "version": "1.4.3",
       "port-version": 1


### PR DESCRIPTION
A small follow-up to #37086, which unintentionally disabled the stack protector on non-WASM platforms.

This adds it to the set of default features (on all non-WASM platforms), which should fix this.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.