### PR TITLE
[Thorvg] Update Thorvg port to v0.13.2

### DIFF
--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO thorvg/thorvg
     REF "v${VERSION}"
-    SHA512 2bc5f34ecdf988b755a8efc40dccebdedfa039164d6e23f0560aaa361ed3994620af4d5ab9d66377544b07a1eca4eaebdae8b7761d234da4c4b43075ca9aebb2
+    SHA512 c999789d828dc7d695db72486b85e50f30b5f3f0e583ce0302b24118d733a4baa2c58af4d8e122fd69aba7ad5fe678185a26954b68ffdb5e3e1a31c69072e798
     HEAD_REF master
 )
 

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "thorvg",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8613,7 +8613,7 @@
       "port-version": 0
     },
     "thorvg": {
-      "baseline": "0.13.1",
+      "baseline": "0.13.2",
       "port-version": 0
     },
     "threadpool": {

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af489e2c5bbfe72ec76d833704efb520277951d3",
+      "version": "0.13.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff74a95dc13702754581b945fd22d61e539419a0",
       "version": "0.13.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
