### PR TITLE
[meson] update to 1.3.2

### DIFF
--- a/ports/vcpkg-tool-meson/meson-intl.patch
+++ b/ports/vcpkg-tool-meson/meson-intl.patch
@@ -1,12 +1,14 @@
+diff --git a/mesonbuild/dependencies/misc.py b/mesonbuild/dependencies/misc.py
+index b255813b6..65fe75c30 100644
 --- a/mesonbuild/dependencies/misc.py
 +++ b/mesonbuild/dependencies/misc.py
-@@ -610,7 +610,8 @@ iconv_factory = DependencyFactory(
+@@ -591,7 +591,8 @@ packages['iconv'] = iconv_factory = DependencyFactory(
  
- intl_factory = DependencyFactory(
+ packages['intl'] = intl_factory = DependencyFactory(
      'intl',
+-    [DependencyMethods.BUILTIN, DependencyMethods.SYSTEM],
 +    [DependencyMethods.BUILTIN, DependencyMethods.SYSTEM, DependencyMethods.CMAKE],
 +    cmake_name='Intl',
--    [DependencyMethods.BUILTIN, DependencyMethods.SYSTEM],
      builtin_class=IntlBuiltinDependency,
      system_class=IntlSystemDependency,
  )

--- a/ports/vcpkg-tool-meson/portfile.cmake
+++ b/ports/vcpkg-tool-meson/portfile.cmake
@@ -31,8 +31,8 @@ vcpkg_find_acquire_program(PYTHON3)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mesonbuild/meson
-    REF bb91cea0d66d8d036063dedec1f194d663399cdf
-    SHA512 e5888eb35dd4ab5fc0a16143cfbb5a7849f6d705e211a80baf0a8b753e2cf877a4587860a79cad129ec5f3474c12a73558ffe66439b1633d80b8044eceaff2da
+    REF "${VERSION}"
+    SHA512 b44c28bb8d5ca955b74d64c13b845adfeed814afd92d15ecc8cedb0674932063972644b7fba3a1e60aa76ff2ecea8ab40108a8210ff3698900215342096f35d2
     PATCHES
         meson-intl.patch
         remove-freebsd-pcfile-specialization.patch

--- a/ports/vcpkg-tool-meson/remove-freebsd-pcfile-specialization.patch
+++ b/ports/vcpkg-tool-meson/remove-freebsd-pcfile-specialization.patch
@@ -1,17 +1,22 @@
+diff --git a/mesonbuild/modules/pkgconfig.py b/mesonbuild/modules/pkgconfig.py
+index ebe0d92d5..16a447a6d 100644
 --- a/mesonbuild/modules/pkgconfig.py
 +++ b/mesonbuild/modules/pkgconfig.py
-@@ -583,12 +583,8 @@ class PkgConfigModule(ExtensionModule):
+@@ -693,15 +693,8 @@ class PkgConfigModule(NewExtensionModule):
          pcfile = filebase + '.pc'
-         pkgroot = pkgroot_name = kwargs.get('install_dir', default_install_dir)
+         pkgroot = pkgroot_name = kwargs['install_dir'] or default_install_dir
          if pkgroot is None:
 -            if mesonlib.is_freebsd():
--                pkgroot = os.path.join(state.environment.coredata.get_option(mesonlib.OptionKey('prefix')), 'libdata', 'pkgconfig')
+-                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))), 'libdata', 'pkgconfig')
 -                pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
+-            elif mesonlib.is_haiku():
+-                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
+-                pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
 -            else:
--                pkgroot = os.path.join(state.environment.coredata.get_option(mesonlib.OptionKey('libdir')), 'pkgconfig')
+-                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('libdir'))), 'pkgconfig')
 -                pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
 +            pkgroot = os.path.join(state.environment.coredata.get_option(mesonlib.OptionKey('libdir')), 'pkgconfig')
 +            pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
-         if not isinstance(pkgroot, str):
-             raise mesonlib.MesonException('Install_dir must be a string.')
+         relocatable = state.get_option('relocatable', module='pkgconfig')
          self._generate_pkgconfig_file(state, deps, subdirs, name, description, url,
+                                       version, pcfile, conflicts, variables,

--- a/ports/vcpkg-tool-meson/vcpkg.json
+++ b/ports/vcpkg-tool-meson/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vcpkg-tool-meson",
-  "version": "0.63",
-  "port-version": 2,
+  "version": "1.3.2",
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9021,8 +9021,8 @@
       "port-version": 1
     },
     "vcpkg-tool-meson": {
-      "baseline": "0.63",
-      "port-version": 2
+      "baseline": "1.3.2",
+      "port-version": 0
     },
     "vcpkg-tool-mozbuild": {
       "baseline": "4.0.2",

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a27be7ea6e4eef688f8fabbfb1359bd4025fd2a6",
+      "version": "1.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f6f5419cfc743a85e4f1fb1b582d4728b79c1e2",
       "version": "0.63",
       "port-version": 2


### PR DESCRIPTION
The latest gstreamer require meson >= 1.1, So I update it. I have update gstreamer to 1.24.0 in my local repo, but updating meson effect too many ports, I need this port merged first.
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
