### PR TITLE
[glib] Update to 2.80.0

### DIFF
--- a/ports/glib/0005-pr-4133-4143-avoid-package-packaging.patch
+++ b/ports/glib/0005-pr-4133-4143-avoid-package-packaging.patch
@@ -1,0 +1,59 @@
+diff --git a/gio/gdbus-2.0/codegen/utils.py b/gio/gdbus-2.0/codegen/utils.py
+index 08f1ba9..af803c0 100644
+--- a/gio/gdbus-2.0/codegen/utils.py
++++ b/gio/gdbus-2.0/codegen/utils.py
+@@ -19,10 +19,9 @@
+ #
+ # Author: David Zeuthen <davidz@redhat.com>
+
+-import packaging.version
+ import os
+ import sys
+-
++import re
+
+ # pylint: disable=too-few-public-methods
+ class Color:
+@@ -166,4 +165,28 @@ def version_cmp_key(key):
+         v = str(key[0])
+     else:
+         v = "0"
+-    return (packaging.version.Version(v), key[1])
++    return (_parse_version(v), key[1])
++
++
++def _parse_version(version):
++    """
++    Parse a version string into a list of integers and strings.
++
++    This function takes a version string and breaks it down into its component parts.
++    It separates numeric and non-numeric segments, converting numeric segments to integers.
++
++    Args:
++        version (str): The version string to parse.
++
++    Returns:
++        list: A list where each element is either an integer (for numeric parts)
++              or a string (for non-numeric parts).
++
++    Example:
++        >>> parseversion("1.2.3a")
++        [1, 2, 3, 'a']
++        >>> parseversion("2.0.0-rc1")
++        [2, 0, 0, 'rc1']
++    """
++    blocks = re.findall(r"(\d+|\w+)", version)
++    return [int(b) if b.isdigit() else b for b in blocks]
+diff --git a/meson.build b/meson.build
+index a400965..576a939 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2420,7 +2420,7 @@ endif
+
+ glib_conf.set('HAVE_PROC_SELF_CMDLINE', have_proc_self_cmdline)
+
+-python = import('python').find_installation(modules: ['packaging'])
++python = import('python').find_installation()
+ # used for '#!/usr/bin/env <name>'
+ python_name = 'python3'
+

--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -2,7 +2,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIB_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIB_ARCHIVE
     URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${VERSION}.tar.xz"
     FILENAME "glib-${VERSION}.tar.xz"
-    SHA512 6f3a06e10e7373a2dbf0688512de4126472fb73cbec488b7983b5ffecff09c64d7e1ca462f892e8f215d3d277d103ca802bad7ef0bd0f91edf26fc6ce67187b6
+    SHA512 1514d62aeb4c4a1a1048ae0f84f7db7f0dbf355772b2dadf6a34ec547045b163a5e28331b096e7616fe3c9c19bed98025a0202b05073f5d7ee901d0efaffe143
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH
@@ -10,6 +10,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     PATCHES
         use-libiconv-on-windows.patch
         libintl.patch
+        0005-pr-4133-4143-avoid-package-packaging.patch # Backport from 2.81.1
 )
 
 set(LANGUAGES C CXX)
@@ -47,10 +48,10 @@ vcpkg_configure_meson(
         ${ADDITIONAL_BINARIES}
     OPTIONS
         ${OPTIONS}
-        -Dgtk_doc=false
+        -Ddocumentation=false
         -Dinstalled_tests=false
         -Dlibelf=disabled
-        -Dman=false
+        -Dman-pages=disabled
         -Dtests=false
         -Dxattr=false
 )
@@ -73,6 +74,9 @@ endforeach()
 set(GLIB_TOOLS
     gapplication
     gdbus
+    gi-compile-repository
+    gi-decompile-typelib
+    gi-inspect-typelib
     gio
     gio-querymodules
     glib-compile-resources

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glib",
-  "version": "2.78.4",
-  "port-version": 4,
+  "version": "2.80.0",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3129,8 +3129,8 @@
       "port-version": 2
     },
     "glib": {
-      "baseline": "2.78.4",
-      "port-version": 4
+      "baseline": "2.80.0",
+      "port-version": 0
     },
     "glib-networking": {
       "baseline": "2.78.0",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98c1acbee23caa1307827ce7d8e4f6e38954e560",
+      "version": "2.80.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ee1411dc98162edf7c0e77780050dc8ddc7b3aae",
       "version": "2.78.4",
       "port-version": 4


### PR DESCRIPTION
Fix #37286, update `glib` to `2.80.0`.

### Change

* Backport patch to avoid package packaging, from [4133](https://gitlab.gnome.org/GNOME/glib/-/commit/38faeca62ebd5be89b1ec3e6c530e499ce2d7240) and [4143](https://gitlab.gnome.org/GNOME/glib/-/commit/3993d8db52f1426920285543fbcd8d7ee9327825). That is, python package `packaging` module required in `meson.build` at [GNOME - GLib - 2.79.0](https://gitlab.gnome.org/GNOME/glib/-/releases/2.79.0)
* Change `meson` build option `gtk_doc=false` to `documentation=false` and `man=false` to `man-pages=disabled` at [GNOME - GLib - 2.79.0](https://gitlab.gnome.org/GNOME/glib/-/releases/2.79.0)
* Add tools of `gi-compile-repository`, `gi-decompile-typelib` and `gi-inspect-typeli` at [GNOME - GLib - 2.79.2](https://gitlab.gnome.org/GNOME/glib/-/releases/2.79.2)

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

Port usage and feature `libmount` test pass with following triplets:

* x64-linux
* x64-windows