### PR TITLE
[pocketpy] update to 1.4.3

### DIFF
--- a/ports/pocketpy/portfile.cmake
+++ b/ports/pocketpy/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocketpy/pocketpy
     REF "v${VERSION}"
-    SHA512 994736b57250d415fbae7c7fcb82c7bed6423fb9eb97ab7fd7d1c3ad584dfa32f85dda31fa1dc49842b900d1bdf73f825a220587342cf8d0b0f85cc06c27a15a
+    SHA512 e0c4b70727d47ae0b26c520528ffadfe63a8986b674f12b91260f42ae25975af4f64dfd71e056e7627d35b10eddcd34b396ca3b01c931f5bb8a4b15431da5426
     HEAD_REF master
 )
 
@@ -16,6 +16,7 @@ vcpkg_cmake_configure(
         -DPK_BUILD_STATIC_LIB=${BUILD_STATIC}
         -DPK_ENABLE_OS=OFF
         -DPK_USE_CJSON=OFF
+        -DPK_INSTALL=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/pocketpy/vcpkg.json
+++ b/ports/pocketpy/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pocketpy",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "pkpy is a lightweight(~15K LOC) Python interpreter for game scripting, built on C++17 with STL.",
   "homepage": "https://github.com/pocketpy/pocketpy",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6837,7 +6837,7 @@
       "port-version": 0
     },
     "pocketpy": {
-      "baseline": "1.4.2",
+      "baseline": "1.4.3",
       "port-version": 0
     },
     "poco": {

--- a/versions/p-/pocketpy.json
+++ b/versions/p-/pocketpy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6201adac8d1d96a89ff044aedea7a76f1c324fd",
+      "version": "1.4.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "88488b1ef4b08c21131fda6ab424947992657b7b",
       "version": "1.4.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.