### PR TITLE
[luasec] linux and macos support

### DIFF
--- a/ports/luasec/CMakeLists.txt
+++ b/ports/luasec/CMakeLists.txt
@@ -10,8 +10,10 @@ set(LUASEC_LIBRARIES
     ${LUA_LIBRARY}
     OpenSSL::SSL
     OpenSSL::Crypto
-    OpenSSL::applink
-    ws2_32)
+    OpenSSL::applink)
+if(WIN32)
+    set(PLATFORM_LIBRARIES ws2_32)
+endif()
 
 add_library(lua-ssl
     src/config.c
@@ -22,11 +24,17 @@ add_library(lua-ssl
     src/options.c
     src/luasocket/buffer.c
     src/luasocket/io.c
-    src/luasocket/timeout.c
-    src/luasocket/wsocket.c)
+    src/luasocket/timeout.c)
+if(WIN32)
+    target_sources(lua-ssl PRIVATE
+        src/luasocket/wsocket.c)
+else()
+    target_sources(lua-ssl PRIVATE
+        src/luasocket/usocket.c)
+endif()
 
 target_include_directories(lua-ssl PRIVATE ${LUASEC_INCLUDES})
-target_link_libraries(lua-ssl PRIVATE ${LUASEC_LIBRARIES})
+target_link_libraries(lua-ssl PRIVATE ${LUASEC_LIBRARIES} ${PLATFORM_LIBRARIES})
 set_target_properties(lua-ssl PROPERTIES PREFIX "")
 
 install(TARGETS lua-ssl

--- a/ports/luasec/portfile.cmake
+++ b/ports/luasec/portfile.cmake
@@ -1,11 +1,8 @@
-
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-endif()
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO brunoos/luasec
+    REPO lunarmodules/luasec
     REF "v${VERSION}"
     SHA512 8f0c4b5ff87c024685b23770e1d342467554b8dc19a1704076e184d9e84b966f171091c31d1da135ab009e850275adc2bf2720fc9f32c83ac23f0a42f13d311f
     HEAD_REF master

--- a/ports/luasec/vcpkg.json
+++ b/ports/luasec/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "name": "luasec",
   "version": "1.3.2",
-  "port-version": 1,
+  "port-version": 2,
   "maintainers": "Stephen Baker <baker.stephen.e@gmail.com>",
   "description": "LuaSec depends on OpenSSL, and integrates with LuaSocket to make it easy to add secure connections to any Lua applications or scripts.",
-  "homepage": "https://github.com/brunoos/luasec",
+  "homepage": "https://github.com/lunarmodules/luasec",
   "license": "MIT",
-  "supports": "windows & !staticcrt",
+  "supports": "!staticcrt",
   "dependencies": [
     "lua",
     "luasocket",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5450,7 +5450,7 @@
     },
     "luasec": {
       "baseline": "1.3.2",
-      "port-version": 1
+      "port-version": 2
     },
     "luasocket": {
       "baseline": "3.1.0",

--- a/versions/l-/luasec.json
+++ b/versions/l-/luasec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7274433449f340b73ab11cf6339bc54e3e96b1be",
+      "version": "1.3.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "f2a73d4b729a49aede6db4b11d904bb12224fad6",
       "version": "1.3.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
