### PR TITLE
[sbp] update to 5.0.4

### DIFF
--- a/ports/sbp/portfile.cmake
+++ b/ports/sbp/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO swift-nav/libsbp
-    REF v3.4.10
-    SHA512 bbdcefad9ff8995759b577790bcffb94355bd0ee29f259fa8d51f54907e252b55871dc5a841e21d23e661fd5b33109761eb20b66c2fb73e9e7de8a34cc8d6528
+    REF "v${VERSION}"
+    SHA512 4d86f71cffa57a2c028dd9e81505b6e277fc39ab0a8214660df1d4cbe6d26bbe5f7ba0b56456dc3fb1995628ddefe3b6e557f36abf1fc98dd3813213a024fdb4
     HEAD_REF master
     PATCHES
       "win32-install-fix.patch"
@@ -17,8 +17,8 @@ vcpkg_from_github(
 vcpkg_from_github(
     OUT_SOURCE_PATH CMAKE_EXTRA_MODS
     REPO swift-nav/cmake
-    REF 373d4fcafbbc0c208dc9ecb278d36ed8c9448eda
-    SHA512 afefc8c7a3fb43ee65b9b8733968a5836938460abbf1bc9e8330f83c3ac4a5819f71a36dcb034004296161c592f4d61545ba10016d6666e7eaf1dca556d99e2e
+    REF "v${VERSION}"
+    SHA512 4d86f71cffa57a2c028dd9e81505b6e277fc39ab0a8214660df1d4cbe6d26bbe5f7ba0b56456dc3fb1995628ddefe3b6e557f36abf1fc98dd3813213a024fdb4
     HEAD_REF master
 )
 

--- a/ports/sbp/vcpkg.json
+++ b/ports/sbp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sbp",
-  "version-semver": "3.4.10",
-  "port-version": 1,
+  "version-semver": "5.0.4",
   "description": "Swift Navigation Binary Protocol (SBP) is a binary protocol for communicating GNSS data used by Piksi devices.",
   "homepage": "https://github.com/swift-nav/libsbp",
   "documentation": "https://support.swiftnav.com/support/solutions/articles/44001850782-swift-binary-protocol",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7829,8 +7829,8 @@
       "port-version": 0
     },
     "sbp": {
-      "baseline": "3.4.10",
-      "port-version": 1
+      "baseline": "5.0.4",
+      "port-version": 0
     },
     "scenepic": {
       "baseline": "1.1.0",

--- a/versions/s-/sbp.json
+++ b/versions/s-/sbp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45f68901b44b545905092618eaccc9813f24173a",
+      "version-semver": "5.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "ef46c718c23128379c5050d907d0a90d335206b3",
       "version-semver": "3.4.10",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

