### PR TITLE
[aws-c-sdkutils] update to 0.1.15

### DIFF
--- a/ports/aws-c-sdkutils/portfile.cmake
+++ b/ports/aws-c-sdkutils/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-sdkutils
     REF "v${VERSION}"
-    SHA512 e364613363c6dd50a97209bd4fa7b926fec2ca5eb4bac07fb0c44eecbf847d2d1a671ffa7edda613bbbab4eaf27973945be61d66b32b851ae31c8f3508e7137a
+    SHA512 ea2a018393f93a453f45a369915ce8155f88d4014e3eb622063813060ca72e941356cac3dfa4a83617ab36876521f58ce73beaffea352fbeb0745247271bf5ae
     HEAD_REF master
 )
 

--- a/ports/aws-c-sdkutils/vcpkg.json
+++ b/ports/aws-c-sdkutils/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-sdkutils",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "C99 library implementing AWS SDK specific utilities. Includes utilities for ARN parsing, reading AWS profiles, etc...",
   "homepage": "https://github.com/awslabs/aws-c-sdkutils",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-sdkutils.json
+++ b/versions/a-/aws-c-sdkutils.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "059bddb8a37a8cabda35680b9c212e9a0bdb1134",
+      "version": "0.1.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "40dbafcbc75133f129ea11d38162703f40dadd86",
       "version": "0.1.14",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -401,7 +401,7 @@
       "port-version": 0
     },
     "aws-c-sdkutils": {
-      "baseline": "0.1.14",
+      "baseline": "0.1.15",
       "port-version": 0
     },
     "aws-checksums": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

