### PR TITLE
[azure-*-cpp] Add HEAD_REF to manifests

### DIFF
--- a/ports/azure-core-tracing-opentelemetry-cpp/portfile.cmake
+++ b/ports/azure-core-tracing-opentelemetry-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-core-tracing-opentelemetry_1.0.0-beta.4
+    REF "azure-core-tracing-opentelemetry_${VERSION}"
     SHA512 645c616fe54024f30a6e4b9c2626bfeaf906086be7bbeccc4a1155178670fb70d9818938db2f9fa8e3b9593ca45e0b10042dcd67fde04d2542f6f72a74884697
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/core/azure-core-tracing-opentelemetry")

--- a/ports/azure-core-tracing-opentelemetry-cpp/vcpkg.json
+++ b/ports/azure-core-tracing-opentelemetry-cpp/vcpkg.json
@@ -5,7 +5,7 @@
   ],
   "name": "azure-core-tracing-opentelemetry-cpp",
   "version-semver": "1.0.0-beta.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "Microsoft Azure Core Tracing OpenTelemetry SDK for C++",
     "This library provides support for modern Azure SDK client libraries written in C++ to leverage OpenTelemetry APIs."

--- a/ports/azure-identity-cpp/portfile.cmake
+++ b/ports/azure-identity-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-identity_1.6.0
+    REF "azure-identity_${VERSION}"
     SHA512 a856bc8f3c536d0ac2a5d7817d4bb890bf0688940075ea191df45a58faff46790acda9cdd917cd4f14496c9a696c8cf31be7935b08dd2d549e8ea5d30dbe2c94
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/identity/azure-identity")

--- a/ports/azure-identity-cpp/vcpkg.json
+++ b/ports/azure-identity-cpp/vcpkg.json
@@ -1,7 +1,11 @@
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-identity-cpp",
   "version-semver": "1.6.0",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Identity SDK for C++",
     "This library provides common authentication-related abstractions for Azure SDK."

--- a/ports/azure-messaging-eventhubs-checkpointstore-blob-cpp/portfile.cmake
+++ b/ports/azure-messaging-eventhubs-checkpointstore-blob-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-messaging-eventhubs-checkpointstore-blob_1.0.0-beta.1
+    REF "azure-messaging-eventhubs-checkpointstore-blob_${VERSION}"
     SHA512 7c55eda0c04bbc57729a7b479d8d5874b0e06927aff1916833520a3a944e63b6fceabd3565fd91549ec00157f2c4af5a87a6a2db55a5c24df611cd96572f9a08
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob")

--- a/ports/azure-messaging-eventhubs-checkpointstore-blob-cpp/vcpkg.json
+++ b/ports/azure-messaging-eventhubs-checkpointstore-blob-cpp/vcpkg.json
@@ -5,7 +5,7 @@
   ],
   "name": "azure-messaging-eventhubs-checkpointstore-blob-cpp",
   "version-semver": "1.0.0-beta.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Microsoft Azure Messaging Event Hubs Blob Checkpoint Store SDK for C++",
     "This library provides an Azure-Storage-Blobs based implementation of an Azure Messaging Event Hubs SDK Checkpoint Store."

--- a/ports/azure-security-attestation-cpp/portfile.cmake
+++ b/ports/azure-security-attestation-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-attestation_1.1.0
+    REF "azure-security-attestation_${VERSION}"
     SHA512 bf5c0ab830122838045e3e5ff03aae38f81082b50b9b0c61fa21a8c101a2fd98ad98b136d49702665d720f59baa6a89c8af3f161a44c09d24ad747fb1828cbca
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/attestation/azure-security-attestation")

--- a/ports/azure-security-attestation-cpp/vcpkg.json
+++ b/ports/azure-security-attestation-cpp/vcpkg.json
@@ -5,7 +5,7 @@
   ],
   "name": "azure-security-attestation-cpp",
   "version-semver": "1.1.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "Microsoft Azure Attestation Service SDK for C++",
     "This library provides API access to the Microsoft Azure Attestation service."

--- a/ports/azure-security-keyvault-administration-cpp/portfile.cmake
+++ b/ports/azure-security-keyvault-administration-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-administration_4.0.0-beta.4
+    REF "azure-security-keyvault-administration_${VERSION}"
     SHA512 2a9c04fd2d98484632e3a53b98c09bd1c30cf117f34baa15e859d50736c2cfc26c19c6e846be6ad71f1b6b3def317dfb28d0586a1b0b55949246218479445660
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-administration")

--- a/ports/azure-security-keyvault-administration-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-administration-cpp/vcpkg.json
@@ -5,6 +5,7 @@
   ],
   "name": "azure-security-keyvault-administration-cpp",
   "version-semver": "4.0.0-beta.4",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Key Vault Administration SDK for C++",
     "This library provides Azure Key Vault Administration SDK."

