### PR TITLE
[litehtml] update to 0.9

### DIFF
--- a/ports/litehtml/portfile.cmake
+++ b/ports/litehtml/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO litehtml/litehtml
-    REF v0.6
-    SHA512 b774ed96e53780865e789875f571f96ebce1cd2ff0c05a06ae68a67aec44375cc282c07f77fc87131d422aceddba32bbf3e8e498c870883d8e042adb30834c39
+    REF "v${VERSION}"
+    SHA512 2a156671b770a6a20ab00184d9869af779248dd1fb898930b3b479ee88d8b7d84f51fdbd689ae4124530ab70c8697b6641cf06b220631ce4fec4622e63845ea3
     PATCHES 
       use-vcpkg-gumbo.patch
       fix-relative-includes.patch

--- a/ports/litehtml/vcpkg.json
+++ b/ports/litehtml/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "litehtml",
-  "version": "0.6.0",
-  "port-version": 2,
+  "version": "0.9",
   "description": "litehtml is the lightweight HTML rendering engine with CSS2/CSS3 support.",
   "homepage": "https://github.com/litehtml/litehtml",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5317,8 +5317,8 @@
       "port-version": 0
     },
     "litehtml": {
-      "baseline": "0.6.0",
-      "port-version": 2
+      "baseline": "0.9",
+      "port-version": 0
     },
     "live555": {
       "baseline": "2023-11-30",

--- a/versions/l-/litehtml.json
+++ b/versions/l-/litehtml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd2ad44eb53905a8289a36710294d228d9139398",
+      "version": "0.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "fbbd4d593d570ec75f5a02fea10a236aecc810d4",
       "version": "0.6.0",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

