### PR TITLE
[rmlui] Add patch to remove std:: before uint*

### DIFF
--- a/ports/rmlui/portfile.cmake
+++ b/ports/rmlui/portfile.cmake
@@ -1,10 +1,10 @@
 vcpkg_from_github(
-	OUT_SOURCE_PATH SOURCE_PATH
-	REPO mikke89/RmlUi
-	REF ${VERSION}
-	SHA512 06bf1a24c6ff3f164ef1af80186d5f974e6a5467f6f0d50ec33bb14516e4899321fe7a5b9c4912def908a53711bf302bc782cf78117e0930862f5d1ad07dec18
-	HEAD_REF master
-	PATCHES
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mikke89/RmlUi
+    REF ${VERSION}
+    SHA512 06bf1a24c6ff3f164ef1af80186d5f974e6a5467f6f0d50ec33bb14516e4899321fe7a5b9c4912def908a53711bf302bc782cf78117e0930862f5d1ad07dec18
+    HEAD_REF master
+    PATCHES
         add-robin-hood.patch
         remove-std-before-uint.patch
 )

--- a/ports/rmlui/portfile.cmake
+++ b/ports/rmlui/portfile.cmake
@@ -1,11 +1,12 @@
 vcpkg_from_github(
 	OUT_SOURCE_PATH SOURCE_PATH
 	REPO mikke89/RmlUi
-	REF 5.1
+	REF ${VERSION}
 	SHA512 06bf1a24c6ff3f164ef1af80186d5f974e6a5467f6f0d50ec33bb14516e4899321fe7a5b9c4912def908a53711bf302bc782cf78117e0930862f5d1ad07dec18
 	HEAD_REF master
 	PATCHES
-		add-robin-hood.patch
+        add-robin-hood.patch
+        remove-std-before-uint.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -16,7 +17,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 # Remove built-in header, instead we use vcpkg version (from robin-hood-hashing port)
-file(REMOVE ${SOURCE_PATH}/Include/RmlUi/Core/Containers/robin_hood.h)
+file(REMOVE "${SOURCE_PATH}/Include/RmlUi/Core/Containers/robin_hood.h")
 
 vcpkg_cmake_configure(
 	SOURCE_PATH ${SOURCE_PATH}
@@ -25,32 +26,30 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(
-	CONFIG_PATH  lib/RmlUi/cmake
-)
+vcpkg_cmake_config_fixup(CONFIG_PATH  lib/RmlUi/cmake)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE 
-	${CURRENT_PACKAGES_DIR}/debug/include
-	${CURRENT_PACKAGES_DIR}/debug/lib/RmlUi
-	${CURRENT_PACKAGES_DIR}/lib/RmlUi
+	"${CURRENT_PACKAGES_DIR}/debug/include"
+	"${CURRENT_PACKAGES_DIR}/debug/lib/RmlUi"
+	"${CURRENT_PACKAGES_DIR}/lib/RmlUi"
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-	vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/RmlUi/Core/Header.h
+	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/RmlUi/Core/Header.h"
 		"#if !defined RMLUI_STATIC_LIB"
 		"#if 0"
 	)
-	vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/RmlUi/Debugger/Header.h
+	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/RmlUi/Debugger/Header.h"
 		"#if !defined RMLUI_STATIC_LIB"
 		"#if 0"
 	)
 	if ("lua" IN_LIST FEATURES)
