### PR TITLE
[libmesh] update to 1.7.1

### DIFF
--- a/ports/libmesh/portfile.cmake
+++ b/ports/libmesh/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libMesh/libmesh
-    REF  21f623c837b3865ed65ec9608b357bdb1935d428 #1.5.0
-    SHA512 53ad41ed0cd99cb5096ff338a3ff5d8a8ecbfb17dc1d7ee0d2b0cbffecbede7f7c11b7c3c2233cec9dde0988c8828ba0199247effd3442befc72230e641a185e
+    REF "v${VERSION}"
+    SHA512 ede76a0e9f772c559422c229b33027493654c465ad335da9a4060fe885ddb18c6472deea52b6ce6fe92f8bfb5c9c8144c23d356b92f72083a4dde922a06dc287
     HEAD_REF master
 )
 

--- a/ports/libmesh/vcpkg.json
+++ b/ports/libmesh/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmesh",
-  "version": "1.5.0",
-  "port-version": 6,
+  "version": "1.7.1",
   "description": "The libMesh library provides a framework for the numerical simulation of partial differential equations using arbitrary unstructured discretizations on serial and parallel platforms. A major goal of the library is to provide support for adaptive mesh refinement (AMR) computations in parallel while allowing a research scientist to focus on the physics they are modeling.",
   "homepage": "https://github.com/libMesh/libmesh",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4597,8 +4597,8 @@
       "port-version": 0
     },
     "libmesh": {
-      "baseline": "1.5.0",
-      "port-version": 6
+      "baseline": "1.7.1",
+      "port-version": 0
     },
     "libmicrodns": {
       "baseline": "0.2.0",

--- a/versions/l-/libmesh.json
+++ b/versions/l-/libmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a09748e8e00b69a0f61b44e65984ed249008d23",
+      "version": "1.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7c6d096079002a5a867cccb4f6204f871eeaf2e1",
       "version": "1.5.0",
       "port-version": 6


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

