### PR TITLE
[gettext*] Update 0.22.5, fix Intl wrapper

### DIFF
--- a/ports/gettext-libintl/portfile.cmake
+++ b/ports/gettext-libintl/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/pub/gnu/gettext/gettext-${VERSION}.tar.gz"
          "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gettext/gettext-${VERSION}.tar.gz"
     FILENAME "gettext-${VERSION}.tar.gz"
-    SHA512 ad2fa2f69be996a637e9b51e8941a39e10050060245dcec1fe75c15b68d0ff973043c87b77e4e2830e407e3bdd040b578f8e24fd05bba43adb94eaee34001aa5
+    SHA512 d8b22d7fba10052a2045f477f0a5b684d932513bdb3b295c22fbd9dfc2a9d8fccd9aefd90692136c62897149aa2f7d1145ce6618aa1f0be787cb88eba5bc09be
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/gettext-libintl/vcpkg-cmake-wrapper.cmake
+++ b/ports/gettext-libintl/vcpkg-cmake-wrapper.cmake
@@ -10,5 +10,8 @@ if(Intl_FOUND AND Intl_LIBRARIES)
     find_package(Iconv) # Since CMake 3.11
     if(Iconv_FOUND AND NOT Iconv_IS_BUILT_IN)
         list(APPEND Intl_LIBRARIES ${Iconv_LIBRARIES})
+        if(TARGET Intl::Intl) # Since CMake 3.20
+            set_property(TARGET Intl::Intl APPEND PROPERTY INTERFACE_LINK_LIBRARIES $<LINK_ONLY:Iconv::Iconv>)
+        endif()
     endif()
 endif()

--- a/ports/gettext-libintl/vcpkg.json
+++ b/ports/gettext-libintl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gettext-libintl",
-  "version": "0.22.4",
-  "port-version": 1,
+  "version": "0.22.5",
   "description": "The libintl C library from GNU gettext-runtime.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "LGPL-2.1-or-later",

--- a/ports/gettext/install-autopoint.cmake
+++ b/ports/gettext/install-autopoint.cmake
@@ -26,7 +26,7 @@ function(install_autopoint)
     configure_file("${SOURCE_PATH}/gettext-tools/misc/autopoint.in" "${WORKING_DIR}/autopoint" @ONLY)
 
     # data tarball
-    if(WIN32)
+    if(CMAKE_HOST_WIN32)
         vcpkg_acquire_msys(MSYS_ROOT PACKAGES gzip)
         vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
     endif()

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/pub/gnu/gettext/gettext-${VERSION}.tar.gz"
          "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gettext/gettext-${VERSION}.tar.gz"
     FILENAME "gettext-${VERSION}.tar.gz"
-    SHA512 ad2fa2f69be996a637e9b51e8941a39e10050060245dcec1fe75c15b68d0ff973043c87b77e4e2830e407e3bdd040b578f8e24fd05bba43adb94eaee34001aa5
+    SHA512 d8b22d7fba10052a2045f477f0a5b684d932513bdb3b295c22fbd9dfc2a9d8fccd9aefd90692136c62897149aa2f7d1145ce6618aa1f0be787cb88eba5bc09be
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/gettext/uwp.patch
+++ b/ports/gettext/uwp.patch
@@ -38,10 +38,10 @@ index ec75427..9e063e4 100644
  # elif defined WINDOWS_NATIVE
  
    char buf[2 + 10 + 1];
-diff --git a/gettext-runtime/gnulib-lib/localename.c b/gettext-runtime/gnulib-lib/localename.c
+diff --git a/gettext-runtime/gnulib-lib/localename-unsafe.c b/gettext-runtime/gnulib-lib/localename-unsafe.c
 index d77bb81..3c6e055 100644
---- a/gettext-runtime/gnulib-lib/localename.c
-+++ b/gettext-runtime/gnulib-lib/localename.c
+--- a/gettext-runtime/gnulib-lib/localename-unsafe.c
++++ b/gettext-runtime/gnulib-lib/localename-unsafe.c
 @@ -69,6 +69,11 @@ extern char * getlocalename_l(int, locale_t);
  
  #if defined _WIN32 && !defined __CYGWIN__

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gettext",
-  "version": "0.22.4",
-  "port-version": 2,
+  "version": "0.22.5",
   "description": "A GNU framework to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2973,12 +2973,12 @@
       "port-version": 0
     },
     "gettext": {
-      "baseline": "0.22.4",
-      "port-version": 2
+      "baseline": "0.22.5",
+      "port-version": 0
     },
     "gettext-libintl": {
-      "baseline": "0.22.4",
-      "port-version": 1
+      "baseline": "0.22.5",
+      "port-version": 0
     },
     "gettimeofday": {
       "baseline": "2017-10-14",

--- a/versions/g-/gettext-libintl.json
+++ b/versions/g-/gettext-libintl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e843b89b04541ca0f59e3c28e70a78910247615e",
+      "git-tree": "8a3f80e31783a834e0fdc9d231136651cb2f08b4",
       "version": "0.22.5",
       "port-version": 0
     },

--- a/versions/g-/gettext-libintl.json
+++ b/versions/g-/gettext-libintl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e843b89b04541ca0f59e3c28e70a78910247615e",
+      "version": "0.22.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "b81c3757a4f5b2eb78c45e29d51803e5a3418fdb",
       "version": "0.22.4",
       "port-version": 1

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e488174a8ae6382bf09d7305e6b480c0a9085efa",
+      "version": "0.22.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "d9cc9b8256d9653fe2d484ecf268f7368666d942",
       "version": "0.22.4",
       "port-version": 2

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e488174a8ae6382bf09d7305e6b480c0a9085efa",
+      "git-tree": "a9e016b098d97663485848b70db782306ecde601",
       "version": "0.22.5",
       "port-version": 0
     },


### PR DESCRIPTION
The iconv usage requirement must also be added to the target.
Noticed with liblzma 5.6.0, https://github.com/microsoft/vcpkg/pull/37199.