### PR TITLE
[libsm] update to 1.2.4

### DIFF
--- a/ports/libsm/portfile.cmake
+++ b/ports/libsm/portfile.cmake
@@ -7,8 +7,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libsm
-    REF a52c79544fcd6b5e2242b9122dfaa34be07aebb2 # 1.2.3
-    SHA512  379e450d90e61d80d4fea8449a582b3eee3968bef137022053cb3bd51fa2815d8fccc43ff11e3b593c4a67ad64e93209c25111a20ac88e38c1f663cd274f5d56
+    REF "libSM-${VERSION}"
+    SHA512 329bee06d11f18975fb0702e86703244e33112727ef587ab0b3b5a52a99508f8a3ce203b4f3a47d5e4559323b905f6b1f9a818c9fb614a4b498499f6539b1b82
     HEAD_REF master
     PATCHES windows.patch
             missing-include.patch # avoids: warning C4013: '_getpid' undefined; assuming extern returning int

--- a/ports/libsm/vcpkg.json
+++ b/ports/libsm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libsm",
-  "version": "1.2.3",
-  "port-version": 1,
+  "version": "1.2.4",
   "description": "X Session Management Library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libsm",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4885,8 +4885,8 @@
       "port-version": 0
     },
     "libsm": {
-      "baseline": "1.2.3",
-      "port-version": 1
+      "baseline": "1.2.4",
+      "port-version": 0
     },
     "libsmacker": {
       "baseline": "1.2.0",

--- a/versions/l-/libsm.json
+++ b/versions/l-/libsm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d5a3654261c1eec4e96f659e8847db9660993c0",
+      "version": "1.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6104db124805dd5c763dc15cbaed0e42254241c",
       "version": "1.2.3",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

