### PR TITLE
[aws-c-cal] update to 0.6.10

### DIFF
--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-cal
     REF "v${VERSION}"
-    SHA512 deee106b366522e6781974c92b1aa06542b7857b91a8d4cb59eb0e17247ce7fc3ffacb044c032ff7f2a0f9baca807d4c2d9a14934d4576966f48bfc0661e5edb
+    SHA512 b3a00aa7cd322e16216744f622b7e36028da4a7a085e7bd967d5946ca4026f8d88c1d3891e970e2d8ae96939cb2c1b4ae30f8ca8117187877309979810863f36
     HEAD_REF master
     PATCHES remove-libcrypto-messages.patch
 )

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-cal",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "C99 wrapper for cryptography primitives.",
   "homepage": "https://github.com/awslabs/aws-c-cal",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-cal.json
+++ b/versions/a-/aws-c-cal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd087ffda02ff69b1ce404a3e6247220c1c4c62f",
+      "version": "0.6.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "43c961d933d7a928c15cdfb7c5f7a6c16875bed5",
       "version": "0.6.9",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -369,7 +369,7 @@
       "port-version": 0
     },
     "aws-c-cal": {
-      "baseline": "0.6.9",
+      "baseline": "0.6.10",
       "port-version": 0
     },
     "aws-c-common": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

