### PR TITLE
[hunspell] Add support for feature tools

### DIFF
--- a/ports/hunspell/vcpkg.json
+++ b/ports/hunspell/vcpkg.json
@@ -26,7 +26,7 @@
     },
     "tools": {
       "description": "Build hunspell tools",
-      "supports": "!windows"
+      "supports": "!windows | mingw"
     }
   }
 }

--- a/ports/hunspell/vcpkg.json
+++ b/ports/hunspell/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "hunspell",
   "version": "1.7.2",
+  "port-version": 1,
   "description": "The most popular spellchecking library.",
   "homepage": "https://github.com/hunspell/hunspell",
   "license": "MPL-1.1 OR LGPL-2.1-or-later OR GPL-2.0-or-later",
@@ -24,7 +25,8 @@
       ]
     },
     "tools": {
-      "description": "Build hunspell tools"
+      "description": "Build hunspell tools",
+      "supports": "!windows"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3426,7 +3426,7 @@
     },
     "hunspell": {
       "baseline": "1.7.2",
-      "port-version": 0
+      "port-version": 1
     },
     "hwloc": {
       "baseline": "2.10.0",

--- a/versions/h-/hunspell.json
+++ b/versions/h-/hunspell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b1e7a3a76a3c2b946c8396b5ed43d71658dd366",
+      "version": "1.7.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "adbb8a9460f3c540d3d5719c519c32b97b3f5844",
       "version": "1.7.2",
       "port-version": 0

--- a/versions/h-/hunspell.json
+++ b/versions/h-/hunspell.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5b1e7a3a76a3c2b946c8396b5ed43d71658dd366",
+      "git-tree": "1d470eb79853a55a2bcbf8fce3e41f0cf7c737a3",
       "version": "1.7.2",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #30633, the feature `tools` build failed with the following error:
```
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(351): error C2065: 'mode_t': undeclared identifier
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(351): error C2146: syntax error: missing ';' before identifier 'mask'
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(351): error C2065: 'mask': undeclared identifier
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(351): error C2065: 'S_IXUSR': undeclared identifier
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(351): error C2065: 'S_IRWXG': undeclared identifier
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(351): error C2065: 'S_IRWXO': undeclared identifier
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(351): error C3861: 'umask': identifier not found
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(352): error C3861: 'mkstemp': identifier not found
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(353): error C2065: 'mask': undeclared identifier
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(353): error C3861: 'umask': identifier not found
buildtrees\hunspell\src\v1.7.2-ed1399a63f\src\tools\hzip.cxx(361): error C3861: 'close': identifier not found
```
`S_IXUSR` `S_IRWXG` and `S_IRWXO` need include header file `<unistd.h>`, it is a header file for Unix systems, so add support to feature `tools`.
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
