### PR TITLE
liborigin: Fix installing import and static libraries with MSVC

### DIFF
--- a/ports/liborigin/fix-installing-import-library-with-MSVC.patch
+++ b/ports/liborigin/fix-installing-import-library-with-MSVC.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 24ebee5..a0b88b7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -78,7 +78,7 @@ if (BUILD_STATIC_LIBS)
+     add_library (origin_static STATIC $<TARGET_OBJECTS:origin>)
+     set_target_properties(origin_static PROPERTIES OUTPUT_NAME "origin" )
+     install( TARGETS origin_static
+-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     )
+ endif ()
+@@ -100,6 +100,7 @@ if (BUILD_SHARED_LIBS)
+     install( TARGETS origin_shared
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     )
+ endif ()
+ 

--- a/ports/liborigin/portfile.cmake
+++ b/ports/liborigin/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_sourceforge(
     REF liborigin/3.0
     FILENAME liborigin-${VERSION}.tar.gz
     SHA512 9fb5ae6d8aa8fb54e659482f8f5dc581b8d0ace2ebca7bb9f092b7ec753049d497491eb47ad89b12c8ddf7e19dc47f76e76c51ace789366370bd056d99e091ee
+    PATCHES
+        fix-installing-import-library-with-MSVC.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -20,11 +22,6 @@ vcpkg_cmake_build()
 vcpkg_cmake_install()
 
 vcpkg_fixup_pkgconfig()
-
-if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-  file(COPY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/origin.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
-  file(COPY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/origin.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
-endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/liborigin/vcpkg.json
+++ b/ports/liborigin/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "liborigin",
   "version": "3.0.2",
+  "port-version": 1,
   "description": "A library for reading OriginLab OPJ project files.",
   "homepage": "https://sourceforge.net/projects/liborigin/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4722,7 +4722,7 @@
     },
     "liborigin": {
       "baseline": "3.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libosip2": {
       "baseline": "5.3.1",

--- a/versions/l-/liborigin.json
+++ b/versions/l-/liborigin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1af8619df06f9a9519e035cd59b7bfe89f25b59d",
+      "version": "3.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "4ad9ef1e0eddb7bc93dbf08548d7daead3c5d73d",
       "version": "3.0.2",
       "port-version": 0


### PR DESCRIPTION

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
