### PR TITLE
[restinio] update to 0.7.2

### DIFF
--- a/ports/restinio/portfile.cmake
+++ b/ports/restinio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stiffstream/restinio
     REF "v.${VERSION}"
-    SHA512 b5932a08687ef2d3ae02d0b0b1384b3462706ce207f16126efa8cd3dcea130d823863169dd5088b12b8c69761ccd044b447c2fe04f31ee10d26ff33d088606ee
+    SHA512 ac47e83b2fdcbf5a42b3b5af8f5db7f400baa18515c6a042ee6aacc77df03aa1a90f14a57a1127ce2472bf72dc568160ff3c07aaddd4235910b7b831bcfcf569
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only

--- a/ports/restinio/vcpkg.json
+++ b/ports/restinio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "restinio",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A header-only C++14 library that gives you an embedded HTTP/Websocket server targeted primarily for asynchronous processing of HTTP-requests.",
   "homepage": "https://github.com/Stiffstream/restinio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7641,7 +7641,7 @@
       "port-version": 0
     },
     "restinio": {
-      "baseline": "0.7.1",
+      "baseline": "0.7.2",
       "port-version": 0
     },
     "rexo": {

--- a/versions/r-/restinio.json
+++ b/versions/r-/restinio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa093f294381710788902b37a1d8e4625d730990",
+      "version": "0.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b59b3fc1e00b5abdfbbedaeb495e2816aeee1b44",
       "version": "0.7.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

