### PR TITLE
[qscintilla] update to 2.14.1

### DIFF
--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.13.4/QScintilla_src-2.13.4.tar.gz"
-    FILENAME "QScintilla-2.13.4.tar.gz"
-    SHA512 591379f4d48a6de1bc61db93f6c0d1c48b6830a852679b51e27debb866524c320e2db27d919baf32576c2bf40bba62e38378673a86f22db9839746e26b0f77cd
+    URLS "https://www.riverbankcomputing.com/static/Downloads/QScintilla/${VERSION}/QScintilla_src-${VERSION}.tar.gz"
+    FILENAME "QScintilla-${VERSION}.tar.gz"
+    SHA512 19e2f9e0a14947501c575018df368d24eb7f8c74e74faa5246db36415bf28dc0beee507ed0e73107c02b36a99bbaf55f0ef3349f479d2332e1b92b2c4a32788a
 )
 
 vcpkg_extract_source_archive(

--- a/ports/qscintilla/vcpkg.json
+++ b/ports/qscintilla/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qscintilla",
-  "version": "2.13.4",
-  "port-version": 2,
+  "version": "2.14.1",
   "description": "QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)",
   "homepage": "https://www.riverbankcomputing.com/software/qscintilla",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7061,8 +7061,8 @@
       "port-version": 1
     },
     "qscintilla": {
-      "baseline": "2.13.4",
-      "port-version": 2
+      "baseline": "2.14.1",
+      "port-version": 0
     },
     "qt": {
       "baseline": "6.6.1",

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3280645a840ece797868b44065cbbe3b609b4099",
+      "version": "2.14.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9b86f317966ccab4dcfecbff35fd2496ac29541e",
       "version": "2.13.4",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

