### PR TITLE
[opencc] update to 1.1.7

### DIFF
--- a/ports/opencc/portfile.cmake
+++ b/ports/opencc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BYVoid/OpenCC
     REF "ver.${VERSION}"
-    SHA512 bfc40bdf1348e6a265b3304ab1e8acee2f4b6ac9c377ff3d8c996435a92dee98c3758503186b4fd424653faf44db339f8a90300e3290c59942ccf04b1bbb2a30
+    SHA512 26e4b12238f853b0fa91f9f0d9af7985bf04a0763185cc3b50b69ba99a2d80091b8c3160176d0d4cd348fbf1a680bfd80dc740dc60c938a256dc2dac8ef49f15
     HEAD_REF master
     PATCHES 
         fix-dependencies.patch

--- a/ports/opencc/vcpkg.json
+++ b/ports/opencc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "opencc",
-  "version": "1.1.6",
-  "port-version": 1,
+  "version": "1.1.7",
   "description": "A project for conversions between Traditional Chinese, Simplified Chinese and Japanese Kanji (Shinjitai)",
   "homepage": "https://github.com/BYVoid/OpenCC",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6369,8 +6369,8 @@
       "port-version": 0
     },
     "opencc": {
-      "baseline": "1.1.6",
-      "port-version": 1
+      "baseline": "1.1.7",
+      "port-version": 0
     },
     "opencensus-cpp": {
       "baseline": "2021-08-26",

--- a/versions/o-/opencc.json
+++ b/versions/o-/opencc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5740be326a2e1ae0837c751e8b15e2ce33bd36c8",
+      "version": "1.1.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "85a9b30209f5cd7460d2be2c8e1cc206fab66aaa",
       "version": "1.1.6",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

