### PR TITLE
[json-schema-validator] Fix CMake install target on Windows

### DIFF
--- a/ports/json-schema-validator/portfile.cmake
+++ b/ports/json-schema-validator/portfile.cmake
@@ -1,26 +1,34 @@
+vcpkg_download_distfile(PATCH_JSON_SCHEMA_VALIDATOR_PR_315
+    URLS https://github.com/pboettch/json-schema-validator/commit/0034c113477f83c28d4380de1ee189c25b1168e6.patch
+    SHA512 5c165b50813b0d9937ff0eb4d4a81e2d1e77718ac3b0d02b93931c8eddb4e06e4fae1822c5cc97a5b01c995916a29d0af03fcbcd8f059cb29cfeb0e2371b15e3
+    FILENAME 0034c113477f83c28d4380de1ee189c25b1168e6.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pboettch/json-schema-validator
     REF "${VERSION}"
     SHA512 6d207031acdb94c44f96ff6346dccaf98f2c9d3619d71e419ddabff548ea34d50e8eb103622c99ae28ecb7fddedd687b297e5ad934aa0106c58ac59fc4d65ea9
     HEAD_REF master
+    PATCHES
+        "${PATCH_JSON_SCHEMA_VALIDATOR_PR_315}"
 )
+
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" BUILD_SHARED_LIBS)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DJSON_VALIDATOR_INSTALL=ON
         -DJSON_VALIDATOR_BUILD_TESTS=OFF
         -DJSON_VALIDATOR_BUILD_EXAMPLES=OFF
+        -DJSON_VALIDATOR_SHARED_LIBS=${BUILD_SHARED_LIBS}
 )
 
 vcpkg_cmake_install()
-
-vcpkg_cmake_config_fixup(PACKAGE_NAME nlohmann_json_schema_validator CONFIG_PATH lib/cmake/nlohmann_json_schema_validator)
-
 vcpkg_copy_pdbs()
 
+vcpkg_cmake_config_fixup(PACKAGE_NAME "nlohmann_json_schema_validator" CONFIG_PATH "lib/cmake/nlohmann_json_schema_validator")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-

--- a/ports/json-schema-validator/usage
+++ b/ports/json-schema-validator/usage
@@ -1,4 +1,0 @@
-json-schema-validator provides CMake integration:
-
-    find_package(nlohmann_json_schema_validator REQUIRED)
-    target_link_libraries(main PRIVATE nlohmann_json_schema_validator::validator)

--- a/ports/json-schema-validator/vcpkg.json
+++ b/ports/json-schema-validator/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "json-schema-validator",
   "version": "2.3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ library for validating JSON documents based on a JSON Schema. This validator is based on the nlohmann-json library.",
   "homepage": "https://github.com/pboettch/json-schema-validator",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3750,7 +3750,7 @@
     },
     "json-schema-validator": {
       "baseline": "2.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "json-spirit": {
       "baseline": "4.1.0",

--- a/versions/j-/json-schema-validator.json
+++ b/versions/j-/json-schema-validator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8982b7778711884f44358d66f92ddb1f0ad4b99d",
+      "version": "2.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "31c71975b94068010a3985ac84deed50047c6820",
       "version": "2.3.0",
       "port-version": 1


### PR DESCRIPTION
Fix #37972.

Apply upstream fix patch https://github.com/pboettch/json-schema-validator/commit/0034c113477f83c28d4380de1ee189c25b1168e6.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
Port usage tests pass with following triplets:
* x64-linux
* x64-windows
* x64-windows-static