### PR TITLE
[openmvg] update to 2.1

### DIFF
--- a/ports/openmvg/portfile.cmake
+++ b/ports/openmvg/portfile.cmake
@@ -10,8 +10,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openMVG/openMVG
-    REF d0fe73dd426ae4001631a51272cff71047522df9  # v2.0
-    SHA512 1d5c68971ad63ced46d8b9070bdacc1065b4ba950fe919e11f952a004def87d4d83a474d48aee714c21b12106d7d81187d3670d8a2e6daf2d3c5fceb008a5de3
+    REF "v${VERSION}"
+    SHA512 edc4ecf9846fb7d7bb4db0470742b5d6aea7e141e60fbc30563522381e8cb08d65f2a7158a46e65f61b9c96da02efc80251d1b91264ba9e73496a21d7880d2aa
     PATCHES
         build_fixes.patch
         0001-eigen_3.4.0.patch

--- a/ports/openmvg/vcpkg.json
+++ b/ports/openmvg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openmvg",
-  "version": "2.0",
-  "port-version": 9,
+  "version": "2.1",
   "description": "open Multiple View Geometry library. Basis for 3D computer vision and Structure from Motion.",
   "license": "MPL-2.0-no-copyleft-exception",
   "supports": "(x86 | x64 | arm64) & !xbox",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6461,8 +6461,8 @@
       "port-version": 1
     },
     "openmvg": {
-      "baseline": "2.0",
-      "port-version": 9
+      "baseline": "2.1",
+      "port-version": 0
     },
     "openmvs": {
       "baseline": "2.1.0",

--- a/versions/o-/openmvg.json
+++ b/versions/o-/openmvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e5917c3f6b1bf3d14324c20aa47c0a93e1832ac",
+      "version": "2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6ddaa3bedcc57eb498c9e180bb8546a2726a1ddc",
       "version": "2.0",
       "port-version": 9


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

