### PR TITLE
[raudio2] add new port

### DIFF
--- a/ports/raudio2/portfile.cmake
+++ b/ports/raudio2/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO oddlf/raudio2
+    REF "v${VERSION}"
+    SHA512 fe4cc6facbbc42f58a22ea4a52ec3041a3a5ab637766a7f37d72f96c12b9a01d6667887ddc65a64018ff25ce56918166e337f94dfbb6e9f6e568ee7bf3eb60a8
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        gzip       RAUDIO2_ARCHIVE_GZIP
+        libarchive RAUDIO2_ARCHIVE_LIBARCHIVE
+        drflac     RAUDIO2_INPUT_DRFLAC
+        drmp3      RAUDIO2_INPUT_DRMP3
+        flac       RAUDIO2_INPUT_FLAC
+        gme        RAUDIO2_INPUT_GME
+        modplug    RAUDIO2_INPUT_MODPLUG
+        mpg123     RAUDIO2_INPUT_MPG123
+        openmpt    RAUDIO2_INPUT_OPENMPT
+        opus       RAUDIO2_INPUT_OPUS
+        sndfile    RAUDIO2_INPUT_SNDFILE
+        stbvorbis  RAUDIO2_INPUT_STBVORBIS
+        vorbis     RAUDIO2_INPUT_VORBIS
+        wav        RAUDIO2_INPUT_WAV
+)
+
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" RAUDIO2_STATIC_CRT)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DRAUDIO2_STANDALONE_PLUGIN=OFF
+        -DRAUDIO2_STATIC_CRT=${RAUDIO2_STATIC_CRT}
+        -DRAUDIO2_PACK_WITH_UPX=OFF
+        -DRAUDIO2_BUILD_EXAMPLES=OFF
+        -DRAUDIO2_INSTALL=ON
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/raudio2)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/raudio2/usage
+++ b/ports/raudio2/usage
@@ -1,0 +1,4 @@
+raudio2 provides CMake targets:
+
+  find_package(raudio2 CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE raudio2::raudio2)

--- a/ports/raudio2/vcpkg.json
+++ b/ports/raudio2/vcpkg.json
@@ -1,0 +1,114 @@
+{
+  "name": "raudio2",
+  "version": "1.0.2",
+  "description": "A simple and easy-to-use audio library based on raudio + miniaudio",
+  "homepage": "https://github.com/oddlf/raudio2",
+  "license": "Zlib",
+  "supports": "!(android | osx | uwp)",
+  "dependencies": [
+    "miniaudio",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "drflac",
+    "gme",
+    "modplug",
+    "mpg123",
+    "opus",
+    "vorbis",
+    "wav"
+  ],
+  "features": {
+    "drflac": {
+      "description": "FLAC (dr_flac) input plugin",
+      "dependencies": [
+        "drlibs"
+      ]
+    },
+    "drmp3": {
+      "description": "MP3 (dr_mp3) input plugin",
+      "dependencies": [
+        "drlibs"
+      ]
+    },
+    "flac": {
+      "description": "FLAC (libflac) input plugin",
+      "dependencies": [
+        "libflac"
+      ]
+    },
+    "gme": {
+      "description": "GME input plugin",
+      "dependencies": [
+        "libgme"
+      ]
+    },
+    "gzip": {
+      "description": "GZIP archive plugin",
+      "dependencies": [
+        "zlib"
+      ]
+    },
+    "libarchive": {
+      "description": "LibArchive archive plugin",
+      "dependencies": [
+        "libarchive"
+      ]
+    },
+    "modplug": {
+      "description": "Tracker music (ModPlug) input plugin",
+      "dependencies": [
+        "libmodplug"
+      ]
+    },
+    "mpg123": {
+      "description": "MP3 (mpg123) input plugin",
+      "dependencies": [
+        "mpg123"
+      ]
+    },
+    "openmpt": {
+      "description": "Tracker music (OpenMPT) input plugin",
+      "dependencies": [
+        "libopenmpt"
+      ]
+    },
+    "opus": {
+      "description": "OPUS input plugin",
+      "dependencies": [
+        "opusfile"
+      ]
+    },
+    "sndfile": {
+      "description": "SndFile input plugin",
+      "dependencies": [
+        "sndfile"
+      ]
+    },
+    "stbvorbis": {
+      "description": "Vorbis (stb_vorbis) input plugin",
+      "dependencies": [
+        "stb"
+      ]
+    },
+    "vorbis": {
+      "description": "Vorbis (vorbisfile) input plugin",
+      "dependencies": [
+        "libvorbis"
+      ]
+    },
+    "wav": {
+      "description": "WAV (dr_wav) input plugin",
+      "dependencies": [
+        "drlibs"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7608,6 +7608,10 @@
       "baseline": "1.9",
       "port-version": 4
     },
+    "raudio2": {
+      "baseline": "1.0.2",
+      "port-version": 0
+    },
     "raygui": {
       "baseline": "4.0",
       "port-version": 0

--- a/versions/r-/raudio2.json
+++ b/versions/r-/raudio2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "518725bbaf52d68a1c234d1a4c0618a37f147eae",
+      "version": "1.0.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.