### PR TITLE
[ktx] Feature tools doesn't support UWP

### DIFF
--- a/ports/ktx/vcpkg.json
+++ b/ports/ktx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ktx",
   "version-semver": "4.3.1",
+  "port-version": 1,
   "description": [
     "The Khronos KTX library and tools.",
     "Functions for writing and reading KTX files, and instantiating OpenGL®, OpenGL ES™️ and Vulkan® textures from them."
@@ -22,7 +23,7 @@
   "features": {
     "tools": {
       "description": "Build tools",
-      "supports": "!android",
+      "supports": "!android & !uwp",
       "dependencies": [
         "cxxopts",
         "fmt"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4014,7 +4014,7 @@
     },
     "ktx": {
       "baseline": "4.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "kubazip": {
       "baseline": "0.2.6",

--- a/versions/k-/ktx.json
+++ b/versions/k-/ktx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "665cd07792ee19ad6c1c2582a75c996ac93639c2",
+      "version-semver": "4.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "61e81d296c64a64fb9c8d217d763fd61bd012b2a",
       "version-semver": "4.3.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #33687.
The latest build error of `ktx[core,tools]:x64-uwp` as below:
```
[111/135] C:\PROGRA~1\MICROS~3\2022\ENTERP~1\VC\Tools\MSVC\1438~1.331\bin\Hostx64\x64\cl.exe   /TP -DBASISU_NO_ITERATOR_DEBUG_LEVEL -DDEBUG -DFMT_SHARED -DKTX_FEATURE_KTX1 -DKTX_FEATURE_KTX2 -DKTX_FEATURE_WRITE -D_DEBUG -IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\tools\imageio\. -IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\utils -external:IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\other_include -external:IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\lib\astc-encoder\Source -external:IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\lib\basisu -external:IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\lib\dfdutils -external:IF:\0218\installed\x64-uwp\include -external:W0 /DWIN32 /D_WINDOWS /D_UNICODE /DUNICODE /DWINAPI_FAMILY=WINAPI_FAMILY_APP /D__WRL_NO_DEFAULT_LIB__ /nologo /Z7 /MP /GS /Gd /Gm- /W3 /WX- /Zc:wchar_t /Zc:inline /Zc:forScope /fp:precise /Oy- /EHsc  /utf-8  /D_DEBUG /MDd /Od /RTC1  -std:c++17 -MDd /W4 /utf-8 /showIncludes /Fotools\imageio\CMakeFiles\imageio.dir\imageinput.cc.obj /Fdtools\imageio\CMakeFiles\imageio.dir\imageio.pdb /FS -c F:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\tools\imageio\imageinput.cc
FAILED: tools/imageio/CMakeFiles/imageio.dir/imageinput.cc.obj 
C:\PROGRA~1\MICROS~3\2022\ENTERP~1\VC\Tools\MSVC\1438~1.331\bin\Hostx64\x64\cl.exe   /TP -DBASISU_NO_ITERATOR_DEBUG_LEVEL -DDEBUG -DFMT_SHARED -DKTX_FEATURE_KTX1 -DKTX_FEATURE_KTX2 -DKTX_FEATURE_WRITE -D_DEBUG -IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\tools\imageio\. -IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\utils -external:IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\other_include -external:IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\lib\astc-encoder\Source -external:IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\lib\basisu -external:IF:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\lib\dfdutils -external:IF:\0218\installed\x64-uwp\include -external:W0 /DWIN32 /D_WINDOWS /D_UNICODE /DUNICODE /DWINAPI_FAMILY=WINAPI_FAMILY_APP /D__WRL_NO_DEFAULT_LIB__ /nologo /Z7 /MP /GS /Gd /Gm- /W3 /WX- /Zc:wchar_t /Zc:inline /Zc:forScope /fp:precise /Oy- /EHsc  /utf-8  /D_DEBUG /MDd /Od /RTC1  -std:c++17 -MDd /W4 /utf-8 /showIncludes /Fotools\imageio\CMakeFiles\imageio.dir\imageinput.cc.obj /Fdtools\imageio\CMakeFiles\imageio.dir\imageio.pdb /FS -c F:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\tools\imageio\imageinput.cc
cl : Command line warning D9025 : overriding '/W3' with '/W4'
F:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\utils\platform_utils.h(51): error C3861: 'CommandLineToArgvW': identifier not found
F:\0218\buildtrees\ktx\src\v4.3.1-3a53d3f003\utils\platform_utils.h(69): error C2664: 'errno_t _wfopen_s(FILE **,const wchar_t *,const wchar_t *)': cannot convert argument 2 from 'const _Elem *' to 'const wchar_t *'
```
Function `CommandLineToArgvW` is from windows header file [`shellapi.h`](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw), but this file doesn't support UWP.
The related upstream comment: https://github.com/KhronosGroup/KTX-Software/pull/800#issuecomment-1818893577
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
