### PR TITLE
[paraview] Try optimize build

### DIFF
--- a/ports/paraview/portfile.cmake
+++ b/ports/paraview/portfile.cmake
@@ -133,20 +133,8 @@ file(REMOVE "${CURRENT_PACKAGES_DIR}/include/paraview-${VERSION_MAJOR_MINOR}/vtk
 
 set(TOOLVER pv${VERSION_MAJOR_MINOR})
 
-if(tools IN_LIST FEATURE_OPTIONS)
-    vcpkg_copy_tools(
-        TOOL_NAMES
-            paraview
-            pvbatch
-            pvdataserver
-            pvpython
-            pvrenderserver
-            pvserver
-            smTestDriver
-            vtkProcessXML
-            vtkWrapClientServer
-        AUTO_CLEAN
-    )
+if(tools IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES paraview pvbatch pvdataserver pvpython pvrenderserver pvserver smTestDriver vtkProcessXML vtkWrapClientServer AUTO_CLEAN)
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/paraview/portfile.cmake
+++ b/ports/paraview/portfile.cmake
@@ -131,10 +131,46 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 # see https://gitlab.kitware.com/paraview/paraview/-/issues/21328
 file(REMOVE "${CURRENT_PACKAGES_DIR}/include/paraview-${VERSION_MAJOR_MINOR}/vtkCPConfig.h")
 
-set(TOOLVER pv${VERSION_MAJOR_MINOR})
+if("tools" IN_LIST FEATURES)
+    set(TOOLVER "pv${VERSION_MAJOR_MINOR}")
+    set(TOOLS   paraview
+                pvbatch
+                pvdataserver
+                pvpython
+                pvrenderserver
+                pvserver
+                smTestDriver
+                vtkProcessXML
+                vtkWrapClientServer)
 
-if(tools IN_LIST FEATURES)
-    vcpkg_copy_tools(TOOL_NAMES paraview pvbatch pvdataserver pvpython pvrenderserver pvserver smTestDriver vtkProcessXML vtkWrapClientServer AUTO_CLEAN)
+    foreach(tool ${TOOLS})
+        # Remove debug tools
+        set(filename "${CURRENT_PACKAGES_DIR}/debug/bin/${tool}${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+        if(EXISTS "${filename}")
+            file(REMOVE "${filename}")
+        endif()
+        set(filename "${CURRENT_PACKAGES_DIR}/debug/bin/${tool}-${TOOLVER}${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+        if(EXISTS "${filename}")
+            file(REMOVE "${filename}")
+        endif()
+        set(filename "${CURRENT_PACKAGES_DIR}/debug/bin/${tool}-${TOOLVER}d${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+        if(EXISTS "${filename}")
+            file(REMOVE "${filename}")
+        endif()
+        
+        # Move release tools
+        set(filename "${CURRENT_PACKAGES_DIR}/bin/${tool}${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+        if(EXISTS "${filename}")
+            file(INSTALL "${filename}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+            file(REMOVE "${filename}")
+        endif()
+        set(filename "${CURRENT_PACKAGES_DIR}/bin/${tool}-${TOOLVER}${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+        if(EXISTS "${filename}")
+            file(INSTALL "${filename}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+            file(REMOVE "${filename}")
+        endif()
+    endforeach()
+    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/paraview/vcpkg.json
+++ b/ports/paraview/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "paraview",
   "version": "5.11.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "VTK-based Data Analysis and Visualization Application",
   "homepage": "https://www.paraview.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6614,7 +6614,7 @@
     },
     "paraview": {
       "baseline": "5.11.0",
-      "port-version": 4
+      "port-version": 5
     },
     "parmetis": {
       "baseline": "2022-07-27",

--- a/versions/p-/paraview.json
+++ b/versions/p-/paraview.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0143325ff0d592c8b128aa0248b6bbcdfe7c14f4",
+      "git-tree": "7aa1c619caf85975cd02f534251ba2dfbb03b2cf",
       "version": "5.11.0",
       "port-version": 5
     },

--- a/versions/p-/paraview.json
+++ b/versions/p-/paraview.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c7472609c64853cb88b0d6d723787919e463cb4",
+      "version": "5.11.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "2aa3d8185a319a76c7961608ecce8b2f03c08cd7",
       "version": "5.11.0",
       "port-version": 4

--- a/versions/p-/paraview.json
+++ b/versions/p-/paraview.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6c7472609c64853cb88b0d6d723787919e463cb4",
+      "git-tree": "0143325ff0d592c8b128aa0248b6bbcdfe7c14f4",
       "version": "5.11.0",
       "port-version": 5
     },


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
