### PR TITLE
[seal] Fix package hexl not found error

### DIFF
--- a/ports/seal/fix-hexl.patch
+++ b/ports/seal/fix-hexl.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index edf69a3..e64672e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -223,7 +223,7 @@ if(SEAL_USE_INTEL_HEXL)
+         message(STATUS "Intel HEXL: download ...")
+         seal_fetch_thirdparty_content(ExternalIntelHEXL)
+     else()
+-        find_package(HEXL 1.2.4)
++        find_package(HEXL CONFIG REQUIRED)
+         if (NOT TARGET HEXL::hexl)
+             message(FATAL_ERROR "Intel HEXL: not found")
+         endif()

--- a/ports/seal/fix-hexl.patch
+++ b/ports/seal/fix-hexl.patch
@@ -7,7 +7,7 @@ index edf69a3..e64672e 100644
          seal_fetch_thirdparty_content(ExternalIntelHEXL)
      else()
 -        find_package(HEXL 1.2.4)
-+        find_package(HEXL 1.2.5)
++        find_package(HEXL CONFIG REQUIRED)
          if (NOT TARGET HEXL::hexl)
              message(FATAL_ERROR "Intel HEXL: not found")
          endif()

--- a/ports/seal/fix-hexl.patch
+++ b/ports/seal/fix-hexl.patch
@@ -7,7 +7,7 @@ index edf69a3..e64672e 100644
          seal_fetch_thirdparty_content(ExternalIntelHEXL)
      else()
 -        find_package(HEXL 1.2.4)
-+        find_package(HEXL CONFIG REQUIRED)
++        find_package(HEXL 1.2.5)
          if (NOT TARGET HEXL::hexl)
              message(FATAL_ERROR "Intel HEXL: not found")
          endif()

--- a/ports/seal/portfile.cmake
+++ b/ports/seal/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         shared-zstd.patch
+        fix-hexl.patch
 )
 
 vcpkg_replace_string(

--- a/ports/seal/vcpkg.json
+++ b/ports/seal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "seal",
   "version": "4.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Microsoft SEAL is an easy-to-use and powerful homomorphic encryption library.",
   "homepage": "https://github.com/microsoft/SEAL",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7970,7 +7970,7 @@
     },
     "seal": {
       "baseline": "4.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "seasocks": {
       "baseline": "1.4.6",

--- a/versions/s-/seal.json
+++ b/versions/s-/seal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "90ddcfb2adf93a2bf7cbad776f62cb84f6145114",
+      "version": "4.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "b40b9aa4145e13facd191ec957a4cefa586d6f7f",
       "version": "4.1.1",
       "port-version": 1

--- a/versions/s-/seal.json
+++ b/versions/s-/seal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d37aff029ea8de0983d4a0af10f72edade1f9d53",
+      "git-tree": "90ddcfb2adf93a2bf7cbad776f62cb84f6145114",
       "version": "4.1.1",
       "port-version": 2
     },

--- a/versions/s-/seal.json
+++ b/versions/s-/seal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "90ddcfb2adf93a2bf7cbad776f62cb84f6145114",
+      "git-tree": "d37aff029ea8de0983d4a0af10f72edade1f9d53",
       "version": "4.1.1",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes #38323.

Fix package `hexl` not found error:
```
CMake Warning at vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package):
  Could not find a configuration file for package "HEXL" that is compatible
  with requested version "1.2.4".

  The following configuration files were considered but not accepted:

    vcpkg/installed/x64-linux/share/HEXL/HEXLConfig.cmake, version: 1.2.5
    /usr/local/lib/cmake/hexl-1.2.5/HEXLConfig.cmake, version: 1.2.5

Call Stack (most recent call first):
  CMakeLists.txt:226 (find_package)


CMake Error at CMakeLists.txt:228 (message):
  Intel HEXL: not found
```

Feature `hexl` is tested successfully in the following triplet:
```
x64-windows
x64-windows-static
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


