### PR TITLE
[libfontenc] update to 1.1.8

### DIFF
--- a/ports/libfontenc/portfile.cmake
+++ b/ports/libfontenc/portfile.cmake
@@ -7,8 +7,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libfontenc
-    REF  2baea13978759d1a011fc6d739465893b554d30a #1.1.4
-    SHA512 5ebef8b516a2377b004894b53d56ad960bc5179d9f9a36e18bc2228ea04e8f87e9baffd4883c21783dd1f4c57d7f521cdfa42c1e9facae60c6fc2c9f5472230e
+    REF "libfontenc-${VERSION}"
+    SHA512 2bb9d65f240de503cb3aca629eddf22e5d1f445804ed6fe4ede7354d1b26468dcb4766c438a562e52b885180ce4a24524f400fbf5d52dcba8f3f62d69c3d7730
     HEAD_REF master
     PATCHES configure.ac.patch
             build.patch

--- a/ports/libfontenc/vcpkg.json
+++ b/ports/libfontenc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libfontenc",
-  "version": "1.1.4",
+  "version": "1.1.8",
   "description": "X font encoding library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libfontenc",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4353,7 +4353,7 @@
       "port-version": 2
     },
     "libfontenc": {
-      "baseline": "1.1.4",
+      "baseline": "1.1.8",
       "port-version": 0
     },
     "libfork": {

--- a/versions/l-/libfontenc.json
+++ b/versions/l-/libfontenc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0bb2cc19f2d8397091fbab90648e49bff8a5340f",
+      "version": "1.1.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "4201b994bdcfcf20458025d0fcfffe1f97d444dc",
       "version": "1.1.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

