### PR TITLE
[correlation-vector-cpp] new port

### DIFF
--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -1,16 +1,13 @@
 diff --git a/CorrelationVector/CMakeLists.txt b/CorrelationVector/CMakeLists.txt
-index 2b32f8b..7685b31 100644
+index 2b32f8b..2c3a0ec 100644
 --- a/CorrelationVector/CMakeLists.txt
 +++ b/CorrelationVector/CMakeLists.txt
-@@ -9,7 +9,10 @@ include (CVOptions)
+@@ -9,7 +9,7 @@ include (CVOptions)
  include (CVHelpers)
  
  add_global_definitions ()
 -set_global_compile_flags ()
 +#set_global_compile_flags ()
-+
-+# Necessary to create an export .lib file in case of dynamic linkage
-+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
  
  set(CORRELATION_VECTOR_VERSION_MAJOR 1)
  set(CORRELATION_VECTOR_VERSION_MINOR 0)

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -1,13 +1,16 @@
 diff --git a/CorrelationVector/CMakeLists.txt b/CorrelationVector/CMakeLists.txt
-index 2b32f8b..2c3a0ec 100644
+index 2b32f8b..7685b31 100644
 --- a/CorrelationVector/CMakeLists.txt
 +++ b/CorrelationVector/CMakeLists.txt
-@@ -9,7 +9,7 @@ include (CVOptions)
+@@ -9,7 +9,10 @@ include (CVOptions)
  include (CVHelpers)
  
  add_global_definitions ()
 -set_global_compile_flags ()
 +#set_global_compile_flags ()
++
++# Necessary to create an export .lib file in case of dynamic linkage
++set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
  
  set(CORRELATION_VECTOR_VERSION_MAJOR 1)
  set(CORRELATION_VECTOR_VERSION_MINOR 0)

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -25,7 +25,7 @@ index 6b389d5..9c4fb5a 100644
  include("${CMAKE_CURRENT_LIST_DIR}/correlation_vector-targets.cmake")
 \ No newline at end of file
 diff --git a/CorrelationVector/src/CMakeLists.txt b/CorrelationVector/src/CMakeLists.txt
-index 00baa66..5f11c75 100644
+index 00baa66..3f533cf 100644
 --- a/CorrelationVector/src/CMakeLists.txt
 +++ b/CorrelationVector/src/CMakeLists.txt
 @@ -15,16 +15,9 @@ else()
@@ -48,6 +48,15 @@ index 00baa66..5f11c75 100644
      endif()
  endif()
  
+@@ -71,7 +64,7 @@ if(CORRELATION_VECTOR_INSTALL)
+ 
+         install(
+                 FILES ${CV_PDB_FILES}
+-                DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                DESTINATION ${CMAKE_INSTALL_BINDIR}
+                 CONFIGURATIONS "Debug"
+                 OPTIONAL
+         )
 @@ -86,7 +79,7 @@ if(CORRELATION_VECTOR_INSTALL)
      install(
          EXPORT correlation_vector-targets

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -12,17 +12,20 @@ index 2b32f8b..2c3a0ec 100644
  set(CORRELATION_VECTOR_VERSION_MAJOR 1)
  set(CORRELATION_VECTOR_VERSION_MINOR 0)
 diff --git a/CorrelationVector/cmake/correlation_vector-config.in.cmake b/CorrelationVector/cmake/correlation_vector-config.in.cmake
-index 6b389d5..0c0bb72 100644
+index 6b389d5..9c4fb5a 100644
 --- a/CorrelationVector/cmake/correlation_vector-config.in.cmake
 +++ b/CorrelationVector/cmake/correlation_vector-config.in.cmake
-@@ -1 +1,4 @@
+@@ -1 +1,7 @@
 +# Optional dependency for Linux
-+find_package(unofficial-libuuid)
++if(UNIX)
++    include(CMakeFindDependencyMacro)
++    find_dependency(unofficial-libuuid)
++endif()
 +
  include("${CMAKE_CURRENT_LIST_DIR}/correlation_vector-targets.cmake")
 \ No newline at end of file
 diff --git a/CorrelationVector/src/CMakeLists.txt b/CorrelationVector/src/CMakeLists.txt
-index 00baa66..cc98572 100644
+index 00baa66..5f11c75 100644
 --- a/CorrelationVector/src/CMakeLists.txt
 +++ b/CorrelationVector/src/CMakeLists.txt
 @@ -15,16 +15,9 @@ else()
@@ -45,20 +48,13 @@ index 00baa66..cc98572 100644
      endif()
  endif()
  
-@@ -81,12 +74,12 @@ if(CORRELATION_VECTOR_INSTALL)
- 
-     install(
-         FILES "${CMAKE_CURRENT_BINARY_DIR}/correlation_vector-config.cmake"
--        DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CORRELATION_VECTOR_EXPORT_DIR}
-+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CORRELATION_VECTOR_EXPORT_DIR}"
-     )
+@@ -86,7 +79,7 @@ if(CORRELATION_VECTOR_INSTALL)
      install(
          EXPORT correlation_vector-targets
          FILE correlation_vector-targets.cmake
 -        NAMESPACE microsoft::
--        DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CORRELATION_VECTOR_EXPORT_DIR}
 +        NAMESPACE unofficial::microsoft::
