### PR TITLE
[qtbase] fix cross compiling build error

### DIFF
--- a/ports/qtbase/cmake/qt_install_submodule.cmake
+++ b/ports/qtbase/cmake/qt_install_submodule.cmake
@@ -119,7 +119,6 @@ function(qt_cmake_configure)
     if(VCPKG_CROSSCOMPILING)
         list(APPEND _qarg_OPTIONS "-DQT_HOST_PATH=${CURRENT_HOST_INSTALLED_DIR}")
         list(APPEND _qarg_OPTIONS "-DQT_HOST_PATH_CMAKE_DIR:PATH=${CURRENT_HOST_INSTALLED_DIR}/share")
-        list(APPEND _qarg_OPTIONS "-DQT_FORCE_BUILD_TOOLS=ON")
         list(APPEND _qarg_OPTIONS "-DQT_FORCE_FIND_TOOLS=ON")
     endif()
 

--- a/ports/qtbase/cmake/qt_install_submodule.cmake
+++ b/ports/qtbase/cmake/qt_install_submodule.cmake
@@ -119,6 +119,8 @@ function(qt_cmake_configure)
     if(VCPKG_CROSSCOMPILING)
         list(APPEND _qarg_OPTIONS "-DQT_HOST_PATH=${CURRENT_HOST_INSTALLED_DIR}")
         list(APPEND _qarg_OPTIONS "-DQT_HOST_PATH_CMAKE_DIR:PATH=${CURRENT_HOST_INSTALLED_DIR}/share")
+        list(APPEND _qarg_OPTIONS "-DQT_FORCE_BUILD_TOOLS=ON")
+        list(APPEND _qarg_OPTIONS "-DQT_FORCE_FIND_TOOLS=ON")
     endif()
 
     # Disable warning for CMAKE_(REQUIRE|DISABLE)_FIND_PACKAGE_<packagename>

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.6.1",
-  "port-version": 12,
+  "port-version": 13,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7286,7 +7286,7 @@
     },
     "qtbase": {
       "baseline": "6.6.1",
-      "port-version": 12
+      "port-version": 13
     },
     "qtcharts": {
       "baseline": "6.6.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7286,7 +7286,7 @@
     },
     "qtbase": {
       "baseline": "6.6.1",
-      "port-version": 13
+      "port-version": 12
     },
     "qtcharts": {
       "baseline": "6.6.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "ec9fce73c97c9a1a70f91ecb4308a883857f38f6",
-      "version": "6.6.1",
-      "port-version": 13
-    },
-    {
       "git-tree": "25f62a554ceec4eb297697d178df6ac0d231a5ea",
       "version": "6.6.1",
       "port-version": 12

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ea501bf8372d0d5912bc79f6c2f354ff22109eb",
+      "version": "6.6.1",
+      "port-version": 13
+    },
+    {
       "git-tree": "25f62a554ceec4eb297697d178df6ac0d231a5ea",
       "version": "6.6.1",
       "port-version": 12

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ec9fce73c97c9a1a70f91ecb4308a883857f38f6",
+      "version": "6.6.1",
+      "port-version": 13
+    },
+    {
       "git-tree": "25f62a554ceec4eb297697d178df6ac0d231a5ea",
       "version": "6.6.1",
       "port-version": 12


### PR DESCRIPTION
Fixes #38175.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
