### PR TITLE
[rtabmap] Fix platform and linkage support

### DIFF
--- a/ports/rtabmap-res-tool/CMakeLists.txt
+++ b/ports/rtabmap-res-tool/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.10)
+project(rtabmap)
+set(PROJECT_PREFIX rtabmap)
+
+include(GenerateExportHeader)
+include(GNUInstallDirs)
+
+list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake_modules")
+
+add_subdirectory(utilite)

--- a/ports/rtabmap-res-tool/portfile.cmake
+++ b/ports/rtabmap-res-tool/portfile.cmake
@@ -1,0 +1,30 @@
+# Only the standalone tool
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+set(VCPKG_BUILD_TYPE release)
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO introlab/rtabmap
+    REF ${VERSION}
+    SHA512 2b424f5b6458cf0f976e711985708f104b56d11921c9c43c6a837f9d3dc9e9e802308f1aa2b6d0e7e6ddf13623ff1ad2922b5f54254d16ee5811e786d27b9f98
+    HEAD_REF master
+)
+file(COPY "${CURRENT_PORT_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DINSTALL_INCLUDE_DIR=include
+        -DINSTALL_CMAKE_DIR=lib/cmake
+        -DRTABMAP_VERSION=${VERSION}
+)
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
+file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rtabmap-res-tool/vcpkg.json
+++ b/ports/rtabmap-res-tool/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "rtabmap-res-tool",
+  "version": "0.21.4.1",
+  "description": "Real-Time Appearance-Based Mapping, resource generator",
+  "homepage": "https://introlab.github.io/rtabmap/",
+  "license": "BSD-3-Clause",
+  "supports": "native",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/ports/rtabmap/apple.patch
+++ b/ports/rtabmap/apple.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 024c729..ddb1cae 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,8 +119,6 @@ endif()
+ #Other paths...
+ IF(APPLE)
+    # For Mac ports
+-   SET(CMAKE_INCLUDE_PATH "/opt/local/include;${CMAKE_INCLUDE_PATH}")
+-   SET(CMAKE_LIBRARY_PATH "/opt/local/lib;${CMAKE_LIBRARY_PATH}")
+ ENDIF()
+ 
+ ####### Build libraries as shared or static #######

