### PR TITLE
[sqlcipher] Update to 4.5.6

### DIFF
--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sqlcipher/sqlcipher
     REF "v${VERSION}"
-    SHA512 deb592d6f27e7cc02bd641bb8f6e07b242f0dc6c7d8732e7a1e70e457eadd487add7d95c881fe9afbff516f4641a6e603473e47c63afa8396a0ddf007a5818fd
+    SHA512 656206cd6f8eaec15a8c409c47c1c2ca7fa3d30f3b124f89ceeff3c0c8772e0b3cc942ef93a18a4ce4dee12b1d9bd94d7e4132cea35707871fe8c08b13f87797
     HEAD_REF master
 )
 
@@ -78,7 +78,7 @@ configure_file(
     @ONLY
 )
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_copy_pdbs()
 vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")

--- a/ports/sqlcipher/vcpkg.json
+++ b/ports/sqlcipher/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlcipher",
-  "version": "4.5.4",
+  "version": "4.5.6",
   "description": "SQLCipher extends the SQLite database library to add security enhancements that make it more suitable for encrypted local data storage.",
   "homepage": "https://www.zetetic.net/sqlcipher",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4308,10 +4308,6 @@
       "baseline": "1.2.6",
       "port-version": 2
     },
-    "libfuse": {
-      "baseline": "3.16.2",
-      "port-version": 0
-    },
     "libenvpp": {
       "baseline": "1.4.0",
       "port-version": 0
@@ -4391,6 +4387,10 @@
     "libftdi1": {
       "baseline": "1.5",
       "port-version": 4
+    },
+    "libfuse": {
+      "baseline": "3.16.2",
+      "port-version": 0
     },
     "libgcrypt": {
       "baseline": "1.10.2",
@@ -8297,7 +8297,7 @@
       "port-version": 3
     },
     "sqlcipher": {
-      "baseline": "4.5.4",
+      "baseline": "4.5.6",
       "port-version": 0
     },
     "sqlite-modern-cpp": {

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cd71e0db4fe329a414dd99173f358d4bfe3eb847",
+      "version": "4.5.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "81b4c14ac8275c922f1a972db7452c98b002526b",
       "version": "4.5.4",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
