### PR TITLE
[yomm2] Update to 1.5.0

### DIFF
--- a/ports/yomm2/fix_install.patch
+++ b/ports/yomm2/fix_install.patch
@@ -11,37 +11,3 @@ index 7e8a282..f550c2d 100644
  message(STATUS "Using Boost libraries from ${Boost_INCLUDE_DIRS}")
  
  if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
-index 7272504..6423a17 100644
---- a/cmake/Config.cmake.in
-+++ b/cmake/Config.cmake.in
-@@ -1,7 +1,7 @@
- include(CMakeFindDependencyMacro)
- 
- # Tell library users about the Boost dependency
--find_dependency(Boost 1.53 HINTS ${CMAKE_CURRENT_LIST_DIR}/..)
-+find_dependency(Boost REQUIRED)
- 
- # Add the targets file
- include("${CMAKE_CURRENT_LIST_DIR}/YOMM2Targets.cmake")
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 7e8a282..f550c2d 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -26,6 +29,5 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
-   target_include_directories(
-     yomm2 INTERFACE
-     $<BUILD_INTERFACE:${YOMM2_SOURCE_DIR}/include>
-     $<INSTALL_INTERFACE:include>
--    $<INSTALL_INTERFACE:Boost::yomm2>
-   )
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -36,5 +36,6 @@
- install(TARGETS yomm2
-   EXPORT YOMM2Targets
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-+  RUNTIME DESTINATION bin
- )

--- a/ports/yomm2/fix_install.patch
+++ b/ports/yomm2/fix_install.patch
@@ -1,14 +1,16 @@
-diff --git a/cmake/find_or_download_package.cmake b/cmake/find_or_download_package.cmake
-index 7e8a282..f550c2d 100644
---- a/cmake/find_or_download_package.cmake
-+++ b/cmake/find_or_download_package.cmake
-@@ -7,6 +7,5 @@
-   set(DEPENDENCY_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/dependencies/${PACKAGE})
-   find_package(
-     ${PACKAGE} QUIET
--     HINTS ${DEPENDENCY_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}
-   )
-  if(NOT ${${PACKAGE}_FOUND})
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c50fd44..f550c2e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,7 +15,7 @@
+ # Find Boost dependency
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+ include(cmake/find_or_download_package.cmake)
+-find_or_download_package(Boost INSTALL_WITH_YOMM)
++find_package(Boost REQUIRED)
+ message(STATUS "Using Boost libraries from ${Boost_INCLUDE_DIRS}")
+ 
+ if(NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug") AND (CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index c50fd44..f550c2d 100644
 --- a/CMakeLists.txt

--- a/ports/yomm2/fix_install.patch
+++ b/ports/yomm2/fix_install.patch
@@ -1,13 +1,24 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
+diff --git a/cmake/find_or_download_package.cmake b/cmake/find_or_download_package.cmake
 index 7e8a282..f550c2d 100644
+--- a/cmake/find_or_download_package.cmake
++++ b/cmake/find_or_download_package.cmake
+@@ -7,6 +7,5 @@
+   set(DEPENDENCY_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/dependencies/${PACKAGE})
+   find_package(
+     ${PACKAGE} QUIET
+-     HINTS ${DEPENDENCY_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}
+   )
+  if(NOT ${${PACKAGE}_FOUND})
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c50fd44..f550c2d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -15,7 +15,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
- # Find Boost dependency
- list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
- include(find_or_download_package)
--find_or_download_package(Boost INSTALL_WITH_YOMM)
-+find_package(Boost REQUIRED)
- message(STATUS "Using Boost libraries from ${Boost_INCLUDE_DIRS}")
+@@ -73,7 +73,6 @@
+     COMMAND ${CMAKE_SOURCE_DIR}/dev/code2md "${readme_cpp}" "${readme_md}"
+     DEPENDS "${readme_cpp}")
+ endif()
  
- if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+-add_subdirectory(docs.in)
+ 
+ ## Install instruction
+ # Create version file for cmake package

--- a/ports/yomm2/portfile.cmake
+++ b/ports/yomm2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jll63/yomm2
     REF "v${VERSION}"
-    SHA512  35d869f79b278ae219d61e0ae3b01902c5df5457d2ced7bfd109cf0e75f3f7835ce3d4751c34838d134531f6483dc89b7d67d5ecab6e8af42b4b735284573db4
+    SHA512  5b2c4e68df88893e0179f355da255401bc13863079a040c6b3b942c6be076263911bde51afca73e69fbb1e8bec5bc0f9d9549974bdd8ab01ea8dc571dcf8de4b
     HEAD_REF master
     PATCHES "fix_install.patch"
 )
@@ -20,6 +20,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
         -DYOMM2_ENABLE_EXAMPLES=OFF
+        -DYOMM2_ENABLE_TESTS=OFF
         -DYOMM2_SHARED=${YOMM2_SHARED}
 )
 vcpkg_cmake_install()

--- a/ports/yomm2/portfile.cmake
+++ b/ports/yomm2/portfile.cmake
@@ -12,6 +12,10 @@ if(VCPKG_LIBRARY_LINKAGE MATCHES "dynamic")
     set(YOMM2_SHARED ON)
 endif()
 
+if(VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    set(VCPKG_BUILD_TYPE release) # header-only
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 

--- a/ports/yomm2/vcpkg.json
+++ b/ports/yomm2/vcpkg.json
@@ -8,7 +8,6 @@
     "boost-dynamic-bitset",
     "boost-mp11",
     "boost-preprocessor",
-    "boost-type-traits",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/yomm2/vcpkg.json
+++ b/ports/yomm2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "yomm2",
-  "version": "1.4.0",
-  "port-version": 1,
+  "version": "1.5.0",
   "description": "YOMM2 is an implementation of open multi-methods.",
   "homepage": "https://github.com/jll63/yomm2",
   "license": "BSL-1.0",
@@ -9,6 +8,7 @@
     "boost-dynamic-bitset",
     "boost-mp11",
     "boost-preprocessor",
+    "boost-type-traits",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9577,8 +9577,8 @@
       "port-version": 0
     },
     "yomm2": {
-      "baseline": "1.4.0",
-      "port-version": 1
+      "baseline": "1.5.0",
+      "port-version": 0
     },
     "yyjson": {
       "baseline": "0.8.0",

--- a/versions/y-/yomm2.json
+++ b/versions/y-/yomm2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cd0e4a794685da4c848998d46cf242a716dee35c",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7fb081bdba7637ab5c5bc26d1dfb2a80a1fd1303",
       "version": "1.4.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

@jll63 I was not sure I could push on your branch so I made the separate PR

