### PR TITLE
[libfs] update to 1.0.9

### DIFF
--- a/ports/libfs/portfile.cmake
+++ b/ports/libfs/portfile.cmake
@@ -7,8 +7,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libfs
-    REF 02de7390e58f00a3701f656a2b205dc6c8dafb58 # 1.0.8
-    SHA512  7395434c20cebc45213122c12dc272773d100ade606d6fb2cacf94e2d102c9869124a89dbd0ddf2fa9128e8b238cf2f52b89d356b296e8d95ff352be48a4bc54
+    REF "libFS-${VERSION}"
+    SHA512 8d21f82fb335b3ff2f09875a118e90ab1425ce3456ee5d9cbd319491c8def5b8318860d427e1bbb74eae8fbc8f6f199375d4765b2e409ea91a82ecb852a7bab4
     HEAD_REF master
 ) 
 

--- a/ports/libfs/vcpkg.json
+++ b/ports/libfs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libfs",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "X Font Service client library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libfs",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4369,7 +4369,7 @@
       "port-version": 1
     },
     "libfs": {
-      "baseline": "1.0.8",
+      "baseline": "1.0.9",
       "port-version": 0
     },
     "libftdi": {

--- a/versions/l-/libfs.json
+++ b/versions/l-/libfs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a995cbd80fc7904508d36ccf3a46cdadc4f9ce38",
+      "version": "1.0.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "48390af67d3ade78652e3b646864aa96b7cde8c0",
       "version": "1.0.8",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

