### PR TITLE
[lunasvg] update to 2.3.9

### DIFF
--- a/ports/lunasvg/portfile.cmake
+++ b/ports/lunasvg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO sammycage/lunasvg
   REF "v${VERSION}"
-  SHA512 368f76ae3c04fbcb08406d9e7793af37b5e28ab90ffe0978fae8783620a45af3270fcd4e895c553e3e651f0ba07e37355acffd9f0aab1bf9ef822f465de21073
+  SHA512 912e5f8ab186ac8c9275096ec8a82d2cf958e1fd0bb30d35fa8287817fe279e7247e99e3629ed2de854fb1deb80dd105faf0ef16cf1cc14ad077850469e1bee8
   HEAD_REF master
   PATCHES
     fix-cmake.patch

--- a/ports/lunasvg/vcpkg.json
+++ b/ports/lunasvg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "lunasvg",
-  "version": "2.3.8",
-  "port-version": 1,
+  "version": "2.3.9",
   "description": "lunasvg is a standalone SVG rendering library in C++",
   "homepage": "https://github.com/sammycage/lunasvg",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5445,8 +5445,8 @@
       "port-version": 0
     },
     "lunasvg": {
-      "baseline": "2.3.8",
-      "port-version": 1
+      "baseline": "2.3.9",
+      "port-version": 0
     },
     "luv": {
       "baseline": "1.44.2",

--- a/versions/l-/lunasvg.json
+++ b/versions/l-/lunasvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4366912e559388c6d2d862fe3b0b6e1132dd433b",
+      "version": "2.3.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "27a82fac0168f7e17be4e9b8981833ed381197dc",
       "version": "2.3.8",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

