### PR TITLE
[libcoro] Improved usability.

### DIFF
--- a/ports/libcoro/portfile.cmake
+++ b/ports/libcoro/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/libcoro/usage
+++ b/ports/libcoro/usage
@@ -1,0 +1,6 @@
+libcoro does not directly provide CMake targets.
+CMake targets can be created using PkgConfig though:
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(libcoro REQUIRED IMPORTED_TARGET libcoro)
+    target_link_libraries(main PkgConfig::libcoro)

--- a/ports/libcoro/vcpkg.json
+++ b/ports/libcoro/vcpkg.json
@@ -6,12 +6,12 @@
   "license": "Apache-2.0",
   "dependencies": [
     {
-      "name": "vcpkg-cmake",
+      "name": "pkgconf",
       "host": true
     },
     {
-        "name": "pkgconf",
-        "host": true
+      "name": "vcpkg-cmake",
+      "host": true
     }
   ],
   "features": {

--- a/ports/libcoro/vcpkg.json
+++ b/ports/libcoro/vcpkg.json
@@ -8,6 +8,10 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+        "name": "pkgconf",
+        "host": true
     }
   ],
   "features": {

--- a/versions/l-/libcoro.json
+++ b/versions/l-/libcoro.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b518fbd7c395e04a3a720c1aba78a3a9a94930e9",
+      "git-tree": "da0255d04de666156d6d8b1e0f22359caede95bd",
       "version": "0.11.1",
       "port-version": 0
     },


### PR DESCRIPTION
- Added usage instructions.
- Added PkgConfig as dependency since it is needed for linking.

Fixes #37697 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.