### PR TITLE
[libarchive] Add Linux static build patch

### DIFF
--- a/ports/libarchive/fix-linux-static-build.patch
+++ b/ports/libarchive/fix-linux-static-build.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f4784d49..f9e8a190 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -672,6 +672,9 @@ ENDIF(ZSTD_FOUND)
+ MARK_AS_ADVANCED(CLEAR ZSTD_INCLUDE_DIR)
+ MARK_AS_ADVANCED(CLEAR ZSTD_LIBRARY)
+ 
++IF(UNIX AND NOT APPLE)
++  LIST(APPEND ADDITIONAL_LIBS "dl")
++ENDIF(UNIX AND NOT APPLE)
+ 
+ #
+ # Check headers

--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix-buildsystem.patch
         fix-cpu-set.patch
         fix-deps.patch
+        fix-linux-static-build.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libarchive/vcpkg.json
+++ b/ports/libarchive/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libarchive",
   "version": "3.7.2",
+  "port-version": 1,
   "description": "Library for reading and writing streaming archives",
   "homepage": "https://www.libarchive.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4154,7 +4154,7 @@
     },
     "libarchive": {
       "baseline": "3.7.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libass": {
       "baseline": "0.17.1",

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39600cd4eec5d0fe3c38924848c80d3b9055231a",
+      "version": "3.7.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "72eaf4987dd61116706a4279e7789f2a386a05cf",
       "version": "3.7.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

Fixes #37987.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Unchecked items above indicate no change.