### PR TITLE
[llhttp] update to 9.2.0

### DIFF
--- a/ports/llhttp/portfile.cmake
+++ b/ports/llhttp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nodejs/llhttp
     REF refs/tags/release/v${VERSION}
-    SHA512 971ec2cb403942bc43e4b67a6dd392bca10d4233a25f453550d9f2bfbcb9572df309bde77af030e94e2af840aec1d96de164df0cbb1183bb2f5623e8fcf3162c
+    SHA512 563a97301cc07ef8d64ee52572faaa705de0daf1bb428651ada0f22ea0bf7cc617c31883734d8786599c0eff223edfe637739169ee31da5b10f49db8c3ca6ed7
     PATCHES
         fix-usage.patch
 )

--- a/ports/llhttp/vcpkg.json
+++ b/ports/llhttp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "llhttp",
-  "version": "9.1.3",
+  "version": "9.2.0",
   "description": "Port of http_parser to llparse.",
   "homepage": "https://github.com/nodejs/llhttp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5337,7 +5337,7 @@
       "port-version": 0
     },
     "llhttp": {
-      "baseline": "9.1.3",
+      "baseline": "9.2.0",
       "port-version": 0
     },
     "llvm": {

--- a/versions/l-/llhttp.json
+++ b/versions/l-/llhttp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "563107afde7d8885774875d0adcbdaaf06798f7e",
+      "version": "9.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3422384dc0ec7e58827c138826bb666efe850eaa",
       "version": "9.1.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

