### PR TITLE
[qpid-proton] update to 0.39.0

### DIFF
--- a/ports/qpid-proton/portfile.cmake
+++ b/ports/qpid-proton/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/qpid-proton
     REF "${VERSION}"
-    SHA512 05c3fded3db1fae0e6a7b9fbe34fe17af41a676a584ee916cbbeb82e957d7da74861524c5db06634326c403fabc82fddf938d018d9383745a6ce0cbc7a9eada3 
+    SHA512 38659682cc86bf0c910e2a707a5b166b3a7d0fb70fd83d6c5ebcaca53b2cd5a478adf36958d2c4c55a2ea6afcb9b457a12006a7967efae6ca2d0663c0febbc58
     HEAD_REF next
     PATCHES
         fix-dependencies.patch

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qpid-proton",
-  "version": "0.38.0",
-  "port-version": 1,
+  "version": "0.39.0",
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
   "homepage": "https://github.com/apache/qpid-proton",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7057,8 +7057,8 @@
       "port-version": 0
     },
     "qpid-proton": {
-      "baseline": "0.38.0",
-      "port-version": 1
+      "baseline": "0.39.0",
+      "port-version": 0
     },
     "qscintilla": {
       "baseline": "2.13.4",

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db5da8f926ec657a766ad368421593b1e507a05d",
+      "version": "0.39.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0a69d30375c0d5848b12cbdcaab4820b9d639223",
       "version": "0.38.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

