### PR TITLE
[liblzma] Change repo

### DIFF
--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -1,9 +1,8 @@
-vcpkg_from_github(
+vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO tukaani-project/xz
-    REF "v${VERSION}"
-    SHA512 c28461123562564e030f3f733f078bc4c840e87598d9f4b718d4bca639120d8133f969c45d7bdc62f33f081d789ec0f14a1791fb7da18515682bfe3c0c7362e0
-    HEAD_REF master
+    REPO lzmautils
+    FILENAME "xz-5.4.4.tar.gz"
+    SHA512 2e27d864c9f346e53afc549d7046385b5d35a749af15d84f69de14612657df2f0e2ce71d3be03d57adadf8fd28549ecf4ef1c214bdcd1f061b5a47239e0104e8
     PATCHES
         fix_config_include.patch
         win_output_name.patch # Fix output name on Windows. Autotool build does not generate lib prefixed libraries on windows. 

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "liblzma",
   "version": "5.4.4",
+  "port-version": 1,
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4594,7 +4594,7 @@
     },
     "liblzma": {
       "baseline": "5.4.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libmad": {
       "baseline": "0.16.4",

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e043f163404466852c9f05a1a06dc03b08cc7eb7",
+      "version": "5.4.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "b362003b452b95b7fef8577175651a7e33940f7f",
       "version": "5.6.0",
       "port-version": 0


### PR DESCRIPTION
In order to solve the download failure problem caused by the disabled repo due to the planting of backdoor, replace the repo to sourceforge.

Affected version >=5.6.0, so there is no risk on the vcpkg side.

Thanks @AbdulsalamAmin.

Fixes https://github.com/microsoft/vcpkg/issues/37893