### PR TITLE
[skia] Add restrictions to feature harfbuzz

### DIFF
--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "skia",
   "version": "122",
+  "port-version": 1,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",
@@ -135,6 +136,7 @@
     },
     "harfbuzz": {
       "description": "Harfbuzz support",
+      "supports": "!(windows & !static)",
       "dependencies": [
         {
           "name": "harfbuzz",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8086,7 +8086,7 @@
     },
     "skia": {
       "baseline": "122",
-      "port-version": 0
+      "port-version": 1
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5713c16118843da35b1b8d6371144a0bab1efa0d",
+      "version": "122",
+      "port-version": 1
+    },
+    {
       "git-tree": "24ac468e6d009a532784555a2b2cb466683ca914",
       "version": "122",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/36928
Fix based on [comments](https://github.com/microsoft/vcpkg/issues/36928#:~:text=Hm%2C%20skia%5Bharfbuzz%5D%20is%20not%20a%20default%20feature%20for%20windows%20%26%20!static.%20I%20think%20it%20was%20also%20meant%20to%20be%20marked%20as%20unsupported%20on%20windows%20%26%20!static.%20Similar%20to%20skia%5Bicu%5D.).

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

