### PR TITLE
[libuvc] Support more platforms

### DIFF
--- a/ports/libuvc/build_fix.patch
+++ b/ports/libuvc/build_fix.patch
@@ -1,8 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fbaffc9..451b689 100644
+index fbaffc9..672ebb9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -39,10 +39,11 @@ set(SOURCES
+@@ -5,7 +5,6 @@ project(libuvc
+ )
+ 
+ # Additional search scripts path for libusb-1.0, libjpeg, OpenCV
+-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+ 
+ # Xcode and Visual Studio do not using CMAKE_BUILD_TYPE cache variable
+ # so we use Release build type only with single configuration generators.
+@@ -39,10 +38,11 @@ set(SOURCES
    src/misc.c
  )
  
@@ -16,15 +24,32 @@ index fbaffc9..451b689 100644
  if(JPEG_FOUND)
    message(STATUS "Building libuvc with JPEG support.")
    set(LIBUVC_HAS_JPEG TRUE)
-@@ -116,7 +117,7 @@ foreach(target_name IN LISTS UVC_TARGETS)
+@@ -116,8 +116,11 @@ foreach(target_name IN LISTS UVC_TARGETS)
    )
    target_link_libraries(${target_name}
      # libusb-1.0 used internally so we link to it privately.
 -    PRIVATE LibUSB::LibUSB ${threads}
 +    PRIVATE PkgConfig::libusb ${threads}
    )
++  if(APPLE)
++    target_link_libraries(${target_name} PRIVATE "-framework IOKit" "-framework CoreFoundation" "-framework Security")
++  endif()
    if(JPEG_FOUND)
      target_link_libraries(${target_name}
+       PRIVATE JPEG::JPEG
+@@ -191,12 +194,6 @@ install(EXPORT libuvcTargets
+   DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
+ )
+ 
+-install(FILES 
+-    cmake/FindLibUSB.cmake
+-    cmake/FindJpegPkg.cmake
+-  DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
+-)
+-
+ include(CMakePackageConfigHelpers)
+ write_basic_package_version_file(libuvcConfigVersion.cmake
+   COMPATIBILITY AnyNewerVersion
 diff --git a/libuvcConfig.cmake b/libuvcConfig.cmake
 index b9887ea..c704ab5 100644
 --- a/libuvcConfig.cmake

--- a/ports/libuvc/portfile.cmake
+++ b/ports/libuvc/portfile.cmake
@@ -13,20 +13,22 @@ else()
     set(BUILD_TARGET "Static")
 endif()
 
+vcpkg_find_acquire_program(PKGCONFIG)
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
+        -DPKG_CONFIG_EXECUTABLE="${PKGCONFIG}"
         -DCMAKE_BUILD_TARGET=${BUILD_TARGET}
         -DBUILD_EXAMPLE=OFF
+        -DBUILD_TEST=OFF
 )
 vcpkg_cmake_install()
 
-vcpkg_copy_pdbs()
-
-vcpkg_cmake_config_fixup(PACKAGE_NAME libuvc CONFIG_PATH lib/cmake/libuvc)
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
-
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
-# Handle copyright
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libuvc/usage
+++ b/ports/libuvc/usage
@@ -5,4 +5,4 @@ libuvc provides CMake targets:
 
 libuvc provides pkg-config modules:
 
-    libuvc
+  libuvc

--- a/ports/libuvc/usage
+++ b/ports/libuvc/usage
@@ -1,0 +1,8 @@
+libuvc provides CMake targets:
+
+  find_package(libuvc CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:LibUVC::UVCStatic>,LibUVC::UVCStatic,LibUVC::UVCShared>)
+
+libuvc provides pkg-config modules:
+
+    libuvc

--- a/ports/libuvc/vcpkg.json
+++ b/ports/libuvc/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libuvc",
   "version": "0.0.7",
+  "port-version": 1,
   "description": "a cross-platform library for USB video devices",
   "homepage": "https://github.com/libuvc/libuvc",
-  "supports": "linux",
+  "supports": "!uwp & !windows",
   "dependencies": [
     "libjpeg-turbo",
     "libusb",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5126,7 +5126,7 @@
     },
     "libuvc": {
       "baseline": "0.0.7",
-      "port-version": 0
+      "port-version": 1
     },
     "libvault": {
       "baseline": "0.56.0",

--- a/versions/l-/libuvc.json
+++ b/versions/l-/libuvc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8afe81e02f6056b5c776cc11f452a8d9d25a5de2",
+      "version": "0.0.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "930185d807e87c0ebec6aefd21e2ca336ee0cc3c",
       "version": "0.0.7",
       "port-version": 0

--- a/versions/l-/libuvc.json
+++ b/versions/l-/libuvc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8afe81e02f6056b5c776cc11f452a8d9d25a5de2",
+      "git-tree": "7cf3400169bca9ff80a66ef8489038932eeed047",
       "version": "0.0.7",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
