### PR TITLE
[elements] Update port

### DIFF
--- a/ports/elements/fix-linkage.patch
+++ b/ports/elements/fix-linkage.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index f2a2e0ed..13d69653 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -172,7 +172,7 @@ source_group("Header Files\\elements"
+ )
+ 
+ add_subdirectory(infra)
+-add_library(elements STATIC)
++add_library(elements)
+ 
+ target_sources(elements
+    PRIVATE ${ELEMENTS_SOURCES} ${ELEMENTS_HOST}

--- a/ports/elements/portfile.cmake
+++ b/ports/elements/portfile.cmake
@@ -5,19 +5,19 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cycfi/elements
-    REF e2c891bb37b506e3281b902fc0fcc75a5577e476
-    SHA512 3f54c3dcf3fab17eca6a6105f0e77a28a1b77d6354dac12c373c7da84d280abdc8d5bcbe9c42bbc3e38284acbfeb57392ef2538ef7118dd5c34cae29a4e88855
+    REF 83ae36ca102a270c7ebc7ac9d151baba30ccb975
+    SHA512 aba29307edaa86cc9f112b6af0c6a74cd1633c875cc9bf4cc7da135459e817519344cf107b90a1314d9073325b04ef4725b0ee4bd830f2bcb7213cf8efac09d9
     HEAD_REF master
     PATCHES
         asio-headers.patch
-        win-find-libraries.patch
+        fix-linkage.patch
 )
 
 vcpkg_from_github(
     OUT_SOURCE_PATH INFRA_SOURCE_PATH
     REPO cycfi/infra
-    REF 6bc1cc62e3d0a31f92506a577beca3b400b54544
-    SHA512 ceb5acb36210b4fcf4ef3931e718ae1cb09941cc61caab1d20d09003bae2b20fda092e4b1af1bb58444de75f73c04d0651eb5126a87dab7ce14a1b914bccec27
+    REF 2c9e509fc92bb4931fef19cb625817fa6c7da60b
+    SHA512 85fcc273e41ca714d413976578dd0697d7910df75f49249bb4345d7b28ba0f3fe96fabdd7d366f28d862af219fb53eb02751e0dc21f884ebf57cf42ac4d30570
     HEAD_REF master
 )
 if(NOT EXISTS "${SOURCE_PATH}/lib/infra/CMakeLists.txt")
@@ -34,11 +34,13 @@ else()
     set(ELEMENTS_HOST_UI_LIBRARY "gtk")
 endif()
 
+vcpkg_find_acquire_program(PKGCONFIG)
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DELEMENTS_BUILD_EXAMPLES=OFF
         -DELEMENTS_HOST_UI_LIBRARY=${ELEMENTS_HOST_UI_LIBRARY}
+        -DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}
 )
 
 vcpkg_cmake_build()
@@ -46,6 +48,7 @@ vcpkg_cmake_build()
 file(INSTALL "${SOURCE_PATH}/lib/include/elements.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 file(INSTALL "${SOURCE_PATH}/lib/include/elements" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 file(INSTALL "${SOURCE_PATH}/lib/infra/include/infra" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${SOURCE_PATH}/resources" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
     file(GLOB ELEMENTS_LIBS "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/*elements*")

--- a/ports/elements/vcpkg.json
+++ b/ports/elements/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "elements",
-  "version-date": "2022-12-07",
+  "version-date": "2024-04-15",
   "description": "Elements is a lightweight, fine-grained, resolution independent, modular GUI library.",
   "homepage": "https://cycfi.github.io/elements",
   "license": "MIT",
@@ -11,6 +11,7 @@
       "name": "gtk3",
       "platform": "linux"
     },
+    "libwebp",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2481,7 +2481,7 @@
       "port-version": 4
     },
     "elements": {
-      "baseline": "2022-12-07",
+      "baseline": "2024-04-15",
       "port-version": 0
     },
     "elfio": {

--- a/versions/e-/elements.json
+++ b/versions/e-/elements.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a18f167bc34067e582985ae2ef11367c1ac9feb",
+      "version-date": "2024-04-15",
+      "port-version": 0
+    },
+    {
       "git-tree": "ada1c4c9df8d559673c40e083adcab5e94285fc3",
       "version-date": "2022-12-07",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
