### PR TITLE
[nanomsg] update to 1.2.1

### DIFF
--- a/ports/nanomsg/portfile.cmake
+++ b/ports/nanomsg/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nanomsg/nanomsg
-    REF 1.2
-    SHA512 377b3a0b4be6d6decd2711ff84ac1855ae0a298e7557dbe4b7d881c2a76f4e521671b47987b924c434afdad7ff1dfebb50982c8c0afca9b44682c898510d4c92
+    REF "${VERSION}"
+    SHA512 cc119acafe6e000b75299e866b4bace56ec6d8c90e7843ad773efad7b534296d6baf2b75b107c70a0e4fd4cee9763315d87b6f354676b7915732961b89c3adcb
     HEAD_REF master
 )
 

--- a/ports/nanomsg/vcpkg.json
+++ b/ports/nanomsg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nanomsg",
-  "version-semver": "1.2.0",
-  "port-version": 1,
+  "version-semver": "1.2.1",
   "description": [
     "A simple high-performance implementation of several \"scalability protocols\".",
     "These scalability protocols are light-weight messaging protocols which can be used to solve a number of very common messaging patterns, such as request/reply, publish/subscribe, surveyor/respondent, and so forth. These protocols can run over a variety of transports such as TCP, UNIX sockets, and even WebSocket."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5977,8 +5977,8 @@
       "port-version": 0
     },
     "nanomsg": {
-      "baseline": "1.2.0",
-      "port-version": 1
+      "baseline": "1.2.1",
+      "port-version": 0
     },
     "nanopb": {
       "baseline": "0.4.7",

--- a/versions/n-/nanomsg.json
+++ b/versions/n-/nanomsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f153ee28346c2ba03410c8845959d1d549322ecb",
+      "version-semver": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "776c37386c83ec3b242fb17bf418f4a22e5cc300",
       "version-semver": "1.2.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

