### PR TITLE
[vcpkg-qmake] Remove unnecessary directory

### DIFF
--- a/ports/vcpkg-qmake/vcpkg.json
+++ b/ports/vcpkg-qmake/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vcpkg-qmake",
   "version-date": "2023-03-22",
+  "port-version": 1,
   "documentation": "https://vcpkg.io/en/docs/README.html",
   "license": "MIT",
   "supports": "native",

--- a/ports/vcpkg-qmake/vcpkg_qmake_configure.cmake
+++ b/ports/vcpkg-qmake/vcpkg_qmake_configure.cmake
@@ -146,7 +146,6 @@ function(vcpkg_qmake_configure)
         vcpkg_host_path_list(PREPEND PKG_CONFIG_PATH "${prefix}/lib/pkgconfig" "${CURRENT_INSTALLED_DIR}/share/pkgconfig")
 
         message(STATUS "Configuring ${config_triplet}")
-        file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${config_triplet}")
         if(DEFINED arg_OPTIONS OR DEFINED arg_OPTIONS_${buildtype})
             set(options -- ${arg_OPTIONS} ${arg_OPTIONS_${buildtype}})
         endif()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9026,7 +9026,7 @@
     },
     "vcpkg-qmake": {
       "baseline": "2023-03-22",
-      "port-version": 0
+      "port-version": 1
     },
     "vcpkg-tool-bazel": {
       "baseline": "5.2.0",

--- a/versions/v-/vcpkg-qmake.json
+++ b/versions/v-/vcpkg-qmake.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "777a5dadc7b8c11b81d401098c70d3d66d4172b5",
+      "version-date": "2023-03-22",
+      "port-version": 1
+    },
+    {
       "git-tree": "82e22019ae07b7150c3fb2a8672d4192eed2782c",
       "version-date": "2023-03-22",
       "port-version": 0


### PR DESCRIPTION
Recently when I was using vcpkg-qmake, I found that a function in the `ports/vcpkg-qmake/vcpkg_qmake_configure.cmake` file was repeated:
https://github.com/microsoft/vcpkg/blob/be9eb6694585a8db137872b29fcad3619a5f893a/ports/vcpkg-qmake/vcpkg_qmake_configure.cmake#L143
By running this line of code, we will configure the generated `qt.conf` file. At the same time, if the `${CURRENT_BUILDTREES_DIR}/${config_triplet}/` path does not exist, we will also generate it. 
Then we back up the environment variables and run the code https://github.com/microsoft/vcpkg/blob/be9eb6694585a8db137872b29fcad3619a5f893a/ports/vcpkg-qmake/vcpkg_qmake_configure.cmake#L149 to generate the existing path above.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.