### PR TITLE
[qt5] fix build qt5[all] on macos

### DIFF
--- a/ports/qt5/vcpkg.json
+++ b/ports/qt5/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5",
   "version": "5.15.13",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A cross-platform application and UI framework.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -76,17 +76,17 @@
           "name": "qt5",
           "default-features": false,
           "features": [
-            "webengine"
+            "wayland"
           ],
-          "platform": "!static"
+          "platform": "linux"
         },
         {
           "name": "qt5",
           "default-features": false,
           "features": [
-            "wayland"
+            "webengine"
           ],
-          "platform": "!windows"
+          "platform": "!static"
         },
         {
           "name": "qt5-base",
@@ -128,7 +128,7 @@
       "dependencies": [
         {
           "name": "qt5-doc",
-          "platform": "!windows"
+          "platform": "linux"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7086,7 +7086,7 @@
     },
     "qt5": {
       "baseline": "5.15.13",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-3d": {
       "baseline": "5.15.13",

--- a/versions/q-/qt5.json
+++ b/versions/q-/qt5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f508ce98f6759bbd61c29ea9825f2671b557998",
+      "version": "5.15.13",
+      "port-version": 2
+    },
+    {
       "git-tree": "d7256778e43dd4f8b09a2192ce5ca10b9d1050ed",
       "version": "5.15.13",
       "port-version": 1


### PR DESCRIPTION
this PR updates an existing port by sync feature's "platform" with its dependencies

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
