### PR TITLE
Add port - libosdp

### DIFF
--- a/ports/libosdp/portfile.cmake
+++ b/ports/libosdp/portfile.cmake
@@ -1,0 +1,43 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO goToMain/libosdp
+    REF "v${VERSION}"
+    SHA512 ebfc2010a89eb1bca9c47c283016750805f38bd5996d478105782bc54add184d0aa7e0f1b8b2f145e6b3af9584c0635522af6191167eeade88a4d878a0552fa0
+    HEAD_REF master
+)
+
+# Download and extract the c-utils submodule at ${SOURCE_PATH}/utils as
+# it would be during a recursive checkout.
+#
+# Note: During package upgrade, the submodule ref needs to be updated.
+vcpkg_from_github(
+    OUT_SOURCE_PATH UTILS_SOURCE_PATH
+    REPO goToMain/c-utils
+    REF "d295048d0362674e2a4b489b689d029b8f1f3d01"
+    SHA512 a0902a504fe6ffd1ce0f32d0a16decf0e113d1211d19e63f4fb539082254769f0a6484414a49f52956e45ed802b2c2f8430e87a06c24ac84205421cdffb4d3f0
+    HEAD_REF master
+)
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/utils")
+file(COPY "${UTILS_SOURCE_PATH}/" DESTINATION "${SOURCE_PATH}/utils")
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
+
+# Main commands
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCONFIG_OSDP_LIB_ONLY=ON
+        -DCONFIG_BUILD_SHARED=${BUILD_SHARED}
+        -DCONFIG_BUILD_STATIC=${BUILD_STATIC}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libosdp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libosdp/usage
+++ b/ports/libosdp/usage
@@ -1,0 +1,9 @@
+libosdp provides CMake targets:
+
+  find_package(LibOSDP CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:libosdp::osdp>,libosdp::osdp,libosdp::osdpstatic>)
+
+libosdp provides pkg-config modules:
+
+  # Open Supervised Device Protocol (OSDP) Library
+  libosdp

--- a/ports/libosdp/vcpkg.json
+++ b/ports/libosdp/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "libosdp",
+  "version": "3.0.5",
+  "description": "An cross-platform open source implementation of IEC 60839-11-5 Open Supervised Device Protocol (OSDP)",
+  "homepage": "https://github.com/goToMain/libosdp",
+  "documentation": "https://libosdp.sidcha.dev",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4740,6 +4740,10 @@
       "baseline": "3.0.2",
       "port-version": 1
     },
+    "libosdp": {
+      "baseline": "3.0.5",
+      "port-version": 0
+    },
     "libosip2": {
       "baseline": "5.3.1",
       "port-version": 0

--- a/versions/l-/libosdp.json
+++ b/versions/l-/libosdp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fbbc5d6f19e023ef42737fc939fcb9bd186ecc4c",
+      "version": "3.0.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This patch adds a port for libosdp - a cross-platform open source implementation of IEC 60839-11-5 Open Supervised Device Protocol (OSDP). The protocol is intended to improve interoperability among access control and security products. It supports Secure Channel (SC) for encrypted and authenticated communication between configured devices.

Upstream: https://github.com/goToMain/libosdp

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.