### PR TITLE
Update osgEarth port to 3.5

### DIFF
--- a/ports/osgearth/debug_bigobj.patch
+++ b/ports/osgearth/debug_bigobj.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeModules/oe_win32.cmake b/CMakeModules/oe_win32.cmake
+index 1ca36cb7a..134a7ced2 100644
+--- a/CMakeModules/oe_win32.cmake
++++ b/CMakeModules/oe_win32.cmake
+@@ -3,6 +3,7 @@
+ if(WIN32 AND NOT ANDROID)
+     if(MSVC)
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
++        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj")		
+         add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+         add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+     endif(MSVC)    

--- a/ports/osgearth/find-package.patch
+++ b/ports/osgearth/find-package.patch
@@ -1,23 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cf8245b8b..233390a5f 100755
+index 1e65fe25d..64990acab 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -127,9 +127,9 @@ mark_as_advanced(OSGEARTH_ASSUME_SINGLE_GL_CONTEXT)
- 
- # Mobile/GLES:
- IF (OSGEARTH_USE_GLES)
--    find_package(OpenGLES)
-+    find_package(OpenGLES REQUIRED)
- ELSE ()
--    find_package(OpenGL)
-+    find_package(OpenGL REQUIRED)
- ENDIF (OSGEARTH_USE_GLES)
- 
- 
-@@ -147,35 +147,54 @@ if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
- endif()
+@@ -120,50 +120,70 @@ endif()
  
  # required
+ find_package(OpenGL REQUIRED)
 -find_package(OSG REQUIRED)
 +find_package(OSG NAMES unofficial-osg)
 +find_path(OSG_INCLUDE_DIR osg/Version) # For detecting the version and setting the plugin path
@@ -45,6 +33,7 @@ index cf8245b8b..233390a5f 100755
 -find_package(WEBP)
 -find_package(Blend2D)
 -find_package(Blosc)
+-find_package(spdlog)
 +find_package(GEOS CONFIG REQUIRED)
 +set(GEOS_LIBRARY GEOS::geos_c)
 +find_package(SQLITE3 NAMES unofficial-sqlite3 REQUIRED)
@@ -60,6 +49,21 @@ index cf8245b8b..233390a5f 100755
 +    set(BLEND2D_LIBRARY blend2d::blend2d)
 +endif()
 +find_package(BLOSC REQUIRED)
++find_package(spdlog REQUIRED)
+ 
+ if(OSGEARTH_BUILD_CESIUM_NODEKIT)
+     find_package(CesiumNative)
+ endif()
+ 
+ if(OSGEARTH_BUILD_TRITON_NODEKIT)
+-    find_package(Triton)
++    find_package(Triton REQUIRED)
+ endif()
+ 
+ if(OSGEARTH_BUILD_SILVERLINING_NODEKIT)
+-    find_package(SilverLining)
++    find_package(SilverLining REQUIRED)
+ endif()
  
  if(OSGEARTH_ENABLE_PROFILING)
 -    find_package(Tracy)
@@ -72,41 +76,25 @@ index cf8245b8b..233390a5f 100755
 +    set(LIBZIP_LIBRARY libzip::zip)
  endif()
  
