### PR TITLE
[simdutf] Update to 5.2.3

### DIFF
--- a/ports/simdutf/portfile.cmake
+++ b/ports/simdutf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO simdutf/simdutf
     REF "v${VERSION}"
-    SHA512 56c19e52eb8dd3736e984cdc49a92909ffa3240b115c0ea0c3cfd29eca79a2bec1f8489ac030c27cd1f8446bbed27daf3e83e214a0871f4e78d85d1f8ebb964f
+    SHA512 b433abd2ace5fbb5ec598fd16af85c69cd8683f8cb35da27eab07e1e9e899eeee58f176ec7cee40daa6566b367bb9a3e90a96fe99b2007ff05c0d36afc11f5f7
     HEAD_REF master
 )
 

--- a/ports/simdutf/vcpkg.json
+++ b/ports/simdutf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "simdutf",
-  "version-semver": "5.2.2",
+  "version-semver": "5.2.3",
   "description": "Unicode validation and transcoding at billions of characters per second",
   "homepage": "https://github.com/simdutf/simdutf",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8081,7 +8081,7 @@
       "port-version": 0
     },
     "simdutf": {
-      "baseline": "5.2.2",
+      "baseline": "5.2.3",
       "port-version": 0
     },
     "simonbrunel-qtpromise": {

--- a/versions/s-/simdutf.json
+++ b/versions/s-/simdutf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efcb4369394af49aaf2b30f113530327140e931a",
+      "version-semver": "5.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "71f8ed944c9a140b642c6f56f012626cdd1ed898",
       "version-semver": "5.2.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
