### PR TITLE
 [idyntree] Update to 12.1.0 

### DIFF
--- a/ports/idyntree/portfile.cmake
+++ b/ports/idyntree/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO robotology/idyntree
     REF "v${VERSION}"
-    SHA512 36b7fa58e3a3e773dd792d5fe62e4fd16c2265e1ed3ba7b2906fcf19e3f590c0a782beea63f443cb354919b3c9a91b370d3935ef1a39241a5b9be0f506c8a0c9
+    SHA512 9944f91dcfae3381e8a5b36c8ba00b613228c8aa4bc5ee0cdcb6501c8c97f388666635f8df30bb83156ec687c749da689ecf230fb4075e3ab515bac053a6099c
     HEAD_REF master
 )
 
@@ -26,7 +26,6 @@ vcpkg_cmake_configure(
         -DIDYNTREE_USES_ICUB_MAIN:BOOL=OFF
         -DIDYNTREE_USES_ALGLIB:BOOL=OFF
         -DIDYNTREE_USES_WORHP:BOOL=OFF
-        -DIDYNTREE_COMPILE_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/idyntree/vcpkg.json
+++ b/ports/idyntree/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "idyntree",
-  "version": "10.3.0",
+  "version": "12.1.0",
   "description": "Multibody Dynamics Library designed for Free Floating Robots.",
   "homepage": "https://github.com/robotology/idyntree",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3461,7 +3461,7 @@
       "port-version": 0
     },
     "idyntree": {
-      "baseline": "10.3.0",
+      "baseline": "12.1.0",
       "port-version": 0
     },
     "if97": {

--- a/versions/i-/idyntree.json
+++ b/versions/i-/idyntree.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e37ffd4b1f13ea7145f264d95962ae2784f6ee0",
+      "version": "12.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9e480d9ee555087269d114619188461e9b565194",
       "version": "10.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I removed the `IDYNTREE_BUILD_TESTS` as upstream changed to use the standard `BUILD_TESTING` variable, see https://github.com/robotology/idyntree/pull/1167 .
