### PR TITLE
[sail] Bump version to 0.9.4

### DIFF
--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HappySeaFox/sail
     REF "v${VERSION}"
-    SHA512 c8cface60031c5e84b99eaedb216f9e3af0354d24f5db7d6d0ec1f97d593ae46cb13c86bc244b6b8673cddfecf829a8b7738fdde8620472c12e95a5b61495133
+    SHA512 691a7ddb9a14a05d5b6cee82489df228869fd208e4635a00b465dde3e30bf2441e3c565cc6dbe3363368dc93c1ba46545d251b3a5c8a2865ffcc87e90d3e8226
     HEAD_REF master
     PATCHES
         fix-include-directory.patch

--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HappySeaFox/sail
     REF "v${VERSION}"
-    SHA512 60a5923e0b95ecfeeb3f6dbc21f82da322ed34bdfd732501e90f89f5bbbb6907c8dbb79d8da09889df3f5a1e9d440c292d539c984d06c815058852b26658155e
+    SHA512 75d797d3fb36e1712cfdd2f0cc13f9bb20b2fc1fe0546e2046ad4356b608adb0efb9c3d17dd1b3c131e445fd5399705c0598d04ba55b1140d271ba86c6e42744
     HEAD_REF master
     PATCHES
         fix-include-directory.patch

--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HappySeaFox/sail
     REF "v${VERSION}"
-    SHA512 691a7ddb9a14a05d5b6cee82489df228869fd208e4635a00b465dde3e30bf2441e3c565cc6dbe3363368dc93c1ba46545d251b3a5c8a2865ffcc87e90d3e8226
+    SHA512 60a5923e0b95ecfeeb3f6dbc21f82da322ed34bdfd732501e90f89f5bbbb6907c8dbb79d8da09889df3f5a1e9d440c292d539c984d06c815058852b26658155e
     HEAD_REF master
     PATCHES
         fix-include-directory.patch

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sail",
-  "version-semver": "0.9.2",
+  "version-semver": "0.9.3",
   "port-version": 1,
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sail",
-  "version-semver": "0.9.3",
+  "version-semver": "0.9.4",
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sail",
   "version-semver": "0.9.3",
-  "port-version": 1,
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sail",
-  "version-semver": "0.9.1",
+  "version-semver": "0.9.2",
   "port-version": 1,
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7829,7 +7829,7 @@
       "port-version": 0
     },
     "sail": {
-      "baseline": "0.9.3",
+      "baseline": "0.9.4",
       "port-version": 0
     },
     "sajson": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7829,7 +7829,7 @@
       "port-version": 0
     },
     "sail": {
-      "baseline": "0.9.1",
+      "baseline": "0.9.2",
       "port-version": 1
     },
     "sajson": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7829,8 +7829,8 @@
       "port-version": 0
     },
     "sail": {
-      "baseline": "0.9.2",
-      "port-version": 1
+      "baseline": "0.9.3",
+      "port-version": 0
     },
     "sajson": {
       "baseline": "2018-09-21",

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "f9e8507b94002b494c4b841e62cd79c81da190d7",
-      "version-semver": "0.9.3",
-      "port-version": 0
-    },
-    {
       "git-tree": "b5fe68901010efcf15a6025a105333d15bb284bf",
       "version-semver": "0.9.1",
       "port-version": 1

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b94b1a44c9796140c96d60203de76f54dd662d7c",
+      "version-semver": "0.9.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "f9e8507b94002b494c4b841e62cd79c81da190d7",
       "version-semver": "0.9.3",
       "port-version": 0

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9718028d2962617d2a15580dc179864c7f03fa28",
+      "version-semver": "0.9.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "b5fe68901010efcf15a6025a105333d15bb284bf",
       "version-semver": "0.9.1",
       "port-version": 1

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "9718028d2962617d2a15580dc179864c7f03fa28",
-      "version-semver": "0.9.2",
-      "port-version": 1
-    },
-    {
       "git-tree": "b5fe68901010efcf15a6025a105333d15bb284bf",
       "version-semver": "0.9.1",
       "port-version": 1

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f9e8507b94002b494c4b841e62cd79c81da190d7",
+      "version-semver": "0.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "9718028d2962617d2a15580dc179864c7f03fa28",
       "version-semver": "0.9.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Significant changes:
- Added SAIL_WINDOWS_UTF8_PATHS CMake option (Convert file paths to UTF-8 on Windows with `MultiByteToWideChar`). `ON` by default.

