### PR TITLE
[glm] Fix c++ language auto detection

### DIFF
--- a/ports/glm/portfile.cmake
+++ b/ports/glm/portfile.cmake
@@ -11,7 +11,6 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DGLM_ENABLE_CXX_17=ON
         -DGLM_BUILD_LIBRARY=ON
         -DGLM_BUILD_TESTS=OFF
         -DGLM_BUILD_INSTALL=ON

--- a/ports/glm/vcpkg.json
+++ b/ports/glm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glm",
   "version": "1.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenGL Mathematics (GLM)",
   "homepage": "https://glm.g-truc.net",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3070,7 +3070,7 @@
     },
     "glm": {
       "baseline": "1.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "globjects": {
       "baseline": "1.1.0",

--- a/versions/g-/glm.json
+++ b/versions/g-/glm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f323014ca30e742823ae0d6e1a47243000774c1",
+      "version": "1.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "99ce44c81afa595330ff215934019ac06ff34388",
       "version": "1.0.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/g-truc/glm/releases/tag/1.0.1
https://github.com/g-truc/glm/issues/1231
https://github.com/g-truc/glm/issues/1235