### PR TITLE
[qscintilla] Add CMake export

### DIFF
--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -49,5 +49,7 @@ endif()
 
 vcpkg_copy_pdbs()
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-qscintilla-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")
+
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -51,17 +51,5 @@ vcpkg_copy_pdbs()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-qscintilla-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")
 
-if(VCPKG_TARGET_IS_IOS)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-qscintilla-config.cmake"
-        "QT_LINK_LIBRARIES"
-        "Qt6::Widgets"
-    )
-else()
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-qscintilla-config.cmake"
-        "QT_LINK_LIBRARIES"
-        "Qt6::PrintSupport;Qt6::Widgets"
-    )
-endif()
-
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -51,5 +51,17 @@ vcpkg_copy_pdbs()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-qscintilla-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")
 
+if(VCPKG_TARGET_IS_IOS)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-qscintilla-config.cmake"
+        "QT_LINK_LIBRARIES"
+        "Qt6::Widgets"
+    )
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-qscintilla-config.cmake"
+        "QT_LINK_LIBRARIES"
+        "Qt6::PrintSupport;Qt6::Widgets"
+    )
+endif()
+
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qscintilla/unofficial-qscintilla-config.cmake
+++ b/ports/qscintilla/unofficial-qscintilla-config.cmake
@@ -4,6 +4,10 @@ if(NOT TARGET unofficial::qscintilla::qscintilla)
     get_filename_component(z_vcpkg_qscintilla_root "${z_vcpkg_qscintilla_root}" PATH)
     get_filename_component(z_vcpkg_qscintilla_root "${z_vcpkg_qscintilla_root}" PATH)
 
+    include(CMakeFindDependencyMacro)
+    find_dependency(Qt6PrintSupport CONFIG)
+    find_dependency(Qt6Widgets CONFIG)
+
     set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${z_vcpkg_qscintilla_root}/include"
     )
@@ -11,13 +15,17 @@ if(NOT TARGET unofficial::qscintilla::qscintilla)
     find_library(Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE NAMES libqscintilla2_qt6 qscintilla2_qt6 PATHS "${z_vcpkg_qscintilla_root}/lib" NO_DEFAULT_PATH)
     if(EXISTS "${Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE}")
         set_property(TARGET unofficial::qscintilla::qscintilla APPEND PROPERTY IMPORTED_CONFIGURATIONS "Release")
-        set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES IMPORTED_LOCATION_RELEASE "${Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE}")
+        set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES
+            IMPORTED_LOCATION_RELEASE "${Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE}"
+            INTERFACE_LINK_LIBRARIES "Qt::PrintSupport;Qt6::PrintSupport;Qt::PrintSupportPrivate;Qt6::PrintSupportPrivate;Qt::Widgets;Qt6::Widgets;Qt::WidgetsPrivate;Qt6::WidgetsPrivate")
     endif()
 
     find_library(Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG NAMES libqscintilla2_qt6 qscintilla2_qt6d libqscintilla2_qt6_debug PATHS "${z_vcpkg_qscintilla_root}/debug/lib" NO_DEFAULT_PATH)
     if(EXISTS "${Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG}")
         set_property(TARGET unofficial::qscintilla::qscintilla APPEND PROPERTY IMPORTED_CONFIGURATIONS "Debug")
-        set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES IMPORTED_LOCATION_DEBUG "${Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG}")
+        set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES
+            IMPORTED_LOCATION_DEBUG "${Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG}"
+            INTERFACE_LINK_LIBRARIES "Qt::PrintSupport;Qt6::PrintSupport;Qt::PrintSupportPrivate;Qt6::PrintSupportPrivate;Qt::Widgets;Qt6::Widgets;Qt::WidgetsPrivate;Qt6::WidgetsPrivate")
     endif()
 
     unset(z_vcpkg_qscintilla_root)

--- a/ports/qscintilla/unofficial-qscintilla-config.cmake
+++ b/ports/qscintilla/unofficial-qscintilla-config.cmake
@@ -1,31 +1,36 @@
 if(NOT TARGET unofficial::qscintilla::qscintilla)
