### PR TITLE
[libvpx] update to 1.14.0

### DIFF
--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libvpx
     REF "v${VERSION}"
-    SHA512 49706838563c92fab7334376848d0f374efcbc1729ef511e967c908fd2ecd40e8d197f1d85da6553b3a7026bdbc17e5a76595319858af26ce58cb9a4c3854897
+    SHA512 724150c5cafa934e0a8dd9aebbab8afd25aa4f584734e0de37837ec2e8bdcbd9390acd7f883665be7ecdc27af93afda737a4dea7e3bd7531abffcc5bb7c2c7d2
     HEAD_REF master
     PATCHES
         0002-Fix-nasm-debug-format-flag.patch

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libvpx",
-  "version": "1.13.1",
-  "port-version": 2,
+  "version": "1.14.0",
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5105,8 +5105,8 @@
       "port-version": 2
     },
     "libvpx": {
-      "baseline": "1.13.1",
-      "port-version": 2
+      "baseline": "1.14.0",
+      "port-version": 0
     },
     "libwandio": {
       "baseline": "4.2.1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ddbeca8daf914bdf1d311003a58cf3d550dff62",
+      "version": "1.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "66ea767e9ce55da152694d49a74ad2125ca4d937",
       "version": "1.13.1",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

