### PR TITLE
[libjxl] Fix build failures in linux

### DIFF
--- a/ports/libjxl/portfile.cmake
+++ b/ports/libjxl/portfile.cmake
@@ -57,7 +57,7 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 if(JPEGXL_ENABLE_TOOLS)
-    vcpkg_copy_tools(TOOL_NAMES cjxl djxl cjpeg_hdr jxlinfo AUTO_CLEAN)
+    vcpkg_copy_tools(TOOL_NAMES cjxl djxl jxlinfo AUTO_CLEAN)
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/libjxl/vcpkg.json
+++ b/ports/libjxl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libjxl",
   "version-semver": "0.10.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "JPEG XL image format reference implementation",
   "homepage": "https://github.com/libjxl/libjxl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4554,7 +4554,7 @@
     },
     "libjxl": {
       "baseline": "0.10.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libkeyfinder": {
       "baseline": "2.2.8",

--- a/versions/l-/libjxl.json
+++ b/versions/l-/libjxl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3dc92cfa2158aa56d401920855db77bb200395bf",
+      "version-semver": "0.10.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "bbc18681ca0b5dafd7e10b4f8cda55d004b62e9a",
       "version-semver": "0.10.2",
       "port-version": 1


### PR DESCRIPTION
Fix one of https://github.com/microsoft/vcpkg/issues/32398 issue.
When install `libjxl[tools]:x64-linux` will get this error:
````
CMake Error at scripts/cmake/vcpkg_copy_tools.cmake:36 (message):
  Couldn't find tool "cjpeg_hdr":

      "/home/test/Jon/vcpkg/packages/libjxl_x64-linux/bin/cjpeg_hdr" does not exist
````
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.