### PR TITLE
[openldap] update to 2.5.17

### DIFF
--- a/ports/openldap/portfile.cmake
+++ b/ports/openldap/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.5.13.tgz"
-    FILENAME "openldap-2.5.13.tgz"
-    SHA512 30fdc884b513c53169910eec377c2ad05013b9f06bab3123d50d028108b24548791f7f47f18bcb3a2b4868edeab02c10d81ffa320c02d7b562f2e8f2fa25d6c9
+    URLS "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${VERSION}.tgz"
+    FILENAME "openldap-${VERSION}.tgz"
+    SHA512 c23aee0a68a02fa2f5d12fb3b8e31af0c5d70d9a86059d40ad6726fc427f8852ce088eb8ec3bae9f9cb4f2ce0e249b3dbe845ba5d5967cda3ae993c263f3dc03
 )
 
 vcpkg_list(SET EXTRA_PATCHES)

--- a/ports/openldap/vcpkg.json
+++ b/ports/openldap/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openldap",
-  "version": "2.5.13",
-  "port-version": 1,
+  "version": "2.5.17",
   "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
   "homepage": "https://www.openldap.org/software/",
   "license": "OLDAP-2.8",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6473,8 +6473,8 @@
       "port-version": 0
     },
     "openldap": {
-      "baseline": "2.5.13",
-      "port-version": 1
+      "baseline": "2.5.17",
+      "port-version": 0
     },
     "openmama": {
       "baseline": "6.3.2",

--- a/versions/o-/openldap.json
+++ b/versions/o-/openldap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "feb109108e4779365dfc208d784f7fabe09f1f04",
+      "version": "2.5.17",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e20086782fc80cf2c6571a54237e86d0cadf84e",
       "version": "2.5.13",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
