### PR TITLE
[nanomsg] Update nanomsg_BINDIR check

### DIFF
--- a/ports/nanomsg/portfile.cmake
+++ b/ports/nanomsg/portfile.cmake
@@ -53,7 +53,7 @@ endif()
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string(
         ${CURRENT_PACKAGES_DIR}/share/${PORT}/nanomsg-config.cmake
-        "set_and_check(nanomsg_BINDIR \${PACKAGE_PREFIX_DIR}/bin)"
+        "set_and_check(nanomsg_BINDIR \${VCPKG_IMPORT_PREFIX}/bin)"
         ""
     )
 endif()

--- a/ports/nanomsg/vcpkg.json
+++ b/ports/nanomsg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nanomsg",
   "version-semver": "1.2.1",
+  "port-version": 1,
   "description": [
     "A simple high-performance implementation of several \"scalability protocols\".",
     "These scalability protocols are light-weight messaging protocols which can be used to solve a number of very common messaging patterns, such as request/reply, publish/subscribe, surveyor/respondent, and so forth. These protocols can run over a variety of transports such as TCP, UNIX sockets, and even WebSocket."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5990,7 +5990,7 @@
     },
     "nanomsg": {
       "baseline": "1.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "nanopb": {
       "baseline": "0.4.7",

--- a/versions/n-/nanomsg.json
+++ b/versions/n-/nanomsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b2d139f5f6251148a6c9f8ab887ef6c476b2c96b",
+      "version-semver": "1.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "f153ee28346c2ba03410c8845959d1d549322ecb",
       "version-semver": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Update replaced string to make `vcpkg_replace_string` works successfully