### PR TITLE
[v8] Get WINDOWS_SDK error log from portfile.cmake

### DIFF
--- a/ports/v8/portfile.cmake
+++ b/ports/v8/portfile.cmake
@@ -1,3 +1,14 @@
+vcpkg_get_windows_sdk(WINDOWS_SDK)
+
+if (WINDOWS_SDK MATCHES "10.")
+    set(LIBFILEPATH "$ENV{WindowsSdkDir}Lib\\${WINDOWS_SDK}\\um\\${TRIPLET_SYSTEM_ARCH}\\Ws2_32.Lib")
+    set(HEADERSPATH "$ENV{WindowsSdkDir}Include\\${WINDOWS_SDK}\\um")
+elseif(WINDOWS_SDK MATCHES "8.")
+    set(LIBFILEPATH "$ENV{WindowsSdkDir}Lib\\winv6.3\\um\\${TRIPLET_SYSTEM_ARCH}\\Ws2_32.Lib")
+    set(HEADERSPATH "$ENV{WindowsSdkDir}Include\\um")
+else()
+    message(FATAL_ERROR "Portfile not yet configured for Windows SDK with version: ${WINDOWS_SDK}")
+endif()
 
 set(pkgver "9.1.269.39")
 

--- a/ports/v8/vcpkg.json
+++ b/ports/v8/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "v8",
   "version": "9.1.269.39",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Google Chrome's JavaScript engine",
   "homepage": "https://v8.dev",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9002,7 +9002,7 @@
     },
     "v8": {
       "baseline": "9.1.269.39",
-      "port-version": 6
+      "port-version": 7
     },
     "valijson": {
       "baseline": "1.0.2",

--- a/versions/v-/v8.json
+++ b/versions/v-/v8.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c1c08507b831b135750030ed12b1d86e89c3462d",
+      "version": "9.1.269.39",
+      "port-version": 7
+    },
+    {
       "git-tree": "ab4cfc5f196adbe34d9a4d75758137c5fddaafe9",
       "version": "9.1.269.39",
       "port-version": 6


### PR DESCRIPTION
Fixes comments: https://github.com/microsoft/vcpkg/issues/15351#issuecomment-752072575

v8 errors regarding the SDK are currently reported from upstream GN, this error message should be reported in portfile.cmake rather than in the failure log. Adding judgment print messages makes it easier to view errors.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
