### PR TITLE
[wxwidgets] Fix compilation for Windows XP.

### DIFF
--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         gtk3-link-libraries.patch
         sdl2.patch
         fix-glegl.patch
+        taskbar-winxp.patch
 )
 
 vcpkg_check_features(

--- a/ports/wxwidgets/taskbar-winxp.patch
+++ b/ports/wxwidgets/taskbar-winxp.patch
@@ -1,0 +1,20 @@
+--- a/src/msw/taskbar.cpp	2024-03-06 14:24:31.872935600 +0000
++++ b/src/msw/taskbar.cpp	2024-03-06 14:26:44.602376200 +0000
+@@ -258,13 +258,16 @@
+     wxUnusedVar(icon); // It's only unused if not supported actually.
+ 
+     // User specified icon is only supported since Vista
++#if _WIN32_WINNT >= 0x0600
+     if ( icon.IsOk() && wxPlatformInfo::Get().CheckOSVersion(6, 0) )
+     {
+         m_balloonIcon = icon.GetIconFor(m_win);
+         notifyData.hBalloonIcon = GetHiconOf(m_balloonIcon);
+         notifyData.dwInfoFlags |= NIIF_USER | NIIF_LARGE_ICON;
+     }
+-    else if ( flags & wxICON_INFORMATION )
++    else
++#endif
++        if ( flags & wxICON_INFORMATION )
+         notifyData.dwInfoFlags |= NIIF_INFO;
+     else if ( flags & wxICON_WARNING )
+         notifyData.dwInfoFlags |= NIIF_WARNING;

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wxwidgets",
   "version": "3.2.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9318,7 +9318,7 @@
     },
     "wxwidgets": {
       "baseline": "3.2.4",
-      "port-version": 1
+      "port-version": 2
     },
     "wyhash": {
       "baseline": "2023-12-03",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d7404652c204895f6825f87d7bbaabdfd3906c6",
+      "version": "3.2.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "4d0a489a0a24e703960f526ed1c40e8b7ae2a221",
       "version": "3.2.4",
       "port-version": 1


### PR DESCRIPTION
This change fixes compilation when `_WIN32_WINNT` is <0x0600, patch has also been submitted upstream and is pending merging into the 3.2 branch.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.