### PR TITLE
[perfetto] initial port of 43.1

### DIFF
--- a/ports/perfetto/CMakeLists.txt
+++ b/ports/perfetto/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Unofficial perfetto CMakeLists.txt from https://github.com/google/perfetto/blob/v43.1/meson.build
+cmake_minimum_required(VERSION 3.23)
+project(perfetto LANGUAGES CXX)
+
+add_library(perfetto)
+target_compile_features(perfetto PRIVATE cxx_std_17)
+target_sources(perfetto
+    PRIVATE "sdk/perfetto.cc"
+    PUBLIC FILE_SET HEADERS BASE_DIRS "sdk" FILES "sdk/perfetto.h"
+)
+
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+target_link_libraries(perfetto PRIVATE Threads::Threads)
+
+if(ANDROID)
+    target_link_libraries(perfetto PRIVATE log)
+endif(ANDROID)
+
+if(WIN32)
+    target_compile_options(perfetto PRIVATE "/bigobj")
+    target_compile_definitions(perfetto PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX)
+    target_link_libraries(perfetto PRIVATE ws2_32)
+endif(WIN32)
+
+if(MSVC)
+    target_compile_options(perfetto PRIVATE "/permissive-")
+endif(MSVC)
+
+install(TARGETS perfetto
+    EXPORT unofficial-perfetto-config
+    FILE_SET HEADERS DESTINATION "include"
+)
+
+install(EXPORT unofficial-perfetto-config
+    NAMESPACE unofficial::perfetto::
+    DESTINATION "share/unofficial-perfetto"
+)
+
+install(FILES "protos/perfetto/trace/perfetto_trace.proto" DESTINATION "share/unofficial-perfetto")

--- a/ports/perfetto/portfile.cmake
+++ b/ports/perfetto/portfile.cmake
@@ -1,0 +1,28 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/perfetto
+    REF "v${VERSION}"
+    SHA512 9ad6f314e6e56558f7062290afef840d81689776bf3a31708a61fef9ea8d80ac00892b5316856adc784b17e71c67a8429500602b301958ccba24fc4a3b6ac6f8
+    HEAD_REF main
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/perfetto/vcpkg.json
+++ b/ports/perfetto/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "perfetto",
+  "version": "43.1",
+  "description": "System profiling, app tracing and trace analysis",
+  "homepage": "https://perfetto.dev",
+  "license": "Apache-2.0",
+  "supports": "!uwp & !x86",
+  "dependencies": [
+    "pthreads",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6712,6 +6712,10 @@
       "baseline": "2.8.3",
       "port-version": 3
     },
+    "perfetto": {
+      "baseline": "43.1",
+      "port-version": 0
+    },
     "pffft": {
       "baseline": "2021-10-09",
       "port-version": 1

--- a/versions/p-/perfetto.json
+++ b/versions/p-/perfetto.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "db7cf7be562a134411d6aadaeef44df6e9758e6f",
+      "version": "43.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
