### PR TITLE
[tvision] update to the latest version 2024-02-28

### DIFF
--- a/ports/tvision/portfile.cmake
+++ b/ports/tvision/portfile.cmake
@@ -1,15 +1,16 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO magiblot/tvision
-    REF 638f963fe4f6c84854f60f1e9c5772bf6603e4b2
+    REF d1fa783e0fa8685c199563a466cdc221e8d9b85c
     HEAD_REF master
-    SHA512 87c26fed26a332dd4b2a431dfbe0f8629d6565c59f61a3968fc658beda313ee8dad9bb59f53d47b1d664c0494841850b09e5c05533b2a74a372cc03548def2c5
+    SHA512 84c7c4f47274fa4976004b2d542e47446f4bb3eca54b4426f19a2de5e381eb78e42d87f12ab00d7d6ceb05d3d32462da2c02dc3e4a7ef06e3f6fcbbe87c30ac1
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DTV_BUILD_EXAMPLES=OFF
+        -DTV_BUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()
@@ -18,4 +19,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/ports/tvision/vcpkg.json
+++ b/ports/tvision/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tvision",
-  "version-date": "2021-08-10",
-  "port-version": 1,
+  "version-date": "2024-02-28",
   "description": "A modern port of Turbo Vision 2.0, the classical framework for text-based user interfaces.",
   "homepage": "https://github.com/magiblot/tvision",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8853,8 +8853,8 @@
       "port-version": 3
     },
     "tvision": {
-      "baseline": "2021-08-10",
-      "port-version": 1
+      "baseline": "2024-02-28",
+      "port-version": 0
     },
     "tweeny": {
       "baseline": "3.2.0",

--- a/versions/t-/tvision.json
+++ b/versions/t-/tvision.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da8928e7b75f6ad89f6a86a5ed09077fbc4edb1d",
+      "version-date": "2024-02-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "43ab1f9cb4407aab0a936520a82ddee84a48bd92",
       "version-date": "2021-08-10",
       "port-version": 1


### PR DESCRIPTION
Update `tvision` to the latest version 2024-02-28.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
