### PR TITLE
[monkeys-audio] update to 10.52

### DIFF
--- a/ports/monkeys-audio/portfile.cmake
+++ b/ports/monkeys-audio/portfile.cmake
@@ -5,7 +5,7 @@ set(MA_VERSION 1008)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://monkeysaudio.com/files/MAC_${MA_VERSION}_SDK.zip"
     FILENAME "MAC_${MA_VERSION}_SDK.zip"
-    SHA512 0c96b6fa8da9d412679e8c9b43e98d475a650899694a9d085c3b0272775cf229bb09c7c4f24a18ab7ee5516d2d34f7acd59e4216aca8fe08ed04f75e33e29322
+    SHA512 28b214ec72d6ead4be082bd85e8f5a108c922e589a4391404f87a2a8165265960241083fc7fa0a8626b473cd12b2281fdcd74b4ea361b109d1c80d5611fc26c2
 )
 
 vcpkg_extract_source_archive(

--- a/ports/monkeys-audio/vcpkg.json
+++ b/ports/monkeys-audio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "monkeys-audio",
-  "version-string": "10.08",
-  "port-version": 1,
+  "version-string": "10.52",
   "description": [
     "Monkey's Audio is an excellent audio compression tool which has multiple advantages over traditional methods.",
     "Audio files compressed with it end with .ape extension."


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