+    include(CMakeFindDependencyMacro)
+    find_dependency(Qt6Widgets CONFIG)
+    if(NOT IOS)
+        find_dependency(Qt6PrintSupport CONFIG)
+    endif()
+
     add_library(unofficial::qscintilla::qscintilla UNKNOWN IMPORTED)
     get_filename_component(z_vcpkg_qscintilla_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
     get_filename_component(z_vcpkg_qscintilla_root "${z_vcpkg_qscintilla_root}" PATH)
     get_filename_component(z_vcpkg_qscintilla_root "${z_vcpkg_qscintilla_root}" PATH)
-
-    include(CMakeFindDependencyMacro)
-    find_dependency(Qt6PrintSupport CONFIG)
-    find_dependency(Qt6Widgets CONFIG)
-
+    
     set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${z_vcpkg_qscintilla_root}/include"
+      INTERFACE_LINK_LIBRARIES Qt6::Widgets
     )
 
+    if(NOT IOS)
+        set_property(TARGET unofficial::qscintilla::qscintilla APPEND PROPERTY INTERFACE_LINK_LIBRARIES Qt6::PrintSupport)
+    endif()
+    
     find_library(Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE NAMES libqscintilla2_qt6 qscintilla2_qt6 PATHS "${z_vcpkg_qscintilla_root}/lib" NO_DEFAULT_PATH)
     if(EXISTS "${Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE}")
         set_property(TARGET unofficial::qscintilla::qscintilla APPEND PROPERTY IMPORTED_CONFIGURATIONS "Release")
         set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES
-            IMPORTED_LOCATION_RELEASE "${Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE}"
-            INTERFACE_LINK_LIBRARIES "QT_LINK_LIBRARIES")
+            IMPORTED_LOCATION_RELEASE "${Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE}")
     endif()
 
     find_library(Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG NAMES libqscintilla2_qt6 qscintilla2_qt6d libqscintilla2_qt6_debug PATHS "${z_vcpkg_qscintilla_root}/debug/lib" NO_DEFAULT_PATH)
     if(EXISTS "${Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG}")
         set_property(TARGET unofficial::qscintilla::qscintilla APPEND PROPERTY IMPORTED_CONFIGURATIONS "Debug")
         set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES
-            IMPORTED_LOCATION_DEBUG "${Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG}"
-            INTERFACE_LINK_LIBRARIES "QT_LINK_LIBRARIES")
+            IMPORTED_LOCATION_DEBUG "${Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG}")
     endif()
 
     unset(z_vcpkg_qscintilla_root)

--- a/ports/qscintilla/unofficial-qscintilla-config.cmake
+++ b/ports/qscintilla/unofficial-qscintilla-config.cmake
@@ -17,7 +17,7 @@ if(NOT TARGET unofficial::qscintilla::qscintilla)
         set_property(TARGET unofficial::qscintilla::qscintilla APPEND PROPERTY IMPORTED_CONFIGURATIONS "Release")
         set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES
             IMPORTED_LOCATION_RELEASE "${Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE}"
-            INTERFACE_LINK_LIBRARIES "Qt::PrintSupport;Qt6::PrintSupport;Qt::PrintSupportPrivate;Qt6::PrintSupportPrivate;Qt::Widgets;Qt6::Widgets;Qt::WidgetsPrivate;Qt6::WidgetsPrivate")
+            INTERFACE_LINK_LIBRARIES "QT_LINK_LIBRARIES")
     endif()
 
     find_library(Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG NAMES libqscintilla2_qt6 qscintilla2_qt6d libqscintilla2_qt6_debug PATHS "${z_vcpkg_qscintilla_root}/debug/lib" NO_DEFAULT_PATH)
@@ -25,7 +25,7 @@ if(NOT TARGET unofficial::qscintilla::qscintilla)
         set_property(TARGET unofficial::qscintilla::qscintilla APPEND PROPERTY IMPORTED_CONFIGURATIONS "Debug")
         set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES
             IMPORTED_LOCATION_DEBUG "${Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG}"
