### PR TITLE
[poppler] Update to 24.3.0

### DIFF
--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO poppler/poppler
     REF "poppler-${POPPLER_VERSION}"
-    SHA512 3f1cb23f9f89cae24c05618c31e0d6414cfe48cffa6b59fc2a0b0fbe79df2715584e170785d2fdd1e5592af7bda4b3a9e3070e8452a17db86d484dcd6b00138d
+    SHA512 5997af5698a793aefcc1d0d98ea2e0732c0ce0adfa1e5be182ba2d425b1691ba84dfa89f0cdafacf19756d411b2b2de665d1a4682acf21ad5d3353dfeac0727c
     HEAD_REF master
     PATCHES
         export-unofficial-poppler.patch

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "poppler",
-  "version": "24.2.0",
-  "port-version": 1,
+  "version": "24.3.0",
   "description": "A PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6841,8 +6841,8 @@
       "port-version": 5
     },
     "poppler": {
-      "baseline": "24.2.0",
-      "port-version": 1
+      "baseline": "24.3.0",
+      "port-version": 0
     },
     "popsift": {
       "baseline": "0.9",

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "232b46d139c62a87eea2e8d147f52cde5162075f",
+      "version": "24.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "eac143745483dbf2b73b22a965413aa7dd2aa7ec",
       "version": "24.2.0",
       "port-version": 1


### PR DESCRIPTION
Fix #37127.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Port usage and features test pass with following triplets:
* x64-windows