### PR TITLE
[skia] update to m123

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -3,8 +3,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/skia-functions.cmake")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/skia
-    REF "c3feddb877388498cc9a491e9504268a53607b15"
-    SHA512 33238a6d8db4d60edd4ca1255d42ce97f084145e3bc7520ae4723a584c8f99bea0404ff505d6a9be077c0a3cc42be557e00dab3ca572b5803a2453ce363cd8f5
+    REF "aeae2261c7d380404fb8e53eb6062338c4ba0367"
+    SHA512 74eabf6a7cc0ac0cc49a1075bf4ffcee4f006ebe67c02a76a4dc734da1fa430ddd7f3cb070cb0b1ed3ac99cf59d02dc0c8852f3487614ca851673984117ca612
     PATCHES
         disable-msvc-env-setup.patch
         disable-dev-test.patch
@@ -31,7 +31,7 @@ declare_external_from_git(d3d12allocator
 )
 declare_external_from_git(dawn
     URL "https://dawn.googlesource.com/dawn.git"
-    REF "5b45794c2c24c3fa40dc480af92c5284a95423ef"
+    REF "d3e0bd4770cc8115d1342a8dc051a36e50e8bd26"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(dng_sdk
@@ -61,17 +61,17 @@ declare_external_from_git(sfntly
 )
 declare_external_from_git(spirv-cross
     URL "https://github.com/KhronosGroup/SPIRV-Cross"
-    REF "b82536766d1b81631b126d1ddbe49baf42929bd3"
+    REF "b8fcf307f1f347089e3c46eb4451d27f32ebc8d3"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(spirv-headers
     URL "https://github.com/KhronosGroup/SPIRV-Headers.git"
-    REF "7b0309708da5126b89e4ce6f19835f36dc912f2f"
+    REF "05cc486580771e4fa7ddc89f5c9ee1e97382689a"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(spirv-tools
     URL "https://github.com/KhronosGroup/SPIRV-Tools.git"
-    REF "3e6bdd0f99655b1bc6a54aa73e5bfaaa4252198b"
+    REF "dc6676445be97ab19d8191fee019af62e2aaf774"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(wuffs

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "skia",
-  "version": "122",
+  "version": "123",
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/ports/skia/vulkan-headers.patch
+++ b/ports/skia/vulkan-headers.patch
@@ -4,34 +4,27 @@ index 04ab422..5ae82e5 100644
 +++ b/BUILD.gn
 @@ -913,6 +913,7 @@ optional("gpu_shared") {
    }
- 
+
    if (skia_use_vulkan) {
 +    public_deps += [ "//third_party/externals/vulkan-headers:vulkan_headers" ]
      public_defines += [ "SK_VULKAN" ]
      sources += skia_shared_vk_sources
      if (skia_enable_vulkan_debug_layers) {
 diff --git a/include/private/gpu/vk/SkiaVulkan.h b/include/private/gpu/vk/SkiaVulkan.h
-index ca4bcf1..8a52200 100644
+index 412dbf535f..93608dc2be 100644
 --- a/include/private/gpu/vk/SkiaVulkan.h
 +++ b/include/private/gpu/vk/SkiaVulkan.h
-@@ -13,7 +13,7 @@
+@@ -12,6 +12,10 @@
+
  // IWYU pragma: begin_exports
- 
- #if SKIA_IMPLEMENTATION || !defined(SK_VULKAN)
--#include "include/third_party/vulkan/vulkan/vulkan_core.h"
-+#include "vulkan/vulkan_core.h"
+
++#ifndef SK_USE_EXTERNAL_VULKAN_HEADERS
++# define SK_USE_EXTERNAL_VULKAN_HEADERS
++#endif
++
+ #if (SKIA_IMPLEMENTATION || !defined(SK_VULKAN)) && !defined(SK_USE_EXTERNAL_VULKAN_HEADERS)
+ #include "include/third_party/vulkan/vulkan/vulkan_core.h"
  #else
- // For google3 builds we don't set SKIA_IMPLEMENTATION so we need to make sure that the vulkan
- // headers stay up to date for our needs
-@@ -23,7 +23,7 @@
- #ifdef SK_BUILD_FOR_ANDROID
- // This is needed to get android extensions for external memory
- #if SKIA_IMPLEMENTATION || !defined(SK_VULKAN)
--#include "include/third_party/vulkan/vulkan/vulkan_android.h"
-+#include "vulkan/vulkan_android.h"
- #else
- // For google3 builds we don't set SKIA_IMPLEMENTATION so we need to make sure that the vulkan
- // headers stay up to date for our needs
 diff --git a/src/gpu/vk/vulkanmemoryallocator/VulkanMemoryAllocatorWrapper.h b/src/gpu/vk/vulkanmemoryallocator/VulkanMemoryAllocatorWrapper.h
 index 487ea7c..9662c8c 100644
 --- a/src/gpu/vk/vulkanmemoryallocator/VulkanMemoryAllocatorWrapper.h

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8093,7 +8093,7 @@
       "port-version": 0
     },
     "skia": {
-      "baseline": "122",
+      "baseline": "123",
       "port-version": 0
     },
     "skyr-url": {

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e107ca309d637ff07344abd1f1a73b58e36ca152",
+      "version": "123",
+      "port-version": 0
+    },
+    {
       "git-tree": "24ac468e6d009a532784555a2b2cb466683ca914",
       "version": "122",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Updates skia to m123