### PR TITLE
[symcrypt] Add new port

### DIFF
--- a/ports/symcrypt/cmake_build_dir.patch
+++ b/ports/symcrypt/cmake_build_dir.patch
@@ -1,0 +1,156 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 636212d..6c87bba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,9 +9,11 @@ if(WIN32)
+     set(CMAKE_SYSTEM_VERSION 10.0.18362)
+ endif()
+ 
++set(SYMCRYPT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
++
+ # Set version number using helper script
+ execute_process(
+-    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/version.py --build-info
++    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/version.py --build-info
+     OUTPUT_VARIABLE SYMCRYPT_VERSION
+     RESULT_VARIABLE SYMCRYPT_VERSION_RESULT
+ )
+@@ -74,7 +76,7 @@ option(
+     ON, but may need to be disabled for specialized targets such as embedded systems."
+     ON)
+ 
+-include(${CMAKE_SOURCE_DIR}/cmake-configs/SymCrypt-Platforms.cmake)
++include(${CMAKE_CURRENT_SOURCE_DIR}/cmake-configs/SymCrypt-Platforms.cmake)
+ 
+ if(NOT DEFINED CMAKE_BUILD_TYPE)
+   set(CMAKE_BUILD_TYPE Debug)
+@@ -112,4 +114,9 @@ configure_file(build/symcrypt.pc.in symcrypt.pc @ONLY)
+ 
+ add_subdirectory(lib)
+ add_subdirectory(modules)
+-add_subdirectory(unittest)
+\ No newline at end of file
++
++option(SYMCRYPT_BUILD_TESTS "Build unit tests" ON)
++
++if(SYMCRYPT_BUILD_TESTS)
++  add_subdirectory(unittest)
++endif()
+\ No newline at end of file
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 4dfcb46..cc4853c 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -153,10 +153,10 @@ function(process_cppasm filepath outformat archdefine)
+         add_custom_command(
+             OUTPUT ${output_asm}
+             COMMAND "${CMAKE_C_COMPILER}" -E -P -x c ${filepath} -o ${output_asm}
+-                -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/${rootpath} -I${CMAKE_SOURCE_DIR}/inc
++                -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/${rootpath} -I${SYMCRYPT_SOURCE_DIR}/inc
+                 -DSYMCRYPT_${outformatupper} -DSYMCRYPT_CPU_${archdefineupper} ${dbg_definition}
+             MAIN_DEPENDENCY ${filepath}
+-            DEPENDS ${CMAKE_SOURCE_DIR}/inc/C_asm_shared.inc ${filepath} symcryptasm_shared.cppasm
++            DEPENDS ${SYMCRYPT_SOURCE_DIR}/inc/C_asm_shared.inc ${filepath} symcryptasm_shared.cppasm
+             COMMENT "C preprocessing ${filepath} to ${outformat} (${output_asm})"
+             VERBATIM)
+     elseif(outformat STREQUAL masm)
+@@ -164,10 +164,10 @@ function(process_cppasm filepath outformat archdefine)
+         add_custom_command(
+             OUTPUT ${output_asm}
+             COMMAND "${CMAKE_C_COMPILER}" /EP /P /Fi${output_asm} ${filepath}
+-                -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/${rootpath} -I${CMAKE_SOURCE_DIR}/inc
++                -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/${rootpath} -I${SYMCRYPT_SOURCE_DIR}/inc
+                 -DSYMCRYPT_${outformatupper} -DSYMCRYPT_CPU_${archdefineupper} ${dbg_definition}
+             MAIN_DEPENDENCY ${filepath}
+-            DEPENDS ${CMAKE_SOURCE_DIR}/inc/C_asm_shared.inc ${filepath} symcryptasm_shared.cppasm
++            DEPENDS ${SYMCRYPT_SOURCE_DIR}/inc/C_asm_shared.inc ${filepath} symcryptasm_shared.cppasm
+             COMMENT "C preprocessing ${filepath} to ${outformat} (${output_asm})"
+             VERBATIM)
+     endif()
+@@ -196,9 +196,9 @@ function(process_symcryptasm filepath outformat archdefine callingconvention)
+     add_custom_command(
+         OUTPUT ${output_cppasm}
+         COMMAND ${CMAKE_COMMAND} -E make_directory ${output_directory}
+-        COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/symcryptasm_processor.py ${outformat} ${archdefine} ${callingconvention} ${filepath} ${output_cppasm}
++        COMMAND ${Python3_EXECUTABLE} ${SYMCRYPT_SOURCE_DIR}/scripts/symcryptasm_processor.py ${outformat} ${archdefine} ${callingconvention} ${filepath} ${output_cppasm}
+         MAIN_DEPENDENCY ${filepath}
+-        DEPENDS ${CMAKE_SOURCE_DIR}/scripts/symcryptasm_processor.py
++        DEPENDS ${SYMCRYPT_SOURCE_DIR}/scripts/symcryptasm_processor.py
+         COMMENT "Python preprocessing ${filepath} to ${outformat} (${output_cppasm})"
+         VERBATIM)
+ 
+@@ -398,7 +398,7 @@ if(NOT WIN32)
+     target_link_libraries(symcrypt_linuxusermode symcrypt_common)
+ endif()
+ 
+-include_directories(${CMAKE_SOURCE_DIR}/inc)
++include_directories(${SYMCRYPT_SOURCE_DIR}/inc)
+ 
+ add_library(symcrypt_common STATIC ${SOURCES_COMMON})
+ 
+diff --git a/modules/linux/common/CMakeLists.txt b/modules/linux/common/CMakeLists.txt
+index c09ab65..ef38727 100644
+--- a/modules/linux/common/CMakeLists.txt
++++ b/modules/linux/common/CMakeLists.txt
+@@ -2,7 +2,7 @@ set(SOURCES
+     module.c
+     rng.c)
+ 
+-include_directories(${CMAKE_SOURCE_DIR}/inc)
++include_directories(${SYMCRYPT_SOURCE_DIR}/inc)
+ 
+ add_library(symcrypt_module_linux_common STATIC ${SOURCES})
+ 
+@@ -26,5 +26,5 @@ add_custom_target(jitterentropy_lib ALL
+     env "CFLAGS=${jitter_cflags}"
+     env "LDFLAGS=${jitter_ldflags}"
+     make
+-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/3rdparty/jitterentropy-library
++  WORKING_DIRECTORY ${SYMCRYPT_SOURCE_DIR}/3rdparty/jitterentropy-library
+ )
+\ No newline at end of file
+diff --git a/modules/linux/generic/CMakeLists.txt b/modules/linux/generic/CMakeLists.txt
+index 32f0a68..d8b33b6 100644
+--- a/modules/linux/generic/CMakeLists.txt
++++ b/modules/linux/generic/CMakeLists.txt
+@@ -11,12 +11,12 @@ else()
+     list(APPEND SOURCES ../common/nointegrity.c)
+ endif()
+ 
+-include_directories(${CMAKE_SOURCE_DIR}/inc ../common ${CMAKE_SOURCE_DIR}/3rdparty/jitterentropy-library)
++include_directories(${SYMCRYPT_SOURCE_DIR}/inc ../common ${SYMCRYPT_SOURCE_DIR}/3rdparty/jitterentropy-library)
+ 
+ add_library(symcrypt_generic_linux SHARED ${SOURCES})
+ 
+ # Link jitterentropy and libatomic
+-target_link_libraries(symcrypt_generic_linux ${CMAKE_SOURCE_DIR}/3rdparty/jitterentropy-library/libjitterentropy.a pthread atomic)
++target_link_libraries(symcrypt_generic_linux ${SYMCRYPT_SOURCE_DIR}/3rdparty/jitterentropy-library/libjitterentropy.a pthread atomic)
+ 
+ add_dependencies(symcrypt_generic_linux jitterentropy_lib)
+ 
+diff --git a/modules/linux/oe_full/CMakeLists.txt b/modules/linux/oe_full/CMakeLists.txt
+index fec04e1..c20bac4 100644
+--- a/modules/linux/oe_full/CMakeLists.txt
++++ b/modules/linux/oe_full/CMakeLists.txt
+@@ -3,7 +3,7 @@ set(SOURCES
+     statusindicator.c
+     rng.c)
+ 
+-include_directories(${CMAKE_SOURCE_DIR}/inc ../common)
++include_directories(${SYMCRYPT_SOURCE_DIR}/inc ../common)
+ 
+ add_library(symcrypt_oe SHARED ${SOURCES})
+ 
+diff --git a/unittest/lib/CMakeLists.txt b/unittest/lib/CMakeLists.txt
+index 5fa3885..0c96bde 100644
+--- a/unittest/lib/CMakeLists.txt
++++ b/unittest/lib/CMakeLists.txt
+@@ -84,7 +84,7 @@ elseif(SYMCRYPT_USE_ASM) # Linux
+ endif()
+ 
+ # Need to include an asm file from here.
+-include_directories(${CMAKE_SOURCE_DIR}/lib)
++include_directories(${SYMCRYPT_SOURCE_DIR}/lib)
+ 
+ if(WIN32)
+     # DNDEBUG is required to link with msbignum. This should eventually be removed.

--- a/ports/symcrypt/portfile.cmake
+++ b/ports/symcrypt/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/SymCrypt
+    REF "v${VERSION}"
+    SHA512 213b45f4767450f6be0e00fb3bad419cba2a762c13ca868b4376269093e2d552504740140b5988b2aac024b275d75456b547927ee142fe3db06630934bbea5d3
+    HEAD_REF main
+    PATCHES
+        cmake_build_dir.patch
+)
+
+# git branch --show
+set(ENV{SYMCRYPT_BRANCH} "v${VERSION}")
+# git log -1 --format=%h
+set(ENV{SYMCRYPT_COMMIT_HASH} "a84ffe1")
+# git log -1 --date=iso-strict-local --format=%cd
+set(ENV{SYMCRYPT_COMMIT_TIMESTAMP} "2024-01-27T08:00:47+02:00")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()

--- a/ports/symcrypt/vcpkg.json
+++ b/ports/symcrypt/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "symcrypt",
+  "version": "103.4.1",
+  "description": "SymCrypt is the core cryptographic function library currently used by Windows.",
+  "homepage": "https://github.com/microsoft/SymCrypt",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8468,6 +8468,10 @@
       "baseline": "2021-05-22",
       "port-version": 0
     },
+    "symcrypt": {
+      "baseline": "103.4.1",
+      "port-version": 0
+    },
     "symengine": {
       "baseline": "0.11.2",
       "port-version": 0

--- a/versions/s-/symcrypt.json
+++ b/versions/s-/symcrypt.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "53fbe1dc78f6bdf8e9201f3e2621c443f504682b",
+      "version": "103.4.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
