### PR TITLE
[cgal] update to 5.6.1

### DIFF
--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -4,12 +4,9 @@ vcpkg_buildpath_length_warning(37)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CGAL/cgal
-    REF v5.6
-    SHA512 87817169f49c30d8dc4fa5e61ce9b28be5b1f0a9fcd3ebe0cb08b044631a2455de76c53d3cffaa1984f033f5fe21c9b55f54628fc431b7d3a34b3b3e18ad206d
+    REF v5.6.1
+    SHA512 943413bf3b94da066d47051b22f1c1b66a39a43dad865dd0e4912a9ae6508d9a490bcfe4ef7d662844e9a1ba6e552748fad785b52b2cce98133c2dfdfbfe1a4d
     HEAD_REF master
-    PATCHES
-        x86_windows.patch
-        # Upstream patch: https://github.com/CGAL/cgal/pull/7635
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/cgal/vcpkg.json
+++ b/ports/cgal/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cgal",
-  "version": "5.6",
-  "port-version": 1,
+  "version": "5.6.1",
   "description": "The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.",
   "homepage": "https://github.com/CGAL/cgal",
   "license": "GPL-3.0-or-later AND LGPL-3.0-or-later AND BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1533,8 +1533,8 @@
       "port-version": 5
     },
     "cgal": {
-      "baseline": "5.6",
-      "port-version": 1
+      "baseline": "5.6.1",
+      "port-version": 0
     },
     "cgicc": {
       "baseline": "3.2.20",

--- a/versions/c-/cgal.json
+++ b/versions/c-/cgal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b207625af76c42809d62b804390364ea872392b5",
+      "version": "5.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "daf7cc06ce0247101d1f713013a1a12416da5111",
       "version": "5.6",
       "port-version": 1


### PR DESCRIPTION
Updates CGAL port (`cgal`) to version 5.6.1.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
