### PR TITLE
[zstd] Update to 1.5.6

### DIFF
--- a/ports/zstd/portfile.cmake
+++ b/ports/zstd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/zstd
     REF "v${VERSION}"
-    SHA512 356994e0d8188ce97590bf86b602eb50cbcb2f951594afb9c2d6e03cc68f966862505afc4a50e76efd55e4cfb11dbc9b15c7837b7827a961a1311ef72cd23505
+    SHA512 ca12dffd86618ca008e1ecc79056c1129cb4e61668bf13a3cd5b2fa5c93bc9c92c80f64c1870c68b9c20009d9b3a834eac70db72242d5106125a1c53cccf8de8
     HEAD_REF dev
     PATCHES
         no-static-suffix.patch

--- a/ports/zstd/vcpkg.json
+++ b/ports/zstd/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zstd",
-  "version": "1.5.5",
-  "port-version": 2,
+  "version": "1.5.6",
   "description": "Zstandard - Fast real-time compression algorithm",
   "homepage": "https://facebook.github.io/zstd/",
   "license": "BSD-3-Clause OR GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9613,8 +9613,8 @@
       "port-version": 0
     },
     "zstd": {
-      "baseline": "1.5.5",
-      "port-version": 2
+      "baseline": "1.5.6",
+      "port-version": 0
     },
     "zstr": {
       "baseline": "1.0.7",

--- a/versions/z-/zstd.json
+++ b/versions/z-/zstd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee6477f4cc6e0e462a885acdf773d055635aa6b9",
+      "version": "1.5.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "259dc461801ecb946995e13fd3d94b1381d02441",
       "version": "1.5.5",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
