### PR TITLE
[vcpkg baseline][directxsdk] Fix conflict between dxsdk-d3dx and directxsdk

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -266,6 +266,7 @@ dcmtk:x64-uwp=fail
 # legacy directxsdk which conflicts with dxsdk-d3dx
 directxsdk:x86-windows=skip
 directxsdk:x64-windows=skip
+directxsdk:x64-windows-static=skip
 directxsdk:x64-windows-static-md=skip
 discord-rpc:arm64-uwp=fail
 discord-rpc:x64-uwp=fail


### PR DESCRIPTION
Fixes https://dev.azure.com/vcpkg/public/_build/results?buildId=100948&view=results:
```
Building dxsdk-d3dx:x64-windows-static@9.29.952.8#7...
CMake Error at ports/dxsdk-d3dx/portfile.cmake:2 (message):
  Can't build dxsdk-d3dx if directxsdk is installed.  Please remove
  directxsdk, and try to install dxsdk-d3dx again if you need it.
Call Stack (most recent call first):
  scripts/ports.cmake:175 (include)
```

`dxsdk-d3dx:x64-windows-static` is fixed by #37605.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~

