### PR TITLE
[rmlui] Patches RmlUi: Removes `std::` before `uint`*.

### DIFF
--- a/ports/rmlui/portfile.cmake
+++ b/ports/rmlui/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
 	HEAD_REF master
 	PATCHES
 		add-robin-hood.patch
+		remove-std-before-uint.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/rmlui/remove-std-before-uint.patch
+++ b/ports/rmlui/remove-std-before-uint.patch
@@ -1,0 +1,130 @@
+diff --git a/Backends/RmlUi_Backend_GLFW_VK.cpp b/Backends/RmlUi_Backend_GLFW_VK.cpp
+index c1cf80f..7d45299 100644
+--- a/Backends/RmlUi_Backend_GLFW_VK.cpp
++++ b/Backends/RmlUi_Backend_GLFW_VK.cpp
+@@ -35,7 +35,7 @@
+ #include <RmlUi/Core/Core.h>
+ #include <RmlUi/Core/FileInterface.h>
+ #include <GLFW/glfw3.h>
+-#include <cstdint>
++#include <stdint.h>
+ #include <thread>
+ 
+ static void SetupCallbacks(GLFWwindow* window);
+diff --git a/Include/RmlUi/Core/Types.h b/Include/RmlUi/Core/Types.h
+index 28e5ad7..39a5e8a 100644
+--- a/Include/RmlUi/Core/Types.h
++++ b/Include/RmlUi/Core/Types.h
+@@ -32,6 +32,7 @@
+ #include "../Config/Config.h"
+ 
+ #include <cstdlib>
++#include <stdint.h>
+ #include <memory>
+ 
+ #include "Traits.h"
+diff --git a/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp b/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp
+index bcc6f13..da487b0 100644
+--- a/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp
++++ b/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp
+@@ -219,7 +219,7 @@ int FontFaceBitmap::GenerateString(const String& string, const Vector2f& string_
+ 
+ int FontFaceBitmap::GetKerning(Character left, Character right) const
+ {
+-	std::uint64_t key = (((std::uint64_t)left << 32) | (std::uint64_t)right);
++	uint64_t key = (((uint64_t)left << 32) | (uint64_t)right);
+ 
+ 	auto it = kerning.find(key);
+ 	if (it != kerning.end())
+@@ -291,13 +291,13 @@ void FontParserBitmap::HandleElementStart(const String& name, const Rml::XMLAttr
+ 	}
+ 	else if (name == "kerning")
+ 	{
+-		std::uint64_t first = (std::uint64_t)Get(attributes, "first", 0);
+-		std::uint64_t second = (std::uint64_t)Get(attributes, "second", 0);
++		uint64_t first = (uint64_t)Get(attributes, "first", 0);
++		uint64_t second = (uint64_t)Get(attributes, "second", 0);
+ 		int amount = Get(attributes, "amount", 0);
+ 
+ 		if (first != 0 && second != 0 && amount != 0)
+ 		{
+-			std::uint64_t key = ((first << 32) | second);
++			uint64_t key = ((first << 32) | second);
+ 			kerning[key] = amount;
+ 		}
+ 	}
+diff --git a/Samples/basic/bitmapfont/src/FontEngineBitmap.h b/Samples/basic/bitmapfont/src/FontEngineBitmap.h
+index f9fef43..41256c9 100644
+--- a/Samples/basic/bitmapfont/src/FontEngineBitmap.h
++++ b/Samples/basic/bitmapfont/src/FontEngineBitmap.h
+@@ -29,7 +29,6 @@
+ #ifndef FONTENGINEBITMAP_H
+ #define FONTENGINEBITMAP_H
+ 
+-#include <cstdint>
+ #include <RmlUi/Core/Types.h>
+ #include "FontEngineInterfaceBitmap.h"
+ 
+@@ -63,7 +62,7 @@ struct FontMetrics {
+ using FontGlyphs = Rml::UnorderedMap<Character, BitmapGlyph>;
+ 
+ // Mapping of combined (left, right) character to kerning in pixels.
+-using FontKerning = Rml::UnorderedMap<std::uint64_t, int>;
++using FontKerning = Rml::UnorderedMap<uint64_t, int>;
+ 
+ 
+ class FontFaceBitmap {
+diff --git a/Source/Core/ElementStyle.h b/Source/Core/ElementStyle.h
+index a89eb7e..8f62fb7 100644
+--- a/Source/Core/ElementStyle.h
++++ b/Source/Core/ElementStyle.h
+@@ -40,7 +40,7 @@ class ElementDefinition;
+ class PropertiesIterator;
+ enum class RelativeTarget;
+ 
+-enum class PseudoClassState : std::uint8_t { Clear = 0, Set = 1, Override = 2 };
++enum class PseudoClassState : uint8_t { Clear = 0, Set = 1, Override = 2 };
+ using PseudoClassMap = SmallUnorderedMap< String, PseudoClassState >;
+ 
+ 
+diff --git a/Source/Core/FontEngineDefault/FontFaceHandleDefault.h b/Source/Core/FontEngineDefault/FontFaceHandleDefault.h
+index 4e6c4d7..5e92d7b 100644
+--- a/Source/Core/FontEngineDefault/FontFaceHandleDefault.h
++++ b/Source/Core/FontEngineDefault/FontFaceHandleDefault.h
+@@ -143,8 +143,8 @@ private:
+ 	FontLayerCache layer_cache;
+ 
+ 	// Pre-cache kerning pairs for some ascii subset of all characters.
+-	using AsciiPair = std::uint16_t;
+-	using KerningIntType = std::int16_t;
++	using AsciiPair = uint16_t;
++	using KerningIntType = int16_t;
+ 	using KerningPairs = UnorderedMap< AsciiPair, KerningIntType >;
+ 	KerningPairs kerning_pair_cache;
+ 
+diff --git a/Source/Core/LayoutFlex.cpp b/Source/Core/LayoutFlex.cpp
+index b51aa93..074376d 100644
+--- a/Source/Core/LayoutFlex.cpp
++++ b/Source/Core/LayoutFlex.cpp
+@@ -110,7 +110,7 @@ struct FlexItem {
+ 	float hypothetical_main_size; // Outer size
+ 
+ 	// Used for resolving flexible length
+-	enum class Violation : std::uint8_t { None = 0, Min, Max };
++	enum class Violation : uint8_t { None = 0, Min, Max };
+ 	bool frozen;
+ 	Violation violation;
+ 	float target_main_size; // Outer size
+diff --git a/Source/Lottie/ElementLottie.cpp b/Source/Lottie/ElementLottie.cpp
+index 91f4a0e..b5e36a4 100644
+--- a/Source/Lottie/ElementLottie.cpp
++++ b/Source/Lottie/ElementLottie.cpp
+@@ -228,7 +228,7 @@ void ElementLottie::UpdateTexture()
+ 
+ 		byte* p_data = new byte[total_bytes];
+ 
+-		rlottie::Surface surface(reinterpret_cast<std::uint32_t*>(p_data), render_dimensions.x, render_dimensions.y, bytes_per_line);
++		rlottie::Surface surface(reinterpret_cast<uint32_t*>(p_data), render_dimensions.x, render_dimensions.y, bytes_per_line);
+ 		animation->renderSync(next_frame, surface);
+ 
+ 		// Swizzle the channel order from rlottie's BGRA to RmlUi's RGBA, and change pre-multiplied to post-multiplied alpha.

--- a/ports/rmlui/vcpkg.json
+++ b/ports/rmlui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rmlui",
   "version": "5.1",
+  "port-version": 1,
   "maintainers": "Michael R. P. Ragazzon <mikke89@users.noreply.github.com>",
   "description": "RmlUi is the C++ user interface library based on the HTML and CSS standards, designed as a complete solution for any project's interface needs.",
   "homepage": "https://github.com/mikke89/RmlUi",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7654,7 +7654,7 @@
     },
     "rmlui": {
       "baseline": "5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "rmqcpp": {
       "baseline": "1.0.0",

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e4a08156797e770bdacd798712ea7c18151dd03",
+      "version": "5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "eef365a991fcf66a1848ed65bb9af75e767ffce6",
       "version": "5.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


This patch fixes a compilation error that occurs when GCC or newer versions of Clang are used. The issue is that `std::uint`* is optional, and some compiler versions may not support the `std::` version. Refer to 
https://github.com/mikke89/RmlUi/issues/470 for the original issue, and https://github.com/mikke89/RmlUi/commit/313cbab6570a45fba1a08534da7c3b46b812fa48 for the original fix.
