### PR TITLE
[libunistring] update to 1.2

### DIFF
--- a/ports/libunistring/portfile.cmake
+++ b/ports/libunistring/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://ftp.gnu.org/gnu/libunistring/${LIBUNISTRING_FILENAME}"
         "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libunistring/${LIBUNISTRING_FILENAME}"
     FILENAME "${LIBUNISTRING_FILENAME}"
-    SHA512 01a4267bbd301ea5c389b17ee918ae5b7d645da8b2c6c6f0f004ff2dead9f8e50cda2c6047358890a5fceadc8820ffc5154879193b9bb8970f3fb1fea1f411d6
+    SHA512 5fbb5a0a864db73a6d18cdea7b31237da907fff0ef288f3a8db6ebdba8ef61ad8855e5fc780c2bbf632218d8fa59dd119734e5937ca64dc77f53f30f13b80b17
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/libunistring/vcpkg.json
+++ b/ports/libunistring/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libunistring",
-  "version": "1.1",
-  "port-version": 3,
+  "version": "1.2",
   "description": "GNU libunistring provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.",
   "homepage": "https://www.gnu.org/software/libunistring/",
   "license": "LGPL-3.0-or-later OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5049,8 +5049,8 @@
       "port-version": 0
     },
     "libunistring": {
-      "baseline": "1.1",
-      "port-version": 3
+      "baseline": "1.2",
+      "port-version": 0
     },
     "libunwind": {
       "baseline": "1.8.0",

--- a/versions/l-/libunistring.json
+++ b/versions/l-/libunistring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8074c00d32a1844c5ce8edbe3a9cad3a2e4f5ae",
+      "version": "1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2ba0cbad49845cff90c4368b3e2459a9fdd18c00",
       "version": "1.1",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

