### PR TITLE
[libidn2] update to 2.3.7

### DIFF
--- a/ports/libidn2/portfile.cmake
+++ b/ports/libidn2/portfile.cmake
@@ -5,7 +5,7 @@ set(IDN2_FILENAME "libidn2-${VERSION}.tar.gz")
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/gnu/libidn/${IDN2_FILENAME}" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libidn/${IDN2_FILENAME}"
     FILENAME "${IDN2_FILENAME}"
-    SHA512 a6e90ccef56cfd0b37e3333ab3594bb3cec7ca42a138ca8c4f4ce142da208fa792f6c78ca00c01001c2bc02831abcbaf1cf9bcc346a5290fd7b30708f5a462f3
+    SHA512 eab5702bc0baed45492f8dde43a4d2ea3560ad80645e5f9e0cfa8d3b57bccd7fd782d04638e000ba07924a5d9f85e760095b55189188c4017b94705bef9b4a66
 )
 
 vcpkg_list(SET patches)

--- a/ports/libidn2/vcpkg.json
+++ b/ports/libidn2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libidn2",
-  "version": "2.3.4",
-  "port-version": 3,
+  "version": "2.3.7",
   "description": "GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.",
   "homepage": "https://www.gnu.org/software/libidn/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4489,8 +4489,8 @@
       "port-version": 1
     },
     "libidn2": {
-      "baseline": "2.3.4",
-      "port-version": 3
+      "baseline": "2.3.7",
+      "port-version": 0
     },
     "libigl": {
       "baseline": "2.5.0",

--- a/versions/l-/libidn2.json
+++ b/versions/l-/libidn2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e61df62cb1d427e4bf07232a0e4013fb700e43b",
+      "version": "2.3.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "20e169744f242f67bc4b4dc310f5785d55dba58c",
       "version": "2.3.4",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

