### PR TITLE
[shiftmedia-libgcrypt] Update version to 1.10.3-1

### DIFF
--- a/ports/shiftmedia-libgcrypt/portfile.cmake
+++ b/ports/shiftmedia-libgcrypt/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ShiftMediaProject/libgcrypt
     REF libgcrypt-${VERSION}
-    SHA512 9b09c9e598c2f3916d45374d40e1bbc4f69f65c1c64bae2f979d7cfde85d8ca5668624e1193a4e38afea3056a4f84477695bbf61454e8c194bc06119ab8da621
+    SHA512 957f2138d174cd39b3809aabbc6873292c56e596892a2273a77301038473cbcd4c69aa5d3d0ebb98a34cf3a2c30ac3212af16b34a304f81d72f11df18c3601f9
     HEAD_REF master
 )
 

--- a/ports/shiftmedia-libgcrypt/vcpkg.json
+++ b/ports/shiftmedia-libgcrypt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "shiftmedia-libgcrypt",
-  "version": "1.10.1-1",
+  "version": "1.10.3-1",
   "description": "An unofficial LibGCrypt with added custom native Visual Studio project build tools. LibGCrypt",
   "homepage": "https://github.com/ShiftMediaProject/libgcrypt",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7989,7 +7989,7 @@
       "port-version": 0
     },
     "shiftmedia-libgcrypt": {
-      "baseline": "1.10.1-1",
+      "baseline": "1.10.3-1",
       "port-version": 0
     },
     "shiftmedia-libgnutls": {

--- a/versions/s-/shiftmedia-libgcrypt.json
+++ b/versions/s-/shiftmedia-libgcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2fb2a4c19ed2c80762d82655d2d5155f59bef2b",
+      "version": "1.10.3-1",
+      "port-version": 0
+    },
+    {
       "git-tree": "839cbd2fe2f4f3354f100f6b769e34a1294afec5",
       "version": "1.10.1-1",
       "port-version": 0


### PR DESCRIPTION
Fixes #37149

Update port to version 1.10.3-1 to fix the bug.
Note: no feature need to test.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.