### PR TITLE
[libmicrohttpd] update to 1.0.1

### DIFF
--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${VERSION}.tar.gz"
         "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${VERSION}.tar.gz"
     FILENAME "libmicrohttpd-${VERSION}.tar.gz"
-    SHA512 001025c023dd94c4a0cf017ed575e65a577b5ce595e7e450346bfb75def77eaa8a4cfbeffb9f4b912e34165c2cfca147c02c895e067a4f6c5a321a12035758a5
+    SHA512 c99b8b93cae5feee8debcc5667ee3ff043412a84b30696fe852e6c138f3c890bb43c8fcd7199f1d2f809d522fef159e83b607c743d6cf3401a57050fbdf9b5c1
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libmicrohttpd/vcpkg.json
+++ b/ports/libmicrohttpd/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmicrohttpd",
-  "version": "0.9.77",
-  "port-version": 2,
+  "version": "1.0.1",
   "description": "GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application",
   "homepage": "https://www.gnu.org/software/libmicrohttpd/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4605,8 +4605,8 @@
       "port-version": 2
     },
     "libmicrohttpd": {
-      "baseline": "0.9.77",
-      "port-version": 2
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "libmikmod": {
       "baseline": "3.3.11.1",

--- a/versions/l-/libmicrohttpd.json
+++ b/versions/l-/libmicrohttpd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c764a262309da58e1c37962c061c5fa660caff38",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "528d4043cc7a0784b2f1e1ba77455a8559498b2e",
       "version": "0.9.77",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

