### PR TITLE
[netcdf-c] update to 4.9.2

### DIFF
--- a/ports/netcdf-c/portfile.cmake
+++ b/ports/netcdf-c/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Unidata/netcdf-c
-    REF cd6173f472b778fa0e558982c59f7183aa5b8e47 # v4.8.1
-    SHA512 e965b9c865f31abcd0ae045cb709a41710e72bcf5bd237972cd62688f0f099f1b12be316a448d22315b1c73eb99fae3ea38072e9a3646a4f70ba42507d82f537
+    REF "v${VERSION}"
+    SHA512 e0c299843083cde54bfaccebd4f831513c2c531f3a98e37a1bc14d12a5e63af0b994cab9292bcb17e1b162ffe26b49ed3f9c6de7f2f48cdfcfd3f3c4a377bb04
     HEAD_REF master
     PATCHES
         no-install-deps.patch

--- a/ports/netcdf-c/vcpkg.json
+++ b/ports/netcdf-c/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "netcdf-c",
-  "version": "4.8.1",
-  "port-version": 5,
+  "version": "4.9.2",
   "description": "A set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.",
   "homepage": "https://github.com/Unidata/netcdf-c",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6041,8 +6041,8 @@
       "port-version": 0
     },
     "netcdf-c": {
-      "baseline": "4.8.1",
-      "port-version": 5
+      "baseline": "4.9.2",
+      "port-version": 0
     },
     "netcdf-cxx4": {
       "baseline": "4.3.1",

--- a/versions/n-/netcdf-c.json
+++ b/versions/n-/netcdf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad325282719896ad62436a8a37b45902a0519c40",
+      "version": "4.9.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e93ab8e5b418fbc359d4e1dcb888e2e050c83f49",
       "version": "4.8.1",
       "port-version": 5


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

