### PR TITLE
[sdformat6/sdformat9/sdformat10]sets correct environment variable

### DIFF
--- a/ports/sdformat10/portfile.cmake
+++ b/ports/sdformat10/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 # Restore original path
-set(ENV{PATH} ${_path})
+set(ENV{PATH} "${_path}")
 
 # Fix cmake targets and pkg-config file location
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sdformat10")

--- a/ports/sdformat10/vcpkg.json
+++ b/ports/sdformat10/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdformat10",
   "version": "10.0.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "supports": "!uwp & !(arm & osx)",

--- a/ports/sdformat6/portfile.cmake
+++ b/ports/sdformat6/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 # Restore original path
-set(ENV{PATH} ${_path})
+set(ENV{PATH} "${_path}")
 
 # Move location of sdformat.dll from lib to bin
 if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/sdformat.dll")

--- a/ports/sdformat6/vcpkg.json
+++ b/ports/sdformat6/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdformat6",
   "version": "6.2.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "license": "Apache-2.0",

--- a/ports/sdformat9/portfile.cmake
+++ b/ports/sdformat9/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 # Restore original path
-set(ENV{PATH} ${_path})
+set(ENV{PATH} "${_path}")
 
 # Fix cmake targets and pkg-config file location
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sdformat9")

--- a/ports/sdformat9/vcpkg.json
+++ b/ports/sdformat9/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdformat9",
   "version": "9.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7854,7 +7854,7 @@
     },
     "sdformat10": {
       "baseline": "10.0.0",
-      "port-version": 3
+      "port-version": 4
     },
     "sdformat13": {
       "baseline": "13.5.0",
@@ -7862,11 +7862,11 @@
     },
     "sdformat6": {
       "baseline": "6.2.0",
-      "port-version": 6
+      "port-version": 7
     },
     "sdformat9": {
       "baseline": "9.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "sdl1": {
       "baseline": "1.2.15",

--- a/versions/s-/sdformat10.json
+++ b/versions/s-/sdformat10.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1784f42c65cd5b0919a9d6c338bf1ab4f6022a9b",
+      "version": "10.0.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "872ca568e5e49581fe0404d3422230d60b3d9710",
       "version": "10.0.0",
       "port-version": 3

--- a/versions/s-/sdformat6.json
+++ b/versions/s-/sdformat6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e05708a69e80e295caedf2c503461686cabb5d3b",
+      "version": "6.2.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "bdc0f927266aa4195c3795075c9e07c426c4556c",
       "version": "6.2.0",
       "port-version": 6

--- a/versions/s-/sdformat9.json
+++ b/versions/s-/sdformat9.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "faa40ee4c041f6c5d34acbc85008b8f939befc62",
+      "version": "9.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "693fd5dc7bdb0dfe766275719f0b3f85477994aa",
       "version": "9.8.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #37338

Fix error:
````
CMake Warning (dev) at ports/sdformat6/portfile.cmake:30 (set):
  Only the first value argument is used when setting an environment variable.
  Argument 'C:\Program Files\Microsoft Visual
  Studio\2022\Enterprise\Common7\IDE\VC\VCPackages' and later are unused.
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
