### PR TITLE
[mongo-c-driver][libbson] Update version to 1.26.2

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 ef55fadf66a28a7e9dd513ce9cd36fc91898775d5d20903193b1f321f7814129b1d56c980cfc81cf348830d7bbfde81885585fbcf498ead287675b67c91d470d
+    SHA512 78da2fc51515b3b81214246665685680e9821b641cb6d3b821b23bdb3a8290df9d8b27b9aebce1d809454ae0b5619d758e8cb9699ac1096a7cc828994bad8f88
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/disable-dynamic-when-static.patch
+++ b/ports/mongo-c-driver/disable-dynamic-when-static.patch
@@ -1,5 +1,5 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 3070c43..807ef8c 100644
+index 3070c43..0052a4e 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
 @@ -820,7 +820,7 @@ set_property(
@@ -11,15 +11,7 @@ index 3070c43..807ef8c 100644
     add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
     if(WIN32)
        # Add resource-definition script for Windows shared library (.dll).
-@@ -1093,6 +1093,7 @@ set (test-libmongoc-sources
-    ${PROJECT_SOURCE_DIR}/tests/unified/util.c
- )
- 
-+if(NOT MONGOC_ENABLE_STATIC_INSTALL)
- if (MONGOC_ENABLE_SSL)
-    set (test-libmongoc-sources ${test-libmongoc-sources}
-       ${PROJECT_SOURCE_DIR}/tests/ssl-test.c
-@@ -1262,7 +1263,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
+@@ -1262,7 +1262,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
     list (APPEND TARGETS_TO_INSTALL mongoc_static)
  endif ()
  
@@ -28,6 +20,14 @@ index 3070c43..807ef8c 100644
     list (APPEND TARGETS_TO_INSTALL mongoc_shared)
  endif ()
  
+@@ -1317,6 +1317,7 @@ endif()
+ set_property(TARGET ${TARGETS_TO_INSTALL} APPEND PROPERTY pkg_config_INCLUDE_DIRECTORIES "${MONGOC_HEADER_INSTALL_DIR}")
+ 
+ # Deprecated alias for libmongoc-1.0.pc, see CDRIVER-2086.
++if(NOT MONGOC_ENABLE_STATIC_INSTALL)
+ if (MONGOC_ENABLE_SSL)
+    configure_file (
+       ${CMAKE_CURRENT_SOURCE_DIR}/src/libmongoc-ssl-1.0.pc.in
 @@ -1327,6 +1328,7 @@ if (MONGOC_ENABLE_SSL)
        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     )

--- a/ports/mongo-c-driver/disable-dynamic-when-static.patch
+++ b/ports/mongo-c-driver/disable-dynamic-when-static.patch
@@ -1,17 +1,25 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index c36dff1..525e065 100644
+index 3070c43..807ef8c 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -812,7 +812,7 @@ if (MONGOC_ENABLE_STATIC_BUILD)
-    set_target_properties (mcd_rpc PROPERTIES OUTPUT_NAME "mcd-rpc")
- endif ()
+@@ -820,7 +820,7 @@ set_property(
+    "MONGOC_CYRUS_PLUGIN_PATH_PREFIX=$<IF:$<STREQUAL:${CYRUS_PLUGIN_PATH_PREFIX},>,NULL,\"${CYRUS_PLUGIN_PATH_PREFIX}\">"
+ )
  
 -if (ENABLE_SHARED)
 +if (NOT MONGOC_ENABLE_STATIC_BUILD)
     add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
     if(WIN32)
        # Add resource-definition script for Windows shared library (.dll).
-@@ -1253,7 +1253,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
+@@ -1093,6 +1093,7 @@ set (test-libmongoc-sources
+    ${PROJECT_SOURCE_DIR}/tests/unified/util.c
+ )
+ 
++if(NOT MONGOC_ENABLE_STATIC_INSTALL)
+ if (MONGOC_ENABLE_SSL)
+    set (test-libmongoc-sources ${test-libmongoc-sources}
+       ${PROJECT_SOURCE_DIR}/tests/ssl-test.c
+@@ -1262,7 +1263,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
     list (APPEND TARGETS_TO_INSTALL mongoc_static)
  endif ()
  
@@ -20,15 +28,7 @@ index c36dff1..525e065 100644
     list (APPEND TARGETS_TO_INSTALL mongoc_shared)
  endif ()
  
-@@ -1308,6 +1308,7 @@ endif()
- set_property(TARGET ${TARGETS_TO_INSTALL} APPEND PROPERTY pkg_config_INCLUDE_DIRECTORIES "${MONGOC_HEADER_INSTALL_DIR}")
- 
- # Deprecated alias for libmongoc-1.0.pc, see CDRIVER-2086.
-+if(NOT MONGOC_ENABLE_STATIC_INSTALL)
- if (MONGOC_ENABLE_SSL)
-    configure_file (
-       ${CMAKE_CURRENT_SOURCE_DIR}/src/libmongoc-ssl-1.0.pc.in
-@@ -1318,6 +1319,7 @@ if (MONGOC_ENABLE_SSL)
+@@ -1327,6 +1328,7 @@ if (MONGOC_ENABLE_SSL)
        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     )
  endif ()

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 ef55fadf66a28a7e9dd513ce9cd36fc91898775d5d20903193b1f321f7814129b1d56c980cfc81cf348830d7bbfde81885585fbcf498ead287675b67c91d470d
+    SHA512 78da2fc51515b3b81214246665685680e9821b641cb6d3b821b23bdb3a8290df9d8b27b9aebce1d809454ae0b5619d758e8cb9699ac1096a7cc828994bad8f88
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4189,7 +4189,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.26.1",
+      "baseline": "1.26.2",
       "port-version": 0
     },
     "libcaer": {
@@ -5793,7 +5793,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.26.1",
+      "baseline": "1.26.2",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb512263f9f4c415f70c080d8d42d809939af4a4",
+      "version": "1.26.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a5e9407add76bf33b2aa98eafc4d1bad7173f2ba",
       "version": "1.26.1",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4ad0a2c843b34a18eb07be1ec301a8a3734f38e",
+      "version": "1.26.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "692416ecf8db8f3b20661a2a23a3cc37e848fe84",
       "version": "1.26.1",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b4ad0a2c843b34a18eb07be1ec301a8a3734f38e",
+      "git-tree": "863c473a941f5db2ce3878b7290854c96bd561a9",
       "version": "1.26.2",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fix https://github.com/microsoft/vcpkg/issues/37921
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