--- a/ports/rtabmap/link-keywords.patch
+++ b/ports/rtabmap/link-keywords.patch
@@ -1,0 +1,12 @@
+diff --git a/corelib/src/CMakeLists.txt b/corelib/src/CMakeLists.txt
+index 6a4a9ab..85ede4e 100644
+--- a/corelib/src/CMakeLists.txt
++++ b/corelib/src/CMakeLists.txt
+@@ -167,7 +167,6 @@ SET(LIBRARIES
+ # Issue that qhull dependency uses optimized and debug keywords,
+ # which are converted to \$<\$<NOT:\$<CONFIG:DEBUG>> and \$<\$<CONFIG:DEBUG>
+ # in RTABMap_coreTargets.cmake (not sure why?!).
+-list(REMOVE_ITEM PCL_LIBRARIES "debug" "optimized")
+ SET(PUBLIC_LIBRARIES
+ 	${OpenCV_LIBS}
+ 	${PCL_LIBRARIES}

--- a/ports/rtabmap/multi-definition.patch
+++ b/ports/rtabmap/multi-definition.patch
@@ -1,0 +1,96 @@
+diff --git a/corelib/include/rtabmap/core/stereo/stereoRectifyFisheye.h b/corelib/include/rtabmap/core/stereo/stereoRectifyFisheye.h
+index 2fc12a2..5219a38 100644
+--- a/corelib/include/rtabmap/core/stereo/stereoRectifyFisheye.h
++++ b/corelib/include/rtabmap/core/stereo/stereoRectifyFisheye.h
+@@ -39,6 +39,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #if CV_MAJOR_VERSION >= 4
+ #include <opencv2/core/core_c.h>
+ 
++#include <rtabmap/core/rtabmap_core_export.h>
++
++namespace {
++
+ // Opencv4 doesn't expose those functions below anymore, we should recopy all of them!
+ int cvRodrigues2( const CvMat* src, CvMat* dst, CvMat* jacobian CV_DEFAULT(0))
+ {
+@@ -919,13 +923,17 @@ void cvConvertPointsHomogeneous( const CvMat* _src, CvMat* _dst )
+ 
+ #endif // OpenCV3
+ 
++} // namespace
++
+ namespace rtabmap
+ {
+ 
+ void
++RTABMAP_CORE_EXPORT
+ icvGetRectanglesFisheye( const CvMat* cameraMatrix, const CvMat* distCoeffs,
+                  const CvMat* R, const CvMat* newCameraMatrix, CvSize imgSize,
+                  cv::Rect_<float>& inner, cv::Rect_<float>& outer )
++#ifdef RTABMAP_STEREORECTIFIYFISHEYE_IMPLEMENTATION
+ {
+     const int N = 9;
+     int x, y, k;
+@@ -967,12 +975,17 @@ icvGetRectanglesFisheye( const CvMat* cameraMatrix, const CvMat* distCoeffs,
+     inner = cv::Rect_<float>(iX0, iY0, iX1-iX0, iY1-iY0);
+     outer = cv::Rect_<float>(oX0, oY0, oX1-oX0, oY1-oY0);
+ }
++#else
++;
++#endif
+ 
+-void cvStereoRectifyFisheye( const CvMat* _cameraMatrix1, const CvMat* _cameraMatrix2,
++void RTABMAP_CORE_EXPORT
++     cvStereoRectifyFisheye( const CvMat* _cameraMatrix1, const CvMat* _cameraMatrix2,
+                       const CvMat* _distCoeffs1, const CvMat* _distCoeffs2,
+                       CvSize imageSize, const CvMat* matR, const CvMat* matT,
+                       CvMat* _R1, CvMat* _R2, CvMat* _P1, CvMat* _P2,
+                       CvMat* matQ, int flags, double alpha, CvSize newImgSize )
++#ifdef RTABMAP_STEREORECTIFIYFISHEYE_IMPLEMENTATION
+ {
+     double _om[3], _t[3] = {0}, _uu[3]={0,0,0}, _r_r[3][3], _pp[3][4];
+     double _ww[3], _wr[3][3], _z[3] = {0,0,0}, _ri[3][3], _w3[3];
+@@ -1177,14 +1190,20 @@ void cvStereoRectifyFisheye( const CvMat* _cameraMatrix1, const CvMat* _cameraMa
+         cvConvert( &Q, matQ );
+     }
+ }
++#else
++;
++#endif
++
+ 
+-void stereoRectifyFisheye( cv::InputArray _cameraMatrix1, cv::InputArray _distCoeffs1,
++void RTABMAP_CORE_EXPORT
++     stereoRectifyFisheye( cv::InputArray _cameraMatrix1, cv::InputArray _distCoeffs1,
+ 				cv::InputArray _cameraMatrix2, cv::InputArray _distCoeffs2,
+ 				cv::Size imageSize, cv::InputArray _Rmat, cv::InputArray _Tmat,
+ 				cv::OutputArray _Rmat1, cv::OutputArray _Rmat2,
+ 				cv::OutputArray _Pmat1, cv::OutputArray _Pmat2,
+ 				cv::OutputArray _Qmat, int flags,
+ 				double alpha, cv::Size newImageSize)
++#ifdef RTABMAP_STEREORECTIFIYFISHEYE_IMPLEMENTATION
+ {
+     cv::Mat cameraMatrix1 = _cameraMatrix1.getMat(), cameraMatrix2 = _cameraMatrix2.getMat();
+     cv::Mat distCoeffs1 = _distCoeffs1.getMat(), distCoeffs2 = _distCoeffs2.getMat();
+@@ -1238,6 +1257,9 @@ void stereoRectifyFisheye( cv::InputArray _cameraMatrix1, cv::InputArray _distCo
+         CvSize(newImageSize));
+ #endif
+ }
++#else
++;
++#endif
+ 
+ }
+ 
+diff --git a/corelib/src/StereoCameraModel.cpp b/corelib/src/StereoCameraModel.cpp
+index 421d3f4..e7c166c 100644
+--- a/corelib/src/StereoCameraModel.cpp
++++ b/corelib/src/StereoCameraModel.cpp
+@@ -34,6 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <opencv2/imgproc/imgproc.hpp>
+ 
+ #if CV_MAJOR_VERSION > 2 or (CV_MAJOR_VERSION == 2 and (CV_MINOR_VERSION >4 or (CV_MINOR_VERSION == 4 and CV_SUBMINOR_VERSION >=10)))
++#define RTABMAP_STEREORECTIFIYFISHEYE_IMPLEMENTATION
+ #include <rtabmap/core/stereo/stereoRectifyFisheye.h>
+ #endif
+ 

--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix_link.patch
         link-keywords.patch
         multi-definition.patch
+        rtabmap-res-tool.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -38,6 +39,7 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DBUILD_AS_BUNDLE=OFF
         -DBUILD_EXAMPLES=OFF
+        "-DRTABMAP_RES_TOOL=${CURRENT_HOST_INSTALLED_DIR}/tools/rtabmap-res-tool/rtabmap-res_tool${VCPKG_TARGET_EXECUTABLE_SUFFIX}"
         -DWITH_ORB_OCTREE=ON
         -DWITH_TORCH=OFF
         -DWITH_PYTHON=OFF
@@ -86,11 +88,6 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-
-if(NOT VCPKG_TARGET_IS_WINDOWS)
-  vcpkg_copy_tools(TOOL_NAMES rtabmap-res_tool-0.3.0)  
-endif()
-vcpkg_copy_tools(TOOL_NAMES rtabmap-res_tool AUTO_CLEAN)
 
 if("tools" IN_LIST FEATURES)
   vcpkg_copy_tools(

--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO introlab/rtabmap
@@ -7,7 +5,10 @@ vcpkg_from_github(
     SHA512 2b424f5b6458cf0f976e711985708f104b56d11921c9c43c6a837f9d3dc9e9e802308f1aa2b6d0e7e6ddf13623ff1ad2922b5f54254d16ee5811e786d27b9f98
     HEAD_REF master
     PATCHES
+        apple.patch
         fix_link.patch
+        link-keywords.patch
+        multi-definition.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -77,11 +78,18 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME RTABMap CONFIG_PATH CMake)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_cmake_config_fixup(CONFIG_PATH CMake)
+else()
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/rtabmap-0.21)
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+  vcpkg_copy_tools(TOOL_NAMES rtabmap-res_tool-0.3.0)  
+endif()
 vcpkg_copy_tools(TOOL_NAMES rtabmap-res_tool AUTO_CLEAN)
 
 if("tools" IN_LIST FEATURES)

--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -14,17 +14,13 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        gui WITH_QT
-        octomap WITH_OCTOMAP
-        realsense2 WITH_REALSENSE2
-        k4w2 WITH_K4W2
-        openni2 WITH_OPENNI2
-)
-
-vcpkg_check_features(OUT_FEATURE_OPTIONS REL_FEATURE_OPTIONS
-    FEATURES
-        tools BUILD_TOOLS
-        tools BUILD_APP
+        gui         WITH_QT
+        k4w2        WITH_K4W2
+        octomap     WITH_OCTOMAP
+        openni2     WITH_OPENNI2
+        realsense2  WITH_REALSENSE2
+        tools       BUILD_APP
+        tools       BUILD_TOOLS
 )
 
 vcpkg_cmake_configure(
@@ -33,49 +29,48 @@ vcpkg_cmake_configure(
     OPTIONS_DEBUG
         -DBUILD_TOOLS=OFF
         -DBUILD_APP=OFF
-    OPTIONS_RELEASE
-        ${REL_FEATURE_OPTIONS}
     OPTIONS
         ${FEATURE_OPTIONS}
         -DBUILD_AS_BUNDLE=OFF
         -DBUILD_EXAMPLES=OFF
+        -DRTABMAP_QT_VERSION=6
         "-DRTABMAP_RES_TOOL=${CURRENT_HOST_INSTALLED_DIR}/tools/rtabmap-res-tool/rtabmap-res_tool${VCPKG_TARGET_EXECUTABLE_SUFFIX}"
-        -DWITH_ORB_OCTREE=ON
-        -DWITH_TORCH=OFF
-        -DWITH_PYTHON=OFF
-        -DWITH_PYTHON_THREADING=OFF
-        -DWITH_PDAL=OFF
+        -DWITH_ALICE_VISION=OFF
+        -DWITH_CCCORELIB=OFF
+        -DWITH_CERES=ON
+        -DWITH_CPUTSDF=OFF
+        -DWITH_CVSBA=OFF
+        -DWITH_DC1394=OFF
+        -DWITH_DEPTHAI=OFF
+        -DWITH_DVO=OFF
+        -DWITH_FASTCV=OFF
+        -DWITH_FLYCAPTURE2=OFF
+        -DWITH_FOVIS=OFF
         -DWITH_FREENECT=OFF
         -DWITH_FREENECT2=OFF
-        -DWITH_K4A=OFF
-        -DWITH_DC1394=OFF
         -DWITH_G2O=ON
         -DWITH_GTSAM=OFF
-        -DWITH_CERES=ON
-        -DWITH_VERTIGO=OFF
-        -DWITH_CVSBA=OFF
-        -DWITH_POINTMATCHER=OFF
-        -DWITH_CCCORELIB=OFF
+        -DWITH_K4A=OFF
         -DWITH_LOAM=OFF
-        -DWITH_FLYCAPTURE2=OFF
+        -DWITH_MADGWICK=OFF
+        -DWITH_MSCKF_VIO=OFF
+        -DWITH_MYNTEYE=OFF
+        -DWITH_OKVIS=OFF
+        -DWITH_OPENCHISEL=OFF
+        -DWITH_OPENVINS=OFF
+        -DWITH_ORB_OCTREE=ON
+        -DWITH_PDAL=OFF
+        -DWITH_POINTMATCHER=OFF
+        -DWITH_PYTHON_THREADING=OFF
+        -DWITH_PYTHON=OFF
+        -DWITH_REALSENSE_SLAM=OFF
+        -DWITH_REALSENSE=OFF
+        -DWITH_TORCH=OFF
+        -DWITH_VERTIGO=OFF
+        -DWITH_VINS=OFF
+        -DWITH_VISO2=OFF
         -DWITH_ZED=OFF
         -DWITH_ZEDOC=OFF
-        -DWITH_REALSENSE=OFF
-        -DWITH_REALSENSE_SLAM=OFF
-        -DWITH_MYNTEYE=OFF
-        -DWITH_DEPTHAI=OFF
-        -DWITH_CPUTSDF=OFF
-        -DWITH_OPENCHISEL=OFF
-        -DWITH_ALICE_VISION=OFF
-        -DWITH_FOVIS=OFF
-        -DWITH_VISO2=OFF
-        -DWITH_DVO=OFF
-        -DWITH_OKVIS=OFF
-        -DWITH_MSCKF_VIO=OFF
-        -DWITH_VINS=OFF
-        -DWITH_OPENVINS=OFF
-        -DWITH_MADGWICK=OFF
-        -DWITH_FASTCV=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -58,7 +58,8 @@ vcpkg_cmake_configure(
         -DWITH_OKVIS=OFF
         -DWITH_OPENCHISEL=OFF
         -DWITH_OPENVINS=OFF
-        -DWITH_ORB_OCTREE=ON
+        -DWITH_ORB_OCTREE=ON   # GPLv3
+        -DWITH_ORB_SLAM=OFF
         -DWITH_PDAL=OFF
         -DWITH_POINTMATCHER=OFF
         -DWITH_PYTHON_THREADING=OFF
@@ -119,4 +120,10 @@ if("tools" IN_LIST FEATURES)
   endif()
 endif()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    COMMENT [[
+The RTAB-Map main license is BSD-3-Clause, but some parts of the
+source code are under other licenses possibly including GPL-3.0-only.
+]]
+    FILE_LIST "${SOURCE_PATH}/LICENSE" 
+)

--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -122,25 +122,8 @@ if("tools" IN_LIST FEATURES)
             rtabmap-rgbd_camera
         AUTO_CLEAN
     )
-    
-    # Remove duplicate files that were added by qtdeploy 
-    # that would be already deployed by vcpkg_copy_tools
-    file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tmp")
-    file(GLOB RTABMAP_REL_LIBS "${CURRENT_PACKAGES_DIR}/tmp/rtabmap*")
-    file(COPY ${RTABMAP_REL_LIBS} DESTINATION  "${CURRENT_PACKAGES_DIR}/bin")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tmp")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/translations")
-    #qt.conf
     file(COPY "${CURRENT_INSTALLED_DIR}/tools/Qt6/bin/qt.conf" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/qt.conf" "./../../../" "./../../")
-
-    # Debug
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/debug/tmp")
-    file(GLOB RTABMAP_DBG_LIBS "${CURRENT_PACKAGES_DIR}/debug/tmp/rtabmap*")
-    file(COPY ${RTABMAP_DBG_LIBS} DESTINATION  "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/tmp")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/plugins")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/translations")
   endif()
 endif()
 

--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -3,14 +3,12 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO introlab/rtabmap
-    REF 0.21.4
-    SHA512 dedc1ed54560db4d61ca4595d5d90b963da8f3865e9caa58df5b6a1f74b7dfaa59f264c1b71a73f7e0bb3e7791d0cec67eeca8bd52416094f3c87c110b7b8549
+    REF ${VERSION}
+    SHA512 2b424f5b6458cf0f976e711985708f104b56d11921c9c43c6a837f9d3dc9e9e802308f1aa2b6d0e7e6ddf13623ff1ad2922b5f54254d16ee5811e786d27b9f98
     HEAD_REF master
     PATCHES
         fix_link.patch
-        sqlite3.patch
 )
-file(REMOVE "${SOURCE_PATH}/cmake_modules/FindSqlite3.cmake")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES

--- a/ports/rtabmap/rtabmap-res-tool.patch
+++ b/ports/rtabmap/rtabmap-res-tool.patch
@@ -1,0 +1,11 @@
+diff --git a/utilite/resource_generator/CMakeLists.txt b/utilite/resource_generator/CMakeLists.txt
+index 82f1253..eedab31 100644
+--- a/utilite/resource_generator/CMakeLists.txt
++++ b/utilite/resource_generator/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ 
+-if (CMAKE_CROSSCOMPILING OR ANDROID OR IOS)
++if (RTABMAP_RES_TOOL)
+     # See this page about tools being required in the build:
+     # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/CrossCompiling#using-executables-in-the-build-created-during-the-build
+ 

--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -13,10 +13,7 @@
     },
     {
       "name": "pcl",
-      "default-features": false,
-      "features": [
-        "vtk"
-      ]
+      "default-features": false
     },
     {
       "name": "rtabmap-res-tool",
@@ -47,7 +44,8 @@
           "name": "pcl",
           "default-features": false,
           "features": [
-            "qt"
+            "qt",
+            "visualization"
           ]
         },
         {
@@ -58,6 +56,10 @@
             "opengl",
             "widgets"
           ]
+        },
+        {
+          "name": "vtk",
+          "default-features": false
         }
       ]
     },

