### PR TITLE
[pixman] update to 0.43.4

### DIFF
--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -46,8 +46,8 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     GITLAB_URL https://gitlab.freedesktop.org
     REPO pixman/pixman
-    REF  91b8526c1eeb2b45c21f091e890cb74cf6989ff6 # 0.43.2
-    SHA512 cd4ea905a2287ae1ec25720ac90a72b2812dfeb6a5a82e3bbfcfeba91461229cde61b8bc6a5dfe5711f6b2937b3d3d4ade2b0c9a0290880c7d0cc4859344b542
+    REF "pixman-${VERSION}"
+    SHA512 daeb25d91e9cb8d450a6f050cbec1d91e239a03188e993ceb6286605c5ed33d97e08d6f57efaf1d5c6a8a1eedb1ebe6c113849a80d9028d5ea189c54601be424
     PATCHES
         no-host-cpu-checks.patch
         fix_clang-cl.patch

--- a/ports/pixman/vcpkg.json
+++ b/ports/pixman/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pixman",
-  "version": "0.43.2",
+  "version": "0.43.4",
   "description": "Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.",
   "homepage": "https://www.cairographics.org/releases",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6753,7 +6753,7 @@
       "port-version": 1
     },
     "pixman": {
-      "baseline": "0.43.2",
+      "baseline": "0.43.4",
       "port-version": 0
     },
     "pkgconf": {

--- a/versions/p-/pixman.json
+++ b/versions/p-/pixman.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7e1a97a6af1ad657489f901a6ca14db24652eff",
+      "version": "0.43.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "2818a78546de0d60e38b89011073ff7ae398796e",
       "version": "0.43.2",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

