### PR TITLE
[vcpkg baseline][minio-cpp] Passing remove form fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -697,7 +697,6 @@ milerius-sfml-imgui:x64-windows-static=fail
 minifb:arm-neon-android=fail
 minifb:arm64-android=fail
 minifb:x64-android=fail
-minio-cpp:arm-neon-android=fail
 miniply:arm-neon-android=fail
 # Conflicts with signalrclient
 microsoft-signalr:arm64-windows=skip


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=101560&view=results

Added `minio-cpp` to ci.baseline.txt by https://github.com/microsoft/vcpkg/pull/29406, which has been fixed by https://github.com/microsoft/vcpkg/pull/37990.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~


