### PR TITLE
[vtk] FindPEGTL fix

### DIFF
--- a/ports/vtk/pegtl.patch
+++ b/ports/vtk/pegtl.patch
@@ -58,7 +58,7 @@ diff --git a/CMake/FindPEGTL.cmake b/CMake/FindPEGTL.cmake
 index 73eee02f7..22d8bc159 100644
 --- a/CMake/FindPEGTL.cmake	
 +++ b/CMake/FindPEGTL.cmake
-@@ -19,31 +19,43 @@
+@@ -19,31 +19,46 @@
  # Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
  # Redistribution and use is allowed according to the terms of the 2-clause BSD license.
  
@@ -71,7 +71,10 @@ index 73eee02f7..22d8bc159 100644
 +find_package(PEGTL CONFIG REQUIRED)
 +if(TARGET taocpp::pegtl)
 +    message(STATUS "Searching for PEGTL - found target taocpp::pegtl")
-+    set_target_properties(taocpp::pegtl PROPERTIES IMPORTED_GLOBAL TRUE)
++    get_target_property(TARGET_IMPORTED_GLOBAL taocpp::pegtl IMPORTED_GLOBAL)
++    if(NOT TARGET_IMPORTED_GLOBAL)
++      set_target_properties(taocpp::pegtl PROPERTIES IMPORTED_GLOBAL TRUE)
++    endif()
 +    if(NOT TARGET PEGTL::PEGTL)
 +       add_library(PEGTL::PEGTL IMPORTED INTERFACE)
 +       target_link_libraries(PEGTL::PEGTL INTERFACE taocpp::pegtl)

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.2.0-pv5.11.0",
-  "port-version": 10,
+  "port-version": 11,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9126,7 +9126,7 @@
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",
-      "port-version": 10
+      "port-version": 11
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e887b758153039453976be1e5d0bc54d537b0417",
+      "version-semver": "9.2.0-pv5.11.0",
+      "port-version": 11
+    },
+    {
       "git-tree": "6365f197946995803914141a82c1830d165427b3",
       "version-semver": "9.2.0-pv5.11.0",
       "port-version": 10


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #35223

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
