### PR TITLE
[gklib] Fix build error with Android triplet

### DIFF
--- a/ports/gklib/fix-error-in-clang17.patch
+++ b/ports/gklib/fix-error-in-clang17.patch
@@ -1,13 +1,15 @@
 diff --git a/error.c b/error.c
-index e2a18cf..2daeef9 100644
+index e2a18cf..a42122b 100644
 --- a/error.c
 +++ b/error.c
-@@ -15,6 +15,8 @@ This file contains functions dealing with error reporting and termination
+@@ -15,6 +15,10 @@ This file contains functions dealing with error reporting and termination
  
  #include <GKlib.h>
  
-+extern int backtrace(void **buffer, int size);
-+extern char **backtrace_symbols(void *const *buffer, int size);
++#ifdef HAVE_EXECINFO_H
++  extern int backtrace(void **buffer, int size);
++  extern char **backtrace_symbols(void *const *buffer, int size);
++#endif
  
  /* These are the jmp_buf for the graceful exit in case of severe errors.
     Multiple buffers are defined to allow for recursive invokation. */

--- a/ports/gklib/fix-error-in-clang17.patch
+++ b/ports/gklib/fix-error-in-clang17.patch
@@ -1,0 +1,13 @@
+diff --git a/error.c b/error.c
+index e2a18cf..2daeef9 100644
+--- a/error.c
++++ b/error.c
+@@ -15,6 +15,8 @@ This file contains functions dealing with error reporting and termination
+ 
+ #include <GKlib.h>
+ 
++extern int backtrace(void **buffer, int size);
++extern char **backtrace_symbols(void *const *buffer, int size);
+ 
+ /* These are the jmp_buf for the graceful exit in case of severe errors.
+    Multiple buffers are defined to allow for recursive invokation. */

--- a/ports/gklib/fix-mingw.patch
+++ b/ports/gklib/fix-mingw.patch
@@ -6,7 +6,7 @@ index 122e087..c8a322f 100644
  #endif
    #include <inttypes.h>
    #include <sys/types.h>
-+#ifndef _WIN32 # MinGW
++#ifndef _WIN32
    #include <sys/resource.h>
 +#endif
    #include <sys/time.h>

--- a/ports/gklib/portfile.cmake
+++ b/ports/gklib/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         build-fixes.patch
         fix-mingw.patch
+        fix-error-in-clang17.patch
 )
 
 # Delete files that are workarounds for very old copies of msvc.

--- a/ports/gklib/vcpkg.json
+++ b/ports/gklib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gklib",
   "version-date": "2022-07-27",
-  "port-version": 2,
+  "port-version": 3,
   "description": "General helper libraries for KarypisLab.",
   "homepage": "https://github.com/KarypisLab/GKlib/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3010,7 +3010,7 @@
     },
     "gklib": {
       "baseline": "2022-07-27",
-      "port-version": 2
+      "port-version": 3
     },
     "gl2ps": {
       "baseline": "1.4.2",

--- a/versions/g-/gklib.json
+++ b/versions/g-/gklib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "838ab025528e16ce02e01d4ba36f7b3ac7aff4bb",
+      "git-tree": "54f660cd46f930ee5df78cb91188b52fbff38e34",
       "version-date": "2022-07-27",
       "port-version": 3
     },

--- a/versions/g-/gklib.json
+++ b/versions/g-/gklib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "838ab025528e16ce02e01d4ba36f7b3ac7aff4bb",
+      "version-date": "2022-07-27",
+      "port-version": 3
+    },
+    {
       "git-tree": "7f9c6f0e711860da19899fbe78e027d0a5e8cfc1",
       "version-date": "2022-07-27",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/36791

No feature need to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


