### PR TITLE
[chakracore] Avoid using MSVC-internal _STRINGIZE

### DIFF
--- a/ports/chakracore/avoid_msvc_internal_STRINGIZE.patch
+++ b/ports/chakracore/avoid_msvc_internal_STRINGIZE.patch
@@ -1,0 +1,78 @@
+diff --git a/bin/NativeTests/stdafx.h b/bin/NativeTests/stdafx.h
+index c7a021c..77f8299 100644
+--- a/bin/NativeTests/stdafx.h
++++ b/bin/NativeTests/stdafx.h
+@@ -25,11 +25,16 @@
+ 
+ #define DebugOnly(x)          x
+ 
++#if !defined(CHAKRACORE_STRINGIZE)
++#define CHAKRACORE_STRINGIZE_IMPL(x) #x
++#define CHAKRACORE_STRINGIZE(x) CHAKRACORE_STRINGIZE_IMPL(x)
++#endif
++
+ #define AssertMsg(exp, comment)   \
+ do { \
+ if (!(exp)) \
+ { \
+-    fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, _STRINGIZE(exp), comment); \
++    fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, CHAKRACORE_STRINGIZE(exp), comment); \
+     fflush(stderr); \
+     DebugBreak(); \
+ } \
+diff --git a/bin/ch/stdafx.h b/bin/ch/stdafx.h
+index 450a33d..7c5ecc2 100644
+--- a/bin/ch/stdafx.h
++++ b/bin/ch/stdafx.h
+@@ -57,16 +57,16 @@
+ 
+ #if defined(DBG)
+ 
+-#define _STRINGIZE_(x) #x
+-#if !defined(_STRINGIZE)
+-#define _STRINGIZE(x) _STRINGIZE_(x)
++#if !defined(CHAKRACORE_STRINGIZE)
++#define CHAKRACORE_STRINGIZE_IMPL(x) #x
++#define CHAKRACORE_STRINGIZE(x) CHAKRACORE_STRINGIZE_IMPL(x)
+ #endif
+ 
+ #define AssertMsg(exp, comment)   \
+ do { \
+ if (!(exp)) \
+ { \
+-    fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, _STRINGIZE(exp), comment); \
++    fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, CHAKRACORE_STRINGIZE(exp), comment); \
+     fflush(stderr); \
+     DebugBreak(); \
+ } \
+diff --git a/pal/inc/assert_only.h b/pal/inc/assert_only.h
+index eef0e62..644460c 100644
+--- a/pal/inc/assert_only.h
++++ b/pal/inc/assert_only.h
+@@ -6,20 +6,22 @@
+ // PAL free Assert definitions
+ #ifdef DEBUG
+ 
+-#define _QUOTE_(s) #s
+-#define _STRINGIZE_(s) _QUOTE_(s)
++#if !defined(CHAKRACORE_STRINGIZE)
++#define CHAKRACORE_STRINGIZE_IMPL(x) #x
++#define CHAKRACORE_STRINGIZE(x) CHAKRACORE_STRINGIZE_IMPL(x)
++#endif
+ 
+ #ifndef __ANDROID__
+ #define _ERR_OUTPUT_(condition, comment) \
+     fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, \
+-      _STRINGIZE_(condition), comment); \
++      CHAKRACORE_STRINGIZE(condition), comment); \
+     fflush(stderr);
+ #else // ANDROID
+ #include <android/log.h>
+ #define _ERR_OUTPUT_(condition, comment) \
+     __android_log_print(ANDROID_LOG_ERROR, "chakracore-log", \
+       "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, \
+-      _STRINGIZE_(condition), comment);
++      CHAKRACORE_STRINGIZE(condition), comment);
+ #endif
+ 
+ #define _Assert_(condition, comment)   \

--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         add-missing-reference.patch # https://github.com/chakra-core/ChakraCore/pull/6862
+        avoid_msvc_internal_STRINGIZE.patch
 )
 
 set(BUILDTREE_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}")

--- a/ports/chakracore/vcpkg.json
+++ b/ports/chakracore/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "chakracore",
   "version-date": "2022-11-09",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Core part of the Chakra Javascript engine",
   "homepage": "https://github.com/Microsoft/ChakraCore",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1558,7 +1558,7 @@
     },
     "chakracore": {
       "baseline": "2022-11-09",
-      "port-version": 5
+      "port-version": 6
     },
     "charls": {
       "baseline": "2.4.2",

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0389158f1c3dfb6596f8bc991223e384ddeb6673",
+      "version-date": "2022-11-09",
+      "port-version": 6
+    },
+    {
       "git-tree": "98c62c0fbb2d410646eec57ce65ec0b91ad19fcf",
       "version-date": "2022-11-09",
       "port-version": 5


### PR DESCRIPTION
Microsoft's C++ standard library recently merged microsoft/STL#4405 to remove the internal `_STRINGIZE` macro. `chakracore` was using this MSVC internal macro, so `avoid_msvc_internal_STRINGIZE.patch` was added to adapt it to the microsoft/STL changes. Reference: https://github.com/chakra-core/ChakraCore/pull/6970.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

