### PR TITLE
[cryptopp] Update port to support new pem-pack option

### DIFF
--- a/ports/cryptopp/cryptopp-cmake.patch
+++ b/ports/cryptopp/cryptopp-cmake.patch
@@ -1,0 +1,92 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bb3bfbb..d533ed6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -83,6 +83,11 @@ option(
+     ON
+ )
+ 
++option(
++    CRYPTOPP_USE_PEM_PACK
++    "Include the PEM-Pack in compiliation (https://github.com/noloader/cryptopp-pem)"
++)
++
+ if(CRYPTOPP_INCLUDE_PREFIX)
+     set(CRYPTOPP_INCLUDE_PREFIX
+         ${CRYPTOPP_INCLUDE_PREFIX}
+diff --git a/cmake/GetCryptoppSources.cmake b/cmake/GetCryptoppSources.cmake
+index 809596a..3aaaab4 100644
+--- a/cmake/GetCryptoppSources.cmake
++++ b/cmake/GetCryptoppSources.cmake
+@@ -22,6 +22,11 @@ if(GIT_FOUND)
+         SOURCE_DIR
+         ${CRYPTOPP_INCLUDE_PREFIX}
+     )
++    fetchcontent_declare(
++        cryptopp-pem
++        GIT_REPOSITORY "https://github.com/noloader/cryptopp-pem"
++        QUIET
++    )
+ else()
+     message(STATUS "Downloading crypto++ from URL...")
+     cmake_policy(SET CMP0135 NEW)
+@@ -39,5 +44,13 @@ else()
+         cryptopp
+         URL "${source_location}.zip" QUIET SOURCE_DIR ${CRYPTOPP_INCLUDE_PREFIX}
+     )
++    fetchcontent_declare(
++        cryptopp-pem
++        URL "https://github.com/noloader/cryptopp-pem/archive/refs/heads/master.zip"
++        QUIET
++    )
+ endif()
+ fetchcontent_populate(cryptopp)
++if(CRYPTOPP_USE_PEM_PACK)
++    fetchcontent_populate(cryptopp-pem)
++endif()
+diff --git a/cryptopp/sources.cmake b/cryptopp/sources.cmake
+index 7918f03..b0bf7db 100644
+--- a/cryptopp/sources.cmake
++++ b/cryptopp/sources.cmake
+@@ -182,6 +182,12 @@ set(cryptopp_SOURCES
+     zlib.cpp
+ )
+ 
++set(cryptopp_SOURCES_PEM
++    "${cryptopp-pem_SOURCE_DIR}/pem-com.cpp"
++    "${cryptopp-pem_SOURCE_DIR}/pem-rd.cpp"
++    "${cryptopp-pem_SOURCE_DIR}/pem-wr.cpp"
++)
++
+ # ***** Library headers *****
+ set(cryptopp_HEADERS
+     3way.h
+@@ -374,6 +382,11 @@ set(cryptopp_HEADERS
+     zlib.h
+ )
+ 
++set(cryptopp_HEADERS_PEM
++    "${cryptopp-pem_SOURCE_DIR}/pem.h"
++    "${cryptopp-pem_SOURCE_DIR}/pem-com.h"
++)
++
+ # ***** Test sources *****
+ set(cryptopp_SOURCES_TEST
+     # adhoc.cpp
+@@ -448,3 +462,16 @@ if(ANDROID)
+         ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c
+     )
+ endif()
++
++if(CRYPTOPP_USE_PEM_PACK)
++    list(
++        APPEND
++        cryptopp_SOURCES
++        ${cryptopp_SOURCES_PEM}
++    )
++    list(
++        APPEND
++        cryptopp_HEADERS
++        ${cryptopp_HEADERS_PEM}
++    )
++endif()

--- a/ports/cryptopp/portfile.cmake
+++ b/ports/cryptopp/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
   REF "CRYPTOPP_${CRYPTOPP_VERSION}"
   SHA512 3ec33b107ab627a514e1ebbc4b6522ee8552525f36730d9b5feb85e61ba7fc24fd36eb6050e328c6789ff60d47796beaa8eebf7dead787a34395294fae9bb733
   HEAD_REF master
+  PATCHES cryptopp-cmake.patch
 )
 
 vcpkg_from_github(
@@ -24,6 +25,8 @@ file(COPY "${CMAKE_SOURCE_PATH}/test" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_SOURCE_PATH}/cryptopp/cryptoppConfig.cmake" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_SOURCE_PATH}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
+set(CRYPTOPP_USE_PEM_PACK "OFF")
+
 if("pem-pack" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH PEM_PACK_SOURCE_PATH
@@ -33,11 +36,7 @@ if("pem-pack" IN_LIST FEATURES)
         HEAD_REF master
     )
 
-    file(GLOB PEM_PACK_FILES
-        ${PEM_PACK_SOURCE_PATH}/*.h
-        ${PEM_PACK_SOURCE_PATH}/*.cpp
-    )
-    file(INSTALL ${PEM_PACK_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+    set(CRYPTOPP_USE_PEM_PACK "ON")
 endif()
 
 # disable assembly on ARM Windows to fix broken build
@@ -61,9 +60,11 @@ vcpkg_cmake_configure(
         -DBUILD_STATIC=ON
         -DCRYPTOPP_BUILD_TESTING=OFF
         -DCRYPTOPP_BUILD_DOCUMENTATION=OFF
-        -DDISABLE_ASM=${CRYPTOPP_DISABLE_ASM}
+        -DCRYPTOPP_DISABLE_ASM=${CRYPTOPP_DISABLE_ASM}
         -DUSE_INTERMEDIATE_OBJECTS_TARGET=OFF # Not required when we build static only
         -DCMAKE_POLICY_DEFAULT_CMP0063=NEW # Honor "<LANG>_VISIBILITY_PRESET" properties
+        -DCRYPTOPP_USE_PEM_PACK=${CRYPTOPP_USE_PEM_PACK}
+        -Dcryptopp-pem_SOURCE_DIR=${PEM_PACK_SOURCE_PATH} # Usually this would be set when cryptopp-cmake downloads the source, but since we don't, we need to provide it instead
     MAYBE_UNUSED_VARIABLES
         BUILD_STATIC
         USE_INTERMEDIATE_OBJECTS_TARGET

--- a/ports/cryptopp/vcpkg.json
+++ b/ports/cryptopp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cryptopp",
   "version": "8.9.0",
+  "port-version": 1,
   "description": "Crypto++ is a free C++ class library of cryptographic schemes.",
   "homepage": "https://github.com/weidai11/cryptopp",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1998,7 +1998,7 @@
     },
     "cryptopp": {
       "baseline": "8.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cserialport": {
       "baseline": "4.3.0",

--- a/versions/c-/cryptopp.json
+++ b/versions/c-/cryptopp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8716a33de54d6dc90de8609bc71a15c92d2c094a",
+      "version": "8.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "48788514ae1e84dea9055e603527c91f92c124fb",
       "version": "8.9.0",
       "port-version": 0

--- a/versions/c-/cryptopp.json
+++ b/versions/c-/cryptopp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8716a33de54d6dc90de8609bc71a15c92d2c094a",
+      "git-tree": "c4b9ac31756b00115948f55c0d67e4114d7ffc00",
       "version": "8.9.0",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #31849.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.