### PR TITLE
[proxy] update to 2.2.1

### DIFF
--- a/ports/proxy/portfile.cmake
+++ b/ports/proxy/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/proxy
     REF ${VERSION}
-    SHA512 d8e635db541a53c1ea6014bf202dc59c0a358dd9288bcef2eeccc1dfdc0366ed63c8c25663880e65e8e03b8851a208a0a7028439df74cce8600c9cd01c4b8310
+    SHA512 31ccca739eacd3bde8f5db4c4e6350bb37790681186dd6f2d2d8ee3fc1d4e2b42beab2b8c893793cb3ea6128deaf812f8cb658a74a2df5abc1af1eea95972509
     HEAD_REF main
 )
 

--- a/ports/proxy/vcpkg.json
+++ b/ports/proxy/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A single-header C++20 library that facilitates runtime polymorphism.",
   "homepage": "https://github.com/microsoft/proxy",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6933,7 +6933,7 @@
       "port-version": 0
     },
     "proxy": {
-      "baseline": "2.2.0",
+      "baseline": "2.2.1",
       "port-version": 0
     },
     "proxygen": {

--- a/versions/p-/proxy.json
+++ b/versions/p-/proxy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9610b4e09c0a66780511553bae8904777e4c1a7e",
+      "version": "2.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "17cc5c3bc87d03e18204c31f54cf6edaba6329fc",
       "version": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.