### PR TITLE
[directx12-agility] New port for using Microsoft.Direct3D.D3D12

### DIFF
--- a/ports/directx12-agility/directx12-config.cmake.in
+++ b/ports/directx12-agility/directx12-config.cmake.in
@@ -10,13 +10,25 @@ if (EXISTS "${_dx12_root}/bin/D3D12Core.dll")
        message(FATAL_ERROR "D3D12.LIB import library from the Windows SDK is required")
    endif()
 
-   add_library(Microsoft::DirectX12-Agility SHARED IMPORTED)
-   set_target_properties(Microsoft::DirectX12-Agility PROPERTIES
+   add_library(Microsoft::DirectX12-Core SHARED IMPORTED)
+   set_target_properties(Microsoft::DirectX12-Core PROPERTIES
       IMPORTED_LOCATION_RELEASE            "${_dx12_root}/bin/D3D12Core.dll"
-      IMPORTED_LOCATION_DEBUG              "${_dx12_root}/debug/bin/D3D12Core.dll;${_dx12_root}/debug/bin/d3d12SDKLayers.dll"
+      IMPORTED_LOCATION_DEBUG              "${_dx12_root}/debug/bin/D3D12Core.dll"
       IMPORTED_IMPLIB                      "${D3D12_LIB}"
       IMPORTED_CONFIGURATIONS              "Debug;Release"
       IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+
+   add_library(Microsoft::DirectX12-Layers SHARED IMPORTED)
+   set_target_properties(Microsoft::DirectX12-Layers PROPERTIES
+      IMPORTED_LOCATION_RELEASE            "${_dx12_root}/debug/bin/d3d12SDKLayers.dll"
+      IMPORTED_LOCATION_DEBUG              "${_dx12_root}/debug/bin/d3d12SDKLayers.dll"
+      IMPORTED_IMPLIB                      "${D3D12_LIB}"
+      IMPORTED_CONFIGURATIONS              "Debug;Release"
+      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+
+   add_library(Microsoft::DirectX12-Agility INTERFACE IMPORTED)
+   set_target_properties(Microsoft::DirectX12-Agility PROPERTIES
+      INTERFACE_LINK_LIBRARIES "Microsoft::DirectX12-Core;Microsoft::DirectX12-Layers")
 
     set(directx12-agility_FOUND TRUE)
 

--- a/ports/directx12-agility/directx12-config.cmake.in
+++ b/ports/directx12-agility/directx12-config.cmake.in
@@ -1,0 +1,29 @@
+get_filename_component(_dx12_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_dx12_root "${_dx12_root}" PATH)
+get_filename_component(_dx12_root "${_dx12_root}" PATH)
+
+if (EXISTS "${_dx12_root}/bin/D3D12Core.dll")
+
+   find_library(D3D12_LIB NAMES d3d12)
+
+   if("${D3D12_LIB}" STREQUAL "D3D12_LIB-NOTFOUND")
+       message(FATAL_ERROR "D3D12.LIB import library from the Windows SDK is required")
+   endif()
+
+   add_library(Microsoft::DirectX12-Agility SHARED IMPORTED)
+   set_target_properties(Microsoft::DirectX12-Agility PROPERTIES
+      IMPORTED_LOCATION_RELEASE            "${_dx12_root}/bin/D3D12Core.dll"
+      IMPORTED_LOCATION_DEBUG              "${_dx12_root}/debug/bin/D3D12Core.dll;${_dx12_root}/debug/bin/d3d12SDKLayers.dll"
+      IMPORTED_IMPLIB                      "${D3D12_LIB}"
+      IMPORTED_CONFIGURATIONS              "Debug;Release"
+      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+
+    set(directx12-agility_FOUND TRUE)
+
+else()
+
+    set(directx12-agility_FOUND FALSE)
+
+endif()
+
+unset(_dx12_root)

--- a/ports/directx12-agility/portfile.cmake
+++ b/ports/directx12-agility/portfile.cmake
@@ -1,0 +1,43 @@
+set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/${VERSION}"
+    FILENAME "Microsoft.Direct3D.D3D12.${VERSION}.zip"
+    SHA512 9703445beb09808f1edf1320605d870fdfbd74b728227df2c9c99a560400c653f38960b6f54f45dc36fcb2609acb412d30307391ee02df53bc636e2c4c89f22c
+)
+
+vcpkg_extract_source_archive(
+    PACKAGE_PATH
+    ARCHIVE ${ARCHIVE}
+    NO_REMOVE_ONE_LEVEL
+)
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(REDIST_ARCH win32)
+else()
+    set(REDIST_ARCH ${VCPKG_TARGET_ARCHITECTURE})
+endif()
+
+file(COPY "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/D3D12Core.dll" "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/D3D12Core.pdb"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+
+file(COPY "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/D3D12Core.dll" "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/D3D12Core.pdb"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+file(COPY "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/d3d12SDKLayers.dll" "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/d3d12SDKLayers.pdb"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+
+file(COPY "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/d3dconfig.exe" "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/d3dconfig.pdb"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/tools//${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/LICENSE.txt")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/directx12-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" @ONLY)

--- a/ports/directx12-agility/usage
+++ b/ports/directx12-agility/usage
@@ -4,11 +4,11 @@ The DirectX 12 Agility SDK package provides CMake targets:
     find_package(directx12-agility CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::DirectX-Headers Microsoft::DirectX-Guids Microsoft::DirectX12-Agility)
 
-    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
+    if(TARGET Microsoft::DirectX12-Agility)
         file(MAKE_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/D3D12")
         add_custom_command(TARGET main POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E $<IF:$<BOOL:$<TARGET_RUNTIME_DLLS:main>>,copy,true>
-            $<TARGET_RUNTIME_DLLS:main> $<TARGET_FILE_DIR:main>/D3D12
-            COMMAND_EXPAND_LISTS
-            )
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:Microsoft::DirectX12-Core,IMPORTED_LOCATION_RELEASE> $<TARGET_FILE_DIR:main>/D3D12
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:Microsoft::DirectX12-Layers,IMPORTED_LOCATION_DEBUG> $<TARGET_FILE_DIR:main>/D3D12
+           COMMAND_EXPAND_LISTS
+        )
     endif()

--- a/ports/directx12-agility/usage
+++ b/ports/directx12-agility/usage
@@ -1,0 +1,14 @@
+The DirectX 12 Agility SDK package provides CMake targets:
+
+    find_package(directx-headers CONFIG REQUIRED)
+    find_package(directx12-agility CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Microsoft::DirectX-Headers Microsoft::DirectX-Guids Microsoft::DirectX12-Agility)
+
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
+        file(MAKE_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/D3D12")
+        add_custom_command(TARGET main POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E $<IF:$<BOOL:$<TARGET_RUNTIME_DLLS:main>>,copy,true>
+            $<TARGET_RUNTIME_DLLS:main> $<TARGET_FILE_DIR:main>/D3D12
+            COMMAND_EXPAND_LISTS
+            )
+    endif()

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "directx12-agility",
   "version": "1.613.0",
-  "port-version": 1,
   "description": "DirectX 12 Agility SDK",
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "directx12-agility",
+  "version": "1.613.0",
+  "port-version": 1,
+  "description": "DirectX 12 Agility SDK",
+  "homepage": "https://aka.ms/directx12agility",
+  "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",
+  "license": null,
+  "supports": "windows & !uwp & !xbox",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "directx-headers"
+    }
+  ]
+}

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -8,6 +8,7 @@
   "license": null,
   "supports": "windows & !uwp & !xbox",
   "dependencies": [
+    "directx-headers",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -15,9 +16,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "directx-headers"
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2214,7 +2214,7 @@
     },
     "directx12-agility": {
       "baseline": "1.613.0",
-      "port-version": 1
+      "port-version": 0
     },
     "directxmath": {
       "baseline": "2024-02-14",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2212,6 +2212,10 @@
       "baseline": "1.613.0",
       "port-version": 0
     },
+    "directx12-agility": {
+      "baseline": "1.613.0",
+      "port-version": 1
+    },
     "directxmath": {
       "baseline": "2024-02-14",
       "port-version": 1

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "934f2cd8dc507acb000a767c4b4b57d35d0aa21b",
+      "git-tree": "ce465a2354a287618369d8f590866bafe62f3c11",
       "version": "1.613.0",
       "port-version": 0
     }

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -3,7 +3,7 @@
     {
       "git-tree": "934f2cd8dc507acb000a767c4b4b57d35d0aa21b",
       "version": "1.613.0",
-      "port-version": 1
+      "port-version": 0
     }
   ]
 }

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "934f2cd8dc507acb000a767c4b4b57d35d0aa21b",
+      "version": "1.613.0",
+      "port-version": 1
+    }
+  ]
+}

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce465a2354a287618369d8f590866bafe62f3c11",
+      "git-tree": "9ff3410dacd22191327748dd1949cfcaf8e337f4",
       "version": "1.613.0",
       "port-version": 0
     }


### PR DESCRIPTION
The **directx-headers** port already provides the latest DirectX 12 headers from the GitHub project that hosts them, as well as the "GUIDS" library.

This new port adds VCPKG support for using the *DirectX 12 Agility SDK* redistributable binaries in a project.
