### PR TITLE
[vcpkg-cmake-config] Adapt get_filename_component package prefix for CMake 3.29.1

### DIFF
--- a/ports/vcpkg-cmake-config/vcpkg.json
+++ b/ports/vcpkg-cmake-config/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vcpkg-cmake-config",
-  "version-date": "2022-02-06",
-  "port-version": 1,
+  "version-date": "2024-04-07",
   "documentation": "https://vcpkg.io/en/docs/README.html",
   "license": "MIT"
 }

--- a/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
+++ b/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
@@ -146,9 +146,17 @@ get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)]]
 [[get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)]]
                 contents "${contents}")
             string(REGEX REPLACE
+[[(get_filename_component\(PACKAGE_\${CMAKE_FIND_PACKAGE_NAME}_COUNTER_[1-9][0-9]*) "\${CMAKE_CURRENT_LIST_DIR}/\.\./(\.\./)*" ABSOLUTE\)]]
+"\\1 \"\${CMAKE_CURRENT_LIST_DIR}/../../\" ABSOLUTE)" # adapt to https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9390
+                contents "${contents}")
+            string(REGEX REPLACE
 [[get_filename_component\(PACKAGE_PREFIX_DIR "\${CMAKE_CURRENT_LIST_DIR}/\.\.((\\|/)\.\.)*" ABSOLUTE\)]]
 [[get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)]]
                 contents "${contents}") # This is a meson-related workaround, see https://github.com/mesonbuild/meson/issues/6955
+            string(REGEX REPLACE
+[[(get_filename_component\(PACKAGE_\${CMAKE_FIND_PACKAGE_NAME}_COUNTER_[1-9][0-9]*) "\${CMAKE_CURRENT_LIST_DIR}/\.\.((\\|/)\.\.)*" ABSOLUTE\)]]
+"\\1 \"\${CMAKE_CURRENT_LIST_DIR}/../../\" ABSOLUTE)"
+                contents "${contents}")
         endif()
 
         # Merge release and debug configurations of target property INTERFACE_LINK_LIBRARIES.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9009,8 +9009,8 @@
       "port-version": 0
     },
     "vcpkg-cmake-config": {
-      "baseline": "2022-02-06",
-      "port-version": 1
+      "baseline": "2024-04-07",
+      "port-version": 0
     },
     "vcpkg-cmake-get-vars": {
       "baseline": "2023-12-31",

--- a/versions/v-/vcpkg-cmake-config.json
+++ b/versions/v-/vcpkg-cmake-config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2bb0587c37fbe37db04cf1ca362c6e1811744c6a",
+      "version-date": "2024-04-07",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d54cc4f487d51b655abec5f9c9c3f86ca83311f",
       "version-date": "2022-02-06",
       "port-version": 1


### PR DESCRIPTION
Since `CMake` version `3.29.2` reverted these changes in [Kitware - CMake - 9420](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9420), closed this issue.

See [Kitware - CMake - 25873](https://gitlab.kitware.com/cmake/cmake/-/issues/25873) and [Kitware - CMake - 25827](https://gitlab.kitware.com/cmake/cmake/-/issues/25827)

---

Fix #37968.

Function `vcpkg_cmake_config_fixup` in `vcpkg-cmake-config` cannot adjust the prefix for `CMake` version `3.29.1` because the module `CMakePackageConfigHelpers` altered package config `PACKAGE_PREFIX_DIR` to "package name and a global counter" at [Kitware - CMake - !9390](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9390).

Add replacement for new formats to fix it.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
Port `tinyobjloader` usage tests pass for `CMake` version `3.29.0` and `3.29.1`
* The config file in `lib/tinyobjloader/cmake` was moved to `share/tinyobjloader`.
* The `get_filename_component` prefix was modified to the correct deepness.
  * For `3.29.0`, `get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)`
  * For `3.29.1`, `get_filename_component(PACKAGE_${CMAKE_FIND_PACKAGE_NAME}_COUNTER_1 "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)`