-+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CORRELATION_VECTOR_EXPORT_DIR}"
+         DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CORRELATION_VECTOR_EXPORT_DIR}
      )
  endif()
 \ No newline at end of file

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -1,0 +1,37 @@
+diff --git a/CorrelationVector/CMakeLists.txt b/CorrelationVector/CMakeLists.txt
+index 2b32f8b..2c3a0ec 100644
+--- a/CorrelationVector/CMakeLists.txt
++++ b/CorrelationVector/CMakeLists.txt
+@@ -9,7 +9,7 @@ include (CVOptions)
+ include (CVHelpers)
+ 
+ add_global_definitions ()
+-set_global_compile_flags ()
++#set_global_compile_flags ()
+ 
+ set(CORRELATION_VECTOR_VERSION_MAJOR 1)
+ set(CORRELATION_VECTOR_VERSION_MINOR 0)
+diff --git a/CorrelationVector/src/CMakeLists.txt b/CorrelationVector/src/CMakeLists.txt
+index 00baa66..7058789 100644
+--- a/CorrelationVector/src/CMakeLists.txt
++++ b/CorrelationVector/src/CMakeLists.txt
+@@ -15,16 +15,9 @@ else()
+     if (WIN32)
+         target_compile_definitions(${TARGETNAME} PUBLIC GUID_WINDOWS)
+     elseif (UNIX)
+-        # apt-get install pkg-config uuid-dev
+-        find_package(PkgConfig REQUIRED)
+-        # TODO: move to FindUUID module
+-        pkg_check_modules(UUID uuid)
+-        if (UUID_FOUND)
+-            message("Found and using uuid.")
+-            target_include_directories(${TARGETNAME} PUBLIC ${UUID_INCLUDE_DIRS})
+-            target_link_libraries(${TARGETNAME} PRIVATE ${UUID_LIBRARIES})
+-            target_compile_definitions(${TARGETNAME} PUBLIC GUID_LIBUUID)
+-        endif()
++        find_package(unofficial-libuuid REQUIRED)
++        target_compile_definitions(${TARGETNAME} PUBLIC GUID_LIBUUID)
++        target_link_libraries(${TARGETNAME} PRIVATE uuid)
+     endif()
+ endif()
+ 

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -12,7 +12,7 @@ index 2b32f8b..2c3a0ec 100644
  set(CORRELATION_VECTOR_VERSION_MAJOR 1)
  set(CORRELATION_VECTOR_VERSION_MINOR 0)
 diff --git a/CorrelationVector/src/CMakeLists.txt b/CorrelationVector/src/CMakeLists.txt
-index 00baa66..08f3fc9 100644
+index 00baa66..23241fd 100644
 --- a/CorrelationVector/src/CMakeLists.txt
 +++ b/CorrelationVector/src/CMakeLists.txt
 @@ -15,16 +15,9 @@ else()
@@ -35,3 +35,19 @@ index 00baa66..08f3fc9 100644
      endif()
  endif()
  
+@@ -81,12 +74,12 @@ if(CORRELATION_VECTOR_INSTALL)
+ 
+     install(
+         FILES "${CMAKE_CURRENT_BINARY_DIR}/correlation_vector-config.cmake"
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CORRELATION_VECTOR_EXPORT_DIR}
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CORRELATION_VECTOR_EXPORT_DIR}"
+     )
+     install(
+         EXPORT correlation_vector-targets
+         FILE correlation_vector-targets.cmake
+         NAMESPACE microsoft::
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CORRELATION_VECTOR_EXPORT_DIR}
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CORRELATION_VECTOR_EXPORT_DIR}"
+     )
+ endif()
+\ No newline at end of file

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -12,7 +12,7 @@ index 2b32f8b..2c3a0ec 100644
  set(CORRELATION_VECTOR_VERSION_MAJOR 1)
  set(CORRELATION_VECTOR_VERSION_MINOR 0)
 diff --git a/CorrelationVector/src/CMakeLists.txt b/CorrelationVector/src/CMakeLists.txt
