### PR TITLE
[libdmx] update to 1.1.5

### DIFF
--- a/ports/libdmx/portfile.cmake
+++ b/ports/libdmx/portfile.cmake
@@ -6,8 +6,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libdmx
-    REF  6056db9a2fa8ad1ea55f8b8e2cbf5972408d612f
-    SHA512 f7b0a3fb26bc68e5dd27a0afa98ed29fed31956fd07f89b57171d7f9d9a0a87185876551dbf312b8d90a66fa50de06992cf9eb386fa98dd8133946de3c37e274
+    REF "libdmx-${VERSION}"
+    SHA512 2c634f57a7229e2d10b3ce700fe20d53a1578b9eb6d575eab9f0a9f228410dd6a17aa2a3d60503c0c0a14029d8a4ca8db6061b966108272ac8e8052bd3750300
     HEAD_REF master
 ) 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")

--- a/ports/libdmx/vcpkg.json
+++ b/ports/libdmx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdmx",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "X Window System DMX (Distributed Multihead X) extension library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libdmx",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4277,7 +4277,7 @@
       "port-version": 0
     },
     "libdmx": {
-      "baseline": "1.1.4",
+      "baseline": "1.1.5",
       "port-version": 0
     },
     "libdshowcapture": {

--- a/versions/l-/libdmx.json
+++ b/versions/l-/libdmx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b7ba8558e854fb3da477e6b2538b54931a5316ff",
+      "version": "1.1.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "732f7de5885d8a8897e9f8ad0c36c9f44479332c",
       "version": "1.1.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

