### PR TITLE
[fluidsynth] Update to 2.3.5

### DIFF
--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FluidSynth/fluidsynth
     REF "v${VERSION}"
-    SHA512 79891116d78b9be1c38bce9e5759b9bb732c3d8ee31c6e57d1a3e2b5548879b91d19582e73ee7fb0fd243beba3bf1bbc341a26aab0b6440eef36fc55dce3e8b0
+    SHA512 35eaea8c1709ebbd5dee8f3946ab59c39afe31d92b972a44013fa23987aa48936f7d1326d5bda81c6e66f02bf988e48601367d49276a4dd78dbca7a2571f5e57
     HEAD_REF master
     PATCHES
         gentables.patch

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidsynth",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2749,7 +2749,7 @@
       "port-version": 0
     },
     "fluidsynth": {
-      "baseline": "2.3.4",
+      "baseline": "2.3.5",
       "port-version": 0
     },
     "flux": {

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9015904f6d25bf55671ce9a04665b6a9afa3c909",
+      "version": "2.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "a3a06acfea8bc59c70ac08c3028f9afa40134852",
       "version": "2.3.4",
       "port-version": 0


### PR DESCRIPTION
Fixes #38021.

Features `buildtools,sndfile` are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```
All features are tested successfully in the following triplet:
```
x64-linux
```
The usage test passed on `x64-windows` (header files found):
```
The package fluidsynth provides CMake targets:

    find_package(FluidSynth CONFIG REQUIRED)
    target_link_libraries(main PRIVATE FluidSynth::libfluidsynth)
    add_custom_command(OUTPUT result COMMAND FluidSynth::fluidsynth ARGS ...)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.