### PR TITLE
[sail] fix include directory

### DIFF
--- a/ports/sail/fix-include-directory.patch
+++ b/ports/sail/fix-include-directory.patch
@@ -1,0 +1,79 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ac81279..cfc2f3b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -299,7 +299,7 @@ endif()
+ # Common configuration file
+ #
+ configure_file("${PROJECT_SOURCE_DIR}/src/config.h.in" "${PROJECT_BINARY_DIR}/include/sail-common/config.h" @ONLY)
+-install(FILES "${PROJECT_BINARY_DIR}/include/sail-common/config.h" DESTINATION include/sail/sail-common)
++install(FILES "${PROJECT_BINARY_DIR}/include/sail-common/config.h" DESTINATION include/sail-common)
+ 
+ # Print configuration statistics
+ #
+diff --git a/src/bindings/sail-c++/CMakeLists.txt b/src/bindings/sail-c++/CMakeLists.txt
+index 4b69ad4..f4bac29 100644
+--- a/src/bindings/sail-c++/CMakeLists.txt
++++ b/src/bindings/sail-c++/CMakeLists.txt
+@@ -131,7 +131,7 @@ install(TARGETS sail-c++
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail/sail-c++")
++        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail-c++")
+ 
+ # Install development packages
+ #
+diff --git a/src/sail-common/CMakeLists.txt b/src/sail-common/CMakeLists.txt
+index 06ce246..c8576e5 100644
+--- a/src/sail-common/CMakeLists.txt
++++ b/src/sail-common/CMakeLists.txt
+@@ -114,7 +114,7 @@ endif()
+ 
+ target_include_directories(sail-common
+                             PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+-                                   $<INSTALL_INTERFACE:include/sail>)
++                                   $<INSTALL_INTERFACE:include>)
+ 
+ # pkg-config integration
+ #
+@@ -129,7 +129,7 @@ install(TARGETS sail-common
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail/sail-common")
++        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail-common")
+ 
+ # Install development packages
+ #
+diff --git a/src/sail-manip/CMakeLists.txt b/src/sail-manip/CMakeLists.txt
+index 5740764..47b81bb 100644
+--- a/src/sail-manip/CMakeLists.txt
++++ b/src/sail-manip/CMakeLists.txt
+@@ -59,7 +59,7 @@ install(TARGETS sail-manip
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail/sail-manip")
++        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail-manip")
+ 
+ # Install development packages
+ #
+diff --git a/src/sail/CMakeLists.txt b/src/sail/CMakeLists.txt
+index 85590af..2303f63 100644
+--- a/src/sail/CMakeLists.txt
++++ b/src/sail/CMakeLists.txt
+@@ -118,11 +118,11 @@ install(TARGETS sail
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail/sail")
++        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail")
+ 
+ # Install layouts for debugging codecs
+ #
+-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/layout/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail/sail/layout")
++install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/layout/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sail/layout")
+ 
+ # Install development packages
+ #

--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 c8cface60031c5e84b99eaedb216f9e3af0354d24f5db7d6d0ec1f97d593ae46cb13c86bc244b6b8673cddfecf829a8b7738fdde8620472c12e95a5b61495133
     HEAD_REF master
+    PATCHES
+        fix-include-directory.patch
 )
 
 # Enable selected codecs
@@ -56,7 +58,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake"
 vcpkg_fixup_pkgconfig()
 
 # Unused because SAIL_COMBINE_CODECS is ON
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/sail/sail-common/config.h" "#define SAIL_CODECS_PATH \"${CURRENT_PACKAGES_DIR}/lib/sail/codecs\"" "")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/sail-common/config.h" "#define SAIL_CODECS_PATH \"${CURRENT_PACKAGES_DIR}/lib/sail/codecs\"" "")
 
 # Handle usage
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sail",
   "version-semver": "0.9.1",
+  "port-version": 1,
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7810,7 +7810,7 @@
     },
     "sail": {
       "baseline": "0.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "sajson": {
       "baseline": "2018-09-21",

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b5fe68901010efcf15a6025a105333d15bb284bf",
+      "version-semver": "0.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6e673bf75a449ebb5474953cb8eaa69333fc08b4",
       "version-semver": "0.9.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #37522

the primary header expects to be
`#include <sail/sail.h>`

but vcpkg creates it as
`#include <sail/sail/sail.h>`

... which causes failure to load the content of sail.h:
`#include <sail-common/sail-common.h>`

Solution: Delete the outermost sail directory.

Tested usage successfully by `sail:x64-windows `:
````
The package sail provides CMake targets:

C libraries:

    find_package(Sail CONFIG REQUIRED)
    target_link_libraries(main PRIVATE SAIL::sail)

C++ bindings:

    find_package(SailC++ CONFIG REQUIRED)
    target_link_libraries(main PRIVATE SAIL::sail-c++)

````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
