### PR TITLE
[nghttp2] Update to 1.60.0

### DIFF
--- a/ports/nghttp2/no-tests.patch
+++ b/ports/nghttp2/no-tests.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 58ae48c7..fc3b38a5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -432,7 +432,6 @@ add_subdirectory(lib)
+ add_subdirectory(third-party)
+ add_subdirectory(src)
+ add_subdirectory(examples)
+-add_subdirectory(tests)
+ #add_subdirectory(tests/testdata)
+ add_subdirectory(integration-tests)
+ if(ENABLE_DOC)
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 211c8e43..94e688d4 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -66,6 +66,7 @@ if(BUILD_SHARED_LIBS)
+ endif()
+ 
+ # Static library (for unittests because of symbol visibility)
++if(BUILD_STATIC_LIBS)
+ add_library(${STATIC_LIB} STATIC ${NGHTTP2_SOURCES})
+ 
+ set_target_properties(${STATIC_LIB} PROPERTIES
+@@ -82,7 +83,6 @@ target_include_directories(${STATIC_LIB} INTERFACE
+ 
+ target_compile_definitions(${STATIC_LIB} PUBLIC "-DNGHTTP2_STATICLIB")
+ 
+-if(BUILD_STATIC_LIBS)
+   install(TARGETS ${STATIC_LIB} EXPORT ${EXPORT_SET})
+   list(APPEND nghttp2_exports ${STATIC_LIB})
+ endif()

--- a/ports/nghttp2/portfile.cmake
+++ b/ports/nghttp2/portfile.cmake
@@ -1,36 +1,35 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nghttp2/nghttp2
-    REF v${VERSION}
-    SHA512 bcb53ff45afae003f11a9feaa21dd80a3abfcde9b3a7fd1f04fc4382d71b5d4430e2d015765a7ae8d68454fcf06e4560c4cb585133aefb237d6ea526f61a8ebd
+    REF "v${VERSION}"
+    SHA512 1526418b0cf8e065f00589c5abd0b4ebd32a3128fbedd7c1f8fc9a76b8b2ad9713a8f4b056d29fce454559fe9227392c59dcdffaa665249df94a1fcf85fcfc53
     HEAD_REF master
+    PATCHES
+        no-tests.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" ENABLE_STATIC_CRT)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC_LIB)
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED_LIB)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DENABLE_LIB_ONLY=ON
+        -DENABLE_DOC=OFF
         "-DENABLE_STATIC_CRT=${ENABLE_STATIC_CRT}"
-        "-DENABLE_STATIC_LIB=${ENABLE_STATIC_LIB}"
-        "-DENABLE_SHARED_LIB=${ENABLE_SHARED_LIB}"
+        "-DBUILD_STATIC_LIBS=${ENABLE_STATIC_LIB}"
+        -DCMAKE_DISABLE_FIND_PACKAGE_Python3=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_Libev=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_Libcares=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Libngtcp2=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_Libngtcp2_crypto_openssl=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_Libngtcp2_crypto_quictls=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Libnghttp3=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Systemd=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Jansson=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Libevent=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_LibXml2=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Jemalloc=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_Threads=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_CUnit=ON
+    MAYBE_UNUSED_VARIABLES
+        ENABLE_STATIC_CRT
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
@@ -39,15 +38,12 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
-    "${CURRENT_PACKAGES_DIR}/share/man"
     "${CURRENT_PACKAGES_DIR}/share/doc"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
+    "${CURRENT_PACKAGES_DIR}/lib/cmake"
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE
-        "${CURRENT_PACKAGES_DIR}/bin"
-        "${CURRENT_PACKAGES_DIR}/debug/bin"
-    )
     file(APPEND "${CURRENT_PACKAGES_DIR}/include/nghttp2/nghttp2ver.h" [[
 #ifndef NGHTTP2_STATICLIB
 #  define NGHTTP2_STATICLIB
@@ -55,4 +51,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 ]])
 endif()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/nghttp2/vcpkg.json
+++ b/ports/nghttp2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nghttp2",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "description": "Implementation of the Hypertext Transfer Protocol version 2 in C",
   "homepage": "https://github.com/nghttp2/nghttp2",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6085,7 +6085,7 @@
       "port-version": 4
     },
     "nghttp2": {
-      "baseline": "1.59.0",
+      "baseline": "1.60.0",
       "port-version": 0
     },
     "nghttp2-asio": {

--- a/versions/n-/nghttp2.json
+++ b/versions/n-/nghttp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "31de6aa7aa2d2e068717f30e8949570bdfd53bf6",
+      "version": "1.60.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b5a94a4eb9a90dcd3b34534bd14768d94e7e538",
       "version": "1.59.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
