### PR TITLE
[rtmidi] update to 6.0.0

### DIFF
--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO thestk/rtmidi
-    REF 84a99422a3faf1ab417fe71c0903a48debb9376a # 5.0.0
-    SHA512 388e280b7966281e22b0048d6fb2541921df1113d84e49bbc444fff591d2025588edd8d61dbe5ff017afd76c26fd05edc8f9f15d0cce16315ccc15e6aac1d57f
+    REF "${VERSION}"
+    SHA512 7ff7f85ff86fc019ab7906a46efc986b2a340b2f9a9d504bda85d0afc75921b905b32cb37f87e30ab9d1f13e62587c4ade736dad1609a0880eeab3fe5a936acb
     HEAD_REF master
     PATCHES
         fix-cmake-usage.patch # Remove this patch in the next update

--- a/ports/rtmidi/vcpkg.json
+++ b/ports/rtmidi/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rtmidi",
-  "version": "5.0.0",
-  "port-version": 3,
+  "version": "6.0.0",
   "description": "A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)",
   "homepage": "https://github.com/thestk/rtmidi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7757,8 +7757,8 @@
       "port-version": 0
     },
     "rtmidi": {
-      "baseline": "5.0.0",
-      "port-version": 3
+      "baseline": "6.0.0",
+      "port-version": 0
     },
     "rttr": {
       "baseline": "0.9.6+20210811",

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c560568b8b016483b625d1fa2ff563178250b64a",
+      "version": "6.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "83f2bd1bc41359997ee59a894bbfe5aab7e5a5df",
       "version": "5.0.0",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

