### PR TITLE
[libcerror] Initial Port

### DIFF
--- a/ports/libcerror/portfile.cmake
+++ b/ports/libcerror/portfile.cmake
@@ -64,22 +64,6 @@ vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${options}
-        # Don't use system lib
-        --with-libfuse=no
-        # "no" means: use vendored libyal lib
-        --with-libbfio=no
-        --with-libcdata=no
-        --with-libcerror=no
-        --with-libcfile=no
-        --with-libclocale=no
-        --with-libcnotify=no
-        --with-libcpath=no
-        --with-libcsplit=no
-        --with-libcthreads=no
-        --with-libfcache=no
-        --with-libfdata=no
-        --with-libfguid=no
-        --with-libuna=no
 )
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()

--- a/ports/libcerror/portfile.cmake
+++ b/ports/libcerror/portfile.cmake
@@ -11,8 +11,6 @@ vcpkg_extract_source_archive(SOURCE_PATH
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
     vcpkg_libyal_msvscpp_convert(
         OUT_PROJECT_SUBPATH project_subpath
         SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libcerror/portfile.cmake
+++ b/ports/libcerror/portfile.cmake
@@ -1,0 +1,104 @@
+set(LIB_FILENAME libcerror-beta-${VERSION}.tar.gz)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/libyal/libcerror/releases/download/${VERSION}/${LIB_FILENAME}"
+    FILENAME "${LIB_FILENAME}"
+    SHA512 9fd06098e7d789040ccdbad0d9d824a456cfb6cd90d355a7ea44bbd04bc3d53370025df84721a70fd542b2d691833c4447d4a2230071c3cd987c108a41b73a9b
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+    vcpkg_libyal_msvscpp_convert(
+        OUT_PROJECT_SUBPATH project_subpath
+        SOURCE_PATH "${SOURCE_PATH}"
+        SOLUTION "msvscpp/libcerror.sln"
+    )
+
+    vcpkg_msbuild_install(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PROJECT_SUBPATH "${project_subpath}"
+        DEBUG_CONFIGURATION VSDebug
+    )
+
+    file(GLOB headers "${SOURCE_PATH}/include/libcerror/*.h")
+    file(INSTALL ${headers} DESTINATION "${CURRENT_PACKAGES_DIR}/include/libcerror")
+    file(INSTALL "${SOURCE_PATH}/include/libcerror.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+    file(GLOB tests "${CURRENT_PACKAGES_DIR}/tools/${PORT}/cerror_test*.exe")
+    file(REMOVE_RECURSE ${tests})
+
+    block(SCOPE_FOR VARIABLES)
+        set(prefix [[unused]])
+        set(exec_prefix [[${prefix}]])
+        set(libdir [[${prefiix}/lib]])
+        set(includedir [[${prefix}/include]])
+        configure_file("${SOURCE_PATH}/libcerror.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libcerror.pc" @ONLY)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libcerror.pc" " -lcerror" " -llibcerror")
+        if(NOT VCPKG_BUILD_TYPE)
+            set(includedir [[${prefix}/../include]])
+            configure_file("${SOURCE_PATH}/libcerror.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libcerror.pc" @ONLY)
+            vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libcerror.pc" " -lcerror" " -llibcerror")
+        endif()
+    endblock()
+
+else()
+vcpkg_list(SET options)
+if("nls" IN_LIST FEATURES)
+    vcpkg_list(APPEND options "--enable-nls")
+else()
+    vcpkg_list(APPEND options "--disable-nls")
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND options --with-pthread=no) # may have pthread but not -lpthread
+endif()
+
+vcpkg_configure_make(
+    COPY_SOURCE
+    DETERMINE_BUILD_TRIPLET
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${options}
+        # Don't use system lib
+        --with-libfuse=no
+        # "no" means: use vendored libyal lib
+        --with-libbfio=no
+        --with-libcdata=no
+        --with-libcerror=no
+        --with-libcfile=no
+        --with-libclocale=no
+        --with-libcnotify=no
+        --with-libcpath=no
+        --with-libcsplit=no
+        --with-libcthreads=no
+        --with-libfcache=no
+        --with-libfdata=no
+        --with-libfguid=no
+        --with-libuna=no
+)
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
+
+endif()
+
+file(INSTALL "${CURRENT_PORT_DIR}/unofficial-libcerror-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-libcerror")
+
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${SOURCE_PATH}/include/libcerror/extern.h" "defined( LIBCERROR_DLL_IMPORT )" "1")
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/man1"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/man3"
+    "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libcerror/unofficial-libcerror-config.cmake
+++ b/ports/libcerror/unofficial-libcerror-config.cmake
@@ -1,0 +1,20 @@
+if(NOT TARGET unofficial::libcerror::libcerror)
+    add_library(unofficial::libcerror::libcerror UNKNOWN IMPORTED)
+
+    set_target_properties(unofficial::libcerror::libcerror PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    )
+
+    find_library(VCPKG_LIBCERROR_LIBRARY_RELEASE NAMES cerror libcerror PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib" NO_DEFAULT_PATH)
+    if(EXISTS "${VCPKG_LIBCERROR_LIBRARY_RELEASE}")
+        set_property(TARGET unofficial::libcerror::libcerror APPEND PROPERTY IMPORTED_CONFIGURATIONS "Release")
+        set_target_properties(unofficial::libcerror::libcerror PROPERTIES IMPORTED_LOCATION_RELEASE "${VCPKG_LIBCERROR_LIBRARY_RELEASE}")
+    endif()
+
+    find_library(VCPKG_LIBCERROR_LIBRARY_DEBUG NAMES cerror libcerror PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib" NO_DEFAULT_PATH)
+    if(EXISTS "${VCPKG_LIBCERROR_LIBRARY_DEBUG}")
+        set_property(TARGET unofficial::libcerror::libcerror APPEND PROPERTY IMPORTED_CONFIGURATIONS "Debug")
+        set_target_properties(unofficial::libcerror::libcerror PROPERTIES IMPORTED_LOCATION_DEBUG "${VCPKG_LIBCERROR_LIBRARY_DEBUG}")
+    endif()
+endif()

--- a/ports/libcerror/vcpkg.json
+++ b/ports/libcerror/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Library for cross-platform C error functions ",
   "homepage": "https://github.com/libyal/libcerror",
   "license": "LGPL-3.0-or-later",
-  "supports": "!uwp & !xbox",
+  "supports": "!uwp & !xbox & (!windows | mingw | x86 | x64)",
   "dependencies": [
     {
       "name": "vcpkg-libyal-vstools",

--- a/ports/libcerror/vcpkg.json
+++ b/ports/libcerror/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Library for cross-platform C error functions ",
   "homepage": "https://github.com/libyal/libcerror",
   "license": "LGPL-3.0-or-later",
-  "supports": "!uwp & !xbox & (!windows | mingw | x86 | x64)",
+  "supports": "!uwp & !xbox",
   "dependencies": [
     {
       "name": "vcpkg-libyal-vstools",

--- a/ports/libcerror/vcpkg.json
+++ b/ports/libcerror/vcpkg.json
@@ -1,0 +1,31 @@
+{
+    "name": "libcerror",
+    "version": "20240413",
+    "port-version": 0,
+    "description": "Library for cross-platform C error functions ",
+    "homepage": "https://github.com/libyal/libcerror",
+    "license": "LGPL-3.0-or-later",
+    "supports": "!uwp & !xbox & (!windows | mingw | x86 | x64)",
+    "dependencies": [
+      {
+        "name": "vcpkg-libyal-vstools",
+        "host": true,
+        "platform": "windows & !mingw"
+      },
+      {
+        "name": "vcpkg-msbuild",
+        "host": true,
+        "platform": "windows & !mingw"
+      }
+    ],
+    "features": {
+      "nls": {
+        "description": "Enable native language support",
+        "supports": "!windows | mingw",
+        "dependencies": [
+          "gettext-libintl"
+        ]
+      }
+    }
+  }
+  

--- a/ports/libcerror/vcpkg.json
+++ b/ports/libcerror/vcpkg.json
@@ -1,31 +1,29 @@
 {
-    "name": "libcerror",
-    "version": "20240413",
-    "port-version": 0,
-    "description": "Library for cross-platform C error functions ",
-    "homepage": "https://github.com/libyal/libcerror",
-    "license": "LGPL-3.0-or-later",
-    "supports": "!uwp & !xbox & (!windows | mingw | x86 | x64)",
-    "dependencies": [
-      {
-        "name": "vcpkg-libyal-vstools",
-        "host": true,
-        "platform": "windows & !mingw"
-      },
-      {
-        "name": "vcpkg-msbuild",
-        "host": true,
-        "platform": "windows & !mingw"
-      }
-    ],
-    "features": {
-      "nls": {
-        "description": "Enable native language support",
-        "supports": "!windows | mingw",
-        "dependencies": [
-          "gettext-libintl"
-        ]
-      }
+  "name": "libcerror",
+  "version": "20240413",
+  "description": "Library for cross-platform C error functions ",
+  "homepage": "https://github.com/libyal/libcerror",
+  "license": "LGPL-3.0-or-later",
+  "supports": "!uwp & !xbox & (!windows | mingw | x86 | x64)",
+  "dependencies": [
+    {
+      "name": "vcpkg-libyal-vstools",
+      "host": true,
+      "platform": "windows & !mingw"
+    },
+    {
+      "name": "vcpkg-msbuild",
+      "host": true,
+      "platform": "windows & !mingw"
+    }
+  ],
+  "features": {
+    "nls": {
+      "description": "Enable native language support",
+      "supports": "!windows | mingw",
+      "dependencies": [
+        "gettext-libintl"
+      ]
     }
   }
-  
+}

--- a/ports/vcpkg-libyal-vstools/portfile.cmake
+++ b/ports/vcpkg-libyal-vstools/portfile.cmake
@@ -1,0 +1,13 @@
+file(INSTALL
+    "${CURRENT_PORT_DIR}/vcpkg-port-config.cmake"
+    "${CURRENT_PORT_DIR}/vcpkg_libyal_msvscpp_convert.cmake"
+    "${CURRENT_PORT_DIR}/z_vcpkg_libyal_vstools_download.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+vcpkg_install_copyright(FILE_LIST "${VCPKG_ROOT_DIR}/LICENSE.txt")
+set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
+
+# Fill asset cache when run with --only-downloads
+include("${CURRENT_PORT_DIR}/vcpkg-port-config.cmake")
+z_vcpkg_libyal_vstools_download(unused)
+vcpkg_find_acquire_program(PYTHON3)

--- a/ports/vcpkg-libyal-vstools/vcpkg-port-config.cmake
+++ b/ports/vcpkg-libyal-vstools/vcpkg-port-config.cmake
@@ -1,0 +1,3 @@
+include_guard(GLOBAL)
+include("${CMAKE_CURRENT_LIST_DIR}/vcpkg_libyal_msvscpp_convert.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/z_vcpkg_libyal_vstools_download.cmake")

--- a/ports/vcpkg-libyal-vstools/vcpkg.json
+++ b/ports/vcpkg-libyal-vstools/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "vcpkg-libyal-vstools",
+  "version-date": "2023-12-18",
+  "description": "Maintainer functions for libyal ports",
+  "license": "MIT",
+  "supports": "windows & native"
+}

--- a/ports/vcpkg-libyal-vstools/vcpkg_libyal_msvscpp_convert.cmake
+++ b/ports/vcpkg-libyal-vstools/vcpkg_libyal_msvscpp_convert.cmake
@@ -1,0 +1,49 @@
+function(vcpkg_libyal_msvscpp_convert)
+    cmake_parse_arguments(PARSE_ARGV 0 arg
+        ""
+        "SOLUTION;SOURCE_PATH;OUT_PROJECT_SUBPATH;VS_VERSION"
+        "OPTIONS"
+    )
+
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(WARNING "${CMAKE_CURRENT_FUNCTION} was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
+    endif()
+
+    if(NOT DEFINED arg_SOLUTION)
+        message(FATAL_ERROR "The SOLUTION is mandatory for ${CMAKE_CURRENT_FUNCTION}.")
+    endif()
+
+    if(NOT DEFINED arg_SOURCE_PATH)
+        message(FATAL_ERROR "The SOURCE_PATH is mandatory for ${CMAKE_CURRENT_FUNCTION}.")
+    endif()
+
+    if(NOT DEFINED arg_VS_VERSION)
+        set(arg_VS_VERSION 2022)
+        # Triplet variable
+        if(DEFINED LIBYAL_VS_VERSION)
+            set(arg_VS_VERSION "${LIBYAL_VS_VERSION}")
+        endif()
+    endif()
+
+    cmake_path(GET arg_SOLUTION STEM LAST_ONLY basename)
+    set(vs_project_subpath "vs${arg_VS_VERSION}/${basename}.sln")
+    # Triplet variable
+    if(DEFINED LIBYAL_VS_PROJECT_SUBPATH)
+        set(vs_project_subpath "${LIBYAL_VS_PROJECT_SUBPATH}")
+    endif()
+
+    if(NOT DEFINED arg_OPTIONS)
+        set(arg_OPTIONS --extend-with-x64 --no-python-dll)
+    endif()
+
+    z_vcpkg_libyal_vstools_download(vctools_path)
+    vcpkg_find_acquire_program(PYTHON3)
+    vcpkg_host_path_list(APPEND ENV{PYTHONPATH} "${vctools_path}")
+    vcpkg_execute_required_process(
+        COMMAND "${PYTHON3}" "${vctools_path}/scripts/msvscpp-convert.py" --output-format "${arg_VS_VERSION}" ${arg_OPTIONS} "${arg_SOLUTION}"
+        WORKING_DIRECTORY "${arg_SOURCE_PATH}"
+        LOGNAME "msvscpp-convert-${basename}-${TARGET_TRIPLET}"
+    )
+
+    set("${arg_OUT_PROJECT_SUBPATH}" "${vs_project_subpath}" PARENT_SCOPE)
+endfunction()

--- a/ports/vcpkg-libyal-vstools/z_vcpkg_libyal_vstools_download.cmake
+++ b/ports/vcpkg-libyal-vstools/z_vcpkg_libyal_vstools_download.cmake
@@ -1,0 +1,10 @@
+function(z_vcpkg_libyal_vstools_download OUT_PATH)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH path
+        REPO libyal/vstools
+        REF f412b5f4347839c31a6f7ff2a631990f84d81b40
+        SHA512 f063a951af959e1fb4b52ca2dd028f416e5070573f4c25c012854db5b9ca90c334a3fd7f35c6f3092d2e7b9c0a889baba1cf221558a2406ac58fb7ad8d463f3e
+        HEAD_REF main
+    )
+    set("${OUT_PATH}" "${path}" PARENT_SCOPE)
+endfunction()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4232,6 +4232,10 @@
       "baseline": "1.13",
       "port-version": 4
     },
+    "libcerror": {
+      "baseline": "20240413",
+      "port-version": 0
+    },
     "libconfig": {
       "baseline": "1.7.3",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9060,6 +9060,10 @@
       "baseline": "2024-02-22",
       "port-version": 0
     },
+    "vcpkg-libyal-vstools": {
+      "baseline": "2023-12-18",
+      "port-version": 0
+    },
     "vcpkg-msbuild": {
       "baseline": "2023-08-08",
       "port-version": 0

--- a/versions/l-/libcerror.json
+++ b/versions/l-/libcerror.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "57ee3cdd952c043084cb76bafeb921b7649cf2a3",
+      "git-tree": "3c31ec82cdad8a762c315151b2e283ac07d3a17a",
       "version": "20240413",
       "port-version": 0
     }

--- a/versions/l-/libcerror.json
+++ b/versions/l-/libcerror.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "25a11a2938cb406fdffc2bd43833b74cc13690a3",
+      "version": "20240413",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libcerror.json
+++ b/versions/l-/libcerror.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "25a11a2938cb406fdffc2bd43833b74cc13690a3",
+      "git-tree": "ce99225910b6bfac254d8d95257a039aee502431",
       "version": "20240413",
       "port-version": 0
     }

--- a/versions/l-/libcerror.json
+++ b/versions/l-/libcerror.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce99225910b6bfac254d8d95257a039aee502431",
+      "git-tree": "57ee3cdd952c043084cb76bafeb921b7649cf2a3",
       "version": "20240413",
       "port-version": 0
     }

--- a/versions/l-/libcerror.json
+++ b/versions/l-/libcerror.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3c31ec82cdad8a762c315151b2e283ac07d3a17a",
+      "git-tree": "57ee3cdd952c043084cb76bafeb921b7649cf2a3",
       "version": "20240413",
       "port-version": 0
     }

--- a/versions/l-/libcerror.json
+++ b/versions/l-/libcerror.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "57ee3cdd952c043084cb76bafeb921b7649cf2a3",
+      "git-tree": "33cc557735bc039c85f4a89122ed19930d2fa62d",
       "version": "20240413",
       "port-version": 0
     }

--- a/versions/v-/vcpkg-libyal-vstools.json
+++ b/versions/v-/vcpkg-libyal-vstools.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8094e7f2a97abcca5525e970cd9fa577bb7ca21b",
+      "version-date": "2023-12-18",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
