### PR TITLE
[atomic-queue] update to 1.6.3

### DIFF
--- a/ports/atomic-queue/portfile.cmake
+++ b/ports/atomic-queue/portfile.cmake
@@ -2,9 +2,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO max0x7ba/atomic_queue
     REF "v${VERSION}"
-    SHA512 d2b329698412127d23e9ee55472f65869c59b228439e714ebbe6cc66202b654a102f32583e7cc3b5999c22c1dba69a5aa4365870cc4b88b75b1ac0b4d94b979a
+    SHA512 cd4ca07f04f7c994b0e5dce5b4986192ee77d7ca376140717b2e4f848a2fad4bbe33059a9cb8127a517a859dc2670c3be56bf48f91a1ed77c86509c6b6288ce2
     HEAD_REF master
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 file(
     COPY

--- a/ports/atomic-queue/vcpkg.json
+++ b/ports/atomic-queue/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-queue",
-  "version": "1.5",
+  "version": "1.6.3",
   "description": "Minimalistic header-only thread-safe ultra-low-latency multiple-producer-multiple-consumer lockless queues based on circular buffer with std::atomic.",
   "homepage": "https://github.com/max0x7ba/atomic_queue",
   "license": "MIT"

--- a/versions/a-/atomic-queue.json
+++ b/versions/a-/atomic-queue.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7c36f0997979a0fee5be84c9511ee0f6032057ec",
+      "git-tree": "7b1bca0b58cc1f6d9571df7ab750292a8a4ac25f",
       "version": "1.6.3",
       "port-version": 0
     },

--- a/versions/a-/atomic-queue.json
+++ b/versions/a-/atomic-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c36f0997979a0fee5be84c9511ee0f6032057ec",
+      "version": "1.6.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "045962c06085fe2da8633106b2170b29f4febe47",
       "version": "1.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -321,7 +321,7 @@
       "port-version": 3
     },
     "atomic-queue": {
-      "baseline": "1.5",
+      "baseline": "1.6.3",
       "port-version": 0
     },
     "attr": {


### PR DESCRIPTION
* Stateful allocator support. Constructors accept allocator argument.

* Constructors accept allocator argument.

* CMake support added.

* Fixes C++20 compile errors.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
