### PR TITLE
[catch2] Update to 3.5.4

### DIFF
--- a/ports/catch2/fix-arm-build.patch
+++ b/ports/catch2/fix-arm-build.patch
@@ -1,0 +1,15 @@
+diff --git a/src/catch2/internal/catch_random_integer_helpers.hpp b/src/catch2/internal/catch_random_integer_helpers.hpp
+--- a/src/catch2/internal/catch_random_integer_helpers.hpp
++++ b/src/catch2/internal/catch_random_integer_helpers.hpp
+@@ -21,7 +21,10 @@
+ //       it, and it provides an escape hatch to the users who need it.
+ #if defined( __SIZEOF_INT128__ )
+ #    define CATCH_CONFIG_INTERNAL_UINT128
+-#elif defined( _MSC_VER ) && ( defined( _WIN64 ) || defined( _M_ARM64 ) )
++// Unlike GCC, MSVC does not polyfill umul as mulh + mul pair on ARM machines.
++// Currently we do not bother doing this ourselves, but we could if it became
++// important for perf.
++#elif defined( _MSC_VER ) && defined( _WIN64 )
+ #    define CATCH_CONFIG_INTERNAL_MSVC_UMUL128
+ #endif
+ 

--- a/ports/catch2/fix-arm-build.patch
+++ b/ports/catch2/fix-arm-build.patch
@@ -9,7 +9,7 @@ diff --git a/src/catch2/internal/catch_random_integer_helpers.hpp b/src/catch2/i
 +// Unlike GCC, MSVC does not polyfill umul as mulh + mul pair on ARM machines.
 +// Currently we do not bother doing this ourselves, but we could if it became
 +// important for perf.
-+#elif defined( _MSC_VER ) && defined( _WIN64 )
++#elif defined( _MSC_VER ) && defined( _WIN64 ) && !defined( _M_ARM64 )
  #    define CATCH_CONFIG_INTERNAL_MSVC_UMUL128
  #endif
  

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
     REF v${VERSION}
-    SHA512 57c996f679cbad212cb0fde39e506bade37bd559c0e93e20f407f2a2f029e98b78661e10257f9c8e4cb5fd7d52d0ea1eae3d4a1f989c6d66fcb281e32e1688f6
+    SHA512 c22ad6a2fbf8665b8775d72dcdc6bfde324eb224fcd897ebce5e62c7ac7640823550198fff45e1ea548a5923db4392ce7009ff784ef78bd59356a2aae5337976
     HEAD_REF devel
     PATCHES
         fix-install-path.patch

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF devel
     PATCHES
         fix-install-path.patch
+        fix-arm-build.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version-semver": "3.5.3",
+  "version-semver": "3.5.4",
   "description": "A modern, C++-native, test framework for unit-tests, TDD and BDD.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1489,7 +1489,7 @@
       "port-version": 2
     },
     "catch2": {
-      "baseline": "3.5.3",
+      "baseline": "3.5.4",
       "port-version": 0
     },
     "cblas": {

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd5e0df5ba08c7b81b96e3232de6a100adcccde0",
+      "version-semver": "3.5.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "cc06710d58447379132032c7b5da0ebf6a3fef9f",
       "version-semver": "3.5.3",
       "port-version": 0

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bd5e0df5ba08c7b81b96e3232de6a100adcccde0",
+      "git-tree": "2278e641122299651d947b6a0ffd21c18086b7f3",
       "version-semver": "3.5.4",
       "port-version": 0
     },

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2278e641122299651d947b6a0ffd21c18086b7f3",
+      "git-tree": "79536429a52319190e793f8ec7c19c6142b26bd4",
       "version-semver": "3.5.4",
       "port-version": 0
     },


### PR DESCRIPTION
Update catch2 port from 3.5.3 to 3.5.4 : https://github.com/catchorg/Catch2/releases/tag/v3.5.4

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.