### PR TITLE
[mimalloc] set MI_USE_CXX default off

### DIFF
--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         asm         MI_SEE_ASM
         secure      MI_SECURE
         override    MI_OVERRIDE
+        cxx         MI_USE_CXX
 )
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" MI_BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" MI_BUILD_SHARED)
@@ -25,7 +26,6 @@ vcpkg_cmake_configure(
     OPTIONS_RELEASE
         -DMI_DEBUG_FULL=OFF
     OPTIONS
-        -DMI_USE_CXX=ON
         -DMI_BUILD_TESTS=OFF
         -DMI_BUILD_OBJECT=OFF
         ${FEATURE_OPTIONS}

--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -14,7 +14,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         asm         MI_SEE_ASM
         secure      MI_SECURE
         override    MI_OVERRIDE
-        cxx         MI_USE_CXX
 )
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" MI_BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" MI_BUILD_SHARED)

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mimalloc",
   "version": "2.1.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "license": "MIT",

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -20,9 +20,6 @@
     "asm": {
       "description": "Generate assembly files"
     },
-    "cxx": {
-      "description": "Use the C++ compiler to compile the library (instead of the C compiler)"
-    },
     "override": {
       "description": "Override the standard malloc interface"
     },

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -25,6 +25,9 @@
     },
     "secure": {
       "description": "Use security mitigations (like guard pages and randomization)"
+    },
+    "cxx": {
+      "description": "Use the C++ compiler to compile the library (instead of the C compiler)"
     }
   }
 }

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -20,14 +20,14 @@
     "asm": {
       "description": "Generate assembly files"
     },
+    "cxx": {
+      "description": "Use the C++ compiler to compile the library (instead of the C compiler)"
+    },
     "override": {
       "description": "Override the standard malloc interface"
     },
     "secure": {
       "description": "Use security mitigations (like guard pages and randomization)"
-    },
-    "cxx": {
-      "description": "Use the C++ compiler to compile the library (instead of the C compiler)"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5678,7 +5678,7 @@
     },
     "mimalloc": {
       "baseline": "2.1.2",
-      "port-version": 2
+      "port-version": 1
     },
     "minc": {
       "baseline": "2.4.03",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5678,7 +5678,7 @@
     },
     "mimalloc": {
       "baseline": "2.1.2",
-      "port-version": 1
+      "port-version": 2
     },
     "minc": {
       "baseline": "2.4.03",

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d12250f78514f99f84552feaf9fbc7192f79499b",
+      "git-tree": "8a029c6675c03a9a41c8bb4042ea24c1521f9f09",
       "version": "2.1.2",
       "port-version": 2
     },

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "8a029c6675c03a9a41c8bb4042ea24c1521f9f09",
-      "version": "2.1.2",
-      "port-version": 2
-    },
-    {
       "git-tree": "db19c496e6855e8aeb3a8666ffae862910b403c4",
       "version": "2.1.2",
       "port-version": 1

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e65dd8e008b1867a2242346dfafa5ea300dd758d",
+      "version": "2.1.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "db19c496e6855e8aeb3a8666ffae862910b403c4",
       "version": "2.1.2",
       "port-version": 1

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "db19c496e6855e8aeb3a8666ffae862910b403c4",
+      "git-tree": "d12250f78514f99f84552feaf9fbc7192f79499b",
       "version": "2.1.2",
       "port-version": 1
     },

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -3,6 +3,11 @@
     {
       "git-tree": "d12250f78514f99f84552feaf9fbc7192f79499b",
       "version": "2.1.2",
+      "port-version": 2
+    },
+    {
+      "git-tree": "db19c496e6855e8aeb3a8666ffae862910b403c4",
+      "version": "2.1.2",
       "port-version": 1
     },
     {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.