### PR TITLE
[libunibreak] Add the missing header files

### DIFF
--- a/ports/libunibreak/CMakeLists.txt
+++ b/ports/libunibreak/CMakeLists.txt
@@ -11,6 +11,8 @@ set(libunibreak_srcs
   src/graphemebreak.c
   src/graphemebreakdata.c
   src/emojidef.c
+  src/eastasianwidthdef.c
+  src/eastasianwidthdata.c
   src/unibreakbase.c
   src/unibreakdef.c
 )
@@ -30,6 +32,9 @@ if(NOT DISABLE_INSTALL_HEADERS)
   install(
     FILES
     src/emojidef.h
+    src/eastasianwidthdef.h
+    src/unibreakbase.h
+    src/unibreakdef.h
     src/graphemebreak.h
     src/graphemebreakdef.h
     src/linebreak.h

--- a/ports/libunibreak/fix_export.patch
+++ b/ports/libunibreak/fix_export.patch
@@ -1,0 +1,23 @@
+diff --git a/src/eastasianwidthdef.h b/src/eastasianwidthdef.h
+index 67a41aa..c081a02 100644
+--- a/src/eastasianwidthdef.h
++++ b/src/eastasianwidthdef.h
+@@ -26,6 +26,9 @@
+ 
+ #include "unibreakdef.h"
+ 
++#ifdef __cplusplus
++extern "C" {
++#endif
+ /**
+  * East Asian Width (ea) class.  This is defined in Unicode Standard
+  * Annex 11.
+@@ -52,5 +55,8 @@ struct EastAsianWidthProperties
+ };
+ 
+ enum EastAsianWidthClass ub_get_char_eaw_class(utf32_t ch);
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif /* EASTASIANWIDTHDEF_H */

--- a/ports/libunibreak/portfile.cmake
+++ b/ports/libunibreak/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
   REF "libunibreak_${MAJOR}_${MINOR}"
   SHA512 a85333d59c78b67b1c05d33ab99c069ba493780d6a98ad5ab00e33235c454b8b33515cac4e815de35533f235be7cf5473550b3a6389f7581ba2f6216d42d38e1
   HEAD_REF master
+  PATCHES
+       fix_export.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
@@ -22,4 +24,4 @@ vcpkg_cmake_install()
 configure_file("${CMAKE_CURRENT_LIST_DIR}/libunibreak-config.cmake.in"
         "${CURRENT_PACKAGES_DIR}/share/${PORT}/libunibreak-config.cmake" @ONLY)
 
-file(INSTALL ${SOURCE_PATH}/LICENCE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libunibreak RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENCE")

--- a/ports/libunibreak/vcpkg.json
+++ b/ports/libunibreak/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libunibreak",
   "version": "6.1",
+  "port-version": 1,
   "description": "an implementation of the line breaking and word breaking algorithms as described in [Unicode Standard Annex 14] 1 and [Unicode Standard Annex 29] 2. Check the project's [home page] 3 for up-to-date information.",
   "homepage": "https://github.com/adah1972/libunibreak",
   "license": "zlib-acknowledgement",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5066,7 +5066,7 @@
     },
     "libunibreak": {
       "baseline": "6.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libunifex": {
       "baseline": "0.4.0",

--- a/versions/l-/libunibreak.json
+++ b/versions/l-/libunibreak.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4970494282744de3fbdc2e964fa9d96ad3ddc27e",
+      "version": "6.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "cf6623da9e4002c21327a8ea1451fccc0f54a5ce",
       "version": "6.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/37669
Add a header file containing function ub_get_char_eaw_class().

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
```