### PR TITLE
[octomap] update to 1.10.0

### DIFF
--- a/ports/octomap/portfile.cmake
+++ b/ports/octomap/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OctoMap/octomap
     REF "v${VERSION}"
-    SHA512 60afeecc36a190f136dcbe33cb9cd6c06c16233988b383b0b010f65f81e6a3630b55902c5b5ad756ac35dee4c4ec26ec5722d6bd9b8e079f70b7d286293c518e
+    SHA512 1cbee4f6b3569587986774447ad9ec4190f597310c4d6865ffa7cd8865ece2492e4a42fa369b633d9d7a9da782560d49deaa62a18601ea4f56396bdf1a6a5f52
     HEAD_REF master
     PATCHES
       001-fix-exported-targets.patch

--- a/ports/octomap/vcpkg.json
+++ b/ports/octomap/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "octomap",
-  "version": "1.9.8",
-  "port-version": 1,
+  "version": "1.10.0",
   "description": "An Efficient Probabilistic 3D Mapping Framework Based on Octrees",
   "homepage": "https://octomap.github.io/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6281,8 +6281,8 @@
       "port-version": 0
     },
     "octomap": {
-      "baseline": "1.9.8",
-      "port-version": 1
+      "baseline": "1.10.0",
+      "port-version": 0
     },
     "ode": {
       "baseline": "0.16.4",

--- a/versions/o-/octomap.json
+++ b/versions/o-/octomap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0106d3137deb499ea7624cb13d98770cf849382e",
+      "version": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "18c703e99a9e7da9184b9ebcee3ddfa80d66502e",
       "version": "1.9.8",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

