### PR TITLE
[libice] update to 1.1.1

### DIFF
--- a/ports/libice/portfile.cmake
+++ b/ports/libice/portfile.cmake
@@ -7,8 +7,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libice
-    REF 8e6a14c63d6b73cde87cb331439f2a4d19cba5b9 # 1.0.10
-    SHA512  ad79cfbc3b1d51fb1f019bc088999ac8a64062a71667dbb4ffb62fe6d1b7dba7665944f64be6dcd27de08cc77e91512de97231db1e4ac018088727e90113d040
+    REF "libICE-${VERSION}"
+    SHA512 9517afbed58816534dbff2e2778f8a65fa67181d6c12f8f36b99c87722b1caeb81869486ed7f52e0947ba6b09648f97338c3bc9db189807466f68eeeb28fa97f
     HEAD_REF master
     PATCHES fix_build.patch
             replace_macros.patch

--- a/ports/libice/vcpkg.json
+++ b/ports/libice/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libice",
-  "version": "1.0.10",
-  "port-version": 1,
+  "version": "1.1.1",
   "description": "Inter-Client Exchange Library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libice",
   "license": "MIT-open-group",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4469,8 +4469,8 @@
       "port-version": 0
     },
     "libice": {
-      "baseline": "1.0.10",
-      "port-version": 1
+      "baseline": "1.1.1",
+      "port-version": 0
     },
     "libiconv": {
       "baseline": "1.17",

--- a/versions/l-/libice.json
+++ b/versions/l-/libice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a954fd3e267776a3412d56a3f2bb6ca402ac35c",
+      "version": "1.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c19081b820dd8056dbb7bbb052ca0c3bcf628cd7",
       "version": "1.0.10",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

