### PR TITLE
[libunibreak] update to 6.1

### DIFF
--- a/ports/libunibreak/portfile.cmake
+++ b/ports/libunibreak/portfile.cmake
@@ -1,10 +1,12 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+string(REGEX REPLACE "^([0-9]*)[.].*" "\\1" MAJOR "${VERSION}")
+string(REGEX REPLACE "^.*[.]([0-9]*)" "\\1" MINOR "${VERSION}")
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO adah1972/libunibreak
-  REF libunibreak_5_1
-  SHA512 c47d6445cab36febb214b31aeb48585a4d3685714588079e84be87019f6e6ffb752e0e0e527232e2d164b1efeeeea64b8b4b21e605ebc60f10fb5a169edc2ed0
+  REF "libunibreak_${MAJOR}_${MINOR}"
+  SHA512 a85333d59c78b67b1c05d33ab99c069ba493780d6a98ad5ab00e33235c454b8b33515cac4e815de35533f235be7cf5473550b3a6389f7581ba2f6216d42d38e1
   HEAD_REF master
 )
 

--- a/ports/libunibreak/vcpkg.json
+++ b/ports/libunibreak/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libunibreak",
-  "version": "5.1",
+  "version": "6.1",
   "description": "an implementation of the line breaking and word breaking algorithms as described in [Unicode Standard Annex 14] 1 and [Unicode Standard Annex 29] 2. Check the project's [home page] 3 for up-to-date information.",
   "homepage": "https://github.com/adah1972/libunibreak",
   "license": "zlib-acknowledgement",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5041,7 +5041,7 @@
       "port-version": 3
     },
     "libunibreak": {
-      "baseline": "5.1",
+      "baseline": "6.1",
       "port-version": 0
     },
     "libunifex": {

--- a/versions/l-/libunibreak.json
+++ b/versions/l-/libunibreak.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf6623da9e4002c21327a8ea1451fccc0f54a5ce",
+      "version": "6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "82fb16a307e33e75cbdbd3726f4b7bbcea42eb23",
       "version": "5.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

