### PR TITLE
[CI] Don't test stuff which does not work due to static python

### DIFF
--- a/scripts/test_ports/vcpkg-ci-opencv/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-opencv/vcpkg.json
@@ -67,7 +67,7 @@
       "features": [
         "python"
       ],
-      "platform": "!uwp"
+      "platform": "!uwp & !(windows & static)"
     }
   ]
 }

--- a/scripts/test_ports/vcpkg-ci-openimageio/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-openimageio/vcpkg.json
@@ -13,7 +13,10 @@
         "libraw",
         "opencv",
         "openjpeg",
-        "pybind11",
+        {
+          "name": "pybind11",
+          "platform": "!(windows & static)"
+        }
         "tools",
         "webp"
       ]


### PR DESCRIPTION
opencv even has 
`message(WARNING "The python module is currently unsupported on Windows when building static OpenCV libraries")`

In general static python builds don't support extensions on windows as such a pyd build against a static python can never be used. 
What would work -> static extensions linked into a final executable.

There is no proper way to deactivate extensions if python was statically build on windows. 

Two questions remain here:
Should python be build dynamically on windows for static triplets so that we get a broader CI test? (maybe add a forbidden feature for only windows&static which allows building the static python instead)

