### PR TITLE
[crashpad] Fix std int for linux

### DIFF
--- a/ports/crashpad/fix-stdint.patch
+++ b/ports/crashpad/fix-stdint.patch
@@ -1,0 +1,26 @@
+diff --git a/base/logging.h b/base/logging.h
+index a123535..a87de3d 100644
+--- a/base/logging.h
++++ b/base/logging.h
+@@ -7,7 +7,7 @@
+ 
+ #include <assert.h>
+ #include <errno.h>
+-
++#include <stdint.h>
+ #include <limits>
+ #include <sstream>
+ #include <string>
+diff --git a/base/strings/utf_string_conversion_utils.h b/base/strings/utf_string_conversion_utils.h
+index ed99a23..0ba3fea 100644
+--- a/base/strings/utf_string_conversion_utils.h
++++ b/base/strings/utf_string_conversion_utils.h
+@@ -6,7 +6,7 @@
+ #define MINI_CHROMIUM_BASE_STRINGS_UTF_STRING_CONVERSION_UTILS_H_
+ 
+ #include <string>
+-
++#include <stdint.h>
+ namespace base {
+ 
+ inline bool IsValidCodepoint(uint32_t code_point) {

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -18,17 +18,21 @@ function(checkout_in_path PATH URL REF)
         OUT_SOURCE_PATH DEP_SOURCE_PATH
         URL "${URL}"
         REF "${REF}"
+        PATCHES
+          "${PATCH_FILE}"
     )
     file(RENAME "${DEP_SOURCE_PATH}" "${PATH}")
     file(REMOVE_RECURSE "${DEP_SOURCE_PATH}")
 endfunction()
 
+set(PATCH_FILE "fix-stdint.patch")
 # mini_chromium contains the toolchains and build configuration
 checkout_in_path(
     "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium"
     "https://chromium.googlesource.com/chromium/mini_chromium"
     "5654edb4225bcad13901155c819febb5748e502b"
 )
+set(PATCH_FILE "")
 
 if(VCPKG_TARGET_IS_LINUX)
     # fetch lss

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -25,8 +25,8 @@ function(checkout_in_path PATH URL REF)
     file(REMOVE_RECURSE "${DEP_SOURCE_PATH}")
 endfunction()
 
-set(PATCH_FILE "fix-stdint.patch")
 # mini_chromium contains the toolchains and build configuration
+set(PATCH_FILE "fix-stdint.patch")
 checkout_in_path(
     "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium"
     "https://chromium.googlesource.com/chromium/mini_chromium"

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2022-09-05",
-  "port-version": 4,
+  "port-version": 5,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."
@@ -10,6 +10,7 @@
   "license": "Apache-2.0",
   "supports": "linux | osx | (windows & !uwp)",
   "dependencies": [
+    "curl",
     {
       "name": "vcpkg-cmake-get-vars",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1986,7 +1986,7 @@
     },
     "crashpad": {
       "baseline": "2022-09-05",
-      "port-version": 4
+      "port-version": 5
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7161b19eece4ad2643d6b2baafdb5fd6ec57572",
+      "version-date": "2022-09-05",
+      "port-version": 5
+    },
+    {
       "git-tree": "63c757af964d6d69f6abdeb0a3849889ad3531a9",
       "version-date": "2022-09-05",
       "port-version": 4


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/38308
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

