### PR TITLE
[libmysql] Make "Host" build optional

### DIFF
--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -15,6 +15,11 @@ vcpkg_from_github(
         cross-build.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        host-tools FORCE_CMAKE_CROSSCOMPILING
+)
+
 file(GLOB third_party "${SOURCE_PATH}/extra/*" "${SOURCE_PATH}/include/boost_1_70_0")
 list(REMOVE_ITEM third_party "${SOURCE_PATH}/extra/libedit")
 if (third_party)
@@ -49,6 +54,11 @@ if(VCPKG_CROSSCOMPILING)
             -DHAVE_SETNS=0
         )
     endif()
+endif()
+if ("-DFORCE_CMAKE_CROSSCOMPILING=ON" IN_LIST FEATURE_OPTIONS)
+    list(APPEND cross_options
+        -DCMAKE_CROSSCOMPILING=OFF
+    )
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/libmysql/vcpkg.json
+++ b/ports/libmysql/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmysql",
   "version": "8.0.34",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A MySQL client library for C development",
   "homepage": "https://github.com/mysql/mysql-server",
   "license": "GPL-2.0-or-later",
@@ -12,10 +12,6 @@
     "boost-geometry",
     "boost-graph",
     "boost-optional",
-    {
-      "name": "libmysql",
-      "host": true
-    },
     "lz4",
     {
       "name": "ncurses",
@@ -33,5 +29,19 @@
     },
     "zlib",
     "zstd"
-  ]
+  ],
+  "default-features": [
+    "host-tools"
+  ],
+  "features": {
+    "host-tools": {
+      "description": "Build CLI tools",
+      "dependencies": [
+        {
+          "name": "libmysql",
+          "host": true
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4650,7 +4650,7 @@
     },
     "libmysql": {
       "baseline": "8.0.34",
-      "port-version": 1
+      "port-version": 2
     },
     "libnice": {
       "baseline": "0.1.21",

--- a/versions/l-/libmysql.json
+++ b/versions/l-/libmysql.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45d625f571959fbfb409d0e5a270455240ba987b",
+      "version": "8.0.34",
+      "port-version": 2
+    },
+    {
       "git-tree": "4fa6006119f50a9baff9cdf0966b065097113fd7",
       "version": "8.0.34",
       "port-version": 1


### PR DESCRIPTION
Depending on your triplet it can add >80 extra builds

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
