### PR TITLE
[xmlsec] Update to 1.3.3

### DIFF
--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lsh123/xmlsec
     REF "${release_tag}"
-    SHA512 c7b867edc23cb6cf08228f9737fc50e3bd08ac7baedc43e26d3cfd113ea54256ff357335b23aea7b5e49cd24809c3de9da1c9314eb5ab90727aa821530b72ef8
+    SHA512 32f297fe47c1b79fb8b58dd12ce49aacb408c9361c140567eda6a49e892025fc227efdc7f85c12fe36b79e658e26ee7b0a1fd770bd6ee5b20e4aa5f9fd0e5288
     HEAD_REF master
     PATCHES 
         pkgconfig_fixes.patch

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xmlsec",
-  "version": "1.3.1",
-  "port-version": 2,
+  "version": "1.3.3",
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4308,10 +4308,6 @@
       "baseline": "1.2.6",
       "port-version": 2
     },
-    "libfuse": {
-      "baseline": "3.16.2",
-      "port-version": 0
-    },
     "libenvpp": {
       "baseline": "1.4.0",
       "port-version": 0
@@ -4391,6 +4387,10 @@
     "libftdi1": {
       "baseline": "1.5",
       "port-version": 4
+    },
+    "libfuse": {
+      "baseline": "3.16.2",
+      "port-version": 0
     },
     "libgcrypt": {
       "baseline": "1.10.2",
@@ -9425,8 +9425,8 @@
       "port-version": 0
     },
     "xmlsec": {
-      "baseline": "1.3.1",
-      "port-version": 2
+      "baseline": "1.3.3",
+      "port-version": 0
     },
     "xnnpack": {
       "baseline": "2022-12-22",

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61ac924bc037a2bf6e8afdc898b6d21f0a25c519",
+      "version": "1.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "66d4ee9a9a576f6af80a2b830becab2f6ee7beb7",
       "version": "1.3.1",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