-		vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/RmlUi/Lua/Header.h
+		vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/RmlUi/Lua/Header.h"
 			"#if !defined RMLUI_STATIC_LIB"
 			"#if 0"
 		)
 	endif()
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/rmlui/portfile.cmake
+++ b/ports/rmlui/portfile.cmake
@@ -10,46 +10,46 @@ vcpkg_from_github(
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-	FEATURES 
-		lua             BUILD_LUA_BINDINGS
-	INVERTED_FEATURES
-		freetype        NO_FONT_INTERFACE_DEFAULT
+    FEATURES 
+        lua             BUILD_LUA_BINDINGS
+    INVERTED_FEATURES
+        freetype        NO_FONT_INTERFACE_DEFAULT
 )
 
 # Remove built-in header, instead we use vcpkg version (from robin-hood-hashing port)
 file(REMOVE "${SOURCE_PATH}/Include/RmlUi/Core/Containers/robin_hood.h")
 
 vcpkg_cmake_configure(
-	SOURCE_PATH ${SOURCE_PATH}
-	OPTIONS
-		${FEATURE_OPTIONS}
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH  lib/RmlUi/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/RmlUi/cmake)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE 
-	"${CURRENT_PACKAGES_DIR}/debug/include"
-	"${CURRENT_PACKAGES_DIR}/debug/lib/RmlUi"
-	"${CURRENT_PACKAGES_DIR}/lib/RmlUi"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/RmlUi"
+    "${CURRENT_PACKAGES_DIR}/lib/RmlUi"
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/RmlUi/Core/Header.h"
-		"#if !defined RMLUI_STATIC_LIB"
-		"#if 0"
-	)
-	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/RmlUi/Debugger/Header.h"
-		"#if !defined RMLUI_STATIC_LIB"
-		"#if 0"
-	)
-	if ("lua" IN_LIST FEATURES)
-		vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/RmlUi/Lua/Header.h"
-			"#if !defined RMLUI_STATIC_LIB"
-			"#if 0"
-		)
-	endif()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/RmlUi/Core/Header.h"
+        "#if !defined RMLUI_STATIC_LIB"
+        "#if 0"
+    )
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/RmlUi/Debugger/Header.h"
+        "#if !defined RMLUI_STATIC_LIB"
+        "#if 0"
+    )
+    if ("lua" IN_LIST FEATURES)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/RmlUi/Lua/Header.h"
+            "#if !defined RMLUI_STATIC_LIB"
+            "#if 0"
+        )
+    endif()
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/rmlui/remove-std-before-uint.patch
+++ b/ports/rmlui/remove-std-before-uint.patch
@@ -1,0 +1,130 @@
+diff --git a/Backends/RmlUi_Backend_GLFW_VK.cpp b/Backends/RmlUi_Backend_GLFW_VK.cpp
+index c1cf80f..7d45299 100644
+--- a/Backends/RmlUi_Backend_GLFW_VK.cpp
++++ b/Backends/RmlUi_Backend_GLFW_VK.cpp
+@@ -35,7 +35,7 @@
+ #include <RmlUi/Core/Core.h>
+ #include <RmlUi/Core/FileInterface.h>
+ #include <GLFW/glfw3.h>
+-#include <cstdint>
++#include <stdint.h>
+ #include <thread>
+ 
+ static void SetupCallbacks(GLFWwindow* window);
+diff --git a/Include/RmlUi/Core/Types.h b/Include/RmlUi/Core/Types.h
+index 28e5ad7..39a5e8a 100644
+--- a/Include/RmlUi/Core/Types.h
++++ b/Include/RmlUi/Core/Types.h
+@@ -32,6 +32,7 @@
+ #include "../Config/Config.h"
+ 
+ #include <cstdlib>
++#include <stdint.h>
+ #include <memory>
+ 
+ #include "Traits.h"
+diff --git a/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp b/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp
+index bcc6f13..da487b0 100644
+--- a/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp
++++ b/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp
+@@ -219,7 +219,7 @@ int FontFaceBitmap::GenerateString(const String& string, const Vector2f& string_
+ 
+ int FontFaceBitmap::GetKerning(Character left, Character right) const
+ {
+-	std::uint64_t key = (((std::uint64_t)left << 32) | (std::uint64_t)right);
++	uint64_t key = (((uint64_t)left << 32) | (uint64_t)right);
+ 
+ 	auto it = kerning.find(key);
+ 	if (it != kerning.end())
+@@ -291,13 +291,13 @@ void FontParserBitmap::HandleElementStart(const String& name, const Rml::XMLAttr
+ 	}
+ 	else if (name == "kerning")
+ 	{
+-		std::uint64_t first = (std::uint64_t)Get(attributes, "first", 0);
+-		std::uint64_t second = (std::uint64_t)Get(attributes, "second", 0);
++		uint64_t first = (uint64_t)Get(attributes, "first", 0);
++		uint64_t second = (uint64_t)Get(attributes, "second", 0);
+ 		int amount = Get(attributes, "amount", 0);
+ 
+ 		if (first != 0 && second != 0 && amount != 0)
+ 		{
+-			std::uint64_t key = ((first << 32) | second);
++			uint64_t key = ((first << 32) | second);
+ 			kerning[key] = amount;
+ 		}
+ 	}
+diff --git a/Samples/basic/bitmapfont/src/FontEngineBitmap.h b/Samples/basic/bitmapfont/src/FontEngineBitmap.h
+index f9fef43..41256c9 100644
+--- a/Samples/basic/bitmapfont/src/FontEngineBitmap.h
++++ b/Samples/basic/bitmapfont/src/FontEngineBitmap.h
+@@ -29,7 +29,6 @@
+ #ifndef FONTENGINEBITMAP_H
+ #define FONTENGINEBITMAP_H
+ 
+-#include <cstdint>
+ #include <RmlUi/Core/Types.h>
+ #include "FontEngineInterfaceBitmap.h"
+ 
+@@ -63,7 +62,7 @@ struct FontMetrics {
+ using FontGlyphs = Rml::UnorderedMap<Character, BitmapGlyph>;
+ 
+ // Mapping of combined (left, right) character to kerning in pixels.
+-using FontKerning = Rml::UnorderedMap<std::uint64_t, int>;
++using FontKerning = Rml::UnorderedMap<uint64_t, int>;
+ 
+ 
+ class FontFaceBitmap {
+diff --git a/Source/Core/ElementStyle.h b/Source/Core/ElementStyle.h
+index a89eb7e..8f62fb7 100644
+--- a/Source/Core/ElementStyle.h
++++ b/Source/Core/ElementStyle.h
+@@ -40,7 +40,7 @@ class ElementDefinition;
+ class PropertiesIterator;
+ enum class RelativeTarget;
+ 
+-enum class PseudoClassState : std::uint8_t { Clear = 0, Set = 1, Override = 2 };
++enum class PseudoClassState : uint8_t { Clear = 0, Set = 1, Override = 2 };
+ using PseudoClassMap = SmallUnorderedMap< String, PseudoClassState >;
+ 
+ 
+diff --git a/Source/Core/FontEngineDefault/FontFaceHandleDefault.h b/Source/Core/FontEngineDefault/FontFaceHandleDefault.h
+index 4e6c4d7..5e92d7b 100644
+--- a/Source/Core/FontEngineDefault/FontFaceHandleDefault.h
++++ b/Source/Core/FontEngineDefault/FontFaceHandleDefault.h
+@@ -143,8 +143,8 @@ private:
+ 	FontLayerCache layer_cache;
+ 
+ 	// Pre-cache kerning pairs for some ascii subset of all characters.
+-	using AsciiPair = std::uint16_t;
+-	using KerningIntType = std::int16_t;
++	using AsciiPair = uint16_t;
++	using KerningIntType = int16_t;
+ 	using KerningPairs = UnorderedMap< AsciiPair, KerningIntType >;
+ 	KerningPairs kerning_pair_cache;
+ 
+diff --git a/Source/Core/LayoutFlex.cpp b/Source/Core/LayoutFlex.cpp
+index b51aa93..074376d 100644
+--- a/Source/Core/LayoutFlex.cpp
++++ b/Source/Core/LayoutFlex.cpp
+@@ -110,7 +110,7 @@ struct FlexItem {
+ 	float hypothetical_main_size; // Outer size
+ 
+ 	// Used for resolving flexible length
+-	enum class Violation : std::uint8_t { None = 0, Min, Max };
++	enum class Violation : uint8_t { None = 0, Min, Max };
+ 	bool frozen;
+ 	Violation violation;
+ 	float target_main_size; // Outer size
+diff --git a/Source/Lottie/ElementLottie.cpp b/Source/Lottie/ElementLottie.cpp
+index 91f4a0e..b5e36a4 100644
+--- a/Source/Lottie/ElementLottie.cpp
++++ b/Source/Lottie/ElementLottie.cpp
+@@ -228,7 +228,7 @@ void ElementLottie::UpdateTexture()
+ 
+ 		byte* p_data = new byte[total_bytes];
+ 
+-		rlottie::Surface surface(reinterpret_cast<std::uint32_t*>(p_data), render_dimensions.x, render_dimensions.y, bytes_per_line);
++		rlottie::Surface surface(reinterpret_cast<uint32_t*>(p_data), render_dimensions.x, render_dimensions.y, bytes_per_line);
+ 		animation->renderSync(next_frame, surface);
+ 
+ 		// Swizzle the channel order from rlottie's BGRA to RmlUi's RGBA, and change pre-multiplied to post-multiplied alpha.

--- a/ports/rmlui/vcpkg.json
+++ b/ports/rmlui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rmlui",
   "version": "5.1",
+  "port-version": 1,
   "maintainers": "Michael R. P. Ragazzon <mikke89@users.noreply.github.com>",
   "description": "RmlUi is the C++ user interface library based on the HTML and CSS standards, designed as a complete solution for any project's interface needs.",
   "homepage": "https://github.com/mikke89/RmlUi",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7654,7 +7654,7 @@
     },
     "rmlui": {
       "baseline": "5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "rmqcpp": {
       "baseline": "1.0.0",

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0e83e8e69be5708d0adae6374ffac478157aca19",
+      "git-tree": "cef931b140aa6e09bed6aa57445d5f726ba2bd8b",
       "version": "5.1",
       "port-version": 1
     },

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "43f61f710a9b38b4298182cf0da856debd9e5d58",
+      "git-tree": "0e83e8e69be5708d0adae6374ffac478157aca19",
       "version": "5.1",
       "port-version": 1
     },

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43f61f710a9b38b4298182cf0da856debd9e5d58",
+      "version": "5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "eef365a991fcf66a1848ed65bb9af75e767ffce6",
       "version": "5.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
This change from PR https://github.com/microsoft/vcpkg/pull/37369. 
The related upstream issue: https://github.com/mikke89/RmlUi/issues/470.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
