### PR TITLE
[dstorage] Fix port bug with RelWithDebInfo remap

### DIFF
--- a/ports/dstorage/dstorage-config.cmake.in
+++ b/ports/dstorage/dstorage-config.cmake.in
@@ -1,33 +1,24 @@
 
-get_filename_component(_dstorage_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_dstorage_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
 get_filename_component(_dstorage_root "${_dstorage_root}" PATH)
-get_filename_component(_dstorage_root "${_dstorage_root}" PATH)
 
-set(_dstorage_root_lib "${_dstorage_root}/lib/dstorage.lib")
-if (EXISTS "${_dstorage_root_lib}")
+add_library(Microsoft::DirectStorage SHARED IMPORTED)
+set_target_properties(Microsoft::DirectStorage PROPERTIES
+   IMPORTED_LOCATION                    "${_dstorage_root}/bin/dstorage.dll"
+   IMPORTED_IMPLIB                      "${_dstorage_root}/lib/@lib_name@"
+   INTERFACE_INCLUDE_DIRECTORIES        "${_dstorage_root}/include"
+   INTERFACE_LINK_LIBRARIES             "Microsoft::DirectStorageCore"
+   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
+   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""
+   IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
-   add_library(Microsoft::DirectStorage SHARED IMPORTED)
-   set_target_properties(Microsoft::DirectStorage PROPERTIES
-      IMPORTED_LOCATION                    "${_dstorage_root}/bin/dstorage.dll"
-      IMPORTED_IMPLIB                      "${_dstorage_root_lib}"
-      INTERFACE_INCLUDE_DIRECTORIES        "${_dstorage_root}/include"
-      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+add_library(Microsoft::DirectStorageCore SHARED IMPORTED)
+set_target_properties(Microsoft::DirectStorageCore PROPERTIES
+   IMPORTED_LOCATION                    "${_dstorage_root}/bin/dstoragecore.dll"
+   IMPORTED_IMPLIB                      "${_dstorage_root}/lib/@lib_name@"
+   INTERFACE_INCLUDE_DIRECTORIES        "${_dstorage_root}/include"
+   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
+   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""
+   IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
-   add_library(Microsoft::DirectStorageCore SHARED IMPORTED)
-   set_target_properties(Microsoft::DirectStorageCore PROPERTIES
-      IMPORTED_LOCATION                    "${_dstorage_root}/bin/dstoragecore.dll"
-      IMPORTED_IMPLIB                      "${_dstorage_root_lib}"
-      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
-
-   target_link_libraries(Microsoft::DirectStorage INTERFACE Microsoft::DirectStorageCore)
-
-   set(dstorage_FOUND TRUE)
-
-else()
-
-    set(dstorage_FOUND FALSE)
-
-endif()
-
-unset(_dstorage_root_lib)
 unset(_dstorage_root)

--- a/ports/dstorage/dstorage-config.cmake.in
+++ b/ports/dstorage/dstorage-config.cmake.in
@@ -8,8 +8,6 @@ set_target_properties(Microsoft::DirectStorage PROPERTIES
    IMPORTED_IMPLIB                      "${_dstorage_root}/lib/@lib_name@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dstorage_root}/include"
    INTERFACE_LINK_LIBRARIES             "Microsoft::DirectStorageCore"
-   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
-   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
 add_library(Microsoft::DirectStorageCore SHARED IMPORTED)
@@ -17,8 +15,6 @@ set_target_properties(Microsoft::DirectStorageCore PROPERTIES
    IMPORTED_LOCATION                    "${_dstorage_root}/bin/dstoragecore.dll"
    IMPORTED_IMPLIB                      "${_dstorage_root}/lib/@lib_name@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dstorage_root}/include"
-   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
-   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
 unset(_dstorage_root)

--- a/ports/dstorage/portfile.cmake
+++ b/ports/dstorage/portfile.cmake
@@ -1,6 +1,5 @@
-# Set VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY instead of using `vcpkg_check_linkage` because
-# these DLLs don't link with a CRT.
-set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
+
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/${VERSION}"
@@ -19,13 +18,18 @@ file(INSTALL "${PACKAGE_PATH}/native/include/dstorageerr.h" DESTINATION "${CURRE
 
 file(INSTALL "${PACKAGE_PATH}/native/lib/${VCPKG_TARGET_ARCHITECTURE}/dstorage.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 
-file(COPY "${PACKAGE_PATH}/native/bin/${VCPKG_TARGET_ARCHITECTURE}/dstorage.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-file(COPY "${PACKAGE_PATH}/native/bin/${VCPKG_TARGET_ARCHITECTURE}/dstoragecore.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+file(INSTALL "${PACKAGE_PATH}/native/bin/${VCPKG_TARGET_ARCHITECTURE}/dstorage.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+file(INSTALL "${PACKAGE_PATH}/native/bin/${VCPKG_TARGET_ARCHITECTURE}/dstoragecore.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
 
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug")
-file(COPY "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")
+if(NOT DEFINED VCPKG_BUILD_TYPE)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug")
+    file(INSTALL "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")
+endif()
+
+set(lib_name dstorage.lib)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/dstorage-config.cmake.in"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
+    @ONLY)
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/LICENSE.txt")
-
-configure_file("${CMAKE_CURRENT_LIST_DIR}/dstorage-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" COPYONLY)

--- a/ports/dstorage/vcpkg.json
+++ b/ports/dstorage/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dstorage",
   "version": "1.2.2",
+  "port-version": 1,
   "description": "DirectStorage for Windows",
   "homepage": "https://aka.ms/directstorage/",
   "documentation": "https://github.com/microsoft/DirectStorage",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2326,7 +2326,7 @@
     },
     "dstorage": {
       "baseline": "1.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "dtl": {
       "baseline": "1.20",

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb62cc333e78cefbbee1ff24863bf962f8e1c71c",
+      "version": "1.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "7577afa856f2cf3d3ce28d32f3272344987f2a71",
       "version": "1.2.2",
       "port-version": 0

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eb62cc333e78cefbbee1ff24863bf962f8e1c71c",
+      "git-tree": "1b20b0e0785d67babda3c4aed4372cb9f6ab27f6",
       "version": "1.2.2",
       "port-version": 1
     },


### PR DESCRIPTION
While working on #37401 I realized this port would not work correctly if I use `set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)` which is required for my other ports to work with RelWithDebInfo.

Also includes some cleanup for the port as well as respecting `VCPKG_BUILD_TYPE=release`.

