### PR TITLE
[libmediainfo] update to 24.01

### DIFF
--- a/ports/libmediainfo/portfile.cmake
+++ b/ports/libmediainfo/portfile.cmake
@@ -1,9 +1,8 @@
-string(REGEX REPLACE "^([0-9]+)[.]([1-9])\$" "\\1.0\\2" MEDIAINFO_VERSION "${VERSION}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MediaArea/MediaInfoLib
-    REF "v${MEDIAINFO_VERSION}"
-    SHA512 1407f5690415ccb7997cc9bcbe7d90980a52b1d06e543a446a0da8e4cb3f09ba8fcfbf6be80b043d7f76eeb2ba219242da1c34f3225e0f0bfe044b2394c0c3ae
+    REF "v${VERSION}"
+    SHA512 e664153197611647ee5496a0eb2105ac0574522585ecae2c51e35ea018a33a3da230158a4d1159e0abb5935ef953b7f841c6719eecfbba13de3fd9fdf06b8556
     HEAD_REF master
     PATCHES
         msvc-arm.diff

--- a/ports/libmediainfo/portfile.cmake
+++ b/ports/libmediainfo/portfile.cmake
@@ -1,7 +1,16 @@
+string(REGEX REPLACE "^([0-9]*)[.].*" "\\1" MAJOR "${VERSION}")
+string(REGEX REPLACE "^.*[.]([0-9]*)" "\\1" MINOR "${VERSION}")
+string(LENGTH "${MINOR}" minor_version_length )
+
+set (padding "")
+if(minor_version_length EQUAL 1)
+    set (padding "0")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MediaArea/MediaInfoLib
-    REF "v${VERSION}"
+    REF "v${MAJOR}.${padding}${MINOR}"
     SHA512 e664153197611647ee5496a0eb2105ac0574522585ecae2c51e35ea018a33a3da230158a4d1159e0abb5935ef953b7f841c6719eecfbba13de3fd9fdf06b8556
     HEAD_REF master
     PATCHES

--- a/ports/libmediainfo/portfile.cmake
+++ b/ports/libmediainfo/portfile.cmake
@@ -1,16 +1,8 @@
-string(REGEX REPLACE "^([0-9]*)[.].*" "\\1" MAJOR "${VERSION}")
-string(REGEX REPLACE "^.*[.]([0-9]*)" "\\1" MINOR "${VERSION}")
-string(LENGTH "${MINOR}" minor_version_length )
-
-set (padding "")
-if(minor_version_length EQUAL 1)
-    set (padding "0")
-endif()
-
+string(REGEX REPLACE "^([0-9]+)[.]([1-9])\$" "\\1.0\\2" MEDIAINFO_VERSION "${VERSION}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MediaArea/MediaInfoLib
-    REF "v${MAJOR}.${padding}${MINOR}"
+    REF "v${MEDIAINFO_VERSION}"
     SHA512 e664153197611647ee5496a0eb2105ac0574522585ecae2c51e35ea018a33a3da230158a4d1159e0abb5935ef953b7f841c6719eecfbba13de3fd9fdf06b8556
     HEAD_REF master
     PATCHES

--- a/ports/libmediainfo/vcpkg.json
+++ b/ports/libmediainfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmediainfo",
-  "version-string": "24.01",
+  "version-string": "24.1",
   "description": "Get most relevant technical and tag data from video and audio files",
   "homepage": "https://github.com/MediaArea/MediaInfoLib",
   "dependencies": [

--- a/ports/libmediainfo/vcpkg.json
+++ b/ports/libmediainfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmediainfo",
-  "version-string": "24.1",
+  "version": "24.1",
   "description": "Get most relevant technical and tag data from video and audio files",
   "homepage": "https://github.com/MediaArea/MediaInfoLib",
   "dependencies": [

--- a/ports/libmediainfo/vcpkg.json
+++ b/ports/libmediainfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmediainfo",
-  "version": "23.10",
+  "version-string": "24.01",
   "description": "Get most relevant technical and tag data from video and audio files",
   "homepage": "https://github.com/MediaArea/MediaInfoLib",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4593,7 +4593,7 @@
       "port-version": 0
     },
     "libmediainfo": {
-      "baseline": "24.01",
+      "baseline": "24.1",
       "port-version": 0
     },
     "libmesh": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4593,7 +4593,7 @@
       "port-version": 0
     },
     "libmediainfo": {
-      "baseline": "23.10",
+      "baseline": "24.01",
       "port-version": 0
     },
     "libmesh": {

--- a/versions/l-/libmediainfo.json
+++ b/versions/l-/libmediainfo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "037aa40c1bc9c47b14d92b9656aeda1605eb02a0",
+      "git-tree": "0ee3e4970dcbdc7d4393177cc89797bacb9b6cc5",
       "version": "24.1",
       "port-version": 0
     },

--- a/versions/l-/libmediainfo.json
+++ b/versions/l-/libmediainfo.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "bd7bb56bc78b0a390c9eb654a33b669fdb7e67d9",
-      "version-string": "24.01",
+      "git-tree": "037aa40c1bc9c47b14d92b9656aeda1605eb02a0",
+      "version": "24.1",
       "port-version": 0
     },
     {

--- a/versions/l-/libmediainfo.json
+++ b/versions/l-/libmediainfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd7bb56bc78b0a390c9eb654a33b669fdb7e67d9",
+      "version-string": "24.01",
+      "port-version": 0
+    },
+    {
       "git-tree": "e2bccca86faecebdacabafa1ff7b63e34168d342",
       "version": "23.10",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

