### PR TITLE
[libdwarf] Recover deleted historical versions

### DIFF
--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -9,6 +9,11 @@
       "git-tree": "6159822bb45daaf469ba049ac34ab10bc78bc843",
       "version": "0.9.1",
       "port-version": 0
+    },
+    {
+      "git-tree": "8aa61f875f55fe903c05d51dc9ce4d0301e4ddbf",
+      "version": "0.8.0",
+      "port-version": 0
     }
   ]
 }


### PR DESCRIPTION
When updating the port, the historical version was deleted, making it impossible to download the historical version. This PR will restore the historical version.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```