### PR TITLE
[mdnsresponder] update to 2200.80.16

### DIFF
--- a/ports/mdnsresponder/portfile.cmake
+++ b/ports/mdnsresponder/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apple-oss-distributions/mDNSResponder
-    REF f783506af3836b39b83fc14115bc2728a49db4b2 #mDNSResponder-1557.140.5.0.1
-    SHA512 f5954d3f8ef40790e14d17de4cd861fc7df6900e54affefb8282f080a0bfc8b4ac9d238f2faaea6bb3849b342836e45f3b2cb9361402f89fcdce3c627a2b9b4d
+    REF "mDNSResponder-${VERSION}"
+    SHA512 883ecf0a700568555be0d59adbf979a783b1fd84ddd846246acbb63df83774efd87d25d655e74fb8e57832513bd7ae7ed8571b5a5ba4f679fc74cf16b1d24544
     HEAD_REF main
 )
 

--- a/ports/mdnsresponder/vcpkg.json
+++ b/ports/mdnsresponder/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mdnsresponder",
-  "version": "1557.140.5.0.1",
-  "port-version": 1,
+  "version": "2200.80.16",
   "description": "The mDNSResponder project is a component of Bonjour, Apple's ease-of-use IP networking initiative.",
   "homepage": "https://github.com/apple-oss-distributions/mDNSResponder",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5613,8 +5613,8 @@
       "port-version": 0
     },
     "mdnsresponder": {
-      "baseline": "1557.140.5.0.1",
-      "port-version": 1
+      "baseline": "2200.80.16",
+      "port-version": 0
     },
     "mdspan": {
       "baseline": "0.6.0",

--- a/versions/m-/mdnsresponder.json
+++ b/versions/m-/mdnsresponder.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fe38e3515a6079dc0395f90871c797491ad1ddcf",
+      "version": "2200.80.16",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c54f504ea29603c2a46be74893d406db0956336",
       "version": "1557.140.5.0.1",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

