### PR TITLE
[openssl] Enforce cmd for nmake

### DIFF
--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version": "3.2.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/ports/openssl/windows/portfile.cmake
+++ b/ports/openssl/windows/portfile.cmake
@@ -1,3 +1,8 @@
+# Need cmd to pass quoted CC from nmake to mkbuildinf.pl, GH-37134
+find_program(CMD_EXECUTABLE cmd HINTS ENV PATH NO_DEFAULT_PATH REQUIRED)
+cmake_path(NATIVE_PATH CMD_EXECUTABLE cmd)
+set(ENV{COMSPEC} "${cmd}")
+
 vcpkg_find_acquire_program(PERL)
 get_filename_component(PERL_EXE_PATH "${PERL}" DIRECTORY)
 vcpkg_add_to_path("${PERL_EXE_PATH}")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6482,7 +6482,7 @@
     },
     "openssl": {
       "baseline": "3.2.1",
-      "port-version": 1
+      "port-version": 2
     },
     "openssl-unix": {
       "baseline": "deprecated",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d41de10fe318363c031b97457b7b6d473020a18",
+      "version": "3.2.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "3dc6df970a3aff9c977032299e481fd9872e0970",
       "version": "3.2.1",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/37134.
Fixes https://github.com/microsoft/vcpkg/issues/35949.