### PR TITLE
Recognize new package prefix directory variable in CMake 3.29.1.

### DIFF
--- a/ports/vcpkg-cmake-config/vcpkg.json
+++ b/ports/vcpkg-cmake-config/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vcpkg-cmake-config",
-  "version-date": "2022-02-06",
-  "port-version": 1,
+  "version-date": "2024-04-09",
   "documentation": "https://vcpkg.io/en/docs/README.html",
   "license": "MIT"
 }

--- a/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
+++ b/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
@@ -142,12 +142,12 @@ get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
 get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)]]
                 contents "${contents}") # see #1044 for details why this replacement is necessary. See #4782 why it must be a regex.
             string(REGEX REPLACE
-[[get_filename_component\(PACKAGE_PREFIX_DIR "\${CMAKE_CURRENT_LIST_DIR}/\.\./(\.\./)*" ABSOLUTE\)]]
-[[get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)]]
-                contents "${contents}")
+[[get_filename_component\((PACKAGE_PREFIX_DIR|PACKAGE_\${CMAKE_FIND_PACKAGE_NAME}_COUNTER[0-9]+) "\${CMAKE_CURRENT_LIST_DIR}/\.\./(\.\./)*" ABSOLUTE\)]]
+[[get_filename_component(\1 "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)]]
+                contents "${contents}") # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9390 uses a different package prefix directory variable.
             string(REGEX REPLACE
-[[get_filename_component\(PACKAGE_PREFIX_DIR "\${CMAKE_CURRENT_LIST_DIR}/\.\.((\\|/)\.\.)*" ABSOLUTE\)]]
-[[get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)]]
+[[get_filename_component\((PACKAGE_PREFIX_DIR|PACKAGE_\${CMAKE_FIND_PACKAGE_NAME}_COUNTER_[0-9]+) "\${CMAKE_CURRENT_LIST_DIR}/\.\.((\\|/)\.\.)*" ABSOLUTE\)]]
+[[get_filename_component(\1 "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)]]
                 contents "${contents}") # This is a meson-related workaround, see https://github.com/mesonbuild/meson/issues/6955
         endif()
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9013,8 +9013,8 @@
       "port-version": 0
     },
     "vcpkg-cmake-config": {
-      "baseline": "2022-02-06",
-      "port-version": 1
+      "baseline": "2024-04-09",
+      "port-version": 0
     },
     "vcpkg-cmake-get-vars": {
       "baseline": "2023-12-31",

--- a/versions/v-/vcpkg-cmake-config.json
+++ b/versions/v-/vcpkg-cmake-config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb0f015a7e3d03ac5bdfad4bb8784049f615987a",
+      "version-date": "2024-04-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d54cc4f487d51b655abec5f9c9c3f86ca83311f",
       "version-date": "2022-02-06",
       "port-version": 1


### PR DESCRIPTION
In CMake 3.29.1, the `configure_package_config_file` function changed the name of the variable with the package prefix dictionary from `PACKAGE_PREFIX_DIR` to a name that depends on the current package's name, and a counter variable. This PR updates the `vcpkg_cmake_config_fixup` function accordingly to recognize this new pattern.

Validated locally.

Fixes #37968

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