-index 00baa66..7058789 100644
+index 00baa66..08f3fc9 100644
 --- a/CorrelationVector/src/CMakeLists.txt
 +++ b/CorrelationVector/src/CMakeLists.txt
 @@ -15,16 +15,9 @@ else()
@@ -31,7 +31,7 @@ index 00baa66..7058789 100644
 -        endif()
 +        find_package(unofficial-libuuid REQUIRED)
 +        target_compile_definitions(${TARGETNAME} PUBLIC GUID_LIBUUID)
-+        target_link_libraries(${TARGETNAME} PRIVATE uuid)
++        target_link_libraries(${TARGETNAME} PRIVATE unofficial::UUID::uuid)
      endif()
  endif()
  

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -24,16 +24,27 @@ index 6b389d5..9c4fb5a 100644
 +
  include("${CMAKE_CURRENT_LIST_DIR}/correlation_vector-targets.cmake")
 \ No newline at end of file
-diff --git a/CorrelationVector/include/correlation_vector/guid.h b/CorrelationVector/include/correlation_vector/guid.h
-index 3886b54..bd7dfb1 100644
---- a/CorrelationVector/include/correlation_vector/guid.h
-+++ b/CorrelationVector/include/correlation_vector/guid.h
-@@ -11,7 +11,7 @@
- #if defined(GUID_WINDOWS)
- #include "Objbase.h"
- #elif defined(GUID_LIBUUID)
--#include <uuid/uuid.h>
-+#include <uuid.h>
+diff --git a/CorrelationVector/src/CMakeLists.txt b/CorrelationVector/src/CMakeLists.txt
+index 00baa66..08f3fc9 100644
+--- a/CorrelationVector/src/CMakeLists.txt
++++ b/CorrelationVector/src/CMakeLists.txt
+@@ -15,16 +15,9 @@ else()
+     if (WIN32)
+         target_compile_definitions(${TARGETNAME} PUBLIC GUID_WINDOWS)
+     elseif (UNIX)
+-        # apt-get install pkg-config uuid-dev
+-        find_package(PkgConfig REQUIRED)
+-        # TODO: move to FindUUID module
+-        pkg_check_modules(UUID uuid)
+-        if (UUID_FOUND)
+-            message("Found and using uuid.")
+-            target_include_directories(${TARGETNAME} PUBLIC ${UUID_INCLUDE_DIRS})
+-            target_link_libraries(${TARGETNAME} PRIVATE ${UUID_LIBRARIES})
+-            target_compile_definitions(${TARGETNAME} PUBLIC GUID_LIBUUID)
+-        endif()
++        find_package(unofficial-libuuid REQUIRED)
++        target_compile_definitions(${TARGETNAME} PUBLIC GUID_LIBUUID)
++        target_link_libraries(${TARGETNAME} PRIVATE unofficial::UUID::uuid)
+     endif()
+ endif()
  
- #elif defined(GUID_BOOST)
- #include <boost/uuid/uuid.hpp>

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -22,7 +22,7 @@ index 6b389d5..0c0bb72 100644
  include("${CMAKE_CURRENT_LIST_DIR}/correlation_vector-targets.cmake")
 \ No newline at end of file
 diff --git a/CorrelationVector/src/CMakeLists.txt b/CorrelationVector/src/CMakeLists.txt
-index 00baa66..23241fd 100644
+index 00baa66..cc98572 100644
 --- a/CorrelationVector/src/CMakeLists.txt
 +++ b/CorrelationVector/src/CMakeLists.txt
 @@ -15,16 +15,9 @@ else()
@@ -55,8 +55,9 @@ index 00baa66..23241fd 100644
      install(
          EXPORT correlation_vector-targets
          FILE correlation_vector-targets.cmake
-         NAMESPACE microsoft::
+-        NAMESPACE microsoft::
 -        DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CORRELATION_VECTOR_EXPORT_DIR}
