### PR TITLE
[portmidi] Changes to allow compiling osx with osxcross

### DIFF
--- a/ports/portmidi/framework_link.patch
+++ b/ports/portmidi/framework_link.patch
@@ -35,14 +35,14 @@ index 062887b..e474244 100644
 +      ${CMAKE_THREAD_LIBS_INIT}
 +      -Wl,-framework,CoreAudio
 +      -Wl,-framework,CoreFoundation
-+      -Wl,-framework,CoreMidi
++      -Wl,-framework,CoreMIDI
 +      -Wl,-framework,CoreServices)
 +  target_link_libraries(portmidi
 +    PRIVATE
 +      Threads::Threads
 +      -Wl,-framework,CoreAudio
 +      -Wl,-framework,CoreFoundation
-+      -Wl,-framework,CoreMidi
++      -Wl,-framework,CoreMIDI
 +      -Wl,-framework,CoreServices)
    # set to CMake default; is this right?:
    set_target_properties(portmidi PROPERTIES MACOSX_RPATH ON)

--- a/ports/portmidi/vcpkg.json
+++ b/ports/portmidi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "portmidi",
   "version": "2.0.4",
-  "port-version": 3,
+  "port-version": 4,
   "description": "PortMidi is a cross platform (Windows, macOS, Linux, and BSDs which support alsalib) library for interfacing with operating systems' MIDI I/O APIs.",
   "homepage": "https://github.com/PortMidi/portmidi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6918,7 +6918,7 @@
     },
     "portmidi": {
       "baseline": "2.0.4",
-      "port-version": 3
+      "port-version": 4
     },
     "portsmf": {
       "baseline": "239",

--- a/versions/p-/portmidi.json
+++ b/versions/p-/portmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80f6a561c4ffc824ab014c4c1dfb641023b38cdb",
+      "version": "2.0.4",
+      "port-version": 4
+    },
+    {
       "git-tree": "2e836f32941f2eb402cecca7bff1e0ec566c4287",
       "version": "2.0.4",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.