### PR TITLE
[opensubdiv] Fix build error with feature tbb

### DIFF
--- a/ports/opensubdiv/fix-notfind-header.patch
+++ b/ports/opensubdiv/fix-notfind-header.patch
@@ -1,0 +1,31 @@
+diff --git a/opensubdiv/osd/tbbEvaluator.cpp b/opensubdiv/osd/tbbEvaluator.cpp
+index c98db9f..5a4bc98 100644
+--- a/opensubdiv/osd/tbbEvaluator.cpp
++++ b/opensubdiv/osd/tbbEvaluator.cpp
+@@ -25,7 +25,10 @@
+ #include "../osd/tbbEvaluator.h"
+ #include "../osd/tbbKernel.h"
+ 
++#if defined(TBB_INTERFACE_VERSION_MAJOR) && (TBB_INTERFACE_VERSION_MAJOR < 12)
++// This is deprecated functionality.
+ #include <tbb/task_scheduler_init.h>
++#endif
+ 
+ namespace OpenSubdiv {
+ namespace OPENSUBDIV_VERSION {
+@@ -215,11 +218,15 @@ TbbEvaluator::Synchronize(void *) {
+ /* static */
+ void
+ TbbEvaluator::SetNumThreads(int numThreads) {
++#if defined(TBB_INTERFACE_VERSION_MAJOR) && (TBB_INTERFACE_VERSION_MAJOR < 12)
++    // This is deprecated functionality. We preserve the existing behavior
++    // for consistency (when using older versions of tbb).
+     if (numThreads == -1) {
+         tbb::task_scheduler_init init;
+     } else {
+         tbb::task_scheduler_init init(numThreads);
+     }
++#endif
+ }
+ 
+ }  // end namespace Osd

--- a/ports/opensubdiv/portfile.cmake
+++ b/ports/opensubdiv/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
         fix-build-type.patch
         fix-dependencies.patch
         fix-feature-cuda.patch
+        fix-notfind-header.patch
 )
 
 if(VCPKG_TARGET_IS_LINUX)

--- a/ports/opensubdiv/vcpkg.json
+++ b/ports/opensubdiv/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opensubdiv",
   "version-semver": "3.5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An Open-Source subdivision surface library.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenSubdiv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6526,7 +6526,7 @@
     },
     "opensubdiv": {
       "baseline": "3.5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "opentelemetry-cpp": {
       "baseline": "1.14.2",

--- a/versions/o-/opensubdiv.json
+++ b/versions/o-/opensubdiv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d12fbded4ab0667d082362ae4b6f57506926c9b",
+      "version-semver": "3.5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "8cc627798709caed394f31456098644f359f0936",
       "version-semver": "3.5.0",
       "port-version": 1


### PR DESCRIPTION
Fix one of https://github.com/microsoft/vcpkg/issues/32398 issue.
When install opensubdiv[core,tbb]:x64-windows and  opensubdiv[core,tbb]:x64-linux will get this error:
````
FAILED: opensubdiv/osd/CMakeFiles/osd_cpu_obj.dir/tbbEvaluator.cpp.obj 
C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1439~1.335\bin\Hostx64\x64\cl.exe   /TP -DNOMINMAX -DOPENSUBDIV_HAS_TBB -DOPENSUBDIV_VERSION_STRING=\"3.5.0\" -DTBB_USE_DEBUG -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES -IF:\test\vcpkg\buildtrees\opensubdiv\src\a0796b160c-fe5b1b6d5d\opensubdiv -IF:\test\vcpkg\buildtrees\opensubdiv\x64-windows-dbg\opensubdiv\osd -external:IF:\test\vcpkg\installed\x64-windows\include -external:W0 /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP   /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1    /Wall /W3 /wd4005 /wd4350 /wd4548 /showIncludes /Foopensubdiv\osd\CMakeFiles\osd_cpu_obj.dir\tbbEvaluator.cpp.obj /Fdopensubdiv\osd\CMakeFiles\osd_cpu_obj.dir\ /FS -c F:\test\vcpkg\buildtrees\opensubdiv\src\a0796b160c-fe5b1b6d5d\opensubdiv\osd\tbbEvaluator.cpp
F:\test\vcpkg\buildtrees\opensubdiv\src\a0796b160c-fe5b1b6d5d\opensubdiv\osd\tbbEvaluator.cpp(28): fatal error C1083: Cannot open include file: 'tbb/task_scheduler_init.h': No such file or directory
````
Because the task_scheduler_init.h header file no longer exists in the latest [Tbb](https://github.com/oneapi-src/oneTBB/tree/master/include/tbb) file, I refer to the [upstream](https://github.com/PixarAnimationStudios/OpenSubdiv/blob/7d0ab5530feef693ac0a920585b5c663b80773b3/opensubdiv/osd/tbbEvaluator.cpp#L30) modification to add judgment conditions to ensure that the old version is available.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
