### PR TITLE
[copperspice] Add new port

### DIFF
--- a/ports/copperspice/portfile.cmake
+++ b/ports/copperspice/portfile.cmake
@@ -1,0 +1,114 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO copperspice/copperspice
+    REF cs-${VERSION}
+    SHA512 3eebaa8c50a440d1165eab1a72c9595b03779e11ce293ba61c35a0c4bed9b5b16908a19bd57af22c49294e84aa5f0c0dc4789d0590abdbb06c3cc77b89cfae31
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        gui         WITH_GUI
+        multimedia  WITH_MULTIMEDIA
+        network     WITH_NETWORK
+        opengl      WITH_OPENGL
+        script      WITH_SCRIPT
+        sql         WITH_SQL
+        svg         WITH_SVG
+        vulkan      WITH_VULKAN
+        webkit      WITH_WEBKIT
+        xmlpatterns WITH_XMLPATTERNS
+        # plugins
+        psql        WITH_PSQL_PLUGIN
+        mysql       WITH_MYSQL_PLUGIN
+        odbc        WITH_ODBC_PLUGIN
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DBUILD_TESTS=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_PostgreSQL=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_MySQL=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_ODBC=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_GTK2=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake/CopperSpice)
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/CopperSpice)
+file(RENAME
+    ${CURRENT_PACKAGES_DIR}/bin/lconvert.exe
+    ${CURRENT_PACKAGES_DIR}/tools/CopperSpice/lconvert.exe
+)
+file(RENAME
+    ${CURRENT_PACKAGES_DIR}/bin/lrelease.exe
+    ${CURRENT_PACKAGES_DIR}/tools/CopperSpice/lrelease.exe
+)
+file(RENAME
+    ${CURRENT_PACKAGES_DIR}/bin/lupdate.exe
+    ${CURRENT_PACKAGES_DIR}/tools/CopperSpice/lupdate.exe
+)
+file(RENAME
+    ${CURRENT_PACKAGES_DIR}/bin/rcc.exe
+    ${CURRENT_PACKAGES_DIR}/tools/CopperSpice/rcc.exe
+)
+file(RENAME
+    ${CURRENT_PACKAGES_DIR}/bin/uic.exe
+    ${CURRENT_PACKAGES_DIR}/tools/CopperSpice/uic.exe
+)
+file(REMOVE
+    ${CURRENT_PACKAGES_DIR}/debug/bin/lconvert.exe
+    ${CURRENT_PACKAGES_DIR}/debug/bin/lrelease.exe
+    ${CURRENT_PACKAGES_DIR}/debug/bin/lupdate.exe
+    ${CURRENT_PACKAGES_DIR}/debug/bin/rcc.exe
+    ${CURRENT_PACKAGES_DIR}/debug/bin/uic.exe
+    ${CURRENT_PACKAGES_DIR}/include/QtCore/cs_build_info.h
+)
+
+if(WITH_SQL)
+    if(WITH_PSQL_PLUGIN)
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/lib/CsSqlPsql1.9.dll
+            ${CURRENT_PACKAGES_DIR}/bin/CsSqlPsql1.9.dll
+        )
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/debug/lib/CsSqlPsql1.9.dll
+            ${CURRENT_PACKAGES_DIR}/debug/bin/CsSqlPsql1.9.dll
+        )
+    endif()
+    if(WITH_MYSQL_PLUGIN)
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/lib/CsSqlMySql1.9.dll
+            ${CURRENT_PACKAGES_DIR}/bin/CsSqlMySql1.9.dll
+        )
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/debug/lib/CsSqlMySql1.9.dll
+            ${CURRENT_PACKAGES_DIR}/debug/bin/CsSqlMySql1.9.dll
+        )
+    endif()
+    if(WITH_ODBC_PLUGIN)
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/lib/CsSqlOdbc1.9.dll
+            ${CURRENT_PACKAGES_DIR}/bin/CsSqlOdbc1.9.dll
+        )
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/debug/lib/CsSqlOdbc1.9.dll
+            ${CURRENT_PACKAGES_DIR}/debug/bin/CsSqlOdbc1.9.dll
+        )
+    endif()
+endif()
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/license/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})
+
+file(INSTALL
+    "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)

--- a/ports/copperspice/usage
+++ b/ports/copperspice/usage
@@ -1,0 +1,4 @@
+CopperSpice provides CMake targets:
+
+    find_package(CopperSpice CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CopperSpice::CopperSpice)

--- a/ports/copperspice/vcpkg.json
+++ b/ports/copperspice/vcpkg.json
@@ -1,0 +1,218 @@
+{
+  "name": "copperspice",
+  "version": "1.9.1",
+  "description": "Set of cross platform C++ libraries (Gui, Network, Multimedia, etc).",
+  "homepage": "https://github.com/copperspice/copperspice",
+  "license": "LGPL-2.1",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "ijg-libjpeg"
+    },
+    {
+      "name": "zlib"
+    },
+    {
+      "name": "sqlite3"
+    },
+    {
+      "name": "catch2"
+    },
+    {
+      "name": "alsa",
+      "platform": "!windows"
+    },
+    {
+      "name": "openssl"
+    },
+    {
+      "name": "cs-libguarded"
+    },
+    {
+      "name": "cs-signal"
+    },
+    {
+      "name": "cs-string"
+    }
+  ],
+  "features": {
+    "gui": {
+      "description": "Dialogs, File Selectors, Fonts, Images, Layouts, Menus, Printing, Styles, Widgets (QCalendar, QCheckBox, QComboBox, QLineEdit, QPushButton, QTabWidget ...)",
+      "dependencies": [
+        {
+          "name": "ijg-libjpeg"
+        }
+      ]
+    },
+    "multimedia": {
+      "description": "Audio, Camera, Video (recording and playback)",
+      "dependencies": [
+        {
+          "name": "copperspice",
+          "features": [
+            "gui",
+            "network",
+            "opengl"
+          ]
+        }
+      ]
+    },
+    "network": {
+      "description": "TCP, HTTP, FTP, IPv6, DNS lookups, SSL, URL support"
+    },
+    "opengl": {
+      "description": "Rendering Context, Graphic Formats, Shader Compiler",
+      "dependencies": [
+        {
+          "name": "opengl"
+        },
+        {
+          "name": "copperspice",
+          "features": [
+            "gui"
+          ]
+        }
+      ]
+    },
+    "script": {
+      "description": "JavaScript engine which can be embedded in your application"
+    },
+    "sql": {
+      "description": "Enable Database support"
+    },
+    "db2": {
+      "description": "Enable IBM DB2 support",
+      "dependencies": [
+        {
+          "name": "copperspice",
+          "features": [
+            "sql"
+          ]
+        }
+      ]
+    },
+    "ibase": {
+      "description": "Enable Borland InterBase support",
+      "dependencies": [
+        {
+          "name": "copperspice",
+          "features": [
+            "sql"
+          ]
+        }
+      ]
+    },
+    "mysql": {
+      "description": "Enable MySQL support",
+      "dependencies": [
+        {
+          "name": "libmysql"
+        },
+        {
+          "name": "copperspice",
+          "features": [
+            "sql"
+          ]
+        }
+      ]
+    },
+    "oci": {
+      "description": "Enable Oracle Call Interface support",
+      "dependencies": [
+        {
+          "name": "ocilib"
+        },
+        {
+          "name": "copperspice",
+          "features": [
+            "sql"
+          ]
+        }
+      ]
+    },
+    "odbc": {
+      "description": "Enable ODBC support",
+      "dependencies": [
+        {
+          "name": "libpq"
+        },
+        {
+          "name": "copperspice",
+          "features": [
+            "sql"
+          ]
+        }
+      ]
+    },
+    "psql": {
+      "description": "Enable PostgreSQL support",
+      "dependencies": [
+        {
+          "name": "libpq"
+        },
+        {
+          "name": "copperspice",
+          "features": [
+            "sql"
+          ]
+        }
+      ]
+    },
+    "svg": {
+      "description": "Render and Disply SVG files",
+      "dependencies": [
+        {
+          "name": "copperspice",
+          "features": [
+            "gui"
+          ]
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Vulkan Instance, Vulkan Surface, Vulkan Devices",
+      "dependencies": [
+        {
+          "name": "vulkan"
+        },
+        {
+          "name": "copperspice",
+          "features": [
+            "gui"
+          ]
+        }
+      ]
+    },
+    "webkit": {
+      "description": "Web View, Web Page which can be embedded in your application",
+      "dependencies": [
+        {
+          "name": "copperspice",
+          "features": [
+            "gui",
+            "network",
+            "script"
+          ]
+        }
+      ]
+    },
+    "xmlpatterns": {
+      "description": "Schema Validation, XQuery",
+      "dependencies": [
+        {
+          "name": "copperspice",
+          "features": [
+            "network"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1812,6 +1812,10 @@
       "baseline": "6.4.3",
       "port-version": 3
     },
+    "copperspice": {
+      "baseline": "1.9.1",
+      "port-version": 0
+    },
     "copypp": {
       "baseline": "0.3.0",
       "port-version": 0

--- a/versions/c-/copperspice.json
+++ b/versions/c-/copperspice.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7c92c256069d44e923ee5c9dce0a23f0a34edc1b",
+      "version": "1.9.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #37511

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [ ] ~~Only one version is added to each modified port's versions file.~~
