### PR TITLE
[arrow] Update to 16.0.0

### DIFF
--- a/ports/arrow/android.patch
+++ b/ports/arrow/android.patch
@@ -1,8 +1,8 @@
-diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
-index 05c05c6..f2754a5 100644
---- a/cpp/CMakeLists.txt
-+++ b/cpp/CMakeLists.txt
-@@ -973,7 +973,7 @@ if(WIN32)
+diff --git a/cpp/src/arrow/CMakeLists.txt b/cpp/src/arrow/CMakeLists.txt
+index 026bb5c..5c1b5e3 100644
+--- a/cpp/src/arrow/CMakeLists.txt
++++ b/cpp/src/arrow/CMakeLists.txt
+@@ -166,7 +166,7 @@ if(WIN32)
    list(APPEND ARROW_SYSTEM_LINK_LIBS "ws2_32.dll")
  endif()
  

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE_PATH
     URLS "https://archive.apache.org/dist/arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
     FILENAME apache-arrow-${VERSION}.tar.gz
-    SHA512 6c83e3be1e5840c30387f088315b74aca8e7c2d060793af70a156effb496a71e3e6af0693188c0f46f8a4a061a263a47095912ef04a5dc8141abd59075b14c78
+    SHA512 773f4f3eef603032c8ba0cfdc023bfd2a24bb5e41c82da354a22d7854ab153294ede1f4782cc32b27451cf1b58303f105bac61ceeb3568faea747b93e21d79e4
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "arrow",
-  "version": "15.0.2",
-  "port-version": 1,
+  "version": "16.0.0",
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d68c109745e79bf3ae813428bd0cfda562790381",
+      "version": "16.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "934c1383e14915071a7c9939bd61f38de5bd2c1b",
       "version": "15.0.2",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -241,8 +241,8 @@
       "port-version": 5
     },
     "arrow": {
-      "baseline": "15.0.2",
-      "port-version": 1
+      "baseline": "16.0.0",
+      "port-version": 0
     },
     "arsenalgear": {
       "baseline": "2.1.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
