### PR TITLE
[ffmpeg] Add Little CMS 2 feature

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -337,6 +337,12 @@ else()
     set(OPTIONS "${OPTIONS} --disable-libilbc")
 endif()
 
+if("lcms" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-lcms2")
+else()
+    set(OPTIONS "${OPTIONS} --disable-lcms2")
+endif()
+
 if("lzma" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --enable-lzma")
 else()

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "6.1.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -42,6 +42,7 @@
             "bzip2",
             "freetype",
             "iconv",
+            "lcms",
             "lzma",
             "mp3lame",
             "openjpeg",
@@ -440,6 +441,12 @@
       "description": "iLBC de/encoding via libilbc",
       "dependencies": [
         "libilbc"
+      ]
+    },
+    "lcms": {
+      "description": "ICC profile support via LittleCMS 2",
+      "dependencies": [
+        "lcms"
       ]
     },
     "lzma": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2666,7 +2666,7 @@
     },
     "ffmpeg": {
       "baseline": "6.1.1",
-      "port-version": 2
+      "port-version": 3
     },
     "ffnvcodec": {
       "baseline": "12.1.14.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69248291df0ee68bfcb673b98128a4ba37ef332d",
+      "version": "6.1.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "2b85222da88d04c67c9b83d24a278c5821f5f0b0",
       "version": "6.1.1",
       "port-version": 2


### PR DESCRIPTION
Add Little CMS 2 feature to FFmpeg port.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.