### PR TITLE
[linux ci] install libbluetooth-dev apt package for robotraconteur

### DIFF
--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -94,6 +94,9 @@ APT_PACKAGES="$APT_PACKAGES golang-go"
 ## required by libdecor and mesa
 APT_PACKAGES="$APT_PACKAGES wayland-protocols"
 
+## required by robotraconteur
+APT_PACKAGES="$APT_PACKAGES libbluetooth-dev"
+
 ## CUDA
 APT_PACKAGES="$APT_PACKAGES cuda-compiler-12-1 cuda-libraries-dev-12-1 cuda-driver-dev-12-1 \
   cuda-cudart-dev-12-1 libcublas-12-1 libcurand-dev-12-1 cuda-nvml-dev-12-1 libcudnn8-dev libnccl2 \


### PR DESCRIPTION
This PR adds `libbluetooth-dev` to the apt packages installed when provisioning the Linux CI image. `libbluetooth-dev` is a required system dependency to build `robotraconteur` on Linux. See https://github.com/microsoft/vcpkg/pull/36596 for the discussion of why this package is necessary.