### PR TITLE
[libe57] update to 1.1.334

### DIFF
--- a/ports/libe57/portfile.cmake
+++ b/ports/libe57/portfile.cmake
@@ -1,11 +1,10 @@
-set(VERSION 1.1.332)
 set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/E57RefImpl_src-${VERSION}")
 
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO e57-3d-imgfmt
     FILENAME "E57RefImpl_src-${VERSION}.zip"
-    SHA512 86adb88cff32d72905e923b1205d609a2bce2eabd78995c59a7957395b233766a5ce31481db08977117abc1a70bbed90d2ce0cdb9897704a8c63d992e91a3907
+    SHA512 0
     PATCHES 
         "0001_cmake.patch"
         "0002_replace_tr1_with_cpp11.patch"

--- a/ports/libe57/vcpkg.json
+++ b/ports/libe57/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libe57",
-  "version-semver": "1.1.332",
-  "port-version": 4,
+  "version-semver": "1.1.334",
   "description": "An open source implementation of the ASTM E2807 Standard Specification for 3D Imaging Data Exchange in the C++ language.",
   "homepage": "http://www.libe57.org/",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4289,8 +4289,8 @@
       "port-version": 1
     },
     "libe57": {
-      "baseline": "1.1.332",
-      "port-version": 4
+      "baseline": "1.1.334",
+      "port-version": 0
     },
     "libe57format": {
       "baseline": "3.1.1",

--- a/versions/l-/libe57.json
+++ b/versions/l-/libe57.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "490c66c815c9d1c25f45f6782b2734953adb32c4",
+      "version-semver": "1.1.334",
+      "port-version": 0
+    },
+    {
       "git-tree": "d5a7a88a7e28608ff30f48533cec32ac07f6f7c2",
       "version-semver": "1.1.332",
       "port-version": 4


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

