### PR TITLE
[nettle] Update to 3.9.1

### DIFF
--- a/ports/nettle/ccas.patch
+++ b/ports/nettle/ccas.patch
@@ -1,59 +1,57 @@
 diff --git a/Makefile.in b/Makefile.in
-index d00b565..c465d0b 100644
+index 964ba18..3194735 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -294,7 +294,7 @@ libhogweed.a: $(hogweed_OBJS)
+@@ -302,7 +302,7 @@ libhogweed.a: $(hogweed_OBJS)
  
  %.$(OBJEXT): %.asm $(srcdir)/m4-utils.m4 $(srcdir)/asm.m4 config.m4 machine.m4
  	$(M4) $(srcdir)/m4-utils.m4 $(srcdir)/asm.m4 config.m4 machine.m4 $< >$*.s
--	$(COMPILE) -c $*.s
+-	$(COMPILE) $(ASM_FLAGS) -c $*.s
 +	$(COMPILE_AS) -c $*.s -o $@
  
  %.$(OBJEXT): %.c
  	$(COMPILE) -c $< \
 diff --git a/aclocal.m4 b/aclocal.m4
-index 1d218a0..1ff02c8 100644
+index 0d97388..98f6916 100644
 --- a/aclocal.m4
 +++ b/aclocal.m4
