### PR TITLE
[QCA] add openssl feature

### DIFF
--- a/ports/qca/portfile.cmake
+++ b/ports/qca/portfile.cmake
@@ -51,6 +51,9 @@ set(PLUGINS gnupg logger softstore wincrypto)
 if("botan" IN_LIST FEATURES)
     list(APPEND PLUGINS botan)
 endif()
+if ("ossl" IN_LIST FEATURES)
+    list(APPEND PLUGINS ossl)
+endif()
 
 # Configure and build
 vcpkg_cmake_configure(

--- a/ports/qca/vcpkg.json
+++ b/ports/qca/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qca",
   "version": "2.3.7",
+  "port-version": 1,
   "description": "Qt Cryptographic Architecture (QCA).",
   "homepage": "https://userbase.kde.org/QCA",
   "dependencies": [
@@ -29,6 +30,12 @@
       "description": "Build with botan",
       "dependencies": [
         "botan"
+      ]
+    },
+    "ossl": {
+      "description": "Build with openssl",
+      "dependencies": [
+        "openssl"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7038,7 +7038,7 @@
     },
     "qca": {
       "baseline": "2.3.7",
-      "port-version": 0
+      "port-version": 1
     },
     "qcoro": {
       "baseline": "0.10.0",

--- a/versions/q-/qca.json
+++ b/versions/q-/qca.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aaecacb5189f66099801d583df1cd73e97d74034",
+      "version": "2.3.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "f4a6f18e51fa29570a8e35e20668aa86e60f6ff7",
       "version": "2.3.7",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
