### PR TITLE
[cpuid] Update to 0.6.4

### DIFF
--- a/ports/cpuid/portfile.cmake
+++ b/ports/cpuid/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO anrieff/libcpuid
-    REF v0.6.2
-    SHA512 36175387ae86e6f602544c516a875ac7fe0a3bde52e3e3c09f8852a804dd252694e17c638723aa3d36219d4588981cfd2261086bcf561d175e7c038e3a69e2ff
+    REF "v${VERSION}"
+    SHA512 855dab45ec12b817fb18948442cebc22abaf915a7230e3d1a3f0e2fc7d0e3fe4a39e7c5744be1f4c7e3cb7b082012e6b0b0677a967beba5d404c6c48467eedce
     HEAD_REF master
     PATCHES
         fix-build.patch
@@ -23,4 +23,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/cpuid/vcpkg.json
+++ b/ports/cpuid/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpuid",
-  "version": "0.6.2",
+  "version": "0.6.4",
   "description": "Provides CPU identification for the x86 (and x86_64)",
   "homepage": "https://github.com/anrieff/libcpuid",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1957,7 +1957,7 @@
       "port-version": 0
     },
     "cpuid": {
-      "baseline": "0.6.2",
+      "baseline": "0.6.4",
       "port-version": 0
     },
     "cpuinfo": {
@@ -4308,10 +4308,6 @@
       "baseline": "1.2.6",
       "port-version": 2
     },
-    "libfuse": {
-      "baseline": "3.16.2",
-      "port-version": 0
-    },
     "libenvpp": {
       "baseline": "1.4.0",
       "port-version": 0
@@ -4391,6 +4387,10 @@
     "libftdi1": {
       "baseline": "1.5",
       "port-version": 4
+    },
+    "libfuse": {
+      "baseline": "3.16.2",
+      "port-version": 0
     },
     "libgcrypt": {
       "baseline": "1.10.2",

--- a/versions/c-/cpuid.json
+++ b/versions/c-/cpuid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fe355f57cd08fb6530cd893d7d3c130a15f2ce13",
+      "version": "0.6.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "38d8b8a97510236c2a41d0f903b609be0d3cf580",
       "version": "0.6.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #37419, update `cpuid` to 0.6.4.

The usage test passed on `x64-windows` (header files found):
```
cpuid provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(cpuid CONFIG REQUIRED)
  target_link_libraries(main PRIVATE cpuid::cpuid)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
