### PR TITLE
[microsoft-ui-uiautomation] Add new port

### DIFF
--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_msbuild_install(
     OPTIONS
         "/r:True"
 	    "/p:RestorePackagesConfig=True"
+        "/p:Platform=x64"
 )
 
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_msbuild_install(
     OPTIONS
         "/r:True"
 	    "/p:RestorePackagesConfig=True"
+        "/p:Platform=Any CPU"
 )
 else()
     message(FATAL_ERROR "Unsupported system: microsoft-ui-uiautomation is not currently ported to VCPKG in ${VCPKG_CMAKE_SYSTEM_NAME}!")

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
 if (VCPKG_TARGET_IS_WINDOWS) # Win32:
 vcpkg_msbuild_install(
     SOURCE_PATH "${SOURCE_PATH}/src/UIAutomation/"
-    PROJECT_SUBPATH "UiaOperationAbstraction\UiaOperationAbstraction.vcxproj"
+    PROJECT_SUBPATH "UiaOperationAbstraction/UiaOperationAbstraction.vcxproj"
     OPTIONS
         "/r:True"
 	    "/p:RestorePackagesConfig=True"

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -1,5 +1,5 @@
 # portfile.cmake
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -9,15 +9,14 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
+vcpkg_msbuild_install(
+    SOURCE_PATH "${SOURCE_PATH}/src/UIAutomation/"
+    PROJECT_SUBPATH "UIAutomation.sln"
+    OPTIONS
+        "/r:True"
+	    "/p:RestorePackagesConfig=True"
 )
 
-vcpkg_cmake_install()
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "Microsoft-UI-UIAutomation")
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_msbuild_install(
     OPTIONS
         "/r:True"
 	    "/p:RestorePackagesConfig=True"
-        "/p:Platform=x64"
+        "/p:Platform=Win32"
 )
 
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -7,7 +7,6 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-if (VCPKG_TARGET_IS_WINDOWS) # Win32:
 vcpkg_msbuild_install(
     SOURCE_PATH "${SOURCE_PATH}/src/UIAutomation/"
     PROJECT_SUBPATH "UiaOperationAbstraction/UiaOperationAbstraction.vcxproj"
@@ -16,9 +15,6 @@ vcpkg_msbuild_install(
 	    "/p:RestorePackagesConfig=True"
         "/p:configuration=Release"
 )
-else()
-    message(FATAL_ERROR "Unsupported system: microsoft-ui-uiautomation is not currently ported to VCPKG in ${VCPKG_CMAKE_SYSTEM_NAME}!")
-endif()
 
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -1,6 +1,4 @@
 # portfile.cmake
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/Microsoft-UI-UIAutomation

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
 if (VCPKG_TARGET_IS_WINDOWS) # Win32:
 vcpkg_msbuild_install(
     SOURCE_PATH "${SOURCE_PATH}/src/UIAutomation/"
-    PROJECT_SUBPATH "UIAutomation.sln"
+    PROJECT_SUBPATH "UiaOperationAbstraction\UiaOperationAbstraction.vcxproj"
     OPTIONS
         "/r:True"
 	    "/p:RestorePackagesConfig=True"

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -11,7 +11,6 @@ if (VCPKG_TARGET_IS_WINDOWS) # Win32:
 vcpkg_msbuild_install(
     SOURCE_PATH "${SOURCE_PATH}/src/UIAutomation/"
     PROJECT_SUBPATH "UIAutomation.sln"
-    PLATFORM "x64"
     OPTIONS
         "/r:True"
 	    "/p:RestorePackagesConfig=True"

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -11,10 +11,10 @@ if (VCPKG_TARGET_IS_WINDOWS) # Win32:
 vcpkg_msbuild_install(
     SOURCE_PATH "${SOURCE_PATH}/src/UIAutomation/"
     PROJECT_SUBPATH "UIAutomation.sln"
+    PLATFORM "x64"
     OPTIONS
         "/r:True"
 	    "/p:RestorePackagesConfig=True"
-        "/p:Platform=x64"
 )
 else()
     message(FATAL_ERROR "Unsupported system: microsoft-ui-uiautomation is not currently ported to VCPKG in ${VCPKG_CMAKE_SYSTEM_NAME}!")

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -1,0 +1,21 @@
+# portfile.cmake
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Microsoft/Microsoft-UI-UIAutomation
+    REF master
+    SHA512 a1388b50a70b14d545adfdce995cc8c88b410d49166ec58ed12b8457248884574e428d8d22c01510907b49042363f4608d4fb4a86f3d79f9fefff746c692e9d1
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_install_copyright(FILE_PATH "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -7,14 +7,18 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+if (VCPKG_TARGET_IS_WINDOWS) # Win32:
 vcpkg_msbuild_install(
     SOURCE_PATH "${SOURCE_PATH}/src/UIAutomation/"
     PROJECT_SUBPATH "UIAutomation.sln"
     OPTIONS
         "/r:True"
 	    "/p:RestorePackagesConfig=True"
-        "/p:Platform=Win32"
+        "/p:Platform=x64"
 )
+else()
+    message(FATAL_ERROR "Unsupported system: microsoft-ui-uiautomation is not currently ported to VCPKG in ${VCPKG_CMAKE_SYSTEM_NAME}!")
+endif()
 
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_msbuild_install(
     OPTIONS
         "/r:True"
 	    "/p:RestorePackagesConfig=True"
-        "/p:Platform=Any CPU"
+        "/p:configuration=Release"
 )
 else()
     message(FATAL_ERROR "Unsupported system: microsoft-ui-uiautomation is not currently ported to VCPKG in ${VCPKG_CMAKE_SYSTEM_NAME}!")

--- a/ports/microsoft-ui-uiautomation/portfile.cmake
+++ b/ports/microsoft-ui-uiautomation/portfile.cmake
@@ -1,21 +1,23 @@
 # portfile.cmake
-include(vcpkg_common_functions)
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/Microsoft-UI-UIAutomation
-    REF master
-    SHA512 a1388b50a70b14d545adfdce995cc8c88b410d49166ec58ed12b8457248884574e428d8d22c01510907b49042363f4608d4fb4a86f3d79f9fefff746c692e9d1
-    HEAD_REF master
+    REF d8c87fae212678915d9b73505e188c3b63db0d79
+    SHA512 4266d5f236ee7f4e2daf02177544876f025b6ec04e9ce0ad63afd0c4674ef1411865a9188d6a8a3a13b64bab1da70bebba25f03b3fc1bf39272f0c04bcbbe28f
+    HEAD_REF main
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_pkgconfig()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-vcpkg_install_copyright(FILE_PATH "${SOURCE_PATH}/LICENSE.txt")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "Microsoft-UI-UIAutomation")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/microsoft-ui-uiautomation/vcpkg.json
+++ b/ports/microsoft-ui-uiautomation/vcpkg.json
@@ -1,21 +1,18 @@
 {
     "name": "microsoft-ui-uiautomation",
-    "version": "1.0.0",
+    "version-date": "2022-04-26",
     "description": "Microsoft UI Automation library",
-    "homepage": "https://github.com/microsoft/microsoft.ui.uiautomation",
+    "homepage": "https://github.com/microsoft/Microsoft-UI-UIAutomation",
     "license": "MIT",
     "dependencies": [
         {
-            "name": "boost",
-            "version>=": "1.75.0"
+            "name" : "vcpkg-cmake",
+            "host" : true
         },
         {
-            "name": "cpprestsdk",
-            "version>=": "2.10.18"
+            "name" : "vcpkg-cmake-config",
+            "host" : true
         },
-        {
-            "name": "gsl",
-            "version>=": "3.1.0"
-        }
+        "fmt"
     ]
 }

--- a/ports/microsoft-ui-uiautomation/vcpkg.json
+++ b/ports/microsoft-ui-uiautomation/vcpkg.json
@@ -7,15 +7,15 @@
     "dependencies": [
         {
             "name": "boost",
-            "version": "1.75.0"
+            "version>=": "1.75.0"
         },
         {
             "name": "cpprestsdk",
-            "version": "2.10.18"
+            "version>=": "2.10.18"
         },
         {
             "name": "gsl",
-            "version": "3.1.0"
+            "version>=": "3.1.0"
         }
     ]
 }

--- a/ports/microsoft-ui-uiautomation/vcpkg.json
+++ b/ports/microsoft-ui-uiautomation/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Microsoft UI Automation library",
   "homepage": "https://github.com/microsoft/Microsoft-UI-UIAutomation",
   "license": "MIT",
-   "supports": "windows",
+  "supports": "windows",
   "dependencies": [
     {
       "name": "vcpkg-msbuild",

--- a/ports/microsoft-ui-uiautomation/vcpkg.json
+++ b/ports/microsoft-ui-uiautomation/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Microsoft UI Automation library",
   "homepage": "https://github.com/microsoft/Microsoft-UI-UIAutomation",
   "license": "MIT",
+   "supports": "windows",
   "dependencies": [
     {
       "name": "vcpkg-msbuild",

--- a/ports/microsoft-ui-uiautomation/vcpkg.json
+++ b/ports/microsoft-ui-uiautomation/vcpkg.json
@@ -6,13 +6,9 @@
     "license": "MIT",
     "dependencies": [
         {
-            "name" : "vcpkg-cmake",
-            "host" : true
-        },
-        {
-            "name" : "vcpkg-cmake-config",
-            "host" : true
-        },
-        "fmt"
+            "name": "vcpkg-msbuild",
+            "host": true,
+            "platform": "windows"
+        }
     ]
 }

--- a/ports/microsoft-ui-uiautomation/vcpkg.json
+++ b/ports/microsoft-ui-uiautomation/vcpkg.json
@@ -1,0 +1,21 @@
+{
+    "name": "microsoft-ui-uiautomation",
+    "version": "1.0.0",
+    "description": "Microsoft UI Automation library",
+    "homepage": "https://github.com/microsoft/microsoft.ui.uiautomation",
+    "license": "MIT",
+    "dependencies": [
+        {
+            "name": "boost",
+            "version": "1.75.0"
+        },
+        {
+            "name": "cpprestsdk",
+            "version": "2.10.18"
+        },
+        {
+            "name": "gsl",
+            "version": "3.1.0"
+        }
+    ]
+}

--- a/ports/microsoft-ui-uiautomation/vcpkg.json
+++ b/ports/microsoft-ui-uiautomation/vcpkg.json
@@ -1,14 +1,14 @@
 {
-    "name": "microsoft-ui-uiautomation",
-    "version-date": "2022-04-26",
-    "description": "Microsoft UI Automation library",
-    "homepage": "https://github.com/microsoft/Microsoft-UI-UIAutomation",
-    "license": "MIT",
-    "dependencies": [
-        {
-            "name": "vcpkg-msbuild",
-            "host": true,
-            "platform": "windows"
-        }
-    ]
+  "name": "microsoft-ui-uiautomation",
+  "version-date": "2022-04-26",
+  "description": "Microsoft UI Automation library",
+  "homepage": "https://github.com/microsoft/Microsoft-UI-UIAutomation",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-msbuild",
+      "host": true,
+      "platform": "windows"
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5672,10 +5672,6 @@
       "baseline": "0.1.0-alpha4",
       "port-version": 8
     },
-    "microsoft-ui-uiautomation": {
-      "baseline": "1.0.0",
-      "port-version": 0
-    },
     "mikktspace": {
       "baseline": "2020-10-06",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5672,6 +5672,10 @@
       "baseline": "0.1.0-alpha4",
       "port-version": 8
     },
+    "microsoft-ui-uiautomation": {
+      "baseline": "2022-04-26",
+      "port-version": 0
+    },
     "mikktspace": {
       "baseline": "2020-10-06",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5672,6 +5672,10 @@
       "baseline": "0.1.0-alpha4",
       "port-version": 8
     },
+    "microsoft-ui-uiautomation": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "mikktspace": {
       "baseline": "2020-10-06",
       "port-version": 3

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -1,7 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "4040cb6cdbd8cb35b36a3df6aa4119288d3336e0",
       "version-date": "2022-04-26"
     }
   ]

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "20463b47befe46d09368fa1678f04783df7d878c"
+      "git-tree": "da51692d097681972a7a8213ebdf027f2761077c"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "a1388b50a70b14d545adfdce995cc8c88b410d49166ec58ed12b8457248884574e428d8d22c01510907b49042363f4608d4fb4a86f3d79f9fefff746c692e9d1",
-      "version": "1.0.0"
+      "version-date": "2022-04-26"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a1388b50a70b14d545adfdce995cc8c88b410d49166ec58ed12b8457248884574e428d8d22c01510907b49042363f4608d4fb4a86f3d79f9fefff746c692e9d1",
+      "git-tree": "4040cb6cdbd8cb35b36a3df6aa4119288d3336e0",
       "version-date": "2022-04-26"
     }
   ]

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "53173358f428c4ebc6ab87c28a90a197b3fdf50e"
+      "git-tree": "4d57e698dcc56207e19d0d99db396b7af6182593"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -1,7 +1,8 @@
 {
   "versions": [
     {
-      "version-date": "2022-04-26"
+      "version-date": "2022-04-26",
+      "git-tree": "53173358f428c4ebc6ab87c28a90a197b3fdf50e"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "e6e6f425cd39768ddaef8a082c21ad926c402950"
+      "git-tree": "20463b47befe46d09368fa1678f04783df7d878c"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "da51692d097681972a7a8213ebdf027f2761077c"
+      "git-tree": "7b854f6e10a11a5257660ce259c94499eb6da800"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "7b854f6e10a11a5257660ce259c94499eb6da800"
+      "git-tree": "d708bf06334c1ff88eb0b7f671e845ac3efb3af0"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -1,8 +1,8 @@
 {
-    "versions": [
-      {
-        "git-tree": "a1388b50a70b14d545adfdce995cc8c88b410d49166ec58ed12b8457248884574e428d8d22c01510907b49042363f4608d4fb4a86f3d79f9fefff746c692e9d1",
-        "version": "1.0.0"
-      }
-    ]
+  "versions": [
+    {
+      "git-tree": "a1388b50a70b14d545adfdce995cc8c88b410d49166ec58ed12b8457248884574e428d8d22c01510907b49042363f4608d4fb4a86f3d79f9fefff746c692e9d1",
+      "version": "1.0.0"
+    }
+  ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "4d57e698dcc56207e19d0d99db396b7af6182593"
+      "git-tree": "4639cc0560626ee47527551802c087f2f8d662e1"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "d708bf06334c1ff88eb0b7f671e845ac3efb3af0"
+      "git-tree": "7d036af8137d0338b129f705f5ad9b71e67dc050"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "7d036af8137d0338b129f705f5ad9b71e67dc050"
+      "git-tree": "0beae2ab44813fbe5e0aa61ea6d89fdda097f4ad"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "4639cc0560626ee47527551802c087f2f8d662e1"
+      "git-tree": "e6e6f425cd39768ddaef8a082c21ad926c402950"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "a785c01466b2a2df89c4aafc0d9a58d23d90e107"
+      "git-tree": "3bc0ecee9dffe5f7f3f4bb0e1abcacf960347dfb"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "version-date": "2022-04-26",
-      "git-tree": "0beae2ab44813fbe5e0aa61ea6d89fdda097f4ad"
+      "git-tree": "a785c01466b2a2df89c4aafc0d9a58d23d90e107"
     }
   ]
 }

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -1,7 +1,7 @@
 {
     "versions": [
       {
-        "git-tree": "d8c87fae212678915d9b73505e188c3b63db0d79",
+        "git-tree": "a1388b50a70b14d545adfdce995cc8c88b410d49166ec58ed12b8457248884574e428d8d22c01510907b49042363f4608d4fb4a86f3d79f9fefff746c692e9d1",
         "version": "1.0.0"
       }
     ]

--- a/versions/m-/microsoft-ui-uiautomation.json
+++ b/versions/m-/microsoft-ui-uiautomation.json
@@ -1,0 +1,8 @@
+{
+    "versions": [
+      {
+        "git-tree": "d8c87fae212678915d9b73505e188c3b63db0d79",
+        "version": "1.0.0"
+      }
+    ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [ x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md). 
- [ x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines. 
- [ x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ x] The license declaration in `vcpkg.json` matches what upstream says.
- [ x] The installed as the "copyright" file matches what upstream says.
- [ x] The source code of the component installed comes from an authoritative source.
- [ x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is in the new port's versions file.
- [ x] Only one version is added to each modified port's versions file.
