### PR TITLE
[docopt]Enable docopt shared build on non-windows OS

### DIFF
--- a/ports/docopt/portfile.cmake
+++ b/ports/docopt/portfile.cmake
@@ -23,7 +23,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     file(READ "${CURRENT_PACKAGES_DIR}/include/docopt/docopt.h" _contents)
-    string(REPLACE "#ifdef DOCOPT_DLL" "#if 1" _contents "${_contents}")
+    string(REPLACE "#ifdef DOCOPT_DLL" "#ifdef _WIN32" _contents "${_contents}")
     file(WRITE "${CURRENT_PACKAGES_DIR}/include/docopt/docopt.h" "${_contents}")
 endif()
 

--- a/ports/docopt/vcpkg.json
+++ b/ports/docopt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "docopt",
   "version-date": "2022-03-15",
+  "port-version": 1,
   "description": "Command line arguments parser that will make you smile (C++11 port).",
   "license": "MIT OR BSL-1.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2302,7 +2302,7 @@
     },
     "docopt": {
       "baseline": "2022-03-15",
-      "port-version": 0
+      "port-version": 1
     },
     "doctest": {
       "baseline": "2.4.11",

--- a/versions/d-/docopt.json
+++ b/versions/d-/docopt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b5aa0bd1e02e5c3a66e56b084c951069a591151",
+      "version-date": "2022-03-15",
+      "port-version": 1
+    },
+    {
       "git-tree": "98cead1c88cad77bef9acf4571d6bd8a2a06cf3a",
       "version-date": "2022-03-15",
       "port-version": 0


### PR DESCRIPTION
Only activate declspec import/export attributes on Windows. The resulting header is close to CMakes suggestions:

https://cmake.org/cmake/help/latest/guide/tutorial/Selecting%20Static%20or%20Shared%20Libraries.html

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

Fixes #36117

Note: I chose option B) from my post in the issue.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. UNCHANGED!
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
What is the "supports" clause?
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
