### PR TITLE
[liblzma] update to version 5.6.0

### DIFF
--- a/ports/liblzma/add_support_ios.patch
+++ b/ports/liblzma/add_support_ios.patch
@@ -1,20 +1,26 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 52439b3..0b5e371 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -574,6 +574,7 @@ if(HAVE_GETOPT_LONG)
+@@ -1555,6 +1555,7 @@ if(HAVE_DECODERS AND (NOT MSVC OR MSVC_VERSION GREATER_EQUAL 1900))
  
-     install(TARGETS xzdec
+         install(TARGETS "${XZDEC}"
+                 RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++                BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+                         COMPONENT "${XZDEC}_Runtime")
+     endforeach()
+ 
+@@ -1618,6 +1619,7 @@ if(HAVE_DECODERS AND (NOT MSVC OR MSVC_VERSION GREATER_EQUAL 1900))
+ 
+     install(TARGETS lzmainfo
              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-                     COMPONENT xzdec)
+                     COMPONENT lzmainfo_Runtime)
  
      if(UNIX)
-@@ -701,6 +702,7 @@ if(NOT MSVC AND HAVE_GETOPT_LONG)
- 
+@@ -1827,6 +1829,7 @@ if(NOT MSVC OR MSVC_VERSION GREATER_EQUAL 1900)
+     # builds because the generated cmake_install.cmake executes serially.
      install(TARGETS xz
              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-                     COMPONENT xz)
+                     COMPONENT xz_Runtime)
  
      if(UNIX)

--- a/ports/liblzma/build-tools.patch
+++ b/ports/liblzma/build-tools.patch
@@ -1,20 +1,20 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 03b8301..820d08e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -584,6 +584,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblzma-config.cmake"
-         COMPONENT liblzma_Development)
+@@ -1438,7 +1443,7 @@ function(my_install_man COMPONENT SRC_FILE LINK_NAMES)
+     endif()
+ endfunction()
  
- 
+-
 +if(BUILD_TOOLS)
  #############################################################################
- # getopt_long
+ # libgnu (getopt_long)
  #############################################################################
-@@ -793,6 +794,7 @@ if(NOT MSVC AND HAVE_GETOPT_LONG)
-         endforeach()
+@@ -1853,7 +1858,7 @@ if(NOT MSVC OR MSVC_VERSION GREATER_EQUAL 1900)
+         my_install_man(xz_Documentation src/xz/xz.1 "${XZ_LINKS}")
      endif()
  endif()
-+endif()
- 
+-
++endif(BUILD_TOOLS)
  
  #############################################################################
