### PR TITLE
[brpc] x64-linux-dynamic link error(brpc.so undefined reference to leveldb

### DIFF
--- a/ports/brpc/fix-build.patch
+++ b/ports/brpc/fix-build.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4ac815d6..dbb9b7ee 100644
+index f364cd13..f4add26d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -66,7 +66,8 @@ endif()
@@ -91,7 +91,7 @@ index dfad5fd8..8423d55a 100644
    set(GFLAGS_FOUND TRUE)
  endif(GFLAGS_INCLUDE_PATH AND GFLAGS_LIBRARY)
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index fbcc7cc5..95037a0d 100644
+index fbcc7cc5..868270ea 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -31,16 +31,24 @@ add_dependencies(SOURCES_LIB PROTO_LIB)
@@ -121,7 +121,7 @@ index fbcc7cc5..95037a0d 100644
  # for protoc-gen-mcpack
  set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/output/bin)
      
-@@ -49,35 +57,62 @@ set(protoc_gen_mcpack_SOURCES
+@@ -49,35 +57,63 @@ set(protoc_gen_mcpack_SOURCES
   )
      
  add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
@@ -131,7 +131,7 @@ index fbcc7cc5..95037a0d 100644
      add_library(brpc-shared SHARED $<TARGET_OBJECTS:BUTIL_LIB> 
                                     $<TARGET_OBJECTS:SOURCES_LIB>
                                     $<TARGET_OBJECTS:PROTO_LIB>)
--    target_link_libraries(brpc-shared ${DYNAMIC_LIB})
+     target_link_libraries(brpc-shared ${DYNAMIC_LIB})
 +    target_include_directories(brpc-shared PUBLIC $<INSTALL_INTERFACE:include>)
      if(BRPC_WITH_GLOG)
          target_link_libraries(brpc-shared ${GLOG_LIB})

--- a/ports/brpc/fix-glog.patch
+++ b/ports/brpc/fix-glog.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f4add26..b87e845 100644
+index f4add26d..b87e8455 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -80,9 +80,10 @@ include(GNUInstallDirs)
@@ -54,7 +54,7 @@ index f4add26..b87e845 100644
  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
      #required by butil/crc32.cc to boost performance for 10x
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 95037a0..24007d7 100644
+index 868270ea..a70ad23f 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -31,6 +31,10 @@ add_dependencies(SOURCES_LIB PROTO_LIB)
@@ -78,9 +78,9 @@ index 95037a0..24007d7 100644
  target_include_directories(brpc-static PUBLIC $<INSTALL_INTERFACE:include>)
  SET_TARGET_PROPERTIES(brpc-static PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
  
-@@ -64,9 +65,6 @@ if(BUILD_SHARED_LIBS)
-                                    $<TARGET_OBJECTS:SOURCES_LIB>
+@@ -65,9 +66,6 @@ if(BUILD_SHARED_LIBS)
                                     $<TARGET_OBJECTS:PROTO_LIB>)
+     target_link_libraries(brpc-shared ${DYNAMIC_LIB})
      target_include_directories(brpc-shared PUBLIC $<INSTALL_INTERFACE:include>)
 -    if(BRPC_WITH_GLOG)
 -        target_link_libraries(brpc-shared ${GLOG_LIB})

--- a/ports/brpc/vcpkg.json
+++ b/ports/brpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "brpc",
   "version": "1.6.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Industrial-grade RPC framework used throughout Baidu, with 1,000,000+ instances and thousands kinds of services, called \"baidu-rpc\" inside Baidu.",
   "homepage": "https://github.com/apache/incubator-brpc",
   "license": "Apache-2.0",

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4aa97cf4dfb7c0ff2537a3b0e324daa97940d2c5",
+      "version": "1.6.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "3fd0bfb30a96852a7a92e0526c411ef9f95bed83",
       "version": "1.6.1",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1350,7 +1350,7 @@
     },
     "brpc": {
       "baseline": "1.6.1",
-      "port-version": 2
+      "port-version": 3
     },
     "brunocodutra-metal": {
       "baseline": "2.1.4",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
