### PR TITLE
[libssh] update to 0.10.6

### DIFF
--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(distfile
     URLS https://www.libssh.org/files/0.10/libssh-${VERSION}.tar.xz
     FILENAME libssh-${VERSION}.tar.xz
-    SHA512 2b758f9df2b5937865d4aee775ffeafafe3ae6739a89dfc470e38c7394e3c3cb5fcf8f842fdae04929890ee7e47bf8f50e3a38e82dfd26a009f3aae009d589e0
+    SHA512 40c62d63c44e882999b71552c237d73fc7364313bd00b15a211a34aeff1b73693da441d2c8d4e40108d00fb7480ec7c5b6d472f9c0784b2359a179632ab0d6c1
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${distfile}"

--- a/ports/libssh/vcpkg.json
+++ b/ports/libssh/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libssh",
-  "version": "0.10.5",
-  "port-version": 1,
+  "version": "0.10.6",
   "description": "libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side",
   "homepage": "https://www.libssh.org/",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4953,8 +4953,8 @@
       "port-version": 1
     },
     "libssh": {
-      "baseline": "0.10.5",
-      "port-version": 1
+      "baseline": "0.10.6",
+      "port-version": 0
     },
     "libssh2": {
       "baseline": "1.11.0",

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e5c748bf2124bbd1eebe4ded850c5bc80ebf5ae",
+      "version": "0.10.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "000173abb6b45433339e0c85179bd3b4e4a36684",
       "version": "0.10.5",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

