### PR TITLE
[approval-tests-cpp] Update to 10.13.0

### DIFF
--- a/ports/approval-tests-cpp/portfile.cmake
+++ b/ports/approval-tests-cpp/portfile.cmake
@@ -1,14 +1,14 @@
 vcpkg_download_distfile(single_header
-    URLS https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.12.2/ApprovalTests.v.10.12.2.hpp
-    FILENAME ApprovalTests.v.10.12.2.hpp
-    SHA512 ed59736f52afff246409dcf435ad12a8f15697ae80962c456ca877fbf8adcb99af1bb71424ebcb214df719506015aac27006c1cfec174700b1833db64efb3568
+    URLS "https://github.com/approvals/ApprovalTests.cpp/releases/download/v.${VERSION}/ApprovalTests.v.${VERSION}.hpp"
+    FILENAME "ApprovalTests.v.${VERSION}.hpp"
+    SHA512 06887b2a7d9c9a18b052065e5a43bb02aeadb31095f655bf65c17f39271c5ede881afa521597a42820fd30d2680cfc2f2f516a9d74880b2d15bedf259c3881b6
 )
 
 vcpkg_download_distfile(license_file
-    URLS https://raw.githubusercontent.com/approvals/ApprovalTests.cpp/v.10.12.2/LICENSE
-    FILENAME ApprovalTestsLicense.v.10.12.2
+    URLS "https://raw.githubusercontent.com/approvals/ApprovalTests.cpp/v.${VERSION}/LICENSE"
+    FILENAME "ApprovalTestsLicense.v.${VERSION}"
     SHA512 dc6b68d13b8cf959644b935f1192b02c71aa7a5cf653bd43b4480fa89eec8d4d3f16a2278ec8c3b40ab1fdb233b3173a78fd83590d6f739e0c9e8ff56c282557
 )
 
 file(INSTALL "${single_header}" DESTINATION "${CURRENT_PACKAGES_DIR}/include" RENAME ApprovalTests.hpp)
-file(INSTALL "${license_file}" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${license_file}")

--- a/ports/approval-tests-cpp/vcpkg.json
+++ b/ports/approval-tests-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "approval-tests-cpp",
-  "version": "10.12.2",
+  "version": "10.13.0",
   "description": "Approval Tests allow you to verify a chunk of output (such as a file) in one operation as opposed to writing test assertions for each element.",
-  "homepage": "https://github.com/approvals/ApprovalTests.cpp"
+  "homepage": "https://github.com/approvals/ApprovalTests.cpp",
+  "license": "Apache-2.0"
 }

--- a/versions/a-/approval-tests-cpp.json
+++ b/versions/a-/approval-tests-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7443ac60c577f354895635fdf011818f46853ecc",
+      "version": "10.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "84c554ce63a6fb5ba80ecf7b3b27bf7c577471a2",
       "version": "10.12.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -161,7 +161,7 @@
       "port-version": 0
     },
     "approval-tests-cpp": {
-      "baseline": "10.12.2",
+      "baseline": "10.13.0",
       "port-version": 0
     },
     "apr": {


### PR DESCRIPTION
Update `approval-tests-cpp` to the latest version 10.13.0.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
