### PR TITLE
[ngtcp2] update to 1.3.0

### DIFF
--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ngtcp2/ngtcp2
     REF "v${VERSION}"
-    SHA512 3d266b80fbc44bf0711f4791db4787d80c989beb84ff4fe33e0f8fd25b8bb6d6d768bcbf990ca4bde0bcbaad5c7566bfb6a431b5bbec844247d8a4b417d451d9
+    SHA512 b2da92da68424678c4c2f24da3fff88d425a5db231f12f44f979da97f1ed65945e2775f730d8d397d82c39047f4d7c8045d667450ac6822392f4bb99f6224a1f
     HEAD_REF master
     PATCHES
       export-unofficical-target.patch

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ngtcp2",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6081,7 +6081,7 @@
       "port-version": 0
     },
     "ngtcp2": {
-      "baseline": "1.2.0",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "nifly": {

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52d70411928cd52e202159e36fe44b6f9b8a757a",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "afc1585394c775f2989331db3baaa1b2c7449516",
       "version": "1.2.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

