### PR TITLE
[qt5-webengine] Depend on atl instead of atlmfc

### DIFF
--- a/ports/qt5-webengine/vcpkg.json
+++ b/ports/qt5-webengine/vcpkg.json
@@ -1,13 +1,13 @@
 {
   "name": "qt5-webengine",
   "version": "5.15.13",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt WebEngine provides functionality for rendering regions of dynamic web content.",
   "license": null,
   "supports": "!static",
   "dependencies": [
     {
-      "name": "atlmfc",
+      "name": "atl",
       "platform": "windows"
     },
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7218,7 +7218,7 @@
     },
     "qt5-webengine": {
       "baseline": "5.15.13",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-webglplugin": {
       "baseline": "5.15.13",

--- a/versions/q-/qt5-webengine.json
+++ b/versions/q-/qt5-webengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "91b4cbf2c91549380aa26377330c142a6e408414",
+      "version": "5.15.13",
+      "port-version": 2
+    },
+    {
       "git-tree": "0214bdc43ab8f108c976e57f4ae394032671d123",
       "version": "5.15.13",
       "port-version": 1


### PR DESCRIPTION
qt5-webengine only requires atl, it does not use mfc. Switching to just atl means installations of Visual Studio and Visual Studio Build Tools do not need to explicitly include
Microsoft.VisualStudio.Component.VC.ATLMFC.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
