### PR TITLE
[hjson-cpp] New port

### DIFF
--- a/ports/hjson-cpp/fix-runtime-destination.patch
+++ b/ports/hjson-cpp/fix-runtime-destination.patch
@@ -1,0 +1,12 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f1f6cf4..05189a3 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -33,6 +33,6 @@ set_target_properties(hjson PROPERTIES
+ )
+ 
+ if(HJSON_ENABLE_INSTALL)
+-  install(TARGETS hjson EXPORT hjson DESTINATION ${lib_dest})
++  install(TARGETS hjson EXPORT hjson DESTINATION ${lib_dest} RUNTIME DESTINATION bin)
+   install(FILES ${header} DESTINATION ${include_dest})
+ endif()

--- a/ports/hjson-cpp/portfile.cmake
+++ b/ports/hjson-cpp/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO hjson/hjson-cpp
+    REF "${VERSION}"
+    SHA512 89b13091c1c89007b8be71b9e9e2d86e69226f9a4479b52357981c04d3409dc9ba8b709eaa96ed547b9b68a548991d75224596920186d8109f99380c646c9956
+    HEAD_REF master
+    PATCHES
+        fix-runtime-destination.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DHJSON_ENABLE_INSTALL=ON
+        -DHJSON_ENABLE_TEST=OFF
+        -DHJSON_ENABLE_PERFTEST=OFF
+        -DHJSON_VERSIONED_INSTALL=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME hjson CONFIG_PATH lib/hjson)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hjson-cpp/vcpkg.json
+++ b/ports/hjson-cpp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "hjson-cpp",
+  "version": "2.4.1",
+  "description": "Hjson for C++",
+  "homepage": "https://hjson.github.io",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3404,6 +3404,10 @@
       "baseline": "1.2.0",
       "port-version": 0
     },
+    "hjson-cpp": {
+      "baseline": "2.4.1",
+      "port-version": 0
+    },
     "hnswlib": {
       "baseline": "0.8.0",
       "port-version": 0

--- a/versions/h-/hjson-cpp.json
+++ b/versions/h-/hjson-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fd0ae6a65d85cb782888aaf31fe4dcec0b47892d",
+      "version": "2.4.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
