### PR TITLE
[arpack-ng] Update version to 3.9.1

### DIFF
--- a/ports/arpack-ng/portfile.cmake
+++ b/ports/arpack-ng/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO opencollab/arpack-ng
     REF ${VERSION}
-    SHA512 fbcaa2179dd1aa5a39fc3e7d80f377ec90ddf16ef93184a88e6ecfc464ed97e5659f2cf578294ac3e0b0c0da6408c86acf5bbdce533e1e9d2a3121848340d282
+    SHA512 1ca590a8c4f75aa74402f9bd62e63851039687f4cb11afa8acb05fce1f22a512bff5fd1709ea85fdbea90b344fbbc01e3944c770b5ddc4d1aabc98ac334f78d2
     HEAD_REF master
 )
 

--- a/ports/arpack-ng/vcpkg.json
+++ b/ports/arpack-ng/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "arpack-ng",
-  "version": "3.9.0",
-  "port-version": 1,
+  "version": "3.9.1",
   "description": "ARPACK-NG is a collection of Fortran77 subroutines designed to solve large scale eigenvalue problems.",
   "homepage": "https://github.com/opencollab/arpack-ng",
   "license": "BSD-3-Clause",

--- a/versions/a-/arpack-ng.json
+++ b/versions/a-/arpack-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7dd6a7103d3c8f2b5377921d2edc2b29d330a531",
+      "version": "3.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8bee9f6f6141b136982fd4b4b1d7e6a4a6d9a0df",
       "version": "3.9.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -233,8 +233,8 @@
       "port-version": 1
     },
     "arpack-ng": {
-      "baseline": "3.9.0",
-      "port-version": 1
+      "baseline": "3.9.1",
+      "port-version": 0
     },
     "arrayfire": {
       "baseline": "3.8.0",


### PR DESCRIPTION
Update `arpack-ng` version to 3.9.1

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.