### PR TITLE
[freeimage] Don't depend on default features

### DIFF
--- a/ports/freeimage/vcpkg.json
+++ b/ports/freeimage/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "freeimage",
   "version": "3.18.0",
-  "port-version": 25,
+  "port-version": 26,
   "description": "Support library for graphics image formats",
   "homepage": "https://sourceforge.net/projects/freeimage/",
   "license": "GPL-2.0-only OR GPL-3.0-only OR FreeImage",
@@ -13,11 +13,15 @@
     "libraw",
     {
       "name": "libwebp",
+      "default-features": false,
       "platform": "!uwp"
     },
     "openexr",
     "openjpeg",
-    "tiff",
+    {
+      "name": "tiff",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2822,7 +2822,7 @@
     },
     "freeimage": {
       "baseline": "3.18.0",
-      "port-version": 25
+      "port-version": 26
     },
     "freeopcua": {
       "baseline": "20190125",

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7b2a65974c7375dc69526c2c5390f1c7932aa1b",
+      "version": "3.18.0",
+      "port-version": 26
+    },
+    {
       "git-tree": "423daf86bc904882a1fa9c68d56d56d7c52ac35f",
       "version": "3.18.0",
       "port-version": 25


### PR DESCRIPTION
Fixes #38013:

> Make lzma an optional dependency. Seems to be pulled in via tiff at least.