### PR TITLE
[pe-parse] update to 2.1.1

### DIFF
--- a/ports/pe-parse/portfile.cmake
+++ b/ports/pe-parse/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO trailofbits/pe-parse
-    REF v2.1.0
-    SHA512 2589e4049b9edb5aa733684405f77a7d0c2a36c44a9473ff286fa387468600453c908770d6c2b9d635553bfb0fb2a547326c0aa2e4db5ca1f824de64ec3f61d0
+    REF "v${VERSION}"
+    SHA512 fae9060c48e2cebdfbb742c52bc39c36335c1ad4fc7e6bc75a7da012f59d16497630d40ca814c8da71acc44dcce82983ebe13da3a0d389cc53032261fcd1f6bb
     HEAD_REF master
     PATCHES
         arm64-windows-fix.patch

--- a/ports/pe-parse/vcpkg.json
+++ b/ports/pe-parse/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pe-parse",
-  "version": "2.1.0",
-  "port-version": 1,
+  "version": "2.1.1",
   "description": "pe-parse is a principled, lightweight C/C++ PE parser",
   "homepage": "https://github.com/trailofbits/pe-parse",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6689,8 +6689,8 @@
       "port-version": 2
     },
     "pe-parse": {
-      "baseline": "2.1.0",
-      "port-version": 1
+      "baseline": "2.1.1",
+      "port-version": 0
     },
     "pegtl": {
       "baseline": "3.2.7",

--- a/versions/p-/pe-parse.json
+++ b/versions/p-/pe-parse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20bff5e992991e9824bfbcd42ea6a52313cb5446",
+      "version": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d3e0e5dcb11738632d8eba03e22e4f0530ae5445",
       "version": "2.1.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