--- a/ports/azure-security-keyvault-certificates-cpp/portfile.cmake
+++ b/ports/azure-security-keyvault-certificates-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-certificates_4.2.1
+    REF "azure-security-keyvault-certificates_${VERSION}"
     SHA512 f18d205ee0be9ab4289860fe4fdc0f4a6c3571eb0a8d0ca0ea66e7fef477e04ed0ba455e1a5af687e0980d7f12b919d1a5c85ee40d41dbcfd695f5d62843dcd5
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-certificates")

--- a/ports/azure-security-keyvault-certificates-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-certificates-cpp/vcpkg.json
@@ -5,6 +5,7 @@
   ],
   "name": "azure-security-keyvault-certificates-cpp",
   "version-semver": "4.2.1",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Key Vault Certificates SDK for C++",
     "This library provides Azure Key Vault Certificates SDK."

--- a/ports/azure-security-keyvault-keys-cpp/portfile.cmake
+++ b/ports/azure-security-keyvault-keys-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-keys_4.4.1
+    REF "azure-security-keyvault-keys_${VERSION}"
     SHA512 758ff05ce33672d81cf14d347edada2a7c008c7df61639b7bac9ce1a1114144a1f6fcc3d364d1d90f5f9cda8f8c1db14f80873403d4190d4aca1844fb25dd517
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys")

--- a/ports/azure-security-keyvault-keys-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-keys-cpp/vcpkg.json
@@ -5,6 +5,7 @@
   ],
   "name": "azure-security-keyvault-keys-cpp",
   "version-semver": "4.4.1",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Key Vault Keys SDK for C++",
     "This library provides Azure Key Vault Keys SDK."

--- a/ports/azure-security-keyvault-secrets-cpp/portfile.cmake
+++ b/ports/azure-security-keyvault-secrets-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-secrets_4.2.1
+    REF "azure-security-keyvault-secrets_${VERSION}"
     SHA512 8d944bbcc29b670b884234a789455bb6b33e33fa45c7b02a4200c2267189597cb849f3cbbaa5f7c4db013ec74a2ea0b073237254db7fcac96c290888c05dcba5
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-secrets")

--- a/ports/azure-security-keyvault-secrets-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-secrets-cpp/vcpkg.json
@@ -5,6 +5,7 @@
   ],
   "name": "azure-security-keyvault-secrets-cpp",
   "version-semver": "4.2.1",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Key Vault Secrets SDK for C++",
     "This library provides Azure Key Vault Secrets SDK."

--- a/ports/azure-storage-blobs-cpp/portfile.cmake
+++ b/ports/azure-storage-blobs-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-blobs_12.10.0
+    REF "azure-storage-blobs_${VERSION}"
     SHA512 652b4edf2e049b33ef37734ab3e421a7b2b8d2f497da2859fe73ae665e8fd76b360d02c9f64c42cd6dbc8baa7150a031263942fc7d6b311d2c051ccd044a0064
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-blobs")

--- a/ports/azure-storage-blobs-cpp/vcpkg.json
+++ b/ports/azure-storage-blobs-cpp/vcpkg.json
@@ -1,7 +1,11 @@
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-blobs-cpp",
   "version-semver": "12.10.0",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Storage Blobs SDK for C++",
     "This library provides Azure Storage Blobs SDK."

--- a/ports/azure-storage-common-cpp/portfile.cmake
+++ b/ports/azure-storage-common-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-common_12.5.0
+    REF "azure-storage-common_${VERSION}"
     SHA512 46c9cc4ebec54f289ba7270356da4e89e5f8e890004c7a232200b87ca33357064c2f46670a1090fe41ca6962cdbc76d2e3520bb600438cbc0f21f15cf7816f04
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-common")

--- a/ports/azure-storage-common-cpp/vcpkg.json
+++ b/ports/azure-storage-common-cpp/vcpkg.json
@@ -1,7 +1,11 @@
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-common-cpp",
   "version-semver": "12.5.0",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Common Storage SDK for C++",
     "This library provides common Azure Storage-related abstractions for Azure SDK."

