### PR TITLE
[libexif] Fix usage

### DIFF
--- a/ports/libexif/unofficial-libexif-config.cmake
+++ b/ports/libexif/unofficial-libexif-config.cmake
@@ -7,8 +7,8 @@ if(NOT TARGET unofficial::libexif::libexif)
     set_target_properties(unofficial::libexif::libexif PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${z_vcpkg_libexif_root}/include"
     )
-    find_library(Z_VCPKG_LIBEXIF_LIBRARY_RELEASE NAMES libexif PATHS "${z_vcpkg_LIBEXIF_root }/lib" NO_DEFAULT_PATH REQUIRED)
-    find_library(Z_VCPKG_LIBEXIF_LIBRARY_DEBUG NAMES libexif PATHS "${z_vcpkg_LIBEXIF_root }/debug/lib" NO_DEFAULT_PATH)
+    find_library(Z_VCPKG_LIBEXIF_LIBRARY_RELEASE NAMES libexif PATHS "${z_vcpkg_LIBEXIF_root}/lib" NO_DEFAULT_PATH REQUIRED)
+    find_library(Z_VCPKG_LIBEXIF_LIBRARY_DEBUG NAMES libexif PATHS "${z_vcpkg_LIBEXIF_root}/debug/lib" NO_DEFAULT_PATH)
     
     if(EXISTS "${Z_VCPKG_LIBEXIF_LIBRARY_RELEASE}")
         set_property(TARGET unofficial::libexif::libexif APPEND PROPERTY IMPORTED_CONFIGURATIONS "Release")

--- a/ports/libexif/unofficial-libexif-config.cmake
+++ b/ports/libexif/unofficial-libexif-config.cmake
@@ -2,13 +2,13 @@
 if(NOT TARGET unofficial::libexif::libexif)
     add_library(unofficial::libexif::libexif UNKNOWN IMPORTED)
     get_filename_component(z_vcpkg_LIBEXIF_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
-    get_filename_component(z_vcpkg_LIBEXIF_root "${z_vcpkg_libexif_root}" PATH)
-    get_filename_component(z_vcpkg_LIBEXIF_root "${z_vcpkg_libexif_root}" PATH)
+    get_filename_component(z_vcpkg_LIBEXIF_ROOT "${z_vcpkg_LIBEXIF_root}" PATH)
+    get_filename_component(z_VCPKG_LIBEXIF_ROOT "${z_vcpkg_LIBEXIF_ROOT}" PATH)
     set_target_properties(unofficial::libexif::libexif PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${z_vcpkg_libexif_root}/include"
+      INTERFACE_INCLUDE_DIRECTORIES "${z_VCPKG_LIBEXIF_ROOT}/include"
     )
-    find_library(Z_VCPKG_LIBEXIF_LIBRARY_RELEASE NAMES libexif PATHS "${z_vcpkg_LIBEXIF_root}/lib" NO_DEFAULT_PATH REQUIRED)
-    find_library(Z_VCPKG_LIBEXIF_LIBRARY_DEBUG NAMES libexif PATHS "${z_vcpkg_LIBEXIF_root}/debug/lib" NO_DEFAULT_PATH)
+    find_library(Z_VCPKG_LIBEXIF_LIBRARY_RELEASE NAMES exif PATHS "${z_VCPKG_LIBEXIF_ROOT}/lib" NO_DEFAULT_PATH REQUIRED)
+    find_library(Z_VCPKG_LIBEXIF_LIBRARY_DEBUG NAMES exif PATHS "${z_VCPKG_LIBEXIF_ROOT}/debug/lib" NO_DEFAULT_PATH)
     
     if(EXISTS "${Z_VCPKG_LIBEXIF_LIBRARY_RELEASE}")
         set_property(TARGET unofficial::libexif::libexif APPEND PROPERTY IMPORTED_CONFIGURATIONS "Release")
@@ -25,4 +25,6 @@ if(NOT TARGET unofficial::libexif::libexif)
     endif()
 
     unset(z_vcpkg_LIBEXIF_root)
+    unset(z_vcpkg_LIBEXIF_ROOT)
+    unset(z_VCPKG_LIBEXIF_ROOT)
 endif()

--- a/ports/libexif/vcpkg.json
+++ b/ports/libexif/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libexif",
   "version": "0.6.24",
-  "port-version": 2,
+  "port-version": 3,
   "description": "a library for parsing, editing, and saving EXIF data",
   "homepage": "https://libexif.github.io/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4334,7 +4334,7 @@
     },
     "libexif": {
       "baseline": "0.6.24",
-      "port-version": 2
+      "port-version": 3
     },
     "libfabric": {
       "baseline": "1.13.2",

--- a/versions/l-/libexif.json
+++ b/versions/l-/libexif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc80c798f28200feba34f7f17c34619dc52cc9d4",
+      "version": "0.6.24",
+      "port-version": 3
+    },
+    {
       "git-tree": "de3b3a5ade33ccafbeb4a00cde07954717240eee",
       "version": "0.6.24",
       "port-version": 2

--- a/versions/l-/libexif.json
+++ b/versions/l-/libexif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc80c798f28200feba34f7f17c34619dc52cc9d4",
+      "git-tree": "f24b507dc606ff933aec00cf716c4ca27a48e13e",
       "version": "0.6.24",
       "port-version": 3
     },


### PR DESCRIPTION
Fixes #37184
When use libexif provide usage, you will get three error:
````
1> [CMake] CMake Error at F:/test/vcpkg/installed/x64-windows/share/unofficial-libexif/unofficial-libexif-config.cmake:10 (find_library):
1> [CMake]   Syntax error in cmake code at
1> [CMake] 
1> [CMake]     F:/test/vcpkg/installed/x64-windows/share/unofficial-libexif/unofficial-libexif-config.cmake:10
1> [CMake] 
1> [CMake]   when parsing string
1> [CMake] 
1> [CMake]     ${z_vcpkg_LIBEXIF_root }/lib
1> [CMake] 
1> [CMake]   Invalid character (' ') in a variable name: 'z_vcpkg_LIBEXIF_root'
````
````
1> [CMake] CMake Error at F:/test/vcpkg/installed/x64-windows/share/unofficial-libexif/unofficial-libexif-config.cmake:10 (find_library):
1> [CMake]   Could not find Z_VCPKG_LIBEXIF_LIBRARY_RELEASE using the following names:
1> [CMake]   libexif
````
````
1> [CMake] CMake Error in CMakeProject1/CMakeLists.txt:
1> [CMake]   Imported target "unofficial::libexif::libexif" includes non-existent path
1> [CMake] 
1> [CMake]     "/include"
````
Change the `unofficial-libexif-config.cmake` file to fix usage error.

Usage tested successfully by `libexif:x64-windows`:
````
libexif provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(unofficial-libexif CONFIG REQUIRED)
  target_link_libraries(main PRIVATE unofficial::libexif::libexif)
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
