### PR TITLE
[awlib] Add new port

### DIFF
--- a/ports/awlib/portfile.cmake
+++ b/ports/awlib/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO absurdworlds/awlib
+    REF ${VERSION}
+    SHA512 bfb4668abc3db176744bb674a20bf770c6406db522a14191069b8d833414285ca784f042c3ad50404f7f8bc76afe69627dfcf540080e12316abbbfe420955526
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    hudf             AW_ENABLE_HUDF
+    graphics         AW_ENABLE_GRAPHICS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH lib/cmake/${PORT})
+
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_copy_pdbs()

--- a/ports/awlib/portfile.cmake
+++ b/ports/awlib/portfile.cmake
@@ -24,7 +24,7 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH lib/cmake/${PORT})
 
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/awlib/vcpkg.json
+++ b/ports/awlib/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Cross-platform utility library",
   "homepage": "https://github.com/absurdworlds/awlib",
   "license": "LGPL-3.0-or-later",
-  "supports": "!android",
+  "supports": "!uwp & !android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/awlib/vcpkg.json
+++ b/ports/awlib/vcpkg.json
@@ -20,7 +20,8 @@
       "description": "Build graphics library",
       "supports": "!uwp",
       "dependencies": [
-        "glfw3"
+        "glfw3",
+        "libpng"
       ]
     },
     "hudf": {

--- a/ports/awlib/vcpkg.json
+++ b/ports/awlib/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "awlib",
+  "version-date": "2024-04-06",
+  "description": "Cross-platform utility library",
+  "homepage": "https://github.com/absurdworlds/awlib",
+  "license": "LGPL-3.0-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "graphics": {
+      "description": "Build graphics library",
+      "supports": "!uwp",
+      "dependencies": [
+        "glfw3"
+      ]
+    },
+    "hudf": {
+      "description": "Build HuDF support"
+    }
+  }
+}

--- a/ports/awlib/vcpkg.json
+++ b/ports/awlib/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Cross-platform utility library",
   "homepage": "https://github.com/absurdworlds/awlib",
   "license": "LGPL-3.0-or-later",
+  "supports": "!android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/a-/awlib.json
+++ b/versions/a-/awlib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "539db7a8b7652c86c735594e04dc1a1e09647035",
+      "version-date": "2024-04-06",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -368,6 +368,10 @@
       "baseline": "1.11.3",
       "port-version": 0
     },
+    "awlib": {
+      "baseline": "2024-04-06",
+      "port-version": 0
+    },
     "aws-c-auth": {
       "baseline": "0.7.16",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
