### PR TITLE
Avoid optional dependencies in zlmediakit.

### DIFF
--- a/ports/zlmediakit/portfile.cmake
+++ b/ports/zlmediakit/portfile.cmake
@@ -37,12 +37,14 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" static ZLMEDIAKIT_CRT_STATIC)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         openssl ENABLE_OPENSSL
+        openssl CMAKE_REQUIRE_FIND_PACKAGE_OpenSSL
         mp4     ENABLE_MP4
         mp4     ENABLE_RTPPROXY
         mp4     ENABLE_HLS
         sctp    ENABLE_SCTP
         webrtc  ENABLE_WEBRTC
     INVERTED_FEATURES
+        openssl CMAKE_DISABLE_FIND_PACKAGE_OpenSSL
 )
 
 vcpkg_cmake_configure(
@@ -67,6 +69,9 @@ vcpkg_cmake_configure(
         -DUSE_SOLUTION_FOLDERS=ON
         -DENABLE_TESTS=OFF
         -DENABLE_MEM_DEBUG=OFF # only valid on Linux
+        -DCMAKE_DISABLE_FIND_PACKAGE_GIT=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_JEMALLOC=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_SDL2=ON
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/zlmediakit/vcpkg.json
+++ b/ports/zlmediakit/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zlmediakit",
   "version-date": "2024-03-30",
+  "port-version": 1,
   "description": "A high-performance carrier-grade streaming media service framework based on C++11.",
   "homepage": "https://github.com/ZLMediaKit/ZLMediaKit",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9602,7 +9602,7 @@
     },
     "zlmediakit": {
       "baseline": "2024-03-30",
-      "port-version": 0
+      "port-version": 1
     },
     "zoe": {
       "baseline": "3.0",

--- a/versions/z-/zlmediakit.json
+++ b/versions/z-/zlmediakit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f84ad2056d32e9ea7bdc07160784c2458c12e15d",
+      "version-date": "2024-03-30",
+      "port-version": 1
+    },
+    {
       "git-tree": "1af9543148c012a8e58061be6e613dc28f38d0d5",
       "version-date": "2024-03-30",
       "port-version": 0


### PR DESCRIPTION
This was detected by a nightly CI run: https://dev.azure.com/vcpkg/public/_build/results?buildId=101423

Probably broken by https://github.com/microsoft/vcpkg/pull/37654

```console
FAILED: src/CMakeFiles/zlmediakit.dir/Common/JemallocUtil.cpp.o 
/Library/Developer/CommandLineTools/usr/bin/c++ -DENABLE_HLS -DENABLE_MP4 -DENABLE_OPENSSL -DENABLE_RTPPROXY -DENABLE_VERSION -DUSE_JEMALLOC -I/Users/vcpkg/Data/b/zlmediakit/x64-osx-dbg -I/Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/3rdpart -I/Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/src -I/Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/3rdpart/media-server/libflv/include -I/Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/3rdpart/media-server/libmov/include -I/Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/3rdpart/media-server/libmpeg/include -I/Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/3rdpart/ZLToolKit/src -isystem /Users/vcpkg/Data/installed/x64-osx/include -fPIC -g -std=gnu++11 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk -fPIC -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-declarations -Wno-error=extra -Wno-error=missing-field-initializers -Wno-error=type-limits -g3 -MD -MT src/CMakeFiles/zlmediakit.dir/Common/JemallocUtil.cpp.o -MF src/CMakeFiles/zlmediakit.dir/Common/JemallocUtil.cpp.o.d -o src/CMakeFiles/zlmediakit.dir/Common/JemallocUtil.cpp.o -c /Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/src/Common/JemallocUtil.cpp
/Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/src/Common/JemallocUtil.cpp:25:15: error: use of undeclared identifier 'mallctl'
    int err = mallctl("prof.active", nullptr, nullptr, (void *)&active, sizeof(active));
              ^
/Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/src/Common/JemallocUtil.cpp:41:15: error: use of undeclared identifier 'mallctl'
    int err = mallctl("prof.dump", nullptr, nullptr, &c_str, sizeof(const char *));
              ^
/Users/vcpkg/Data/b/zlmediakit/src/577f9abf4e-b61b46e79b.clean/src/Common/JemallocUtil.cpp:50:5: error: use of undeclared identifier 'malloc_stats_print'; did you mean 'je_malloc_stats_print'?
    malloc_stats_print([](void *opaque, const char *s) { ((std::string *)opaque)->append(s); }, &res, "J");
    ^~~~~~~~~~~~~~~~~~
    je_malloc_stats_print
```