### PR TITLE
[abseil] Update to 20240116.1

### DIFF
--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -10,10 +10,23 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cxx17 ABSL_USE_CXX17
+)
+
+# With ABSL_PROPAGATE_CXX_STD=ON abseil automatically detect if it is being
+# compiled with C++14 or C++17, and modifies the installed `absl/base/options.h`
+# header accordingly. This works even if CMAKE_CXX_STANDARD is not set. Abseil
+# uses the compiler default behavior to update `absl/base/options.h` as needed.
+if (ABSL_USE_CXX17)
+    set(ABSL_USE_CXX17_OPTION "-DCMAKE_CXX_STANDARD=17")
+endif ()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    OPTIONS -DABSL_PROPAGATE_CXX_STD=ON
+    OPTIONS -DABSL_PROPAGATE_CXX_STD=ON ${ABSL_USE_CXX17_OPTION}
 )
 
 vcpkg_cmake_install()

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -6,27 +6,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO abseil/abseil-cpp
     REF "${VERSION}"
-    SHA512 14390380655c41483a98487e3b012110dd8d1743fdd68d8cde7e0d7c2730312d564b15726d8c9d2fff237d2fce3983bbbb5213f59612c7c6feaeb402dff9609f
+    SHA512 41504899ac4fd4a6eaa0a5fdf27a7765ec81962fb99b6a07982ceed32c5289e9eb12206c83a70fd44c5c3e1b96c2bfa160eb12f1dbbb45f1109d632c7690de90
     HEAD_REF master
 )
-
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        cxx17 ABSL_USE_CXX17
-)
-
-# With ABSL_PROPAGATE_CXX_STD=ON abseil automatically detect if it is being
-# compiled with C++14 or C++17, and modifies the installed `absl/base/options.h`
-# header accordingly. This works even if CMAKE_CXX_STANDARD is not set. Abseil
-# uses the compiler default behavior to update `absl/base/options.h` as needed.
-if (ABSL_USE_CXX17)
-    set(ABSL_USE_CXX17_OPTION "-DCMAKE_CXX_STANDARD=17")
-endif ()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    OPTIONS -DABSL_PROPAGATE_CXX_STD=ON ${ABSL_USE_CXX17_OPTION}
+    OPTIONS -DABSL_PROPAGATE_CXX_STD=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -18,5 +18,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "cxx17": {
+      "description": "Enable compiler C++17."
+    }
+  }
 }

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "abseil",
-  "version": "20230802.1",
+  "version": "20240116.1",
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
@@ -18,10 +18,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "cxx17": {
-      "description": "Enable compiler C++17."
-    }
-  }
+  ]
 }

--- a/ports/grpc/00016_add_header.patch
+++ b/ports/grpc/00016_add_header.patch
@@ -1,0 +1,12 @@
+diff --git a/src/core/lib/iomgr/tcp_posix.cc b/src/core/lib/iomgr/tcp_posix.cc
+index 72e1b66..8dc1fd1 100644
+--- a/src/core/lib/iomgr/tcp_posix.cc
++++ b/src/core/lib/iomgr/tcp_posix.cc
+@@ -47,6 +47,7 @@
+ #include <grpc/support/string_util.h>
+ #include <grpc/support/sync.h>
+ #include <grpc/support/time.h>
++#include <absl/strings/str_cat.h>
+ 
+ #include "src/core/lib/address_utils/sockaddr_utils.h"
+ #include "src/core/lib/debug/event_log.h"

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_from_github(
         00012-fix-use-cxx17.patch
         00014-pkgconfig-upbdefs.patch
         00015-disable-download-archive.patch
+        00016_add_header.patch
 )
 
 if(NOT TARGET_TRIPLET STREQUAL HOST_TRIPLET)

--- a/ports/grpc/vcpkg.json
+++ b/ports/grpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "grpc",
   "version-semver": "1.51.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An RPC library and framework",
   "homepage": "https://github.com/grpc/grpc",
   "license": "Apache-2.0",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "de638f704027c9c82de8fc6fadc25b840c3cffb4",
+      "git-tree": "a8b26862556884ff981430b54b130d4b1ef6eef7",
       "version": "20240116.1",
       "port-version": 0
     },

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de638f704027c9c82de8fc6fadc25b840c3cffb4",
+      "version": "20240116.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "49a35a30915907a4e46b57bb33b8aa1f2185e757",
       "version": "20230802.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3174,7 +3174,7 @@
     },
     "grpc": {
       "baseline": "1.51.1",
-      "port-version": 1
+      "port-version": 2
     },
     "grppi": {
       "baseline": "0.4.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,7 +17,7 @@
       "port-version": 0
     },
     "abseil": {
-      "baseline": "20230802.1",
+      "baseline": "20240116.1",
       "port-version": 0
     },
     "absent": {

--- a/versions/g-/grpc.json
+++ b/versions/g-/grpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d904c97eca4bce7c1a9a0293b9101b831d0bb03f",
+      "version-semver": "1.51.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "cb74de57b43021aafda930876608035b03eb80a8",
       "version-semver": "1.51.1",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/37439
Delete feature cxx17.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```