### PR TITLE
[luasocket] Support linux and macos

### DIFF
--- a/ports/luasec/vcpkg.json
+++ b/ports/luasec/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "luasec",
   "version": "1.3.2",
+  "port-version": 1,
   "maintainers": "Stephen Baker <baker.stephen.e@gmail.com>",
   "description": "LuaSec depends on OpenSSL, and integrates with LuaSocket to make it easy to add secure connections to any Lua applications or scripts.",
   "homepage": "https://github.com/brunoos/luasec",
   "license": "MIT",
-  "supports": "!(windows & static)",
+  "supports": "windows & !staticcrt",
   "dependencies": [
     "lua",
     "luasocket",

--- a/ports/luasocket/CMakeLists.txt
+++ b/ports/luasocket/CMakeLists.txt
@@ -1,14 +1,14 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.10)
 project(luasocket)
 
-if(NOT WIN32)
-    message(FATAL_ERROR "Written for windows only")
+if(WIN32)
+    set(PLATFORM_LIBRARIES ws2_32)
 endif()
 
 find_path(LUA_INCLUDE_DIR lua.h PATH_SUFFIXES lua)
 find_library(LUA_LIBRARY lua)
 set(LUASOCKET_INCLUDES ${LUA_INCLUDE_DIR} src)
-set(LUASOCKET_LIBRARIES ${LUA_LIBRARY} ws2_32)
+set(LUASOCKET_LIBRARIES ${LUA_LIBRARY} ${PLATFORM_LIBRARIES})
 
 add_library(socket.core
     src/luasocket.c
@@ -22,32 +22,105 @@ add_library(socket.core
     src/select.c
     src/tcp.c
     src/udp.c
-    src/compat.c
-    src/wsocket.c)
+    src/compat.c)
+if(WIN32)
+    target_sources(socket.core PRIVATE
+        src/wsocket.c)
+elseif (UNIX)
+    target_sources(socket.core PRIVATE
+        src/usocket.c)
+endif()
+set_target_properties(socket.core PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "socket"
+    LIBRARY_OUTPUT_DIRECTORY "socket"
+    PREFIX ""
+    RUNTIME_OUTPUT_NAME "core"
+    LIBRARY_OUTPUT_NAME "core")
+target_include_directories(socket.core PRIVATE ${LUASOCKET_INCLUDES})
+target_link_libraries(socket.core PRIVATE ${LUASOCKET_LIBRARIES})
 
 add_library(mime.core
     src/mime.c
     src/compat.c)
-
-target_include_directories(socket.core PRIVATE ${LUASOCKET_INCLUDES})
-target_link_libraries(socket.core PRIVATE ${LUASOCKET_LIBRARIES})
-
+set_target_properties(mime.core PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "mime"
+    LIBRARY_OUTPUT_DIRECTORY "mime"
+    PREFIX ""
+    RUNTIME_OUTPUT_NAME "core"
+    LIBRARY_OUTPUT_NAME "core")
 target_include_directories(mime.core PRIVATE ${LUASOCKET_INCLUDES})
 target_link_libraries(mime.core PRIVATE ${LUASOCKET_LIBRARIES})
 
-add_definitions(
-    "-DLUASOCKET_API=__declspec(dllexport)"
-    "-DMIME_API=__declspec(dllexport)")
+if(UNIX)
+    add_library(socket.unix
+        src/buffer.c
+        src/compat.c
+        src/auxiliar.c
+        src/options.c
+        src/timeout.c
+        src/io.c
+        src/usocket.c
+        src/unix.c
+        src/unixdgram.c
+        src/unixstream.c)
+    set_target_properties(socket.unix PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "socket"
+        LIBRARY_OUTPUT_DIRECTORY "socket"
+        PREFIX ""
+        RUNTIME_OUTPUT_NAME "unix"
+        LIBRARY_OUTPUT_NAME "unix")
+    target_include_directories(socket.unix PRIVATE ${LUASOCKET_INCLUDES})
+    target_link_libraries(socket.unix PRIVATE ${LUASOCKET_LIBRARIES})
+
+    add_library(socket.serial
+        src/buffer.c
+        src/compat.c
+        src/auxiliar.c
+        src/options.c
+        src/timeout.c
+        src/io.c
+        src/usocket.c
+        src/serial.c)
+    set_target_properties(socket.serial PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "socket"
+        LIBRARY_OUTPUT_DIRECTORY "socket"
+        PREFIX ""
+        RUNTIME_OUTPUT_NAME "serial"
+        LIBRARY_OUTPUT_NAME "serial")
+    target_include_directories(socket.serial PRIVATE ${LUASOCKET_INCLUDES})
+    target_link_libraries(socket.serial PRIVATE ${LUASOCKET_LIBRARIES})
+endif()
+
+if(WIN32)
+    if("${BUILD_TYPE}" STREQUAL "STATIC")
+        add_definitions(
+            "-DLUASOCKET_API=")
+    else()
+        add_definitions(
+            "-DLUASOCKET_API=__declspec(dllexport)")
+    endif()
+endif()
 
 install(TARGETS socket.core
     RUNTIME DESTINATION bin/socket
-    LIBRARY DESTINATION lib
+    LIBRARY DESTINATION lib/socket
     ARCHIVE DESTINATION lib)
 
 install(TARGETS mime.core
     RUNTIME DESTINATION bin/mime
-    LIBRARY DESTINATION lib
+    LIBRARY DESTINATION lib/mime
     ARCHIVE DESTINATION lib)
