### PR TITLE
[heimdal] WIP new port

### DIFF
--- a/ports/heimdal/portfile.cmake
+++ b/ports/heimdal/portfile.cmake
@@ -1,0 +1,47 @@
+# "supports": "!uwp & !(osx & arm64)",
+set(VERSION 7.8.0)
+
+if(VCPKG_TARGET_IS_OSX)
+  message("${PORT} currently requires the following packages:\n    autoconf\n    libtool\nThis can be installed on MacOS systems via\n    brew install -y autoconf libtool\nNote that Homebrew installs `libtool` as `glibtool` by default.")
+elseif(NOT VCPKG_TARGET_IS_WINDOWS)
+  message("${PORT} currently requires the following library from the system package manager:\n    gettext\n    automake\n    libtool\nIt can be installed with apt-get install gettext automake libtool")
+endif()
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/heimdal/heimdal/releases/download/heimdal-${VERSION}/heimdal-${VERSION}.tar.gz"
+    FILENAME "heimdal-${VERSION}.tar.gz"
+    SHA512 0167345aca77d65b7a1113874eee5b65ec6e1fec1f196d57e571265409fa35ef95a673a4fd4aafbb0ab5fb5b246b97412353a68d6613a8aff6393a9f1e72999e
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        ldap       HEIMDAL_LDAP
+)
+
+vcpkg_list(SET options)
+vcpkg_list(APPEND options "--without-berkeley-db")
+vcpkg_list(APPEND options "--disable-otp")
+vcpkg_list(APPEND options "--disable-heimdal-documentation")
+
+if(HEIMDAL_LDAP)
+    vcpkg_list(APPEND options "--with-openldap")
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DETERMINE_BUILD_TRIPLET
+    OPTIONS
+        ${options}
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/heimdal/vcpkg.json
+++ b/ports/heimdal/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "heimdal",
+  "version": "7.8.0",
+  "description": "Heimdal is an implementation of: ASN.1/DER, PKIX, and Kerberos.",
+  "homepage": "https://github.com/heimdal/heimdal",
+  "license": "BSD-3-Clause",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true,
+      "platform": "windows"
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true,
+      "platform": "windows"
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3412,6 +3412,10 @@
       "baseline": "15",
       "port-version": 0
     },
+    "heimdal": {
+      "baseline": "7.8.0",
+      "port-version": 0
+    },
     "hello-imgui": {
       "baseline": "1.4.2",
       "port-version": 1

--- a/versions/h-/heimdal.json
+++ b/versions/h-/heimdal.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ad22f8063c810a1d16bde46cdd22e881fb9aab65",
+      "version-semver": "7.8.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
this is a work in progress, im working on this + `cyrus-sasl` + `librdkafka` for sasl support in the last.
fixes: https://github.com/microsoft/vcpkg/issues/5890

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


