### PR TITLE
[nghttp2] update to 1.60.0

### DIFF
--- a/ports/nghttp2/portfile.cmake
+++ b/ports/nghttp2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nghttp2/nghttp2
     REF v${VERSION}
-    SHA512 bcb53ff45afae003f11a9feaa21dd80a3abfcde9b3a7fd1f04fc4382d71b5d4430e2d015765a7ae8d68454fcf06e4560c4cb585133aefb237d6ea526f61a8ebd
+    SHA512 1526418b0cf8e065f00589c5abd0b4ebd32a3128fbedd7c1f8fc9a76b8b2ad9713a8f4b056d29fce454559fe9227392c59dcdffaa665249df94a1fcf85fcfc53
     HEAD_REF master
 )
 

--- a/ports/nghttp2/vcpkg.json
+++ b/ports/nghttp2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nghttp2",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "description": "Implementation of the Hypertext Transfer Protocol version 2 in C",
   "homepage": "https://github.com/nghttp2/nghttp2",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6065,7 +6065,7 @@
       "port-version": 4
     },
     "nghttp2": {
-      "baseline": "1.59.0",
+      "baseline": "1.60.0",
       "port-version": 0
     },
     "nghttp2-asio": {

--- a/versions/n-/nghttp2.json
+++ b/versions/n-/nghttp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4e6fc03c163caccab50f417a533ebe4c2393130",
+      "version": "1.60.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b5a94a4eb9a90dcd3b34534bd14768d94e7e538",
       "version": "1.59.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

