### PR TITLE
[skia] update to 125

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -3,8 +3,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/skia-functions.cmake")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/skia
-    REF "e7bf161ff959268a2a2f37530a6ea61c27019d33"
-    SHA512 9cb0c39c6721c5e27a24bee97c93925b7b1f4dd774c08520384ccdf736ab5097e49692529a9fe46f50ae799e6aa9f3e8d7ec43cf9177914fcd6f6f01b76a52c4
+    REF "ec3813eabd24854a1b82457064e9e3031ccc06d7"
+    SHA512 352572467643693e9da6fbb5e6e466bf8c09f290565770d413729d4dcaad2c210dbb717cc53ab5e963311dd88a082639deba21ff93a68e8b5e0b02b23f816370
     PATCHES
         disable-msvc-env-setup.patch
         disable-dev-test.patch
@@ -31,7 +31,7 @@ declare_external_from_git(d3d12allocator
 )
 declare_external_from_git(dawn
     URL "https://dawn.googlesource.com/dawn.git"
-    REF "bac513d0ae286600ea0f75a75223a5b52a198b9b"
+    REF "f20a53466bc2cd5c86f0f903a9eea322cadf8b77"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(dng_sdk
@@ -61,12 +61,12 @@ declare_external_from_git(spirv-cross
 )
 declare_external_from_git(spirv-headers
     URL "https://github.com/KhronosGroup/SPIRV-Headers.git"
-    REF "8b246ff75c6615ba4532fe4fde20f1be090c3764"
+    REF "4f7b471f1a66b6d06462cd4ba57628cc0cd087d7"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(spirv-tools
     URL "https://github.com/KhronosGroup/SPIRV-Tools.git"
-    REF "f20663ca7fec48fdc88e4c4d7c5889f8b4cc5664"
+    REF "2904985aee4de2fd67d697242a267f5ec31814ce"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(wuffs

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "skia",
-  "version": "124",
+  "version": "125",
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8137,7 +8137,7 @@
       "port-version": 0
     },
     "skia": {
-      "baseline": "124",
+      "baseline": "125",
       "port-version": 0
     },
     "skyr-url": {

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e91664b1af91c4f238329a7f3fedac8abc2d78a6",
+      "version": "125",
+      "port-version": 0
+    },
+    {
       "git-tree": "b993a94ad57f5f651ac7dfa08cf20f17134a1b0d",
       "version": "124",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
