### PR TITLE
[re2] Fix checksum of PATCH_488

### DIFF
--- a/ports/re2/portfile.cmake
+++ b/ports/re2/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_download_distfile(PATCH_488
     URLS https://github.com/google/re2/commit/9ebe4a22cad8a025b68a9594bdff3c047a111333.patch?full_index=1
-    SHA512 167a0153bf24e77db2b8555a7d6391acf740dc4720a71e6ce19a3533c7e0a49923d9584ff32544a454837a25eedace00cb2ef9ddbf4250deb5f2c5aeda04ac26
+    SHA512 83c1a4cc4ddd6e1443f5201f7f00cf6a0729d0a0fb8fc5068c3d80766238d72f019f1fddaeffebcc2d4322a07daf2203214121cdda039b10a5f39214b9fa8647
     FILENAME 9ebe4a22cad8a025b68a9594bdff3c047a111333.patch
 )
 

--- a/ports/re2/vcpkg.json
+++ b/ports/re2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "re2",
   "version-date": "2024-04-01",
-  "port-version": 1,
+  "port-version": 2,
   "description": "RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python. It is a C++ library.",
   "homepage": "https://github.com/google/re2",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7574,7 +7574,7 @@
     },
     "re2": {
       "baseline": "2024-04-01",
-      "port-version": 1
+      "port-version": 2
     },
     "reactiveplusplus": {
       "baseline": "2.0.0",

--- a/versions/r-/re2.json
+++ b/versions/r-/re2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c0f4eacf4c6b1c048bb3fc11fd0abf9e4981aa64",
+      "version-date": "2024-04-01",
+      "port-version": 2
+    },
+    {
       "git-tree": "19e35429ba172da1f08743ff317d504fa21bebf3",
       "version-date": "2024-04-01",
       "port-version": 1


### PR DESCRIPTION
Fix #38146 for the `PATCH_488` checksum of `vcpkg_download_distfile`.

It might be same name file caching that causes patch changes not to be detected by `vcpkg` and `CI` in #38067.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.