### PR TITLE
[vcpkg baseline][Qt] Switch binary source to https://code.qt.io/cgit/

### DIFF
--- a/ports/libsrt/vcpkg.json
+++ b/ports/libsrt/vcpkg.json
@@ -16,6 +16,9 @@
       "host": true
     }
   ],
+  "default-features": [
+    "tool"
+  ],
   "features": {
     "bonding": {
       "description": "Enables the Connection Bonding feature"

--- a/ports/libsrt/vcpkg.json
+++ b/ports/libsrt/vcpkg.json
@@ -16,9 +16,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "tool"
-  ],
   "features": {
     "bonding": {
       "description": "Enables the Connection Bonding feature"

--- a/ports/qtbase/cmake/qt_install_submodule.cmake
+++ b/ports/qtbase/cmake/qt_install_submodule.cmake
@@ -19,14 +19,14 @@ function(qt_download_submodule_impl)
         # qtinterfaceframework is not available in the release, so we fall back to a `git clone`.
         vcpkg_from_git(
             OUT_SOURCE_PATH SOURCE_PATH
-            URL "https://code.qt.io/qt/${_qarg_SUBMODULE}.git"
+            URL "https://code.qt.io/cgit/qt/${_qarg_SUBMODULE}.git"
             REF "${${_qarg_SUBMODULE}_REF}"
             PATCHES ${_qarg_PATCHES}
         )
         if(PORT STREQUAL "qttools") # Keep this for beta & rc's
             vcpkg_from_git(
                 OUT_SOURCE_PATH SOURCE_PATH_QLITEHTML
-                URL git://code.qt.io/playground/qlitehtml.git # git://code.qt.io/playground/qlitehtml.git
+                URL git://code.qt.io/cgit/playground/qlitehtml.git # git://code.qt.io/playground/qlitehtml.git
                 REF "${${PORT}_qlitehtml_REF}"
                 FETCH_REF master
                 HEAD_REF master
@@ -44,7 +44,7 @@ function(qt_download_submodule_impl)
         elseif(PORT STREQUAL "qtwebengine")
             vcpkg_from_git(
                 OUT_SOURCE_PATH SOURCE_PATH_WEBENGINE
-                URL git://code.qt.io/qt/qtwebengine-chromium.git
+                URL git://code.qt.io/cgit/qt/qtwebengine-chromium.git
                 REF "${${PORT}_chromium_REF}"
             )
             if(NOT EXISTS "${SOURCE_PATH}/src/3rdparty/chromium")

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.6.1",
-  "port-version": 12,
+  "port-version": 13,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7294,7 +7294,7 @@
     },
     "qtbase": {
       "baseline": "6.6.1",
-      "port-version": 12
+      "port-version": 13
     },
     "qtcharts": {
       "baseline": "6.6.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "567d0f819df86207acab47745ee37705c64d0c36",
+      "version": "6.6.1",
+      "port-version": 13
+    },
+    {
       "git-tree": "25f62a554ceec4eb297697d178df6ac0d231a5ea",
       "version": "6.6.1",
       "port-version": 12


### PR DESCRIPTION
At present, all the original links of qt have expired. https://code.qt.io
```
fatal: unable to access 'https://code.qt.io/qt/qtinterfaceframework.git/': Failed to connect to code.qt.io port 443 after 2824 ms: Couldn't connect to server
```
 Switch binary source to https://code.qt.io/cgit/
 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
