### PR TITLE
[ryu] update to 4.30

### DIFF
--- a/ports/ryu/portfile.cmake
+++ b/ports/ryu/portfile.cmake
@@ -40,8 +40,8 @@ endfunction()
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ulfjack/ryu
-        REF v2.0
-        SHA512 88a0cca74a4889e8e579987abdc75a6ac87c1cdae557e5a15c29dbfd65733f9e591d6569e97a9374444918475099087f8056e696a97c9be24e38eb737e2304c2
+        REF "v${VERSION}"
+        SHA512 0
         HEAD_REF master
 )
 

--- a/ports/ryu/vcpkg.json
+++ b/ports/ryu/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ryu",
-  "version": "2.0",
-  "port-version": 9,
+  "version": "4.30",
   "description": "Ryu generates the shortest decimal representation of a floating point number that maintains round-trip safety.",
   "homepage": "https://github.com/ulfjack/ryu",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7785,8 +7785,8 @@
       "port-version": 0
     },
     "ryu": {
-      "baseline": "2.0",
-      "port-version": 9
+      "baseline": "4.30",
+      "port-version": 0
     },
     "s2geometry": {
       "baseline": "0.11.1",

--- a/versions/r-/ryu.json
+++ b/versions/r-/ryu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99fdd393611df3edf304ad8153575622f836208b",
+      "version": "4.30",
+      "port-version": 0
+    },
+    {
       "git-tree": "c19f7f75e6695396873fa98b4d39512899a34fb5",
       "version": "2.0",
       "port-version": 9


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

