### PR TITLE
[parallel-hashmap] update to 1.3.12

### DIFF
--- a/ports/parallel-hashmap/portfile.cmake
+++ b/ports/parallel-hashmap/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO greg7mdp/parallel-hashmap
     REF "v${VERSION}"
-    SHA512 2b9445ecf71d3b5705304e970dea1db314c80b4ee112436939bffeaac43db6199ed566bec0e68f95a4dfab415cfe6aaecd7083ef9d7b8f6b6c612e4f24612f43
+    SHA512 cf7892194b518cc207558bc024469bb3c345e427b71f4ecaaa7ec5ba30cd23005d005d80295edc7bf3a0805a4c1c747d6eec855fdc4828ccdc3adb5ffa1d8c6b
     HEAD_REF master
 )
 

--- a/ports/parallel-hashmap/vcpkg.json
+++ b/ports/parallel-hashmap/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-hashmap",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "A header-only, very fast and memory-friendly family of C++ hash map & btree containers.",
   "license": "Apache-2.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6621,7 +6621,7 @@
       "port-version": 3
     },
     "parallel-hashmap": {
-      "baseline": "1.3.11",
+      "baseline": "1.3.12",
       "port-version": 0
     },
     "parallelstl": {

--- a/versions/p-/parallel-hashmap.json
+++ b/versions/p-/parallel-hashmap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4e2fc2791da985acdc7214048c247a151d5b492",
+      "version": "1.3.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "48536bee28b7473d0e838f70946ddfe8afdba2e2",
       "version": "1.3.11",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

