### PR TITLE
[calceph] update to version 4.0.0

### DIFF
--- a/ports/calceph/portfile.cmake
+++ b/ports/calceph/portfile.cmake
@@ -1,4 +1,4 @@
-set(CALCEPH_HASH bbb60179b36f3ea9f05daa43e7950494d058137cf5a92e6c7b9742048dc0767490b7b42d2d2db7329f5ca96ffc4f2f32443abacb1073e29af78e58935b8b3edc)
+set(CALCEPH_HASH f8d7d2ce2e043f79364bb7bf5e8d74a9b0be8a6c29895068ac8f5936d11fd3c82747a3ab2f9fefc6a66762f35d622497b6088d24b76060b5b722e3c8c3b76c6b)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-${VERSION}.tar.gz"
@@ -11,39 +11,19 @@ vcpkg_extract_source_archive(
     ARCHIVE ${ARCHIVE}
 )
 
-if (VCPKG_TARGET_IS_WINDOWS)
-
-    vcpkg_install_nmake(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
-        OPTIONS_DEBUG
-            DESTDIR="${CURRENT_INSTALLED_DIR}/calceph/debug"
-            CFLAGS="${VCPKG_C_FLAGS_DEBUG} "
-        OPTIONS_RELEASE
-            DESTDIR="${CURRENT_INSTALLED_DIR}/calceph"
-            CFLAGS="${VCPKG_C_FLAGS_RELEASE} "
-    )
-    file(INSTALL "${CURRENT_INSTALLED_DIR}/calceph/include/calceph.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-    file(INSTALL "${CURRENT_INSTALLED_DIR}/calceph/lib/libcalceph.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-    if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-      file(INSTALL "${CURRENT_INSTALLED_DIR}/calceph/debug/lib/libcalceph.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
-    endif()
-	file(REMOVE_RECURSE "${CURRENT_INSTALLED_DIR}/calceph")
-
-else() # Build in UNIX
-    vcpkg_configure_make(
-    AUTOCONFIG
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${OPTIONS}
-      --enable-fortran=no
-      --enable-thread=yes
-    )
+)
 
-    vcpkg_install_make()
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_copy_tools(TOOL_NAMES calceph_inspector calceph_queryposition calceph_queryorientation AUTO_CLEAN)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-    file(INSTALL "${SOURCE_PATH}/README.rst" DESTINATION "${CURRENT_PACKAGES_DIR}/share/calceph" RENAME readme.rst)
-    file(INSTALL "${SOURCE_PATH}/COPYING_CECILL_B.LIB" DESTINATION "${CURRENT_PACKAGES_DIR}/share/calceph" RENAME copyright)
-    file(INSTALL "${SOURCE_PATH}/doc/calceph_c.pdf" DESTINATION "${CURRENT_PACKAGES_DIR}/share/calceph" RENAME calceph_c.pdf)
+file(INSTALL "${SOURCE_PATH}/README.rst" DESTINATION "${CURRENT_PACKAGES_DIR}/share/calceph" RENAME readme.rst)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING_CECILL_B.LIB")

--- a/ports/calceph/vcpkg.json
+++ b/ports/calceph/vcpkg.json
@@ -1,9 +1,19 @@
 {
   "name": "calceph",
-  "version": "3.5.5",
+  "version": "4.0.0",
   "description": "C library to access the binary planetary ephemeris files.",
   "homepage": "https://www.imcce.fr/inpop/calceph/",
-  "documentation": "https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/html/c/index.html",
+  "documentation": "https://calceph.imcce.fr/docs/latest/html/c/index.html",
   "license": "CECILL-2.1 OR CECILL-B OR CECILL-C",
-  "supports": "!uwp"
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1453,7 +1453,7 @@
       "port-version": 1
     },
     "calceph": {
-      "baseline": "3.5.5",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "camport3": {

--- a/versions/c-/calceph.json
+++ b/versions/c-/calceph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e91c8461694ab6c706f739be3be47f367464157",
+      "version": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "068e74605df6b8a253d6f659db2e2114d1764588",
       "version": "3.5.5",
       "port-version": 0


### PR DESCRIPTION


- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


