### PR TITLE
[curl] Add http3 feature, Remove ssl feature, Add ca-native feature.

### DIFF
--- a/ports/curl/openssl_quic.patch
+++ b/ports/curl/openssl_quic.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -719,9 +719,22 @@
+   include_directories(${MSH3_INCLUDE_DIRS})
+   list(APPEND CURL_LIBS ${MSH3_LIBRARIES})
+ endif()
+ 
+-if(CURL_WITH_MULTI_SSL AND (USE_NGTCP2 OR USE_QUICHE OR USE_MSH3))
++option(USE_OPENSSL_QUIC "Use openssl and nghttp3 libraries for HTTP/3 support" OFF)
++if(USE_OPENSSL_QUIC)
++  if(USE_NGTCP2 OR USE_QUICHE OR USE_MSH3)
++    message(FATAL_ERROR "Only one HTTP/3 backend can be selected!")
++  endif()
++  find_package(OpenSSL 3.2.0 REQUIRED)
++
++  find_package(NGHTTP3 REQUIRED)
++  set(USE_NGHTTP3 ON)
++  include_directories(${NGHTTP3_INCLUDE_DIRS})
++  list(APPEND CURL_LIBS ${NGHTTP3_LIBRARIES})
++endif()
++
++if(CURL_WITH_MULTI_SSL AND (USE_NGTCP2 OR USE_QUICHE OR USE_MSH3 OR USE_OPENSSL_QUIC))
+   message(FATAL_ERROR "MultiSSL cannot be enabled with HTTP/3 and vice versa.")
+ endif()
+ 
+ if(NOT CURL_DISABLE_SRP AND (HAVE_GNUTLS_SRP OR HAVE_OPENSSL_SRP))
+@@ -1541,9 +1554,9 @@
+                           (use_curl_ntlm_core OR USE_WINDOWS_SSPI) AND
+                           NOT CURL_DISABLE_HTTP AND NTLM_WB_ENABLED)
+   _add_if("TLS-SRP"       USE_TLS_SRP)
+   _add_if("HTTP2"         USE_NGHTTP2)
+-  _add_if("HTTP3"         USE_NGTCP2 OR USE_QUICHE)
++  _add_if("HTTP3"         USE_NGTCP2 OR USE_QUICHE OR USE_OPENSSL_QUIC)
+   _add_if("MultiSSL"      CURL_WITH_MULTI_SSL)
+   # TODO wolfSSL only support this from v5.0.0 onwards
+   _add_if("HTTPS-proxy"   SSL_ENABLED AND (USE_OPENSSL OR USE_GNUTLS
+                           OR USE_SCHANNEL OR USE_RUSTLS OR USE_BEARSSL OR
+diff --git a/lib/curl_config.h.cmake b/lib/curl_config.h.cmake
+--- a/lib/curl_config.h.cmake
++++ b/lib/curl_config.h.cmake
+@@ -719,8 +719,11 @@
+ 
+ /* to enable quiche */
+ #cmakedefine USE_QUICHE 1
+ 
++/* to enable openssl + nghttp3 */
++#cmakedefine USE_OPENSSL_QUIC 1
++
+ /* Define to 1 if you have the quiche_conn_set_qlog_fd function. */
+ #cmakedefine HAVE_QUICHE_CONN_SET_QLOG_FD 1
+ 
+ /* to enable msh3 */

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -15,12 +15,14 @@ vcpkg_from_github(
         export-components.patch
         dependencies.patch
         cmake-config.patch
+        openssl_quic.patch        
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         # Support HTTP2 TLS Download https://curl.haxx.se/ca/cacert.pem rename to curl-ca-bundle.crt, copy it to libcurl.dll location.
         http2       USE_NGHTTP2
+        http3       USE_OPENSSL_QUIC
         wolfssl     CURL_USE_WOLFSSL
         openssl     CURL_USE_OPENSSL
         mbedtls     CURL_USE_MBEDTLS

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -15,7 +15,8 @@ vcpkg_from_github(
         export-components.patch
         dependencies.patch
         cmake-config.patch
-        openssl_quic.patch        
+        openssl_quic.patch
+        use_ca_native.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -38,6 +39,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         winldap     USE_WIN32_LDAP
         websockets  ENABLE_WEBSOCKETS
         zstd        CURL_ZSTD
+        ca-native   CURL_USE_CA_NATIVE
     INVERTED_FEATURES
         non-http    HTTP_ONLY
         winldap     CURL_DISABLE_LDAP # Only WinLDAP support ATM

--- a/ports/curl/use_ca_native.patch
+++ b/ports/curl/use_ca_native.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 656aa7c740facf..6d3baccda703f9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -399,6 +399,8 @@ cmake_dependent_option(CURL_USE_BEARSSL "Enable BearSSL for SSL/TLS" OFF CURL_EN
+ cmake_dependent_option(CURL_USE_WOLFSSL "Enable wolfSSL for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
+ cmake_dependent_option(CURL_USE_GNUTLS "Enable GnuTLS for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
+ 
++option(CURL_USE_CA_NATIVE "Use standard certificate store of operating system" OFF)
++
+ set(openssl_default ON)
+ if(WIN32 OR CURL_USE_SECTRANSP OR CURL_USE_SCHANNEL OR CURL_USE_MBEDTLS OR CURL_USE_WOLFSSL)
+   set(openssl_default OFF)
+@@ -430,6 +432,9 @@ endif()
+ if(CURL_WINDOWS_SSPI)
+   set(USE_WINDOWS_SSPI ON)
+ endif()
++if(CURL_USE_CA_NATIVE)
++  set(USE_CA_NATIVE ON)
++endif()
+ 
+ if(CURL_USE_SECTRANSP)
+   set(use_core_foundation_and_core_services ON)
+diff --git a/lib/curl_config.h.cmake b/lib/curl_config.h.cmake
+index 0f4db69820ed17..901d4bce698d59 100644
+--- a/lib/curl_config.h.cmake
++++ b/lib/curl_config.h.cmake
+@@ -741,6 +741,9 @@ ${SIZEOF_TIME_T_CODE}
+ /* to enable Windows SSL  */
+ #cmakedefine USE_SCHANNEL 1
+ 
++/* Use standard certificate store of operating system */
++#cmakedefine CURL_USE_CA_NATIVE 1
++
+ /* enable multiple SSL backends */
+ #cmakedefine CURL_WITH_MULTI_SSL 1
+ 
+diff --git a/lib/setopt.c b/lib/setopt.c
+index 8a5a5d7c33d21d..180098c5e82ef8 100644
+--- a/lib/setopt.c
++++ b/lib/setopt.c
+@@ -2370,6 +2370,9 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+     data->set.ssl.no_partialchain = !!(arg & CURLSSLOPT_NO_PARTIALCHAIN);
+     data->set.ssl.revoke_best_effort = !!(arg & CURLSSLOPT_REVOKE_BEST_EFFORT);
+     data->set.ssl.native_ca_store = !!(arg & CURLSSLOPT_NATIVE_CA);
++#if defined(USE_CA_NATIVE)
++    data->set.ssl.native_ca_store = true;
++#endif
+     data->set.ssl.auto_client_cert = !!(arg & CURLSSLOPT_AUTO_CLIENT_CERT);
+     /* If a setting is added here it should also be added in dohprobe()
+        which sets its own CURLOPT_SSL_OPTIONS based on these settings. */

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -48,6 +48,7 @@
     },
     "http3": {
       "description": "HTTP3 support",
+      "supports": "(uwp | !windows) & !(osx | ios) & !mingw",
       "dependencies": [
         {
           "name": "curl",
@@ -56,7 +57,11 @@
             "openssl"
           ]
         },
-        "nghttp3"
+        "nghttp3",
+        {
+          "name": "openssl",
+          "version>=": "3.2.0"
+        }
       ]
     },
     "idn": {

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -17,8 +17,9 @@
     "zlib"
   ],
   "default-features": [
+    "ca-native",
     "non-http",
-    "ssl"
+    "openssl"
   ],
   "features": {
     "brotli": {
@@ -33,6 +34,9 @@
         "c-ares"
       ]
     },
+    "ca-native": {
+      "description": "Use standard certificate store of operating system"
+    },
     "http2": {
       "description": "HTTP2 support",
       "dependencies": [
@@ -40,7 +44,7 @@
           "name": "curl",
           "default-features": false,
           "features": [
-            "ssl"
+            "openssl"
           ]
         },
         "nghttp2"
@@ -48,7 +52,6 @@
     },
     "http3": {
       "description": "HTTP3 support",
-      "supports": "(uwp | !windows) & !(osx | ios) & !mingw",
       "dependencies": [
         {
           "name": "curl",
@@ -141,35 +144,6 @@
           ]
         },
         "libssh2"
-      ]
-    },
-    "ssl": {
-      "description": "Default SSL backend",
-      "dependencies": [
-        {
-          "name": "curl",
-          "default-features": false,
-          "features": [
-            "sectransp"
-          ],
-          "platform": "osx | ios"
-        },
-        {
-          "name": "curl",
-          "default-features": false,
-          "features": [
-            "schannel"
-          ],
-          "platform": "(windows & !uwp) | mingw"
-        },
-        {
-          "name": "curl",
-          "default-features": false,
-          "features": [
-            "openssl"
-          ],
-          "platform": "(uwp | !windows) & !(osx | ios) & !mingw"
-        }
       ]
     },
     "sspi": {

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "curl",
   "version": "8.6.0",
+  "port-version": 1,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",
@@ -43,6 +44,19 @@
           ]
         },
         "nghttp2"
+      ]
+    },
+    "http3": {
+      "description": "HTTP3 support",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": [
+            "openssl"
+          ]
+        },
+        "nghttp3"
       ]
     },
     "idn": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2062,7 +2062,7 @@
     },
     "curl": {
       "baseline": "8.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "curlpp": {
       "baseline": "2018-06-15",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8c1fb523e9f0ccd18a4f3e2e832e2ecab7dd9f15",
+      "git-tree": "488a1338ca73d6226654f1e158525133a2d4ecd6",
       "version": "8.6.0",
       "port-version": 1
     },

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c1fb523e9f0ccd18a4f3e2e832e2ecab7dd9f15",
+      "version": "8.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "dba7665cff5bd6f1a31ad0aa864fd83049eac93e",
       "version": "8.6.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

@BillyONeal 
continue work of this PR:
#37146