### PR TITLE
[neoslippi] Add neoslippi

### DIFF
--- a/ports/neoslippi/portfile.cmake
+++ b/ports/neoslippi/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            neoslippi
+    FILENAME        "NeoSlippi-${VERSION}.zip"
+    SHA512          a1fdd19c0de2e59d3de778be98216702a9c1de05a87b6d7126a6d1ef96c270624f4890ae8d6199498d91e89d2b8219381cb1bf15d29730a402d5152f05c7ea6c
+    NO_REMOVE_ONE_LEVEL
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_TESTING=False
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/NeoSlippi)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(COPY "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/neoslippi/usage
+++ b/ports/neoslippi/usage
@@ -1,0 +1,5 @@
+neoslippi provides CMake targets:
+
+  find_package(NeoSlippi CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE NeoSlippi::NeoSlippi)
+

--- a/ports/neoslippi/vcpkg.json
+++ b/ports/neoslippi/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "neoslippi",
+  "version": "1.0.3.18",
+  "description": "C++ Slippi replay file parser.",
+  "homepage": "https://sourceforge.net/projects/neoslippi/",
+  "license": "MIT",
+  "dependencies": [
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6704,6 +6704,10 @@
       "baseline": "2024-11-24",
       "port-version": 0
     },
+    "neoslippi": {
+      "baseline": "1.0.3.18",
+      "port-version": 0
+    },
     "netcdf-c": {
       "baseline": "4.9.3",
       "port-version": 0

--- a/versions/n-/neoslippi.json
+++ b/versions/n-/neoslippi.json
@@ -1,0 +1,14 @@
+{
+  "versions": [
+    {
+      "git-tree": "b0c3b8d511cc5835218f0fd6f5ebf63580ec0059",
+      "version": "1.0.3.18",
+      "port-version": 0
+    },
+    {
+      "git-tree": "4e7689cb67f0b860e296a85c56782f3270aa9775",
+      "version": "1.0.3.16",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/n-/neoslippi.json
+++ b/versions/n-/neoslippi.json
@@ -4,11 +4,6 @@
       "git-tree": "b0c3b8d511cc5835218f0fd6f5ebf63580ec0059",
       "version": "1.0.3.18",
       "port-version": 0
-    },
-    {
-      "git-tree": "4e7689cb67f0b860e296a85c56782f3270aa9775",
-      "version": "1.0.3.16",
-      "port-version": 0
     }
   ]
 }


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
