### PR TITLE
[presentmon] update to 1.10.0

### DIFF
--- a/ports/presentmon/portfile.cmake
+++ b/ports/presentmon/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GameTechDev/PresentMon
-    REF 47669ad0efaddc9787772d5e4900734417b2c07c # 1.7.0
-    SHA512 fac2e2ca4d8476e2cdde7c3f77cf1881b7d7a9208387f12dbf07f3ea7f4012ce79602f4fedbf1e778871fd9ce898b101659a6f192de29dc6a4404213aee444be
+    REF "v${VERSION}"
+    SHA512 d593a4066e3087abd02df5bd049bb1cbe1a91ac07a4efb53bae7a44bcb98dc67f7e2f2688dd339292eeaf9b96f35d5790a86d355faacad5cf61dafa0fa584edc
     HEAD_REF main
 )
 

--- a/ports/presentmon/vcpkg.json
+++ b/ports/presentmon/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "presentmon",
-  "version-semver": "1.7.0",
-  "port-version": 2,
+  "version-semver": "1.10.0",
   "description": "PresentMon is a tool to capture and analyze ETW events related to swap chain presentation on Windows.",
   "supports": "windows & !uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6917,8 +6917,8 @@
       "port-version": 0
     },
     "presentmon": {
-      "baseline": "1.7.0",
-      "port-version": 2
+      "baseline": "1.10.0",
+      "port-version": 0
     },
     "proj": {
       "baseline": "9.3.1",

--- a/versions/p-/presentmon.json
+++ b/versions/p-/presentmon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "417fbf81c84e94583e4e8b852412d15e799cfd99",
+      "version-semver": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a0ec5e22d9a5d03756ac641d8ff2430beae43080",
       "version-semver": "1.7.0",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

