### PR TITLE
[qt5-base] deploy all platform plugins on Windows

### DIFF
--- a/ports/qt5-base/qtdeploy.ps1
+++ b/ports/qt5-base/qtdeploy.ps1
@@ -31,16 +31,11 @@ function deployPluginsIfQt([string]$targetBinaryDir, [string]$QtPluginsDir, [str
             "[Paths]" | Out-File -encoding ascii "$targetBinaryDir\qt.conf"
         }
     } elseif ($targetBinaryName -match "Qt5Guid?.dll") {
-        Write-Verbose "  Deploying platforms"
-        New-Item "$targetBinaryDir\plugins\platforms" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
-        Get-ChildItem "$QtPluginsDir\platforms\qwindows*.dll" | % {
-            deployBinary "$targetBinaryDir\plugins\platforms" "$QtPluginsDir\platforms" $_.Name
-        }
-
         deployPlugins "accessible"
-        deployPlugins "imageformats"
         deployPlugins "iconengines"
+        deployPlugins "imageformats"
         deployPlugins "platforminputcontexts"
+        deployPlugins "platforms"
         deployPlugins "styles"
     } elseif ($targetBinaryName -match "Qt5Networkd?.dll") {
         deployPlugins "bearer"

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.13",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Base provides the basic non-GUI functionality required by all Qt applications.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7102,7 +7102,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.13",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-canvas3d": {
       "baseline": "0",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dffd73a5cc9bf206c1f1da7ec83ba7d27ac84d5f",
+      "version": "5.15.13",
+      "port-version": 2
+    },
+    {
       "git-tree": "0a70734eb07533aeba97b75a928fdf8a47d1e1d3",
       "version": "5.15.13",
       "port-version": 1


### PR DESCRIPTION
This is necessary as consuming applications may use e.g the offscreen plugin for unit tests. There is no real downside to deploying all platform plugins - they are small and qtdeploy.ps1 already deploys all other plugin types than platforms fully. The additional deployed plugins are these:

* direct2d.dll
* minimal.dll
* offscreen.dll

Fixes #37897

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
