### PR TITLE
[rapidcheck] Upgrade to 2023-12-14.

### DIFF
--- a/ports/rapidcheck/portfile.cmake
+++ b/ports/rapidcheck/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO emil-e/rapidcheck
-    REF 1505cbbce733bde3b78042cf2e9309c0b7f227a2
-    SHA512 4759f84ee71f08108e0ad61436c940e96f494816d6b0d1fda64d880a6cb2eaa54f6422fa2ae680564d8cb8bd52b3589a4a92bed9422077d9b1ee4ee874b6ef7e
+    REF ff6af6fc683159deb51c543b065eba14dfcf329b
+    SHA512 79f1e869a3c55f62d3609cc4b3a56977f720c3eacf5e1792aa3a9bd5ab90aa077371bc0902d6c31503885f9ebcc633ed242ae6995866cb46fd12afdf425500e3
     HEAD_REF master
 )
 
@@ -17,6 +17,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "share/${PORT}/cmake")
 vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/rapidcheck/vcpkg.json
+++ b/ports/rapidcheck/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rapidcheck",
-  "version-date": "2023-01-13",
+  "version-date": "2023-12-14",
   "description": "A property-based testing library for C++ (a la QuickCheck) with the goal of being simple to use with as little boilerplate as possible.",
   "homepage": "https://github.com/emil-e/rapidcheck",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7505,7 +7505,7 @@
       "port-version": 2
     },
     "rapidcheck": {
-      "baseline": "2023-01-13",
+      "baseline": "2023-12-14",
       "port-version": 0
     },
     "rapidcsv": {

--- a/versions/r-/rapidcheck.json
+++ b/versions/r-/rapidcheck.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae0c6ab09dc7d61410a0e349cad8e93eb5df7cd8",
+      "version-date": "2023-12-14",
+      "port-version": 0
+    },
+    {
       "git-tree": "877f68258111c56c800195acac48c034458933d4",
       "version-date": "2023-01-13",
       "port-version": 0


### PR DESCRIPTION
~~Later revisions are available but they introduce pkgconfig support which make vcpkg complain that hard coded file paths are deployed to lib/pkgconfig/*.pc files and I am not sure what to do about them.~~
Upgraded to the latest revision to date.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