--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "0.21.4.1",
   "description": "Real-Time Appearance-Based Mapping",
   "homepage": "https://introlab.github.io/rtabmap/",
-  "license": "BSD-3-Clause",
+  "license": null,
   "dependencies": [
     "ceres",
     "g2o",

--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -18,6 +18,10 @@
         "vtk"
       ]
     },
+    {
+      "name": "rtabmap-res-tool",
+      "host": true
+    },
     "sqlite3",
     {
       "name": "vcpkg-cmake",

--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "Real-Time Appearance-Based Mapping",
   "homepage": "https://introlab.github.io/rtabmap/",
   "license": "BSD-3-Clause",
-  "supports": "windows & !static",
   "dependencies": [
     "ceres",
     "g2o",

--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rtabmap",
-  "version": "0.21.4",
-  "port-version": 1,
+  "version": "0.21.4.1",
   "description": "Real-Time Appearance-Based Mapping",
   "homepage": "https://introlab.github.io/rtabmap/",
   "license": "BSD-3-Clause",

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -57,6 +57,7 @@ vcpkg_from_github(
         "${MPI4PY_PATCH_2}"
         9690.diff
         missing-include-fixes.patch
+        remove-prefix-changes.patch
 )
 
 # =============================================================================

--- a/ports/vtk/remove-prefix-changes.patch
+++ b/ports/vtk/remove-prefix-changes.patch
@@ -1,0 +1,14 @@
+diff --git a/CMake/vtk-config.cmake.in b/CMake/vtk-config.cmake.in
+index 9f095ba..8cf7ee2 100644
+--- a/CMake/vtk-config.cmake.in
++++ b/CMake/vtk-config.cmake.in
+@@ -114,8 +114,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/vtk-prefix.cmake")
+ set("${CMAKE_FIND_PACKAGE_NAME}_PREFIX_PATH"
+   "${_vtk_module_import_prefix}")
+ unset(_vtk_module_import_prefix)
+-list(INSERT CMAKE_PREFIX_PATH 0
+-  "${${CMAKE_FIND_PACKAGE_NAME}_PREFIX_PATH}")
+ 
+ set("${CMAKE_FIND_PACKAGE_NAME}_VERSION" "@VTK_MAJOR_VERSION@.@VTK_MINOR_VERSION@.@VTK_BUILD_VERSION@")
+ set("${CMAKE_FIND_PACKAGE_NAME}_MAJOR_VERSION" "@VTK_MAJOR_VERSION@")
+

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.2.0-pv5.11.0",
-  "port-version": 11,
+  "port-version": 12,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7745,8 +7745,12 @@
       "port-version": 3
     },
     "rtabmap": {
-      "baseline": "0.21.4",
-      "port-version": 1
+      "baseline": "0.21.4.1",
+      "port-version": 0
+    },
+    "rtabmap-res-tool": {
+      "baseline": "0.21.4.1",
+      "port-version": 0
     },
     "rtaudio": {
       "baseline": "6.0.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9146,7 +9146,7 @@
     },
     "vtk": {
       "baseline": "9.2.0-pv5.11.0",
-      "port-version": 11
+      "port-version": 12
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/r-/rtabmap-res-tool.json
+++ b/versions/r-/rtabmap-res-tool.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "459047a0d2fb7d01cdfd1758985d74dbce0b0f53",
+      "version": "0.21.4.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/r-/rtabmap.json
+++ b/versions/r-/rtabmap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce0d77ecd72de4931d1230d3d0383a7f2e7295b7",
+      "version": "0.21.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b50a72e16aaa8ba99447348c26463d8b47cb34f5",
       "version": "0.21.4",
       "port-version": 1

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f1473cbde3a447a1068779a42704a92b8eecccb",
+      "version-semver": "9.2.0-pv5.11.0",
+      "port-version": 12
+    },
+    {
       "git-tree": "e887b758153039453976be1e5d0bc54d537b0417",
       "version-semver": "9.2.0-pv5.11.0",
       "port-version": 11


### PR DESCRIPTION
`rtabmap-res_tool` is moved to a separate port because it is a host dependency, and actual dependencies of `rtabmap` are heavy and non opt-out. Only minimal patching needed.

CC @matlabbe.