### PR TITLE
[libmupdf] update to 1.24.0

### DIFF
--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ArtifexSoftware/mupdf
     REF "${VERSION}"
-    SHA512 248340d2cde5d97b4ccfabbdf5e8f2080dba6233031fa384dcfdb98022ecfd7d7feebe38b19f9b94c2768bfef41c361417c73240ea7f8a458c6b9ea9cfedf665
+    SHA512 a68f9f825bd10edc5094021bf8e151644beeb0b168cd1970e85064cc8e3d8dd2619102fa7b6e51e55c85bb70cd691cb6e4970c26df4d469edc7c6471402fef11
     HEAD_REF master
     PATCHES
         dont-generate-extract-3rd-party-things.patch

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmupdf",
-  "version": "1.23.11",
+  "version": "1.24.0",
   "description": "a lightweight PDF, XPS, and E-book library",
   "homepage": "https://github.com/ArtifexSoftware/mupdf",
   "license": "AGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4661,7 +4661,7 @@
       "port-version": 0
     },
     "libmupdf": {
-      "baseline": "1.23.11",
+      "baseline": "1.24.0",
       "port-version": 0
     },
     "libmysql": {

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02e40dc916bffa429388f01bdd28c9b2241432aa",
+      "version": "1.24.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ea6f82cee63a1056bfa2d88f5e7d0dbee3f64a5f",
       "version": "1.23.11",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

