### PR TITLE
[qtbase] Fix "There should be no absolute paths"

### DIFF
--- a/ports/qtbase/cmake/qt_install_submodule.cmake
+++ b/ports/qtbase/cmake/qt_install_submodule.cmake
@@ -323,6 +323,7 @@ function(qt_fixup_and_cleanup)
         endif()
     endif()
 
+    vcpkg_fixup_pkgconfig()
 endfunction()
 
 function(qt_install_submodule)

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.6.1",
-  "port-version": 11,
+  "port-version": 12,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7270,7 +7270,7 @@
     },
     "qtbase": {
       "baseline": "6.6.1",
-      "port-version": 11
+      "port-version": 12
     },
     "qtcharts": {
       "baseline": "6.6.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25f62a554ceec4eb297697d178df6ac0d231a5ea",
+      "version": "6.6.1",
+      "port-version": 12
+    },
+    {
       "git-tree": "e811ae376e4bc28336b62caaad1d59c277db3b98",
       "version": "6.6.1",
       "port-version": 11


### PR DESCRIPTION
Problem occurs on x64-linux-dynamic.

```
warning: There should be no absolute paths, such as the following, in an installed package:
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic
  /home/XXX/prog/vcpkg/installed
  /home/XXX/prog/vcpkg/buildtrees/qtbase
  /home/XXX/prog/vcpkg/downloads
Absolute paths were found in the following files:
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6Concurrent.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6Core.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6DBus.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6Gui.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6Network.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6OpenGL.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6OpenGLWidgets.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6Platform.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6PrintSupport.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6Sql.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6Test.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6Widgets.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/debug/lib/pkgconfig/Qt6Xml.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6Concurrent.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6Core.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6DBus.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6Gui.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6Network.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6OpenGL.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6OpenGLWidgets.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6Platform.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6PrintSupport.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6Sql.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6Test.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6Widgets.pc
  /home/XXX/prog/vcpkg/packages/qtbase_x64-linux-dynamic/lib/pkgconfig/Qt6Xml.pc
error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: /home/XXX/prog/vcpkg/ports/qtbase/portfile.cmake
```

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
