### PR TITLE
[opensubdiv] update to 3.6.0

### DIFF
--- a/ports/opensubdiv/portfile.cmake
+++ b/ports/opensubdiv/portfile.cmake
@@ -1,12 +1,13 @@
 if (VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_IOS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
+string(REPLACE "." "_" OpenSubdiv_VERSION "${VERSION}")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PixarAnimationStudios/OpenSubdiv
-    REF 8ffa2b6566be10209529d7a0d1db02a0796b160c # v3.5.0
-    SHA512 cb48470f044ca4e9fcdfb3ff05d710fd710212d5a2f539f3f90ebb33cc6a6b1530fd9deb7d3eb25b275133dbdf5c1a5d4777b289d13b15006a59db12e8b28398
+    REF "v${OpenSubdiv_VERSION}" # v3.5.0
+    SHA512 a976733a26e2c0f6510f59d4372b1b33f5404a9d536bcbd6ae3a1a0ffd1bba5495df7108bebc854d5c069575772c97c0d00f0f16f79e87611376ba84e9ae7a4b
     HEAD_REF release
     PATCHES
         fix_compile-option.patch

--- a/ports/opensubdiv/vcpkg.json
+++ b/ports/opensubdiv/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "opensubdiv",
-  "version-semver": "3.5.0",
-  "port-version": 1,
+  "version-semver": "3.6.0",
   "description": "An Open-Source subdivision surface library.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenSubdiv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6497,8 +6497,8 @@
       "port-version": 0
     },
     "opensubdiv": {
-      "baseline": "3.5.0",
-      "port-version": 1
+      "baseline": "3.6.0",
+      "port-version": 0
     },
     "opentelemetry-cpp": {
       "baseline": "1.14.2",

--- a/versions/o-/opensubdiv.json
+++ b/versions/o-/opensubdiv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f028cd5f807b7f3e20ab37d5d81854bc62d49676",
+      "version-semver": "3.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8cc627798709caed394f31456098644f359f0936",
       "version-semver": "3.5.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

