### PR TITLE
[sdformat13] Update to 13.6.0

### DIFF
--- a/ports/sdformat13/no-absolute.patch
+++ b/ports/sdformat13/no-absolute.patch
@@ -9,11 +9,11 @@ index d1b3db53..9a9ce91d 100644
 -#define SDF_VERSION_PATH "${CMAKE_INSTALL_FULL_DATAROOTDIR}/sdformat${SDF_MAJOR_VERSION}/${SDF_PKG_VERSION}"
  
 diff --git a/src/SDF.cc b/src/SDF.cc
-index 20dcd4c6..802cbde3 100644
+index 07056d7..57e8a2c 100644
 --- a/src/SDF.cc
 +++ b/src/SDF.cc
-@@ -97,22 +97,6 @@ std::string findFile(const std::string &_filename, bool _searchLocalPath,
-     filename = filename.substr(idx + sep.length());
+@@ -108,24 +108,8 @@ std::string findFile(const std::string &_filename, bool _searchLocalPath,
+     }
    }
  
 -  // Next check the install path.
@@ -32,7 +32,9 @@ index 20dcd4c6..802cbde3 100644
 -    return path;
 -  }
 -
-   // Next check to see if the given file exists.
--   path = filename;
-+   std::string path = filename;
+   // Finally check to see if the given file exists.
+-  path = filename;
++  std::string path = filename;
    if (sdf::filesystem::exists(path))
+   {
+     return path;

--- a/ports/sdformat13/portfile.cmake
+++ b/ports/sdformat13/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gazebosim/sdformat
     REF "sdformat13_${VERSION}"
-    SHA512 adc555527aadaede84d6fde11555bf4872028d9e895fc47c89f4077452fde9a52b233d60d0cbff5a098e261c7810aa2dc38a6275ec9f37ba4d0161af98e2aade
+    SHA512 10c56fab3957fff759c3ff7db401e162c5d353221e3895617182031be41e10a5234607fb7d1afb0ec453f3e1f20ddcc36b8488ed3d1cc2d1d0e915fc3a74ddbd
     HEAD_REF sdf13
     PATCHES
         no-absolute.patch

--- a/ports/sdformat13/vcpkg.json
+++ b/ports/sdformat13/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdformat13",
-  "version": "13.5.0",
-  "port-version": 1,
+  "version": "13.6.0",
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7885,8 +7885,8 @@
       "port-version": 4
     },
     "sdformat13": {
-      "baseline": "13.5.0",
-      "port-version": 1
+      "baseline": "13.6.0",
+      "port-version": 0
     },
     "sdformat6": {
       "baseline": "6.2.0",

--- a/versions/s-/sdformat13.json
+++ b/versions/s-/sdformat13.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9fd5b67f5e6c73b950fcb1b9e3bb6d9fd369dee4",
+      "version": "13.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "88424090fdd3b2122094e75be5c68b3f2f58cda5",
       "version": "13.5.0",
       "port-version": 1


### PR DESCRIPTION
Follow-up to #37776, update `sdformat13` to 13.6.0.

No feature needs to be tested, the usage test passed on `x64-windows`(header files found):
```
sdformat13 provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(sdformat13 CONFIG REQUIRED)
  # note: 1 additional targets are not displayed.
  target_link_libraries(main PRIVATE sdformat13::core GzURDFDOM::GzURDFDOM sdformat13::requested sdformat13::sdformat13)

sdformat13 provides pkg-config modules:

    # A set of sdformat classes for robot applications
    sdformat13
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
