### PR TITLE
[openmvs] update to 2.2.0

### DIFF
--- a/ports/openmvs/portfile.cmake
+++ b/ports/openmvs/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cdcseacave/openMVS
-    REF v2.1.0
-    SHA512 95d83c6694b63b6fd27657c4c5e22ddbc078d26b7324b8f17952a6c7e4547028698aa155077c0cfb916d3497ca31c365e0cbcd81f3cbe959ef40a7ee2e5cd300
+    REF "v${VERSION}"
+    SHA512 5e6ba09a1a32f914c24ce5e51f769e24ecedc1eaee2cc74ed75fe618fd1d4514e872b09e82b6715549796f052c568442e7e5893d25b65a0bfeb93551aac91606
     HEAD_REF master
     PATCHES
         fix-build.patch

--- a/ports/openmvs/vcpkg.json
+++ b/ports/openmvs/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openmvs",
-  "version": "2.1.0",
-  "port-version": 2,
+  "version": "2.2.0",
   "description": "OpenMVS: open Multi-View Stereo reconstruction library",
   "homepage": "https://cdcseacave.github.io/openMVS",
   "license": "AGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6465,8 +6465,8 @@
       "port-version": 9
     },
     "openmvs": {
-      "baseline": "2.1.0",
-      "port-version": 2
+      "baseline": "2.2.0",
+      "port-version": 0
     },
     "openni2": {
       "baseline": "2.2.0.33",

--- a/versions/o-/openmvs.json
+++ b/versions/o-/openmvs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5998c1a3a5fefc265b6fb2673ac1202274bbc6a4",
+      "version": "2.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8779bcf1acd942b029c79791b2335b252e151f20",
       "version": "2.1.0",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

