### PR TITLE
[rply] Add support for non-prefixed includes

### DIFF
--- a/ports/rply/CMakeLists.txt
+++ b/ports/rply/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library (${target_name} ${target_srcs} ${target_headers} ${sources_msvc})
 
 target_include_directories (${target_name}
     PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${target_name}>
 )
 
 set_target_properties(${target_name} PROPERTIES

--- a/ports/rply/portfile.cmake
+++ b/ports/rply/portfile.cmake
@@ -28,5 +28,4 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup()
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rply/portfile.cmake
+++ b/ports/rply/portfile.cmake
@@ -27,5 +27,5 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup()
 
-# Handle copyright
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rply/usage
+++ b/ports/rply/usage
@@ -1,0 +1,4 @@
+The rply port provides an unofficial CMake target:
+
+    find_package(rply REQUIRED)
+    target_link_libraries(main PRIVATE rply::rply)

--- a/ports/rply/vcpkg.json
+++ b/ports/rply/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rply",
   "version": "1.1.4",
-  "port-version": 3,
+  "port-version": 4,
   "description": "ANSI C Library for PLY file format input and output",
   "homepage": "http://w3.impa.br/~diego/software/rply",
   "dependencies": [

--- a/ports/rply/vcpkg.json
+++ b/ports/rply/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 4,
   "description": "ANSI C Library for PLY file format input and output",
   "homepage": "http://w3.impa.br/~diego/software/rply",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -998,15 +998,6 @@ rest-rpc:arm64-osx=skip
 rpclib:arm64-windows=fail
 rpclib:arm64-uwp=fail
 rpclib:x64-uwp=fail
-#The website of rply http://w3.impa.br/~diego/software/rply cannot be accessed
-rply:x86-windows=skip
-rply:x64-windows=skip
-rply:x64-windows-static=skip
-rply:x64-uwp=skip
-rply:arm64-windows=skip
-rply:x64-linux=skip
-rply:x64-osx=skip
-rply:x64-windows-static-md=skip
 salome-medcoupling:x64-linux=fail
 scintilla:arm-neon-android=fail
 scintilla:arm64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7714,7 +7714,7 @@
     },
     "rply": {
       "baseline": "1.1.4",
-      "port-version": 3
+      "port-version": 4
     },
     "rsasynccpp": {
       "baseline": "0.0.7",

--- a/versions/r-/rply.json
+++ b/versions/r-/rply.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a51554c8ca47a6eaf4494d991cf8acb96d5a1b1",
+      "git-tree": "b74bc6cd3468c54791750803926f2d58a54d2ab9",
       "version": "1.1.4",
       "port-version": 4
     },

--- a/versions/r-/rply.json
+++ b/versions/r-/rply.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b74bc6cd3468c54791750803926f2d58a54d2ab9",
+      "git-tree": "7adc1bc3b350c2a61baf3d54bf4cdfdc02e11392",
       "version": "1.1.4",
       "port-version": 4
     },

--- a/versions/r-/rply.json
+++ b/versions/r-/rply.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a51554c8ca47a6eaf4494d991cf8acb96d5a1b1",
+      "version": "1.1.4",
+      "port-version": 4
+    },
+    {
       "git-tree": "824058a46ec01bf8d290a56e3b42f1b01ef4ce68",
       "version": "1.1.4",
       "port-version": 3


### PR DESCRIPTION
The custom CMakeLists.txt in the port installs headers under `rply/` and expects `#include <rply/rply.h>` correspondingly as the include. However, the code samples in the RPly project use a plain `#include "rply.h"` instead: https://w3.impa.br/~diego/software/rply/

This PR adds `include/rply/` to the `target_include_directories()` to support both conventions.

The project exports only two distinctly-named headers (`rply.h` and `rplyfile.h`) so the non-prefixed includes causing a collision somewhere is unlikely.

Also added license info to vcpkg.json and a usage file.