### PR TITLE
[qhull] Patch for C++20 support

### DIFF
--- a/ports/qhull/fix-qhullcpp-cpp20-support.patch
+++ b/ports/qhull/fix-qhullcpp-cpp20-support.patch
@@ -1,0 +1,93 @@
+From bdd99371b995e02d6b39acc93221c477aafd284a Mon Sep 17 00:00:00 2001
+From: Jeremy Nimmer <jeremy.nimmer@tri.global>
+Date: Thu, 22 Sep 2022 17:39:19 -0700
+Subject: [PATCH] Fix build errors when in C++20 mode
+
+---
+ src/libqhullcpp/QhullLinkedList.h | 12 +++++++-----
+ src/libqhullcpp/QhullSet.h        | 22 +++++++++++-----------
+ 2 files changed, 18 insertions(+), 16 deletions(-)
+
+diff --git a/src/libqhullcpp/QhullLinkedList.h b/src/libqhullcpp/QhullLinkedList.h
+index 9f145ee..7c7104d 100644
+--- a/src/libqhullcpp/QhullLinkedList.h
++++ b/src/libqhullcpp/QhullLinkedList.h
+@@ -62,16 +62,18 @@ private:
+ 
+ #//!\name Constructors
+ public:
+-                        QhullLinkedList<T>(T b, T e) : begin_node(b), end_node(e) {}
++
++                        QhullLinkedList(T b, T e) : begin_node(b), end_node(e) {}
+                         //! Copy constructor copies begin_node and end_node, but not the list elements.  Needed for return by value and parameter passing.
+-                        QhullLinkedList<T>(const QhullLinkedList<T> &other) : begin_node(other.begin_node), end_node(other.end_node) {}
++
++                        QhullLinkedList(const QhullLinkedList<T> &other) : begin_node(other.begin_node), end_node(other.end_node) {}
+                         //! Copy assignment copies begin_node and end_node, but not the list elements.
+-                        QhullLinkedList<T> & operator=(const QhullLinkedList<T> &other) { begin_node= other.begin_node; end_node= other.end_node; return *this; }
+-                        ~QhullLinkedList<T>() {}
++                        QhullLinkedList & operator=(const QhullLinkedList &other) { begin_node= other.begin_node; end_node= other.end_node; return *this; }
++                        ~QhullLinkedList() {}
+ 
+ private:
+                         //!disabled since a sentinel must be allocated as the private type
+-                        QhullLinkedList<T>() {}
++                        QhullLinkedList() {}
+ 
+ public:
+ 
+diff --git a/src/libqhullcpp/QhullSet.h b/src/libqhullcpp/QhullSet.h
+index f6b248a..803e703 100644
+--- a/src/libqhullcpp/QhullSet.h
++++ b/src/libqhullcpp/QhullSet.h
+@@ -110,17 +110,17 @@ public:
+     typedef typename QhullSet<T>::const_iterator ConstIterator;
+ 
+ #//!\name Constructors
+-                        QhullSet<T>(const Qhull &q, setT *s) : QhullSetBase(q, s) { }
+-                        QhullSet<T>(QhullQh *qqh, setT *s) : QhullSetBase(qqh, s) { }
++                        QhullSet(const Qhull &q, setT *s) : QhullSetBase(q, s) { }
++                        QhullSet(QhullQh *qqh, setT *s) : QhullSetBase(qqh, s) { }
+                         //Conversion from setT* is not type-safe.  Implicit conversion for void* to T
+                         //Copy constructor copies pointer but not contents.  Needed for return by value.
+-                        QhullSet<T>(const QhullSet<T> &other) : QhullSetBase(other) {}
+-    QhullSet<T> &       operator=(const QhullSet<T> &other) { QhullSetBase::operator=(other); return *this; }
+-                        ~QhullSet<T>() {}
++                        QhullSet(const QhullSet &other) : QhullSetBase(other) {}
++    QhullSet<T> &       operator=(const QhullSet &other) { QhullSetBase::operator=(other); return *this; }
++                        ~QhullSet() {}
+ 
+ private:
+                         //!Disable default constructor.  See QhullSetBase
+-                        QhullSet<T>();
++                        QhullSet();
+ public:
+ 
+ #//!\name Conversion
+@@ -136,8 +136,8 @@ public:
+     using QhullSetBase::count;
+     using QhullSetBase::isEmpty;
+     // operator== defined for QhullSets of the same type
+-    bool                operator==(const QhullSet<T> &other) const { return qh_setequal(getSetT(), other.getSetT()); }
+-    bool                operator!=(const QhullSet<T> &other) const { return !operator==(other); }
++    bool                operator==(const QhullSet &other) const { return qh_setequal(getSetT(), other.getSetT()); }
++    bool                operator!=(const QhullSet &other) const { return !operator==(other); }
+ 
+ #//!\name Element access
+     // Constructs T.  Cannot return reference.
+@@ -294,9 +294,9 @@ private:
+ 
+ public:
+ #//!\name Constructors
+-                        QhullSetIterator<T>(const QhullSet<T> &s) : i(s.data()), begin_i(i), end_i(s.endData()), qh_qh(s.qh()) {}
+-                        QhullSetIterator<T>(const QhullSetIterator<T> &o) : i(o.i), begin_i(o.begin_i), end_i(o.end_i), qh_qh(o.qh_qh) {}
+-    QhullSetIterator<T> &operator=(const QhullSetIterator<T> &o) { i= o.i; begin_i= o.begin_i; end_i= o.end_i; qh_qh= o.qh_qh; return *this; }
++                        QhullSetIterator(const QhullSet<T> &s) : i(s.data()), begin_i(i), end_i(s.endData()), qh_qh(s.qh()) {}
++                        QhullSetIterator(const QhullSetIterator<T> &o) : i(o.i), begin_i(o.begin_i), end_i(o.end_i), qh_qh(o.qh_qh) {}
++    QhullSetIterator &operator=(const QhullSetIterator &o) { i= o.i; begin_i= o.begin_i; end_i= o.end_i; qh_qh= o.qh_qh; return *this; }
+ 
+ #//!\name ReadOnly
+     countT              countRemaining() { return static_cast<countT>(end_i-i); } // WARN64
+-- 
+2.44.0
+

