### PR TITLE
[libgnutls] Update 3.8.5

### DIFF
--- a/ports/libgnutls/link-zlib.patch
+++ b/ports/libgnutls/link-zlib.patch
@@ -1,0 +1,48 @@
+diff --git a/lib/Makefile.am b/lib/Makefile.am
+index a50d311..0a8b711 100644
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -158,6 +158,7 @@ libgnutls_la_LIBADD = ../gl/libgnu.la x509/libgnutls_x509.la \
+ 	extras/libgnutls_extras.la
+ thirdparty_libadd = $(LTLIBINTL) $(LIBSOCKET) $(LTLIBNSL) \
+ 	$(P11_KIT_LIBS) $(LIB_SELECT) $(GNUTLS_LIBS_PRIVATE)
++thirdparty_libadd += $(LTLIBZ)
+ 
+ if HAVE_LIBIDN2
+ thirdparty_libadd += $(LIBIDN2_LIBS)
+diff --git a/lib/compress.c b/lib/compress.c
+index a0a7c69..ed2c743 100644
+--- a/lib/compress.c
++++ b/lib/compress.c
+@@ -59,16 +59,19 @@ static int (*_gnutls_zlib_uncompress)(Bytef *dest, uLongf *destLen,
+ 
+ static void zlib_deinit(void)
+ {
++#if 0 // using libdl
+ #ifndef _WIN32
+ 	if (_zlib_handle != NULL) {
+ 		dlclose(_zlib_handle);
+ 		_zlib_handle = NULL;
+ 	}
+ #endif /* _WIN32 */
++#endif // using libdl
+ }
+ 
+ static int zlib_init(void)
+ {
++#if 0 // using libdl
+ #ifndef _WIN32
+ 	if (_zlib_handle != NULL)
+ 		return 0;
+@@ -90,6 +93,11 @@ error:
+ #else
+ 	return gnutls_assert_val(GNUTLS_E_UNIMPLEMENTED_FEATURE);
+ #endif /* _WIN32 */
++#else  // ^ using libdl | v not using libdl
++	_gnutls_zlib_compressBound = &compressBound;
++	_gnutls_zlib_compress = &compress;
++	_gnutls_zlib_uncompress = &uncompress;
++#endif // using libdl
+ }
+ #endif /* HAVE_LIBZ */
+ 

--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -5,13 +5,14 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
     FILENAME "gnutls-${VERSION}.tar.xz"
-    SHA512 74eddba01ce4c2ffdca781c85db3bb52c85f1db3c09813ee2b8ceea0608f92ca3912fd9266f55deb36a8ba4d01802895ca5d5d219e7d9caec45e1a8534e45a84
+    SHA512 4bac1aa7ec1dce9b3445cc515cc287a5af032d34c207399aa9722e3dc53ed652f8a57cfbc9c5e40ccc4a2631245d89ab676e3ba2be9563f60ba855aaacb8e23c
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${tarball}"
     SOURCE_BASE "v${VERSION}"
     PATCHES
         use-gmp-pkgconfig.patch
+        link-zlib.patch   # directly as before 3.8.4
 )
 
 vcpkg_list(SET options)
@@ -57,6 +58,7 @@ vcpkg_configure_make(
         --with-tpm=no
         --with-tpm2=no
         --with-zstd=no
+        --with-zlib=yes
         ${options}
         YACC=false # false, the program - not used here
     OPTIONS_DEBUG

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgnutls",
-  "version": "3.8.3",
+  "version": "3.8.5",
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols.",
   "homepage": "https://www.gnutls.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4437,7 +4437,7 @@
       "port-version": 0
     },
     "libgnutls": {
-      "baseline": "3.8.3",
+      "baseline": "3.8.5",
       "port-version": 0
     },
     "libgo": {

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3e31974234b23cde0cd18912c88c4bc9e05c2ef",
+      "version": "3.8.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f2317b82e7f26359ebabb66b377f064731ffe19",
       "version": "3.8.3",
       "port-version": 0


### PR DESCRIPTION
Unlike upstream, zlib compression is directly linked (almost) as before 3.8.4, not dlopened.