### PR TITLE
[liblzma] Workaround source repo having been disabled

### DIFF
--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO tukaani-project/xz
+    REPO bminor/xz
     REF "v${VERSION}"
     SHA512 c28461123562564e030f3f733f078bc4c840e87598d9f4b718d4bca639120d8133f969c45d7bdc62f33f081d789ec0f14a1791fb7da18515682bfe3c0c7362e0
     HEAD_REF master

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "liblzma",
   "version": "5.4.4",
+  "port-version": 1,
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4594,7 +4594,7 @@
     },
     "liblzma": {
       "baseline": "5.4.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libmad": {
       "baseline": "0.16.4",

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ec260f57568e859f5eb0f08e120c712af5dc7343",
+      "version": "5.4.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "b362003b452b95b7fef8577175651a7e33940f7f",
       "version": "5.6.0",
       "port-version": 0


### PR DESCRIPTION
https://github.com/tukaani-project/xz has been disabled.

Use bminor's fork of xz until the liblzma project publishes a new official repository, as proposed by @MichaelCurrie in a comment on microsoft/vcpkg#37839 .

Fixes #37893 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
