### PR TITLE
[krb5, curl] Add new port, and add new feature curl[gssapi]

### DIFF
--- a/ports/curl/dependencies.patch
+++ b/ports/curl/dependencies.patch
@@ -74,3 +74,18 @@ index 049ac34..cc0fe19 100644
    if(LIBSSH2_FOUND)
      list(APPEND CURL_LIBS ${LIBSSH2_LIBRARY})
      list(APPEND CMAKE_REQUIRED_INCLUDES "${LIBSSH2_INCLUDE_DIR}")
+@@ -917,6 +917,14 @@ option(CURL_USE_GSSAPI "Use GSSAPI implementation (right now only Heimdal is sup
+ mark_as_advanced(CURL_USE_GSSAPI)
+ 
+ if(CURL_USE_GSSAPI)
++  find_package(PkgConfig REQUIRED)
++  pkg_check_modules(KRB5 REQUIRED krb5 krb5-gssapi)
++  list(APPEND CURL_LIBS ${KRB5_LINK_LIBRARIES} resolv)
++  set(HAVE_GSSAPI_GSSAPI_H ON)
++  set(HAVE_GSSAPI_GSSAPI_GENERIC_H ON)
++  set(HAVE_GSSAPI_GSSAPI_KRB5_H ON)
++  set(HAVE_GSSAPI ON)
++  elseif(0)
+   find_package(GSS)
+ 
+   set(HAVE_GSSAPI ${GSS_FOUND})

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -46,6 +46,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         websockets  ENABLE_WEBSOCKETS
         zstd        CURL_ZSTD
         psl         CURL_USE_LIBPSL
+        gssapi      CURL_USE_GSSAPI
     INVERTED_FEATURES
         ldap        CURL_DISABLE_LDAP
         ldap        CURL_DISABLE_LDAPS

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curl",
   "version": "8.7.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",
@@ -31,6 +31,12 @@
       "description": "c-ares support",
       "dependencies": [
         "c-ares"
+      ]
+    },
+    "gssapi": {
+      "description": "krb5 support",
+      "dependencies": [
+        "krb5"
       ]
     },
     "http2": {

--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}/src"
     AUTOCONFIG
     OPTIONS
-    CFLAGS=-fcommon
+        "CFLAGS=-fcommon \$CFLAGS"
 )
 
 vcpkg_install_make()
@@ -28,5 +28,10 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/krb5/")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/krb5/")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/var")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/var")
+
+# remove due to absolute path error
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/krb5/bin/compile_et")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/krb5/bin/krb5-config")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/krb5/debug/")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/copyright.rst")

--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://kerberos.org/dist/krb5/1.21/krb5-${VERSION}.tar.gz"
+    FILENAME "krb5-${VERSION}.tar.gz"
+    SHA512 4e09296b412383d53872661718dbfaa90201e0d85f69db48e57a8d4bd73c95a90c7ec7b6f0f325f6bc967f8d203b256b071c0191facf080aca0e2caec5d0ac49
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}/src"
+    AUTOCONFIG
+    OPTIONS
+    CFLAGS=-fcommon
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat1")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat5")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat7")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat8")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/krb5/")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/krb5/")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/var")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/var")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/copyright.rst")

--- a/ports/krb5/vcpkg.json
+++ b/ports/krb5/vcpkg.json
@@ -3,5 +3,6 @@
   "version": "1.21.2",
   "description": "Network authentication protocol",
   "homepage": "https://web.mit.edu/kerberos/",
-  "license": "MIT"
+  "license": "MIT",
+  "supports": "linux"
 }

--- a/ports/krb5/vcpkg.json
+++ b/ports/krb5/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "krb5",
+  "version": "1.21.2",
+  "description": "Network authentication protocol",
+  "homepage": "https://web.mit.edu/kerberos/",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2078,7 +2078,7 @@
     },
     "curl": {
       "baseline": "8.7.1",
-      "port-version": 2
+      "port-version": 3
     },
     "curlpp": {
       "baseline": "2018-06-15",
@@ -4034,6 +4034,10 @@
     },
     "krabsetw": {
       "baseline": "4.3.2",
+      "port-version": 0
+    },
+    "krb5": {
+      "baseline": "1.21.2",
       "port-version": 0
     },
     "ktx": {

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32945fcb82088dc4055db602b3ebe95f67f04326",
+      "version": "8.7.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "b72d99e7315d0669d227580f056f7d4ea7303a58",
       "version": "8.7.1",
       "port-version": 2

--- a/versions/k-/krb5.json
+++ b/versions/k-/krb5.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "287bac02bb53283b043688050edd9d02e0b039c7",
+      "version": "1.21.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

krb5 have an issue of absolute paths that I am not sure how to fix, also I didn't succeeded to compile it on windows, but this PR is a good start. 

```
warning: There should be no absolute paths, such as the following, in an installed package:
  /home/tal/vcpkg/packages/krb5_x64-linux
  /home/tal/vcpkg/installed
  /home/tal/vcpkg/buildtrees/krb5
  /home/tal/vcpkg/downloads
Absolute paths were found in the following files:
  /home/tal/vcpkg/packages/krb5_x64-linux/tools/krb5/bin/compile_et
  /home/tal/vcpkg/packages/krb5_x64-linux/tools/krb5/bin/krb5-config
  /home/tal/vcpkg/packages/krb5_x64-linux/tools/krb5/debug/bin/compile_et
  /home/tal/vcpkg/packages/krb5_x64-linux/tools/krb5/debug/bin/krb5-config
error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: /home/tal/vcpkg/ports/krb5/portfile.cmake
```