### PR TITLE
[argh] Fix cmake config fixup

### DIFF
--- a/ports/argh/portfile.cmake
+++ b/ports/argh/portfile.cmake
@@ -25,6 +25,6 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
 endif()
 vcpkg_cmake_config_fixup(CONFIG_PATH "${CONFIG_PATH}")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc" "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/argh/portfile.cmake
+++ b/ports/argh/portfile.cmake
@@ -3,10 +3,12 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO adishavit/argh
-    REF v1.3.2
+    REF "v${VERSION}"
     SHA512 66073718ef1fc31fbd0feb9daf366a2e28c759de44fb1882dc46a6d10f7a44635ae1155882dff916f55c51fad88bedebdfe361418f7669fac241feead68f2b5b
     HEAD_REF master
 )
+
+set(VCPKG_BUILD_TYPE release)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -16,15 +18,8 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
-if(EXISTS "${CURRENT_PACKAGES_DIR}/CMake")
-    vcpkg_cmake_config_fixup(CONFIG_PATH CMake)
-elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}")
-    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
-endif()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/argh/portfile.cmake
+++ b/ports/argh/portfile.cmake
@@ -18,7 +18,12 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+
+set(CONFIG_PATH lib/cmake/argh)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
+    set(CONFIG_PATH cmake)
+endif()
+vcpkg_cmake_config_fixup(CONFIG_PATH "${CONFIG_PATH}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
 

--- a/ports/argh/vcpkg.json
+++ b/ports/argh/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "argh",
   "version": "1.3.2",
+  "port-version": 1,
   "description": "Argh! A minimalist argument handler.",
   "homepage": "https://github.com/adishavit/argh",
   "license": "BSD-3-Clause",

--- a/versions/a-/argh.json
+++ b/versions/a-/argh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f5dc3a23475cf3f13f50bd525da82edb8fa58aea",
+      "git-tree": "f49ea6340959a94fbdf41c1bf84f85b5940e7e0e",
       "version": "1.3.2",
       "port-version": 1
     },

--- a/versions/a-/argh.json
+++ b/versions/a-/argh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5dc3a23475cf3f13f50bd525da82edb8fa58aea",
+      "version": "1.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "2ee3072431f9d1aa18b5810e61398b9373fdc0d7",
       "version": "1.3.2",
       "port-version": 0

--- a/versions/a-/argh.json
+++ b/versions/a-/argh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f49ea6340959a94fbdf41c1bf84f85b5940e7e0e",
+      "git-tree": "b78bb1481da9a23d979d9d5a6f1652f3097a53da",
       "version": "1.3.2",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -198,7 +198,7 @@
     },
     "argh": {
       "baseline": "1.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "argon2": {
       "baseline": "20190702",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.