### PR TITLE
[scnlib] Fix scn-config.cmake dependency error

### DIFF
--- a/ports/scnlib/fix_usage.patch
+++ b/ports/scnlib/fix_usage.patch
@@ -7,11 +7,11 @@ index 5e9dfa1..5f0fd55 100644
  
  if (@SCN_USE_EXTERNAL_SIMDUTF@)
 -    find_dependency(simdutf 4.0.0)
-+    find_package(simdutf CONFIG REQUIRED)
++    find_dependency(simdutf)
  endif ()
  if (@SCN_USE_EXTERNAL_FAST_FLOAT@)
 -    find_dependency(FastFloat 6.0.0)
-+    find_package(FastFloat CONFIG REQUIRED)
++    find_dependency(FastFloat)
  endif ()
  
  if ((@SCN_REGEX_BACKEND@ STREQUAL "Boost") AND @SCN_USE_EXTERNAL_REGEX_BACKEND@)

--- a/ports/scnlib/fix_usage.patch
+++ b/ports/scnlib/fix_usage.patch
@@ -1,0 +1,17 @@
+diff --git a/cmake/scn-config.cmake.in b/cmake/scn-config.cmake.in
+index 5e9dfa1..5f0fd55 100644
+--- a/cmake/scn-config.cmake.in
++++ b/cmake/scn-config.cmake.in
+@@ -8,10 +8,10 @@ if (UNIX)
+ endif ()
+ 
+ if (@SCN_USE_EXTERNAL_SIMDUTF@)
+-    find_dependency(simdutf 4.0.0)
++    find_package(simdutf CONFIG REQUIRED)
+ endif ()
+ if (@SCN_USE_EXTERNAL_FAST_FLOAT@)
+-    find_dependency(FastFloat 6.0.0)
++    find_package(FastFloat CONFIG REQUIRED)
+ endif ()
+ 
+ if ((@SCN_REGEX_BACKEND@ STREQUAL "Boost") AND @SCN_USE_EXTERNAL_REGEX_BACKEND@)

--- a/ports/scnlib/portfile.cmake
+++ b/ports/scnlib/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         fix-SCN_HAS_STD_REGEX_MULTILINE-marco.patch
         remove-simdutf-dependency-version.patch
+        fix_usage.patch
 )
 
 vcpkg_cmake_configure(
@@ -18,7 +19,6 @@ vcpkg_cmake_configure(
       -DSCN_EXAMPLES=OFF
       -DSCN_BENCHMARKS=OFF
       -DSCN_DOCS=OFF
-      -DSCN_RANGES=OFF
       -DSCN_USE_EXTERNAL_SIMDUTF=ON
       -DSCN_USE_EXTERNAL_FAST_FLOAT=ON
 )
@@ -32,6 +32,4 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/scn"
 )
 
-file(INSTALL "${SOURCE_PATH}/LICENSE"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-    RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/scnlib/vcpkg.json
+++ b/ports/scnlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "scnlib",
   "version": "2.0.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "scnlib is a modern C++ library for replacing scanf and std::istream",
   "homepage": "https://scnlib.dev/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7886,7 +7886,7 @@
     },
     "scnlib": {
       "baseline": "2.0.2",
-      "port-version": 1
+      "port-version": 2
     },
     "scope-guard": {
       "baseline": "1.1.0",

--- a/versions/s-/scnlib.json
+++ b/versions/s-/scnlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eec936a91ffd2de9869ae670cdb9d34b9f482519",
+      "version": "2.0.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "2ab6b65ae15e7ce03c1d57ad16ee80f6186dfee5",
       "version": "2.0.2",
       "port-version": 1

--- a/versions/s-/scnlib.json
+++ b/versions/s-/scnlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eec936a91ffd2de9869ae670cdb9d34b9f482519",
+      "git-tree": "1d738fcd95126a94ae210d79017cc8c7a88c3171",
       "version": "2.0.2",
       "port-version": 2
     },


### PR DESCRIPTION
Fix based on [comments](https://github.com/microsoft/vcpkg/pull/38342#:~:text=I%20have%20discovered,dependency%20of%20scnlib)).
When using it, it prompts that the dependent simdutf and FastFloat cannot be found.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```