### PR TITLE
[cs-signal] Add new port

### DIFF
--- a/ports/cs-signal/portfile.cmake
+++ b/ports/cs-signal/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO copperspice/cs_signal
+    REF "signal-${VERSION}"
+    SHA512 75b1f6852f8e75067d91fe33092758dd6c9dad13bde699e5b053e64822add454c6a1a0d1d149e67c0bd5a1f7fb95482ead1c988ec1e1336bf05c57f791fab419
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME cssignal
+    CONFIG_PATH cmake/CsSignal
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cs-signal/usage
+++ b/ports/cs-signal/usage
@@ -1,0 +1,4 @@
+CsSignal provides CMake targets:
+
+    find_package(CsSignal CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CsSignal::CsSignal)

--- a/ports/cs-signal/vcpkg.json
+++ b/ports/cs-signal/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "cs-signal",
+  "version": "1.3.1",
+  "description": "Thread aware Signal/Slot library",
+  "homepage": "https://github.com/copperspice/cs_signal",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "cs-libguarded"
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2008,6 +2008,10 @@
       "baseline": "67",
       "port-version": 3
     },
+    "cs-signal": {
+      "baseline": "1.3.1",
+      "port-version": 0
+    },
     "ctbench": {
       "baseline": "1.3.3",
       "port-version": 0

--- a/versions/c-/cs-signal.json
+++ b/versions/c-/cs-signal.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "56bbab6a7e6983357de92dfa6d8fab1f0a3daa0f",
+      "version": "1.3.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #37511.

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.