### PR TITLE
[cpptrace] Add v0.5.3

### DIFF
--- a/ports/cpptrace/portfile.cmake
+++ b/ports/cpptrace/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jeremy-rifkin/cpptrace
     REF "v${VERSION}"
-    SHA512 e05a8a070ec7be0a1b36f25901c3ed7b566e4ca69e8e87cde558a0e65743d2dabd4cbad614af32d62a4da4b6a77144853adf7cb1be33335a86f7b1ef2d08c72f
+    SHA512 545d9ccb4484d6324e17eb0e0f24c1593f792340740bf633d948dbbbf5bcf893bc6db3d1aa43edc139a24a3c99a6da7568289c18e1fc4827e1a7e92f5afe508f
     HEAD_REF main
 )
 

--- a/ports/cpptrace/vcpkg.json
+++ b/ports/cpptrace/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpptrace",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Simple, portable, and self-contained stacktrace library for C++11 and newer",
   "homepage": "https://github.com/jeremy-rifkin/cpptrace",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1941,7 +1941,7 @@
       "port-version": 4
     },
     "cpptrace": {
-      "baseline": "0.5.2",
+      "baseline": "0.5.3",
       "port-version": 0
     },
     "cppunit": {

--- a/versions/c-/cpptrace.json
+++ b/versions/c-/cpptrace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b2825a7e9368cf8cb4e49eb096bafc228d4ff37",
+      "version": "0.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "0a6d8ee3f2b6703cd13fc89da435f20ecca0759c",
       "version": "0.5.2",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
