### PR TITLE
[aws-crt-cpp] update to 0.26.4

### DIFF
--- a/ports/aws-crt-cpp/portfile.cmake
+++ b/ports/aws-crt-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-crt-cpp
     REF "v${VERSION}"
-    SHA512 f48c955fb1e9feef2a963572ed1bdc49e52f5ea6b3150d2f49f1c6d94e58ecd016ff020bf8ee272e5c192f0e214dbf8e47aad5f4fa722d4d207c170b029b3c80
+    SHA512 357fd22056b24e939d300a2e5f3eb61e6f2683cc1ec187a3a198b25b5908f07c07af38c3e862befb17254a0029f4994e4af43c070620a6a03e7d112c6eabcd25
     PATCHES
         no-werror.patch
 )

--- a/ports/aws-crt-cpp/vcpkg.json
+++ b/ports/aws-crt-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-crt-cpp",
-  "version": "0.26.1",
+  "version": "0.26.4",
   "description": "C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Protocols and SSL/TLS implementations for C++.",
   "homepage": "https://github.com/awslabs/aws-crt-cpp",
   "license": "Apache-2.0",

--- a/versions/a-/aws-crt-cpp.json
+++ b/versions/a-/aws-crt-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e12f07da72d8c435c8a68fae965c42cff40661ad",
+      "version": "0.26.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "110c01a23de8f129c041243ea29a8d9483665ec8",
       "version": "0.26.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -409,7 +409,7 @@
       "port-version": 0
     },
     "aws-crt-cpp": {
-      "baseline": "0.26.1",
+      "baseline": "0.26.4",
       "port-version": 0
     },
     "aws-lambda-cpp": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

