### PR TITLE
[icu] Bump ICU Version to 74.2

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS "https://github.com/unicode-org/icu/releases/download/release-${VERSION3}/icu4c-${VERSION2}-src.tgz"
     FILENAME "icu4c-${VERSION2}-src.tgz"
-    SHA512 32c28270aa5d94c58d2b1ef46d4ab73149b5eaa2e0621d4a4c11597b71d146812f5e66db95f044e8aaa11b94e99edd4a48ab1aa8efbe3d72a73870cd56b564c2
+    SHA512 e6c7876c0f3d756f3a6969cad9a8909e535eeaac352f3a721338b9cbd56864bf7414469d29ec843462997815d2ca9d0dab06d38c37cdd4d8feb28ad04d8781b0
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "icu",
-  "version": "74.1",
+  "version": "74.2",
   "port-version": 1,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3441,7 +3441,7 @@
       "port-version": 0
     },
     "icu": {
-      "baseline": "74.1",
+      "baseline": "74.2",
       "port-version": 1
     },
     "ideviceinstaller": {

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd30ff59dbfac290a1547dccc5ba44646fffa018",
+      "version": "74.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "8fda8f4d0ca5b0a97ac61432d85ad0449995a763",
       "version": "74.1",
       "port-version": 1


### PR DESCRIPTION
If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


