### PR TITLE
[spirv-reflect] Fix missing usage and include file

### DIFF
--- a/ports/spirv-reflect/export-targets.patch
+++ b/ports/spirv-reflect/export-targets.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 040c818..0e1476c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -111,8 +111,20 @@ if(SPIRV_REFLECT_STATIC_LIB)
+     add_library(spirv-reflect-static STATIC ${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.h
+                                      ${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.c)
+ 
+-    target_include_directories(spirv-reflect-static
+-                               PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+-    install(TARGETS spirv-reflect-static LIBRARY DESTINATION lib)
++    target_include_directories(spirv-reflect-static INTERFACE $<INSTALL_INTERFACE:include/spirv-reflect>)
++                               
++    set_target_properties(spirv-reflect-static PROPERTIES EXPORT_NAME spirv-reflect)
++    
++    install(TARGETS spirv-reflect-static
++            EXPORT unofficial-spirv-reflect-config
++            LIBRARY DESTINATION lib)
++            
++    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv/unified1/spirv.h DESTINATION include/spirv-reflect)
++    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.h DESTINATION include/spirv-reflect)
++    
++    install(EXPORT unofficial-spirv-reflect-config
++            FILE unofficial-spirv-reflect-config.cmake
++            NAMESPACE unofficial::
++            DESTINATION share/unofficial-spirv-reflect)
+ endif()
+ 

--- a/ports/spirv-reflect/portfile.cmake
+++ b/ports/spirv-reflect/portfile.cmake
@@ -5,21 +5,28 @@ vcpkg_from_github(
     REPO KhronosGroup/SPIRV-Reflect
     REF "vulkan-sdk-${VERSION}"
     SHA512 b09a9c6ea4fb28bf860026e0dd7a95db30c191da29a3fb936d80f9b95d1e1ac665e3a9a8941687eb4a8d1a85447209c718d310241d41c0779aef8d33851bc7ba
-    HEAD_REF master
+    HEAD_REF main
+    PATCHES
+        export-targets.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS -DSPIRV_REFLECT_STATIC_LIB=ON
+    OPTIONS
+        -DSPIRV_REFLECT_STATIC_LIB=ON
+        -DSPIRV_REFLECT_EXAMPLES=OFF
+        -DSPIRV_REFLECT_BUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-spirv-reflect)
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/spirv-reflect/spirv_reflect.h" "./include/spirv/unified1/spirv.h" "spirv.h")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-
-set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
 vcpkg_copy_tools(TOOL_NAMES spirv-reflect-pp spirv-reflect AUTO_CLEAN)

--- a/ports/spirv-reflect/vcpkg.json
+++ b/ports/spirv-reflect/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "spirv-reflect",
   "version": "1.3.280.0",
+  "port-version": 1,
   "description": "SPIRV-Reflect is a lightweight library that provides a C/C++ reflection API for SPIR-V shader bytecode in Vulkan applications.",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Reflect",
   "license": "Apache-2.0",
   "dependencies": [
-    "spirv-headers",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8318,7 +8318,7 @@
     },
     "spirv-reflect": {
       "baseline": "1.3.280.0",
-      "port-version": 0
+      "port-version": 1
     },
     "spirv-tools": {
       "baseline": "1.3.280.0",

--- a/versions/s-/spirv-reflect.json
+++ b/versions/s-/spirv-reflect.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5cfadd5ead0c5a5e825e2e21b314bc902a43261",
+      "version": "1.3.280.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "dbbfffe0c147230e88f43f57d77b34c59f29b3f6",
       "version": "1.3.280.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes https://github.com/microsoft/vcpkg/issues/29496

- Remove unnecessary dependencies: `spirv-headers`.
- Add export for target `spirv-reflect-static`.
- Install headers of the port and fix usage defects.

Usage test passed with `x64-windows` triplet.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