-            INTERFACE_LINK_LIBRARIES "Qt::PrintSupport;Qt6::PrintSupport;Qt::PrintSupportPrivate;Qt6::PrintSupportPrivate;Qt::Widgets;Qt6::Widgets;Qt::WidgetsPrivate;Qt6::WidgetsPrivate")
+            INTERFACE_LINK_LIBRARIES "QT_LINK_LIBRARIES")
     endif()
 
     unset(z_vcpkg_qscintilla_root)

--- a/ports/qscintilla/unofficial-qscintilla-config.cmake
+++ b/ports/qscintilla/unofficial-qscintilla-config.cmake
@@ -1,0 +1,24 @@
+if(NOT TARGET unofficial::qscintilla::qscintilla)
+    add_library(unofficial::qscintilla::qscintilla UNKNOWN IMPORTED)
+    get_filename_component(z_vcpkg_qscintilla_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
+    get_filename_component(z_vcpkg_qscintilla_root "${z_vcpkg_qscintilla_root}" PATH)
+    get_filename_component(z_vcpkg_qscintilla_root "${z_vcpkg_qscintilla_root}" PATH)
+
+    set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${z_vcpkg_qscintilla_root}/include"
+    )
+
+    find_library(Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE NAMES libqscintilla2_qt6 qscintilla2_qt6 PATHS "${z_vcpkg_qscintilla_root}/lib" NO_DEFAULT_PATH)
+    if(EXISTS "${Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE}")
+        set_property(TARGET unofficial::qscintilla::qscintilla APPEND PROPERTY IMPORTED_CONFIGURATIONS "Release")
+        set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES IMPORTED_LOCATION_RELEASE "${Z_VCPKG_QSCINTILLA_LIBRARY_RELEASE}")
+    endif()
+
+    find_library(Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG NAMES libqscintilla2_qt6 qscintilla2_qt6d libqscintilla2_qt6_debug PATHS "${z_vcpkg_qscintilla_root}/debug/lib" NO_DEFAULT_PATH)
+    if(EXISTS "${Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG}")
+        set_property(TARGET unofficial::qscintilla::qscintilla APPEND PROPERTY IMPORTED_CONFIGURATIONS "Debug")
+        set_target_properties(unofficial::qscintilla::qscintilla PROPERTIES IMPORTED_LOCATION_DEBUG "${Z_VCPKG_QSCINTILLA_LIBRARY_DEBUG}")
+    endif()
+
+    unset(z_vcpkg_qscintilla_root)
+endif()

--- a/ports/qscintilla/vcpkg.json
+++ b/ports/qscintilla/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qscintilla",
   "version": "2.14.1",
-  "port-version" 1,
+  "port-version": 1,
   "description": "QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)",
   "homepage": "https://www.riverbankcomputing.com/software/qscintilla",
   "license": "GPL-3.0-or-later",

--- a/ports/qscintilla/vcpkg.json
+++ b/ports/qscintilla/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qscintilla",
   "version": "2.14.1",
+  "port-version" 1,
   "description": "QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)",
   "homepage": "https://www.riverbankcomputing.com/software/qscintilla",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7066,7 +7066,7 @@
     },
     "qscintilla": {
       "baseline": "2.14.1",
-      "port-version": 0
+      "port-version": 1
     },
     "qt": {
       "baseline": "6.6.1",

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e1bdacefcc3ae894f0a19a81d46a1e28989b1ccd",
+      "git-tree": "dc5fd8d8484f29c7fd10d360f74d6b1bff6bd884",
       "version": "2.14.1",
       "port-version": 1
     },

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "11f003526f21400d16d6abb581c55cbd5958f346",
+      "git-tree": "fd44a9e9c7623875efcf3df7a478f9910fa9502c",
       "version": "2.14.1",
       "port-version": 1
     },

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fd44a9e9c7623875efcf3df7a478f9910fa9502c",
+      "git-tree": "e1bdacefcc3ae894f0a19a81d46a1e28989b1ccd",
       "version": "2.14.1",
       "port-version": 1
     },

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11f003526f21400d16d6abb581c55cbd5958f346",
+      "version": "2.14.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "3280645a840ece797868b44065cbbe3b609b4099",
       "version": "2.14.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #36817 
Usage test passed on `x64-windows` and `x64-windows-static`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
