### PR TITLE
[libavif] add dav1d feature

### DIFF
--- a/ports/libavif/portfile.cmake
+++ b/ports/libavif/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         aom AVIF_CODEC_AOM
+        dav1d AVIF_CODEC_DAV1D
 )
 
 vcpkg_cmake_configure(

--- a/ports/libavif/vcpkg.json
+++ b/ports/libavif/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libavif",
   "version-semver": "1.0.4",
+  "port-version": 1,
   "description": "Library for encoding and decoding AVIF files",
   "homepage": "https://github.com/AOMediaCodec/libavif",
   "license": "BSD-2-Clause AND Apache-2.0",
@@ -20,6 +21,12 @@
       "description": "AV1 codec library",
       "dependencies": [
         "aom"
+      ]
+    },
+    "dav1d": {
+      "description": "dav1d decoder library",
+      "dependencies": [
+        "dav1d"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4186,7 +4186,7 @@
     },
     "libavif": {
       "baseline": "1.0.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libb2": {
       "baseline": "0.98.1",

--- a/versions/l-/libavif.json
+++ b/versions/l-/libavif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5464a231b3a83e3d8a076b339d93c5247d04b36b",
+      "version-semver": "1.0.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "c605ded0da0ce19d14810f9d5f6d430965facbbb",
       "version-semver": "1.0.4",
       "port-version": 0


### PR DESCRIPTION

This feature adds dav1d (AV1 decoder) to libavif which is smaller and way faster than the AOM one that's already there.

I'm actually not sure if you consider this a feature or an alternative. It's a bit of an edge case. The decoder itself is definitely an alternative to the one that's already there, but: libavif supports several codecs at once so adding both aom and dav1d at the same time works, and the user can choose the preferred codec via libavif's API surface. So pedantically spoken it adds and doesn't take away.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md). (...ish)
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
