### PR TITLE
Revert [liblzma] update to version 5.6.0 (#37199)

### DIFF
--- a/ports/liblzma/add_support_ios.patch
+++ b/ports/liblzma/add_support_ios.patch
@@ -1,26 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 52439b3..0b5e371 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1555,6 +1555,7 @@ if(HAVE_DECODERS AND (NOT MSVC OR MSVC_VERSION GREATER_EQUAL 1900))
+@@ -574,6 +574,7 @@ if(HAVE_GETOPT_LONG)
  
-         install(TARGETS "${XZDEC}"
-                 RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-+                BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-                         COMPONENT "${XZDEC}_Runtime")
-     endforeach()
- 
-@@ -1618,6 +1619,7 @@ if(HAVE_DECODERS AND (NOT MSVC OR MSVC_VERSION GREATER_EQUAL 1900))
- 
-     install(TARGETS lzmainfo
+     install(TARGETS xzdec
              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-                     COMPONENT lzmainfo_Runtime)
+                     COMPONENT xzdec)
  
      if(UNIX)
-@@ -1827,6 +1829,7 @@ if(NOT MSVC OR MSVC_VERSION GREATER_EQUAL 1900)
-     # builds because the generated cmake_install.cmake executes serially.
+@@ -701,6 +702,7 @@ if(NOT MSVC AND HAVE_GETOPT_LONG)
+ 
      install(TARGETS xz
              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-                     COMPONENT xz_Runtime)
+                     COMPONENT xz)
  
      if(UNIX)

--- a/ports/liblzma/build-tools.patch
+++ b/ports/liblzma/build-tools.patch
@@ -1,20 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 03b8301..820d08e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1438,7 +1443,7 @@ function(my_install_man COMPONENT SRC_FILE LINK_NAMES)
-     endif()
- endfunction()
+@@ -584,6 +584,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblzma-config.cmake"
+         COMPONENT liblzma_Development)
  
--
+ 
 +if(BUILD_TOOLS)
  #############################################################################
- # libgnu (getopt_long)
+ # getopt_long
  #############################################################################
-@@ -1853,7 +1858,7 @@ if(NOT MSVC OR MSVC_VERSION GREATER_EQUAL 1900)
-         my_install_man(xz_Documentation src/xz/xz.1 "${XZ_LINKS}")
+@@ -793,6 +794,7 @@ if(NOT MSVC AND HAVE_GETOPT_LONG)
+         endforeach()
      endif()
  endif()
--
-+endif(BUILD_TOOLS)
++endif()
+ 
  
  #############################################################################
- # Scripts

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tukaani-project/xz
     REF "v${VERSION}"
-    SHA512 0aa74e01c019c1d3893cf16f53b300ba4e74c6aa9febabf57ddb49b28615d76862eeb746c54c2085efd37c7e8cc0829014d9b7ad481a76294bc929b3cca91336
+    SHA512 c28461123562564e030f3f733f078bc4c840e87598d9f4b718d4bca639120d8133f969c45d7bdc62f33f081d789ec0f14a1791fb7da18515682bfe3c0c7362e0
     HEAD_REF master
     PATCHES
         fix_config_include.patch
@@ -29,7 +29,6 @@ vcpkg_cmake_configure(
         -DCREATE_XZ_SYMLINKS=OFF
         -DCREATE_LZMA_SYMLINKS=OFF
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=   # using flags from (vcpkg) toolchain
-        -DENABLE_NLS=OFF # nls is not supported by this port, yet
     MAYBE_UNUSED_VARIABLES
         CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
         CREATE_XZ_SYMLINKS
@@ -42,7 +41,7 @@ set(exec_prefix "\${prefix}")
 set(libdir "\${prefix}/lib")
 set(includedir "\${prefix}/include")
 set(PACKAGE_URL https://tukaani.org/xz/)
-set(PACKAGE_VERSION "${VERSION}")
+set(PACKAGE_VERSION 5.4.3)
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     set(PTHREAD_CFLAGS -pthread)
 endif()
@@ -68,7 +67,7 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/man"
 )
 
-set(TOOLS xz xzdec lzmadec lzmainfo)
+set(TOOLS xz xzdec)
 foreach(_tool IN LISTS TOOLS)
     if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/bin/${_tool}${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
         list(REMOVE_ITEM TOOLS ${_tool})

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblzma",
-  "version": "5.6.0",
+  "version": "5.4.4",
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/ports/liblzma/win_output_name.patch
+++ b/ports/liblzma/win_output_name.patch
@@ -1,19 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0c6d4b7..62a824a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1273,10 +1273,15 @@ set_target_properties(liblzma PROPERTIES
+@@ -868,8 +868,11 @@ set_target_properties(liblzma PROPERTIES
  
      # It's liblzma.so or liblzma.dll, not libliblzma.so or lzma.dll.
      # Avoid the name lzma.dll because it would conflict with LZMA SDK.
 -    PREFIX ""
 +    OUTPUT_NAME lzma
-     IMPORT_PREFIX ""
  )
- 
 +if(WIN32 AND NOT MINGW)
 +    set_target_properties(liblzma PROPERTIES RUNTIME_OUTPUT_NAME liblzma)
 +endif()
-+
-+
+ 
  # Create liblzma-config-version.cmake.
  #
- # FIXME: SameMajorVersion is correct for stable releases but it is wrong

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4589,7 +4589,7 @@
       "port-version": 1
     },
     "liblzma": {
-      "baseline": "5.6.0",
+      "baseline": "5.4.4",
       "port-version": 0
     },
     "libmad": {


### PR DESCRIPTION
Resolves https://github.com/microsoft/vcpkg/issues/37839
Reverts #37199

See https://www.openwall.com/lists/oss-security/2024/03/29/4

Note that the version database is unmodified, only the baseline is changed.

Because vcpkg builds liblzma from cmake sources downloaded from github and this backdoor required modifications only present in the release tarballs, it is our belief that vcpkg customers are not affected by this problem. However, we are reverting this version out of an abundance of caution as the threat actor clearly has broad access to liblzma infrastructure, and because we believe customers will start flagging this package by version as being a problem.