### PR TITLE
[mp3lame] Changes to allow compiling osx with osxcross

### DIFF
--- a/ports/mp3lame/portfile.cmake
+++ b/ports/mp3lame/portfile.cmake
@@ -99,6 +99,10 @@ else()
         list(APPEND OPTIONS --with-pic=yes)
     endif()
 
+    if(VCPKG_TARGET_IS_OSX AND VCPKG_CROSSCOMPILING AND VCPKG_OSX_ARCHITECTURES STREQUAL "x86_64")
+        list(APPEND OPTIONS --host "${VCPKG_OSX_ARCHITECTURES}-apple-darwin")
+    endif()
+
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"
         DETERMINE_BUILD_TRIPLET

--- a/ports/mp3lame/vcpkg.json
+++ b/ports/mp3lame/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mp3lame",
   "version": "3.100",
-  "port-version": 12,
+  "port-version": 13,
   "description": "LAME is a high quality MPEG Audio Layer III (MP3) encoder licensed under the LGPL.",
   "homepage": "https://sourceforge.net/projects/lame",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5850,7 +5850,7 @@
     },
     "mp3lame": {
       "baseline": "3.100",
-      "port-version": 12
+      "port-version": 13
     },
     "mpark-patterns": {
       "baseline": "2019-10-03",

--- a/versions/m-/mp3lame.json
+++ b/versions/m-/mp3lame.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f47ad3d675167ae285f37a1a68b85f29f6e7731",
+      "version": "3.100",
+      "port-version": 13
+    },
+    {
       "git-tree": "af04a48e3995bd88563c0dab302c5c7793e09173",
       "version": "3.100",
       "port-version": 12


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.