### PR TITLE
[vk-bootstrap] Fix usage

### DIFF
--- a/ports/vk-bootstrap/fix-targets.patch
+++ b/ports/vk-bootstrap/fix-targets.patch
@@ -7,7 +7,7 @@ index 43bc5cd..7d626fb 100644
              endif()
          endif()
 -        include(@PACKAGE_VK_BOOTSTRAP_EXPORT_TARGETS@)
-+        include(vk-bootstrap-targets.cmake)
++        include("${CMAKE_CURRENT_LIST_DIR}/vk-bootstrap-targets.cmake")
      ]=])
  
      configure_package_config_file(

--- a/ports/vk-bootstrap/fix-targets.patch
+++ b/ports/vk-bootstrap/fix-targets.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 43bc5cd..7d626fb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -137,7 +137,7 @@ if (VK_BOOTSTRAP_INSTALL)
+                 message(FATAL_ERROR "Unable to locate required dependency Vulkan::Headers!")
+             endif()
+         endif()
+-        include(@PACKAGE_VK_BOOTSTRAP_EXPORT_TARGETS@)
++        include(vk-bootstrap-targets.cmake)
+     ]=])
+ 
+     configure_package_config_file(

--- a/ports/vk-bootstrap/portfile.cmake
+++ b/ports/vk-bootstrap/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 f925665b1d7a1c5069ca2cb6786f537bcc4b3060757db50d931091dc37ff4ef3b73b1b3adf0da84c256979fd780a2f6203de3299f634292600dcee925b9a5091
     HEAD_REF master
+    PATCHES
+        fix-targets.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/vk-bootstrap/vcpkg.json
+++ b/ports/vk-bootstrap/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vk-bootstrap",
   "version": "1.3.279",
+  "port-version": 1,
   "description": "Vulkan bootstraping library",
   "homepage": "https://github.com/charles-lunarg/vk-bootstrap",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9094,7 +9094,7 @@
     },
     "vk-bootstrap": {
       "baseline": "1.3.279",
-      "port-version": 0
+      "port-version": 1
     },
     "vkfft": {
       "baseline": "1.2.31",

--- a/versions/v-/vk-bootstrap.json
+++ b/versions/v-/vk-bootstrap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "458caf649650dd286434d892ecaaa9d08c5d5c16",
+      "version": "1.3.279",
+      "port-version": 1
+    },
+    {
       "git-tree": "21ca238dc37af23280c0bc7755bfbb7055057188",
       "version": "1.3.279",
       "port-version": 0

--- a/versions/v-/vk-bootstrap.json
+++ b/versions/v-/vk-bootstrap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "458caf649650dd286434d892ecaaa9d08c5d5c16",
+      "git-tree": "33aa9fad865d5e7536507780f794845077d75a9c",
       "version": "1.3.279",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
