### PR TITLE
[Eigen3] Fix target check in cmake config.

### DIFF
--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -27,6 +27,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/eigen3/Eigen3Config.cmake" "if (NOT TARGET eigen)" "if (NOT TARGET Eigen3::Eigen)")
 endblock()
 
 if(NOT VCPKG_BUILD_TYPE)

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "eigen3",
   "version": "3.4.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "http://eigen.tuxfamily.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2458,7 +2458,7 @@
     },
     "eigen3": {
       "baseline": "3.4.0",
-      "port-version": 3
+      "port-version": 4
     },
     "elements": {
       "baseline": "2022-12-07",

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17249b310c689b0722c3ee825780a8e24c7d73a2",
+      "version": "3.4.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "38fc865a94dea7a84f8b1350936ed4fcc3e638cc",
       "version": "3.4.0",
       "port-version": 3


### PR DESCRIPTION
This has already been fixed upstream. The Eigen version in vcpkg is just extremely old since there has been no new release done upstream. 