### PR TITLE
[google-cloud-cpp] update to the latest release (v2.23)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 5e77e08a5321f5cf794cb9e4cc4745e069a7dbc161414dac309f1bb5ea52d0adae086b13aed7195a7725a59cbc92206dd391aeef86dbf44bec7a8bee266c8881
+    SHA512 52cab0e1ee1ebd51097d28b2cd9a390110ce3f45e92d262fb301cfebdea369ea8b9290c44c26d6b6ba568b0dab1e4871ea819f8a440efeefb38c99f2776aac27
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch
@@ -48,10 +48,6 @@ vcpkg_cmake_configure(
         -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF
         -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
         -DBUILD_TESTING=OFF
-        # This is needed by the `experimental-storage-grpc` feature until vcpkg
-        # gets Protobuf >= 4.23.0.  It has no effect for other features, so
-        # it is simpler to just always turn it on.
-        -DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.22.0",
-  "port-version": 1,
+  "version": "2.23.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -123,6 +122,18 @@
         }
       ]
     },
+    "apphub": {
+      "description": "App Hub API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "artifactregistry": {
       "description": "Artifact Registry API C++ Client Library",
       "dependencies": [
@@ -164,6 +175,18 @@
     },
     "automl": {
       "description": "Cloud AutoML API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "backupdr": {
+      "description": "Backup and DR Service API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -286,6 +309,18 @@
     },
     "cloudbuild": {
       "description": "Cloud Build API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "cloudcontrolspartner": {
+      "description": "Cloud Controls Partner API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -1311,6 +1346,18 @@
           "default-features": false,
           "features": [
             "rest-common"
+          ]
+        }
+      ]
+    },
+    "storagecontrol": {
+      "description": "Cloud Storage Control API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
           ]
         }
       ]

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -7,7 +7,10 @@
   "supports": "!uwp",
   "dependencies": [
     "abseil",
-    "openssl",
+    {
+      "name": "openssl",
+      "platform": "!windows"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3125,8 +3125,8 @@
       "port-version": 8
     },
     "google-cloud-cpp": {
-      "baseline": "2.22.0",
-      "port-version": 1
+      "baseline": "2.23.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6bae5dadcbbf9c7127fdeb029746b605431b171",
+      "version": "2.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "671453ab8dafcf8bb0bbfa87a3649c26c6236942",
       "version": "2.22.0",
       "port-version": 1

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e6bae5dadcbbf9c7127fdeb029746b605431b171",
+      "git-tree": "bdd2c8a586337113246e4bb739b6d1d21e638b34",
       "version": "2.23.0",
       "port-version": 0
     },


### PR DESCRIPTION
Updates google-cloud-cpp to the latest release (v2.23.0)

Removed `DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND` since it is no longer used because it is automatically set now (https://github.com/googleapis/google-cloud-cpp/pull/13877).

Tested locally (on x64-linux) with:

```
 for feature in "cloudcontrolspartner" "storagecontrol" "apphub" "backupdr"; do ./vcpkg remove google-cloud-cpp; ./vcpkg install "google-cloud-cpp[core,${feature}]" || break; done
```

and

```
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'
```

-  [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.