### PR TITLE
[freeimage] patch typedef for MacOS

### DIFF
--- a/ports/freeimage/portfile.cmake
+++ b/ports/freeimage/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_sourceforge(
         use-functions-to-override-libtiff-warning-error-handlers.patch
         remove_auto_ptr.patch
         rawlib-build-fix.patch
+        typedef-xcode.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"

--- a/ports/freeimage/typedef-xcode.patch
+++ b/ports/freeimage/typedef-xcode.patch
@@ -1,0 +1,14 @@
+diff --git a/Source/FreeImage.h b/Source/FreeImage.h
+index ad2574d..9588944 100644
+--- a/Source/FreeImage.h
++++ b/Source/FreeImage.h
+@@ -155,7 +155,9 @@ FI_STRUCT (FIMULTIBITMAP) { void *data; };
+ #ifndef _MSC_VER
+ // define portable types for 32-bit / 64-bit OS
+ #include <inttypes.h>
++#ifndef OBJC_BOOL_DEFINED
+ typedef int32_t BOOL;
++#endif
+ typedef uint8_t BYTE;
+ typedef uint16_t WORD;
+ typedef uint32_t DWORD;

--- a/ports/freeimage/vcpkg.json
+++ b/ports/freeimage/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "freeimage",
   "version": "3.18.0",
-  "port-version": 26,
+  "port-version": 27,
   "description": "Support library for graphics image formats",
   "homepage": "https://sourceforge.net/projects/freeimage/",
   "license": "GPL-2.0-only OR GPL-3.0-only OR FreeImage",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2830,7 +2830,7 @@
     },
     "freeimage": {
       "baseline": "3.18.0",
-      "port-version": 26
+      "port-version": 27
     },
     "freeopcua": {
       "baseline": "20190125",

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1255d729b57a487ed7e6be58bb9feb8b8b3fd44",
+      "version": "3.18.0",
+      "port-version": 27
+    },
+    {
       "git-tree": "e7b2a65974c7375dc69526c2c5390f1c7932aa1b",
       "version": "3.18.0",
       "port-version": 26


### PR DESCRIPTION
The idea of the PR is to check if `OBJC_BOOL_DEFINED` is defined to avoid a second redefinition with a different type.

Fixes #38260

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
