### PR TITLE
Version database consistency fixes 20240313

### DIFF
--- a/ports/theia/vcpkg.json
+++ b/ports/theia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "theia",
   "version": "0.8",
-  "port-version": 9,
+  "port-version": 10,
   "description": "An open source library for multiview geometry and structure from motion",
   "homepage": "https://github.com/sweeneychris/TheiaSfM",
   "license": "BSD-3-Clause",

--- a/ports/velodyne-decoder/vcpkg.json
+++ b/ports/velodyne-decoder/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "velodyne-decoder",
   "version": "3.0.0",
+  "port-version": 1,
   "description": "A decoder library for raw Velodyne data and telemetry info",
   "homepage": "https://github.com/valgur/velodyne_decoder",
   "license": "BSD-3-Clause",
@@ -16,7 +17,7 @@
     },
     {
       "name": "yaml-cpp",
-      "version>=": "0.7"
+      "version>=": "0.7.0"
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6492,10 +6492,6 @@
       "baseline": "1.14.2",
       "port-version": 0
     },
-    "opentelemetry-fluentd": {
-      "baseline": "2.0.0",
-      "port-version": 2
-    },
     "opentracing": {
       "baseline": "1.6.0",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3792,10 +3792,6 @@
       "baseline": "1.7",
       "port-version": 0
     },
-    "kd-soap": {
-      "baseline": "2.1.1",
-      "port-version": 1
-    },
     "kdalgorithms": {
       "baseline": "1.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9062,7 +9062,7 @@
     },
     "velodyne-decoder": {
       "baseline": "3.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "verdict": {
       "baseline": "1.4.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8542,7 +8542,7 @@
     },
     "theia": {
       "baseline": "0.8",
-      "port-version": 9
+      "port-version": 10
     },
     "think-cell-range": {
       "baseline": "2023.1",

--- a/versions/s-/septag-sx.json
+++ b/versions/s-/septag-sx.json
@@ -29,11 +29,6 @@
       "git-tree": "b3ce911c8e33a6b93f67b77676b8b52ebafc9d8d",
       "version-string": "2019-05-07",
       "port-version": 0
-    },
-    {
-      "git-tree": "b9e21c1d4135ab98fcecc9970d8520afb9b39743",
-      "version-string": "2019-04-27",
-      "port-version": 0
     }
   ]
 }

--- a/versions/t-/theia.json
+++ b/versions/t-/theia.json
@@ -6,7 +6,7 @@
       "port-version": 10
     },
     {
-      "git-tree": "f33100aa143474a7207ee0f2ec7daf0fda3a74a5",
+      "git-tree": "244b1ee4928a23a5394691a642a1b56125198228",
       "version": "0.8",
       "port-version": 9
     },

--- a/versions/t-/theia.json
+++ b/versions/t-/theia.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "244b1ee4928a23a5394691a642a1b56125198228",
+      "git-tree": "e0486585337480c0d2d32a30cebbbc14be00eec4",
       "version": "0.8",
       "port-version": 10
     },

--- a/versions/t-/try-catcher.json
+++ b/versions/t-/try-catcher.json
@@ -4,11 +4,6 @@
       "git-tree": "d1059d2b27b1ec41ff2c734707359af6f2f1aba3",
       "version": "1.0.1",
       "port-version": 0
-    },
-    {
-      "git-tree": "df67c1225008bf10a22e3da1aa5a27a42e38e223",
-      "version": "1.0.0",
-      "port-version": 0
     }
   ]
 }

--- a/versions/v-/velodyne-decoder.json
+++ b/versions/v-/velodyne-decoder.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "750a76436e6efb88a97b30a3a4c17ccafe869f2a",
+      "version": "3.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "14057817c4d38c4c315e12a837213035d5f8eed0",
       "version": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
In `Manifest mode` with `builtin-baseline`, some ports failed to install.
And there are some errors checked by `vcpkg x-ci-verify-versions --verify-git-trees`.


### Changes

#### Port update

* [velodyne-decoder] Fix error with no version database entry

#### Version baseline
* [kd-soap] Remove non-existent ports in baseline.json (Renamed at #36101)
* [opentelemetry-fluentd] Remove non-existent ports in baseline.json (Moved at #36816)

#### Version database
* [septag-sx] Delete broken entries in version database for mismatched port names at version 2019-05-07 (Renamed at #6327 and added version at #15652)
* [theia] Reset theia@0.8#10 to synchronize the fixes and changes in ports/theia (Changed at 5db545950d273aa3af8f18a159d851a62274cc7c)
* [theia] Restore git-tree for theia@0.8#9
* [try-catcher] Remove non-existent versions that should not be added (Added at 8c91c8da33b38c16a78315e78eabf8ec1796faab)


### Reference

Command `vcpkg x-ci-verify-versions` in https://github.com/microsoft/vcpkg-tool/pull/1210.

Quotes from #34078
> Under normal circumstances, things can't be removed from the version database, because that breaks outstanding references to those versions. However, these entries can't be parsed in the first place which means nobody can be depending on them being there.
