### PR TITLE
[botan] Fixes for building with clang/libc++/winpthreads.

### DIFF
--- a/ports/botan/libcxx-winpthread-fixes.patch
+++ b/ports/botan/libcxx-winpthread-fixes.patch
@@ -1,0 +1,23 @@
+--- a/src/tests/tests.h
++++ b/src/tests/tests.h
+@@ -17,6 +17,9 @@
+ #include <map>
+ #include <memory>
+ #include <optional>
++#ifndef __ANDROID__
++#include <ranges>
++#endif
+ #include <set>
+ #include <sstream>
+ #include <string>
+--- a/src/lib/utils/os_utils.cpp
++++ b/src/lib/utils/os_utils.cpp
+@@ -627,6 +627,8 @@
+    static_cast<void>(pthread_set_name_np(thread.native_handle(), name.c_str()));
+    #elif defined(BOTAN_TARGET_OS_IS_NETBSD)
+    static_cast<void>(pthread_set_name_np(thread.native_handle(), "%s", const_cast<char*>(name.c_str())));
++   #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
++   static_cast<void>(pthread_setname_np(thread.native_handle(), name.c_str()));
+    #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(BOTAN_BUILD_COMPILER_IS_MSVC)
+    typedef HRESULT(WINAPI * std_proc)(HANDLE, PCWSTR);
+    HMODULE kern = GetModuleHandleA("KernelBase.dll");

--- a/ports/botan/vcpkg.json
+++ b/ports/botan/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "botan",
   "version": "3.2.0",
+  "port-version": 1,
   "description": "A cryptography library written in C++11",
   "homepage": "https://botan.randombit.net",
   "license": "BSD-2-Clause",

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "58e4e0d2f8ecb96bd426a29704c21b53a8490e94",
+      "git-tree": "4c689678282e82a42d29348c05a022f237e54700",
       "version": "3.2.0",
       "port-version": 1
     },

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "58e4e0d2f8ecb96bd426a29704c21b53a8490e94",
+      "version": "3.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3482b0255e093b6d091aa4aff11992c89ec45d6e",
       "version": "3.2.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1326,7 +1326,7 @@
     },
     "botan": {
       "baseline": "3.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "box2d": {
       "baseline": "2.4.1",


### PR DESCRIPTION
This change allows building the botan port using the Clang toolchain in VS2022 and a custom libc++/winpthreads runtime (custom triplet based on https://github.com/Neumann-A/my-vcpkg-triplets/blob/master/x86-win-llvm.cmake), I have verified the port still builds using the vanilla MSVC compiler and runtime.

I'm not a regular contributor to vcpkg, so please let me know if any of the things I've changed here should be done differently.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.