### PR TITLE
[arrow] Update to 15.0.2

### DIFF
--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE_PATH
     URLS "https://archive.apache.org/dist/arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
     FILENAME apache-arrow-${VERSION}.tar.gz
-    SHA512 b426421336c6bc3757626b2743a039d3c7030ad257c3bcf3247a236462dbc140b7eff4476cb727f4d048144a90c1368740c139318f8237d6cc20e87d3efdaf74
+    SHA512 6c83e3be1e5840c30387f088315b74aca8e7c2d060793af70a156effb496a71e3e6af0693188c0f46f8a4a061a263a47095912ef04a5dc8141abd59075b14c78
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arrow",
-  "version": "15.0.1",
+  "version": "15.0.2",
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28965b502b1501b7832c506ea728e37924902909",
+      "version": "15.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "874763622bfd5b5d118109e44f25460c4b34af57",
       "version": "15.0.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -241,7 +241,7 @@
       "port-version": 5
     },
     "arrow": {
-      "baseline": "15.0.1",
+      "baseline": "15.0.2",
       "port-version": 0
     },
     "arsenalgear": {


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
