### PR TITLE
[cnats] update to 3.8.0

### DIFF
--- a/ports/cnats/portfile.cmake
+++ b/ports/cnats/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nats-io/nats.c
     REF "v${VERSION}"
-    SHA512 0670a2b7fb70a49e2b1f5cbccf2406a3ecaf04b48b4147dc2ead9cb106f1673efa79b5e40d3bb557986ade35da2158b58b324603f98a58258a497dc57cb5d700
+    SHA512 d32979a686420fe23af96b58efcf366ff9ff315531ca54962f2ae8ae7126174b5ca10a74152cc14f49be1143d0ad7dd5a68beeb31126410c76dbaa0468a45382
     HEAD_REF main
     PATCHES
         fix-sodium-dep.patch

--- a/ports/cnats/vcpkg.json
+++ b/ports/cnats/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cnats",
-  "version": "3.7.0",
-  "port-version": 1,
+  "version": "3.8.0",
   "description": "A C client for the NATS messaging system",
   "homepage": "https://github.com/nats-io/nats.c",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1701,8 +1701,8 @@
       "port-version": 3
     },
     "cnats": {
-      "baseline": "3.7.0",
-      "port-version": 1
+      "baseline": "3.8.0",
+      "port-version": 0
     },
     "cnl": {
       "baseline": "1.1.7",

--- a/versions/c-/cnats.json
+++ b/versions/c-/cnats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "963d6b12fba8001c650cc6d56a21a1a5122cf845",
+      "version": "3.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cce27b1efc5af15e4222a5fdc5502959f24e9d03",
       "version": "3.7.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

