### PR TITLE
[usockets] Update to 0.8.8 and fix CMake dependencies

### DIFF
--- a/ports/usockets/CMakeLists.txt
+++ b/ports/usockets/CMakeLists.txt
@@ -1,68 +1,123 @@
-cmake_minimum_required(VERSION 3.13)
-project(uSockets C CXX)
+# Unofficial uSockets CMakeLists.txt from Makefile of https://github.com/uNetworking/uSockets/blob/v0.8.8/Makefile
+cmake_minimum_required(VERSION 3.25.1)
+project(uSockets VERSION ${VERSION} LANGUAGES C CXX)
 
-option(INSTALL_HEADERS "Install header files" ON)
+# options
+option(WITH_OPENSSL "enables OpenSSL 1.1+ support"      OFF)
+option(WITH_LIBUV   "builds with libuv as event-loop"   OFF)
 
-if (CMAKE_USE_OPENSSL)
-    find_package(OpenSSL REQUIRED)
-    set(USE_OPENSSL "-DUSE_OPENSSL -DLIBUS_USE_OPENSSL")
-    #set(OPENSSL_LIB "OpenSSL::SSL OpenSSL::Crypto")
-    list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
+# global variables
+set(uSockets_installable_libs)
+set(uSockets_find_dependency_calls)
+
+# target usockets
+add_library(uSockets)
+list(APPEND uSockets_installable_libs uSockets)
+foreach(dir IN ITEMS "src" "src/eventing" "src/crypto" "src/io_uring")
+    aux_source_directory(${dir} uSockets_sources)
+endforeach()
+list(FILTER uSockets_sources INCLUDE REGEX ".+\\.c$")
+target_sources(uSockets PRIVATE ${uSockets_sources})
+if(WIN32)
+    target_link_libraries(uSockets PRIVATE ws2_32)
+endif(WIN32)
+
+# target coupling options
+add_library(us_target_coupling INTERFACE)
+list(APPEND uSockets_installable_libs us_target_coupling)
+# global include
+target_include_directories(us_target_coupling INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>")
+
+# global std
+target_compile_features(us_target_coupling INTERFACE "c_std_11")
+if(WITH_OPENSSL)
+    target_compile_features(us_target_coupling INTERFACE "cxx_std_17")
 else()
-    set(NOT_USE_OPENSSL "-DLIBUS_NO_SSL")
+    target_compile_features(us_target_coupling INTERFACE "cxx_std_14")
 endif()
 
-find_package(libuv CONFIG REQUIRED)
-if (TARGET libuv::uv)
-    set(LIBUV_LIBRARY libuv::uv)
-else()
-    set(LIBUV_LIBRARY libuv::uv_a)
-endif()
-
-file(GLOB SOURCES src/*.c src/eventing/*.c)
-
-set(USOCKETS_EXT_INCLUDE_DIR )
-set(USOCKETS_EXT_LIBS )
-
-if (CMAKE_USE_OPENSSL)
-    # It requires C++17 or later, see https://github.com/uNetworking/uSockets/blob/0ebdde0601cc82349fc11a7c4bbb6dc5c9f28f42/Makefile#L55
-    set(CMAKE_CXX_STANDARD 17)
+# ssl
+if(WITH_OPENSSL)
+    target_compile_definitions(us_target_coupling INTERFACE "-DLIBUS_USE_OPENSSL")
     find_package(OpenSSL REQUIRED)
-    file(GLOB SSL_SOURCES src/crypto/*.c*)
-    list(APPEND SOURCES ${SSL_SOURCES})
-    list(APPEND USOCKETS_EXT_LIBS OpenSSL::SSL OpenSSL::Crypto)
+    list(APPEND uSockets_find_dependency_calls "OpenSSL")
+    target_link_libraries(us_target_coupling INTERFACE OpenSSL::SSL OpenSSL::Crypto)
+else()
+    target_compile_definitions(us_target_coupling INTERFACE "-DLIBUS_NO_SSL")
 endif()
 
-if (CMAKE_USE_EVENT)
-    file(GLOB SSL_SOURCES src/eventing/*.c)
-    list(APPEND SOURCES ${SSL_SOURCES})
-    list(APPEND USOCKETS_EXT_INCLUDE_DIR src/internal/eventing)
+# event-loop
+if(WITH_LIBUV)
+    target_compile_definitions(us_target_coupling INTERFACE "-DLIBUS_USE_LIBUV")
+    find_package(libuv CONFIG REQUIRED)
+    list(APPEND uSockets_find_dependency_calls "libuv CONFIG")
+    target_link_libraries(us_target_coupling INTERFACE $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>)
+else()
+    if(WIN32)
+        message(FATAL_ERROR "Windows should use LIBUV as default event loop")
+    elseif(APPLE OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"))
+        message("Apple or FreeBSD use KQUEUE as default event loop")
+    else()
+        message("Use EPOLL as default event loop")
+    endif()
 endif()
 
-if (CMAKE_USE_NETWORK)
-    list(APPEND USOCKETS_EXT_INCLUDE_DIR src/internal/networking)
-    list(APPEND USOCKETS_EXT_LIBS ws2_32)
+# target crypto
+if(WITH_OPENSSL)
+    add_library(us_target_crypto OBJECT)
+    list(APPEND uSockets_installable_libs us_target_crypto)
+    foreach(dir IN ITEMS "src/crypto")
+        aux_source_directory(${dir} us_target_crypto_sources)
+    endforeach()
+    list(FILTER us_target_crypto_sources INCLUDE REGEX ".+\\.cpp$")
+    target_sources(us_target_crypto PRIVATE ${us_target_crypto_sources})
+    target_link_libraries(us_target_crypto PUBLIC us_target_coupling)
+    target_link_libraries(uSockets PRIVATE us_target_crypto)
 endif()
 
-add_library(uSockets ${SOURCES})
+# target link
+target_link_libraries(uSockets PRIVATE us_target_coupling)
 
-if (${LIBUS_USE_LIBUV})
-  target_compile_definitions(uSockets PRIVATE -DLIBUS_USE_LIBUV)
-endif()
+# install init
+set(PACKAGE_NAME "unofficial-uSockets")
+set(PACKAGE_NAMESPACE "unofficial::uSockets::")
+set(PACKAGE_CONFIG_NAME "${PACKAGE_NAME}Config")
+set(PACKAGE_INSTALL_SHARE "share/${PACKAGE_NAME}")
+set(PACKAGE_INSTALL_INCLUDE "include/${PACKAGE_NAME}")
+set(uSockets_targets_name "uSocketsTargets")
+set(PACKAGE_CONFIG_TEMPLATE_PATH "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake.in")
+file(GLOB PACKAGE_HEADERS "src/*.h")
 
-target_compile_definitions(uSockets PRIVATE ${NOT_USE_OPENSSL} ${USE_OPENSSL})
-target_include_directories(uSockets PUBLIC ${OPENSSL_INCLUDE_DIR} ${USOCKETS_EXT_INCLUDE_DIR} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/src")
-target_link_libraries(uSockets PUBLIC ${OPENSSL_LIBRARIES} ${LIBUV_LIBRARY} ${USOCKETS_EXT_LIBS})
+# install headers
+target_include_directories(uSockets PUBLIC "$<INSTALL_INTERFACE:${PACKAGE_INSTALL_INCLUDE}>")
+install(FILES ${PACKAGE_HEADERS} DESTINATION "${PACKAGE_INSTALL_INCLUDE}")
 
-install(TARGETS uSockets
-    RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+# install targets
+install(TARGETS ${uSockets_installable_libs}
+    EXPORT "${uSockets_targets_name}"
 )
 
-if(INSTALL_HEADERS)
-    file(GLOB HEADERS src/*.h)
-    install(FILES ${HEADERS} DESTINATION include)
-    file(GLOB HEADERS src/interfaces/*.h)
-    install(FILES ${HEADERS} DESTINATION include/interfaces)
-endif()
+install(EXPORT "${uSockets_targets_name}"
+    NAMESPACE "${PACKAGE_NAMESPACE}"
+    DESTINATION "${PACKAGE_INSTALL_SHARE}"
+)
+
+# generate configs
+set(PACKAGE_CONFIG_TEMPLATE "@PACKAGE_INIT@\n\n")
+string(APPEND PACKAGE_CONFIG_TEMPLATE "include(CMakeFindDependencyMacro)\n")
+list(REMOVE_DUPLICATES uSockets_find_dependency_calls)
+foreach(dep_call IN LISTS uSockets_find_dependency_calls)
+    string(APPEND PACKAGE_CONFIG_TEMPLATE "find_dependency(${dep_call})\n")
+endforeach()
+string(APPEND PACKAGE_CONFIG_TEMPLATE "\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/${uSockets_targets_name}.cmake\")\n")
+
+file(WRITE "${PACKAGE_CONFIG_TEMPLATE_PATH}" "${PACKAGE_CONFIG_TEMPLATE}")
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file("${PACKAGE_CONFIG_TEMPLATE_PATH}"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_CONFIG_NAME}.cmake"
+  INSTALL_DESTINATION "${PACKAGE_INSTALL_SHARE}"
+)
+
+# install configs
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_CONFIG_NAME}.cmake" DESTINATION ${PACKAGE_INSTALL_SHARE})

--- a/ports/usockets/portfile.cmake
+++ b/ports/usockets/portfile.cmake
@@ -1,28 +1,21 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY) #Upstream only support static compilation: https://github.com/uNetworking/uSockets/commit/b950efd6b10f06dd3ecb5b692e5d415f48474647
-
-if(NOT VCPKG_TARGET_IS_LINUX)
-   set(USE_LIBUV ON)
-endif()
-
-if ("network" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_WINDOWS)
-    message(FATAL_ERROR "Feature 'network' is only supported on Windows")
-endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uNetworking/uSockets
     REF "v${VERSION}"
-    SHA512 a4f71e146003056c4a3e99512e6989fd4a37b5943dfcaf593b7b276231c426abd2e1f60de752443fb62ac5926ecf9812866af3c8ce6c8eeeddffc92fa0eb5afb
+    SHA512 726b1665209d0006d6621352c12019bbab22bed75450c5ef1509b409d3c19c059caf94775439d3b910676fa2a4a790d490c3e25e5b8141423d88823642be7ac7
     HEAD_REF master
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        ssl CMAKE_USE_OPENSSL
-        event CMAKE_USE_EVENT
-        network CMAKE_USE_NETWORK
+        ssl     WITH_OPENSSL
 )
+set(LIBUS_COMPLEMENT_OPTIONS "")
+if(VCPKG_TARGET_IS_WINDOWS) # windows requires a third party event-loop
+    list(APPEND LIBUS_COMPLEMENT_OPTIONS "-DWITH_LIBUV=ON") # system default or WITH_LIBUV
+endif()
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
@@ -30,13 +23,15 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        "-DLIBUS_USE_LIBUV=${USE_LIBUV}"
-    OPTIONS_DEBUG
-        -DINSTALL_HEADERS=OFF
+        ${LIBUS_COMPLEMENT_OPTIONS}
+        -DVERSION=${VERSION}
 )
 
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-uSockets")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-
-vcpkg_copy_pdbs()
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/usockets/usage
+++ b/ports/usockets/usage
@@ -1,0 +1,4 @@
+The port uSockets provides CMake targets:
+
+  find_package(unofficial-uSockets CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unofficial::uSockets::uSockets)

--- a/ports/usockets/vcpkg.json
+++ b/ports/usockets/vcpkg.json
@@ -1,29 +1,26 @@
 {
   "name": "usockets",
-  "version": "0.8.6",
-  "port-version": 1,
+  "version": "0.8.8",
   "description": "Miniscule cross-platform eventing, networking & crypto for async applications",
   "homepage": "https://github.com/uNetworking/uSockets",
   "license": "Apache-2.0",
   "dependencies": [
-    "libuv",
+    {
+      "name": "libuv",
+      "platform": "windows"
+    },
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ],
   "features": {
-    "event": {
-      "description": "Build usockets with epoll support"
-    },
-    "network": {
-      "description": "Build usockets with winsock support",
-      "dependencies": [
-        "winsock2"
-      ]
-    },
     "ssl": {
-      "description": "Build usockets with openssl support",
+      "description": "Enable SSL support (default OpenSSL)",
       "dependencies": [
         "openssl"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8925,8 +8925,8 @@
       "port-version": 0
     },
     "usockets": {
-      "baseline": "0.8.6",
-      "port-version": 1
+      "baseline": "0.8.8",
+      "port-version": 0
     },
     "usrsctp": {
       "baseline": "0.9.5.0",

--- a/versions/u-/usockets.json
+++ b/versions/u-/usockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "735855f6a24a056a18672a7ed145d8a5a37d9e39",
+      "version": "0.8.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "178ef570c3acdb03066628f05aa564af7609f48c",
       "version": "0.8.6",
       "port-version": 1


### PR DESCRIPTION
Update dependency for #37355.

### Change
* Update `usockets` to `0.8.8`.
* Change dependency `libuv` for windows only because `usockets` select `epoll` or `kqueue` [as eventing system by default](https://github.com/uNetworking/uSockets/blob/v0.8.8/src/libusockets.h#L340-L348).
* Remove feature `event` since `usockets` must have one event-loop backend.
* Remove feature `network` and dependency `winsock2` since `ws2_32` is required in platform `windows`.
* Check `WIN32` and then `target_link_libraries(uSockets PRIVATE ws2_32)` to explicit link for possible platform `mingw`, which indicated from [#pragma comment(lib, "ws2_32.lib")](https://github.com/uNetworking/uSockets/blob/v0.8.8/src/internal/networking/bsd.h#L34), related to #25079.
* Add `CMake` export config `unofficial-uSockets` with dependencies.

### Info
* After `usockets` removing the dependency on `winsock2`, there will no ports depend on it.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
Port usage and features test pass with following triplets:
* x64-linux
* x64-windows
* x64-windows-static