++        NAMESPACE unofficial::microsoft::
 +        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CORRELATION_VECTOR_EXPORT_DIR}"
      )
  endif()

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -24,46 +24,16 @@ index 6b389d5..9c4fb5a 100644
 +
  include("${CMAKE_CURRENT_LIST_DIR}/correlation_vector-targets.cmake")
 \ No newline at end of file
-diff --git a/CorrelationVector/src/CMakeLists.txt b/CorrelationVector/src/CMakeLists.txt
-index 00baa66..3f533cf 100644
---- a/CorrelationVector/src/CMakeLists.txt
-+++ b/CorrelationVector/src/CMakeLists.txt
-@@ -15,16 +15,9 @@ else()
-     if (WIN32)
-         target_compile_definitions(${TARGETNAME} PUBLIC GUID_WINDOWS)
-     elseif (UNIX)
--        # apt-get install pkg-config uuid-dev
--        find_package(PkgConfig REQUIRED)
--        # TODO: move to FindUUID module
--        pkg_check_modules(UUID uuid)
--        if (UUID_FOUND)
--            message("Found and using uuid.")
--            target_include_directories(${TARGETNAME} PUBLIC ${UUID_INCLUDE_DIRS})
--            target_link_libraries(${TARGETNAME} PRIVATE ${UUID_LIBRARIES})
--            target_compile_definitions(${TARGETNAME} PUBLIC GUID_LIBUUID)
--        endif()
-+        find_package(unofficial-libuuid REQUIRED)
-+        target_compile_definitions(${TARGETNAME} PUBLIC GUID_LIBUUID)
-+        target_link_libraries(${TARGETNAME} PRIVATE unofficial::UUID::uuid)
-     endif()
- endif()
+diff --git a/CorrelationVector/include/correlation_vector/guid.h b/CorrelationVector/include/correlation_vector/guid.h
+index 3886b54..bd7dfb1 100644
+--- a/CorrelationVector/include/correlation_vector/guid.h
++++ b/CorrelationVector/include/correlation_vector/guid.h
+@@ -11,7 +11,7 @@
+ #if defined(GUID_WINDOWS)
+ #include "Objbase.h"
+ #elif defined(GUID_LIBUUID)
+-#include <uuid/uuid.h>
++#include <uuid.h>
  
-@@ -71,7 +64,7 @@ if(CORRELATION_VECTOR_INSTALL)
- 
-         install(
-                 FILES ${CV_PDB_FILES}
--                DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+                DESTINATION ${CMAKE_INSTALL_BINDIR}
-                 CONFIGURATIONS "Debug"
-                 OPTIONAL
-         )
-@@ -86,7 +79,7 @@ if(CORRELATION_VECTOR_INSTALL)
-     install(
-         EXPORT correlation_vector-targets
-         FILE correlation_vector-targets.cmake
--        NAMESPACE microsoft::
-+        NAMESPACE unofficial::microsoft::
-         DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CORRELATION_VECTOR_EXPORT_DIR}
-     )
- endif()
-\ No newline at end of file
+ #elif defined(GUID_BOOST)
+ #include <boost/uuid/uuid.hpp>

--- a/ports/correlation-vector-cpp/correlation-vector.patch
+++ b/ports/correlation-vector-cpp/correlation-vector.patch
@@ -11,6 +11,16 @@ index 2b32f8b..2c3a0ec 100644
  
  set(CORRELATION_VECTOR_VERSION_MAJOR 1)
  set(CORRELATION_VECTOR_VERSION_MINOR 0)
+diff --git a/CorrelationVector/cmake/correlation_vector-config.in.cmake b/CorrelationVector/cmake/correlation_vector-config.in.cmake
+index 6b389d5..0c0bb72 100644
+--- a/CorrelationVector/cmake/correlation_vector-config.in.cmake
++++ b/CorrelationVector/cmake/correlation_vector-config.in.cmake
+@@ -1 +1,4 @@
++# Optional dependency for Linux
++find_package(unofficial-libuuid)
++
+ include("${CMAKE_CURRENT_LIST_DIR}/correlation_vector-targets.cmake")
+\ No newline at end of file
 diff --git a/CorrelationVector/src/CMakeLists.txt b/CorrelationVector/src/CMakeLists.txt
 index 00baa66..23241fd 100644
 --- a/CorrelationVector/src/CMakeLists.txt

--- a/ports/correlation-vector-cpp/portfile.cmake
+++ b/ports/correlation-vector-cpp/portfile.cmake
@@ -14,7 +14,7 @@ set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(PACKAGE_NAME correlation_vector CONFIG_PATH lib/cmake/correlation_vector)
+vcpkg_cmake_config_fixup(PACKAGE_NAME correlation_vector CONFIG_PATH lib/correlation_vector)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 

