### PR TITLE
[onnxruntime-cuda12] new port

### DIFF
--- a/ports/onnxruntime-cuda12/onnxruntime-cuda12-base-config.cmake
+++ b/ports/onnxruntime-cuda12/onnxruntime-cuda12-base-config.cmake
@@ -1,0 +1,28 @@
+# Compute the installation prefix relative to this file.
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
+add_library(onnxruntime-cuda12::onnxruntime SHARED IMPORTED)
+set_target_properties(onnxruntime-cuda12::onnxruntime PROPERTIES 
+    IMPORTED_CONFIGURATIONS RELEASE
+    IMPORTED_CONFIGURATIONS DEBUG
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/onnxruntime"
+    IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
+    IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
+)
+
+function(import_providers provider_name)
+    message("import provider ${provider_name}")
+    add_library(onnxruntime-cuda12::onnxruntime_providers_${provider_name} MODULE IMPORTED)
+    set_target_properties(onnxruntime-cuda12::onnxruntime_providers_${provider_name} PROPERTIES 
+      IMPORTED_CONFIGURATIONS RELEASE
+      IMPORTED_CONFIGURATIONS DEBUG
+      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/onnxruntime"
+      IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
+      IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
+    )
+endfunction(import_providers)

--- a/ports/onnxruntime-cuda12/onnxruntime-cuda12-linux-config.cmake.in
+++ b/ports/onnxruntime-cuda12/onnxruntime-cuda12-linux-config.cmake.in
@@ -1,0 +1,28 @@
+include("${CMAKE_CURRENT_LIST_DIR}/onnxruntime-cuda12-base-config.cmake")
+
+set_target_properties(onnxruntime-cuda12::onnxruntime PROPERTIES 
+  IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib/libonnxruntime.so.@VERSION@"
+  IMPORTED_LOCATION_DEBUG "${_IMPORT_PREFIX}/debug/lib/libonnxruntime.so.@VERSION@"
+)
+
+foreach(provider shared cuda tensorrt)
+  import_providers(${provider})
+  set_target_properties(onnxruntime-cuda12::onnxruntime_providers_${provider} PROPERTIES 
+    IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib/libonnxruntime_providers_${provider}.so"
+    IMPORTED_LOCATION_DEBUG "${_IMPORT_PREFIX}/debug/lib/libonnxruntime_providers_${provider}.so"
+  )
+endforeach()
+
+list(APPEND _cmake_import_check_targets onnxruntime-cuda12::onnxruntime)
+list(APPEND _cmake_import_check_files_for_onnxruntime-cuda12::onnxruntime 
+  "${_IMPORT_PREFIX}/lib/libonnxruntime.so.@VERSION@"
+  "${_IMPORT_PREFIX}/debug/lib/libonnxruntime.so.@VERSION@"
+)
+
+foreach(provider shared cuda tensorrt)
+  list(APPEND _cmake_import_check_targets onnxruntime-cuda12::onnxruntime_providers_${provider})
+  list(APPEND _cmake_import_check_files_for_onnxruntime-cuda12::onnxruntime_providers_${provider} 
+    "${_IMPORT_PREFIX}/lib/libonnxruntime_providers_${provider}.so"
+    "${_IMPORT_PREFIX}/debug/lib/libonnxruntime_providers_${provider}.so"
+  )
+endforeach()

