### PR TITLE
[curl] fix idn2 dependency

### DIFF
--- a/ports/curl/0012-fix-dependency-idn2.patch
+++ b/ports/curl/0012-fix-dependency-idn2.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index a54c2ff..3b83a7f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -852,11 +852,8 @@ endif()
+@@ -852,11 +852,9 @@ endif()
  # Check for idn2
  option(USE_LIBIDN2 "Use libidn2 for IDN support" ON)
  if(USE_LIBIDN2)
@@ -13,6 +13,7 @@ index a54c2ff..3b83a7f 100644
 -  endif()
 +  set(HAVE_LIBIDN2 TRUE)
 +  list(INSERT CURL_LIBS 0 ${LIBIDN2_LINK_LIBRARIES})
++  set(HAVE_IDN2_H TRUE)
  else()
    set(HAVE_LIBIDN2 OFF)
  endif()

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "curl",
   "version": "8.7.1",
+  "port-version": 1,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2078,7 +2078,7 @@
     },
     "curl": {
       "baseline": "8.7.1",
-      "port-version": 0
+      "port-version": 1
     },
     "curlpp": {
       "baseline": "2018-06-15",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02d67d58e781c841960533d52713bb9fffb2c950",
+      "version": "8.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "4f3aa7f4fd142a1c5822e4f36e0a4c45c031134a",
       "version": "8.7.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

When you install curl[tool,idn2] with vcpkg, and the you do:
```
curl --version
```
You can see the lib that it install with, and even you install the feature idn2, it missing. I fix it. 
It should look similar to that:
```
curl 8.7.0-DEV (Linux) libcurl/8.7.0-DEV ... libidn2/2.3.4  ...
```