### PR TITLE
[c-ares] Update to 1.28.1

### DIFF
--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
     REF "cares-${_c_ares_version_major}_${_c_ares_version_minor}_${_c_ares_version_patch}"
-    SHA512 ccbff47f5dd58c7c91e100b3e05b7714142787b45072459dc17b7d404431a303b3023a3b06c8fd41d245e4e36fd2968ba4937eb50a44ba8215603136eabf90e0
+    SHA512 6c2f98055792880abb298c9d8c4f20460fe33b7b247d450b33e9c4e87d58b32c8fce371084b4bde42f50508e957b3fa5c897b1a3dcdcd214506c2bad4fd90c66
     HEAD_REF main
     PATCHES
         avoid-docs.patch

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c-ares",
-  "version-semver": "1.28.0",
+  "version-semver": "1.28.1",
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1413,7 +1413,7 @@
       "port-version": 5
     },
     "c-ares": {
-      "baseline": "1.28.0",
+      "baseline": "1.28.1",
       "port-version": 0
     },
     "c-dbg-macro": {

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d722fc1278ff74fed3795592feffd8c08a46ffe",
+      "version-semver": "1.28.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e9cfe35b81874e6ebf35f9ab346f7e86365b5fc1",
       "version-semver": "1.28.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
