### PR TITLE
[vsg] Update to v1.1.2

### DIFF
--- a/ports/vsg/devendor-glslang.patch
+++ b/ports/vsg/devendor-glslang.patch
@@ -1,12 +1,15 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 883b103a..105bf015 100644
+index 85d18322..0ad18049 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -36,10 +36,11 @@ endif()
+@@ -36,13 +36,14 @@ endif()
  find_package(Vulkan ${Vulkan_MIN_VERSION} REQUIRED)
  
  find_package(Threads REQUIRED)
 +find_package(glslang CONFIG REQUIRED)
+ 
+ # Set the instrumentation level to compile into sources
+ set(VSG_MAX_INSTRUMENTATION_LEVEL 1 CACHE STRING "Set the instrumentation level to build into the VSG ibrary, 0 for off, 1 coarse grained, 2 medium, 3 fine grained." )
  
  # Enable/disable shader compilation support that pulls in glslang
  set(VSG_SUPPORTS_ShaderCompiler  1 CACHE STRING "Optional shader compiler support, 0 for off, 1 for enabled." )
@@ -16,11 +19,11 @@ index 883b103a..105bf015 100644
  
          if (Git_FOUND)
 diff --git a/src/vsg/CMakeLists.txt b/src/vsg/CMakeLists.txt
-index 188cfbe2..7a67538d 100644
+index 36597e0f..9f8cd47e 100644
 --- a/src/vsg/CMakeLists.txt
 +++ b/src/vsg/CMakeLists.txt
-@@ -226,7 +226,7 @@ set(SOURCES
-     utils/LoadPagedLOD.cpp
+@@ -254,7 +254,7 @@ set(SOURCES
+     utils/Profiler.cpp
  )
  
 -if (${VSG_SUPPORTS_ShaderCompiler})
@@ -28,7 +31,7 @@ index 188cfbe2..7a67538d 100644
  
      # include glslang source code directly into the VulkanScenegraph library build.
      include(../glslang/build_vars.cmake)
-@@ -236,6 +236,10 @@ endif()
+@@ -264,6 +264,10 @@ endif()
  set(LIBRARIES PUBLIC
          Vulkan::Vulkan
          Threads::Threads
@@ -39,7 +42,7 @@ index 188cfbe2..7a67538d 100644
  )
  
  # Check for std::atomic
-@@ -374,9 +378,6 @@ target_include_directories(vsg
+@@ -402,9 +406,6 @@ target_include_directories(vsg
      PUBLIC
          $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/include>
          $<BUILD_INTERFACE:${VSG_BINARY_DIR}/include>
@@ -50,7 +53,7 @@ index 188cfbe2..7a67538d 100644
  
  target_link_libraries(vsg ${LIBRARIES})
 diff --git a/src/vsg/utils/ShaderCompiler.cpp b/src/vsg/utils/ShaderCompiler.cpp
-index 71a7f09f..803f26a1 100644
+index a8f8dec9..2ca86f87 100644
 --- a/src/vsg/utils/ShaderCompiler.cpp
 +++ b/src/vsg/utils/ShaderCompiler.cpp
 @@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vsg-dev/VulkanSceneGraph
     REF "v${VERSION}"
-    SHA512 79ea02c5816c6b99ce847938d9004e0078cb685523c720d4abce5136b91bf4d17fff52893eba972ce9ac3d6db7fe92581039cba6ef72fb9e44ff37f9d9b314f3
+    SHA512 01502b0f812b3325dcb95511ea61f7c64bb476d7644f79f05b0106cf14a6442235f1d7ecb4d604b1668d99ca01db804d241dd4bbab7cad48307b03bc35cce4d1
     HEAD_REF master
 	PATCHES devendor-glslang.patch
 )

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vsg",
-  "version": "1.0.9",
-  "port-version": 1,
+  "version": "1.1.2",
   "description": "A modern, cross platform, high performance scene graph library built upon Vulkan.",
   "homepage": "http://www.vulkanscenegraph.org/",
   "license": "MIT",
@@ -15,6 +14,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "vulkan"
+    "vulkan",
+    {
+      "name": "xcb",
+      "platform": "!(android | windows | osx)"
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9165,8 +9165,8 @@
       "port-version": 2
     },
     "vsg": {
-      "baseline": "1.0.9",
-      "port-version": 1
+      "baseline": "1.1.2",
+      "port-version": 0
     },
     "vsgimgui": {
       "baseline": "0.1.0",

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b85c33c8bf83e25afe90f8f02dbd5dd5c77bed5",
+      "version": "1.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "517afc5c16fc874b01e79b737f64436ff3a28045",
       "version": "1.0.9",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

