### PR TITLE
[tiff] Enable config file deployment

### DIFF
--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -38,6 +38,7 @@ vcpkg_cmake_configure(
         -Dtiff-docs=OFF
         -Dtiff-contrib=OFF
         -Dtiff-tests=OFF
+        -Dtiff-install=ON
         -Djbig=OFF # This is disabled by default due to GPL/Proprietary licensing.
         -Djpeg12=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_OpenGL=ON
@@ -54,9 +55,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-# CMake config wasn't packaged in the past and is not yet usable now,
-# cf. https://gitlab.com/libtiff/libtiff/-/merge_requests/496
-# vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/tiff")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/tiff")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake" "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
 
 set(_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libtiff-4.pc")

--- a/ports/tiff/vcpkg.json
+++ b/ports/tiff/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tiff",
   "version": "4.6.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A library that supports the manipulation of TIFF image files",
   "homepage": "https://libtiff.gitlab.io/libtiff/",
   "license": "libtiff",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8610,7 +8610,7 @@
     },
     "tiff": {
       "baseline": "4.6.0",
-      "port-version": 4
+      "port-version": 5
     },
     "tinkerforge": {
       "baseline": "2.1.25",

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50091b984e63d446c30ad8a7ee130f5f836f0d30",
+      "version": "4.6.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "9aa03ccc8de52590c49943ca462d6f833d0a9118",
       "version": "4.6.0",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [NA] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

It has been tested on windows and linux.
