### PR TITLE
[curl] add psl feature

### DIFF
--- a/ports/curl/0012-fix-dependency-idn2.patch
+++ b/ports/curl/0012-fix-dependency-idn2.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index a54c2ff..3b83a7f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -852,11 +852,9 @@ endif()
+@@ -852,11 +852,11 @@ endif()
  # Check for idn2
  option(USE_LIBIDN2 "Use libidn2 for IDN support" ON)
  if(USE_LIBIDN2)
@@ -11,6 +11,8 @@ index a54c2ff..3b83a7f 100644
 -    set(CURL_LIBS "idn2;${CURL_LIBS}")
 -    check_include_file_concat("idn2.h" HAVE_IDN2_H)
 -  endif()
++  find_package(PkgConfig REQUIRED)
++  pkg_check_modules(LIBIDN2 REQUIRED libidn2)
 +  set(HAVE_LIBIDN2 TRUE)
 +  list(INSERT CURL_LIBS 0 ${LIBIDN2_LINK_LIBRARIES})
 +  set(HAVE_IDN2_H TRUE)

--- a/ports/curl/cmake-project-include.cmake
+++ b/ports/curl/cmake-project-include.cmake
@@ -77,11 +77,6 @@ function(vcpkg_curl_flatten input output)
     set("${output}" "${output_libs}" PARENT_SCOPE)
 endfunction()
 
-if(USE_LIBIDN2)
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(LIBIDN2 REQUIRED libidn2)
-endif()
-
 if(NOT CURL_DISABLE_LDAP AND NOT WIN32)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(LDAP REQUIRED ldap)

--- a/ports/curl/dependencies.patch
+++ b/ports/curl/dependencies.patch
@@ -23,7 +23,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 049ac34..cc0fe19 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -178,7 +178,8 @@ set(CURL_LIBS "")
+@@ -163,7 +163,8 @@ set(CURL_LIBS "")
  
  if(ENABLE_ARES)
    set(USE_ARES 1)
@@ -33,7 +33,7 @@ index 049ac34..cc0fe19 100644
    list(APPEND CURL_LIBS ${CARES_LIBRARY})
  endif()
  
-@@ -590,7 +591,9 @@ endif()
+@@ -575,7 +576,9 @@ endif()
  option(CURL_BROTLI "Set to ON to enable building curl with brotli support." OFF)
  set(HAVE_BROTLI OFF)
  if(CURL_BROTLI)
@@ -44,7 +44,22 @@ index 049ac34..cc0fe19 100644
    if(BROTLI_FOUND)
      set(HAVE_BROTLI ON)
      set(CURL_LIBS "${BROTLI_LIBRARIES};${CURL_LIBS}")  # For 'ld' linker. Emulate `list(PREPEND ...)` to stay compatible with <v3.15 CMake.
-@@ -873,7 +876,13 @@ mark_as_advanced(CURL_USE_LIBSSH2)
+@@ -876,11 +879,10 @@ mark_as_advanced(CURL_USE_LIBPSL)
+ set(USE_LIBPSL OFF)
+ 
+ if(CURL_USE_LIBPSL)
+-  find_package(LibPSL)
++  find_package(PkgConfig REQUIRED)
++  pkg_check_modules(LIBPSL REQUIRED libpsl)
+   if(LIBPSL_FOUND)
+-    list(APPEND CURL_LIBS ${LIBPSL_LIBRARY})
+-    list(APPEND CMAKE_REQUIRED_INCLUDES "${LIBPSL_INCLUDE_DIR}")
+-    include_directories("${LIBPSL_INCLUDE_DIR}")
++    list(APPEND CURL_LIBS ${LIBPSL_LINK_LIBRARIES})
+     set(USE_LIBPSL ON)
+   endif()
+ endif()
+@@ -891,7 +893,13 @@ mark_as_advanced(CURL_USE_LIBSSH2)
  set(USE_LIBSSH2 OFF)
  
  if(CURL_USE_LIBSSH2)

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -45,6 +45,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         winidn      USE_WIN32_IDN
         websockets  ENABLE_WEBSOCKETS
         zstd        CURL_ZSTD
+        psl         CURL_USE_LIBPSL
     INVERTED_FEATURES
         ldap        CURL_DISABLE_LDAP
         ldap        CURL_DISABLE_LDAPS
@@ -83,7 +84,6 @@ vcpkg_cmake_configure(
         -DBUILD_TESTING=OFF
         -DENABLE_CURL_MANUAL=OFF
         -DCURL_CA_FALLBACK=ON
-        -DCURL_USE_LIBPSL=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_Perl=ON
     OPTIONS_DEBUG
         -DENABLE_DEBUG=ON

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curl",
   "version": "8.7.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",
@@ -103,6 +103,12 @@
       "description": "SSL support (OpenSSL)",
       "dependencies": [
         "openssl"
+      ]
+    },
+    "psl": {
+      "description": "Use psl support (libpsl)",
+      "dependencies": [
+        "libpsl"
       ]
     },
     "schannel": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2078,7 +2078,7 @@
     },
     "curl": {
       "baseline": "8.7.1",
-      "port-version": 1
+      "port-version": 2
     },
     "curlpp": {
       "baseline": "2018-06-15",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b72d99e7315d0669d227580f056f7d4ea7303a58",
+      "version": "8.7.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "02d67d58e781c841960533d52713bb9fffb2c950",
       "version": "8.7.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