--- a/ports/azure-storage-common-cpp/vcpkg.json
+++ b/ports/azure-storage-common-cpp/vcpkg.json
@@ -20,6 +20,7 @@
     },
     {
       "name": "libxml2",
+      "default-features": false,
       "platform": "!windows"
     },
     {

--- a/ports/azure-storage-files-datalake-cpp/portfile.cmake
+++ b/ports/azure-storage-files-datalake-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-files-datalake_12.9.0
+    REF "azure-storage-files-datalake_${VERSION}"
     SHA512 3314adc2c43b54f3bb776b099876062dc157cb35215c8efb49c1d23474479601ab0c067f901809c9ee4bce646feabf0065e8e8b96ae77f4d0f8585e8e269294b
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-files-datalake")

--- a/ports/azure-storage-files-datalake-cpp/vcpkg.json
+++ b/ports/azure-storage-files-datalake-cpp/vcpkg.json
@@ -1,7 +1,11 @@
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-files-datalake-cpp",
   "version-semver": "12.9.0",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Storage Files Data Lake SDK for C++",
     "This library provides Azure Storage Files Data Lake SDK."

--- a/ports/azure-storage-files-shares-cpp/portfile.cmake
+++ b/ports/azure-storage-files-shares-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-files-shares_12.8.0
+    REF "azure-storage-files-shares_${VERSION}"
     SHA512 a22cce4f43fd77aabdb43fdbc9ea3e5a501f5abeaafe5f5fea7e8737b6b017dc2ca3b674ac0c5f8bcda9b836af7644b3c17db050b02db5e076728047aa5c2ec0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-files-shares")

--- a/ports/azure-storage-files-shares-cpp/vcpkg.json
+++ b/ports/azure-storage-files-shares-cpp/vcpkg.json
@@ -1,7 +1,11 @@
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-files-shares-cpp",
   "version-semver": "12.8.0",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Storage Files Shares SDK for C++",
     "This library provides Azure Storage Files Shares SDK."

--- a/ports/azure-storage-queues-cpp/portfile.cmake
+++ b/ports/azure-storage-queues-cpp/portfile.cmake
@@ -4,8 +4,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-queues_12.2.0
+    REF "azure-storage-queues_${VERSION}"
     SHA512 ce0a89e3ae5e49f495904a614615906119ba09606ac2e781aae59cf2f4a00e6d4afe9bdd9675ec4cc59b50b47b5123a6333f125871df42db5d6554d341132676
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-queues")

--- a/ports/azure-storage-queues-cpp/vcpkg.json
+++ b/ports/azure-storage-queues-cpp/vcpkg.json
@@ -1,7 +1,11 @@
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-queues-cpp",
   "version-semver": "12.2.0",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Storage Queues SDK for C++",
     "This library provides Azure Storage Queues SDK."

--- a/versions/a-/azure-core-tracing-opentelemetry-cpp.json
+++ b/versions/a-/azure-core-tracing-opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c98ff298b59faef771f5020d2b6ae31b2a9c568a",
+      "version-semver": "1.0.0-beta.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "0fb3475fbd40be762b7bb9a1a85fef10eb4af9a3",
       "version-semver": "1.0.0-beta.4",
       "port-version": 2

--- a/versions/a-/azure-identity-cpp.json
+++ b/versions/a-/azure-identity-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f1b7552f9fa0111e34ea72e722f9f4512f612b3",
+      "version-semver": "1.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cb43628d1a08baa198ed4cdc7d317ed73ed3815f",
       "version-semver": "1.6.0",
       "port-version": 0

--- a/versions/a-/azure-messaging-eventhubs-checkpointstore-blob-cpp.json
+++ b/versions/a-/azure-messaging-eventhubs-checkpointstore-blob-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03dbf04a656de3308127d2d2c979e355b163d2da",
+      "version-semver": "1.0.0-beta.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "44c7021f43e5786d7be87b935868e4c283d72755",
       "version-semver": "1.0.0-beta.1",
       "port-version": 1

--- a/versions/a-/azure-security-attestation-cpp.json
+++ b/versions/a-/azure-security-attestation-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14d1242810e6d4de5c6fc523ae4d9ecb4904b58e",
+      "version-semver": "1.1.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "ece7b864d0d0ab18ba081e5695efea98c5aa2bdf",
       "version-semver": "1.1.0",
       "port-version": 2

--- a/versions/a-/azure-security-keyvault-administration-cpp.json
+++ b/versions/a-/azure-security-keyvault-administration-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a15b58595ed231b1806d0d28996d72417d82867a",
+      "version-semver": "4.0.0-beta.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "dd36ccbfee4987cbea6cee9fae8e752b1fc9f3cb",
       "version-semver": "4.0.0-beta.4",
       "port-version": 0

--- a/versions/a-/azure-security-keyvault-certificates-cpp.json
+++ b/versions/a-/azure-security-keyvault-certificates-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "acf18957f24ce055dd972e0c4dfe0063811cdaec",
+      "version-semver": "4.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "24b5030675a24e25b0fb571b39d33e7ee6caa61e",
       "version-semver": "4.2.1",
       "port-version": 0

--- a/versions/a-/azure-security-keyvault-keys-cpp.json
+++ b/versions/a-/azure-security-keyvault-keys-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d6d591db10c8696d1866c04d9aa5df6f8a23868",
+      "version-semver": "4.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6ca701263f474612b070c37fbc5a7932a562838e",
       "version-semver": "4.4.1",
       "port-version": 0

--- a/versions/a-/azure-security-keyvault-secrets-cpp.json
+++ b/versions/a-/azure-security-keyvault-secrets-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7225e1286b3ede5419906d317929a3b62507a9a9",
+      "version-semver": "4.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "5edd7b9816c3c93ff452244bb579effa3c863787",
       "version-semver": "4.2.1",
       "port-version": 0

--- a/versions/a-/azure-storage-blobs-cpp.json
+++ b/versions/a-/azure-storage-blobs-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6571c6c7a51e9a51637d042a5852b9867d51d239",
+      "version-semver": "12.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "902107525b099bb6c915311567519dcd55bd2aea",
       "version-semver": "12.10.0",
       "port-version": 0

--- a/versions/a-/azure-storage-common-cpp.json
+++ b/versions/a-/azure-storage-common-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f63d964333a534c50873f945a46c043902960cec",
+      "git-tree": "6bcfda73c7ab29e1dfbd7c66878294577ac45420",
       "version-semver": "12.5.0",
       "port-version": 1
     },

