### PR TITLE
[imgui] WIP: allow split outputs

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -8,13 +8,15 @@ if(APPLE)
     enable_language(OBJCXX)
 endif()
 
+include(GNUInstallDirs) # Defines CMAKE_INSTALL_INCLUDEDIR if not set
+
 add_library(${PROJECT_NAME} "")
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(
     ${PROJECT_NAME}
     PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_SOURCE_DIR}/test-engine>"
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_sources(
@@ -148,18 +150,32 @@ list(REMOVE_DUPLICATES BINDINGS_SOURCES)
 install(
     TARGETS ${PROJECT_NAME}
     EXPORT ${PROJECT_NAME}_target
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
+    ARCHIVE
+        COMPONENT Development
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY
+        COMPONENT Runtime
+        NAMELINK_COMPONENT Development
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME
+        COMPONENT Runtime
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 foreach(BINDING_TARGET ${BINDING_TARGETS})
     install(
         TARGETS ${BINDING_TARGET}
         EXPORT ${PROJECT_NAME}_target
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
+        ARCHIVE
+            COMPONENT Development
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY
+            COMPONENT Runtime
+            NAMELINK_COMPONENT Development
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME
+            COMPONENT Runtime
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 endforeach()
 
@@ -172,47 +188,47 @@ if(NOT IMGUI_SKIP_HEADERS)
         ${CMAKE_CURRENT_SOURCE_DIR}/imstb_rectpack.h
         ${CMAKE_CURRENT_SOURCE_DIR}/imstb_truetype.h
         ${CMAKE_CURRENT_SOURCE_DIR}/misc/cpp/imgui_stdlib.h
-        DESTINATION include
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 
     if(IMGUI_BUILD_ALLEGRO5_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_allegro5.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_allegro5.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if (IMGUI_BUILD_ANDROID_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_android.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_android.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_DX9_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx9.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx9.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_DX10_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx10.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx10.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_DX11_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx11.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx11.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_DX12_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx12.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx12.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_GLFW_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glfw.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glfw.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_GLUT_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glut.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glut.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_METAL_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_OPENGL2_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl2.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_OPENGL3_BINDING)
@@ -221,32 +237,32 @@ if(NOT IMGUI_SKIP_HEADERS)
                 ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3_loader.h
             DESTINATION
-                include
+                ${CMAKE_INSTALL_INCLUDEDIR}
         )
     endif()
 
     if(IMGUI_BUILD_OSX_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_osx.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_osx.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_SDL2_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl2.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_SDL2_RENDERER_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer2.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_VULKAN_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_vulkan.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_vulkan.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_BUILD_WIN32_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_win32.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_win32.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_FREETYPE)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/misc/freetype/imgui_freetype.h DESTINATION include)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/misc/freetype/imgui_freetype.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     endif()
 
     if(IMGUI_TEST_ENGINE)
@@ -269,13 +285,13 @@ if(NOT IMGUI_SKIP_HEADERS)
 endif()
 
 include(CMakePackageConfigHelpers)
-configure_package_config_file(imgui-config.cmake.in imgui-config.cmake INSTALL_DESTINATION share/imgui)
+configure_package_config_file(imgui-config.cmake.in imgui-config.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/imgui)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/imgui-config.cmake DESTINATION share/imgui)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/imgui-config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/imgui)
 
 install(
     EXPORT ${PROJECT_NAME}_target
     NAMESPACE ${PROJECT_NAME}::
     FILE ${PROJECT_NAME}-targets.cmake
-    DESTINATION share/${PROJECT_NAME}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )

--- a/ports/implot/CMakeLists.txt
+++ b/ports/implot/CMakeLists.txt
@@ -8,6 +8,8 @@ get_target_property(IMGUI_INCLUDE_DIRS imgui::imgui
 
 set(CMAKE_DEBUG_POSTFIX d)
 
+include(GNUInstallDirs) # Defines CMAKE_INSTALL_INCLUDEDIR if not set
+
 add_library(${PROJECT_NAME} "")
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
@@ -15,7 +17,7 @@ target_include_directories(
 	${PROJECT_NAME}
 	PUBLIC
 	   	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-		$<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 	PRIVATE
 		${IMGUI_INCLUDE_DIRS}
 )
@@ -31,16 +33,23 @@ target_sources(
 install(
 	TARGETS ${PROJECT_NAME}
 	EXPORT ${PROJECT_NAME}_target
-	ARCHIVE DESTINATION lib
-	LIBRARY DESTINATION lib
-	RUNTIME DESTINATION bin
+    ARCHIVE
+        COMPONENT Development
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY
+        COMPONENT Runtime
+        NAMELINK_COMPONENT Development
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME
+        COMPONENT Runtime
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 if(NOT IMPLOT_SKIP_HEADERS)
     install(FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/implot.h
 		${CMAKE_CURRENT_SOURCE_DIR}/implot_internal.h
-        DESTINATION include
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 endif()
 
@@ -48,5 +57,5 @@ install(
 	EXPORT ${PROJECT_NAME}_target
 	NAMESPACE ${PROJECT_NAME}::
 	FILE ${PROJECT_NAME}-config.cmake
-	DESTINATION share/${PROJECT_NAME}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )


### PR DESCRIPTION
A minimal set of changes required to allow "splayed layouts", installation of different components into independent prefixes, in https://github.com/NixOS/nixpkgs/pull/303682. This is currently pretty coarse and oblivious of vcpkg' styles and practices, but I can adapt this further after we've confirmed this might be eventually merged

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