- if(OSGEARTH_BUILD_TRITON_NODEKIT)
--    find_package(Triton QUIET)
-+    find_package(Triton QUIET REQUIRED)
- endif()
- 
- if(OSGEARTH_BUILD_SILVERLINING_NODEKIT)
--    find_package(SilverLining QUIET)
-+    find_package(SilverLining QUIET REQUIRED)
- endif()
- 
- # Sqlite enables the MBTiles format:
-@@ -221,7 +240,7 @@ SET (PROTOBUF_USE_DLLS FALSE CACHE BOOL "Set this to true if Protobuf is compile
- # Duktape is the JavaScript interpreter
- SET (WITH_EXTERNAL_DUKTAPE FALSE CACHE BOOL "Use bundled or system wide version of Duktape")
- IF (WITH_EXTERNAL_DUKTAPE)
+ set(WITH_EXTERNAL_DUKTAPE FALSE CACHE BOOL "Use external Duktape instead of inlining it")
+ if(WITH_EXTERNAL_DUKTAPE)
 -    find_package(Duktape)
 +    find_package(Duktape REQUIRED)
- ENDIF (WITH_EXTERNAL_DUKTAPE)
+ endif(WITH_EXTERNAL_DUKTAPE)
  
- # Whether to install shaders (glsl files).
-@@ -232,7 +251,8 @@ OPTION(OSGEARTH_INSTALL_SHADERS "Whether to deploy GLSL shaders when doing a Mak
- # TinyXML is an XML parsing library
- SET (WITH_EXTERNAL_TINYXML FALSE CACHE BOOL "Use bundled or system wide version of TinyXML")
- IF (WITH_EXTERNAL_TINYXML)
+ set(WITH_EXTERNAL_TINYXML FALSE CACHE BOOL "Use external TinyXML instead of inlining it")
+ if(WITH_EXTERNAL_TINYXML)
 -    find_package(TinyXML)
 +    find_package(TINYXML NAMES tinyxml REQUIRED)
 +    set(TINYXML_LIBRARY unofficial-tinyxml::unofficial-tinyxml)
- ENDIF (WITH_EXTERNAL_TINYXML)
+ endif(WITH_EXTERNAL_TINYXML)
  
- # postfix settings for various configs
-@@ -307,6 +327,7 @@ IF(OSGEARTH_BUILD_SHARED_LIBS)
-     SET(OSGEARTH_DYNAMIC_OR_STATIC "SHARED")
- ELSE()
-     SET(OSGEARTH_DYNAMIC_OR_STATIC "STATIC")
-+    add_definitions(-DOSGEARTH_LIBRARY_STATIC)
- ENDIF()
  
- 	
+@@ -268,6 +288,7 @@ if(OSGEARTH_BUILD_SHARED_LIBS)
+     set(OSGEARTH_DYNAMIC_OR_STATIC "SHARED")
+ else()
+     set(OSGEARTH_DYNAMIC_OR_STATIC "STATIC")
++    add_definitions(-DOSGEARTH_LIBRARY_STATIC)	
+ endif()
+ 
+ 

--- a/ports/osgearth/link-libraries.patch
+++ b/ports/osgearth/link-libraries.patch
@@ -1,16 +1,16 @@
 diff --git a/CMakeModules/OsgEarthMacroUtils.cmake b/CMakeModules/OsgEarthMacroUtils.cmake
-index 7dd0998..730af85 100644
+index 1c589252c..0369097dd 100644
 --- a/CMakeModules/OsgEarthMacroUtils.cmake
 +++ b/CMakeModules/OsgEarthMacroUtils.cmake
-@@ -92,6 +92,11 @@ ENDMACRO(DETECT_OSG_VERSION)
+@@ -91,6 +91,11 @@ ENDMACRO(DETECT_OSG_VERSION)
+ #######################################################################################################
  
  MACRO(LINK_WITH_VARIABLES TRGTNAME)
++	string(REPLACE "_LIBRARY" "_LIBRARIES" lwv_libraries "${varname}")
++	if(DEFINED ${lwv_libraries})
++		TARGET_LINK_LIBRARIES(${TRGTNAME} ${${lwv_libraries}})
++		continue()
++	endif()
      FOREACH(varname ${ARGN})
-+        string(REPLACE "_LIBRARY" "_LIBRARIES" lwv_libraries "${varname}")
-+        if(DEFINED ${lwv_libraries})
-+            TARGET_LINK_LIBRARIES(${TRGTNAME} ${${lwv_libraries}})
-+            continue()
-+        endif()
          IF(${varname}_DEBUG)
              IF(${varname}_RELEASE)
-                 TARGET_LINK_LIBRARIES(${TRGTNAME} optimized "${${varname}_RELEASE}" debug "${${varname}_DEBUG}")

--- a/ports/osgearth/portfile.cmake
+++ b/ports/osgearth/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gwaldron/osgearth
     REF "osgearth-${VERSION}"
-    SHA512 f65c31922bebcbf722474a047dc29c8c1ceec9c037b0704811af2627fc2d0a124b6e95888e7d3b9b0e5acc146a88ebf8669e3f864a75a91751c3a4571d05a630
+    SHA512 6b884aee638e5266825e5f2898a39db61f99a30ebc82eb4415de1a589441b3805152d1963473040855e9fbe4d2642f504e9f365c787e48dc1604f55d939b707e
     HEAD_REF master
     PATCHES
         link-libraries.patch
@@ -10,6 +10,7 @@ vcpkg_from_github(
         remove-tool-debug-suffix.patch
 		remove-lerc-gltf.patch
 		export-plugins.patch
+		debug_bigobj.patch
 )
 
 if("tools" IN_LIST FEATURES)

--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "osgearth",
-  "version": "3.4",
+  "version": "3.5",
   "port-version": 1,
   "description": "osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2021 Pelican Mapping.",
   "homepage": "https://github.com/gwaldron/osgearth",
@@ -25,6 +25,7 @@
     },
     "protobuf",
     "pthreads",
+    "spdlog",
     "sqlite3",
     "tinyxml",
     {

--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "osgearth",
   "version": "3.5",
-  "port-version": 1,
   "description": "osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2021 Pelican Mapping.",
   "homepage": "https://github.com/gwaldron/osgearth",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6561,7 +6561,7 @@
       "port-version": 3
     },
     "osgearth": {
-      "baseline": "3.4",
+      "baseline": "3.5",
       "port-version": 1
     },
     "osmanip": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6562,7 +6562,7 @@
     },
     "osgearth": {
       "baseline": "3.5",
-      "port-version": 1
+      "port-version": 0
     },
     "osmanip": {
       "baseline": "4.6.1",

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59600c7811c1784eac8b8602cd15d10d2815ac17",
+      "version": "3.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "4c7eac5ebac0fb2f82b730a863d50278a83955a9",
       "version": "3.4",
       "port-version": 1

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "59600c7811c1784eac8b8602cd15d10d2815ac17",
+      "git-tree": "eccf094477a189a7069a047453f06fddd81dabfc",
       "version": "3.5",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "4c7eac5ebac0fb2f82b730a863d50278a83955a9",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

 If this PR updates an existing port, please uncomment and fill out this checklist:

- [x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x] SHA512s are updated for each updated download.
- [ x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ x] Any patches that are no longer applied are deleted from the port's directory.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
