### PR TITLE
[libxt] update to 1.3.0

### DIFF
--- a/ports/libxt/portfile.cmake
+++ b/ports/libxt/portfile.cmake
@@ -17,8 +17,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libxt
-    REF edd70bdfbbd16247e3d9564ca51d864f82626eb7 # 1.2.1
-    SHA512  c49876253dfd187e7d56a098d3d992157daefa2c25ee732eaae5818ee04513bedd807d2f265085db2e82c0b1821e152a88fb4998c0002f6ac57204543fe18566
+    REF "libXt-${VERSION}"
+    SHA512 7cb22be9706bd7d089e84c09a99597f730ca858a9f8134d2741916b28cd4786e236beaad568c8b7ab8cdcfdea1c49140cefac528244bab8c94d48dc4729267e8
     HEAD_REF master
     PATCHES
         windows_build.patch

--- a/ports/libxt/vcpkg.json
+++ b/ports/libxt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxt",
-  "version": "1.2.1",
-  "port-version": 1,
+  "version": "1.3.0",
   "description": "X Toolkit Intrinsics library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxt",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5265,8 +5265,8 @@
       "port-version": 3
     },
     "libxt": {
-      "baseline": "1.2.1",
-      "port-version": 1
+      "baseline": "1.3.0",
+      "port-version": 0
     },
     "libxtst": {
       "baseline": "1.2.4",

--- a/versions/l-/libxt.json
+++ b/versions/l-/libxt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0bb02545da1d28c209ba8d237070b61239f3a6cb",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f31aa9aa9e1f86b0f2ca59be16b76ceb156696e1",
       "version": "1.2.1",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

