### PR TITLE
[dxsdk-d3dx] port update to support static crt scenarios

### DIFF
--- a/ports/dxsdk-d3dx/dxsdk-d3dx-config.cmake.in
+++ b/ports/dxsdk-d3dx/dxsdk-d3dx-config.cmake.in
@@ -1,6 +1,5 @@
 
-get_filename_component(_d3dx_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(_d3dx_root "${_d3dx_root}" PATH)
+get_filename_component(_d3dx_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
 get_filename_component(_d3dx_root "${_d3dx_root}" PATH)
 
 set(_d3dx_root_lib "${_d3dx_root}/lib/d3dx9.lib")

--- a/ports/dxsdk-d3dx/portfile.cmake
+++ b/ports/dxsdk-d3dx/portfile.cmake
@@ -4,8 +4,7 @@ endif()
 
 message(WARNING "Use of ${PORT} is not recommended for new projects. See https://aka.ms/dxsdk for more information.")
 
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
+set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 set(VCPKG_POLICY_ALLOW_OBSOLETE_MSVCRT enabled)
 
 vcpkg_download_distfile(ARCHIVE
@@ -26,15 +25,18 @@ file(INSTALL ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT
 file(GLOB RELEASE_LIB_FILES "${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/*.lib")
 file(INSTALL ${RELEASE_LIB_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/lib/")
 
-file(GLOB DEBUG_LIB_FILES "${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/*.lib")
-file(INSTALL ${DEBUG_LIB_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/")
-
 file(GLOB RELEASE_DLL_FILES "${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/*.dll")
 file(INSTALL ${RELEASE_DLL_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/bin/")
 
-file(GLOB DEBUG_DLL_FILES "${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/*.dll")
-file(INSTALL ${DEBUG_DLL_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/")
+if(NOT DEFINED VCPKG_BUILD_TYPE)
+    file(GLOB DEBUG_LIB_FILES "${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/*.lib")
+    file(INSTALL ${DEBUG_LIB_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/")
 
-file(INSTALL "${PACKAGE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+    file(GLOB DEBUG_DLL_FILES "${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/*.dll")
+    file(INSTALL ${DEBUG_DLL_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/")
+endif()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/LICENSE.txt")
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/dxsdk-d3dx-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" COPYONLY)

--- a/ports/dxsdk-d3dx/usage
+++ b/ports/dxsdk-d3dx/usage
@@ -1,6 +1,6 @@
 The legacy DirectX SDK D3DX package provides CMake targets:
 
-    find_package(dxdsdk-d3dx CONFIG REQUIRED)
+    find_package(dxsdk-d3dx CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::D3DX9 Microsoft::D3DX10 Microsoft::D3DX11)
 
 NOTE: This port is not recommended for use in new projects and is incompatible with the deprecated directxsdk port.

--- a/ports/dxsdk-d3dx/usage
+++ b/ports/dxsdk-d3dx/usage
@@ -1,0 +1,6 @@
+The legacy DirectX SDK D3DX package provides CMake targets:
+
+    find_package(dxdsdk-d3dx CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Microsoft::D3DX9 Microsoft::D3DX10 Microsoft::D3DX11)
+
+NOTE: This port is not recommended for use in new projects and is incompatible with the deprecated directxsdk port.

--- a/ports/dxsdk-d3dx/vcpkg.json
+++ b/ports/dxsdk-d3dx/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "dxsdk-d3dx",
   "version": "9.29.952.8",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Redistributable package for the legacy DirectX SDK's D3DX9, D3DX10, and/or D3DX11 utility libraries.",
   "homepage": "https://walbourn.github.io/legacy-d3dx-on-nuget/",
   "license": null,
-  "supports": "windows & !arm & !uwp & !xbox & !staticcrt"
+  "supports": "windows & !arm & !uwp & !xbox"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2366,7 +2366,7 @@
     },
     "dxsdk-d3dx": {
       "baseline": "9.29.952.8",
-      "port-version": 6
+      "port-version": 7
     },
     "dxut": {
       "baseline": "11.31",

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d93355946ca37b53e6dc1162e967e42da0b10cc6",
+      "git-tree": "e71fae4b2d12e35a21d5963aa8c59c8ebf5d6586",
       "version": "9.29.952.8",
       "port-version": 7
     },

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d93355946ca37b53e6dc1162e967e42da0b10cc6",
+      "version": "9.29.952.8",
+      "port-version": 7
+    },
+    {
       "git-tree": "bca406e04cfde4f63d430a5f2f10273701747f31",
       "version": "9.29.952.8",
       "port-version": 6


### PR DESCRIPTION
* The legacy D3DX DLLs don't use the retail CRT, so they can support 'staticcrt' scenarios
* Updated port to respect the `VCPKG_BUILD_TYPE` == `release' settings
* Minor code review and best practice update