### PR TITLE
[vcpkg baseline][mesa] Fix flex command deleting file error

### DIFF
--- a/ports/mesa/portfile.cmake
+++ b/ports/mesa/portfile.cmake
@@ -100,6 +100,7 @@ endif()
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -Dgles-lib-suffix=_mesa
         #-D egl-lib-suffix=_mesa

--- a/ports/mesa/vcpkg.json
+++ b/ports/mesa/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mesa",
   "version": "23.2.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Mesa - The 3D Graphics Library",
   "homepage": "https://www.mesa3d.org/",
   "license": "MIT AND BSL-1.0 AND SGI-B-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5642,7 +5642,7 @@
     },
     "mesa": {
       "baseline": "23.2.1",
-      "port-version": 1
+      "port-version": 2
     },
     "meschach": {
       "baseline": "1.2b",

--- a/versions/m-/mesa.json
+++ b/versions/m-/mesa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11c5e75bda82a6db79c2ce76ca5cb615dc5f650c",
+      "version": "23.2.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "cf4f628acb3c66d2c99544f1acd2a76f576f3f4b",
       "version": "23.2.1",
       "port-version": 1


### PR DESCRIPTION
Fixes CI REGRESSIONS: https://dev.azure.com/vcpkg/public/_build/results?buildId=100713&view=results
````
REGRESSION: mesa:x86-windows failed with BUILD_FAILED
````
````
FAILED: src/compiler/glsl/glcpp/glcpp-lex.c 
"D:/downloads/tools/win_flex/2.5.25\win_flex.EXE" "--wincompat" "-DYY_USE_CONST=" "-o" "src/compiler/glsl/glcpp/glcpp-lex.c" "../src/esa-23.2.1-34ec6884e4.clean/src/compiler/glsl/glcpp/glcpp-lex.l"
win_flex.EXE: error deleting file C:\Users\AzDevOps\AppData\Local\Temp\~flex_out_main_2
````
This fails intermittently in CI. A crash usually occurs: https://github.com/microsoft/vcpkg/issues/29139.
Just due to `a runtime error when running multiple Flex processes`: https://github.com/lexxmark/winflexbison/issues/86,
According to the [comments](https://github.com/lexxmark/winflexbison/issues/86#issuecomment-1455195570) this issue is not yet fully fixed, at least not on Windows.
So I followed the suggestion and used the parallel configuration temporarily: https://github.com/microsoft/vcpkg/pull/34670#pullrequestreview-1692187226

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
