### PR TITLE
[libxcrypt] Add build requirements

### DIFF
--- a/ports/libxcrypt/portfile.cmake
+++ b/ports/libxcrypt/portfile.cmake
@@ -1,5 +1,20 @@
 set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS enabled)
 
+# Requirements from https://github.com/besser82/libxcrypt?tab=readme-ov-file#build-requirements-and-instructions
+message(
+"${PORT} currently requires the following libraries from the system package manager:
+    autoconf automake libtool pkg-config
+These can be installed on Debian systems via sudo apt install autoconf automake libtool pkg-config"
+)
+find_program(AUTORECONF_BIN autoreconf)
+if(NOT AUTORECONF_BIN)
+    message(FATAL_ERROR "${PORT} requires autoconf from the system package manager (example: \"sudo apt install autoconf\")")
+endif()
+find_program(LIBTOOL_BIN libtoolize)
+if(NOT LIBTOOL_BIN)
+    message(FATAL_ERROR "${PORT} requires libtool from the system package manager (example: \"sudo apt install libtool\")")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO besser82/libxcrypt

--- a/ports/libxcrypt/vcpkg.json
+++ b/ports/libxcrypt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libxcrypt",
   "version": "4.4.36",
+  "port-version": 1,
   "description": "libxcrypt is a modern library for one-way hashing of passwords. On Linux-based systems, by default libxcrypt will be binary backward compatible with the libcrypt.so.1 shipped as part of the GNU C Library.",
   "homepage": "https://github.com/besser82/libxcrypt",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5182,7 +5182,7 @@
     },
     "libxcrypt": {
       "baseline": "4.4.36",
-      "port-version": 0
+      "port-version": 1
     },
     "libxcvt": {
       "baseline": "0.1.2",

--- a/versions/l-/libxcrypt.json
+++ b/versions/l-/libxcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89d7de97e87cb0eb10479d47ec43e1cc732b2734",
+      "version": "4.4.36",
+      "port-version": 1
+    },
+    {
       "git-tree": "85a0274aca1b0c7bf756cb41f77d9dbfc2b6fb78",
       "version": "4.4.36",
       "port-version": 0


### PR DESCRIPTION
Fix #38372

Add message of build requirements `autoconf` `automake` `libtool` `pkg-config` from [upstream README](https://github.com/besser82/libxcrypt?tab=readme-ov-file#build-requirements-and-instructions)

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
Port install tests pass with following triplets:
* x64-linux