### PR TITLE
[nameof] update to 0.10.4

### DIFF
--- a/ports/nameof/portfile.cmake
+++ b/ports/nameof/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/nameof
     REF "v${VERSION}"
-    SHA512 2b0bad2a3309202bcd6e361c2f2d4a61b474359a6c2df0a8b9e1a6c9e077bbf0c0d18dc5b603ecb4f82cc1f74656aae51e52ece0f7049ac3f75b593f14542b93
+    SHA512 88eff4fb9a137c388b39d67eb9e213ed93e6a553dd1295d5db04c6fbc254f6df3da8800de2e0675f574bb3f83ae05141f71efe30ccdd4601a42cf19adaea6e79
     HEAD_REF master
 )
 

--- a/ports/nameof/vcpkg.json
+++ b/ports/nameof/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nameof",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Nameof operator for modern C++, simply obtain the name of a variable, type, function, macro, and enum.",
   "homepage": "https://github.com/Neargye/nameof",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5945,7 +5945,7 @@
       "port-version": 1
     },
     "nameof": {
-      "baseline": "0.10.3",
+      "baseline": "0.10.4",
       "port-version": 0
     },
     "nana": {

--- a/versions/n-/nameof.json
+++ b/versions/n-/nameof.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60e906146f2d83899688b0f478dcabaad9aaeace",
+      "version": "0.10.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "f82961138b18791ffba3efef021f008c467988fb",
       "version": "0.10.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

