### PR TITLE
[libspnav] update to 1.1

### DIFF
--- a/ports/libspnav/portfile.cmake
+++ b/ports/libspnav/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FreeSpacenav/libspnav
-    REF libspnav-0.2.3 # v0.2.3 seems to be outdated. libspnav-0.2.3 is the same as 0.2.3 on their sourceforge
-    SHA512 6c06344813ddf7e2bc7981932b4a901334de2b91d8c3abb23828869070dc73ed1c19c5bf7ff9338cc673c8f0dc7394608652afd0cdae093149c0a24460f0a8fb
+    REF "v${VERSION}"
+    SHA512 94770d9449dd02ade041d3589bcae7664fa990c4a4feca7b2b1e6542b65aa7073305595310b9e639f10716cf15aaad913e57496fb79bdd4dba5bf703ec8299ab
     HEAD_REF master
 )
 

--- a/ports/libspnav/vcpkg.json
+++ b/ports/libspnav/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libspnav",
-  "version": "0.2.3",
-  "port-version": 2,
+  "version": "1.1",
   "description": "Library for communicating with spacenavd or 3dxsrv to get input from 6-dof devices.",
   "homepage": "https://github.com/FreeSpacenav/libspnav",
   "supports": "linux"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4929,8 +4929,8 @@
       "port-version": 1
     },
     "libspnav": {
-      "baseline": "0.2.3",
-      "port-version": 2
+      "baseline": "1.1",
+      "port-version": 0
     },
     "libspng": {
       "baseline": "0.7.4",

--- a/versions/l-/libspnav.json
+++ b/versions/l-/libspnav.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78eb76fc617e7426c84408289e45e298261e87b5",
+      "version": "1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6c31fef991e0961c3194b1f9847469e98a1bdb03",
       "version": "0.2.3",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

