### PR TITLE
[libassuan] update to 2.5.7

### DIFF
--- a/ports/libassuan/portfile.cmake
+++ b/ports/libassuan/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/libassuan/libassuan-${VERSION}.tar.bz2"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libassuan/libassuan-${VERSION}.tar.bz2"
     FILENAME "libassuan-${VERSION}.tar.bz2"
-    SHA512 dcca942d222a2c226a7e34ba7988ee0c3c55bd6032166eb472caf2053db89aeeea7a40e93d8c2887c7ee73c5f838e8b0725e8cfb595accc1606646559362f7ee
+    SHA512 ca33bd0325bbebccb63b6a84cc0aa5c85b25c6275a68df83aeb3f3729b2cd38220198a941c3479bd461f16b7ddb6b558c0664697ca3153c7fb430544303d773f
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/libassuan/vcpkg.json
+++ b/ports/libassuan/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libassuan",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "A library implementing the so-called Assuan protocol",
   "homepage": "https://gnupg.org/software/libassuan/index.html",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4149,7 +4149,7 @@
       "port-version": 2
     },
     "libassuan": {
-      "baseline": "2.5.6",
+      "baseline": "2.5.7",
       "port-version": 0
     },
     "libatomic-ops": {

--- a/versions/l-/libassuan.json
+++ b/versions/l-/libassuan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f619f927aa36d89e928f02b815690fe87164ff9",
+      "version": "2.5.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "5eb84b4591e790d4fe81a7a5cd37ebd6e567d40e",
       "version": "2.5.6",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