--- a/ports/correlation-vector-cpp/portfile.cmake
+++ b/ports/correlation-vector-cpp/portfile.cmake
@@ -8,9 +8,6 @@ vcpkg_from_github(
         "correlation-vector.patch"
 )
 
-set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
-set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
-
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
@@ -24,9 +21,7 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}
 # Remove duplicated include files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Remove lib dir if empty due to configuration
-file(GLOB LIBDIR_FILES "${CURRENT_PACKAGES_DIR}/lib/*")
-list(LENGTH LIBDIR_FILES LIBDIR_FILES_LEN)
-if(LIBDIR_FILES_LEN EQUAL 0)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+# Remove bin dir if empty due to configuration. It is getting created when building in static linkage
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()

--- a/ports/correlation-vector-cpp/portfile.cmake
+++ b/ports/correlation-vector-cpp/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/CorrelationVector-Cpp
+    REF cf38d2b44baaf352509ad9980786bc49554c32e4
+    SHA512 f97eaef649ffd010fb79bca0ae6cb7ce6792dcb38f6a5180d04dc6542589d0d727583455bbafb319982cfed1291384180d49c7f32ebe7560b444ec132c76d0c4
+    HEAD_REF master
+    PATCHES
+        "correlation-vector.patch"
+)
+
+set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
+set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# Handle usage
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# Remove duplicated include files
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/correlation-vector-cpp/portfile.cmake
+++ b/ports/correlation-vector-cpp/portfile.cmake
@@ -8,7 +8,6 @@ vcpkg_from_github(
         "correlation-vector.patch"
 )
 
-# Using static linkage since library does not provide dll exports
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
@@ -20,11 +19,10 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME correlation_vector CONFIG_PATH lib/correla
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
-# Handle usage
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-# Remove duplicated include files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Remove bin dir which is always being created and not needed due to static linkage
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()

--- a/ports/correlation-vector-cpp/portfile.cmake
+++ b/ports/correlation-vector-cpp/portfile.cmake
@@ -7,13 +7,12 @@ vcpkg_from_github(
     PATCHES
         "correlation-vector.patch"
 )
-vcpkg_find_acquire_program(PKGCONFIG)
 
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}" OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(PACKAGE_NAME correlation_vector CONFIG_PATH lib/correlation_vector)

--- a/ports/correlation-vector-cpp/portfile.cmake
+++ b/ports/correlation-vector-cpp/portfile.cmake
@@ -7,12 +7,13 @@ vcpkg_from_github(
     PATCHES
         "correlation-vector.patch"
 )
+vcpkg_find_acquire_program(PKGCONFIG)
 
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}" OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(PACKAGE_NAME correlation_vector CONFIG_PATH lib/correlation_vector)

--- a/ports/correlation-vector-cpp/portfile.cmake
+++ b/ports/correlation-vector-cpp/portfile.cmake
@@ -8,6 +8,11 @@ vcpkg_from_github(
         "correlation-vector.patch"
 )
 
+# Using static linkage since library does not provide dll exports
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
@@ -21,7 +26,5 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}
 # Remove duplicated include files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Remove bin dir if empty due to configuration. It is getting created when building in static linkage
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
+# Remove bin dir which is always being created and not needed due to static linkage
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/correlation-vector-cpp/portfile.cmake
+++ b/ports/correlation-vector-cpp/portfile.cmake
@@ -14,6 +14,7 @@ set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(PACKAGE_NAME correlation_vector CONFIG_PATH lib/cmake/correlation_vector)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
@@ -22,3 +23,10 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}
 
 # Remove duplicated include files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Remove lib dir if empty due to configuration
+file(GLOB LIBDIR_FILES "${CURRENT_PACKAGES_DIR}/lib/*")
+list(LENGTH LIBDIR_FILES LIBDIR_FILES_LEN)
+if(LIBDIR_FILES_LEN EQUAL 0)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+endif()

--- a/ports/correlation-vector-cpp/usage
+++ b/ports/correlation-vector-cpp/usage
@@ -1,4 +1,4 @@
 The package CorrelationVector-Cpp provides CMake targets:
 
     find_package(correlation_vector CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE microsoft::correlation_vector)
+    target_link_libraries(main PRIVATE unofficial::microsoft::correlation_vector)

