### PR TITLE
[robotraconteur] Update to 1.1.0

### DIFF
--- a/ports/robotraconteur/portfile.cmake
+++ b/ports/robotraconteur/portfile.cmake
@@ -5,7 +5,7 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
 	REPO robotraconteur/robotraconteur
-	REF v1.1.0
+	REF "v${VERSION}"
 	SHA512 8717c2b61555882a553e9b77becb79be0f69d4ebf3d167c90961457a5e0cacef2814b8411c1f0bfbb93fede3168ca0096457c0c4ad32476985bd2e90b8976839
 	HEAD_REF master
 )

--- a/ports/robotraconteur/portfile.cmake
+++ b/ports/robotraconteur/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
 	REPO robotraconteur/robotraconteur
-	REF v1.0.0
-	SHA512 c21dd0af579272c565dd66ca935aababfa3742db524fae66fe82c929561680608e5759ce954f31a8bbcb4ffb7c4e5314f2050b513ccddb8fb49a005c6cfa6d74
+	REF v1.1.0
+	SHA512 8717c2b61555882a553e9b77becb79be0f69d4ebf3d167c90961457a5e0cacef2814b8411c1f0bfbb93fede3168ca0096457c0c4ad32476985bd2e90b8976839
 	HEAD_REF master
 )
 

--- a/ports/robotraconteur/vcpkg.json
+++ b/ports/robotraconteur/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "robotraconteur",
-  "version-semver": "1.0.0",
+  "version-semver": "1.1.0",
   "description": "The Robot Raconteur communication framework core library",
   "homepage": "http://robotraconteur.com",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7685,7 +7685,7 @@
       "port-version": 0
     },
     "robotraconteur": {
-      "baseline": "1.0.0",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "robotraconteur-companion": {

--- a/versions/r-/robotraconteur.json
+++ b/versions/r-/robotraconteur.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80e8b9bddc2e18b4c57bda0cf853ca86d7684699",
+      "version-semver": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3c14da3e3dcf13b70904a04d988437c786032398",
       "version-semver": "1.0.0",
       "port-version": 0


### PR DESCRIPTION


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


