### PR TITLE
[rocksdb] update to v9.0.0

### DIFF
--- a/ports/rocksdb/0001-fix-dependencies.patch
+++ b/ports/rocksdb/0001-fix-dependencies.patch
@@ -3,10 +3,10 @@
  2 files changed, 23 insertions(+), 21 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 23a4014bc..045f5a36d 100644
+index 5cfc1b480..a18af5817 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -87,7 +87,7 @@ endif()
+@@ -82,7 +82,7 @@ endif()
  
  include(CMakeDependentOption)
  
@@ -15,7 +15,7 @@ index 23a4014bc..045f5a36d 100644
    option(WITH_GFLAGS "build with GFlags" OFF)
    option(WITH_XPRESS "build with windows built in compression" OFF)
    option(ROCKSDB_SKIP_THIRDPARTY "skip thirdparty.inc" OFF)
-@@ -136,10 +136,7 @@ else()
+@@ -131,10 +131,7 @@ else()
    endif()
  
    if(WITH_SNAPPY)
@@ -27,7 +27,7 @@ index 23a4014bc..045f5a36d 100644
      add_definitions(-DSNAPPY)
      list(APPEND THIRDPARTY_LIBS Snappy::snappy)
    endif()
-@@ -163,16 +160,19 @@ else()
+@@ -158,16 +155,19 @@ else()
    endif()
  
    if(WITH_LZ4)
@@ -41,7 +41,7 @@ index 23a4014bc..045f5a36d 100644
 -    find_package(zstd REQUIRED)
 +    find_package(zstd CONFIG REQUIRED)
      add_definitions(-DZSTD)
--    include_directories(${ZSTD_INCLUDE_DIR})
+-    include_directories(${ZSTD_INCLUDE_DIRS})
 -    list(APPEND THIRDPARTY_LIBS zstd::zstd)
 +    if(TARGET zstd::libzstd_shared)
 +      list(APPEND THIRDPARTY_LIBS zstd::libzstd_shared)
@@ -51,7 +51,7 @@ index 23a4014bc..045f5a36d 100644
    endif()
  endif()
  
-@@ -312,11 +312,10 @@ int main() {
+@@ -307,11 +307,10 @@ int main() {
  endif()
  
  if (WITH_LIBURING)
@@ -67,7 +67,7 @@ index 23a4014bc..045f5a36d 100644
  endif()
  
  # Reset the required flags
-@@ -382,9 +381,9 @@ endif()
+@@ -377,9 +376,9 @@ endif()
  
  option(WITH_TBB "build with Threading Building Blocks (TBB)" OFF)
  if(WITH_TBB)
@@ -79,7 +79,7 @@ index 23a4014bc..045f5a36d 100644
  endif()
  
  # Stall notifications eat some performance from inserts
-@@ -1202,8 +1201,6 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
+@@ -1197,8 +1196,6 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
      endforeach()
    endforeach()
  

--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb
   REF "v${VERSION}"
-  SHA512 df701e8f3a94efe351c5dfec691635b6cff9b5902e8d5bd714caa7389bbbfd8ce7f7e91f1549978b47b934449fb3b77581dfcc2811a7727be049709a330ca71e
+  SHA512 b1a37784db800e571b1ed6529bebdb452d6c8e495bd51401f021d1a2e07bae3b3be9ed0e69a8798b6ebce16e4af3e7cf83c73842d2eb4c9fd2d11d9528026ffd
   HEAD_REF main
   PATCHES
     0001-fix-dependencies.patch

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rocksdb",
-  "version": "8.11.3",
+  "version": "9.0.0",
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7693,7 +7693,7 @@
       "port-version": 0
     },
     "rocksdb": {
-      "baseline": "8.11.3",
+      "baseline": "9.0.0",
       "port-version": 0
     },
     "rpclib": {

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4cb8ef91306fda868ede38beecc64af96d804923",
+      "version": "9.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "83270ff433858db27ac486fe2cf6f9c1e96b5576",
       "version": "8.11.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
