### PR TITLE
[arrow] Remove the suffix .dll of ws2_32

### DIFF
--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive(
         msvc-static-name.patch
         utf8proc.patch
         thrift.patch
+        remove-dll-suffix.patch #Upstream PR: https://github.com/apache/arrow/pull/41341
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/arrow/remove-dll-suffix.patch
+++ b/ports/arrow/remove-dll-suffix.patch
@@ -1,0 +1,39 @@
+diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
+index 941f5db..473e380 100644
+--- a/cpp/CMakeLists.txt
++++ b/cpp/CMakeLists.txt
+@@ -711,7 +711,7 @@ list(APPEND ARROW_TEST_LINK_LIBS ${ARROW_GTEST_GMOCK} ${ARROW_GTEST_GTEST_MAIN})
+ if(ARROW_BUILD_BENCHMARKS)
+   set(ARROW_BENCHMARK_LINK_LIBS benchmark::benchmark_main ${ARROW_TEST_LINK_LIBS})
+   if(WIN32)
+-    list(APPEND ARROW_BENCHMARK_LINK_LIBS Shlwapi.dll)
++    list(APPEND ARROW_BENCHMARK_LINK_LIBS Shlwapi)
+   endif()
+ endif()
+ 
+diff --git a/cpp/src/arrow/CMakeLists.txt b/cpp/src/arrow/CMakeLists.txt
+index 5c1b5e3..f16ee55 100644
+--- a/cpp/src/arrow/CMakeLists.txt
++++ b/cpp/src/arrow/CMakeLists.txt
+@@ -163,7 +163,7 @@ if(CMAKE_THREAD_LIBS_INIT)
+ endif()
+ 
+ if(WIN32)
+-  list(APPEND ARROW_SYSTEM_LINK_LIBS "ws2_32.dll")
++  list(APPEND ARROW_SYSTEM_LINK_LIBS "ws2_32")
+ endif()
+ 
+ if(NOT WIN32 AND NOT APPLE AND NOT ANDROID)
+@@ -628,9 +628,9 @@ else()
+   list(APPEND ARROW_TESTING_STATIC_INSTALL_INTERFACE_LIBS ArrowTesting::gtest)
+ endif()
+ if(WIN32)
+-  list(APPEND ARROW_TESTING_SHARED_LINK_LIBS "ws2_32.dll")
+-  list(APPEND ARROW_TESTING_STATIC_LINK_LIBS "ws2_32.dll")
+-  list(APPEND ARROW_TESTING_STATIC_INSTALL_INTERFACE_LIBS "ws2_32.dll")
++  list(APPEND ARROW_TESTING_SHARED_LINK_LIBS "ws2_32")
++  list(APPEND ARROW_TESTING_STATIC_LINK_LIBS "ws2_32")
++  list(APPEND ARROW_TESTING_STATIC_INSTALL_INTERFACE_LIBS "ws2_32")
+ endif()
+ 
+ set(ARROW_TESTING_SRCS

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arrow",
   "version": "16.0.0",
+  "port-version": 1,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "413da38f4ffabc5fd1273aff3ed2a7c6226f1ba6",
+      "version": "16.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d68c109745e79bf3ae813428bd0cfda562790381",
       "version": "16.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -242,7 +242,7 @@
     },
     "arrow": {
       "baseline": "16.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "arsenalgear": {
       "baseline": "2.1.0",


### PR DESCRIPTION
Fixes #38305, the upstream issue https://github.com/apache/arrow/issues/41340 and PR https://github.com/apache/arrow/pull/41341.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
