### PR TITLE
[libdeflate] Update to v1.20

### DIFF
--- a/ports/libdeflate/portfile.cmake
+++ b/ports/libdeflate/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ebiggers/libdeflate
     REF "v${VERSION}"
-    SHA512 fe57542a0d28ad61d70bef9b544bb6805f9f30930b16432712b3b1caab041f1f4e64315a4306a0635b96c2632239c5af0e45a3915581d0b89975729fc2e95613
+    SHA512 5ebe6af9ce81872cba508d1f0aa087ddeb0e0f0c8e6360da66b8a9db2a76203dafbf3d3f6b3b791618ea9c6d0231fab5b4a55badb31a4480fb4174b9445c658b
     HEAD_REF master
     PATCHES
         remove_wrong_c_flags_modification.diff

--- a/ports/libdeflate/vcpkg.json
+++ b/ports/libdeflate/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libdeflate",
-  "version": "1.19",
-  "port-version": 1,
+  "version": "1.20",
   "description": "libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.",
   "homepage": "https://github.com/ebiggers/libdeflate",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4269,8 +4269,8 @@
       "port-version": 0
     },
     "libdeflate": {
-      "baseline": "1.19",
-      "port-version": 1
+      "baseline": "1.20",
+      "port-version": 0
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/l-/libdeflate.json
+++ b/versions/l-/libdeflate.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "021898704c19afd68d49fb56f26db8061e3c7957",
+      "version": "1.20",
+      "port-version": 0
+    },
+    {
       "git-tree": "76f16e38faecc95d0dc0c1a4a2ac32a4983f4775",
       "version": "1.19",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.