### PR TITLE
[openexr] package fix

### DIFF
--- a/ports/openexr/fix-cmake-package.patch
+++ b/ports/openexr/fix-cmake-package.patch
@@ -1,0 +1,21 @@
+diff --git a/cmake/OpenEXRConfig.cmake.in b/cmake/OpenEXRConfig.cmake.in
+index fbb98c0a..37073a69 100644
+--- a/cmake/OpenEXRConfig.cmake.in
++++ b/cmake/OpenEXRConfig.cmake.in
+@@ -8,11 +8,12 @@ include(CMakeFindDependencyMacro)
+ set(openexr_needthreads @OPENEXR_ENABLE_THREADING@)
+ if (openexr_needthreads)
+   set(THREADS_PREFER_PTHREAD_FLAG ON)
+-  find_dependency(Threads REQUIRED)
++  find_dependency(Threads)
+ endif()
+ unset(openexr_needthreads)
+ 
+-find_dependency(Imath REQUIRED)
++find_dependency(Imath)
++find_dependency(libdeflate)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+ check_required_components("@PROJECT_NAME@")
+
+

--- a/ports/openexr/portfile.cmake
+++ b/ports/openexr/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 6e0a6fdcfae57c6e8b060d9aeed57140d96d39bffe5e40edd6ea5beb06e569323833d07906316ffca05f48e8409d0ea4174e2cd84d554404a4ee432e07d7b5e6
     HEAD_REF main
+    PATCHES
+        fix-cmake-package.patch # https://github.com/AcademySoftwareFoundation/openexr/pull/1674
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS

--- a/ports/openexr/vcpkg.json
+++ b/ports/openexr/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openexr",
   "version": "3.2.3",
+  "port-version": 1,
   "description": "OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications",
   "homepage": "https://www.openexr.com/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6398,7 +6398,7 @@
     },
     "openexr": {
       "baseline": "3.2.3",
-      "port-version": 0
+      "port-version": 1
     },
     "openfbx": {
       "baseline": "2022-07-18",

--- a/versions/o-/openexr.json
+++ b/versions/o-/openexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99e1e8599b1c2601a39f94b511b623ac51878793",
+      "version": "3.2.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "ccd582f25f0177e879cd408487d541865569dd3a",
       "version": "3.2.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #37394.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

