### PR TITLE
[ompl] update to 1.6.0

### DIFF
--- a/ports/ompl/portfile.cmake
+++ b/ports/ompl/portfile.cmake
@@ -7,13 +7,11 @@ else()
     vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
-set(OMPL_VERSION 1.5.1)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ompl/ompl
-    REF 1.5.1
-    SHA512 2f28d29f32f3bb03e67b29ce251e4786364847a25e3c4cf66d7663ed38dca4da71d4e03cf9ce647710d9524a3907c76c09795e77f041cb8822f695d28f5ca570
+    REF "${VERSION}"
+    SHA512 d1024d7cc8e309a1df94a950be67eefae1e66abaccd6b6b8980939559aee3d73c05c838ab24c818b6b57ce6c4b3181fde7595d3d1dd36d6cd0c6d125338084ac
     HEAD_REF master
     PATCHES
         0001_Export_targets.patch

--- a/ports/ompl/vcpkg.json
+++ b/ports/ompl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ompl",
-  "version": "1.5.1",
-  "port-version": 5,
+  "version": "1.6.0",
   "description": "The Open Motion Planning Library, consists of many state-of-the-art sampling-based motion planning algorithms",
   "homepage": "https://ompl.kavrakilab.org/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6293,8 +6293,8 @@
       "port-version": 2
     },
     "ompl": {
-      "baseline": "1.5.1",
-      "port-version": 5
+      "baseline": "1.6.0",
+      "port-version": 0
     },
     "omplapp": {
       "baseline": "1.5.1",

--- a/versions/o-/ompl.json
+++ b/versions/o-/ompl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "966ff2b855ecec90ee992450afab5d4ea6b2dd5d",
+      "version": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "262729470ab00b469cfb9d63e196ebf4006d35cd",
       "version": "1.5.1",
       "port-version": 5


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

