### PR TITLE
[qt-advanced-docking-system] Mimate qt_install_submodule

### DIFF
--- a/ports/qt-advanced-docking-system/modules-json.patch
+++ b/ports/qt-advanced-docking-system/modules-json.patch
@@ -1,0 +1,16 @@
+--- 4.3.0-1678e4b489.clean/src/CMakeLists.txt.old	2024-04-16 16:38:02.165998200 +0200
++++ 4.3.0-1678e4b489.clean/src/CMakeLists.txt	2024-04-16 16:37:35.949034500 +0200
+@@ -113,6 +113,13 @@ elseif(QT_VERSION_MAJOR STREQUAL "6")
+         CXX_STANDARD_REQUIRED ON)
+ endif()
+ 
++include(QtInstallHelpers)
++include(QtCMakeHelpers)
++include(QtModuleHelpers)
++qt_describe_module(${library_name})
++install(FILES "${CMAKE_BINARY_DIR}/share/Qt6/modules/qt6advanceddocking.json" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/Qt6/modules/ OPTIONAL)
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/share/Qt6/modules/qt6advanceddocking.json" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/Qt6/modules/ OPTIONAL)
++
+ include(CMakePackageConfigHelpers)
+ write_basic_package_version_file(
+     "${library_name}ConfigVersion.cmake"

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -1,37 +1,36 @@
+set(SCRIPT_PATH "${CURRENT_INSTALLED_DIR}/share/qtbase")
+include("${SCRIPT_PATH}/qt_install_submodule.cmake")
+
+# qt_install_submodule() from qtbase/cmake/qt_install_submodule
+set(qt_plugindir ${QT6_DIRECTORY_PREFIX}plugins)
+set(qt_qmldir ${QT6_DIRECTORY_PREFIX}qml)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO githubuser0xFFFF/Qt-Advanced-Docking-System
     REF "${VERSION}"
     SHA512 fabb5329e93288993fa2d662fd1a7b678f61bdc9c12c9370de4879f82971471615c50c9a2313fe8d07647efc36bc8c4863333cd7ec573e52475aad48191718c7
-    HEAD_REF master
-)
-
-if(VCPKG_CROSSCOMPILING)
-    list(APPEND _qarg_OPTIONS "-DQT_HOST_PATH=${CURRENT_HOST_INSTALLED_DIR}")
-    list(APPEND _qarg_OPTIONS "-DQT_HOST_PATH_CMAKE_DIR:PATH=${CURRENT_HOST_INSTALLED_DIR}/share")
-endif()
+    HEAD_REF master)
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
+qt_cmake_configure(
     OPTIONS
-        ${_qarg_OPTIONS}
         -DBUILD_EXAMPLES=OFF
         -DADS_VERSION=${VERSION}
         -DQT_VERSION_MAJOR=6
         -DBUILD_STATIC=${BUILD_STATIC}
+    OPTIONS_MAYBE_UNUSED
+        INSTALL_MKSPECSDIR
+        QT_BUILD_BENCHMARKS
+        QT_BUILD_EXAMPLES
+        QT_BUILD_TESTS
+        QT_MKSPECS_DIR
+        QT_USE_DEFAULT_CMAKE_OPTIMIZATION_FLAGS
 )
-vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "qt6advanceddocking" CONFIG_PATH "lib/cmake/qt6advanceddocking")
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/qt6advanceddocking/qt6advanceddockingConfig.cmake"
-"include(CMakeFindDependencyMacro)"
-[[include(CMakeFindDependencyMacro)
-find_dependency(Qt6 COMPONENTS Core Gui Widgets)]])
+vcpkg_cmake_install(ADD_BIN_TO_PATH)
+vcpkg_cmake_config_fixup(PACKAGE_NAME "qt6advanceddocking"
+                         CONFIG_PATH "lib/cmake/qt6advanceddocking")
+qt_fixup_and_cleanup()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/license")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/license")
-
-file(INSTALL "${SOURCE_PATH}/gnu-lgpl-v2.1.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -1,4 +1,5 @@
 set(SCRIPT_PATH "${CURRENT_INSTALLED_DIR}/share/qtbase")
+set(QT_CMAKE_DIR "${CURRENT_INSTALLED_DIR}/share/Qt6")
 include("${SCRIPT_PATH}/qt_install_submodule.cmake")
 
 # qt_install_submodule() from qtbase/cmake/qt_install_submodule
@@ -10,7 +11,9 @@ vcpkg_from_github(
     REPO githubuser0xFFFF/Qt-Advanced-Docking-System
     REF "${VERSION}"
     SHA512 fabb5329e93288993fa2d662fd1a7b678f61bdc9c12c9370de4879f82971471615c50c9a2313fe8d07647efc36bc8c4863333cd7ec573e52475aad48191718c7
-    HEAD_REF master)
+    HEAD_REF master
+    PATCHES modules-json.patch
+)
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
 qt_cmake_configure(
@@ -19,6 +22,7 @@ qt_cmake_configure(
         -DADS_VERSION=${VERSION}
         -DQT_VERSION_MAJOR=6
         -DBUILD_STATIC=${BUILD_STATIC}
+        -DQT_CMAKE_DIR=${QT_CMAKE_DIR}
     OPTIONS_MAYBE_UNUSED
         INSTALL_MKSPECSDIR
         QT_BUILD_BENCHMARKS

--- a/ports/qt-advanced-docking-system/vcpkg.json
+++ b/ports/qt-advanced-docking-system/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt-advanced-docking-system",
   "version": "4.3.0",
+  "port-version": 1,
   "description": "Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio",
   "homepage": "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7094,7 +7094,7 @@
     },
     "qt-advanced-docking-system": {
       "baseline": "4.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qt3d": {
       "baseline": "6.6.1",

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9878f064cc8c045d430d78b4daf9f4e8448f80a",
+      "git-tree": "16a09128f4529949d14831862e71e9d8a932e3cc",
       "version": "4.3.0",
       "port-version": 1
     },

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9878f064cc8c045d430d78b4daf9f4e8448f80a",
+      "version": "4.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "324c0ad43c0ab27845205f4539e925e627ce321a",
       "version": "4.3.0",
       "port-version": 0


### PR DESCRIPTION
**Problems**

Windows binaries was not copied on `tools` path. winqtdeploy couldn't work.

Missing pdb files.

**Solution**

`qt_install_submodule` can only be used to download module of Qt. I duplicated it and replaced the download step.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