-@@ -301,7 +301,7 @@ AC_DEFUN([GMP_TRY_ASSEMBLE],
+@@ -302,7 +302,7 @@ AC_DEFUN([GMP_TRY_ASSEMBLE],
  [cat >conftest.s <<EOF
  [$1]
  EOF
--gmp_assemble="$CC $CFLAGS $CPPFLAGS -c conftest.s >conftest.out 2>&1"
-+gmp_assemble="$CCAS $CPPFLAGS $ASMFLAGS -c conftest.s >conftest.out 2>&1"
+-gmp_assemble="$CC $CFLAGS $CPPFLAGS $ASM_FLAGS -c conftest.s >conftest.out 2>&1"
++gmp_assemble="$CCAS $CPPFLAGS $ASM_FLAGS -c conftest.s >conftest.out 2>&1"
  if AC_TRY_EVAL(gmp_assemble); then
    cat conftest.out >&AC_FD_CC
    ifelse([$2],,:,[$2])
 diff --git a/config.make.in b/config.make.in
-index f8e1f74..4668884 100644
+index 6aec7c7..8bc5599 100644
 --- a/config.make.in
 +++ b/config.make.in
-@@ -73,6 +73,9 @@ TEST_SHLIB_DIR = ${abs_top_builddir}/.lib
+@@ -74,6 +74,8 @@ TEST_SHLIB_DIR = ${abs_top_builddir}/.lib
  # flags before CPPFLAGS and LDFLAGS. While EXTRA_CFLAGS are added at the end.
  
  COMPILE = $(CC) $(PRE_CPPFLAGS) $(CPPFLAGS) $(DEFS) $(CFLAGS) $(EXTRA_CFLAGS) $(DEP_FLAGS)
 +CCAS = @CCAS@
-+ASMFLAGS = @ASMFLAGS@
-+COMPILE_AS = $(CCAS) $(PRE_CPPFLAGS) $(CPPFLAGS) $(DEFS) $(ASMFLAGS) $(DEP_FLAGS)
++COMPILE_AS = $(CCAS) $(PRE_CPPFLAGS) $(CPPFLAGS) $(DEFS) $(ASM_FLAGS) $(DEP_FLAGS)
  COMPILE_CXX = $(CXX) $(PRE_CPPFLAGS) $(CPPFLAGS) $(DEFS) $(CXXFLAGS) $(DEP_FLAGS)
  LINK = $(CC) $(CFLAGS) $(PRE_LDFLAGS) $(LDFLAGS)
  LINK_CXX = $(CXX) $(CXXFLAGS) $(PRE_LDFLAGS) $(LDFLAGS)
 diff --git a/configure.ac b/configure.ac
-index 1012718..8db139d 100644
+index dad15f6..7a17853 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -134,6 +134,10 @@ LSH_RPATH_INIT([`echo $with_lib_path | sed 's/:/ /g'` \
+@@ -148,6 +148,9 @@ LSH_RPATH_INIT([`echo $with_lib_path | sed 's/:/ /g'` \
  
  # Checks for programs.
  AC_PROG_CC
 +# Copied from gmp
 +test -n "$CCAS" || CCAS='$(CC)'
 +AC_SUBST(CCAS)
-+AC_SUBST(ASMFLAGS)
  
  NETTLE_CHECK_IFUNC
  
-@@ -321,7 +325,7 @@ W64_ABI=no   # For x86_64 windows
+@@ -335,7 +338,7 @@ W64_ABI=no   # For x86_64 windows
  case "$host_cpu" in
    [x86_64 | amd64])
      AC_TRY_COMPILE([
@@ -62,7 +60,7 @@ index 1012718..8db139d 100644
  #error 64-bit x86
  #endif
      ], [], [
-@@ -374,7 +378,7 @@ case "$host_cpu" in
+@@ -388,7 +391,7 @@ case "$host_cpu" in
      ;;
    aarch64*)
      AC_TRY_COMPILE([

--- a/ports/nettle/hogweed-arm.def
+++ b/ports/nettle/hogweed-arm.def
@@ -65,6 +65,7 @@ EXPORTS
      _nettle_ecc_add_eh
      _nettle_ecc_dup_eh
      _nettle_ecc_eh_to_a
+     _nettle_ecc_nonsec_add_jjj
      _nettle_ecc_add_jjj
      _nettle_ecc_add_jja
      _nettle_ecc_dup_jj
@@ -119,7 +120,6 @@ EXPORTS
      _nettle_gmp_free_limbs
      _nettle_gmp_alloc
      _nettle_gmp_free
-     _nettle_sec_tabselect
      _nettle_sec_sub_1
      _nettle_sec_add_1
      nettle_dsa_params_from_der_iterator

--- a/ports/nettle/hogweed-arm64.def
+++ b/ports/nettle/hogweed-arm64.def
@@ -65,6 +65,7 @@ EXPORTS
      _nettle_ecc_add_eh
      _nettle_ecc_dup_eh
      _nettle_ecc_eh_to_a
+     _nettle_ecc_nonsec_add_jjj
      _nettle_ecc_add_jjj
      _nettle_ecc_add_jja
      _nettle_ecc_dup_jj
@@ -119,7 +120,6 @@ EXPORTS
      _nettle_gmp_free_limbs
      _nettle_gmp_alloc
      _nettle_gmp_free
-     _nettle_sec_tabselect
      _nettle_sec_sub_1
      _nettle_sec_add_1
      nettle_dsa_params_from_der_iterator

--- a/ports/nettle/hogweed-x64.def
+++ b/ports/nettle/hogweed-x64.def
@@ -72,6 +72,7 @@ EXPORTS
      _nettle_ecc_add_eh
      _nettle_ecc_dup_eh
      _nettle_ecc_eh_to_a
+     _nettle_ecc_nonsec_add_jjj
      _nettle_ecc_add_jjj
      _nettle_ecc_add_jja
      _nettle_ecc_dup_jj
@@ -126,7 +127,6 @@ EXPORTS
      _nettle_gmp_free_limbs
      _nettle_gmp_alloc
      _nettle_gmp_free
-     _nettle_sec_tabselect
      _nettle_sec_sub_1
      _nettle_sec_add_1
      nettle_dsa_params_from_der_iterator

--- a/ports/nettle/hogweed-x86.def
+++ b/ports/nettle/hogweed-x86.def
@@ -65,6 +65,7 @@ EXPORTS
      _nettle_ecc_add_eh
      _nettle_ecc_dup_eh
      _nettle_ecc_eh_to_a
+     _nettle_ecc_nonsec_add_jjj
      _nettle_ecc_add_jjj
      _nettle_ecc_add_jja
      _nettle_ecc_dup_jj
@@ -119,7 +120,6 @@ EXPORTS
      _nettle_gmp_free_limbs
      _nettle_gmp_alloc
      _nettle_gmp_free
-     _nettle_sec_tabselect
      _nettle_sec_sub_1
      _nettle_sec_add_1
      nettle_dsa_params_from_der_iterator

--- a/ports/nettle/msvc-support.patch
+++ b/ports/nettle/msvc-support.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile.in b/Makefile.in
-index 6e1585b..88c8b05 100644
+index 3194735..669bdfe 100644
 --- a/Makefile.in
 +++ b/Makefile.in
 @@ -29,8 +29,9 @@ include config.make
@@ -13,7 +13,7 @@ index 6e1585b..88c8b05 100644
  
  getopt_SOURCES = getopt.c getopt1.c
  getopt_TARGETS = $(getopt_SOURCES:.c=.$(OBJEXT))
-@@ -279,13 +280,13 @@ nettle_OBJS = $(nettle_SOURCES:.c=.$(OBJEXT)) \
+@@ -288,13 +289,13 @@ nettle_OBJS = $(nettle_SOURCES:.c=.$(OBJEXT)) \
  hogweed_OBJS = $(hogweed_SOURCES:.c=.$(OBJEXT)) \
  	       $(OPT_HOGWEED_OBJS) @IF_MINI_GMP@ mini-gmp.$(OBJEXT)
  
@@ -29,7 +29,7 @@ index 6e1585b..88c8b05 100644
  	-rm -f $@
  	$(AR) $(ARFLAGS) $@ $(hogweed_OBJS)
  	$(RANLIB) $@
-@@ -491,8 +492,8 @@ install-static: $(LIBTARGETS)
+@@ -500,8 +501,8 @@ install-static: $(LIBTARGETS)
  	done
  
  install-dll-nettle:
@@ -40,7 +40,7 @@ index 6e1585b..88c8b05 100644
  
  install-shared-nettle: $(LIBNETTLE_FORLINK) @IF_DLL@ install-dll-nettle
  	$(MKDIR_P) $(DESTDIR)$(libdir)
-@@ -504,8 +505,8 @@ install-shared-nettle: $(LIBNETTLE_FORLINK) @IF_DLL@ install-dll-nettle
+@@ -513,8 +514,8 @@ install-shared-nettle: $(LIBNETTLE_FORLINK) @IF_DLL@ install-dll-nettle
  		&& $(LN_S) $(LIBNETTLE_FILE) $(LIBNETTLE_FORLINK))
  
  install-dll-hogweed:
@@ -52,10 +52,10 @@ index 6e1585b..88c8b05 100644
  install-shared-hogweed: $(LIBHOGWEED_FORLINK) @IF_DLL@ install-dll-hogweed
  	$(MKDIR_P) $(DESTDIR)$(libdir)
 diff --git a/configure.ac b/configure.ac
-index d50d1f5..2464514 100644
+index 7a17853..c854679 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -877,6 +877,27 @@ case "$host_os" in
+@@ -907,6 +907,27 @@ case "$host_os" in
      LIBHOGWEED_LIBS='libnettle.so $(LIBS)'
      ;;
  esac
@@ -83,3 +83,17 @@ index d50d1f5..2464514 100644
  
  ASM_SYMBOL_PREFIX=''
  ASM_ELF_STYLE='no'
+diff --git a/getopt.c b/getopt.c
+index 9d29de7..42df5a6 100644
+--- a/getopt.c
++++ b/getopt.c
+@@ -32,7 +32,9 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#ifndef _MSC_VER
+ #include <unistd.h>
++#endif
+ 
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not

--- a/ports/nettle/nettle-arm.def
+++ b/ports/nettle/nettle-arm.def
@@ -50,6 +50,10 @@ EXPORTS
      _nettle_umac_l2_final
      _nettle_umac_nh_n
      _nettle_umac_nh
+     nettle_sm4
+     nettle_sm4_set_encrypt_key
+     nettle_sm4_set_decrypt_key
+     nettle_sm4_crypt
      nettle_twofish128
      nettle_twofish192
      nettle_twofish256
@@ -107,6 +111,7 @@ EXPORTS
      nettle_sha512_init
      nettle_sha512_update
      nettle_sha512_digest
+     nettle_sha512_compress
      nettle_sha384_init
      nettle_sha384_digest
      nettle_sha512_224_init
@@ -115,10 +120,11 @@ EXPORTS
      nettle_sha512_256_digest
      nettle_sha256
      nettle_sha224
-     _nettle_sha256_compress
+     _nettle_sha256_compress_n
      nettle_sha256_init
      nettle_sha256_update
      nettle_sha256_digest
+     nettle_sha256_compress
      nettle_sha224_init
      nettle_sha224_digest
      nettle_sha1
@@ -141,6 +147,7 @@ EXPORTS
      nettle_ripemd160_digest
      nettle_realloc
      nettle_xrealloc
+     _nettle_poly1305_update
      _nettle_poly1305_set_key
      _nettle_poly1305_digest
      _nettle_poly1305_block
@@ -154,6 +161,23 @@ EXPORTS
      nettle_pbkdf2_hmac_sha1
      nettle_pbkdf2_hmac_gosthash94cp
      nettle_pbkdf2
+     nettle_ocb_aes128_set_encrypt_key
+     nettle_ocb_aes128_set_decrypt_key
+     nettle_ocb_aes128_set_nonce
+     nettle_ocb_aes128_update
+     nettle_ocb_aes128_encrypt
+     nettle_ocb_aes128_decrypt
+     nettle_ocb_aes128_digest
+     nettle_ocb_aes128_encrypt_message
+     nettle_ocb_aes128_decrypt_message
+     nettle_ocb_set_key
+     nettle_ocb_set_nonce
+     nettle_ocb_update
+     nettle_ocb_encrypt
+     nettle_ocb_decrypt
+     nettle_ocb_digest
+     nettle_ocb_encrypt_message
+     nettle_ocb_decrypt_message
      _nettle_macs
      nettle_get_macs
      _nettle_hashes
@@ -266,6 +290,13 @@ EXPORTS
      nettle_cmac128_init
      nettle_cmac128_update
      nettle_cmac128_digest
+     nettle_gcm_sm4
+     nettle_gcm_sm4_set_key
+     nettle_gcm_sm4_set_iv
+     nettle_gcm_sm4_update
+     nettle_gcm_sm4_encrypt
+     nettle_gcm_sm4_decrypt
+     nettle_gcm_sm4_digest
      nettle_gcm_camellia256
      nettle_gcm_camellia256_set_key
      nettle_gcm_camellia256_set_iv
@@ -313,6 +344,8 @@ EXPORTS
      nettle_gcm_encrypt
      nettle_gcm_decrypt
      nettle_gcm_digest
+     _nettle_siv_ghash_update
+     _nettle_siv_ghash_set_key
      _nettle_ghash_update
      _nettle_ghash_set_key
      nettle_eax_aes128
@@ -354,6 +387,12 @@ EXPORTS
      nettle_chacha_crypt
      nettle_chacha_crypt32
      nettle_cnd_memcpy
+     nettle_siv_gcm_aes256_encrypt_message
+     nettle_siv_gcm_aes256_decrypt_message
+     nettle_siv_gcm_aes128_encrypt_message
+     nettle_siv_gcm_aes128_decrypt_message
+     nettle_siv_gcm_encrypt_message
+     nettle_siv_gcm_decrypt_message
      nettle_siv_cmac_aes256_set_key
      nettle_siv_cmac_aes256_encrypt_message
      nettle_siv_cmac_aes256_decrypt_message
@@ -455,6 +494,12 @@ EXPORTS
      nettle_base16_decode_final
      nettle_base16_encode_single
      nettle_base16_encode_update
+     nettle_balloon_sha512
+     nettle_balloon_sha384
+     nettle_balloon_sha256
+     nettle_balloon_sha1
+     nettle_balloon
+     nettle_balloon_itch
      nettle_blowfish_bcrypt_hash
      nettle_blowfish_bcrypt_verify
      _nettle_blowfish_initial_ctx
@@ -476,9 +521,9 @@ EXPORTS
      nettle_arctwo128_set_key_gutmann
      nettle_arctwo_encrypt
      nettle_arctwo_decrypt
-     nettle_arcfour_crypt
      nettle_arcfour_set_key
      nettle_arcfour128_set_key
+     nettle_arcfour_crypt
      nettle_nist_keywrap16
      nettle_nist_keyunwrap16
      nettle_aes128_keywrap

--- a/ports/nettle/nettle-arm64.def
+++ b/ports/nettle/nettle-arm64.def
@@ -1,5 +1,5 @@
 EXPORTS
-     _nettle_sha256_compress_arm64
+     _nettle_sha256_compress_n_arm64
      _nettle_sha1_compress_arm64
      _nettle_ghash_update_arm64
      _nettle_ghash_set_key_arm64
@@ -22,7 +22,7 @@ EXPORTS
      _nettle_ghash_set_key
      _nettle_ghash_update
      nettle_sha1_compress
-     _nettle_sha256_compress
+     _nettle_sha256_compress_n
      nettle_xts_aes256_set_encrypt_key
      nettle_xts_aes256_set_decrypt_key
      nettle_xts_aes256_encrypt_message
@@ -74,6 +74,10 @@ EXPORTS
      _nettle_umac_l2_final
      _nettle_umac_nh_n
      _nettle_umac_nh
+     nettle_sm4
+     nettle_sm4_set_encrypt_key
+     nettle_sm4_set_decrypt_key
+     nettle_sm4_crypt
      nettle_twofish128
      nettle_twofish192
      nettle_twofish256
@@ -131,6 +135,7 @@ EXPORTS
      nettle_sha512_init
      nettle_sha512_update
      nettle_sha512_digest
+     nettle_sha512_compress
      nettle_sha384_init
      nettle_sha384_digest
      nettle_sha512_224_init
@@ -139,10 +144,11 @@ EXPORTS
      nettle_sha512_256_digest
      nettle_sha256
      nettle_sha224
-     _nettle_sha256_compress_c
+     _nettle_sha256_compress_n_c
      nettle_sha256_init
      nettle_sha256_update
      nettle_sha256_digest
+     nettle_sha256_compress
      nettle_sha224_init
      nettle_sha224_digest
      nettle_sha1
@@ -165,6 +171,7 @@ EXPORTS
      nettle_ripemd160_digest
      nettle_realloc
      nettle_xrealloc
+     _nettle_poly1305_update
      _nettle_poly1305_set_key
      _nettle_poly1305_digest
      _nettle_poly1305_block
@@ -178,6 +185,23 @@ EXPORTS
      nettle_pbkdf2_hmac_sha1
      nettle_pbkdf2_hmac_gosthash94cp
      nettle_pbkdf2
+     nettle_ocb_aes128_set_encrypt_key
+     nettle_ocb_aes128_set_decrypt_key
+     nettle_ocb_aes128_set_nonce
+     nettle_ocb_aes128_update
+     nettle_ocb_aes128_encrypt
+     nettle_ocb_aes128_decrypt
+     nettle_ocb_aes128_digest
+     nettle_ocb_aes128_encrypt_message
+     nettle_ocb_aes128_decrypt_message
+     nettle_ocb_set_key
+     nettle_ocb_set_nonce
+     nettle_ocb_update
+     nettle_ocb_encrypt
+     nettle_ocb_decrypt
+     nettle_ocb_digest
+     nettle_ocb_encrypt_message
+     nettle_ocb_decrypt_message
      _nettle_macs
      nettle_get_macs
      _nettle_hashes
@@ -290,6 +314,13 @@ EXPORTS
      nettle_cmac128_init
      nettle_cmac128_update
      nettle_cmac128_digest
+     nettle_gcm_sm4
+     nettle_gcm_sm4_set_key
+     nettle_gcm_sm4_set_iv
+     nettle_gcm_sm4_update
+     nettle_gcm_sm4_encrypt
+     nettle_gcm_sm4_decrypt
+     nettle_gcm_sm4_digest
      nettle_gcm_camellia256
      nettle_gcm_camellia256_set_key
      nettle_gcm_camellia256_set_iv
@@ -337,6 +368,8 @@ EXPORTS
      nettle_gcm_encrypt
      nettle_gcm_decrypt
      nettle_gcm_digest
+     _nettle_siv_ghash_update
+     _nettle_siv_ghash_set_key
      _nettle_ghash_update_c
      _nettle_ghash_set_key_c
      nettle_eax_aes128
@@ -378,6 +411,12 @@ EXPORTS
      nettle_chacha_crypt
      nettle_chacha_crypt32
      nettle_cnd_memcpy
+     nettle_siv_gcm_aes256_encrypt_message
+     nettle_siv_gcm_aes256_decrypt_message
+     nettle_siv_gcm_aes128_encrypt_message
+     nettle_siv_gcm_aes128_decrypt_message
+     nettle_siv_gcm_encrypt_message
+     nettle_siv_gcm_decrypt_message
      nettle_siv_cmac_aes256_set_key
      nettle_siv_cmac_aes256_encrypt_message
      nettle_siv_cmac_aes256_decrypt_message
@@ -479,6 +518,12 @@ EXPORTS
      nettle_base16_decode_final
      nettle_base16_encode_single
      nettle_base16_encode_update
+     nettle_balloon_sha512
+     nettle_balloon_sha384
+     nettle_balloon_sha256
+     nettle_balloon_sha1
+     nettle_balloon
+     nettle_balloon_itch
      nettle_blowfish_bcrypt_hash
      nettle_blowfish_bcrypt_verify
      _nettle_blowfish_initial_ctx
@@ -500,9 +545,9 @@ EXPORTS
      nettle_arctwo128_set_key_gutmann
      nettle_arctwo_encrypt
      nettle_arctwo_decrypt
-     nettle_arcfour_crypt
      nettle_arcfour_set_key
      nettle_arcfour128_set_key
+     nettle_arcfour_crypt
      nettle_nist_keywrap16
      nettle_nist_keyunwrap16
      nettle_aes128_keywrap

--- a/ports/nettle/nettle-x64.def
+++ b/ports/nettle/nettle-x64.def
@@ -1,9 +1,10 @@
 EXPORTS
-     _nettle_sha256_compress_sha_ni
+     _nettle_sha256_compress_n_sha_ni
      _nettle_sha1_compress_sha_ni
      _nettle_salsa20_2core
      _nettle_ghash_update_pclmul
      _nettle_ghash_set_key_pclmul
+     _nettle_poly1305_blocks
      _nettle_cbc_aes256_encrypt_aesni
      _nettle_cbc_aes192_encrypt_aesni
      _nettle_cbc_aes128_encrypt_aesni
@@ -28,7 +29,7 @@ EXPORTS
      nettle_cbc_aes192_encrypt
      nettle_cbc_aes256_encrypt
      nettle_sha1_compress
-     _nettle_sha256_compress
+     _nettle_sha256_compress_n
      nettle_xts_aes256_set_encrypt_key
      nettle_xts_aes256_set_decrypt_key
      nettle_xts_aes256_encrypt_message
@@ -80,6 +81,10 @@ EXPORTS
      _nettle_umac_l2_final
      _nettle_umac_nh_n
      _nettle_umac_nh
+     nettle_sm4
+     nettle_sm4_set_encrypt_key
+     nettle_sm4_set_decrypt_key
+     nettle_sm4_crypt
      nettle_twofish128
      nettle_twofish192
      nettle_twofish256
@@ -137,6 +142,7 @@ EXPORTS
      nettle_sha512_init
      nettle_sha512_update
      nettle_sha512_digest
+     nettle_sha512_compress
      nettle_sha384_init
      nettle_sha384_digest
      nettle_sha512_224_init
@@ -145,10 +151,11 @@ EXPORTS
      nettle_sha512_256_digest
      nettle_sha256
      nettle_sha224
-     _nettle_sha256_compress_x86_64
+     _nettle_sha256_compress_n_x86_64
      nettle_sha256_init
      nettle_sha256_update
      nettle_sha256_digest
+     nettle_sha256_compress
      nettle_sha224_init
      nettle_sha224_digest
      nettle_sha1
@@ -171,6 +178,7 @@ EXPORTS
      nettle_ripemd160_digest
      nettle_realloc
      nettle_xrealloc
+     _nettle_poly1305_update
      _nettle_poly1305_set_key
      _nettle_poly1305_block
      _nettle_poly1305_digest
@@ -184,6 +192,23 @@ EXPORTS
      nettle_pbkdf2_hmac_sha1
      nettle_pbkdf2_hmac_gosthash94cp
      nettle_pbkdf2
+     nettle_ocb_aes128_set_encrypt_key
+     nettle_ocb_aes128_set_decrypt_key
+     nettle_ocb_aes128_set_nonce
+     nettle_ocb_aes128_update
+     nettle_ocb_aes128_encrypt
+     nettle_ocb_aes128_decrypt
+     nettle_ocb_aes128_digest
+     nettle_ocb_aes128_encrypt_message
+     nettle_ocb_aes128_decrypt_message
+     nettle_ocb_set_key
+     nettle_ocb_set_nonce
+     nettle_ocb_update
+     nettle_ocb_encrypt
+     nettle_ocb_decrypt
+     nettle_ocb_digest
+     nettle_ocb_encrypt_message
+     nettle_ocb_decrypt_message
      _nettle_macs
      nettle_get_macs
      _nettle_hashes
@@ -296,6 +321,13 @@ EXPORTS
      nettle_cmac128_init
      nettle_cmac128_update
      nettle_cmac128_digest
+     nettle_gcm_sm4
+     nettle_gcm_sm4_set_key
+     nettle_gcm_sm4_set_iv
+     nettle_gcm_sm4_update
+     nettle_gcm_sm4_encrypt
+     nettle_gcm_sm4_decrypt
+     nettle_gcm_sm4_digest
      nettle_gcm_camellia256
      nettle_gcm_camellia256_set_key
      nettle_gcm_camellia256_set_iv
@@ -343,6 +375,8 @@ EXPORTS
      nettle_gcm_encrypt
      nettle_gcm_decrypt
      nettle_gcm_digest
+     _nettle_siv_ghash_update
+     _nettle_siv_ghash_set_key
      _nettle_ghash_update_table
      _nettle_ghash_set_key_c
      nettle_eax_aes128
@@ -384,6 +418,12 @@ EXPORTS
      nettle_chacha_crypt
      nettle_chacha_crypt32
      nettle_cnd_memcpy
+     nettle_siv_gcm_aes256_encrypt_message
+     nettle_siv_gcm_aes256_decrypt_message
+     nettle_siv_gcm_aes128_encrypt_message
+     nettle_siv_gcm_aes128_decrypt_message
+     nettle_siv_gcm_encrypt_message
+     nettle_siv_gcm_decrypt_message
      nettle_siv_cmac_aes256_set_key
      nettle_siv_cmac_aes256_encrypt_message
      nettle_siv_cmac_aes256_decrypt_message
@@ -485,6 +525,12 @@ EXPORTS
      nettle_base16_decode_final
      nettle_base16_encode_single
      nettle_base16_encode_update
+     nettle_balloon_sha512
+     nettle_balloon_sha384
+     nettle_balloon_sha256
+     nettle_balloon_sha1
+     nettle_balloon
+     nettle_balloon_itch
      nettle_blowfish_bcrypt_hash
      nettle_blowfish_bcrypt_verify
      _nettle_blowfish_initial_ctx
@@ -506,9 +552,9 @@ EXPORTS
      nettle_arctwo128_set_key_gutmann
      nettle_arctwo_encrypt
      nettle_arctwo_decrypt
-     nettle_arcfour_crypt
      nettle_arcfour_set_key
      nettle_arcfour128_set_key
+     nettle_arcfour_crypt
      nettle_nist_keywrap16
      nettle_nist_keyunwrap16
      nettle_aes128_keywrap

--- a/ports/nettle/nettle-x86.def
+++ b/ports/nettle/nettle-x86.def
@@ -50,6 +50,10 @@ EXPORTS
      _nettle_umac_l2_final
      _nettle_umac_nh_n
      _nettle_umac_nh
+     nettle_sm4
+     nettle_sm4_set_encrypt_key
+     nettle_sm4_set_decrypt_key
+     nettle_sm4_crypt
      nettle_twofish128
      nettle_twofish192
      nettle_twofish256
@@ -107,6 +111,7 @@ EXPORTS
      nettle_sha512_init
      nettle_sha512_update
      nettle_sha512_digest
+     nettle_sha512_compress
      nettle_sha384_init
      nettle_sha384_digest
      nettle_sha512_224_init
@@ -115,10 +120,11 @@ EXPORTS
      nettle_sha512_256_digest
      nettle_sha256
      nettle_sha224
-     _nettle_sha256_compress
+     _nettle_sha256_compress_n
      nettle_sha256_init
      nettle_sha256_update
      nettle_sha256_digest
+     nettle_sha256_compress
      nettle_sha224_init
      nettle_sha224_digest
      nettle_sha1
@@ -141,6 +147,7 @@ EXPORTS
      nettle_ripemd160_digest
      nettle_realloc
      nettle_xrealloc
+     _nettle_poly1305_update
      _nettle_poly1305_set_key
      _nettle_poly1305_digest
      _nettle_poly1305_block
@@ -154,6 +161,23 @@ EXPORTS
      nettle_pbkdf2_hmac_sha1
      nettle_pbkdf2_hmac_gosthash94cp
      nettle_pbkdf2
+     nettle_ocb_aes128_set_encrypt_key
+     nettle_ocb_aes128_set_decrypt_key
+     nettle_ocb_aes128_set_nonce
+     nettle_ocb_aes128_update
+     nettle_ocb_aes128_encrypt
+     nettle_ocb_aes128_decrypt
+     nettle_ocb_aes128_digest
+     nettle_ocb_aes128_encrypt_message
+     nettle_ocb_aes128_decrypt_message
+     nettle_ocb_set_key
+     nettle_ocb_set_nonce
+     nettle_ocb_update
+     nettle_ocb_encrypt
+     nettle_ocb_decrypt
+     nettle_ocb_digest
+     nettle_ocb_encrypt_message
+     nettle_ocb_decrypt_message
      _nettle_macs
      nettle_get_macs
      _nettle_hashes
@@ -266,6 +290,13 @@ EXPORTS
      nettle_cmac128_init
      nettle_cmac128_update
      nettle_cmac128_digest
+     nettle_gcm_sm4
+     nettle_gcm_sm4_set_key
+     nettle_gcm_sm4_set_iv
+     nettle_gcm_sm4_update
+     nettle_gcm_sm4_encrypt
+     nettle_gcm_sm4_decrypt
+     nettle_gcm_sm4_digest
      nettle_gcm_camellia256
      nettle_gcm_camellia256_set_key
      nettle_gcm_camellia256_set_iv
@@ -313,6 +344,8 @@ EXPORTS
      nettle_gcm_encrypt
      nettle_gcm_decrypt
      nettle_gcm_digest
+     _nettle_siv_ghash_update
+     _nettle_siv_ghash_set_key
      _nettle_ghash_update
      _nettle_ghash_set_key
      nettle_eax_aes128
@@ -354,6 +387,12 @@ EXPORTS
      nettle_chacha_crypt
      nettle_chacha_crypt32
      nettle_cnd_memcpy
+     nettle_siv_gcm_aes256_encrypt_message
+     nettle_siv_gcm_aes256_decrypt_message
+     nettle_siv_gcm_aes128_encrypt_message
+     nettle_siv_gcm_aes128_decrypt_message
+     nettle_siv_gcm_encrypt_message
+     nettle_siv_gcm_decrypt_message
      nettle_siv_cmac_aes256_set_key
      nettle_siv_cmac_aes256_encrypt_message
      nettle_siv_cmac_aes256_decrypt_message
@@ -455,6 +494,12 @@ EXPORTS
      nettle_base16_decode_final
      nettle_base16_encode_single
      nettle_base16_encode_update
+     nettle_balloon_sha512
+     nettle_balloon_sha384
+     nettle_balloon_sha256
+     nettle_balloon_sha1
+     nettle_balloon
+     nettle_balloon_itch
      nettle_blowfish_bcrypt_hash
      nettle_blowfish_bcrypt_verify
      _nettle_blowfish_initial_ctx
@@ -476,9 +521,9 @@ EXPORTS
      nettle_arctwo128_set_key_gutmann
      nettle_arctwo_encrypt
      nettle_arctwo_decrypt
-     nettle_arcfour_crypt
      nettle_arcfour_set_key
      nettle_arcfour128_set_key
+     nettle_arcfour_crypt
      nettle_nist_keywrap16
      nettle_nist_keyunwrap16
      nettle_aes128_keywrap

--- a/ports/nettle/portfile.cmake
+++ b/ports/nettle/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://git.lysator.liu.se/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nettle/nettle
-    REF nettle_3.8.1_release_20220727
-    SHA512 ed1fa1b77afd61fafa15b63f4324809fa69569691d16b93f403c83794672859a1760d102902349f93b1632de568c36e06a0e2b5b61877082b1982dfcf2c52172
+    REF nettle_3.9.1_release_20230601
+    SHA512 4938d31d9183fd143c6d43a43bda8372bd8899c51c18dfb8640065bffd4c5928006481d16679b1ad057404697f7af06bf1630de4b8072592c38cbb7113d16b21
     HEAD_REF master
     PATCHES 
         subdirs.patch
@@ -62,7 +62,7 @@ elseif(ccas)
     cmake_path(GET ccas PARENT_PATH ccas_dir)
     vcpkg_add_to_path("${ccas_dir}")
     cmake_path(GET ccas FILENAME ccas_command)
-    vcpkg_list(APPEND OPTIONS "CCAS=${ccas_command}" "ASMFLAGS=${asmflags}")
+    vcpkg_list(APPEND OPTIONS "CCAS=${ccas_command}" "ASM_FLAGS=${asmflags}")
 endif()
 
 if(VCPKG_CROSSCOMPILING)

--- a/ports/nettle/vcpkg.json
+++ b/ports/nettle/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nettle",
-  "version": "3.8.1",
-  "port-version": 1,
+  "version": "3.9.1",
   "description": "Nettle is a low-level cryptographic library that is designed to fit easily in more or less any context: In crypto toolkits for object-oriented languages (C++, Python, Pike, ...), in applications like LSH or GNUPG, or even in kernel space.",
   "homepage": "https://git.lysator.liu.se/nettle/nettle",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6101,8 +6101,8 @@
       "port-version": 0
     },
     "nettle": {
-      "baseline": "3.8.1",
-      "port-version": 1
+      "baseline": "3.9.1",
+      "port-version": 0
     },
     "networkdirect-sdk": {
       "baseline": "2.0.1",

--- a/versions/n-/nettle.json
+++ b/versions/n-/nettle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b3f0bbb2ea2c2fb1bbb016d80d7c5e867b0f1a7",
+      "version": "3.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7734b67cb656bf12488ea137779b56d8865bbb02",
       "version": "3.8.1",
       "port-version": 1


### PR DESCRIPTION
Port:  
Switching from our `ASMFLAGS` to upstream's new `ASM_FLAGS`.
arm DEF file changes untested, updated based on x86 CI.
