### PR TITLE
[ogre] Update to 14.2.2

### DIFF
--- a/ports/ogre/fix-dependencies.patch
+++ b/ports/ogre/fix-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/CMake/Dependencies.cmake b/CMake/Dependencies.cmake
-index b0c5ba3..27d7bd2 100644
+index 804602e0f..e7b665004 100644
 --- a/CMake/Dependencies.cmake
 +++ b/CMake/Dependencies.cmake
-@@ -194,11 +194,14 @@ endif()
+@@ -210,11 +210,14 @@ endif()
  #######################################################################
  
  # Find FreeImage
@@ -19,7 +19,7 @@ index b0c5ba3..27d7bd2 100644
  macro_log_feature(FREETYPE_FOUND "freetype" "Portable font engine" "http://www.freetype.org")
  
  # Find X11
-@@ -254,13 +257,17 @@ endif ()
+@@ -270,13 +273,17 @@ endif ()
  macro_log_feature(ENV{VULKAN_SDK} "Vulkan SDK" "Vulkan RenderSystem, glslang Plugin. Alternatively use system packages" "https://vulkan.lunarg.com/")
  
  # OpenEXR
@@ -40,7 +40,7 @@ index b0c5ba3..27d7bd2 100644
  macro_log_feature(PYTHONLIBS_FOUND "Python" "Language bindings to use OGRE from Python" "http://www.python.org/")
  
  # SWIG
-@@ -268,7 +275,7 @@ find_package(SWIG 3.0.8 QUIET)
+@@ -284,7 +291,7 @@ find_package(SWIG 3.0.8 QUIET)
  macro_log_feature(SWIG_FOUND "SWIG" "Language bindings (Python, Java, C#) for OGRE" "http://www.swig.org/")
  
  # pugixml
@@ -49,7 +49,7 @@ index b0c5ba3..27d7bd2 100644
  macro_log_feature(pugixml_FOUND "pugixml" "Needed for XMLConverter and DotScene Plugin" "https://pugixml.org/")
  
  # Find zlib
-@@ -276,7 +283,7 @@ find_package(ZLIB)
+@@ -292,7 +299,7 @@ find_package(ZLIB)
  macro_log_feature(ZLIB_FOUND "zlib" "Simple data compression library" "http://www.zlib.net")
  
  # Assimp
@@ -58,7 +58,7 @@ index b0c5ba3..27d7bd2 100644
  macro_log_feature(assimp_FOUND "Assimp" "Needed for the AssimpLoader Plugin" "https://www.assimp.org/")
  
  # Bullet
-@@ -284,6 +291,8 @@ find_package(Bullet QUIET)
+@@ -300,6 +307,8 @@ find_package(Bullet QUIET)
  macro_log_feature(BULLET_FOUND "Bullet" "Bullet physics" "https://pybullet.org")
  
  if(assimp_FOUND)