--- a/versions/a-/azure-storage-common-cpp.json
+++ b/versions/a-/azure-storage-common-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f63d964333a534c50873f945a46c043902960cec",
+      "version-semver": "12.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "97351c3b87aae118c657334bb527c220e196aac7",
       "version-semver": "12.5.0",
       "port-version": 0

--- a/versions/a-/azure-storage-files-datalake-cpp.json
+++ b/versions/a-/azure-storage-files-datalake-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3450cc1269a67f290703a583559fb37b6ef08fb5",
+      "version-semver": "12.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "eef43191bf50fe79ddd687b71761765a2400a0c2",
       "version-semver": "12.9.0",
       "port-version": 0

--- a/versions/a-/azure-storage-files-shares-cpp.json
+++ b/versions/a-/azure-storage-files-shares-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29a98ee7af38db39f74336c93f98141fd6996952",
+      "version-semver": "12.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "98ae8cc3d7bad139e05b550c17fc37da3c5c1cef",
       "version-semver": "12.8.0",
       "port-version": 0

--- a/versions/a-/azure-storage-queues-cpp.json
+++ b/versions/a-/azure-storage-queues-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "206bd0c788a577bd105fa5edf6d4e57feb43285b",
+      "version-semver": "12.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7e74bf6adaa2794ef229e4a605d31fea0b3b19bd",
       "version-semver": "12.2.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -446,7 +446,7 @@
     },
     "azure-core-tracing-opentelemetry-cpp": {
       "baseline": "1.0.0-beta.4",
-      "port-version": 2
+      "port-version": 3
     },
     "azure-data-tables-cpp": {
       "baseline": "1.0.0-beta.2",
@@ -454,7 +454,7 @@
     },
     "azure-identity-cpp": {
       "baseline": "1.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-iot-sdk-c": {
       "baseline": "2024-03-04",
@@ -470,7 +470,7 @@
     },
     "azure-messaging-eventhubs-checkpointstore-blob-cpp": {
       "baseline": "1.0.0-beta.1",
-      "port-version": 1
+      "port-version": 2
     },
     "azure-messaging-eventhubs-cpp": {
       "baseline": "1.0.0-beta.7",
@@ -478,31 +478,31 @@
     },
     "azure-security-attestation-cpp": {
       "baseline": "1.1.0",
-      "port-version": 2
+      "port-version": 3
     },
     "azure-security-keyvault-administration-cpp": {
       "baseline": "4.0.0-beta.4",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-security-keyvault-certificates-cpp": {
       "baseline": "4.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-security-keyvault-keys-cpp": {
       "baseline": "4.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-security-keyvault-secrets-cpp": {
       "baseline": "4.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-blobs-cpp": {
       "baseline": "12.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-common-cpp": {
       "baseline": "12.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-cpp": {
       "baseline": "7.5.0",
@@ -510,15 +510,15 @@
     },
     "azure-storage-files-datalake-cpp": {
       "baseline": "12.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-files-shares-cpp": {
       "baseline": "12.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-queues-cpp": {
       "baseline": "12.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-uamqp-c": {
       "baseline": "2024-03-04",


### PR DESCRIPTION
In #38085, we released 4 azure SDK libraries, and updated port manifest files to use `HEAD_REF` and `${VERSION}`.
This PR updates the rest of the https://github.com/Azure/azure-sdk-for-cpp/ ports to have the same changes, and also updates the remaining Azure SDK for C++ ports to have multi-line `$comment`.

This will keep all Azure SDK for C++ ports in uniform state when it comes to portfiles, reflects the mainfest changes from the repo, and will help to see minimalistic diffs during the next releases and in daily validation runs (#34835).

cc @WangWeiLin-MV