### PR TITLE
[vcpkg baseline][blitz] Passing remove form fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -84,7 +84,6 @@ berkeleydb:x64-android=fail
 binlog:arm-neon-android=fail
 blas:arm-neon-android=fail
 blitz:x64-android=fail
-blitz:x64-osx=fail
 boinc:arm-neon-android=fail
 boinc:arm64-android=fail
 boinc:x64-android=fail


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=101160&view=results

Added `blitz` to ci.baseline.txt by #33722, which has been fixed by #37723.

```
PASSING, REMOVE FROM FAIL LIST: blitz:x64-osx
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~