### PR TITLE
Make qtbase dependencies explicit in various ports

### DIFF
--- a/ports/mapnik/vcpkg.json
+++ b/ports/mapnik/vcpkg.json
@@ -221,7 +221,13 @@
     "viewer": {
       "description": "Make demo viewer application",
       "dependencies": [
-        "qtbase"
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "widgets"
+          ]
+        }
       ]
     },
     "webp": {

--- a/ports/mapnik/vcpkg.json
+++ b/ports/mapnik/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mapnik",
   "version-date": "2023-06-12",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Mapnik is an open source toolkit for developing mapping applications.",
   "homepage": "https://github.com/mapnik/mapnik",
   "license": "LGPL-2.1-only",

--- a/ports/qcoro/vcpkg.json
+++ b/ports/qcoro/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qcoro",
   "version": "0.10.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Coroutine support for Qt",
   "homepage": "https://www.github.com/danvratil/qcoro",
   "documentation": "https://qcoro.dvratil.cz",
@@ -59,13 +59,19 @@
     "qml": {
       "description": "Coroutine support for QtQml module",
       "dependencies": [
-        "qtdeclarative"
+        {
+          "name": "qtdeclarative",
+          "default-features": false
+        }
       ]
     },
     "quick": {
       "description": "Coroutine support for QtQuick module",
       "dependencies": [
-        "qtdeclarative"
+        {
+          "name": "qtdeclarative",
+          "default-features": false
+        }
       ]
     },
     "test": {
@@ -83,7 +89,10 @@
     "websockets": {
       "description": "Coroutine support for QtWebSockets module",
       "dependencies": [
-        "qtwebsockets"
+        {
+          "name": "qtwebsockets",
+          "default-features": false
+        }
       ]
     }
   }

--- a/ports/qcoro/vcpkg.json
+++ b/ports/qcoro/vcpkg.json
@@ -1,12 +1,19 @@
 {
   "name": "qcoro",
   "version": "0.10.0",
+  "port-version": 1,
   "description": "Coroutine support for Qt",
   "homepage": "https://www.github.com/danvratil/qcoro",
   "documentation": "https://qcoro.dvratil.cz",
   "license": "MIT",
   "dependencies": [
-    "qtbase",
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "thread"
+      ]
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -26,10 +33,28 @@
   ],
   "features": {
     "dbus": {
-      "description": "Coroutine support for QtDBus module"
+      "description": "Coroutine support for QtDBus module",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "dbus"
+          ]
+        }
+      ]
     },
     "network": {
-      "description": "Coroutine support for QtNetwork module"
+      "description": "Coroutine support for QtNetwork module",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "network"
+          ]
+        }
+      ]
     },
     "qml": {
       "description": "Coroutine support for QtQml module",
@@ -44,7 +69,16 @@
       ]
     },
     "test": {
-      "description": "Support code for easier testing of coroutines with QtTest."
+      "description": "Support code for easier testing of coroutines with QtTest.",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "testlib"
+          ]
+        }
+      ]
     },
     "websockets": {
       "description": "Coroutine support for QtWebSockets module",

--- a/ports/simonbrunel-qtpromise/vcpkg.json
+++ b/ports/simonbrunel-qtpromise/vcpkg.json
@@ -1,12 +1,19 @@
 {
   "name": "simonbrunel-qtpromise",
   "version": "0.7.0",
+  "port-version": 1,
   "maintainers": "Simon Brunel",
   "description": "Promises/A+ implementation for Qt/C++",
   "homepage": "https://qtpromise.netlify.app/",
   "license": "MIT",
   "dependencies": [
-    "qtbase",
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "thread"
+      ]
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7070,7 +7070,7 @@
     },
     "qcoro": {
       "baseline": "0.10.0",
-      "port-version": 1
+      "port-version": 2
     },
     "qcustomplot": {
       "baseline": "2.1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7070,7 +7070,7 @@
     },
     "qcoro": {
       "baseline": "0.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qcustomplot": {
       "baseline": "2.1.1",
@@ -8118,7 +8118,7 @@
     },
     "simonbrunel-qtpromise": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "simple-fft": {
       "baseline": "2020-06-14",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5590,7 +5590,7 @@
     },
     "mapnik": {
       "baseline": "2023-06-12",
-      "port-version": 4
+      "port-version": 5
     },
     "marble": {
       "baseline": "24.02.0",

--- a/versions/m-/mapnik.json
+++ b/versions/m-/mapnik.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad0af0a0c2a6c1ee6c9cd6c7570cd5989ce8f2e6",
+      "version-date": "2023-06-12",
+      "port-version": 5
+    },
+    {
       "git-tree": "d8915c1366bfeff48042954ef522e5aec82b3058",
       "version-date": "2023-06-12",
       "port-version": 4

--- a/versions/q-/qcoro.json
+++ b/versions/q-/qcoro.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0f9f873ee5b1f7e59e931d9b04d319d3adef968",
+      "version": "0.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "98bf3c0f6c546401e5976e2d474765d838050fd3",
       "version": "0.10.0",
       "port-version": 0

--- a/versions/q-/qcoro.json
+++ b/versions/q-/qcoro.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ab505291e6d67f955a33344efe1f5564e212604",
+      "version": "0.10.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "d0f9f873ee5b1f7e59e931d9b04d319d3adef968",
       "version": "0.10.0",
       "port-version": 1

--- a/versions/s-/simonbrunel-qtpromise.json
+++ b/versions/s-/simonbrunel-qtpromise.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59810a66dd9ac5835daf50142809cf315a61f67d",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b416eec5f84996491c4656f6b01723453abac31f",
       "version": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
This came out of the discussion with @dg0yt on #38138.   I found a few other ports that depended on `qtbase` directly and added the explicit feature dependencies.   I did not make any other changes to the version, patches, or port file behavior.  

My verification was to run `.\vcpkg.exe install --dry-run --host-triplet x64-windows  qtbase[core]` with each of the updated port's feature enabled to ensure that only the requested features are added.   I tried to inspect the build options for `mapnik` but it doesn't look like it needs any other dependencies.

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

