### PR TITLE
[asiochan] fix MiSo1289#10

### DIFF
--- a/ports/asiochan/fix-10.patch
+++ b/ports/asiochan/fix-10.patch
@@ -1,0 +1,16 @@
+diff --git a/include/asiochan/channel.hpp b/include/asiochan/channel.hpp
+index 4ffd88c..1af7547 100644
+--- a/include/asiochan/channel.hpp
++++ b/include/asiochan/channel.hpp
+@@ -55,6 +55,11 @@ namespace asiochan
+             return *shared_state_;
+         }
+ 
++        [[nodiscard]] auto shared_state() const noexcept -> const shared_state_type&
++        {
++            return *shared_state_;
++        }
++
+         [[nodiscard]] friend auto operator==(
+             channel_base const& lhs,
+             channel_base const& rhs) noexcept -> bool

--- a/ports/asiochan/portfile.cmake
+++ b/ports/asiochan/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 837d7eb78ca9796af800ca3cd91ce0a8fe297785
     SHA512 58e1e3291dc980ed59b0bc1fdcaa35db007e0044f4cbd352917caefa2d30b0c76a3db180091c1895867a3d026ce69f3a82b33dde3970cba5bef596620a2b20f8
     HEAD_REF master
+    PATCHES
+        fix-10.patch
 )
 
 file(COPY "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")

--- a/ports/asiochan/vcpkg.json
+++ b/ports/asiochan/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "asiochan",
   "version-date": "2022-11-25",
+  "port-version": 1,
   "description": "C++20 coroutine channels for ASIO",
   "homepage": "https://github.com/MiSo1289/asiochan",
   "license": "MIT"

--- a/versions/a-/asiochan.json
+++ b/versions/a-/asiochan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f50cae4125b9c7d28002560aa2b7a16f8d7baa8",
+      "version-date": "2022-11-25",
+      "port-version": 1
+    },
+    {
       "git-tree": "857feb5fd868cdae02e6bb9d6252174a9a39cb61",
       "version-date": "2022-11-25",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -262,7 +262,7 @@
     },
     "asiochan": {
       "baseline": "2022-11-25",
-      "port-version": 0
+      "port-version": 1
     },
     "asiosdk": {
       "baseline": "2.3.3",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

Here is my [pr](https://github.com/MiSo1289/asiochan/pull/11) for upstream. There has been no response for one week, so I think the upstream is not maintained. So I decide change the repo to my fork. If the author resume, I will switch back.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
