### PR TITLE
[skia] update to chrome/124

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -3,8 +3,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/skia-functions.cmake")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/skia
-    REF "aeae2261c7d380404fb8e53eb6062338c4ba0367"
-    SHA512 74eabf6a7cc0ac0cc49a1075bf4ffcee4f006ebe67c02a76a4dc734da1fa430ddd7f3cb070cb0b1ed3ac99cf59d02dc0c8852f3487614ca851673984117ca612
+    REF "e7bf161ff959268a2a2f37530a6ea61c27019d33"
+    SHA512 9cb0c39c6721c5e27a24bee97c93925b7b1f4dd774c08520384ccdf736ab5097e49692529a9fe46f50ae799e6aa9f3e8d7ec43cf9177914fcd6f6f01b76a52c4
     PATCHES
         disable-msvc-env-setup.patch
         disable-dev-test.patch
@@ -31,7 +31,7 @@ declare_external_from_git(d3d12allocator
 )
 declare_external_from_git(dawn
     URL "https://dawn.googlesource.com/dawn.git"
-    REF "d3e0bd4770cc8115d1342a8dc051a36e50e8bd26"
+    REF "bac513d0ae286600ea0f75a75223a5b52a198b9b"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(dng_sdk
@@ -54,11 +54,6 @@ declare_external_from_git(piex
     REF "bb217acdca1cc0c16b704669dd6f91a1b509c406"
     LICENSE_FILE LICENSE
 )
-declare_external_from_git(sfntly
-    URL "https://github.com/googlei18n/sfntly.git"
-    REF "b55ff303ea2f9e26702b514cf6a3196a2e3e2974"
-    LICENSE_FILE README.md
-)
 declare_external_from_git(spirv-cross
     URL "https://github.com/KhronosGroup/SPIRV-Cross"
     REF "b8fcf307f1f347089e3c46eb4451d27f32ebc8d3"
@@ -66,12 +61,12 @@ declare_external_from_git(spirv-cross
 )
 declare_external_from_git(spirv-headers
     URL "https://github.com/KhronosGroup/SPIRV-Headers.git"
-    REF "05cc486580771e4fa7ddc89f5c9ee1e97382689a"
+    REF "8b246ff75c6615ba4532fe4fde20f1be090c3764"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(spirv-tools
     URL "https://github.com/KhronosGroup/SPIRV-Tools.git"
-    REF "dc6676445be97ab19d8191fee019af62e2aaf774"
+    REF "f20663ca7fec48fdc88e4c4d7c5889f8b4cc5664"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(wuffs
@@ -141,7 +136,6 @@ set(required_externals
     libpng
     libwebp
     piex
-    sfntly
     zlib
     wuffs
 )

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "skia",
-  "version": "123",
-  "port-version": 1,
+  "version": "124",
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8113,8 +8113,8 @@
       "port-version": 0
     },
     "skia": {
-      "baseline": "123",
-      "port-version": 1
+      "baseline": "124",
+      "port-version": 0
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b993a94ad57f5f651ac7dfa08cf20f17134a1b0d",
+      "version": "124",
+      "port-version": 0
+    },
+    {
       "git-tree": "7f28b1cde0213f46543981ad97545a9c005eb332",
       "version": "123",
       "port-version": 1


### PR DESCRIPTION
Support to sfntly was removed in f4f7364eb73a016f363d3d66ff3007e3a94e3f5e

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.