### PR TITLE
[libtorch] Linking static libraries on non-Windows platforms

### DIFF
--- a/ports/libtorch/fix_build_static.patch
+++ b/ports/libtorch/fix_build_static.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/MiscCheck.cmake b/cmake/MiscCheck.cmake
+index 71d7386..0ac8c7a 100644
+--- a/cmake/MiscCheck.cmake
++++ b/cmake/MiscCheck.cmake
+@@ -96,10 +96,10 @@ endif()
+ # -table. We need this to get symbols when generating backtrace at
+ # -runtime.
+ if(NOT MSVC)
+-  check_cxx_compiler_flag("-rdynamic" COMPILER_SUPPORTS_RDYNAMIC)
++  check_cxx_compiler_flag("-rstatic" COMPILER_SUPPORTS_RDYNAMIC)
+   if(${COMPILER_SUPPORTS_RDYNAMIC})
+-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -rdynamic")
+-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
++    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -rstatic")
++    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rstatic")
+   endif()
+ endif()
+ 

--- a/ports/libtorch/portfile.cmake
+++ b/ports/libtorch/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_github(
         fix-glog.patch
         fix-msvc-ICE.patch
         fix-calculate-minloglevel.patch
+        fix_build_static.patch
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/caffe2/core/macros.h") # We must use generated header files
 
@@ -211,7 +212,7 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/torch/TorchConfig.cmake" "/.
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/caffe2/Caffe2Config.cmake" "/../../../" "/../../")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/caffe2/Caffe2Config.cmake"
   "set(Caffe2_MAIN_LIBS torch_library)"
-  "set(Caffe2_MAIN_LIBS torch_library)\nfind_dependency(Eigen3)")
+  "set(Caffe2_MAIN_LIBS torch_library)\ninclude(CMakeFindDependencyMacro)\nfind_dependency(Eigen3)")
 
 
 

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "2.1.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4308,10 +4308,6 @@
       "baseline": "1.2.6",
       "port-version": 2
     },
-    "libfuse": {
-      "baseline": "3.16.2",
-      "port-version": 0
-    },
     "libenvpp": {
       "baseline": "1.4.0",
       "port-version": 0
@@ -4391,6 +4387,10 @@
     "libftdi1": {
       "baseline": "1.5",
       "port-version": 4
+    },
+    "libfuse": {
+      "baseline": "3.16.2",
+      "port-version": 0
     },
     "libgcrypt": {
       "baseline": "1.10.2",
@@ -5022,7 +5022,7 @@
     },
     "libtorch": {
       "baseline": "2.1.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libtorrent": {
       "baseline": "2.0.10",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d9bd82b1486265aeb741764616484fe3566b91c",
+      "version": "2.1.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "19855d043442630ea2d8060e49c66cc50c0c9d7a",
       "version": "2.1.2",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/37141

`ERROR: something wrong with flag 'timestamp_in_logfile_name' in file '/opt/vcpkg/buildtrees/glog/src/v0.6.0-1e4356b0ac.clean/src/logging.cc'. One possibility: file '/opt/vcpkg/buildtrees/glog/src/v0.6.0-1e4356b0ac.clean/src/logging.cc' is being linked both statically and dynamically into this executable.`

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-linux
```