### PR TITLE
[gdk-pixbuf] jpeg and tiff support windows

### DIFF
--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.10",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",
@@ -39,7 +39,6 @@
     },
     "jpeg": {
       "description": "Enable JPEG loader (requires libjpeg)",
-      "supports": "!windows",
       "dependencies": [
         "libjpeg-turbo"
       ]
@@ -52,7 +51,6 @@
     },
     "tiff": {
       "description": "Enable TIFF loader (requires libtiff)",
-      "supports": "!windows",
       "dependencies": [
         {
           "name": "tiff",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -361,6 +361,8 @@ gamenetworkingsockets:x64-android=fail
 # VS 2022 Update 3 seems to have broken Gazebo: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1522474
 # gazebo is broken due it depend on old ports that already in the new versions.
 # There is an open PR that try to fix that.
+gazebo:x64-windows=fail
+gazebo:x86-windows=fail
 gazebo:x64-linux=fail
 gdk-pixbuf:arm-neon-android=fail
 gdk-pixbuf:arm64-android=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -420,6 +420,7 @@ gstreamer:x64-android=fail
 # upstream issue https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1629.
 gstreamer:x64-windows-static = skip
 gstreamer:x64-windows-static-md = skip
+gtk:x64-windows-static-md=fail
 gul14:arm-neon-android=fail
 gul14:arm64-android=fail
 gul14:x64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2958,7 +2958,7 @@
     },
     "gdk-pixbuf": {
       "baseline": "2.42.10",
-      "port-version": 5
+      "port-version": 6
     },
     "gemmlowp": {
       "baseline": "2021-09-28",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20f10a57d8a363c929b92c881e25750db32f59fe",
+      "version": "2.42.10",
+      "port-version": 6
+    },
+    {
       "git-tree": "42ac551a9c1a0035116dd3fa21f6d5e0c34085f3",
       "version": "2.42.10",
       "port-version": 5


### PR DESCRIPTION
Amends https://github.com/microsoft/vcpkg/pull/38033.
Fixes #38360.
