### PR TITLE
[opencsg] Update to 1.6.0

### DIFF
--- a/ports/opencsg/CMakeLists.txt
+++ b/ports/opencsg/CMakeLists.txt
@@ -21,9 +21,6 @@ set(SRCS
 	src/renderSCS.cpp
 	src/scissorMemo.cpp
 	src/settings.cpp
-	src/stencilManager.cpp
-	src/pBufferTexture.cpp
-	RenderTexture/RenderTexture.cpp
 )
 
 

--- a/ports/opencsg/portfile.cmake
+++ b/ports/opencsg/portfile.cmake
@@ -1,23 +1,25 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+string(REPLACE "." "-" VERSION_CSG "${VERSION}")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO floriankirsch/OpenCSG
-    REF "opencsg-1-4-2-release"
-    SHA512 df117a1b7153a95332d236918d1547b0afe6f3ead46af2733c5feee6e25cec984b21affc41fd8320a45be9292bd3b32e21ed8bb3d08371ddd657f659b9bb932a
+    REF "opencsg-${VERSION_CSG}-release"
+    SHA512 531dda97fbbcfca9bd57eb2d62b34ed382788bafffff05aa4007cf6dd7093c478e6364020e58cda8adcc1bc45485c22e3a94dbc52916da6a8b418412ce7712c6
     HEAD_REF master
-    PATCHES illegal_char.patch
+    PATCHES
+        illegal_char.patch
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS -DUNICODE=1 -D_UNICODE=1
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS_DEBUG
+        -DDISABLE_INSTALL_HEADERS=ON
 )
 
 vcpkg_cmake_install()
 
-file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/license/gpl-2.0.txt" "${SOURCE_PATH}/doc/license/gpl-3.0.txt")

--- a/ports/opencsg/vcpkg.json
+++ b/ports/opencsg/vcpkg.json
@@ -1,16 +1,13 @@
 {
   "name": "opencsg",
-  "version": "1.4.2",
-  "port-version": 4,
+  "version": "1.6.0",
   "description": "OpenCSG is a library that does image-based CSG rendering using OpenGL. OpenCSG is written in C++ and supports most modern graphics hardware using Microsoft Windows or the Linux operating system.",
+  "homepage": "https://github.com/floriankirsch/OpenCSG",
+  "license": "GPL-2.0-or-later",
   "dependencies": [
     "glew",
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6377,8 +6377,8 @@
       "port-version": 1
     },
     "opencsg": {
-      "baseline": "1.4.2",
-      "port-version": 4
+      "baseline": "1.6.0",
+      "port-version": 0
     },
     "openctm": {
       "baseline": "1.0.3",

--- a/versions/o-/opencsg.json
+++ b/versions/o-/opencsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6979934362ae4a808ccef45ee20545d7422c8e0f",
+      "version": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "48c6aea4f747325a26bec13cf9a93f94c21f4fd2",
       "version": "1.4.2",
       "port-version": 4


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #37446.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
