### PR TITLE
[botan] update to 3.3.0

### DIFF
--- a/ports/botan/fix-cmake-usage.patch
+++ b/ports/botan/fix-cmake-usage.patch
@@ -1,0 +1,62 @@
+diff --git a/src/build-data/botan-config.cmake.in b/src/build-data/botan-config.cmake.in
+index 8d14c4e..46e2cbc 100644
+--- a/src/build-data/botan-config.cmake.in
++++ b/src/build-data/botan-config.cmake.in
+@@ -65,21 +65,29 @@ if(DEFINED ${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT ${${CMAKE_FIND_PACKAGE_NAME}
+   return()
+ endif()
+ 
+-# botan-config.cmake lives in "${_Botan_PREFIX}/lib/cmake/Botan-X": traverse up to $_Botan_PREFIX
++# botan-config.cmake lives in "${_Botan_PREFIX}/share/botan": traverse up to $_Botan_PREFIX
+ set(_Botan_PREFIX "${CMAKE_CURRENT_LIST_DIR}")
+ get_filename_component(_Botan_PREFIX "${_Botan_PREFIX}" DIRECTORY)
+ get_filename_component(_Botan_PREFIX "${_Botan_PREFIX}" DIRECTORY)
+-get_filename_component(_Botan_PREFIX "${_Botan_PREFIX}" DIRECTORY)
+ 
+ %{if build_static_lib}
+ if(NOT TARGET Botan::Botan-static)
+   add_library(Botan::Botan-static STATIC IMPORTED)
+   set_target_properties(Botan::Botan-static
+     PROPERTIES
+-      IMPORTED_LOCATION                 "${_Botan_PREFIX}/lib/%{static_lib_name}"
+-      INTERFACE_INCLUDE_DIRECTORIES     "${_Botan_PREFIX}/include/botan-%{version_major}"
++      INTERFACE_INCLUDE_DIRECTORIES     "${_Botan_PREFIX}/include"
+       IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+       INTERFACE_LINK_OPTIONS            "SHELL:%{cxx_abi_flags}")
++  if(EXISTS "${_Botan_PREFIX}/debug/lib/%{static_lib_name}")
++    set_property(TARGET Botan::Botan-static APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
++    set_target_properties(Botan::Botan-static PROPERTIES
++      IMPORTED_LOCATION_DEBUG "${_Botan_PREFIX}/debug/lib/%{static_lib_name}"
++    )
++  endif()
++  set_property(TARGET Botan::Botan-static APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
++  set_target_properties(Botan::Botan-static PROPERTIES
++    IMPORTED_LOCATION_RELEASE "${_Botan_PREFIX}/lib/%{static_lib_name}"
++    )
+ endif()
+ %{endif}
+ 
+@@ -100,10 +108,20 @@ if(NOT TARGET Botan::Botan)
+   add_library(Botan::Botan SHARED IMPORTED)
+   set_target_properties(Botan::Botan
+     PROPERTIES
+-      IMPORTED_LOCATION             "${_Botan_shared_lib}"
+-      IMPORTED_IMPLIB               "${_Botan_implib}"
+-      INTERFACE_INCLUDE_DIRECTORIES "${_Botan_PREFIX}/include/botan-%{version_major}"
++      INTERFACE_INCLUDE_DIRECTORIES "${_Botan_PREFIX}/include"
+       INTERFACE_LINK_OPTIONS        "SHELL:%{cxx_abi_flags}")
++  if(EXISTS "${_Botan_PREFIX}/debug/lib/%{implib_name}")
++    set_property(TARGET Botan::Botan APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
++    set_target_properties(Botan::Botan PROPERTIES
++      IMPORTED_IMPLIB_DEBUG "${_Botan_PREFIX}/debug/lib/%{implib_name}"
++      IMPORTED_LOCATION_DEBUG "${_Botan_PREFIX}/debug/bin/%{shared_lib_name}"
++    )
++  endif()
++  set_property(TARGET Botan::Botan APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
++  set_target_properties(Botan::Botan PROPERTIES
++    IMPORTED_IMPLIB_RELEASE "${_Botan_PREFIX}/lib/%{implib_name}"
++    IMPORTED_LOCATION_RELEASE "${_Botan_PREFIX}/bin/%{shared_lib_name}"
++    )
+   set_property(TARGET Botan::Botan APPEND PROPERTY IMPORTED_CONFIGURATIONS NOCONFIG)
+   set_target_properties(Botan::Botan
+     PROPERTIES

--- a/ports/botan/libcxx-winpthread-fixes.patch
+++ b/ports/botan/libcxx-winpthread-fixes.patch
@@ -15,7 +15,7 @@
 @@ -627,6 +627,8 @@
     static_cast<void>(pthread_set_name_np(thread.native_handle(), name.c_str()));
     #elif defined(BOTAN_TARGET_OS_IS_NETBSD)
-    static_cast<void>(pthread_set_name_np(thread.native_handle(), "%s", const_cast<char*>(name.c_str())));
+    static_cast<void>(pthread_setname_np(thread.native_handle(), "%s", const_cast<char*>(name.c_str())));
 +   #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
 +   static_cast<void>(pthread_setname_np(thread.native_handle(), name.c_str()));
     #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(BOTAN_BUILD_COMPILER_IS_MSVC)

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO randombit/botan
     REF "${VERSION}"
-    SHA512 13f40635fc92b00b9392aa8ed96b5825f0cc8147d51337e2c225e0f29d0428732293190aa5fb2a7d2c5e7d57db748ae0fbed4536dee8af00e8d6fd405e784e1d
+    SHA512 5b3e22ad14bf0c37d97835c8309d1a5797cfab67b14ebfad9fd69a999ee27fe97d42ecff5e57e598d21575d053c07c30995f8c2d5f3a23433fb59d6bab45e1e7
     HEAD_REF master
     PATCHES
         embed-debug-info.patch
@@ -11,6 +11,7 @@ vcpkg_from_github(
         configure-zlib.patch
         fix_android.patch
         libcxx-winpthread-fixes.patch
+        fix-cmake-usage.patch
 )
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/configure" DESTINATION "${SOURCE_PATH}")
 
@@ -175,6 +176,8 @@ else()
         vcpkg_copy_tools(TOOL_NAMES botan AUTO_CLEAN)
     endif()
 endif()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Botan-3.3.0)
 
 file(RENAME "${CURRENT_PACKAGES_DIR}/include/botan-3/botan" "${CURRENT_PACKAGES_DIR}/include/botan")
 

--- a/ports/botan/vcpkg.json
+++ b/ports/botan/vcpkg.json
@@ -1,12 +1,15 @@
 {
   "name": "botan",
-  "version": "3.2.0",
-  "port-version": 1,
+  "version": "3.3.0",
   "description": "A cryptography library written in C++11",
   "homepage": "https://botan.randombit.net",
   "license": "BSD-2-Clause",
   "supports": "!uwp",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake-get-vars",
       "host": true

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -97,6 +97,10 @@ boringssl:x64-windows=skip
 boringssl:x64-windows-static=skip
 boringssl:x64-windows-static-md=skip
 boringssl:x86-windows=skip
+# Broken with NDK r25 and fixed in NDK r26
+botan:arm-neon-android=fail
+botan:arm64-android=fail
+botan:x64-android=fail
 brpc:x64-android=fail
 buck-yeh-bux:x64-android=fail
 c4core:arm-neon-android=fail

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "35b513ac4631f0d6986d8627b001f97f8b6bc934",
+      "git-tree": "559118768851fefb7f0bbcbf363863d907fd6a12",
       "version": "3.3.0",
       "port-version": 0
     },

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35b513ac4631f0d6986d8627b001f97f8b6bc934",
+      "version": "3.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c689678282e82a42d29348c05a022f237e54700",
       "version": "3.2.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1325,8 +1325,8 @@
       "port-version": 0
     },
     "botan": {
-      "baseline": "3.2.0",
-      "port-version": 1
+      "baseline": "3.3.0",
+      "port-version": 0
     },
     "box2d": {
       "baseline": "2.4.1",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/37068
Fixes https://github.com/microsoft/vcpkg/issues/35950
- Since the upstream's commit [2ff1de9](https://github.com/randombit/botan/commit/2ff1de9ff8d493d7b571bfa53ac9feca6a362bd4), upstream provided an option to generate cmake usage, but the generated config.cmake file does not fit the vcpkg environment, so I added a patch to make it compatible with the vcpkg system.

- All features and usage passed with following triplets:
  x86-windows 
  x64-windows 
  x64-windows-static 

- Since the commit https://github.com/randombit/botan/commit/3ab7159b02c35e7c62c11467edbf680090fba82e, the upstream added `#include <ranges>` in the source, which causes `Botan` to fail on Android platforms using `ndkr25`. Although this issue has been fixed in [`ndkr26`](https://github.com/android/ndk/wiki/Changelog-r26#changes), since vcpkg ci currently uses `ndkr25`, I have added the Botan android triplet to `ci.baseline.txt`.

- Update `libcxx-winpthread-fixes.patch` due to https://github.com/randombit/botan/commit/2fad3fd8b780b845dfcb1859fd94afb78debabd6.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
