### PR TITLE
[iowa-hills-dsp] Add new port

### DIFF
--- a/ports/iowa-hills-dsp/portfile.cmake
+++ b/ports/iowa-hills-dsp/portfile.cmake
@@ -1,21 +1,22 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO DigitalInBlue/iowahills_dsp
+    REPO hayguen/iowahills_dsp
     REF "v${VERSION}"
-    SHA512 0047d8f8f2962b082d14b0a93c30b0a9d5a8be106a71053d15c5743dc4a1ad2744e0261989a42d190536fb8fb203c8ab2d50bac1fcdad309e75d07fd0dfadfa6
+    SHA512 095fecb1a4bf074a3e11da7e6edaba4d375c5603bed5f2578b52f900dbd20ac59f2414a8f9432eba1742807fe8553cc1edd63606fc38400cdda77bf32ee49eb1
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/iowa_hills_dsp.lib")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/iowa_hills_dsp" RENAME copyright)
+# debug/share was not being generated, so the VCPKG_BUILD_TYPE is being set to
+# "release" so that fixup completes successfully.
+set(VCPKG_BUILD_TYPE "release")
+vcpkg_cmake_config_fixup(PACKAGE_NAME iowa_hills_dsp)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/iowa-hills-dsp/portfile.cmake
+++ b/ports/iowa-hills-dsp/portfile.cmake
@@ -14,9 +14,4 @@ vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# debug/share was not being generated, so the VCPKG_BUILD_TYPE is being set to
-# "release" so that fixup completes successfully.
-set(VCPKG_BUILD_TYPE "release")
-vcpkg_cmake_config_fixup(PACKAGE_NAME iowa_hills_dsp)
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/iowa-hills-dsp/portfile.cmake
+++ b/ports/iowa-hills-dsp/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO DigitalInBlue/iowahills_dsp
+    REF "v${VERSION}"
+    SHA512 0047d8f8f2962b082d14b0a93c30b0a9d5a8be106a71053d15c5743dc4a1ad2744e0261989a42d190536fb8fb203c8ab2d50bac1fcdad309e75d07fd0dfadfa6
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/iowa_hills_dsp.lib")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/iowa_hills_dsp" RENAME copyright)

--- a/ports/iowa-hills-dsp/vcpkg.json
+++ b/ports/iowa-hills-dsp/vcpkg.json
@@ -8,10 +8,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/iowa-hills-dsp/vcpkg.json
+++ b/ports/iowa-hills-dsp/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "iowa-hills-dsp",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "A platform-independent C/C++ library with many DSP (digital signal processing) functions, amongst also FIR and IIR filter design - but also FFT, DFT, Goertzel and Windowing functions.",
-  "homepage": "https://github.com/DigitalInBlue/iowahills_dsp",
+  "homepage": "https://github.com/hayguen/iowahills_dsp",
   "license": "MIT",
   "dependencies": [
     {

--- a/ports/iowa-hills-dsp/vcpkg.json
+++ b/ports/iowa-hills-dsp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "iowa-hills-dsp",
+  "version": "1.0.0",
+  "description": "A platform-independent C/C++ library with many DSP (digital signal processing) functions, amongst also FIR and IIR filter design - but also FFT, DFT, Goertzel and Windowing functions.",
+  "homepage": "https://github.com/DigitalInBlue/iowahills_dsp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3628,6 +3628,10 @@
       "baseline": "2020-09-14",
       "port-version": 5
     },
+    "iowa-hills-dsp": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "irrlicht": {
       "baseline": "1.8.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3629,7 +3629,7 @@
       "port-version": 5
     },
     "iowa-hills-dsp": {
-      "baseline": "1.0.0",
+      "baseline": "0.1.0",
       "port-version": 0
     },
     "irrlicht": {

--- a/versions/i-/iowa-hills-dsp.json
+++ b/versions/i-/iowa-hills-dsp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "63f6e1a300b25d1d916f8136e3321e2538b03014",
+      "git-tree": "1b8ddb77c959a1c4a95f69e10f621873d233557f",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/i-/iowa-hills-dsp.json
+++ b/versions/i-/iowa-hills-dsp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "612d82276c740b725905c56be33f19019468acfb",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/i-/iowa-hills-dsp.json
+++ b/versions/i-/iowa-hills-dsp.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "612d82276c740b725905c56be33f19019468acfb",
-      "version": "1.0.0",
+      "git-tree": "63f6e1a300b25d1d916f8136e3321e2538b03014",
+      "version": "0.1.0",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.