### PR TITLE
[amd-amf] Update to 1.4.33

### DIFF
--- a/ports/amd-amf/portfile.cmake
+++ b/ports/amd-amf/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO GPUOpen-LibrariesAndSDKs/AMF
-        REF "v${VERSION}"
-        SHA512 43d7d3c05cb385cc5b0b76562dae3f8d5fb0123300291019ddce1032eec55a664290bd9b0552073d3a5cc7036886a015d9edb1f17e2f0f8ffd07acf57360ec18
-        HEAD_REF master
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO GPUOpen-LibrariesAndSDKs/AMF
+    REF "v${VERSION}"
+    SHA512 43d7d3c05cb385cc5b0b76562dae3f8d5fb0123300291019ddce1032eec55a664290bd9b0552073d3a5cc7036886a015d9edb1f17e2f0f8ffd07acf57360ec18
+    HEAD_REF master
 )
 
 # Install the AMF headers to the default vcpkg location

--- a/ports/amd-amf/vcpkg.json
+++ b/ports/amd-amf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "amd-amf",
-  "version": "1.4.29",
+  "version": "1.4.33",
   "description": "AMD Advanced Media Framework headers",
   "homepage": "https://github.com/GPUOpen-LibrariesAndSDKs/AMF",
   "license": "MIT",

--- a/versions/a-/amd-amf.json
+++ b/versions/a-/amd-amf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e928a59c07245a0a665b008fc7a9d01cf816450c",
+      "version": "1.4.33",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ab17b71ee3b3f99c9a7c83abd3a4cb1c6c5bcfc",
       "version": "1.4.29",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -101,7 +101,7 @@
       "port-version": 0
     },
     "amd-amf": {
-      "baseline": "1.4.29",
+      "baseline": "1.4.33",
       "port-version": 0
     },
     "ampl-asl": {


### PR DESCRIPTION
Update `amd-amf` to 1.4.33.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
