### PR TITLE
[netgen] Optional features to reduce dependencies

### DIFF
--- a/ports/netgen/cross-build.patch
+++ b/ports/netgen/cross-build.patch
@@ -41,7 +41,7 @@ diff --git a/rules/CMakeLists.txt b/rules/CMakeLists.txt
 index 2c281ca3..e2982f28 100644
 --- a/rules/CMakeLists.txt
 +++ b/rules/CMakeLists.txt
-@@ -1,14 +1,12 @@
+@@ -1,14 +1,14 @@
  # this file is included from the parent directory (otherwise generated source files are not recognized properly by cmake)
  
  # generate .cpp files containing the string of the .rls meshing rule files
@@ -51,22 +51,14 @@ index 2c281ca3..e2982f28 100644
 -    )
 -  set(rules_command ${CMAKE_BINARY_DIR}/makerls)
 -else(EMSCRIPTEN)
-+if("${MAKERLS_EXECUTABLE}")
++if(MAKERLS_EXECUTABLE)
 +  add_executable(makerls IMPORTED)
 +  set_target_properties(makerls PROPERTIES IMPORTED_LOCATION "${MAKERLS_EXECUTABLE}")
++  set(rules_command makerls)
 +else()
    add_executable(makerls rules/makerlsfile.cpp)
--  set(rules_command makerls)
+   set(rules_command makerls)
 +  install(TARGETS makerls DESTINATION ${NG_INSTALL_DIR} COMPONENT netgen)
  endif()
  
  set(rules
-@@ -29,7 +27,7 @@ foreach(rule ${rules})
-     set(rule_cpp ${CMAKE_CURRENT_BINARY_DIR}/rules/rule_${rule}.cpp)
- 
-     add_custom_command(OUTPUT ${rule_cpp}
--      COMMAND ${rules_command} ${rule_file} ${rule_cpp} ${rule}
-+      COMMAND $<TARGET_FILE:makerls> ${rule_file} ${rule_cpp} ${rule}
-       DEPENDS makerls ${rule_file}
-     )
- endforeach()

--- a/ports/netgen/fix-cross-compil.patch
+++ b/ports/netgen/fix-cross-compil.patch
@@ -1,0 +1,72 @@
+diff --git a/libsrc/core/exception.cpp b/libsrc/core/exception.cpp
+index 9c99a138..2d5a1ede 100644
+--- a/libsrc/core/exception.cpp
++++ b/libsrc/core/exception.cpp
+@@ -36,7 +36,7 @@ namespace ngcore
+ 
+ 
+ // ********* STUFF FOR GETBACKTRACE ***************************
+-#if defined __GNUC__ && !defined __EMSCRIPTEN__
++#if defined __GNUC__ && !defined __EMSCRIPTEN__ && !defined __ANDROID__
+ 
+ #include <execinfo.h>
+ #include <string.h>
+diff --git a/libsrc/core/simd.hpp b/libsrc/core/simd.hpp
+index d5a6341f..5f07a6d3 100644
+--- a/libsrc/core/simd.hpp
++++ b/libsrc/core/simd.hpp
+@@ -28,7 +28,7 @@
+ #include "simd_avx512.hpp"
+ #endif
+ 
+-#ifdef __aarch64__
++#if defined __aarch64__ && !defined __ANDROID__
+ #include "simd_arm64.hpp"
+ #endif
+ 
+diff --git a/libsrc/core/utils.hpp b/libsrc/core/utils.hpp
+index 79d919c0..1318debf 100644
+--- a/libsrc/core/utils.hpp
++++ b/libsrc/core/utils.hpp
+@@ -74,7 +74,7 @@ namespace ngcore
+ #elif defined(__EMSCRIPTEN__)
+     return std::chrono::high_resolution_clock::now().time_since_epoch().count();
+ #else
+-#warning "Unsupported CPU architecture"
++#pragma message ( "Unsupported CPU architecture" )
+     return 0;
+ #endif
+   }
+diff --git a/rules/CMakeLists.txt b/rules/CMakeLists.txt
+index 2c281ca3..e2982f28 100644
+--- a/rules/CMakeLists.txt
++++ b/rules/CMakeLists.txt
+@@ -1,14 +1,12 @@
+ # this file is included from the parent directory (otherwise generated source files are not recognized properly by cmake)
+ 
+ # generate .cpp files containing the string of the .rls meshing rule files
+-if(EMSCRIPTEN)
+-  add_custom_command(OUTPUT makerls
+-    COMMAND g++ ${CMAKE_CURRENT_SOURCE_DIR}/rules/makerlsfile.cpp -o ${CMAKE_CURRENT_BINARY_DIR}/makerls
+-    )
+-  set(rules_command ${CMAKE_BINARY_DIR}/makerls)
+-else(EMSCRIPTEN)
++if("${MAKERLS_EXECUTABLE}")
++  add_executable(makerls IMPORTED)
++  set_target_properties(makerls PROPERTIES IMPORTED_LOCATION "${MAKERLS_EXECUTABLE}")
++else()
+   add_executable(makerls rules/makerlsfile.cpp)
+-  set(rules_command makerls)
++  install(TARGETS makerls DESTINATION ${NG_INSTALL_DIR} COMPONENT netgen)
+ endif()
+ 
+ set(rules
+@@ -29,7 +27,7 @@ foreach(rule ${rules})
+     set(rule_cpp ${CMAKE_CURRENT_BINARY_DIR}/rules/rule_${rule}.cpp)
+ 
+     add_custom_command(OUTPUT ${rule_cpp}
+-      COMMAND ${rules_command} ${rule_file} ${rule_cpp} ${rule}
++      COMMAND $<TARGET_FILE:makerls> ${rule_file} ${rule_cpp} ${rule}
+       DEPENDS makerls ${rule_file}
+     )
+ endforeach()

--- a/ports/netgen/portfile.cmake
+++ b/ports/netgen/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
       add_filesystem.patch
       occ-78.patch
       142.diff
+      fix-cross-compil.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -29,17 +30,22 @@ endif()
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         python   USE_PYTHON
+        cgns     USE_CGNS
+        mpeg     USE_MPEG
+        jpeg     USE_JPEG
+        occ      USE_OCC
 )
