### PR TITLE
Fix vcpkg_extract_archive to support 7z/exe extracting

### DIFF
--- a/scripts/cmake/vcpkg_extract_archive.cmake
+++ b/scripts/cmake/vcpkg_extract_archive.cmake
@@ -33,7 +33,7 @@ function(vcpkg_extract_archive)
                 /qn "TARGETDIR=${destination_native_path}"
             WORKING_DIRECTORY "${archive_directory}"
         )
-    elseif("${archive_extension}" MATCHES [[\.7z\.exe$]])
+    elseif("${archive_extension}" MATCHES [[\.7z|\.exe$]])
         vcpkg_find_acquire_program(7Z)
         vcpkg_execute_in_download_mode(
             COMMAND ${7Z} x


### PR DESCRIPTION
Fixes #34881

While attempting to unpack a downloaded 7z/exe archive using `vcpkg_extract_source_archive`, I encountered a malfunction, prompting an investigation into alternative methods. My exploration led me to utilize `vcpkg_extract_archive`, where I discovered an issue in the extension handling logic.

The existing implementation intended to support unpacking files with either a `.7z` or `.exe` extension but failed due to an incorrect regex pattern. Specifically, the pattern `[[\.7z\.exe$]]` does not correctly separate the two intended extensions, resulting in unsuccessful archive extraction operations.

To validate my findings, I constructed a sandbox environment within a `portfile.cmake` script, enabling me to simulate the extraction process and pinpoint the precise issue. Upon correcting the regex pattern to `[[\.7z|\.exe$]]`, `vcpkg_extract_archive` successfully unpacked archives with both `.7z` and `.exe` extensions.

```cmake
set(PORT_DEBUG ON)

vcpkg_download_sourceforge(
    7ZIPBIN_ARCHIVE
    REPO sevenzip/7-Zip
    REF 16.04
    FILENAME "7z1604.exe"
    SHA512 939869d9a60571c2f380ffe29ec40e7930d47e8295a2995e9ec56143319584b809fddd39a6e9df6e4b7c5e29b4925f588ca483e3c6f6758c5db54e13e2a3388c
)

cmake_path(APPEND CURRENT_BUILDTREES_DIR "src" OUTPUT_VARIABLE working_directory)
cmake_path(GET 7ZIPBIN_ARCHIVE STEM SOURCE_BASE)
file(SHA512 "${7ZIPBIN_ARCHIVE}" patchset_hash)
string(SHA512 patchset_hash "${patchset_hash}")
string(SUBSTRING "${patchset_hash}" 0 10 patchset_hash)
cmake_path(APPEND working_directory "${SOURCE_BASE}-${patchset_hash}" OUTPUT_VARIABLE source_path)
cmake_path(APPEND_STRING source_path ".clean")
file(REMOVE_RECURSE "${source_path}")
cmake_path(APPEND_STRING source_path ".tmp" OUTPUT_VARIABLE temp_dir)
file(REMOVE_RECURSE "${temp_dir}")
vcpkg_extract_archive(
    ARCHIVE "${7ZIPBIN_ARCHIVE}"
    DESTINATION "${temp_dir}"
)
cmake_path(SET temp_source_path "${temp_dir}")

file(RENAME "${temp_source_path}" "${source_path}")
file(REMOVE_RECURSE "${temp_dir}")
```