### PR TITLE
[optional-lite] update to 3.6.0

### DIFF
--- a/ports/optional-lite/portfile.cmake
+++ b/ports/optional-lite/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinmoene/optional-lite
-    REF v3.5.0
-    SHA512 e578d391bc95e2a5302b4b02e0b17659026b2743fc5c1e16cd83f6227fa9b5990fa3fa23e808a4ea0f5bdafbf80834b0c462d563ab615907f113ee5a09ae88f5
+    REF "v${VERSION}"
+    SHA512 6ec7dbd11947376cc46502cdab866e171fca7123b317887889022d22b003e4fd96d26816046e8e24b1b83fb5190ae6232cbbacfcb20fcb78200878bd73d7adc4
 )
 
 vcpkg_cmake_configure(

--- a/ports/optional-lite/vcpkg.json
+++ b/ports/optional-lite/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "optional-lite",
-  "version": "3.5.0",
-  "port-version": 1,
+  "version": "3.6.0",
   "description": "A C++17-like optional, a nullable object for C++98, C++11 and later in a single-file header-only library",
   "homepage": "https://github.com/martinmoene/optional-lite",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6525,8 +6525,8 @@
       "port-version": 3
     },
     "optional-lite": {
-      "baseline": "3.5.0",
-      "port-version": 1
+      "baseline": "3.6.0",
+      "port-version": 0
     },
     "opus": {
       "baseline": "1.4",

--- a/versions/o-/optional-lite.json
+++ b/versions/o-/optional-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15df59b4622c57d3191829231ed161faa74e94db",
+      "version": "3.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "224a4268fcaf8ff0756fce0de1818939e95cbbc4",
       "version": "3.5.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

