### PR TITLE
[OpenFX]: add version for Davinci Resolve 18.x

### DIFF
--- a/ports/openfx/portfile.cmake
+++ b/ports/openfx/portfile.cmake
@@ -1,4 +1,5 @@
 string(REPLACE "." "_" UNDERSCORE_VERSION "${VERSION}")
+string(REPLACE "-davinci-18_x" "" UNDERSCORE_VERSION "${UNDERSCORE_VERSION}")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -9,6 +10,15 @@ vcpkg_from_github(
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+set(DRAW_SUITE_COMMIT_REFERENCE "c0167e114582cdf373507f65f60f8e50e2076434")
+vcpkg_download_distfile(
+    OFX_DRAW_SUITE_H
+    URLS "https://github.com/AcademySoftwareFoundation/openfx/raw/${DRAW_SUITE_COMMIT_REFERENCE}/include/ofxDrawSuite.h"
+    FILENAME "ofxDrawSuite.h"
+    SHA512 9afd8d93ff4816004ac2d89d45255801d0c09ee8f5acb72dbc37048483fa7ca0637fe028554910039de5f60c9450cb5dc5e2d27477c1a0c5595c9bdf09312ec5
+)
+file(COPY ${OFX_DRAW_SUITE_H} DESTINATION ${SOURCE_PATH}/include/)
 
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()

--- a/ports/openfx/portfile.cmake
+++ b/ports/openfx/portfile.cmake
@@ -1,5 +1,4 @@
 string(REPLACE "." "_" UNDERSCORE_VERSION "${VERSION}")
-string(REPLACE "-davinci-18_x" "" UNDERSCORE_VERSION "${UNDERSCORE_VERSION}")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -11,14 +10,16 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-set(DRAW_SUITE_COMMIT_REFERENCE "c0167e114582cdf373507f65f60f8e50e2076434")
-vcpkg_download_distfile(
-    OFX_DRAW_SUITE_H
-    URLS "https://github.com/AcademySoftwareFoundation/openfx/raw/${DRAW_SUITE_COMMIT_REFERENCE}/include/ofxDrawSuite.h"
-    FILENAME "ofxDrawSuite.h"
-    SHA512 9afd8d93ff4816004ac2d89d45255801d0c09ee8f5acb72dbc37048483fa7ca0637fe028554910039de5f60c9450cb5dc5e2d27477c1a0c5595c9bdf09312ec5
-)
-file(COPY ${OFX_DRAW_SUITE_H} DESTINATION ${SOURCE_PATH}/include/)
+if("davinci-18" IN_LIST FEATURES)
+    set(DRAW_SUITE_COMMIT_REFERENCE "c0167e114582cdf373507f65f60f8e50e2076434")
+    vcpkg_download_distfile(
+        OFX_DRAW_SUITE_H
+        URLS "https://github.com/AcademySoftwareFoundation/openfx/raw/${DRAW_SUITE_COMMIT_REFERENCE}/include/ofxDrawSuite.h"
+        FILENAME "ofxDrawSuite.h"
+        SHA512 9afd8d93ff4816004ac2d89d45255801d0c09ee8f5acb72dbc37048483fa7ca0637fe028554910039de5f60c9450cb5dc5e2d27477c1a0c5595c9bdf09312ec5
+    )
+    file(COPY ${OFX_DRAW_SUITE_H} DESTINATION ${CURRENT_PACKAGES_DIR}/include/openfx/)
+endif()
 
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()

--- a/ports/openfx/vcpkg.json
+++ b/ports/openfx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openfx",
-  "version": "1.4",
+  "version": "1.4-davinci-18.x",
   "maintainers": "Reza Alizadeh Majd <r.a.majd@gmail.com>, Behnam Binesh <BehnamBih@gmail.com>",
   "summary": "OpenFX - An open-source plugin API for visual effects",
   "homepage": "https://github.com/AcademySoftwareFoundation/openfx",

--- a/ports/openfx/vcpkg.json
+++ b/ports/openfx/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openfx",
-  "version": "1.4-davinci-18.x",
+  "version": "1.4",
+  "port-version": 1,
   "maintainers": "Reza Alizadeh Majd <r.a.majd@gmail.com>, Behnam Binesh <BehnamBih@gmail.com>",
   "summary": "OpenFX - An open-source plugin API for visual effects",
   "homepage": "https://github.com/AcademySoftwareFoundation/openfx",
@@ -15,5 +16,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "davinci-18": {
+      "description": "Installs the custom header files shipped with the Davinci Resolve 18.x"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6445,7 +6445,7 @@
       "port-version": 0
     },
     "openfx": {
-      "baseline": "1.4",
+      "baseline": "1.4-davinci-18.x",
       "port-version": 0
     },
     "opengl": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6445,8 +6445,8 @@
       "port-version": 0
     },
     "openfx": {
-      "baseline": "1.4-davinci-18.x",
-      "port-version": 0
+      "baseline": "1.4",
+      "port-version": 1
     },
     "opengl": {
       "baseline": "2022-12-04",

--- a/versions/o-/openfx.json
+++ b/versions/o-/openfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41b03f17ba4bf8955b93615e561d11a40cf4c0b7",
+      "version": "1.4-davinci-18.x",
+      "port-version": 0
+    },
+    {
       "git-tree": "9bfae0126edf500cbdcb8592715c9bd176b79bfb",
       "version": "1.4",
       "port-version": 0

--- a/versions/o-/openfx.json
+++ b/versions/o-/openfx.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "41b03f17ba4bf8955b93615e561d11a40cf4c0b7",
-      "version": "1.4-davinci-18.x",
-      "port-version": 0
+      "git-tree": "cad799a186079389ce775b06354858f7365be407",
+      "version": "1.4",
+      "port-version": 1
     },
     {
       "git-tree": "9bfae0126edf500cbdcb8592715c9bd176b79bfb",


### PR DESCRIPTION

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

