### PR TITLE
[openblas] Clean up portfile.cmake

### DIFF
--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -16,7 +16,7 @@ find_program(GIT NAMES git git.cmd)
 get_filename_component(GIT_EXE_PATH "${GIT}" DIRECTORY)
 set(SED_EXE_PATH "${GIT_EXE_PATH}/../usr/bin")
 
-# openblas require perl to generate .def for exports
+# openblas requires perl to generate .def for exports
 vcpkg_find_acquire_program(PERL)
 get_filename_component(PERL_EXE_PATH "${PERL}" DIRECTORY)
 set(PATH_BACKUP "$ENV{PATH}")
@@ -44,8 +44,7 @@ if(VCPKG_TARGET_IS_ANDROID)
 endif()
 
 set(OPENBLAS_EXTRA_OPTIONS)
-# for UWP version, must build non uwp first for helper
-# binaries.
+# For UWP version, must build non-UWP first for helper binaries
 if(VCPKG_TARGET_IS_UWP)
     list(APPEND OPENBLAS_EXTRA_OPTIONS "-DBLASHELPER_BINARY_DIR=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}")
 elseif(NOT (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW))
@@ -53,7 +52,7 @@ elseif(NOT (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW))
     string(APPEND VCPKG_CXX_FLAGS " -DNEEDBUNDERSCORE")
     list(APPEND OPENBLAS_EXTRA_OPTIONS
                 -DNOFORTRAN=ON
-                -DBU=_  #required for all blas functions to append extra _ using NAME
+                -DBU=_  # Required for all BLAS functions to append extra _ using NAME
     )
 endif()
 
@@ -99,11 +98,12 @@ if(EXISTS "${pcfile}")
     #file(CREATE_LINK "${pcfile}" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/blas.pc" COPY_ON_ERROR)
 endif()
 vcpkg_fixup_pkgconfig()
-#maybe we need also to write a wrapper inside share/blas to search implicitly for openblas, whenever we feel it's ready for its own -config.cmake file
+# Maybe we need also to write a wrapper inside share/blas to search implicitly for openblas,
+# whenever we feel it's ready for its own -config.cmake file.
 
-# openblas do not make the config file , so I manually made this
-# but I think in most case, libraries will not include these files, they define their own used function prototypes
-# this is only to quite vcpkg
+# openblas does not have a config file, so I manually made this.
+# But I think in most cases, libraries will not include these files, they define their own used function prototypes.
+# This is only to quite vcpkg.
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/openblas_common.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 vcpkg_replace_string(

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openblas",
   "version": "0.3.26",
-  "port-version": 2,
+  "port-version": 3,
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/OpenMathLib/OpenBLAS",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6354,7 +6354,7 @@
     },
     "openblas": {
       "baseline": "0.3.26",
-      "port-version": 2
+      "port-version": 3
     },
     "opencascade": {
       "baseline": "7.8.0",

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f97eabf45b244d0c7cc374e23b818627fc82ffae",
+      "version": "0.3.26",
+      "port-version": 3
+    },
+    {
       "git-tree": "e4543de7cb4becef05c5da248b647730031bd0c1",
       "version": "0.3.26",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
