### PR TITLE
[cairo] Move hard lzo dependency to feature

### DIFF
--- a/ports/cairo/cairo_add_lzo_feature_option.patch
+++ b/ports/cairo/cairo_add_lzo_feature_option.patch
@@ -1,0 +1,25 @@
+diff --git a/meson.build b/meson.build
+index 03eb140f0..eadd32088 100644
+--- a/meson.build
++++ b/meson.build
+@@ -196,7 +196,7 @@ else
+   endif
+ endif
+ 
+-lzo_dep = dependency('lzo2', required: false)
++lzo_dep = dependency('lzo2', required: get_option('lzo'))
+ if lzo_dep.found()
+   conf.set('HAVE_LZO', 1)
+ endif
+diff --git a/meson_options.txt b/meson_options.txt
+index f481ef3ea..3ba4dacb1 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -23,6 +23,7 @@ option('glib', type : 'feature', value : 'auto')
+ option('spectre', type : 'feature', value : 'auto')
+ option('symbol-lookup', type: 'feature', value : 'auto',
+        description: 'Symbol lookup in debug utils via binutils/bfd')
++option('lzo', type : 'feature', value : 'auto')
+ 
+ # Documentation
+ option('gtk_doc', type : 'boolean', value : false,

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_gitlab(
         fix-static-missing-lib-msimg32.patch
         ${PATCHES}
         fix-alloca-undefine.patch # Upstream PR: https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/520
+        cairo_add_lzo_feature_option.patch
 )
 
 if("fontconfig" IN_LIST FEATURES)
@@ -41,6 +42,12 @@ if("gobject" IN_LIST FEATURES)
     list(APPEND OPTIONS -Dglib=enabled)
 else()
     list(APPEND OPTIONS -Dglib=disabled)
+endif()
+
+if("lzo" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dlzo=enabled)
+else()
+    list(APPEND OPTIONS -Dlzo=disabled)
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -20,8 +20,7 @@
   ],
   "default-features": [
     "fontconfig",
-    "freetype",
-    "lzo"
+    "freetype"
   ],
   "features": {
     "fontconfig": {

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cairo",
   "version": "1.18.0",
+  "port-version": 1,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1-only OR MPL-1.1",
@@ -9,7 +10,6 @@
     "dirent",
     "expat",
     "libpng",
-    "lzo",
     "pixman",
     "pthread",
     {
@@ -20,7 +20,8 @@
   ],
   "default-features": [
     "fontconfig",
-    "freetype"
+    "freetype",
+    "lzo"
   ],
   "features": {
     "fontconfig": {
@@ -39,6 +40,12 @@
       "description": "build gobject module",
       "dependencies": [
         "glib"
+      ]
+    },
+    "lzo": {
+      "description": "build with lzo support",
+      "dependencies": [
+        "lzo"
       ]
     },
     "x11": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1446,7 +1446,7 @@
     },
     "cairo": {
       "baseline": "1.18.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cairomm": {
       "baseline": "1.17.1",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46df53beeabedd3103782fe2dad2e185b6e55fc4",
+      "version": "1.18.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3b9181491cc6b0a115afa8dd5af2fca420a5cddd",
       "version": "1.18.0",
       "port-version": 0

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89a4a02291e9810a4048ad9be1d9a16a7f7f4ac1",
+      "git-tree": "0fda02793cfc3911468cd200b0a889c65035db1d",
       "version": "1.18.0",
       "port-version": 1
     },

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "46df53beeabedd3103782fe2dad2e185b6e55fc4",
+      "git-tree": "89a4a02291e9810a4048ad9be1d9a16a7f7f4ac1",
       "version": "1.18.0",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #38312

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
