### PR TITLE
[directx-dxc] Fix port bug with TARGET_RUNTIME_DLLS

### DIFF
--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -1,6 +1,5 @@
 
-get_filename_component(_dxc_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(_dxc_root "${_dxc_root}" PATH)
+get_filename_component(_dxc_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
 get_filename_component(_dxc_root "${_dxc_root}" PATH)
 
 set(_dxc_exe "${_dxc_root}/@tool_path@")

--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -11,8 +11,6 @@ set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
    IMPORTED_SONAME                      "@lib_name@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
    INTERFACE_LINK_LIBRARIES             "Microsoft::DXIL"
-   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
-   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""   
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
 add_library(Microsoft::DXIL SHARED IMPORTED)
@@ -21,8 +19,6 @@ set_target_properties(Microsoft::DXIL PROPERTIES
    IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
    IMPORTED_SONAME                      "@lib_name@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
-   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
-   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""   
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
 unset(_dxc_root)

--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -6,10 +6,10 @@ get_filename_component(_dxc_root "${_dxc_root}" PATH)
 set(_dxc_exe "${_dxc_root}/@tool_path@")
 if (EXISTS "${_dxc_exe}")
 
-   add_library(Microsoft::DirectXShaderCompiler SHARED IMPORTED)
-   set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
-      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxc@;${_dxc_root}/@dll_dir@/@dll_name_dxil@"
-      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxc@;${_dxc_root}/@dll_dir@/@dll_name_dxil@"
+   add_library(Microsoft::DXC SHARED IMPORTED)
+   set_target_properties(Microsoft::DXC PROPERTIES
+      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
+      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
       IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/@lib_name@"
       IMPORTED_IMPLIB_DEBUG                "${_dxc_root}/lib/@lib_name@"
       IMPORTED_SONAME_RELEASE              "@lib_name@"
@@ -17,6 +17,22 @@ if (EXISTS "${_dxc_exe}")
       INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
       IMPORTED_CONFIGURATIONS              "Debug;Release"
       IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+
+   add_library(Microsoft::DXIL SHARED IMPORTED)
+   set_target_properties(Microsoft::DXIL PROPERTIES
+      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
+      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
+      IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/@lib_name@"
+      IMPORTED_IMPLIB_DEBUG                "${_dxc_root}/lib/@lib_name@"
+      IMPORTED_SONAME_RELEASE              "@lib_name@"
+      IMPORTED_SONAME_DEBUG                "@lib_name@"
+      INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
+      IMPORTED_CONFIGURATIONS              "Debug;Release"
+      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+
+   add_library(Microsoft::DirectXShaderCompiler INTERFACE IMPORTED)
+   set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
+      INTERFACE_LINK_LIBRARIES "Microsoft::DXC;Microsoft::DXIL")
 
     set(directx-dxc_FOUND TRUE)
     set(DIRECTX_DXC_TOOL ${_dxc_exe})

--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -11,6 +11,8 @@ set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
    IMPORTED_SONAME                      "@lib_name@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
    INTERFACE_LINK_LIBRARIES             "Microsoft::DXIL"
+   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
+   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""   
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
 add_library(Microsoft::DXIL SHARED IMPORTED)
@@ -19,6 +21,8 @@ set_target_properties(Microsoft::DXIL PROPERTIES
    IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
    IMPORTED_SONAME                      "@lib_name@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
+   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
+   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""   
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
 unset(_dxc_root)

--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -8,8 +8,8 @@ if (EXISTS "${_dxc_exe}")
 
    add_library(Microsoft::DirectXShaderCompiler SHARED IMPORTED)
    set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
-      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxc@; ${_dxc_root}/@dll_dir@/@dll_name_dxil@"
-      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxc@; ${_dxc_root}/@dll_dir@/@dll_name_dxil@"
+      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxc@;${_dxc_root}/@dll_dir@/@dll_name_dxil@"
+      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxc@;${_dxc_root}/@dll_dir@/@dll_name_dxil@"
       IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/@lib_name@"
       IMPORTED_IMPLIB_DEBUG                "${_dxc_root}/lib/@lib_name@"
       IMPORTED_SONAME_RELEASE              "@lib_name@"

--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -6,8 +6,8 @@ get_filename_component(_dxc_root "${_dxc_root}" PATH)
 set(_dxc_exe "${_dxc_root}/@tool_path@")
 if (EXISTS "${_dxc_exe}")
 
-   add_library(Microsoft::DXC SHARED IMPORTED)
-   set_target_properties(Microsoft::DXC PROPERTIES
+   add_library(Microsoft::DirectXShaderCompiler SHARED IMPORTED)
+   set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
       IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
       IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
       IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/@lib_name@"
@@ -30,12 +30,10 @@ if (EXISTS "${_dxc_exe}")
       IMPORTED_CONFIGURATIONS              "Debug;Release"
       IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
-   add_library(Microsoft::DirectXShaderCompiler INTERFACE IMPORTED)
-   set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
-      INTERFACE_LINK_LIBRARIES "Microsoft::DXC;Microsoft::DXIL")
+   target_link_libraries(Microsoft::DirectXShaderCompiler INTERFACE Microsoft::DXIL)
 
-    set(directx-dxc_FOUND TRUE)
-    set(DIRECTX_DXC_TOOL ${_dxc_exe})
+   set(directx-dxc_FOUND TRUE)
+   set(DIRECTX_DXC_TOOL ${_dxc_exe})
 
 else()
 

--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -1,44 +1,24 @@
-
 get_filename_component(_dxc_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
 get_filename_component(_dxc_root "${_dxc_root}" PATH)
 
-set(_dxc_exe "${_dxc_root}/@tool_path@")
-if (EXISTS "${_dxc_exe}")
+set(DIRECTX_DXC_TOOL "${_dxc_root}/@tool_path@" CACHE PATH "Location of the dxc tool")
+mark_as_advanced(DIRECTX_DXC_TOOL)
 
-   add_library(Microsoft::DirectXShaderCompiler SHARED IMPORTED)
-   set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
-      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
-      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
-      IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/@lib_name@"
-      IMPORTED_IMPLIB_DEBUG                "${_dxc_root}/lib/@lib_name@"
-      IMPORTED_SONAME_RELEASE              "@lib_name@"
-      IMPORTED_SONAME_DEBUG                "@lib_name@"
-      INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
-      IMPORTED_CONFIGURATIONS              "Debug;Release"
-      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+add_library(Microsoft::DirectXShaderCompiler SHARED IMPORTED)
+set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
+   IMPORTED_LOCATION                    "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
+   IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
+   IMPORTED_SONAME                      "@lib_name@"
+   INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
+   INTERFACE_LINK_LIBRARIES             "Microsoft::DXIL"
+   IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
-   add_library(Microsoft::DXIL SHARED IMPORTED)
-   set_target_properties(Microsoft::DXIL PROPERTIES
-      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
-      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
-      IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/@lib_name@"
-      IMPORTED_IMPLIB_DEBUG                "${_dxc_root}/lib/@lib_name@"
-      IMPORTED_SONAME_RELEASE              "@lib_name@"
-      IMPORTED_SONAME_DEBUG                "@lib_name@"
-      INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
-      IMPORTED_CONFIGURATIONS              "Debug;Release"
-      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+add_library(Microsoft::DXIL SHARED IMPORTED)
+set_target_properties(Microsoft::DXIL PROPERTIES
+   IMPORTED_LOCATION                    "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
+   IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
+   IMPORTED_SONAME                      "@lib_name@"
+   INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
+   IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
-   target_link_libraries(Microsoft::DirectXShaderCompiler INTERFACE Microsoft::DXIL)
-
-   set(directx-dxc_FOUND TRUE)
-   set(DIRECTX_DXC_TOOL ${_dxc_exe})
-
-else()
-
-    set(directx-dxc_FOUND FALSE)
-
-endif()
-
-unset(_dxc_exe)
 unset(_dxc_root)

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -56,13 +56,13 @@ if (VCPKG_TARGET_IS_LINUX)
 
   file(INSTALL
     "${PACKAGE_PATH}/bin/dxc"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/")
 
   set(dll_name_dxc "libdxcompiler.so")
   set(dll_name_dxil "libdxil.so")
   set(dll_dir  "lib")
   set(lib_name "libdxcompiler.so")
-  set(tool_path "bin/dxc")
+  set(tool_path "tools/${PORT}/dxc")
 else()
   # VCPKG_TARGET_IS_WINDOWS
   if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
@@ -109,7 +109,7 @@ else()
   set(dll_name_dxil "dxil.dll")
   set(dll_dir  "bin")
   set(lib_name "dxcompiler.lib")
-  set(tool_path "tools/directx-dxc/dxc.exe")
+  set(tool_path "tools/${PORT}/dxc.exe")
 endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/directx-dxc-config.cmake.in"

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -46,10 +46,13 @@ if (VCPKG_TARGET_IS_LINUX)
     "${PACKAGE_PATH}/lib/libdxcompiler.so"
     "${PACKAGE_PATH}/lib/libdxil.so"
     DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-  file(INSTALL
-    "${PACKAGE_PATH}/lib/libdxcompiler.so"
-    "${PACKAGE_PATH}/lib/libdxil.so"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+  if(NOT DEFINED VCPKG_BUILD_TYPE)
+    file(INSTALL
+      "${PACKAGE_PATH}/lib/libdxcompiler.so"
+      "${PACKAGE_PATH}/lib/libdxil.so"
+      DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+  endif()
 
   file(INSTALL
     "${PACKAGE_PATH}/bin/dxc"
@@ -78,16 +81,21 @@ else()
     DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
   file(INSTALL "${PACKAGE_PATH}/lib/${DXC_ARCH}/dxcompiler.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-  file(INSTALL "${PACKAGE_PATH}/lib/${DXC_ARCH}/dxcompiler.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+  if(NOT DEFINED VCPKG_BUILD_TYPE)
+    file(INSTALL "${PACKAGE_PATH}/lib/${DXC_ARCH}/dxcompiler.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+  endif()
 
   file(INSTALL
     "${PACKAGE_PATH}/bin/${DXC_ARCH}/dxcompiler.dll"
     "${PACKAGE_PATH}/bin/${DXC_ARCH}/dxil.dll"
     DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-  file(INSTALL
-    "${PACKAGE_PATH}/bin/${DXC_ARCH}/dxcompiler.dll"
-    "${PACKAGE_PATH}/bin/${DXC_ARCH}/dxil.dll"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+
+  if(NOT DEFINED VCPKG_BUILD_TYPE)
+    file(INSTALL
+      "${PACKAGE_PATH}/bin/${DXC_ARCH}/dxcompiler.dll"
+      "${PACKAGE_PATH}/bin/${DXC_ARCH}/dxil.dll"
+      DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+  endif()
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/")
 

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -108,6 +108,8 @@ else()
   set(tool_path "tools/${PORT}/dxc.exe")
 endif()
 
+vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+
 configure_file("${CMAKE_CURRENT_LIST_DIR}/directx-dxc-config.cmake.in"
   "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
   @ONLY)

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -1,11 +1,7 @@
-set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
-
 set(DIRECTX_DXC_TAG v1.8.2403)
 set(DIRECTX_DXC_VERSION 2024_03_07)
 
-if (NOT VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-   message(STATUS "Note: ${PORT} always requires dynamic library linkage at runtime.")
-endif()
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 if (VCPKG_TARGET_IS_LINUX)
     vcpkg_download_distfile(ARCHIVE

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -116,7 +116,5 @@ configure_file("${CMAKE_CURRENT_LIST_DIR}/directx-dxc-config.cmake.in"
   "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
   @ONLY)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${LICENSE_TXT}")

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -1,7 +1,11 @@
+set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
+
 set(DIRECTX_DXC_TAG v1.8.2403)
 set(DIRECTX_DXC_VERSION 2024_03_07)
 
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+if (NOT VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+   message(STATUS "Note: ${PORT} always requires dynamic library linkage at runtime.")
+endif()
 
 if (VCPKG_TARGET_IS_LINUX)
     vcpkg_download_distfile(ARCHIVE

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directx-dxc",
   "version-date": "2024-03-07",
+  "port-version": 1,
   "description": "DirectX Shader Compiler (LLVM/Clang)",
   "homepage": "https://github.com/microsoft/DirectXShaderCompiler",
   "documentation": "https://github.com/microsoft/DirectXShaderCompiler/wiki",

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -15,6 +15,10 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    },
+    {
+      "name": "zlib",
+      "platform": "!static"
     }
   ]
 }

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "zlib",
-      "platform": "!static"
+      "platform": "linux & !static"
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2206,7 +2206,7 @@
     },
     "directx-dxc": {
       "baseline": "2024-03-07",
-      "port-version": 0
+      "port-version": 1
     },
     "directx-headers": {
       "baseline": "1.613.0",

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5d9d559c10fa39f84401eecd7e10fcb0295a4e8d",
+      "git-tree": "0ad1b7ec0b5e7567343d6fc8b8ae49555a175822",
       "version-date": "2024-03-07",
       "port-version": 1
     },

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3abc63dfebc4e0a10ccc289558b034aef733e85e",
+      "git-tree": "5d9d559c10fa39f84401eecd7e10fcb0295a4e8d",
       "version-date": "2024-03-07",
       "port-version": 1
     },

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4567b5dacc64424288773483ef92b48a72147f2c",
+      "git-tree": "4a23c6b1ec57df9da29a51afe6045cbd89631ea6",
       "version-date": "2024-03-07",
       "port-version": 1
     },

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bb359aa2753ed65f6158846e29a0b9d127f29a49",
+      "git-tree": "4567b5dacc64424288773483ef92b48a72147f2c",
       "version-date": "2024-03-07",
       "port-version": 1
     },

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0ad1b7ec0b5e7567343d6fc8b8ae49555a175822",
+      "git-tree": "bb359aa2753ed65f6158846e29a0b9d127f29a49",
       "version-date": "2024-03-07",
       "port-version": 1
     },

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3abc63dfebc4e0a10ccc289558b034aef733e85e",
+      "version-date": "2024-03-07",
+      "port-version": 1
+    },
+    {
       "git-tree": "353096a360b10503e2e749b99155ba4ed6751340",
       "version-date": "2024-03-07",
       "port-version": 0

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "108db0dab172b9c70b1e5f7d189a3d5af513715f",
+      "git-tree": "bf2f80689d803678032f2a8d2b8c8deff4952bb9",
       "version-date": "2024-03-07",
       "port-version": 1
     },

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a23c6b1ec57df9da29a51afe6045cbd89631ea6",
+      "git-tree": "108db0dab172b9c70b1e5f7d189a3d5af513715f",
       "version-date": "2024-03-07",
       "port-version": 1
     },


### PR DESCRIPTION
While working with CMake 3.21 or later's `TARGET_RUNTIME_DLLS` I realized the extra space in the .in file was breaking the ``cmake -E copy`` command.

Also includes some cleanup for the port as well as respecting `VCPKG_BUILD_TYPE=release`.