### PR TITLE
[ffmpeg] Add option to disable Truemotion1 decoder

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -513,6 +513,10 @@ else()
     set(OPTIONS "${OPTIONS} --disable-libmfx")
 endif()
 
+if ("disable-decoder-truemotion1" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --disable-decoder=truemotion1")
+endif()
+
 set(OPTIONS_CROSS "--enable-cross-compile")
 
 # ffmpeg needs --cross-prefix option to use appropriate tools for cross-compiling.

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "6.1.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -342,6 +342,9 @@
       "dependencies": [
         "dav1d"
       ]
+    },
+    "disable-decoder-truemotion1": {
+      "description": "Disable truemotion1 decoder"
     },
     "fdk-aac": {
       "description": "AAC de/encoding via libfdk-aac, **including GPL-incompatible patent-encumbered HE-AAC**. If you do not require HE-AAC, use the built-in FFmpeg AAC codec.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2658,7 +2658,7 @@
     },
     "ffmpeg": {
       "baseline": "6.1.1",
-      "port-version": 2
+      "port-version": 3
     },
     "ffnvcodec": {
       "baseline": "12.1.14.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78ff99e8b4f1ffdd419248fda91444c03743ce45",
+      "version": "6.1.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "2b85222da88d04c67c9b83d24a278c5821f5f0b0",
       "version": "6.1.1",
       "port-version": 2


### PR DESCRIPTION
The Truemotion1 decoder uses the truemotion1data.h file, which uses code that was under GPL license. Although the file contains a rationale for why the author believes this code can not be copyrighted, it can be useful with an option to disable the decoder.

Excerpt from truemotion1data.h docstring:

    Data in this file was originally part of VpVision from On2 which is
    distributed under the GNU GPL. It is redistributed with libavcodec under
    the GNU LGPL using the common understanding that data tables necessary
    for decoding algorithms are not necessarily copyrightable.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.