### PR TITLE
[minizip-ng] update to 4.0.5

### DIFF
--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/minizip-ng
     REF "${VERSION}"
-    SHA512 2662ddf90666babe73474f6fc48f5a64f276d555b7a0f04f790b9edef570cb958356e900632c3795fb2053f4813c449240ff101d32b063eca4ad869bef0546fd
+    SHA512 760c540ccedd04c21d72ec7b41bc31a16e4291776580a6febb9400198440b3a64f39d4ba26be2608abf47b9dcc1ed266dad8bc0a8cacb607e4885c9dd05be0d6
     HEAD_REF master
     PATCHES
         fix_find_zstd.patch

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "minizip-ng",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5729,7 +5729,7 @@
       "port-version": 0
     },
     "minizip-ng": {
-      "baseline": "4.0.4",
+      "baseline": "4.0.5",
       "port-version": 0
     },
     "mio": {

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ca6fa97c975c5c3ccac257be25a5b41232f2bc2",
+      "version": "4.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "cfab4e259bccd7d7f1a0470b32c7b7bf912609f4",
       "version": "4.0.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

