### PR TITLE
[luv] update to 1.48.0-2

### DIFF
--- a/ports/luv/portfile.cmake
+++ b/ports/luv/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luvit/luv
-    REF 1f255a7d87cef4a7eb10bd13bbd1e213980e8da2  #v1.44.2
-    SHA512 e9ee9ee6ca8f810c375f3310a119b518da8d15f6e3093aaa6069217f4e3d29a45426cc5e2233b6a8d90876867d9097c938a5b961fb6e46479c62145297f5bb82
+    REF "${VERSION}"
+    SHA512 605caf39b88938832849d9ac982001a3a720ce0b9044462e2f7038c2ba694cc9c5ad73622f8b6623e9afa821edd7361438e913f1a37908a965a6c118fc7b835d
     HEAD_REF master
     PATCHES fix-find-libuv.patch
             fix-find-luajit.patch

--- a/ports/luv/vcpkg.json
+++ b/ports/luv/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "luv",
-  "version-semver": "1.44.2",
-  "port-version": 1,
+  "version-semver": "1.48.0-2",
   "description": "Bare libuv bindings for lua",
   "homepage": "https://github.com/luvit/luv",
   "license": "Apache-2.0",
@@ -9,7 +8,7 @@
   "dependencies": [
     {
       "name": "libuv",
-      "version>=": "1.44.2"
+      "version>=": "1.48.0-2"
     },
     "lua-compat53",
     "luajit",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5449,8 +5449,8 @@
       "port-version": 1
     },
     "luv": {
-      "baseline": "1.44.2",
-      "port-version": 1
+      "baseline": "1.48.0-2",
+      "port-version": 0
     },
     "lv2": {
       "baseline": "1.18.2",

--- a/versions/l-/luv.json
+++ b/versions/l-/luv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00242ffe55e0ee0457eadfa05c67127a3321b66e",
+      "version-semver": "1.48.0-2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d18a8a0efcd76a0b4615d85c8bda26dd4ba1b7ad",
       "version-semver": "1.44.2",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

