### PR TITLE
[llvm] Fix error caused by the upcoming By-Design of MSVC

### DIFF
--- a/ports/llvm/0009-add-missing-typename.patch
+++ b/ports/llvm/0009-add-missing-typename.patch
@@ -1,0 +1,13 @@
+diff --git a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+index 4b281d5f1..0a008ab9b 100644
+--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
++++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+@@ -951,7 +951,7 @@ std::vector<
+ DwarfLinkerForBinary::AddressManager<AddressesMapBase>::getRelocations(
+     const std::vector<ValidReloc> &Relocs, uint64_t StartPos, uint64_t EndPos) {
+   std::vector<
+-      DwarfLinkerForBinary::AddressManager<AddressesMapBase>::ValidReloc>
++      typename DwarfLinkerForBinary::AddressManager<AddressesMapBase>::ValidReloc>
+       Res;
+ 
+   auto CurReloc = partition_point(Relocs, [StartPos](const ValidReloc &Reloc) {

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_from_github(
         0006-create-destination-mlir-directory.patch
         0007-fix-compiler-rt-warnings.patch # fixed in upstream
         0008-add-missing-case.patch # From upstream https://github.com/llvm/llvm-project/pull/72401
-        0009-add-missing-typename.patch
+        0009-add-missing-typename.patch # Fixed in version 18.1.0 and later
 )
 
 vcpkg_check_features(

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         0006-create-destination-mlir-directory.patch
         0007-fix-compiler-rt-warnings.patch # fixed in upstream
         0008-add-missing-case.patch # From upstream https://github.com/llvm/llvm-project/pull/72401
+        0009-add-missing-typename.patch
 )
 
 vcpkg_check_features(

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "17.0.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5370,7 +5370,7 @@
     },
     "llvm": {
       "baseline": "17.0.2",
-      "port-version": 4
+      "port-version": 5
     },
     "lmdb": {
       "baseline": "0.9.31",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39eabdef9a0d846e0717e5ad1e1ba3bdb304fc6f",
+      "version": "17.0.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "9b38326a02fb44545071f8a4ee72ca3e2bc9bd8e",
       "version": "17.0.2",
       "port-version": 4

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39eabdef9a0d846e0717e5ad1e1ba3bdb304fc6f",
+      "git-tree": "3782c35ec8e69e728302f4adeb98dd21d7452fce",
       "version": "17.0.2",
       "port-version": 5
     },


### PR DESCRIPTION
In an internal version of Visual Studio, llvm install failed with following error, the reason is missing `typename` keyword.
```
[4444/5079] C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1438~1.331\bin\Hostx64\x64\cl.exe   /TP -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -ID:\b\llvm\x64-windows-dbg\tools\dsymutil -ID:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil -ID:\b\llvm\x64-windows-dbg\include -ID:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\include -external:ID:\installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /utf-8   /MP  /Zc:inline /Zc:preprocessor /Zc:__cplusplus /Oi /bigobj /permissive- /W4 -wd4141 -wd4146 -wd4244 -wd4267 -wd4291 -wd4351 -wd4456 -wd4457 -wd4458 -wd4459 -wd4503 -wd4624 -wd4722 -wd4100 -wd4127 -wd4512 -wd4505 -wd4610 -wd4510 -wd4702 -wd4245 -wd4706 -wd4310 -wd4701 -wd4703 -wd4389 -wd4611 -wd4805 -wd4204 -wd4577 -wd4091 -wd4592 -wd4319 -wd4709 -wd5105 -wd4324 -w14062 -we4238 /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1  -std:c++17 -MDd  /EHsc /GR /showIncludes /Fotools\dsymutil\CMakeFiles\dsymutil.dir\DwarfLinkerForBinary.cpp.obj /Fdtools\dsymutil\CMakeFiles\dsymutil.dir\ /FS -c D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp
FAILED: tools/dsymutil/CMakeFiles/dsymutil.dir/DwarfLinkerForBinary.cpp.obj 
C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1438~1.331\bin\Hostx64\x64\cl.exe   /TP -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -ID:\b\llvm\x64-windows-dbg\tools\dsymutil -ID:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil -ID:\b\llvm\x64-windows-dbg\include -ID:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\include -external:ID:\installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /utf-8   /MP  /Zc:inline /Zc:preprocessor /Zc:__cplusplus /Oi /bigobj /permissive- /W4 -wd4141 -wd4146 -wd4244 -wd4267 -wd4291 -wd4351 -wd4456 -wd4457 -wd4458 -wd4459 -wd4503 -wd4624 -wd4722 -wd4100 -wd4127 -wd4512 -wd4505 -wd4610 -wd4510 -wd4702 -wd4245 -wd4706 -wd4310 -wd4701 -wd4703 -wd4389 -wd4611 -wd4805 -wd4204 -wd4577 -wd4091 -wd4592 -wd4319 -wd4709 -wd5105 -wd4324 -w14062 -we4238 /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1  -std:c++17 -MDd  /EHsc /GR /showIncludes /Fotools\dsymutil\CMakeFiles\dsymutil.dir\DwarfLinkerForBinary.cpp.obj /Fdtools\dsymutil\CMakeFiles\dsymutil.dir\ /FS -c D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(954): error C2275: 'llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::ValidReloc': expected an expression instead of a type
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(954): note: the template instantiation context (the oldest one first) is
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(557): note: see reference to function template instantiation 'bool llvm::dsymutil::DwarfLinkerForBinary::linkImpl<llvm::dwarflinker_parallel::DWARFLinker,llvm::dwarflinker_parallel::DWARFFile,llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>>(const llvm::dsymutil::DebugMap &,llvm::dwarflinker_parallel::DWARFLinker::OutputFileType)' being compiled
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(651): note: see reference to function template instantiation 'llvm::ErrorOr<std::unique_ptr<llvm::dwarflinker_parallel::DWARFFile,std::default_delete<llvm::dwarflinker_parallel::DWARFFile>>> llvm::dsymutil::DwarfLinkerForBinary::loadObject<llvm::dwarflinker_parallel::DWARFFile,llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>>(const llvm::dsymutil::DebugMapObject &,const llvm::dsymutil::DebugMap &,llvm::remarks::RemarkLinker &)' being compiled
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(237): note: see reference to class template instantiation 'std::unique_ptr<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>,std::default_delete<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>>>' being compiled
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\memory(3335): note: see reference to class template instantiation 'std::default_delete<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>>' being compiled
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\memory(3298): note: while compiling class template member function 'void std::default_delete<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>>::operator ()(_Ty *) noexcept const'
        with
        [
            _Ty=llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>
        ]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\memory(3410): note: see the first reference to 'std::default_delete<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>>::operator ()' in 'std::unique_ptr<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>,std::default_delete<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>>>::~unique_ptr'
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(235): note: see the first reference to 'std::unique_ptr<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>,std::default_delete<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>>>::~unique_ptr' in 'llvm::dsymutil::DwarfLinkerForBinary::loadObject'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\memory(3299): note: see reference to class template instantiation 'llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>' being compiled
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(1034): note: while compiling class template member function 'std::optional<int64_t> llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::getExprOpAddressRelocAdjustment(llvm::DWARFUnit &,const llvm::DWARFExpression::Operation &,uint64_t,uint64_t)'
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(952): note: while compiling class template member function 'std::vector<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::ValidReloc,std::allocator<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::ValidReloc>> llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::getRelocations(const std::vector<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::ValidReloc,std::allocator<llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::ValidReloc>> &,uint64_t,uint64_t)'
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(1114): note: see the first reference to 'llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::getRelocations' in 'llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::applyValidRelocs'
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(953): error C2923: 'std::vector': 'llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::ValidReloc' is not a valid template type argument for parameter '_Ty'
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(954): note: see declaration of 'llvm::dsymutil::DwarfLinkerForBinary::AddressManager<llvm::dwarflinker_parallel::AddressesMap>::ValidReloc'
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(953): error C2976: 'std::vector': too few template arguments
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vector(429): note: see declaration of 'std::vector'
D:\b\llvm\src\org-17.0.2-5fdca9a361.clean\llvm\tools\dsymutil\DwarfLinkerForBinary.cpp(955): error C2641: cannot deduce template arguments for 'std::vector'
```

Reported upstream: https://github.com/llvm/llvm-project/issues/89056.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
