### PR TITLE
[ableton-link] update to 3.1.1

### DIFF
--- a/ports/ableton-link/portfile.cmake
+++ b/ports/ableton-link/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Ableton/link
     REF "Link-${VERSION}"
-    SHA512 4c62357b74ed8bed21455d977504787ff4c11a862a0ee583c491742c93f6f4bc44b98df2a35f7811584277456b7580835098bc7b9afdd57caf7bd91f9462d202
+    SHA512 d82529d08897833c3fd6f19eca1689dfbfeac945daa4f1cb5a5719248ba1428875084155761d4de9521d486552e82ea47c71009fa8ef868ed4dca86a561f5c3e
     HEAD_REF master
     PATCHES
         replace_local_asiostandalone_by_vcpkg_asio.patch

--- a/ports/ableton-link/vcpkg.json
+++ b/ports/ableton-link/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ableton-link",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Ableton Link, a technology that synchronizes musical beat, tempo, and phase across multiple applications running on one or more devices.",
   "homepage": "https://www.ableton.com/en/link/",
   "documentation": "http://ableton.github.io/link/",

--- a/versions/a-/ableton-link.json
+++ b/versions/a-/ableton-link.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e486a5e643aafc9810b1e4c2d9c3da1d3e2d156",
+      "version": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4827f8ad0a42e763cffae490000a08bbd52d7cdf",
       "version": "3.1.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -13,7 +13,7 @@
       "port-version": 2
     },
     "ableton-link": {
-      "baseline": "3.1.0",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "abseil": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