--- a/ports/onnxruntime-cuda12/onnxruntime-cuda12-win-config.cmake
+++ b/ports/onnxruntime-cuda12/onnxruntime-cuda12-win-config.cmake
@@ -1,0 +1,36 @@
+include("${CMAKE_CURRENT_LIST_DIR}/onnxruntime-cuda12-base-config.cmake")
+
+set_target_properties(onnxruntime-cuda12::onnxruntime PROPERTIES 
+  IMPORTED_IMPLIB_RELEASE "${_IMPORT_PREFIX}/lib/onnxruntime.lib"
+  IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/bin/onnxruntime.dll"
+  IMPORTED_IMPLIB_DEBUG "${_IMPORT_PREFIX}/debug/lib/onnxruntime.lib"
+  IMPORTED_LOCATION_DEBUG "${_IMPORT_PREFIX}/debug/bin/onnxruntime.dll"
+)
+
+foreach(provider IN LISTS shared cuda tensorrt)
+  import_providers(${provider})
+  set_target_properties(onnxruntime-cuda12::onnxruntime_providers_${provider} PROPERTIES 
+    IMPORTED_IMPLIB_RELEASE "${_IMPORT_PREFIX}/lib/onnxruntime_providers_${provider}.lib"
+    IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/bin/onnxruntime_providers_${provider}.dll"
+    IMPORTED_IMPLIB_DEBUG "${_IMPORT_PREFIX}/debug/lib/onnxruntime_providers_${provider}.lib"
+    IMPORTED_LOCATION_DEBUG "${_IMPORT_PREFIX}/debug/bin/onnxruntime_providers_${provider}.dll"
+  )
+endforeach()
+
+list(APPEND _cmake_import_check_targets onnxruntime-cuda12::onnxruntime)
+list(APPEND _cmake_import_check_files_for_onnxruntime-cuda12::onnxruntime 
+  "${_IMPORT_PREFIX}/lib/onnxruntime.lib"
+  "${_IMPORT_PREFIX}/bin/onnxruntime.dll"
+  "${_IMPORT_PREFIX}/debug/lib/onnxruntime.lib"
+  "${_IMPORT_PREFIX}/debug/bin/onnxruntime.dll"
+)
+
+foreach(provider IN LISTS shared cuda tensorrt)
+  list(APPEND _cmake_import_check_targets onnxruntime-cuda12::onnxruntime_providers_${provider})
+  list(APPEND _cmake_import_check_files_for_onnxruntime-cuda12::onnxruntime_providers_${provider} 
+    "${_IMPORT_PREFIX}/lib/onnxruntime_providers_${provider}.lib"
+    "${_IMPORT_PREFIX}/bin/onnxruntime_providers_${provider}.dll"
+    "${_IMPORT_PREFIX}/debug/lib/onnxruntime_providers_${provider}.lib"
+    "${_IMPORT_PREFIX}/debug/bin/onnxruntime_providers_${provider}.dll"
+  )
+endforeach()

