### PR TITLE
Don't require vcpkg-msbuild for mingw

### DIFF
--- a/ports/libmicrohttpd/vcpkg.json
+++ b/ports/libmicrohttpd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmicrohttpd",
   "version": "1.0.1",
+  "port-version": 1,
   "description": "GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application",
   "homepage": "https://www.gnu.org/software/libmicrohttpd/",
   "license": "LGPL-2.1-or-later",
@@ -13,7 +14,7 @@
     {
       "name": "vcpkg-msbuild",
       "host": true,
-      "platform": "windows"
+      "platform": "windows & !mingw"
     }
   ],
   "features": {

--- a/ports/libusb/vcpkg.json
+++ b/ports/libusb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libusb",
   "version": "1.0.27",
+  "port-version": 1,
   "description": "a cross-platform library to access USB devices",
   "homepage": "https://github.com/libusb/libusb",
   "license": "LGPL-2.1-or-later",
@@ -9,7 +10,7 @@
     {
       "name": "vcpkg-msbuild",
       "host": true,
-      "platform": "windows"
+      "platform": "windows & !mingw"
     }
   ],
   "default-features": [

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libvpx",
   "version": "1.13.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",
@@ -13,7 +13,7 @@
     {
       "name": "vcpkg-msbuild",
       "host": true,
-      "platform": "windows"
+      "platform": "windows & !mingw"
     }
   ],
   "features": {

--- a/ports/mp3lame/vcpkg.json
+++ b/ports/mp3lame/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mp3lame",
   "version": "3.100",
-  "port-version": 11,
+  "port-version": 12,
   "description": "LAME is a high quality MPEG Audio Layer III (MP3) encoder licensed under the LGPL.",
   "homepage": "https://sourceforge.net/projects/lame",
   "license": "LGPL-2.0-only",
@@ -9,7 +9,7 @@
     {
       "name": "vcpkg-msbuild",
       "host": true,
-      "platform": "windows"
+      "platform": "windows & !mingw"
     }
   ]
 }

--- a/ports/sdl1/vcpkg.json
+++ b/ports/sdl1/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl1",
   "version": "1.2.15",
-  "port-version": 19,
+  "port-version": 20,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "LGPL-2.1-or-later",
@@ -10,7 +10,7 @@
     {
       "name": "vcpkg-msbuild",
       "host": true,
-      "platform": "windows"
+      "platform": "windows & !mingw"
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4606,7 +4606,7 @@
     },
     "libmicrohttpd": {
       "baseline": "1.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libmikmod": {
       "baseline": "3.3.11.1",
@@ -5066,7 +5066,7 @@
     },
     "libusb": {
       "baseline": "1.0.27",
-      "port-version": 0
+      "port-version": 1
     },
     "libusb-win32": {
       "baseline": "1.2.6.0",
@@ -5106,7 +5106,7 @@
     },
     "libvpx": {
       "baseline": "1.13.1",
-      "port-version": 2
+      "port-version": 3
     },
     "libwandio": {
       "baseline": "4.2.1",
@@ -5810,7 +5810,7 @@
     },
     "mp3lame": {
       "baseline": "3.100",
-      "port-version": 11
+      "port-version": 12
     },
     "mpark-patterns": {
       "baseline": "2019-10-03",
@@ -7870,7 +7870,7 @@
     },
     "sdl1": {
       "baseline": "1.2.15",
-      "port-version": 19
+      "port-version": 20
     },
     "sdl1-mixer": {
       "baseline": "2023-03-25",

--- a/versions/l-/libmicrohttpd.json
+++ b/versions/l-/libmicrohttpd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f9c7d4fbd5b0bf34b6d94ece1571170fdc50e17",
+      "version": "1.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c764a262309da58e1c37962c061c5fa660caff38",
       "version": "1.0.1",
       "port-version": 0

--- a/versions/l-/libusb.json
+++ b/versions/l-/libusb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da092fa023f47e3307d55a85bafb31a9c801b715",
+      "version": "1.0.27",
+      "port-version": 1
+    },
+    {
       "git-tree": "b46d634782590b2e45f3a1202144c4e4235a2a43",
       "version": "1.0.27",
       "port-version": 0

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "113a0b3aef3819546a0d8fe587aa37146a7e8f30",
+      "version": "1.13.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "66ea767e9ce55da152694d49a74ad2125ca4d937",
       "version": "1.13.1",
       "port-version": 2

--- a/versions/m-/mp3lame.json
+++ b/versions/m-/mp3lame.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af04a48e3995bd88563c0dab302c5c7793e09173",
+      "version": "3.100",
+      "port-version": 12
+    },
+    {
       "git-tree": "59014e1d1c1232612124cd30de2e73688713c295",
       "version": "3.100",
       "port-version": 11

--- a/versions/s-/sdl1.json
+++ b/versions/s-/sdl1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43661d95f373c57cac7a2d85c00dbc7e077edf67",
+      "version": "1.2.15",
+      "port-version": 20
+    },
+    {
       "git-tree": "201b5219b28e0c1299f7ebda041cbc85115983ba",
       "version": "1.2.15",
       "port-version": 19


### PR DESCRIPTION
Amends #33105 et al.

Ports selected by grep for vcpkg-msbuild in vcpkg.json && MINGW in portfile.cmake.
