### PR TITLE
[clblast] update to 1.6.2

### DIFF
--- a/ports/clblast/portfile.cmake
+++ b/ports/clblast/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CNugteren/CLBlast
     REF "${VERSION}"
-    SHA512 3114b2499f13a8b12dc5dfaf3633d4a25c953da63bea3c2f09a99699ee49239c28a1db0033619ef74234af56068f94413aae8c721d1af6114b862670a32cdb8d
+    SHA512 43920c52b134367c2df86e9019cd3bab2811cf3a6bbc3de780724f4e62239ebaf390635d9dfbd887089753ccb751f7e94a9038c4a8aa23ac1a38f39cde5afdcc
     HEAD_REF master
     PATCHES
         fix_install_path.patch

--- a/ports/clblast/vcpkg.json
+++ b/ports/clblast/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clblast",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A modern, lightweight, performant and tunable OpenCL BLAS library written in C++11.",
   "homepage": "https://github.com/CNugteren/CLBlast",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1637,7 +1637,7 @@
       "port-version": 7
     },
     "clblast": {
-      "baseline": "1.6.1",
+      "baseline": "1.6.2",
       "port-version": 0
     },
     "cld3": {

--- a/versions/c-/clblast.json
+++ b/versions/c-/clblast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ff761d7626dc0d6c85046e00e1b2d7c698686d8",
+      "version": "1.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2f514afe9163a9445befe8ddc91f8cd8f0105c9d",
       "version": "1.6.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

