### PR TITLE
[libcap] Fix download URLS from 2.68 to 2.69

### DIFF
--- a/ports/libcap/portfile.cmake
+++ b/ports/libcap/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-3c7dda330bd9a154bb5b878d31fd591e4951fe17.tar.gz
-    FILENAME libpcap-${VERSION}.tar.gz
-    SHA512 0732c9f07be38c2bb06409f1f31d7ed5ad31b38ae380650b334074856f89b885deabb9603e21a989e81b530050c068bbbf60157adbf3ca3893e4bca7d61f63d2
+    URLS "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-${VERSION}.tar.gz"
+    FILENAME "libcap-${VERSION}.tar.gz"
+    SHA512 b243ae403d45af2ff1204931b9e24c3b7f3e0c444f1ff2f3ed524c212b61a7ff1bc3c98df1855b2f0d300ebabf604b95440cdaddd666914ad60575e2e2f29fe8
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/libcap/vcpkg.json
+++ b/ports/libcap/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libcap",
   "version": "2.69",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A library for getting and setting POSIX.1e (formerly POSIX 6) draft 15 capabilities.",
   "homepage": "https://git.kernel.org/pub/scm/libs/libcap/libcap.git",
   "license": "BSD-3-Clause OR GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4198,7 +4198,7 @@
     },
     "libcap": {
       "baseline": "2.69",
-      "port-version": 3
+      "port-version": 4
     },
     "libcbor": {
       "baseline": "0.11.0",

--- a/versions/l-/libcap.json
+++ b/versions/l-/libcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f81a07cf694095f60c759c9a18adc57e94296a5f",
+      "version": "2.69",
+      "port-version": 4
+    },
+    {
       "git-tree": "23bb9f2743e684bacba57b8cc8a931756f0e7447",
       "version": "2.69",
       "port-version": 3


### PR DESCRIPTION
Fix mismatch, update port download `URLS` from commit `2.68` [3c7dda](https://git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?h=libcap-2.69&id=3c7dda330bd9a154bb5b878d31fd591e4951fe17) to tag `2.69`.

Close #37851, #37875

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
Port usage tests pass with following triplets:
* x64-linux