### PR TITLE
[cli11] Update to 2.4.1

### DIFF
--- a/ports/cli11/portfile.cmake
+++ b/ports/cli11/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CLIUtils/CLI11
-    REF v2.4.0
-    SHA512 21c6e7861c5b5481079f78fd1585c77c7c73dd8f06a58a673922ee12fa0ffd2ba6c485de427a4e4ee3e5d710b8dc9483e70da0dc2a67c46d3fd77ebdfe300f79
+    REF "v${VERSION}"
+    SHA512 965290d09977672d3bc3c57ca4b89a88c2c09461da6e866b18217d702d4d5a0977588fcb8fef1a3c3804e61ad80d276029f47469cc83dbfdc7021ee35f6b7269
     HEAD_REF main
 )
 
@@ -21,5 +21,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/CLI11)
 vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cli11/vcpkg.json
+++ b/ports/cli11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cli11",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "CLI11 is a command line parser for C++11 and beyond that provides a rich feature set with a simple and intuitive interface.",
   "homepage": "https://github.com/CLIUtils/CLI11",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1653,7 +1653,7 @@
       "port-version": 0
     },
     "cli11": {
-      "baseline": "2.4.0",
+      "baseline": "2.4.1",
       "port-version": 0
     },
     "clickhouse-cpp": {

--- a/versions/c-/cli11.json
+++ b/versions/c-/cli11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05a104e144c6cfa16b0a896502ef96f3ccbbdddc",
+      "version": "2.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "396b497f39aff89e8cbfec62a6e2ed8bd5df73a0",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
Fix #37571.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
Port usage tests pass with following triplets:
* x64-windows