### PR TITLE
[qtshadertools] Fix "There should be no absolute paths"

### DIFF
--- a/ports/qtshadertools/portfile.cmake
+++ b/ports/qtshadertools/portfile.cmake
@@ -11,3 +11,5 @@ qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
                      CONFIGURE_OPTIONS_RELEASE
                      CONFIGURE_OPTIONS_DEBUG
                     )
+
+vcpkg_fixup_pkgconfig()

--- a/ports/qtshadertools/vcpkg.json
+++ b/ports/qtshadertools/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtshadertools",
   "version": "6.6.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Qt Shader Tools module is designed to provide a set of tools and utilities to work with graphics shaders.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7402,7 +7402,7 @@
     },
     "qtshadertools": {
       "baseline": "6.6.1",
-      "port-version": 1
+      "port-version": 2
     },
     "qtspeech": {
       "baseline": "6.6.1",

--- a/versions/q-/qtshadertools.json
+++ b/versions/q-/qtshadertools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e30d370b2cf66803b9d6bf3ac75a945a8fd2cc44",
+      "version": "6.6.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "e8264a57d51022b91d8e0770b71e385f3de696b4",
       "version": "6.6.1",
       "port-version": 1


### PR DESCRIPTION
Problem occurs on x64-linux-dynamic

```
warning: There should be no absolute paths, such as the following, in an installed package:
  /home/XXXX/prog/vcpkg/packages/qtshadertools_x64-linux-dynamic
  /home/XXXX/prog/vcpkg/installed
  /home/XXXX/prog/vcpkg/buildtrees/qtshadertools
  /home/XXXX/prog/vcpkg/downloads
Absolute paths were found in the following files:
  /home/XXXX/prog/vcpkg/packages/qtshadertools_x64-linux-dynamic/debug/lib/pkgconfig/Qt6ShaderTools.pc
  /home/XXXX/prog/vcpkg/packages/qtshadertools_x64-linux-dynamic/lib/pkgconfig/Qt6ShaderTools.pc
error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: /home/XXXX/prog/vcpkg/ports/qtshadertools/portfile.cmake
```

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