--- a/ports/correlation-vector-cpp/usage
+++ b/ports/correlation-vector-cpp/usage
@@ -1,4 +1,4 @@
 The package CorrelationVector-Cpp provides CMake targets:
 
     find_package(correlation_vector CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE unofficial::microsoft::correlation_vector)
+    target_link_libraries(main PRIVATE microsoft::correlation_vector)

--- a/ports/correlation-vector-cpp/usage
+++ b/ports/correlation-vector-cpp/usage
@@ -1,4 +1,4 @@
 The package CorrelationVector-Cpp provides CMake targets:
 
-    find_package(correlation_vector REQUIRED)
-    target_link_libraries(main PRIVATE correlation_vector)
+    find_package(correlation_vector CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE microsoft::correlation_vector)

--- a/ports/correlation-vector-cpp/usage
+++ b/ports/correlation-vector-cpp/usage
@@ -1,0 +1,4 @@
+The package CorrelationVector-Cpp provides CMake targets:
+
+    find_package(correlation_vector REQUIRED)
+    target_link_libraries(main PRIVATE correlation_vector)

--- a/ports/correlation-vector-cpp/vcpkg.json
+++ b/ports/correlation-vector-cpp/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "correlation-vector-cpp",
+  "version": "1.0",
+  "description": "CorrelationVector-Cpp provides a reference C++ implementation of the CorrelationVector protocol for tracing and correlation of events through a distributed system.",
+  "homepage": "https://github.com/microsoft/CorrelationVector-Cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "libuuid",
+      "platform": "!windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1824,6 +1824,10 @@
       "baseline": "2020.06",
       "port-version": 8
     },
+    "correlation-vector-cpp": {
+      "baseline": "1.0",
+      "port-version": 0
+    },
     "cpp-async": {
       "baseline": "1.1.0",
       "port-version": 0

--- a/versions/c-/correlation-vector-cpp.json
+++ b/versions/c-/correlation-vector-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e087ff5bf5a41952cc2d4ebafbed592ae2e7b9eb",
+      "version": "1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/correlation-vector-cpp.json
+++ b/versions/c-/correlation-vector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d9f2bcf5d377d6e0b83f2e1bd1c9d7316ef10c7",
+      "git-tree": "004b3aeae78d35b82ed9672a0d94340a82bfdc06",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/c-/correlation-vector-cpp.json
+++ b/versions/c-/correlation-vector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cf5c82ffb6229ece4e817dd3c07cf685516a5fc1",
+      "git-tree": "a2dde814a8c7fd5d0982c0e8ab9160a26b6fe34c",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/c-/correlation-vector-cpp.json
+++ b/versions/c-/correlation-vector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c54770569d35d26ed32181c0c5c42ada91d603bc",
+      "git-tree": "6d9f2bcf5d377d6e0b83f2e1bd1c9d7316ef10c7",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/c-/correlation-vector-cpp.json
+++ b/versions/c-/correlation-vector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a2dde814a8c7fd5d0982c0e8ab9160a26b6fe34c",
+      "git-tree": "c54770569d35d26ed32181c0c5c42ada91d603bc",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/c-/correlation-vector-cpp.json
+++ b/versions/c-/correlation-vector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e087ff5bf5a41952cc2d4ebafbed592ae2e7b9eb",
+      "git-tree": "66a186d01b3a0b241b2f6496c1a9473d1438462c",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/c-/correlation-vector-cpp.json
+++ b/versions/c-/correlation-vector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8f692cc82be783b2c631a620c6d42cf04d9074cc",
+      "git-tree": "cf5c82ffb6229ece4e817dd3c07cf685516a5fc1",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/c-/correlation-vector-cpp.json
+++ b/versions/c-/correlation-vector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "07dd16e8d73162b3968f01e29e97fa9c2e2ea7a9",
+      "git-tree": "8f692cc82be783b2c631a620c6d42cf04d9074cc",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/c-/correlation-vector-cpp.json
+++ b/versions/c-/correlation-vector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "66a186d01b3a0b241b2f6496c1a9473d1438462c",
+      "git-tree": "07dd16e8d73162b3968f01e29e97fa9c2e2ea7a9",
       "version": "1.0",
       "port-version": 0
     }


### PR DESCRIPTION
Closes #37229

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

The latest and only release is v1.0, but the latest commits have made a lot of fixes that properly enable CMake to work for external usages. Since the original maintainer has made no changes in a few years and 1.0 doesn't work, I'm putting the latest commit as 1.0.
