### PR TITLE
[ffnvcodec] update to 12.1.14.0

### DIFF
--- a/ports/ffnvcodec/portfile.cmake
+++ b/ports/ffnvcodec/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FFmpeg/nv-codec-headers
     REF "n${VERSION}"
-    SHA512 386e4e1e0606a5ebd95c0ca60a2cdbadd1e24ac64df65f707dd00ee1fc822f56535637eaf4a375dd25f2f91fb00ffabb95953a1bab9fc101d1c522e2954f37c0
+    SHA512 3c7d06e6a859cab5b915035544cb0103b1b1413c69ac418bc668145445498e1f9cb6ec597c4071f6198e378f6cea60e5a7b0be44b0de3191d65609d50dfdad4a
     HEAD_REF master
 )
 

--- a/ports/ffnvcodec/vcpkg.json
+++ b/ports/ffnvcodec/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ffnvcodec",
-  "version": "11.1.5.3",
+  "version": "12.1.14.0",
   "description": "FFmpeg version of Nvidia Codec SDK headers.",
   "homepage": "https://github.com/FFmpeg/nv-codec-headers",
   "supports": "linux | (!osx & !uwp & !(arm64 & windows))"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2649,7 +2649,7 @@
       "port-version": 2
     },
     "ffnvcodec": {
-      "baseline": "11.1.5.3",
+      "baseline": "12.1.14.0",
       "port-version": 0
     },
     "fftw3": {

--- a/versions/f-/ffnvcodec.json
+++ b/versions/f-/ffnvcodec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95b6f37a43dab098bf4be5c84e15e47a86cf7960",
+      "version": "12.1.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1e9c042e433dca081ec8f18d57d19851bc6182a3",
       "version": "11.1.5.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

