### PR TITLE
[libsercomm] fix C++ compatibility macro usage

### DIFF
--- a/ports/libsercomm/dev-SER_END_DECL-fix.patch
+++ b/ports/libsercomm/dev-SER_END_DECL-fix.patch
@@ -1,0 +1,10 @@
+--- a/include/public/sercomm/dev.h
++++ b/include/public/sercomm/dev.h
+@@ -137,6 +137,6 @@ SER_EXPORT void ser_dev_monitor_stop(ser_dev_mon_t *mon);
+ 
+ /** @} */
+ 
+-SER_BEGIN_DECL
++SER_END_DECL
+ 
+ #endif

--- a/ports/libsercomm/portfile.cmake
+++ b/ports/libsercomm/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 1.3.2
     SHA512 f1581f2dfa262ffb1b3aec5a1e6d32493c322c94541fbacc98efff23b3b42b14c9abdcfb063a78b7c54fb1f9d8dbf59d8064099601de2175af6c6d830708324c
     HEAD_REF master
+    PATCHES
+        dev-SER_END_DECL-fix.patch # https://github.com/ingeniamc/sercomm/pull/3
 )
 
 vcpkg_check_features(

--- a/ports/libsercomm/portfile.cmake
+++ b/ports/libsercomm/portfile.cmake
@@ -24,10 +24,10 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-# Fix CMake files
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sercomm)
-
-vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(
+	PACKAGE_NAME sercomm
+	CONFIG_PATH lib/cmake/sercomm
+)
 
 # Remove includes in debug
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libsercomm/vcpkg.json
+++ b/ports/libsercomm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libsercomm",
   "version": "1.3.2",
+  "port-version": 1,
   "description": "Multiplatform serial communications library",
   "homepage": "https://github.com/ingeniamc/sercomm",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4870,7 +4870,7 @@
     },
     "libsercomm": {
       "baseline": "1.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libsigcpp": {
       "baseline": "3.6.0",

--- a/versions/l-/libsercomm.json
+++ b/versions/l-/libsercomm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "57d489340cd623931cd57abc7698299c7ea96a2c",
+      "git-tree": "69ddaa927709d1ff6f0e28ad74049da2fcd4ac6a",
       "version": "1.3.2",
       "port-version": 1
     },

--- a/versions/l-/libsercomm.json
+++ b/versions/l-/libsercomm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "57d489340cd623931cd57abc7698299c7ea96a2c",
+      "version": "1.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "85fa53c8aa1927afa7844c01b646a86de8803c30",
       "version": "1.3.2",
       "port-version": 0


### PR DESCRIPTION
this fixes a typo in sercomm/dev.h that results in errors when included in C++

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

why a patch?
[upstream](https://github.com/ingeniamc/sercomm) seems to be unmaintained, an [issue](https://github.com/ingeniamc/sercomm/issues/2) & a [pull request](https://github.com/ingeniamc/sercomm/pull/3) regarding this issue have existed for years/months respectively