### PR TITLE
[xtl] Update to 0.7.7

### DIFF
--- a/ports/xtl/fix-fixup-cmake.patch
+++ b/ports/xtl/fix-fixup-cmake.patch
@@ -34,3 +34,16 @@ index 2429881..a816142 100644
  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
 -        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig/")
 +        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+diff --git a/xtlConfig.cmake.in b/xtlConfig.cmake.in
+index 936eef1..ef392c6 100644
+--- a/xtlConfig.cmake.in
++++ b/xtlConfig.cmake.in
+@@ -13,6 +13,8 @@
+ #   xtl_INCLUDE_DIRS - the directory containing xtl headers
+ #   xtl_LIBRARY - empty
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(nlohmann_json)
+ @PACKAGE_INIT@
+ 
+ if(NOT TARGET @PROJECT_NAME@)

--- a/ports/xtl/fix-fixup-cmake.patch
+++ b/ports/xtl/fix-fixup-cmake.patch
@@ -1,8 +1,25 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cbc6651..4e31f71 100644
+index 2429881..a816142 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -122,7 +122,7 @@ install(FILES ${XTL_HEADERS}
+@@ -30,7 +30,7 @@ message(STATUS "xtl v${${PROJECT_NAME}_VERSION}")
+ # ============
+ 
+ if(NOT TARGET nlohmann_json)
+-    find_package(nlohmann_json QUIET)
++    find_package(nlohmann_json CONFIG REQUIRED)
+ endif()
+ 
+ # Build
+@@ -85,6 +85,7 @@ set_target_properties(xtl
+ endif()
+ 
+ target_compile_features(xtl INTERFACE cxx_std_14)
++target_link_libraries(xtl INTERFACE nlohmann_json::nlohmann_json)
+ 
+ option(BUILD_TESTS "xtl test suite" OFF)
+ option(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
+@@ -119,7 +120,7 @@ install(FILES ${XTL_HEADERS}
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xtl)
  endif()
  
@@ -11,7 +28,7 @@ index cbc6651..4e31f71 100644
      STRING "install path for xtlConfig.cmake")
  
  configure_package_config_file(${PROJECT_NAME}Config.cmake.in
-@@ -157,4 +157,4 @@ configure_file(${PROJECT_NAME}.pc.in
+@@ -154,4 +155,4 @@ configure_file(${PROJECT_NAME}.pc.in
                 "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
                  @ONLY)
  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"

--- a/ports/xtl/portfile.cmake
+++ b/ports/xtl/portfile.cmake
@@ -4,11 +4,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtl
     REF "${VERSION}"
-    SHA512 fb447334f68f255d7d28c9202eee2cec70d007c1031f3756a6acd0cc019c0d95ed1d12ec63f2e9fb3df184f9ec305e6a3c808bb88c1e3eb922916ad059d2e856
+    SHA512 07c2a68db3dbac556dbb0397e54792ddc7a3e87573bff04faa4262dc433b710392ff9c915d428f5abd1ae892ac9bc7744645e75fdb2bb2cee83c523e087c793e
     HEAD_REF master
     PATCHES
         fix-fixup-cmake.patch
 )
+
+set(VCPKG_BUILD_TYPE release)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -19,10 +21,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
-
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/xtl)
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(APPEND "${CURRENT_PACKAGES_DIR}/share/xtl/xtlConfig.cmake" "include(CMakeFindDependencyMacro)\nfind_dependency(nlohmann_json)\n")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xtl/portfile.cmake
+++ b/ports/xtl/portfile.cmake
@@ -24,6 +24,4 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/xtl)
 vcpkg_fixup_pkgconfig()
 
-file(APPEND "${CURRENT_PACKAGES_DIR}/share/xtl/xtlConfig.cmake" "include(CMakeFindDependencyMacro)\nfind_dependency(nlohmann_json)\n")
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xtl/vcpkg.json
+++ b/ports/xtl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xtl",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "description": "The x template library",
   "homepage": "https://github.com/xtensor-stack/xtl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9417,7 +9417,7 @@
       "port-version": 1
     },
     "xtl": {
-      "baseline": "0.7.5",
+      "baseline": "0.7.7",
       "port-version": 0
     },
     "xtrans": {

--- a/versions/x-/xtl.json
+++ b/versions/x-/xtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8c50a22df0f3861827aa7159a6445b9810874b7",
+      "version": "0.7.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "f5cad9625b1b7459135265c4f8647b2bcae0e252",
       "version": "0.7.5",
       "port-version": 0

--- a/versions/x-/xtl.json
+++ b/versions/x-/xtl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b8c50a22df0f3861827aa7159a6445b9810874b7",
+      "git-tree": "854560a164cf34eea22f3757ea47927d32979179",
       "version": "0.7.7",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