+
+if (VCPKG_CROSSCOMPILING)
+  set(MAKERLS_EXECUTABLE ${CURRENT_HOST_INSTALLED_DIR}/bin/makerls${VCPKG_HOST_EXECUTABLE_SUFFIX})
+endif()
 
 vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS  ${OPTIONS}
       ${FEATURE_OPTIONS}
-      -DUSE_JPEG=ON
-      -DUSE_CGNS=ON
-      -DUSE_OCC=ON
-      -DUSE_MPEG=ON
+      -DMAKERLS_EXECUTABLE=${MAKERLS_EXECUTABLE}
       -DUSE_SPDLOG=OFF # will be vendored otherwise
       -DUSE_GUI=OFF
       -DPREFER_SYSTEM_PYBIND11=ON

--- a/ports/netgen/vcpkg.json
+++ b/ports/netgen/vcpkg.json
@@ -1,25 +1,15 @@
 {
   "name": "netgen",
   "version": "6.2.2401",
+  "port-version": 1,
   "description": "NETGEN is an automatic 3d tetrahedral mesh generator. It accepts input from constructive solid geometry (CSG) or boundary representation (BRep) from STL file format. The connection to a geometry kernel allows the handling of IGES and STEP files. NETGEN contains modules for mesh optimization and hierarchical mesh refinement.",
   "homepage": "https://ngsolve.org/",
   "license": "LGPL-2.1-or-later",
   "supports": "arm64 | x64",
   "dependencies": [
     {
-      "name": "cgns",
-      "default-features": false
-    },
-    {
-      "name": "ffmpeg",
-      "default-features": false,
-      "features": [
-        "avcodec"
-      ]
-    },
-    "libjpeg-turbo",
-    {
-      "name": "opencascade",
+      "name": "netgen",
+      "host": true,
       "default-features": false
     },
     {
@@ -33,6 +23,42 @@
     "zlib"
   ],
   "features": {
+    "cgns": {
+      "description": "CGNS file read/write support",
+      "dependencies": [
+        {
+          "name": "cgns",
+          "default-features": false
+        }
+      ]
+    },
+    "jpeg": {
+      "description": "enable snapshots using library libjpeg",
+      "dependencies": [
+        "libjpeg-turbo"
+      ]
+    },
+    "mpeg": {
+      "description": "enable video recording with FFmpeg",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "avcodec"
+          ]
+        }
+      ]
+    },
+    "occ": {
+      "description": "build with OpenCascade geometry kernel interface",
+      "dependencies": [
+        {
+          "name": "opencascade",
+          "default-features": false
+        }
+      ]
+    },
     "python": {
       "description": "Build python bindings",
       "dependencies": [

--- a/scripts/test_ports/vcpkg-ci-netgen/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-netgen/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/scripts/test_ports/vcpkg-ci-netgen/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-netgen/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "vcpkg-ci-netgen",
+  "version-string": "ci",
+  "description": "Force non-default features of netgen within vcpkg CI",
+  "homepage": "https://github.com/microsoft/vcpkg",
+  "dependencies": [
+    {
+      "name": "netgen",
+      "features": [
+        "cgns",
+        "jpeg",
+        "mpeg",
+        "occ"
+      ]
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6094,7 +6094,7 @@
     },
     "netgen": {
       "baseline": "6.2.2401",
-      "port-version": 0
+      "port-version": 1
     },
     "nethost": {
       "baseline": "8.0.3",

--- a/versions/n-/netgen.json
+++ b/versions/n-/netgen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc85c81f938a34b7f454868f68091cde398d6529",
+      "git-tree": "5f32bd93d58e5c5057f30d3564fa0a9b808498d6",
       "version": "6.2.2401",
       "port-version": 1
     },

--- a/versions/n-/netgen.json
+++ b/versions/n-/netgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc85c81f938a34b7f454868f68091cde398d6529",
+      "version": "6.2.2401",
+      "port-version": 1
+    },
+    {
       "git-tree": "289792b9ef5239988ae4c6a418fadfb59fadda5f",
       "version": "6.2.2401",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- ~~[ ] SHA512s are updated for each updated download.~~
- ~~[ ] The "supports" clause reflects platforms that may be fixed by this new version.~~
- ~~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- ~~[ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


Also:
- fixes Android compilation which wasn't tested the last time this port was modified
- Exclude `uwp` which was indirectly excluded by another optional dependency