+ # Scripts

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         tools BUILD_TOOLS
+        nls ENABLE_NLS
 )
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "wasm32")
@@ -28,7 +29,6 @@ vcpkg_cmake_configure(
         -DBUILD_TESTING=OFF
         -DCREATE_XZ_SYMLINKS=OFF
         -DCREATE_LZMA_SYMLINKS=OFF
-        -DENABLE_NLS=OFF # avoid issues with installing language specific man files
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=   # using flags from (vcpkg) toolchain
     MAYBE_UNUSED_VARIABLES
         CMAKE_MSVC_DEBUG_INFORMATION_FORMAT

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -14,7 +14,6 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         tools BUILD_TOOLS
-        nls ENABLE_NLS
 )
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "wasm32")
@@ -30,8 +29,8 @@ vcpkg_cmake_configure(
         -DCREATE_XZ_SYMLINKS=OFF
         -DCREATE_LZMA_SYMLINKS=OFF
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=   # using flags from (vcpkg) toolchain
+        -DENABLE_NLS=OFF # nls is not supported by this port, yet
     MAYBE_UNUSED_VARIABLES
-        ENABLE_NLS
         CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
         CREATE_XZ_SYMLINKS
         CREATE_LZMA_SYMLINKS

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -31,6 +31,7 @@ vcpkg_cmake_configure(
         -DCREATE_LZMA_SYMLINKS=OFF
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=   # using flags from (vcpkg) toolchain
     MAYBE_UNUSED_VARIABLES
+        ENABLE_NLS
         CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
         CREATE_XZ_SYMLINKS
         CREATE_LZMA_SYMLINKS

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tukaani-project/xz
     REF "v${VERSION}"
-    SHA512 c28461123562564e030f3f733f078bc4c840e87598d9f4b718d4bca639120d8133f969c45d7bdc62f33f081d789ec0f14a1791fb7da18515682bfe3c0c7362e0
+    SHA512 0aa74e01c019c1d3893cf16f53b300ba4e74c6aa9febabf57ddb49b28615d76862eeb746c54c2085efd37c7e8cc0829014d9b7ad481a76294bc929b3cca91336
     HEAD_REF master
     PATCHES
         fix_config_include.patch
@@ -41,7 +41,7 @@ set(exec_prefix "\${prefix}")
 set(libdir "\${prefix}/lib")
 set(includedir "\${prefix}/include")
 set(PACKAGE_URL https://tukaani.org/xz/)
-set(PACKAGE_VERSION 5.4.3)
+set(PACKAGE_VERSION "${VERSION}")
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     set(PTHREAD_CFLAGS -pthread)
 endif()

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_cmake_configure(
         -DBUILD_TESTING=OFF
         -DCREATE_XZ_SYMLINKS=OFF
         -DCREATE_LZMA_SYMLINKS=OFF
+        -DENABLE_NLS=OFF # avoid issues with installing language specific man files
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=   # using flags from (vcpkg) toolchain
     MAYBE_UNUSED_VARIABLES
         CMAKE_MSVC_DEBUG_INFORMATION_FORMAT

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -67,7 +67,7 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/man"
 )
 
-set(TOOLS xz xzdec)
+set(TOOLS xz xzdec lzmadec lzmainfo)
 foreach(_tool IN LISTS TOOLS)
     if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/bin/${_tool}${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
         list(REMOVE_ITEM TOOLS ${_tool})

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblzma",
-  "version": "5.4.4",
+  "version": "5.6.0",
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -15,20 +15,6 @@
     }
   ],
   "features": {
-    "nls": {
-      "description": "Enable native language support",
-      "supports": "!windows | mingw",
-      "dependencies": [
-        "gettext",
-        {
-          "name": "gettext",
-          "host": true,
-          "features": [
-            "tools"
-          ]
-        }
-      ]
-    },
     "tools": {
       "description": "Build tools",
       "supports": "!windows, mingw"

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -15,6 +15,20 @@
     }
   ],
   "features": {
+    "nls": {
+      "description": "Enable native language support",
+      "supports": "!windows | mingw",
+      "dependencies": [
+        "gettext",
+        {
+          "name": "gettext",
+          "host": true,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
     "tools": {
       "description": "Build tools",
       "supports": "!windows, mingw"

--- a/ports/liblzma/win_output_name.patch
+++ b/ports/liblzma/win_output_name.patch
@@ -1,17 +1,19 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0c6d4b7..62a824a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -868,8 +868,11 @@ set_target_properties(liblzma PROPERTIES
+@@ -1273,10 +1273,15 @@ set_target_properties(liblzma PROPERTIES
  
      # It's liblzma.so or liblzma.dll, not libliblzma.so or lzma.dll.
      # Avoid the name lzma.dll because it would conflict with LZMA SDK.
 -    PREFIX ""
 +    OUTPUT_NAME lzma
+     IMPORT_PREFIX ""
  )
+ 
 +if(WIN32 AND NOT MINGW)
 +    set_target_properties(liblzma PROPERTIES RUNTIME_OUTPUT_NAME liblzma)
 +endif()
- 
++
++
  # Create liblzma-config-version.cmake.
  #
+ # FIXME: SameMajorVersion is correct for stable releases but it is wrong

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4573,7 +4573,7 @@
       "port-version": 0
     },
     "liblzma": {
-      "baseline": "5.4.4",
+      "baseline": "5.6.0",
       "port-version": 0
     },
     "libmad": {

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "648fe4b53b385f43b4c6de3cf716479eacfe1b3a",
+      "git-tree": "6289e147801657852ae96afd3ba10c387ac0dd1f",
       "version": "5.6.0",
       "port-version": 0
     },

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54eb17dfe85798514384c60eb5f55a1c55a800c1",
+      "version": "5.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f285b7c4ffa2cc065c7c6fec4b61006f7fa2714e",
       "version": "5.4.4",
       "port-version": 0

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4839f96c9d86be6cd554a5677df16e2e816affe1",
+      "git-tree": "648fe4b53b385f43b4c6de3cf716479eacfe1b3a",
       "version": "5.6.0",
       "port-version": 0
     },

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6289e147801657852ae96afd3ba10c387ac0dd1f",
+      "git-tree": "b362003b452b95b7fef8577175651a7e33940f7f",
       "version": "5.6.0",
       "port-version": 0
     },

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "54eb17dfe85798514384c60eb5f55a1c55a800c1",
+      "git-tree": "4839f96c9d86be6cd554a5677df16e2e816affe1",
       "version": "5.6.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #37197.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The update to version 5.6.0, includes the following changes
* the patches were adapted for changes in the new version (I cannot check if the patch for iOS support was adapted correctly)
* the new tools `lzmadec` and `lzmainfo` are handled in the same manner as the existing tools `xz` and `xzdec` 
* ~nls was disabled to sidestep an issue with installing the man pages~
* ~a new feature `nls` was added to enable native language support. This was necessary to handle a new optional dependency on `gettext` so that the existing `tools` feature continues to work.~
* nls support was not added, yet. See discussion below for details.

I have successfully built 
* `liblzma:x86-windows`,
* `liblzma:x64-windows`,
* `liblzma:x64-linux`, 
* `liblzma[tools]:x64-linux`,

Note that `tools`  is not supported on `windows`.

Requested by @Neustradamus

EDIT 1: added nls feature
EDIT 2: removed nls feature again