--- a/ports/qhull/portfile.cmake
+++ b/ports/qhull/portfile.cmake
@@ -4,10 +4,11 @@ vcpkg_from_github(
     REF 613debeaea72ee66626dace9ba1a2eff11b5d37d
     SHA512 5b8ff9665ba73621a9859a6e86717b980b67f8d79d6c78cbf5672bce66aed671f7d64fcbec457bca79eef2e17e105f136017afdf442bb430b9f4a059d7cb93c3
     HEAD_REF master
-    PATCHES 
+    PATCHES
         include-qhullcpp-shared.patch
         fix-missing-symbols.patch # upstream https://github.com/qhull/qhull/pull/93
         noapp.patch # upstream https://github.com/qhull/qhull/pull/124
+        fix-qhullcpp-cpp20-support.patch # upstream https://github.com/qhull/qhull/pull/122
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC_LIBS)

--- a/ports/qhull/vcpkg.json
+++ b/ports/qhull/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qhull",
   "version": "8.0.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": "computes the convex hull, Delaunay triangulation, Voronoi diagram",
   "homepage": "https://github.com/qhull/qhull",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7046,7 +7046,7 @@
     },
     "qhull": {
       "baseline": "8.0.2",
-      "port-version": 4
+      "port-version": 5
     },
     "qnnpack": {
       "baseline": "2021-02-26",

--- a/versions/q-/qhull.json
+++ b/versions/q-/qhull.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c30770c608574944db1c98437d356af3e64fe5b",
+      "version": "8.0.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "1cfdbe28c32936c2ac6c9fb8d269f81c2a96415f",
       "version": "8.0.2",
       "port-version": 4


### PR DESCRIPTION
This PR adds a patch from upstream that fixes C++20 support. [In C++20, template parameters from the class template are no longer allowed in constructors and destructors declarations](https://eel.is/c++draft/diff.cpp17#class-2). The Qhull C++ headers have a few instances of these, and don't compile under compliant C++20 (or later). Specifically, since version 11, GCC generates an error diagnostic.

[While this has been fixed in the upstream](https://github.com/qhull/qhull/pull/122), the slow Qhull release cycle means it might be quite a while longer until a new official release it available. It's already been a year and a half since the fix, [and the next release is still in alpha](https://github.com/qhull/qhull/wiki#qhull-81-alpha3-20230102) with no clear timeline. As C++20 becomes more mainstream, I believe it's important to ensure support for this library.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.