### PR TITLE
[cppzmq] add websocket feature

### DIFF
--- a/ports/cppzmq/vcpkg.json
+++ b/ports/cppzmq/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cppzmq",
   "version": "4.10.0",
+  "port-version": 1,
   "description": "Header-only C++ binding for ZeroMQ",
   "homepage": "https://github.com/zeromq/cppzmq",
   "license": "MIT",
@@ -24,6 +25,18 @@
           "default-features": false,
           "features": [
             "draft"
+          ]
+        }
+      ]
+    },
+    "websockets": {
+      "description": "Enable WebSocket transport",
+      "dependencies": [
+        {
+          "name": "zeromq",
+          "default-features": false,
+          "features": [
+            "websockets"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1962,7 +1962,7 @@
     },
     "cppzmq": {
       "baseline": "4.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cpr": {
       "baseline": "1.10.5",

--- a/versions/c-/cppzmq.json
+++ b/versions/c-/cppzmq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46733bb185a6545300caadfef1b430d73a9f3fcf",
+      "version": "4.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8e7a8ca62f55304268afb4ddd9220cc39d6b4831",
       "version": "4.10.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #38407 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
