### PR TITLE
[Avcpp] update to version 2.3.0

### DIFF
--- a/ports/avcpp/portfile.cmake
+++ b/ports/avcpp/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO h4tr3d/avcpp
     REF "v${VERSION}"
-    SHA512 f709b0ef30d4a516747156788716476fb71dda12fbedf6b757bbb82340a0a33bae5cc0e5be1e7fb00e70c8a9a693610e383caab137875d4a5043c1a9801ec9dd
+    SHA512 10e3ab6bb52ceee2f7d6ea9364dbf5f09fdab5b10f34920f1a1df93ad853e0a4b3de9b554be8482d8444b62e10160c3e26f37907fee217bc9d5728329e06ad85
     HEAD_REF master
     PATCHES
         0002-av_init_packet_deprecation.patch

--- a/ports/avcpp/vcpkg.json
+++ b/ports/avcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "avcpp",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Wrapper for the FFmpeg that simplify usage it from C++ projects.",
   "homepage": "https://github.com/h4tr3d/avcpp",
   "license": "LGPL-2.1-only OR BSD-3-Clause",

--- a/versions/a-/avcpp.json
+++ b/versions/a-/avcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0536c50812252994282f92dc60c6be989da16ed3",
+      "version": "2.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "37ae9f7b52ea3f3ce0da3c7564f006639816c084",
       "version": "2.2.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -349,7 +349,7 @@
       "port-version": 1
     },
     "avcpp": {
-      "baseline": "2.2.1",
+      "baseline": "2.3.0",
       "port-version": 0
     },
     "avisynthplus": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


