### PR TITLE
[rocksdb] update to 9.1.0

### DIFF
--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb
   REF "v${VERSION}"
-  SHA512 b1a37784db800e571b1ed6529bebdb452d6c8e495bd51401f021d1a2e07bae3b3be9ed0e69a8798b6ebce16e4af3e7cf83c73842d2eb4c9fd2d11d9528026ffd
+  SHA512 f7c0aade6b9162c358de2c86ff31498ce771635b364262a80027ac4af9288acd53e9a753dbd40b12c3ad9e441ed824a36408262e0d62ab3191ba9c4b137efeb9
   HEAD_REF main
   PATCHES
     0001-fix-dependencies.patch

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rocksdb",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7729,7 +7729,7 @@
       "port-version": 0
     },
     "rocksdb": {
-      "baseline": "9.0.0",
+      "baseline": "9.1.0",
       "port-version": 0
     },
     "rpclib": {

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1460212626dfc8413dd4452c20f1c068acaacb29",
+      "version": "9.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4cb8ef91306fda868ede38beecc64af96d804923",
       "version": "9.0.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