+
+if(UNIX)
+    install(TARGETS socket.unix
+        RUNTIME DESTINATION bin/socket
+        LIBRARY DESTINATION lib/socket
+        ARCHIVE DESTINATION lib)
+    install(TARGETS socket.serial
+        RUNTIME DESTINATION bin/socket
+        LIBRARY DESTINATION lib/socket
+        ARCHIVE DESTINATION lib)
+endif()
 
 install(FILES
     src/ltn12.lua

--- a/ports/luasocket/portfile.cmake
+++ b/ports/luasocket/portfile.cmake
@@ -7,8 +7,16 @@ vcpkg_from_github(
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    set(BUILD_TYPE SHARED)
+else()
+    set(BUILD_TYPE STATIC)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TYPE=${BUILD_TYPE}
 )
 
 vcpkg_cmake_install()
@@ -19,19 +27,6 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-# Handle socket dll name
-    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/socket/socket.core.dll" "${CURRENT_PACKAGES_DIR}/bin/socket/core.dll" RESULT temp)
-    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/socket/socket.core.pdb" "${CURRENT_PACKAGES_DIR}/bin/socket/core.pdb" RESULT temp)
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bin/socket/socket.core.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/socket/core.dll" RESULT temp)
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bin/socket/socket.core.pdb" "${CURRENT_PACKAGES_DIR}/debug/bin/socket/core.pdb" RESULT temp)
-
-# Handle mime dll name
-    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/mime/mime.core.dll" "${CURRENT_PACKAGES_DIR}/bin/mime/core.dll" RESULT temp)
-    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/mime/mime.core.pdb" "${CURRENT_PACKAGES_DIR}/bin/mime/core.pdb" RESULT temp)
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bin/mime/mime.core.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/mime/core.dll" RESULT temp)
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bin/mime/mime.core.pdb" "${CURRENT_PACKAGES_DIR}/debug/bin/mime/core.pdb" RESULT temp)
-endif()
 
 # Allow empty include directory
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/luasocket/vcpkg.json
+++ b/ports/luasocket/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "luasocket",
   "version": "3.1.0",
+  "port-version": 1,
   "description": "LuaSocket is a Lua extension library that is composed by two parts: a C core that provides support for the TCP and UDP transport layers, and a set of Lua modules that add support for functionality commonly needed by applications that deal with the Internet.",
   "homepage": "https://lunarmodules.github.io/luasocket/",
   "license": "MIT",
-  "supports": "windows",
   "dependencies": [
     "lua",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5442,11 +5442,11 @@
     },
     "luasec": {
       "baseline": "1.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "luasocket": {
       "baseline": "3.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "luminoengine": {
       "baseline": "0.10.1",

--- a/versions/l-/luasec.json
+++ b/versions/l-/luasec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2a73d4b729a49aede6db4b11d904bb12224fad6",
+      "version": "1.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "efd0c61de23985278c5d652a4e6273c15d91c58d",
       "version": "1.3.2",
       "port-version": 0

--- a/versions/l-/luasocket.json
+++ b/versions/l-/luasocket.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f28657f71683263f3eff43ee33ee55d8570737d",
+      "version": "3.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "faad47eddfeeb72b135a34c713c20f821ab0261b",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
