### PR TITLE
[embree4] Update embree to 4.3.1

### DIFF
--- a/ports/embree4/001-no-runtime-install.patch
+++ b/ports/embree4/001-no-runtime-install.patch
@@ -1,0 +1,13 @@
+diff --git a/common/cmake/package.cmake b/common/cmake/package.cmake
+index 5429436..8c89f5b 100644
+--- a/common/cmake/package.cmake
++++ b/common/cmake/package.cmake
+@@ -90,7 +90,7 @@ ENDIF()
+ # Install MSVC runtime
+ ##############################################################
+ 
+-IF (WIN32)
++IF (0)
+   IF(SYCL_ONEAPI_ICX AND EMBREE_INSTALL_DEPENDENCIES)
+     GET_FILENAME_COMPONENT(DPCPP_COMPILER_DIR ${CMAKE_CXX_COMPILER} PATH)
+     IF (EXISTS "${DPCPP_COMPILER_DIR}/../redist/intel64_win/compiler/libmmd.dll")

--- a/ports/embree4/002-fix-when-embree3-has-been-installed.patch
+++ b/ports/embree4/002-fix-when-embree3-has-been-installed.patch
@@ -1,0 +1,276 @@
+diff --git a/common/lexers/CMakeLists.txt b/common/lexers/CMakeLists.txt
+index 1e2452cd9..fa6ad90d1 100644
+--- a/common/lexers/CMakeLists.txt
++++ b/common/lexers/CMakeLists.txt
+@@ -1,16 +1,16 @@
+ ## Copyright 2009-2021 Intel Corporation
+ ## SPDX-License-Identifier: Apache-2.0
+ 
+-ADD_LIBRARY(lexers STATIC
++ADD_LIBRARY(embree4_common_lexers STATIC
+  stringstream.cpp
+  tokenstream.cpp
+ )
+-TARGET_LINK_LIBRARIES(lexers sys math)
+-SET_PROPERTY(TARGET lexers PROPERTY FOLDER common)
+-SET_PROPERTY(TARGET lexers APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
++TARGET_LINK_LIBRARIES(embree4_common_lexers embree4_common_sys embree4_common_math)
++SET_PROPERTY(TARGET embree4_common_lexers PROPERTY FOLDER common)
++SET_PROPERTY(TARGET embree4_common_lexers APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
+ 
+ IF (EMBREE_STATIC_LIB)
+-  INSTALL(TARGETS lexers EXPORT lexers-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
++  INSTALL(TARGETS embree4_common_lexers EXPORT lexers-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
+   INSTALL(EXPORT lexers-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
+ ENDIF()
+ 
+diff --git a/common/math/CMakeLists.txt b/common/math/CMakeLists.txt
+index fcfa45598..847c9aeda 100644
+--- a/common/math/CMakeLists.txt
++++ b/common/math/CMakeLists.txt
+@@ -1,12 +1,12 @@
+ ## Copyright 2009-2021 Intel Corporation
+ ## SPDX-License-Identifier: Apache-2.0
+ 
+-ADD_LIBRARY(math STATIC constants.cpp)
+-SET_PROPERTY(TARGET math PROPERTY FOLDER common)
+-SET_PROPERTY(TARGET math APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
++ADD_LIBRARY(embree4_common_math STATIC constants.cpp)
++SET_PROPERTY(TARGET embree4_common_math PROPERTY FOLDER common)
++SET_PROPERTY(TARGET embree4_common_math APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
+ 
+ IF (EMBREE_STATIC_LIB)
+-  INSTALL(TARGETS math EXPORT math-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
++  INSTALL(TARGETS embree4_common_math EXPORT math-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
+   INSTALL(EXPORT math-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
+ ENDIF()
+ 
+diff --git a/common/simd/CMakeLists.txt b/common/simd/CMakeLists.txt
+index 989a00d6e..0ab8df2a3 100644
+--- a/common/simd/CMakeLists.txt
++++ b/common/simd/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ ## Copyright 2009-2021 Intel Corporation
+ ## SPDX-License-Identifier: Apache-2.0
+ 
+-ADD_LIBRARY(simd STATIC sse.cpp)
+-SET_PROPERTY(TARGET simd PROPERTY FOLDER common)
+-SET_PROPERTY(TARGET simd APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
++ADD_LIBRARY(embree4_common_simd STATIC sse.cpp)
++SET_PROPERTY(TARGET embree4_common_simd PROPERTY FOLDER common)
++SET_PROPERTY(TARGET embree4_common_simd APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
+ 
+ IF (EMBREE_STATIC_LIB)
+-  INSTALL(TARGETS simd EXPORT simd-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
++  INSTALL(TARGETS embree4_common_simd EXPORT simd-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
+   INSTALL(EXPORT simd-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
+ ENDIF()
+diff --git a/common/sys/CMakeLists.txt b/common/sys/CMakeLists.txt
+index 66fc70831..c7f816706 100644
+--- a/common/sys/CMakeLists.txt
++++ b/common/sys/CMakeLists.txt
+@@ -4,7 +4,7 @@
+ SET(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+ FIND_PACKAGE(Threads REQUIRED)
+ 
+-ADD_LIBRARY(sys STATIC
++ADD_LIBRARY(embree4_common_sys STATIC
+   sysinfo.cpp
+   alloc.cpp
+   filename.cpp
+@@ -17,16 +17,16 @@ ADD_LIBRARY(sys STATIC
+   barrier.cpp
+ )
+ 
+-SET_PROPERTY(TARGET sys PROPERTY FOLDER common)
+-SET_PROPERTY(TARGET sys APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
++SET_PROPERTY(TARGET embree4_common_sys PROPERTY FOLDER common)
++SET_PROPERTY(TARGET embree4_common_sys APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
+ 
+-TARGET_LINK_LIBRARIES(sys ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
++TARGET_LINK_LIBRARIES(embree4_common_sys ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+ IF (EMBREE_SYCL_SUPPORT)
+-  TARGET_LINK_LIBRARIES(sys ${SYCL_LIB_NAME})
++  TARGET_LINK_LIBRARIES(embree4_common_sys ${SYCL_LIB_NAME})
+ ENDIF()
+ 
+ IF (EMBREE_STATIC_LIB)
+-  INSTALL(TARGETS sys EXPORT sys-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
++  INSTALL(TARGETS embree4_common_sys EXPORT sys-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
+   INSTALL(EXPORT sys-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
+ ENDIF()
+ 
+diff --git a/common/tasking/CMakeLists.txt b/common/tasking/CMakeLists.txt
+index bf790ef63..8ae0ac0b0 100644
+--- a/common/tasking/CMakeLists.txt
++++ b/common/tasking/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ ## SPDX-License-Identifier: Apache-2.0
+ 
+ IF (TASKING_INTERNAL)
+-  ADD_LIBRARY(tasking STATIC taskschedulerinternal.cpp)
++  ADD_LIBRARY(embree4_common_tasking STATIC taskschedulerinternal.cpp)
+ ELSEIF (TASKING_TBB)
+   ##############################################################
+   # Find TBB
+@@ -13,16 +13,16 @@ ELSEIF (TASKING_TBB)
+     list(APPEND CMAKE_PREFIX_PATH ${EMBREE_TBB_ROOT})
+   endif()
+ 
+-  ADD_LIBRARY(tasking STATIC taskschedulertbb.cpp)
++  ADD_LIBRARY(embree4_common_tasking STATIC taskschedulertbb.cpp)
+   
+   if (TARGET TBB::${EMBREE_TBB_COMPONENT})
+     message("-- TBB: reuse existing TBB::${TBB_COMPONENT} target")
+-    TARGET_LINK_LIBRARIES(tasking PUBLIC TBB::${EMBREE_TBB_COMPONENT})
++    TARGET_LINK_LIBRARIES(embree4_common_tasking PUBLIC TBB::${EMBREE_TBB_COMPONENT})
+   else()
+     # Try getting TBB via config first
+     find_package(TBB 2020 COMPONENTS ${EMBREE_TBB_COMPONENT} CONFIG ${TBB_FIND_PACKAGE_OPTION})
+     if (TBB_FOUND)
+-      TARGET_LINK_LIBRARIES(tasking PUBLIC TBB::${EMBREE_TBB_COMPONENT})
++      TARGET_LINK_LIBRARIES(embree4_common_tasking PUBLIC TBB::${EMBREE_TBB_COMPONENT})
+       message("-- Found TBB: ${TBB_VERSION} at ${TBB_DIR} via TBBConfig.cmake")
+     else()
+ 
+@@ -32,8 +32,8 @@ ELSEIF (TASKING_TBB)
+       unset(TBB_DIR CACHE)
+       find_package(TBB 4.1 REQUIRED ${EMBREE_TBB_COMPONENT})
+       if (TBB_FOUND)
+-        TARGET_LINK_LIBRARIES(tasking PUBLIC TBB)
+-        TARGET_INCLUDE_DIRECTORIES(tasking PUBLIC $<BUILD_INTERFACE:${TBB_INCLUDE_DIRS}>)
++        TARGET_LINK_LIBRARIES(embree4_common_tasking PUBLIC TBB)
++        TARGET_INCLUDE_DIRECTORIES(embree4_common_tasking PUBLIC $<BUILD_INTERFACE:${TBB_INCLUDE_DIRS}>)
+ 
+         IF (EMBREE_STATIC_LIB)
+           INSTALL(TARGETS TBB EXPORT TBB-targets)
+@@ -50,8 +50,8 @@ ELSEIF (TASKING_TBB)
+   IF(WIN32)
+     GET_TARGET_PROPERTY(DLL_PATH TBB::${EMBREE_TBB_COMPONENT} IMPORTED_LOCATION_RELEASE)
+     GET_TARGET_PROPERTY(DLL_PATH_DEBUG TBB::${EMBREE_TBB_COMPONENT} IMPORTED_LOCATION_DEBUG)
+-    SET_TARGET_PROPERTIES(tasking PROPERTIES IMPORTED_LOCATION_RELEASE ${DLL_PATH})
+-    SET_TARGET_PROPERTIES(tasking PROPERTIES IMPORTED_LOCATION_DEBUG ${DLL_PATH_DEBUG})
++    SET_TARGET_PROPERTIES(embree4_common_tasking PROPERTIES IMPORTED_LOCATION_RELEASE ${DLL_PATH})
++    SET_TARGET_PROPERTIES(embree4_common_tasking PROPERTIES IMPORTED_LOCATION_DEBUG ${DLL_PATH_DEBUG})
+   ENDIF()
+ 
+   ###############################################################
+@@ -65,14 +65,14 @@ ELSEIF (TASKING_TBB)
+   include(installTBB)
+ 
+ ELSEIF (TASKING_PPL)
+-  ADD_LIBRARY(tasking STATIC taskschedulerppl.cpp)
+-  TARGET_LINK_LIBRARIES(tasking PUBLIC ${PPL_LIBRARIES})
++  ADD_LIBRARY(embree4_common_tasking STATIC taskschedulerppl.cpp)
++  TARGET_LINK_LIBRARIES(embree4_common_tasking PUBLIC ${PPL_LIBRARIES})
+ ENDIF()
+ 
+-SET_PROPERTY(TARGET tasking PROPERTY FOLDER common)
+-SET_PROPERTY(TARGET tasking APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
++SET_PROPERTY(TARGET embree4_common_tasking PROPERTY FOLDER common)
++SET_PROPERTY(TARGET embree4_common_tasking APPEND PROPERTY COMPILE_FLAGS " ${FLAGS_LOWEST}")
+ 
+ IF (EMBREE_STATIC_LIB)
+-  INSTALL(TARGETS tasking EXPORT tasking-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
++  INSTALL(TARGETS embree4_common_tasking EXPORT tasking-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
+   INSTALL(EXPORT tasking-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
+ ENDIF()
+diff --git a/kernels/CMakeLists.txt b/kernels/CMakeLists.txt
+index 7d1386853..376689188 100644
+--- a/kernels/CMakeLists.txt
++++ b/kernels/CMakeLists.txt
+@@ -285,61 +285,61 @@ ENDIF()
+ 
+ IF (EMBREE_ISA_SSE42 AND EMBREE_LIBRARY_FILES_SSE42)
+   DISABLE_STACK_PROTECTOR_FOR_INTERSECTORS(${EMBREE_LIBRARY_FILES_SSE42})
+-  ADD_LIBRARY(embree_sse42 STATIC ${EMBREE_LIBRARY_FILES_SSE42})
+-  TARGET_LINK_LIBRARIES(embree_sse42 PRIVATE tasking)
+-  SET_TARGET_PROPERTIES(embree_sse42 PROPERTIES COMPILE_FLAGS "${FLAGS_SSE42}")
+-  SET_PROPERTY(TARGET embree_sse42 PROPERTY FOLDER kernels)
+-  SET(EMBREE_LIBRARIES ${EMBREE_LIBRARIES} embree_sse42)
+-  CheckGlobals(embree_sse42)
++  ADD_LIBRARY(embree4_sse42 STATIC ${EMBREE_LIBRARY_FILES_SSE42})
++  TARGET_LINK_LIBRARIES(embree4_sse42 PRIVATE embree4_common_tasking)
++  SET_TARGET_PROPERTIES(embree4_sse42 PROPERTIES COMPILE_FLAGS "${FLAGS_SSE42}")
++  SET_PROPERTY(TARGET embree4_sse42 PROPERTY FOLDER kernels)
++  SET(EMBREE_LIBRARIES ${EMBREE_LIBRARIES} embree4_sse42)
++  CheckGlobals(embree4_sse42)
+   IF (EMBREE_STATIC_LIB)
+-    INSTALL(TARGETS embree_sse42 EXPORT embree_sse42-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
+-    INSTALL(EXPORT embree_sse42-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
++    INSTALL(TARGETS embree4_sse42 EXPORT embree4_sse42-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
++    INSTALL(EXPORT embree4_sse42-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
+   ENDIF()
+ ENDIF ()
+ 
+ IF (EMBREE_ISA_AVX  AND EMBREE_LIBRARY_FILES_AVX)
+   DISABLE_STACK_PROTECTOR_FOR_INTERSECTORS(${EMBREE_LIBRARY_FILES_AVX})
+-  ADD_LIBRARY(embree_avx STATIC ${EMBREE_LIBRARY_FILES_AVX})
+-  TARGET_LINK_LIBRARIES(embree_avx PRIVATE tasking)
+-  SET_TARGET_PROPERTIES(embree_avx PROPERTIES COMPILE_FLAGS "${FLAGS_AVX}")
+-  SET_PROPERTY(TARGET embree_avx PROPERTY FOLDER kernels)
+-  SET(EMBREE_LIBRARIES ${EMBREE_LIBRARIES} embree_avx)
+-  CheckGlobals(embree_avx)
++  ADD_LIBRARY(embree4_avx STATIC ${EMBREE_LIBRARY_FILES_AVX})
++  TARGET_LINK_LIBRARIES(embree4_avx PRIVATE embree4_common_tasking)
++  SET_TARGET_PROPERTIES(embree4_avx PROPERTIES COMPILE_FLAGS "${FLAGS_AVX}")
++  SET_PROPERTY(TARGET embree4_avx PROPERTY FOLDER kernels)
++  SET(EMBREE_LIBRARIES ${EMBREE_LIBRARIES} embree4_avx)
++  CheckGlobals(embree4_avx)
+   IF (EMBREE_STATIC_LIB)
+-    INSTALL(TARGETS embree_avx EXPORT embree_avx-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
+-    INSTALL(EXPORT embree_avx-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
++    INSTALL(TARGETS embree4_avx EXPORT embree4_avx-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
++    INSTALL(EXPORT embree4_avx-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
+   ENDIF()
+ ENDIF()
+ 
+ IF (EMBREE_ISA_AVX2 AND EMBREE_LIBRARY_FILES_AVX2)
+   DISABLE_STACK_PROTECTOR_FOR_INTERSECTORS(${EMBREE_LIBRARY_FILES_AVX2})
+-  ADD_LIBRARY(embree_avx2 STATIC ${EMBREE_LIBRARY_FILES_AVX2})
+-  TARGET_LINK_LIBRARIES(embree_avx2 PRIVATE tasking)
+-  SET_TARGET_PROPERTIES(embree_avx2 PROPERTIES COMPILE_FLAGS "${FLAGS_AVX2}")
+-  SET_PROPERTY(TARGET embree_avx2 PROPERTY FOLDER kernels)
+-  SET(EMBREE_LIBRARIES ${EMBREE_LIBRARIES} embree_avx2)
+-  CheckGlobals(embree_avx2)
++  ADD_LIBRARY(embree4_avx2 STATIC ${EMBREE_LIBRARY_FILES_AVX2})
++  TARGET_LINK_LIBRARIES(embree4_avx2 PRIVATE embree4_common_tasking)
++  SET_TARGET_PROPERTIES(embree4_avx2 PROPERTIES COMPILE_FLAGS "${FLAGS_AVX2}")
++  SET_PROPERTY(TARGET embree4_avx2 PROPERTY FOLDER kernels)
++  SET(EMBREE_LIBRARIES ${EMBREE_LIBRARIES} embree4_avx2)
++  CheckGlobals(embree4_avx2)
+   IF (EMBREE_STATIC_LIB)
+-    INSTALL(TARGETS embree_avx2 EXPORT embree_avx2-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
+-    INSTALL(EXPORT embree_avx2-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
++    INSTALL(TARGETS embree4_avx2 EXPORT embree4_avx2-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
++    INSTALL(EXPORT embree4_avx2-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
+   ENDIF()
+ ENDIF()
+ 
+ IF (EMBREE_ISA_AVX512 AND EMBREE_LIBRARY_FILES_AVX512)
+   DISABLE_STACK_PROTECTOR_FOR_INTERSECTORS(${EMBREE_LIBRARY_FILES_AVX512})
+-  ADD_LIBRARY(embree_avx512 STATIC ${EMBREE_LIBRARY_FILES_AVX512})
+-  TARGET_LINK_LIBRARIES(embree_avx512 PRIVATE tasking)
+-  SET_TARGET_PROPERTIES(embree_avx512 PROPERTIES COMPILE_FLAGS "${FLAGS_AVX512}")
+-  SET_PROPERTY(TARGET embree_avx512 PROPERTY FOLDER kernels)
+-  SET(EMBREE_LIBRARIES ${EMBREE_LIBRARIES} embree_avx512)
+-  CheckGlobals(embree_avx512)
++  ADD_LIBRARY(embree4_avx512 STATIC ${EMBREE_LIBRARY_FILES_AVX512})
++  TARGET_LINK_LIBRARIES(embree4_avx512 PRIVATE embree4_common_tasking)
++  SET_TARGET_PROPERTIES(embree4_avx512 PROPERTIES COMPILE_FLAGS "${FLAGS_AVX512}")
++  SET_PROPERTY(TARGET embree4_avx512 PROPERTY FOLDER kernels)
++  SET(EMBREE_LIBRARIES ${EMBREE_LIBRARIES} embree4_avx512)
++  CheckGlobals(embree4_avx512)
+   IF (EMBREE_STATIC_LIB)
+-    INSTALL(TARGETS embree_avx512 EXPORT embree_avx512-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
+-    INSTALL(EXPORT embree_avx512-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
++    INSTALL(TARGETS embree4_avx512 EXPORT embree4_avx512-targets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT devel)
++    INSTALL(EXPORT embree4_avx512-targets DESTINATION "${EMBREE_CMAKEEXPORT_DIR}" COMPONENT devel)
+   ENDIF()
+ ENDIF()
+ 
+-TARGET_LINK_LIBRARIES(embree PRIVATE ${EMBREE_LIBRARIES} sys math simd lexers tasking)
++TARGET_LINK_LIBRARIES(embree PRIVATE ${EMBREE_LIBRARIES} embree4_common_sys embree4_common_math embree4_common_simd embree4_common_lexers embree4_common_tasking)
+ IF (EMBREE_SYCL_SUPPORT)
+   TARGET_LINK_LIBRARIES(embree PRIVATE ${SYCL_LIB_NAME} ze_wrapper PUBLIC embree_sycl)
+ ENDIF()

--- a/ports/embree4/portfile.cmake
+++ b/ports/embree4/portfile.cmake
@@ -1,0 +1,157 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO embree/embree
+    REF v${VERSION}
+    SHA512 da7710c6dfaa90970c223a503702fc7c7dd86c1397372b3d6f51c4377d28d8e62b90ee8c99b70e3aa49e16971a5789bb8f588ea924881b9dd5dd8d5fcd16518a
+    HEAD_REF master
+    PATCHES
+        001-no-runtime-install.patch
+)
+
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} static EMBREE_STATIC_LIB)
+string(COMPARE EQUAL ${VCPKG_CRT_LINKAGE} static EMBREE_STATIC_RUNTIME)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        backface-culling                        EMBREE_BACKFACE_CULLING
+        backface-culling-curves                 EMBREE_BACKFACE_CULLING_CURVES
+        backface-culling-spheres                EMBREE_BACKFACE_CULLING_SPHERES
+        compact-polys                           EMBREE_COMPACT_POLYS
+        disc-point-self-intersection-avoidance  EMBREE_DISC_POINT_SELF_INTERSECTION_AVOIDANCE
+        filter-function                         EMBREE_FILTER_FUNCTION
+        ignore-invalid-rays                     EMBREE_IGNORE_INVALID_RAYS
+        ray-mask                                EMBREE_RAY_MASK
+        ray-packets                             EMBREE_RAY_PACKETS
+
+        geometry-triangle           EMBREE_GEOMETRY_TRIANGLE
+        geometry-quad               EMBREE_GEOMETRY_QUAD
+        geometry-curve              EMBREE_GEOMETRY_CURVE
+        geometry-subdivision        EMBREE_GEOMETRY_SUBDIVISION
+        geometry-user               EMBREE_GEOMETRY_USER
+        geometry-instance           EMBREE_GEOMETRY_INSTANCE
+        geometry-instance-array     EMBREE_GEOMETRY_INSTANCE_ARRAY
+        geometry-grid               EMBREE_GEOMETRY_GRID
+        geometry-point              EMBREE_GEOMETRY_POINT
+)
+
+# Automatically select best ISA based on platform or VCPKG_CMAKE_CONFIGURE_OPTIONS.
+vcpkg_list(SET EXTRA_OPTIONS)
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    # Disable incorrect ISA set for Emscripten and enable NEON which is supported and should provide decent performance.
+    # cf. [Using SIMD with WebAssembly](https://emscripten.org/docs/porting/simd.html#using-simd-with-webassembly)
+    vcpkg_list(APPEND EXTRA_OPTIONS
+        -DEMBREE_MAX_ISA:STRING=NONE
+
+        -DEMBREE_ISA_AVX:BOOL=OFF
+        -DEMBREE_ISA_AVX2:BOOL=OFF
+        -DEMBREE_ISA_AVX512:BOOL=OFF
+        -DEMBREE_ISA_SSE2:BOOL=OFF
+        -DEMBREE_ISA_SSE42:BOOL=OFF
+        -DEMBREE_ISA_NEON:BOOL=ON
+    )
+elseif(VCPKG_TARGET_IS_OSX AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64"))
+    # The best ISA for Apple arm64 is unique and unambiguous.
+    vcpkg_list(APPEND EXTRA_OPTIONS
+        -DEMBREE_MAX_ISA:STRING=NONE
+    )
+elseif(VCPKG_TARGET_IS_OSX AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64") AND (VCPKG_LIBRARY_LINKAGE STREQUAL "static"))
+    # AppleClang >= 9.0 does not support selecting multiple ISAs.
+    # Let Embree select the best and unique one.
+    vcpkg_list(APPEND EXTRA_OPTIONS
+        -DEMBREE_MAX_ISA:STRING=DEFAULT
+    )
+else()
+    # Let Embree select the best ISA set for the targeted platform.
+    vcpkg_list(APPEND EXTRA_OPTIONS
+        -DEMBREE_MAX_ISA:STRING=NONE
+    )
+endif()
+
+if("tasking-tbb" IN_LIST FEATURES)
+    set(EMBREE_TASKING_SYSTEM "TBB")
+else()
+    set(EMBREE_TASKING_SYSTEM "INTERNAL")
+endif()
+
+vcpkg_replace_string("${SOURCE_PATH}/common/cmake/installTBB.cmake" "IF (EMBREE_STATIC_LIB)" "IF (0)")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS ${FEATURE_OPTIONS} ${EXTRA_OPTIONS}
+        -DEMBREE_ISPC_SUPPORT=OFF
+        -DEMBREE_SYCL_SUPPORT=OFF
+        -DEMBREE_TUTORIALS=OFF
+        -DEMBREE_STATIC_RUNTIME=${EMBREE_STATIC_RUNTIME}
+        -DEMBREE_STATIC_LIB=${EMBREE_STATIC_LIB}
+        -DEMBREE_TASKING_SYSTEM:STRING=${EMBREE_TASKING_SYSTEM}
+        -DEMBREE_INSTALL_DEPENDENCIES=OFF
+        -DEMBREE_ZIP_MODE=OFF
+    MAYBE_UNUSED_VARIABLES
+        EMBREE_STATIC_RUNTIME
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/embree-${VERSION} PACKAGE_NAME embree)
+
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/embree" "${CURRENT_PACKAGES_DIR}/share/${PORT}/")
+
+# Fix details in config.
+set(config_file "${CURRENT_PACKAGES_DIR}/share/${PORT}/embree-config.cmake")
+file(READ "${config_file}" contents)
+string(REPLACE "SET(EMBREE_BUILD_TYPE Release)" "" contents "${contents}")
+string(REPLACE "/../../../" "/../../" contents "${contents}")
+string(REPLACE "FIND_PACKAGE" "include(CMakeFindDependencyMacro)\n  find_dependency" contents "${contents}")
+string(REPLACE "REQUIRED" "COMPONENTS" contents "${contents}")
+string(REPLACE "/lib/cmake/embree-${VERSION}" "/share/${PORT}" contents "${contents}")
+if(NOT VCPKG_BUILD_TYPE)
+    string(REPLACE "/lib/embree4.lib" "$<$<CONFIG:DEBUG>:/debug>/lib/embree4.lib" contents "${contents}")
+endif()
+file(WRITE "${config_file}" "${contents}")
+
+function(FIX_DETAILS OLD_NAME NEW_NAME)
+    set(config_file "${CURRENT_PACKAGES_DIR}/share/${PORT}/${OLD_NAME}-targets-debug.cmake")
+    if(EXISTS "${config_file}")
+        file(READ "${config_file}" contents)
+        string(REPLACE "/debug/lib/${OLD_NAME}.lib" "/debug/lib/${NEW_NAME}.lib" contents "${contents}")
+        file(WRITE "${config_file}" "${contents}")
+        endif()
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/${OLD_NAME}.lib")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/${OLD_NAME}.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/${NEW_NAME}.lib")
+    endif()
+    set(config_file "${CURRENT_PACKAGES_DIR}/share/${PORT}/${OLD_NAME}-targets-release.cmake")
+    if(EXISTS "${config_file}")
+        file(READ "${config_file}" contents)
+        string(REPLACE "/lib/${OLD_NAME}.lib" "/lib/${NEW_NAME}.lib" contents "${contents}")
+        file(WRITE "${config_file}" "${contents}")
+    endif()
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/${OLD_NAME}.lib")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/lib/${OLD_NAME}.lib" "${CURRENT_PACKAGES_DIR}/lib/${NEW_NAME}.lib")
+    endif()
+endfunction()
+
+FIX_DETAILS("embree_avx" "embree4_avx")
+FIX_DETAILS("embree_avx2" "embree4_avx2")
+FIX_DETAILS("embree_avx512" "embree4_avx512")
+FIX_DETAILS("embree_sse42" "embree4_sse42")
+FIX_DETAILS("lexers" "embree4_common_lexers")
+FIX_DETAILS("math" "embree4_common_math")
+FIX_DETAILS("simd" "embree4_common_simd")
+FIX_DETAILS("sys" "embree4_common_sys")
+FIX_DETAILS("tasking" "embree4_common_tasking")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+if(APPLE)
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/uninstall.command" "${CURRENT_PACKAGES_DIR}/debug/uninstall.command")
+endif()
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/doc" "${CURRENT_PACKAGES_DIR}/share/${PORT}/doc")
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/embree4/usage
+++ b/ports/embree4/usage
@@ -1,0 +1,4 @@
+The package embree4 provides CMake targets:
+
+    find_package(embree 4 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE embree)

--- a/ports/embree4/vcpkg.json
+++ b/ports/embree4/vcpkg.json
@@ -1,0 +1,95 @@
+{
+  "name": "embree4",
+  "version": "4.3.1",
+  "description": "High Performance Ray Tracing Kernels.",
+  "homepage": "https://github.com/embree/embree",
+  "license": "Apache-2.0",
+  "supports": "!arm | osx",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "disc-point-self-intersection-avoidance",
+    "filter-function",
+    "geometry-curve",
+    "geometry-grid",
+    "geometry-instance",
+    "geometry-instance-array",
+    "geometry-point",
+    "geometry-quad",
+    "geometry-subdivision",
+    "geometry-triangle",
+    "geometry-user",
+    "ray-packets",
+    "tasking-tbb"
+  ],
+  "features": {
+    "backface-culling": {
+      "description": "Enables backface culling."
+    },
+    "backface-culling-curves": {
+      "description": "Enables backface culling for curve primitives."
+    },
+    "backface-culling-spheres": {
+      "description": "Enables backface culling for sphere primitives."
+    },
+    "compact-polys": {
+      "description": "Enables double indexed poly layout."
+    },
+    "disc-point-self-intersection-avoidance": {
+      "description": "Enables self intersection avoidance for ray oriented discs."
+    },
+    "filter-function": {
+      "description": "Enables filter functions."
+    },
+    "geometry-curve": {
+      "description": "Enables support for curve geometries."
+    },
+    "geometry-grid": {
+      "description": "Enables support for grid geometries."
+    },
+    "geometry-instance": {
+      "description": "Enables support for instances."
+    },
+    "geometry-instance-array": {
+      "description": "Enables support for instances arrays."
+    },
+    "geometry-point": {
+      "description": "Enables support for point geometries."
+    },
+    "geometry-quad": {
+      "description": "Enables support for quad geometries."
+    },
+    "geometry-subdivision": {
+      "description": "Enables support for subdiv geometries."
+    },
+    "geometry-triangle": {
+      "description": "Enables support for triangle geometries."
+    },
+    "geometry-user": {
+      "description": "Enables support for user geometries."
+    },
+    "ignore-invalid-rays": {
+      "description": "Ignores invalid rays."
+    },
+    "ray-mask": {
+      "description": "Enables ray mask support."
+    },
+    "ray-packets": {
+      "description": "Enabled support for ray packets."
+    },
+    "tasking-tbb": {
+      "description": "Use oneTBB as task system.",
+      "dependencies": [
+        "tbb"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2496,6 +2496,10 @@
       "baseline": "3.13.5",
       "port-version": 3
     },
+    "embree4": {
+      "baseline": "4.3.1",
+      "port-version": 0
+    },
     "enet": {
       "baseline": "1.3.17",
       "port-version": 2

--- a/versions/e-/embree4.json
+++ b/versions/e-/embree4.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4fe792dedd082fc8be1580e6d5add49f4ec1463e",
+      "version": "4.3.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/e-/embree4.json
+++ b/versions/e-/embree4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4fe792dedd082fc8be1580e6d5add49f4ec1463e",
+      "git-tree": "6da6510c3101940d611ed6ce5f0b583fe37b7259",
       "version": "4.3.1",
       "port-version": 0
     }


### PR DESCRIPTION
Fixes #35683 .

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
