### PR TITLE
[libsrtp] update to 2.6.0

### DIFF
--- a/ports/libsrtp/portfile.cmake
+++ b/ports/libsrtp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cisco/libsrtp
     REF "v${VERSION}"
-    SHA512 bd679ab65ccf22ca30fe867b9649a0b84cfa6fad6e22eb10f081141632f6dd56479a04d525b865f11fd46007303ca211065d9c170e4820d6ea7055403702340a
+    SHA512 96f6e2b7300a416a10e5cc45cf67dadf2f4f81119267689cac4296e2dc6d73398457d1a56b651ab4be6da9e701564d3f256bf6d5f42add5eb2b9b9fe8e438a74
     PATCHES
         fix-runtime-destination.patch
 )

--- a/ports/libsrtp/vcpkg.json
+++ b/ports/libsrtp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libsrtp",
-  "version": "2.5.0",
-  "port-version": 1,
+  "version": "2.6.0",
   "description": "This package provides an implementation of the Secure Real-time Transport Protocol (SRTP), the Universal Security Transform (UST), and a supporting cryptographic kernel.",
   "homepage": "https://github.com/cisco/libsrtp/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4945,8 +4945,8 @@
       "port-version": 3
     },
     "libsrtp": {
-      "baseline": "2.5.0",
-      "port-version": 1
+      "baseline": "2.6.0",
+      "port-version": 0
     },
     "libssh": {
       "baseline": "0.10.5",

--- a/versions/l-/libsrtp.json
+++ b/versions/l-/libsrtp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d6d583763b5bc609539a397e03771dc6e48b764",
+      "version": "2.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "15577c99d2d078770d2e07d2bc8cce770797adb8",
       "version": "2.5.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

