### PR TITLE
[libassert] Update to 2.0.1

### DIFF
--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jeremy-rifkin/libassert
     REF "v${VERSION}"
-    SHA512 35fdf48cc157e0f269ccae66f9d000d3a1e01bdd8a23d04e1a0ddc9e6c962c6507702bb3494cbc4d06d59f1af27e1c053f8ae3167c2ae9efd2644df505058175
+    SHA512 555776f8d23aff3beeeb5989cb04a0dfe759d53b10a0bf5542e52013d27b85e7d8feb3e2a765a12fd194453f36a20209eeaa1bdf73d184fff56c52c3e1aeea15
     HEAD_REF main
 )
 

--- a/ports/libassert/vcpkg.json
+++ b/ports/libassert/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libassert",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The most over-engineered C++ assertion library",
   "homepage": "https://github.com/jeremy-rifkin/libassert",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4161,7 +4161,7 @@
       "port-version": 0
     },
     "libassert": {
-      "baseline": "2.0.0",
+      "baseline": "2.0.1",
       "port-version": 0
     },
     "libassuan": {

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aea452e5687071021efa2261fad44a533ec86928",
+      "version": "2.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "13ac309aa7d3056f9e42c5298157f0c6a1f4c164",
       "version": "2.0.0",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
