### PR TITLE
[icu] Add reminder to install autoconf-archive

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -1,16 +1,16 @@
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     message(WARNING "${PORT} currently requires the following programs from the system package manager:
-    autoconf-archive
+    autoconf automake autoconf-archive
 On Debian and Ubuntu derivatives:
-    sudo apt-get install autoconf-archive
+    sudo apt-get install autoconf automake autoconf-archive
 On recent Red Hat and Fedora derivatives:
-    sudo dnf install autoconf-archive
+    sudo dnf install autoconf automake autoconf-archive
 On Arch Linux and derivatives:
-    sudo pacman -S autoconf-archive
+    sudo pacman -S autoconf automake autoconf-archive
 On Alpine:
-    apk add autoconf-archive
+    apk add autoconf automake autoconf-archive
 On macOS:
-    brew install autoconf-archive\n")
+    brew install autoconf automake autoconf-archive\n")
 endif()
 
 string(REGEX MATCH "^[0-9]*" ICU_VERSION_MAJOR "${VERSION}")

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -1,3 +1,18 @@
+if(NOT VCPKG_HOST_IS_WINDOWS)
+    message(WARNING "${PORT} currently requires the following programs from the system package manager:
+    autoconf-archive
+On Debian and Ubuntu derivatives:
+    sudo apt-get install autoconf-archive
+On recent Red Hat and Fedora derivatives:
+    sudo dnf install autoconf-archive
+On Arch Linux and derivatives:
+    sudo pacman -S autoconf-archive
+On Alpine:
+    apk add autoconf-archive
+On macOS:
+    brew install autoconf-archive\n")
+endif()
+
 string(REGEX MATCH "^[0-9]*" ICU_VERSION_MAJOR "${VERSION}")
 string(REPLACE "." "_" VERSION2 "${VERSION}")
 string(REPLACE "." "-" VERSION3 "${VERSION}")

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -1,4 +1,4 @@
-if(NOT VCPKG_HOST_IS_WINDOWS)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
     message(WARNING "${PORT} currently requires the following programs from the system package manager:
     autoconf-archive
 On Debian and Ubuntu derivatives:

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "74.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3450,7 +3450,7 @@
     },
     "icu": {
       "baseline": "74.2",
-      "port-version": 1
+      "port-version": 2
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e5fa480ab4b85f1e42e72262027c96c7dd5ae0af",
+      "git-tree": "a36199768fe1f9676b61d5d28ed9ac36c9f041c0",
       "version": "74.2",
       "port-version": 2
     },

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ac34dd85b6ed88c8be1f835a7af7421c33b66ff7",
+      "git-tree": "e5fa480ab4b85f1e42e72262027c96c7dd5ae0af",
       "version": "74.2",
       "port-version": 2
     },

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac34dd85b6ed88c8be1f835a7af7421c33b66ff7",
+      "version": "74.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "dd30ff59dbfac290a1547dccc5ba44646fffa018",
       "version": "74.2",
       "port-version": 1


### PR DESCRIPTION
Fixes #38005.
By user request, add a reminder to install `autoconf-archive` on non-windows machines.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ·Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
