### PR TITLE
[nanopb] update to 0.4.8

### DIFF
--- a/ports/nanopb/portfile.cmake
+++ b/ports/nanopb/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nanopb/nanopb
-    REF 0.4.7
-    SHA512 7fb46dad8a432898c8f9e7faa90a55276670dea3b13f15b68010fe126d7f6251ef5715d0dfe5bce66582e80cfdc5d4b1e7f5947e96a058fa7181f0a45da20860
+    REF "${VERSION}"
+    SHA512 635577498dfbfb46fd64b8ec83b2a4a9b03b57c665f3c9f67d35c272810c0330b0e9011d7c0e43623e9da74d6ee3a4c1f012878e2bff7e1a7e57fb7c0857ad42
     HEAD_REF master
     PATCHES 
         fix-cmakelist-and-pb-header.patch

--- a/ports/nanopb/vcpkg.json
+++ b/ports/nanopb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nanopb",
-  "version-semver": "0.4.7",
-  "port-version": 2,
+  "version-semver": "0.4.8",
   "description": "A small code-size Protocol Buffers implementation in ANSI C.",
   "homepage": "https://jpa.kapsi.fi/nanopb/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5981,8 +5981,8 @@
       "port-version": 1
     },
     "nanopb": {
-      "baseline": "0.4.7",
-      "port-version": 2
+      "baseline": "0.4.8",
+      "port-version": 0
     },
     "nanoprintf": {
       "baseline": "0.3.4",

--- a/versions/n-/nanopb.json
+++ b/versions/n-/nanopb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5989b5e9f65a629e1c3d5ab9dcdcd689ea046f67",
+      "version-semver": "0.4.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "b27e85ab51605be4fee299a1dcb14f4fe0ac2429",
       "version-semver": "0.4.7",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

