### PR TITLE
[omniorb] update to 4.3.2

### DIFF
--- a/ports/omniorb/portfile.cmake
+++ b/ports/omniorb/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://netcologne.dl.sourceforge.net/project/omniorb/omniORB/omniORB-4.3.0/omniORB-4.3.0.tar.bz2"
+    URLS "https://netcologne.dl.sourceforge.net/project/omniorb/omniORB/omniORB-${VERSION}/omniORB-${VERSION}.tar.bz2"
     FILENAME "omniORB-${VERSION}.tar.bz2"
-    SHA512 b081c1acbea3c7bee619a288fec209a0705b7d436f8e5fd4743675046356ef271a8c75882334fcbde4ff77d15f54d2da55f6cfcd117b01e42919d04fd29bfe2f
+    SHA512 a17744259042e65bd18172036d85f413d49f473a5ea6ce8ce616a3d33bb4509c4b526df78dd302a304512d163b27e4b4274b0bac9ccbaa29b08e417075d77b6b
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/omniorb/vcpkg.json
+++ b/ports/omniorb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "omniorb",
-  "version": "4.3.0",
-  "port-version": 2,
+  "version": "4.3.2",
   "description": "omniORB is a robust high performance CORBA ORB for C++",
   "homepage": "https://omniorb.sourceforge.io/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6289,8 +6289,8 @@
       "port-version": 1
     },
     "omniorb": {
-      "baseline": "4.3.0",
-      "port-version": 2
+      "baseline": "4.3.2",
+      "port-version": 0
     },
     "ompl": {
       "baseline": "1.5.1",

--- a/versions/o-/omniorb.json
+++ b/versions/o-/omniorb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c29da9ad8b57ed1243a56134b922bb5c454eeb07",
+      "version": "4.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "cca89d0b204e2a74c3e822ef7f8b4878886239d4",
       "version": "4.3.0",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

