### PR TITLE
[libe57] fix some comments

### DIFF
--- a/ports/libe57/0001_cmake.patch
+++ b/ports/libe57/0001_cmake.patch
@@ -21,7 +21,7 @@ diff -Naur a/CMakeLists.txt b/CMakeLists.txt
      set(XERCES_ROOT CACHE PATH "Location of the xerces library")
      message(FATAL_ERROR
  "Unable to find xerces library.
- Please set the the XERCES_ROOT to point to the root of the xerces directory."
+ Please set the XERCES_ROOT to point to the root of the xerces directory."
  )
 -endif (NOT Xerces_FOUND)
 +endif (NOT XercesC_FOUND)

--- a/ports/qt5-base/cmake/configure_qt.cmake
+++ b/ports/qt5-base/cmake/configure_qt.cmake
@@ -157,7 +157,7 @@ function(configure_qt)
                 -hostbindir ${CURRENT_INSTALLED_DIR}/tools/qt5${_path_suffix_${_buildname}}/bin 
                 #-hostbindir ${CURRENT_INSTALLED_DIR}/tools/qt5/bin 
                 # Qt VS Plugin requires a /bin subfolder with the executables in the root dir. But to use the wizard a correctly setup lib folder is also required
-                # So with the vcpkg layout there is no way to make it work unless all dll are are copied to tools/qt5/bin and all libs to tools/qt5/lib
+                # So with the vcpkg layout there is no way to make it work unless all dll are copied to tools/qt5/bin and all libs to tools/qt5/lib
                 -archdatadir ${CURRENT_INSTALLED_DIR}/tools/qt5${_path_suffix_${_buildname}}
                 -datadir ${CURRENT_INSTALLED_DIR}${_path_suffix}/share/qt5${_path_suffix_${_buildname}}
                 -plugindir ${CURRENT_INSTALLED_DIR}${_path_suffix_${_buildname}}/plugins

--- a/versions/l-/libe57.json
+++ b/versions/l-/libe57.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d5a7a88a7e28608ff30f48533cec32ac07f6f7c2",
+      "git-tree": "c70718a956f60dd9695093ba7f80c6c757169025",
       "version-semver": "1.1.332",
       "port-version": 4
     },

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad1dffea8d188fbaf56e7d2564455b96bbce57bb",
+      "git-tree": "f86ba48a48bca0e93d74f2e923ec84d5979d14cc",
       "version": "5.15.13",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
