### PR TITLE
[re2] Backport config fix for CMake 3.29.1

### DIFF
--- a/ports/re2/portfile.cmake
+++ b/ports/re2/portfile.cmake
@@ -1,9 +1,17 @@
+vcpkg_download_distfile(PATCH_488
+    URLS https://github.com/google/re2/commit/9ebe4a22cad8a025b68a9594bdff3c047a111333.patch?full_index=1
+    SHA512 167a0153bf24e77db2b8555a7d6391acf740dc4720a71e6ce19a3533c7e0a49923d9584ff32544a454837a25eedace00cb2ef9ddbf4250deb5f2c5aeda04ac26
+    FILENAME 9ebe4a22cad8a025b68a9594bdff3c047a111333.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/re2
     REF "${VERSION}"
     SHA512 1511d163ee90c724705cc16d2995e777a7d894ff8133bd3457a26d8c6a9dcb8ccdd2e77b73681e623317a1edbbd3c928569358af91e72ce8612f7b7b61108283
     HEAD_REF master
+    PATCHES
+        "${PATCH_488}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/re2/vcpkg.json
+++ b/ports/re2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "re2",
   "version-date": "2024-04-01",
+  "port-version": 1,
   "description": "RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python. It is a C++ library.",
   "homepage": "https://github.com/google/re2",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7562,7 +7562,7 @@
     },
     "re2": {
       "baseline": "2024-04-01",
-      "port-version": 0
+      "port-version": 1
     },
     "reactiveplusplus": {
       "baseline": "2.0.0",

--- a/versions/r-/re2.json
+++ b/versions/r-/re2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19e35429ba172da1f08743ff317d504fa21bebf3",
+      "version-date": "2024-04-01",
+      "port-version": 1
+    },
+    {
       "git-tree": "aa0f6c4f73231f8b623c799eb8d88e67c6a65481",
       "version-date": "2024-04-01",
       "port-version": 0


### PR DESCRIPTION
Fix #38064.

Apply upstream fix patch https://github.com/google/re2/commit/9ebe4a22cad8a025b68a9594bdff3c047a111333.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
Port usage tests pass for `CMake` version `3.29.0` and `3.29.1` with following triplets:
* x64-windows