### PR TITLE
[luafilesystem] Add cmake files

### DIFF
--- a/ports/luafilesystem/CMakeLists.txt
+++ b/ports/luafilesystem/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.11)
 project(luafilesystem)
 
 find_path(LUA_INCLUDE_DIR lua.h PATH_SUFFIXES lua)
@@ -6,12 +6,38 @@ find_library(LUA_LIBRARY lua)
 set(LFS_INCLUDES ${LUA_INCLUDE_DIR})
 set(LFS_LIBRARIES ${LUA_LIBRARY})
 
-add_library( lfs src/lfs.h src/lfs.c src/lfs.def)
+add_library(lfs src/lfs.h src/lfs.c src/lfs.def)
 
 target_include_directories(lfs PRIVATE ${LFS_INCLUDES})
 target_link_libraries(lfs PRIVATE ${LFS_LIBRARIES})
 
 install(TARGETS lfs
+    EXPORT "unofficial-${PROJECT_NAME}-targets"
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/unofficial-${PROJECT_NAME}-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake"
+  INSTALL_DESTINATION "share/unofficial-${PROJECT_NAME}"
+)
+
+set(VERSION_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config-version.cmake")
+write_basic_package_version_file(
+  "${VERSION_FILE_PATH}"
+  VERSION       "${LFS_VERSION}"
+  COMPATIBILITY SameMajorVersion
+)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake"
+  DESTINATION "share/unofficial-${PROJECT_NAME}"
+)
+
+install(
+  EXPORT      "unofficial-${PROJECT_NAME}-targets"
+  NAMESPACE   "unofficial::${PROJECT_NAME}::"
+  DESTINATION "share/unofficial-${PROJECT_NAME}")

--- a/ports/luafilesystem/portfile.cmake
+++ b/ports/luafilesystem/portfile.cmake
@@ -11,16 +11,26 @@ vcpkg_from_github(
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-luafilesystem-config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLFS_VERSION="${VERSION}"
 )
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-luafilesystem")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # Allow empty include directory
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/luafilesystem/unofficial-luafilesystem-config.cmake.in
+++ b/ports/luafilesystem/unofficial-luafilesystem-config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-luafilesystem-targets.cmake")
+
+
+check_required_components(luafilesystem)

--- a/ports/luafilesystem/usage
+++ b/ports/luafilesystem/usage
@@ -1,0 +1,4 @@
+luafilesystem provides CMake targets:
+  
+  find_package(unofficial-luafilesystem CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unofficial::luafilesystem::lfs)

--- a/ports/luafilesystem/vcpkg.json
+++ b/ports/luafilesystem/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "luafilesystem",
   "version": "1.8.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "LuaFileSystem is a Lua library developed to complement the set of functions related to file systems offered by the standard Lua distribution.",
   "homepage": "https://github.com/keplerproject/luafilesystem",
   "supports": "!uwp",
@@ -9,6 +9,10 @@
     "lua",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5478,7 +5478,7 @@
     },
     "luafilesystem": {
       "baseline": "1.8.0",
-      "port-version": 5
+      "port-version": 6
     },
     "luajit": {
       "baseline": "2023-01-04",

--- a/versions/l-/luafilesystem.json
+++ b/versions/l-/luafilesystem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b474bdcc3f49eef949ba79ad3294556e39af778",
+      "version": "1.8.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "7a2e981db39265f79730f1c73502dfa362db30b5",
       "version": "1.8.0",
       "port-version": 5


### PR DESCRIPTION
One of two ports for #38340

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- ~[ ] SHA512s are updated for each updated download.~
- ~[ ] The "supports" clause reflects platforms that may be fixed by this new version.~
- ~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- ~[ ] Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