--- a/ports/onnxruntime-cuda12/portfile.cmake
+++ b/ports/onnxruntime-cuda12/portfile.cmake
@@ -1,0 +1,103 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(ORG_TARGET_OS win)
+    set(ORG_ARCHIVE_EXT ".zip")
+elseif(VCPKG_TARGET_IS_LINUX)
+    set(ORG_TARGET_OS linux)
+    set(ORG_ARCHIVE_EXT ".tgz")
+else()
+    message(FATAL_ERROR "onnxruntime-cuda12 only support windows and linux")
+endif()
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(ORG_TARGET_ARCH x64)
+else()
+    message(FATAL_ERROR "onnxruntime-cuda12 only support x64")
+endif()
+
+if(ORG_TARGET_OS STREQUAL "win")
+    if(ORG_TARGET_ARCH STREQUAL "x64")
+        set(ORG_ARCHIVE_SHA "81fbcb2ca5f245ee320af83ebdd3a5505a23e44d6bd32c47af00972a224ed0d410eef16f592bc9616943443361547128f8ffd8edf3a076708908004aef6225a4")
+    endif()
+elseif(ORG_TARGET_OS STREQUAL "linux")
+    if(ORG_TARGET_ARCH STREQUAL "x64")
+        set(ORG_ARCHIVE_SHA "3f610489a25abecaf9e53b903ed1e84215bbf57a2cb46b88ab5434dd8a63caf5b168b4c0646b0b81a78ea574301ebcbd9b32fd6641844ca2b374c36485f6d098")
+    endif()
+endif()
+
+set(ORG_ARCHIVE_FILE_NAME "onnxruntime-${ORG_TARGET_OS}-${ORG_TARGET_ARCH}-gpu-cuda12-${VERSION}")
+set(ORG_ARCHIVE_ROOT_DIR_NAME "onnxruntime-${ORG_TARGET_OS}-${ORG_TARGET_ARCH}-gpu-${VERSION}")
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/${ORG_ARCHIVE_FILE_NAME}${ORG_ARCHIVE_EXT}"
+    FILENAME "${ORG_ARCHIVE_FILE_NAME}${ORG_ARCHIVE_EXT}"
+    SHA512 "${ORG_ARCHIVE_SHA}"
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+file(MAKE_DIRECTORY
+    ${CURRENT_PACKAGES_DIR}/include
+    ${CURRENT_PACKAGES_DIR}/lib
+    ${CURRENT_PACKAGES_DIR}/debug/lib
+)
+
+file(COPY
+    ${SOURCE_PATH}/${ORG_ARCHIVE_ROOT_DIR_NAME}/include
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+)
+file(RENAME "${CURRENT_PACKAGES_DIR}/include/include" "${CURRENT_PACKAGES_DIR}/include/onnxruntime")
+
+vcpkg_download_distfile(
+    ORT_EXPERIMENTAL_HEADER_API
+    URLS https://raw.githubusercontent.com/microsoft/onnxruntime/v${VERSION}/include/onnxruntime/core/session/experimental_onnxruntime_cxx_api.h
+    FILENAME experimental_onnxruntime_cxx_api.h
+    SHA512 6e62d96b2da12cf92e531296d10982ff0cd62f0b4c67c53aeaee0961122d6965f43139727ed89f89a476c568a99cececb46529513e721223abb1936781d5d0be
+)
+vcpkg_download_distfile(
+    ORT_EXPERIMENTAL_HEADER_INLINE
+    URLS https://raw.githubusercontent.com/microsoft/onnxruntime/v${VERSION}/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
+    FILENAME experimental_onnxruntime_cxx_inline.h
+    SHA512 f158e6c04310d9cb66ddc32b555d61351d3aeeb43631f22124bbad1a115e9fda80832b134f59e4fa5482f5451021adcc616a28aee5fb52871757d2621c2d8d7d
+)
+file(COPY "${ORT_EXPERIMENTAL_HEADER_API}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/onnxruntime/")
+file(COPY "${ORT_EXPERIMENTAL_HEADER_INLINE}" DESTINATION "${CURRENT_PACKAGES_DIR}/include/onnxruntime/")
+
+if(ORG_TARGET_OS STREQUAL "win")
+    file(MAKE_DIRECTORY
+        ${CURRENT_PACKAGES_DIR}/bin
+        ${CURRENT_PACKAGES_DIR}/debug/bin
+    )
+endif()
+
+file(GLOB ORT_LIB_FILES "${SOURCE_PATH}/${ORG_ARCHIVE_ROOT_DIR_NAME}/lib/*.lib" "${SOURCE_PATH}/${ORG_ARCHIVE_ROOT_DIR_NAME}/lib/*.so" "${SOURCE_PATH}/${ORG_ARCHIVE_ROOT_DIR_NAME}/lib/*.so.*")
+file(GLOB ORT_BIN_FILES "${SOURCE_PATH}/${ORG_ARCHIVE_ROOT_DIR_NAME}/lib/*.pdb" "${SOURCE_PATH}/${ORG_ARCHIVE_ROOT_DIR_NAME}/lib/*.dll")
+
+foreach(FILE IN LISTS ORT_LIB_FILES)
+    file(COPY "${FILE}" DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+    file(COPY "${FILE}" DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+endforeach()
+
+foreach(FILE IN LISTS ORT_BIN_FILES)
+    file(COPY "${FILE}" DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+    file(COPY "${FILE}" DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+endforeach()
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/onnxruntime-cuda12-base-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+if(ORG_TARGET_OS STREQUAL "win")
+    file(COPY "${CMAKE_CURRENT_LIST_DIR}/onnxruntime-cuda12-win-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/${PORT}/onnxruntime-cuda12-win-config.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/onnxruntime-cuda12-config.cmake")
+else()
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/onnxruntime-cuda12-linux-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/onnxruntime-cuda12-config.cmake" IMMEDIATE @ONLY)
+endif()
+
+
+vcpkg_fixup_pkgconfig()
+
+# # Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/${ORG_ARCHIVE_ROOT_DIR_NAME}/LICENSE")

--- a/ports/onnxruntime-cuda12/vcpkg.json
+++ b/ports/onnxruntime-cuda12/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "onnxruntime-cuda12",
+  "version": "1.17.3",
+  "description": "onnxruntime (GPU with cuda12)",
+  "homepage": "https://github.com/microsoft/onnxruntime",
+  "license": "MIT",
+  "supports": "(windows | linux) & x64 & !staticcrt & !uwp & !mingw"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6360,6 +6360,10 @@
       "baseline": "0.3.18",
       "port-version": 0
     },
+    "onnxruntime-cuda12": {
+      "baseline": "1.17.3",
+      "port-version": 0
+    },
     "onnxruntime-gpu": {
       "baseline": "1.16.3",
       "port-version": 0

--- a/versions/o-/onnxruntime-cuda12.json
+++ b/versions/o-/onnxruntime-cuda12.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a8bc2dbeb9e199498056faeb8f221e7c69705c3b",
+      "version": "1.17.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


There is already a port named onnxruntime-gpu. But it use cuda 11. And cuda 11 is still the default cuda version of onnxruntime-gpu. This port introduce the onnxruntime-gpu with cuda 12.