@@ -67,7 +67,7 @@ index b0c5ba3..27d7bd2 100644
    # workaround horribly broken assimp cmake, fixed with assimp 5.1
    add_library(fix::assimp INTERFACE IMPORTED)
    set_target_properties(fix::assimp PROPERTIES
-@@ -302,7 +311,7 @@ endif()
+@@ -318,7 +327,7 @@ endif()
  # Find sdl2
  if(NOT ANDROID AND NOT EMSCRIPTEN)
    # find script does not work in cross compilation environment
@@ -77,7 +77,7 @@ index b0c5ba3..27d7bd2 100644
    if(SDL2_FOUND AND NOT TARGET SDL2::SDL2)
      add_library(SDL2::SDL2 INTERFACE IMPORTED)
 diff --git a/CMake/Templates/OGREConfig.cmake.in b/CMake/Templates/OGREConfig.cmake.in
-index 2047f66..a5c7cd0 100644
+index 2047f6648..a5c7cd006 100644
 --- a/CMake/Templates/OGREConfig.cmake.in
 +++ b/CMake/Templates/OGREConfig.cmake.in
 @@ -35,6 +35,25 @@ set(OGRE_LIBRARIES)
@@ -107,24 +107,24 @@ index 2047f66..a5c7cd0 100644
      list(APPEND OGRE_INCLUDE_DIRS @Boost_INCLUDE_DIRS@)
  endif()
 diff --git a/Components/Bites/CMakeLists.txt b/Components/Bites/CMakeLists.txt
-index 8f96cef..045e288 100644
+index 59756c148..9d7cc07ca 100644
 --- a/Components/Bites/CMakeLists.txt
 +++ b/Components/Bites/CMakeLists.txt
-@@ -171,6 +171,12 @@ elseif(NOT EMSCRIPTEN)
+@@ -177,6 +177,12 @@ if(SDL2_FOUND)
+ elseif(NOT EMSCRIPTEN)
    message(WARNING "SDL2 not found - no input handling and reduced window creation capabilites")
  endif()
- 
++ 
 +if(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI)
 +  find_package(imgui CONFIG REQUIRED)
 +  find_path(IMGUI_DIR NAMES imgui.h)
 +  target_link_libraries(OgreBites PRIVATE imgui::imgui)
 +endif()
-+
+ 
  generate_export_header(OgreBites 
      EXPORT_MACRO_NAME _OgreBitesExport
-     EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/OgreBitesPrerequisites.h)
 diff --git a/Components/Overlay/CMakeLists.txt b/Components/Overlay/CMakeLists.txt
-index 0c74ce2..a302b1c 100644
+index 257a30c0c..cdeb6e129 100644
 --- a/Components/Overlay/CMakeLists.txt
 +++ b/Components/Overlay/CMakeLists.txt
 @@ -19,6 +19,8 @@ list(APPEND HEADER_FILES
@@ -133,7 +133,7 @@ index 0c74ce2..a302b1c 100644
  if(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI)
 +  find_package(imgui CONFIG REQUIRED)
 +elseif(0)
-   set(IMGUI_DIR "${PROJECT_BINARY_DIR}/imgui-1.89.7" CACHE PATH "")
+   set(IMGUI_DIR "${PROJECT_BINARY_DIR}/imgui-1.90.4" CACHE PATH "")
    if(NOT EXISTS ${IMGUI_DIR})
      message(STATUS "Downloading imgui")
 @@ -63,6 +65,8 @@ elseif(UNIX)
@@ -146,7 +146,7 @@ index 0c74ce2..a302b1c 100644
      PUBLIC "$<BUILD_INTERFACE:${IMGUI_DIR}>"
      PRIVATE "$<BUILD_INTERFACE:${IMGUI_DIR}/misc/freetype>")
 diff --git a/PlugIns/EXRCodec/src/OgreEXRCodec.cpp b/PlugIns/EXRCodec/src/OgreEXRCodec.cpp
-index 0822081..a22841c 100644
+index efd4b32de..1e3ea2316 100644
 --- a/PlugIns/EXRCodec/src/OgreEXRCodec.cpp
 +++ b/PlugIns/EXRCodec/src/OgreEXRCodec.cpp
 @@ -36,6 +36,9 @@ THE SOFTWARE.
@@ -160,7 +160,7 @@ index 0822081..a22841c 100644
  #include <ImfInputFile.h>
  #include <ImfChannelList.h>
 diff --git a/PlugIns/STBICodec/CMakeLists.txt b/PlugIns/STBICodec/CMakeLists.txt
-index 10283f5..e7edfd3 100644
+index 10283f51e..e7edfd32e 100644
 --- a/PlugIns/STBICodec/CMakeLists.txt
 +++ b/PlugIns/STBICodec/CMakeLists.txt
 @@ -19,8 +19,10 @@ endif()
@@ -175,10 +175,10 @@ index 10283f5..e7edfd3 100644
  
  if(CMAKE_COMPILER_IS_GNUCXX)
 diff --git a/PlugIns/STBICodec/src/OgreSTBICodec.cpp b/PlugIns/STBICodec/src/OgreSTBICodec.cpp
-index 663a1c3..e1452cb 100644
+index f89e9a16c..df648d700 100644
 --- a/PlugIns/STBICodec/src/OgreSTBICodec.cpp
 +++ b/PlugIns/STBICodec/src/OgreSTBICodec.cpp
-@@ -39,7 +39,7 @@ THE SOFTWARE.
+@@ -40,7 +40,7 @@ THE SOFTWARE.
  #define STBI_NO_STDIO
  #define STB_IMAGE_IMPLEMENTATION
  #define STB_IMAGE_STATIC
@@ -187,7 +187,7 @@ index 663a1c3..e1452cb 100644
  
  #ifdef HAVE_ZLIB
  #include <zlib.h>
-@@ -62,7 +62,7 @@ static Ogre::uchar* custom_zlib_compress(Ogre::uchar* data, int data_len, int* o
+@@ -63,7 +63,7 @@ static Ogre::uchar* custom_zlib_compress(Ogre::uchar* data, int data_len, int* o
  
  #define STB_IMAGE_WRITE_IMPLEMENTATION
  #define STBI_WRITE_NO_STDIO
@@ -196,7 +196,7 @@ index 663a1c3..e1452cb 100644
  
  namespace Ogre {
  
-@@ -73,7 +73,7 @@ namespace Ogre {
+@@ -74,7 +74,7 @@ namespace Ogre {
          stbi_convert_iphone_png_to_rgb(1);
          stbi_set_unpremultiply_on_load(1);
  
@@ -206,10 +206,10 @@ index 663a1c3..e1452cb 100644
          // Register codecs
          String exts = "jpeg,jpg,png,bmp,psd,tga,gif,pic,ppm,pgm,hdr";
 diff --git a/Components/Bites/src/OgreImGuiInputListener.cpp b/Components/Bites/src/OgreImGuiInputListener.cpp
-index 2fce0dd0b..631735fb2 100644
+index 3cb237946..5629bb5d7 100644
 --- a/Components/Bites/src/OgreImGuiInputListener.cpp
 +++ b/Components/Bites/src/OgreImGuiInputListener.cpp
-@@ -112,7 +112,7 @@ static bool keyEvent(const KeyboardEvent& arg)
+@@ -116,7 +116,7 @@ static bool keyEvent(const KeyboardEvent& arg)
      if (key == ImGuiKey_None)
          return io.WantCaptureKeyboard;
  

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OGRECave/ogre
     REF "v${VERSION}"
-    SHA512 adadf0ce8510515c7519b87b502090c4a8d6694af0850ebd4a030d2dda497978eeb811746c74aa0cd1dc41adc0bf5f04fe38d02eb4ff03a56999c6635efe1e0e
+    SHA512 8c204aaf9be4e6c8ffcccc9361a3cd7962ac068fc2d88755c2983c821076427b3b0197d2a30f72636c2e35a86bfb89e43ea6f3efae6bd45b061bb64bfceae779
     HEAD_REF master
     PATCHES
         fix-dependencies.patch
@@ -57,9 +57,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 if("java" IN_LIST FEATURES OR "python" IN_LIST FEATURES OR "csharp" IN_LIST FEATURES)
     list(APPEND FEATURE_OPTIONS "-DCMAKE_REQUIRE_FIND_PACKAGE_SWIG=ON")
-endif()
-
-if(CMAKE_REQUIRE_FIND_PACKAGE_SWIG)
     vcpkg_find_acquire_program(SWIG)
     vcpkg_list(APPEND FEATURE_OPTIONS "-DSWIG_EXECUTABLE=${SWIG}")
 endif()

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ogre",
-  "version": "14.0.1",
-  "port-version": 2,
+  "version": "14.2.2",
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6289,8 +6289,8 @@
       "port-version": 0
     },
     "ogre": {
-      "baseline": "14.0.1",
-      "port-version": 2
+      "baseline": "14.2.2",
+      "port-version": 0
     },
     "ogre-next": {
       "baseline": "2.3.3",

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b511cd10a4794ac25d7d8ca997697d25427e483",
+      "version": "14.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a445b3c7be57d018422e139945ff622292cd5cff",
       "version": "14.0.1",
       "port-version": 2


### PR DESCRIPTION
Fix #37079.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
Port usage and features `assimp,bullet,freeimage,openexr,overlay,strict,tools,zip,zziplib` test pass with following triplets:
* x64-linux
* x64-windows
* x64-windows-static