### PR TITLE
[aliyun-oss-c-sdk] Update to 3.10.1

### DIFF
--- a/ports/aliyun-oss-c-sdk/portfile.cmake
+++ b/ports/aliyun-oss-c-sdk/portfile.cmake
@@ -1,15 +1,11 @@
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "${PORT} does not currently support UWP")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aliyun/aliyun-oss-c-sdk
-    REF f9e441137620d712c7d89587c951bed459ebc843 # 3.10.0
-    SHA512 6621d105706fb69b3f1998d7c83c94ff93747946040f0c45ec52986c0e8d8db3d48237d1e3f0959e09536ca43bcbe3bcdb32f90622ce51de6ea7132be6dd7cf7
+    REF ${VERSION}
+    SHA512 f92b2dac43bdfe1a5c9fc012325751ee83d6f5c5f5a646ac8606894c458bd9488bc4a56f926218b213cb905becccddd976e8e94a257d77adf4269d48df27638e
     HEAD_REF master
-	PATCHES
-	patch.patch
+    PATCHES
+        patch.patch
 )
 
 vcpkg_cmake_configure(
@@ -19,4 +15,4 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/aliyun-oss-c-sdk/vcpkg.json
+++ b/ports/aliyun-oss-c-sdk/vcpkg.json
@@ -1,18 +1,15 @@
 {
   "name": "aliyun-oss-c-sdk",
-  "version": "3.10.0",
-  "port-version": 3,
+  "version": "3.10.1",
   "description": "Alibaba Cloud Object Storage Service (OSS) is a cloud storage service provided by Alibaba Cloud, featuring massive capacity, security, a low cost, and high reliability.",
+  "homepage": "https://github.com/aliyun/aliyun-oss-c-sdk",
+  "license": "MIT",
   "supports": "!(uwp | linux | osx)",
   "dependencies": [
     "apr-util",
     "curl",
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/a-/aliyun-oss-c-sdk.json
+++ b/versions/a-/aliyun-oss-c-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "680bc0ab5a25c9d9ef3191d9ba9f7fe2ae3829b7",
+      "version": "3.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a6710098ecdb98956fdde32c883a45e2abae333",
       "version": "3.10.0",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -77,8 +77,8 @@
       "port-version": 0
     },
     "aliyun-oss-c-sdk": {
-      "baseline": "3.10.0",
-      "port-version": 3
+      "baseline": "3.10.1",
+      "port-version": 0
     },
     "allegro5": {
       "baseline": "5.2.9.1",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Update `aliyun-oss-c-sdk` to the latest 3.10.1 version.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
