### PR TITLE
[openssl] Update to 3.3.0, limited cmake config fixup

### DIFF
--- a/ports/openssl/cmake-config.patch
+++ b/ports/openssl/cmake-config.patch
@@ -1,0 +1,52 @@
+diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
+index 4c24cae..2792083 100644
+--- a/Configurations/unix-Makefile.tmpl
++++ b/Configurations/unix-Makefile.tmpl
+@@ -338,7 +338,7 @@ bindir={- file_name_is_absolute($bindir)
+           ? $bindir : '$(INSTALLTOP)/$(BINDIR)' -}
+ 
+ PKGCONFIGDIR=$(libdir)/pkgconfig
+-CMAKECONFIGDIR=$(libdir)/cmake/OpenSSL
++CMAKECONFIGDIR=$(INSTALLTOP)/share/openssl
+ 
+ MANDIR=$(INSTALLTOP)/share/man
+ DOCDIR=$(INSTALLTOP)/share/doc/$(BASENAME)
+diff --git a/Configurations/windows-makefile.tmpl b/Configurations/windows-makefile.tmpl
+index 894834c..d6d3c41 100644
+--- a/Configurations/windows-makefile.tmpl
++++ b/Configurations/windows-makefile.tmpl
+@@ -254,7 +254,7 @@ MODULESDIR=$(MODULESDIR_dev)$(MODULESDIR_dir)
+ libdir={- file_name_is_absolute($libdir)
+           ? $libdir : '$(INSTALLTOP)\$(LIBDIR)' -}
+ 
+-CMAKECONFIGDIR=$(libdir)\cmake\OpenSSL
++CMAKECONFIGDIR=$(INSTALLTOP)\share\openssl
+ 
+ ##### User defined commands and flags ################################
+ 
+diff --git a/exporters/cmake/OpenSSLConfig.cmake.in b/exporters/cmake/OpenSSLConfig.cmake.in
+index 2d23219..3477e20 100644
+--- a/exporters/cmake/OpenSSLConfig.cmake.in
++++ b/exporters/cmake/OpenSSLConfig.cmake.in
+@@ -136,6 +136,14 @@ set(OPENSSL_APPLINK_SOURCE "${_ossl_prefix}/{- unixify($OpenSSL::safe::installda
+ {- output_on() if $disabled{uplink}; "" -}
+ set(OPENSSL_PROGRAM "${OPENSSL_RUNTIME_DIR}/{- platform->bin('openssl') -}")
+ 
++if(NOT Z_VCPKG_OPENSSL_USE_SINGLE_CONFIG)
++  # Prevent loop
++  set(Z_VCPKG_OPENSSL_USE_SINGLE_CONFIG "prevent-loop")
++  # Chainload vcpkg's module-based multi-config target setup
++  find_package(OpenSSL MODULE)
++  set(Z_VCPKG_OPENSSL_USE_SINGLE_CONFIG 0)
++else()
++  # Use official single-config target setup
+ # Set up the imported targets
+ if(_ossl_use_static_libs)
+ {- output_off() unless $no_static; "" -}
+@@ -235,5 +243,6 @@ set_property(TARGET OpenSSL::applink PROPERTY
+   INTERFACE_SOURCES "${OPENSSL_APPLINK_SOURCE}")
+ {- output_on() if $disabled{uplink}; "" -}
+ 
++endif()
+ unset(_ossl_prefix)
+ unset(_ossl_use_static_libs)

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -19,7 +19,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
     REF "openssl-${VERSION}"
-    SHA512 3eed5903f37ac728522cbb0ea0081f1d5a62d9420366d487f838dc22c31813c58584838400bd3d09518608e1e71bafcb1ff83713d351e4876da6625d5543fef6
+    SHA512 42cc11475d8b31706ec151c9aed0178e17b788c6b38636ae1cde363872139ed85f5b9efd0c75012f4d6f15ec8100e1afe5d528e72b88a5d3dea4125c9b0804aa
     PATCHES
         command-line-length.patch
         script-prefix.patch
@@ -77,6 +77,10 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 else()
     include("${CMAKE_CURRENT_LIST_DIR}/unix/portfile.cmake")
 endif()
+
+file(COPY "${CURRENT_PACKAGES_DIR}/lib/cmake/"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake/" "${CURRENT_PACKAGES_DIR}/debug/lib/cmake/")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
     REF "openssl-${VERSION}"
     SHA512 42cc11475d8b31706ec151c9aed0178e17b788c6b38636ae1cde363872139ed85f5b9efd0c75012f4d6f15ec8100e1afe5d528e72b88a5d3dea4125c9b0804aa
     PATCHES
+        cmake-config.patch
         command-line-length.patch
         script-prefix.patch
         windows/install-layout.patch
@@ -77,10 +78,6 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 else()
     include("${CMAKE_CURRENT_LIST_DIR}/unix/portfile.cmake")
 endif()
-
-file(COPY "${CURRENT_PACKAGES_DIR}/lib/cmake/"
-        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake/" "${CURRENT_PACKAGES_DIR}/debug/lib/cmake/")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/openssl/usage
+++ b/ports/openssl/usage
@@ -1,4 +1,5 @@
-The package openssl is compatible with built-in CMake targets:
+openssl is compatible with built-in CMake targets:
 
-    find_package(OpenSSL REQUIRED)
-    target_link_libraries(main PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+  find_package(OpenSSL REQUIRED)
+  target_link_libraries(main PRIVATE OpenSSL::SSL)
+  target_link_libraries(main PRIVATE OpenSSL::Crypto)

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openssl",
-  "version": "3.2.1",
-  "port-version": 2,
+  "version": "3.3.0",
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/ports/openssl/windows/install-pdbs.patch
+++ b/ports/openssl/windows/install-pdbs.patch
@@ -2,14 +2,16 @@ diff --git a/Configurations/windows-makefile.tmpl b/Configurations/windows-makef
 index 5946c89..f71f3bf 100644
 --- a/Configurations/windows-makefile.tmpl
 +++ b/Configurations/windows-makefile.tmpl
-@@ -556,6 +556,7 @@ install_dev: install_runtime_libs
+@@ -564,8 +564,9 @@
+ 				       "$(INSTALLTOP)\include\openssl"
  	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(libdir)"
  	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_LIBS) "$(libdir)"
  	@if "$(SHLIBS)"=="" \
 +	 @if "$(INSTALL_PDBS)"=="ON" \
  	 "$(PERL)" "$(SRCDIR)\util\copy.pl" ossl_static.pdb "$(libdir)"
+ 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(CMAKECONFIGDIR)"
+ 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_EXPORTERS_CMAKE) "$(CMAKECONFIGDIR)"
  
- uninstall_dev:
 @@ -569,6 +570,7 @@ install_engines: _install_modules_deps
  	@if not "$(INSTALL_ENGINES)"=="" \
  	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_ENGINES) "$(ENGINESDIR)"

--- a/ports/openssl/windows/portfile.cmake
+++ b/ports/openssl/windows/portfile.cmake
@@ -137,13 +137,14 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/certs"
     "${CURRENT_PACKAGES_DIR}/misc"
-	"${CURRENT_PACKAGES_DIR}/private"
-	"${CURRENT_PACKAGES_DIR}/lib/engines-3"
-	"${CURRENT_PACKAGES_DIR}/debug/certs"
+    "${CURRENT_PACKAGES_DIR}/private"
+    "${CURRENT_PACKAGES_DIR}/lib/engines-3"
+    "${CURRENT_PACKAGES_DIR}/debug/certs"
     "${CURRENT_PACKAGES_DIR}/debug/misc"
-	"${CURRENT_PACKAGES_DIR}/debug/lib/engines-3"
-	"${CURRENT_PACKAGES_DIR}/debug/private"
-	"${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/engines-3"
+    "${CURRENT_PACKAGES_DIR}/debug/private"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 file(REMOVE
     "${CURRENT_PACKAGES_DIR}/ct_log_list.cnf"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6509,8 +6509,8 @@
       "port-version": 3
     },
     "openssl": {
-      "baseline": "3.2.1",
-      "port-version": 2
+      "baseline": "3.3.0",
+      "port-version": 0
     },
     "openssl-unix": {
       "baseline": "deprecated",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3214421efff0427211936d6f9f78c47e770d43a6",
+      "version": "3.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d41de10fe318363c031b97457b7b6d473020a18",
       "version": "3.2.1",
       "port-version": 2

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3214421efff0427211936d6f9f78c47e770d43a6",
+      "git-tree": "ca010351bb5ec759122044e64a45019feec479d1",
       "version": "3.3.0",
       "port-version": 0
     },

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ca010351bb5ec759122044e64a45019feec479d1",
+      "git-tree": "033278114ce1aff68a03a777df0689c846760006",
       "version": "3.3.0",
       "port-version": 0
     },


### PR DESCRIPTION
Based on #38118, credits: @talregev.

OpenSSL now installs a CMake config, but it is not generated by CMake, and it is not multi-config capable. This limitation affects location properties, interface link libraries and package variables.
This PR just patches the config to chainload CMake's Find module. Together with vcpkg's cmake wrapper, this immediately gives the desired imported targets in a multi-config configuration when a user really requests `OpenSSL CONFIG`.