### PR TITLE
upgrade baresip-libre to 3.10.0

### DIFF
--- a/ports/baresip-libre/portfile.cmake
+++ b/ports/baresip-libre/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO baresip/re
     REF "v${VERSION}"
-    SHA512 d19fc5c48399ad4942c27d86c47350f579f8ebeaf8dc04b13a930b930c13a20e5e7dd5f0fe05d11b6b365667d8306f2499f5cb925850f4484049ba853d36b0b1
+    SHA512 f7aadce42e6d3477ab36cac44557d0c1c2df2f5a4c8f0d295d230345b1a73e2747360893d4d5de7dce3326eb0713680f59865eb86bdd3f224015c197fa41ccfe
     HEAD_REF main
     PATCHES
         fix-static-library-build.patch

--- a/ports/baresip-libre/vcpkg.json
+++ b/ports/baresip-libre/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "baresip-libre",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Generic library for real-time communications with async IO support",
   "homepage": "https://github.com/baresip/re",
   "license": "BSD-3-Clause",

--- a/versions/b-/baresip-libre.json
+++ b/versions/b-/baresip-libre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bce3afb1f6d5fee73e4c7cd0f952df85f4f54de2",
+      "version": "3.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7b7cfa061bebae8f9628f0d56ca21de4ec1c68fa",
       "version": "3.9.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -533,7 +533,7 @@
       "port-version": 1
     },
     "baresip-libre": {
-      "baseline": "3.9.0",
+      "baseline": "3.10.0",
       "port-version": 0
     },
     "basisu": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
