### PR TITLE
[libzim] update to 9.1.0

### DIFF
--- a/ports/libzim/portfile.cmake
+++ b/ports/libzim/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openzim/libzim
     REF "${VERSION}"
-    SHA512 55d18535d677d3249c8331ceac1acd4afa650de1f61a0aa3ffc1c98ca2a395bc657c774d01780f1a2c2aedd7d9c5d2e7d9f5e717ed879de84dc6d1be6accfe5e
+    SHA512 0f365024c31ee350972292979f729a82181ea94c708fae31118b71efa03cbf462ad1b879d9e314c4f28819ff40d73c3808d30d91c10e2af0aa8a81686ff82770
     HEAD_REF main
     PATCHES
         cross-builds.diff

--- a/ports/libzim/vcpkg.json
+++ b/ports/libzim/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libzim",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "The Libzim is the reference implementation for the ZIM file format. It's a software library to read and write ZIM files on many systems and architectures. More information about the ZIM format and the openZIM project at https://openzim.org/.",
   "homepage": "https://github.com/openzim/libzim",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5277,7 +5277,7 @@
       "port-version": 0
     },
     "libzim": {
-      "baseline": "9.0.0",
+      "baseline": "9.1.0",
       "port-version": 0
     },
     "libzip": {

--- a/versions/l-/libzim.json
+++ b/versions/l-/libzim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e417f7dadb1e5a876c1ce8a93407e6cc0925e430",
+      "version": "9.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1b50ef00c5ff7e2ba8f3b064c8ffe6eb14a74f28",
       "version": "9.0.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

