### PR TITLE
[onnx] Add dependency protobuf

### DIFF
--- a/ports/onnx/portfile.cmake
+++ b/ports/onnx/portfile.cmake
@@ -64,6 +64,10 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ONNX)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/ONNXConfig.cmake" "# import targets" 
+[[# import targets
+include(CMakeFindDependencyMacro)
+find_dependency(protobuf CONFIG)]])
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "onnx",
   "version-semver": "1.15.0",
+  "port-version": 1,
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6322,7 +6322,7 @@
     },
     "onnx": {
       "baseline": "1.15.0",
-      "port-version": 0
+      "port-version": 1
     },
     "onnx-optimizer": {
       "baseline": "0.3.18",

--- a/versions/o-/onnx.json
+++ b/versions/o-/onnx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69ad297b15bb801f74d50be6e5d290eab7573be4",
+      "version-semver": "1.15.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c143b899cbe396d82182568746203a3375fc23df",
       "version-semver": "1.15.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/37456

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
x64-windows-static
```