### PR TITLE
[librsvg][gdk-pixbuf] Add librsvg support to gdk-pixbuf by adding librsvg as a dependency to gdk-pixbuf.

### DIFF
--- a/ports/gdk-pixbuf/add_librsvg_dependency.patch
+++ b/ports/gdk-pixbuf/add_librsvg_dependency.patch
@@ -1,0 +1,83 @@
+diff --git a/gdk-pixbuf/gdk-pixbuf-io.c b/gdk-pixbuf/gdk-pixbuf-io.c
+index e207d8143..4366ba191 100644
+--- a/gdk-pixbuf/gdk-pixbuf-io.c
++++ b/gdk-pixbuf/gdk-pixbuf-io.c
+@@ -659,6 +659,9 @@ gdk_pixbuf_io_init_builtin (void)
+         /* Except the gdip-png loader which normally isn't built at all even */
+         load_one_builtin_module (png);
+ #endif
++#ifdef INCLUDE_svg
++        load_one_builtin_module (svg);
++#endif
+ 
+ #undef load_one_builtin_module
+ }
+@@ -695,6 +698,7 @@ module (xbm);
+ module (tga);
+ module (icns);
+ module (qtif);
++module (svg);
+ module (gdip_ico);
+ module (gdip_wmf);
+ module (gdip_emf);
+@@ -777,6 +781,9 @@ gdk_pixbuf_load_module_unlocked (GdkPixbufModule *image_module,
+ #ifdef INCLUDE_qtif
+         try_module (qtif,qtif);
+ #endif
++#ifdef INCLUDE_svg
++        try_module (svg,svg);
++#endif
+ 
+ #undef try_module
+         
+diff --git a/gdk-pixbuf/gdk-pixbuf.c b/gdk-pixbuf/gdk-pixbuf.c
+index 8bdd65035..241ddef5a 100644
+--- a/gdk-pixbuf/gdk-pixbuf.c
++++ b/gdk-pixbuf/gdk-pixbuf.c
+@@ -788,7 +788,6 @@ gboolean
+ gdk_pixbuf_get_has_alpha (const GdkPixbuf *pixbuf)
+ {
+ 	g_return_val_if_fail (GDK_IS_PIXBUF (pixbuf), FALSE);
+-
+ 	return pixbuf->has_alpha ? TRUE : FALSE;
+ }
+ 
+diff --git a/meson.build b/meson.build
+index 8a16c8f97..e6734e41b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -335,6 +335,19 @@ if not tiff_opt.disabled() and not native_windows_loaders
+   endif
+ endif
+ 
++svg_opt = get_option('svg')
++if not svg_opt.disabled()
++  # We currently don't have a fallback subproject, but this handles error
++  # reporting if svg_opt is enabled.
++  svg_dep = dependency('librsvg-2.0', required: svg_opt)
++
++  if svg_dep.found()
++    enabled_loaders += 'svg'
++    gdk_pixbuf_deps += svg_dep
++    add_project_arguments([ '-DINCLUDE_svg' ], language: 'c')
++  endif
++endif
++
+ # Determine whether we enable application bundle relocation support, and we use
+ # this always on Windows
+ if host_system == 'windows'
+diff --git a/meson_options.txt b/meson_options.txt
+index d198d99d5..00ee61af8 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -10,6 +10,10 @@ option('jpeg',
+        description: 'Enable JPEG loader (requires libjpeg), disabled on Windows if "native_windows_loaders" is used',
+        type: 'feature',
+        value: 'enabled')
++option('svg',
++       description: 'Enable SVG loader (requires librsvg)',
++       type: 'feature',
++       value: 'auto')
+ option('builtin_loaders',
+        description: 'Comma-separated list of loaders to build into gdk-pixbuf',
+        type: 'array',

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_gitlab(
         loaders-cache.patch
         use-libtiff-4-pkgconfig.patch
         fix-static-deps.patch
+        add_librsvg_dependency.patch
 )
 
 if("introspection" IN_LIST FEATURES)
@@ -35,6 +36,12 @@ if("jpeg" IN_LIST FEATURES)
     list(APPEND OPTIONS -Djpeg=enabled)
 else()
     list(APPEND OPTIONS -Djpeg=disabled)
+endif()
+
+if("svg" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dsvg=enabled)
+else()
+    list(APPEND OPTIONS -Dsvg=disabled)
 endif()
 
 if(CMAKE_HOST_WIN32 AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.10",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",
@@ -28,6 +28,10 @@
   "default-features": [
     "jpeg",
     "png",
+    {
+      "name": "svg",
+      "platform": "static"
+    },
     "tiff"
   ],
   "features": {
@@ -48,6 +52,17 @@
       "description": "Enable PNG loader (requires libpng)",
       "dependencies": [
         "libpng"
+      ]
+    },
+    "svg": {
+      "description": "Enable SVG loader (requires librsvg)",
+      "dependencies": [
+        {
+          "name": "librsvg",
+          "features": [
+            "pixbufloader"
+          ]
+        }
       ]
     },
     "tiff": {

--- a/ports/librsvg/CMakeLists.txt
+++ b/ports/librsvg/CMakeLists.txt
@@ -12,7 +12,10 @@ Set(libdir "\${prefix}/lib")
 Set(includedir "\${prefix}/include")
 
 # Public required modules (cf. headers and librsvg.pc)
-set(librsvg_pc_requires glib-2.0 gio-2.0 gdk-pixbuf-2.0 cairo)
+set(librsvg_pc_requires glib-2.0 gio-2.0 cairo)
+if (BUILD_SHARED_LIBS)
+    list(APPEND librsvg_pc_requires gdk-pixbuf-2.0)
+endif()
 # Other required modules from configure.ac
 set(librsvg_pc_requires_private
     libxml-2.0
@@ -132,42 +135,71 @@ install(
     DESTINATION include/librsvg-${RSVG_API_VERSION}/librsvg
 )
 
+if (BUILD_SHARED_LIBS)
+    set(gdk_pixbuf_pc_requires_private gdk-pixbuf-2.0)
+    pkg_check_modules(GDK_PIXBUF ${gdk_pixbuf_pc_requires_private} IMPORTED_TARGET REQUIRED)
+    pkg_get_variable(GDK_PIXBUF_MODULEDIR ${gdk_pixbuf_pc_requires_private} gdk_pixbuf_moduledir)
+endif()
 
-set(gdk_pixbuf_pc_requires_private gdk-pixbuf-2.0)
-pkg_check_modules(GDK_PIXBUF ${gdk_pixbuf_pc_requires_private} IMPORTED_TARGET REQUIRED)
-pkg_get_variable(GDK_PIXBUF_MODULEDIR ${gdk_pixbuf_pc_requires_private} gdk_pixbuf_moduledir)
+if (ENABLE_GDK_PIXBUF_LOADER)
+    set(PIXBUFLOADERSVG_SOURCES
+        gdk-pixbuf-loader/io-svg.c
+    )
 
-set(PIXBUFLOADERSVG_SOURCES
-    gdk-pixbuf-loader/io-svg.c
-)
+    if (BUILD_SHARED_LIBS)
+        add_library(pixbufloader-svg MODULE ${PIXBUFLOADERSVG_SOURCES})
+    else()
+        add_library(pixbufloader-svg ${PIXBUFLOADERSVG_SOURCES})
+    endif()
 
-add_library(pixbufloader-svg MODULE ${PIXBUFLOADERSVG_SOURCES})
-target_include_directories(pixbufloader-svg
-    PRIVATE
-        "${CMAKE_CURRENT_BINARY_DIR}"
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-)
-target_compile_definitions(pixbufloader-svg PRIVATE
-    -DRSVG_COMPILATION
-    -D_CRT_SECURE_NO_WARNINGS
-    -DSRCDIR=""
-    -DGDK_PIXBUF_ENABLE_BACKEND
-    -DG_LOG_DOMAIN="libpixbufloader-svg"
-)
-target_link_libraries(pixbufloader-svg
-    PRIVATE
-        ${LIBRSVG_TARGET}
-        PkgConfig::GDK_PIXBUF
-)
-install(TARGETS pixbufloader-svg
-    RUNTIME DESTINATION "${GDK_PIXBUF_MODULEDIR}"
-    LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}"
-)
+    target_include_directories(pixbufloader-svg
+        PRIVATE
+            "${CMAKE_CURRENT_BINARY_DIR}"
+            "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+    target_compile_definitions(pixbufloader-svg PRIVATE
+        -DRSVG_COMPILATION
+        -D_CRT_SECURE_NO_WARNINGS
+        -DSRCDIR=""
+        -DGDK_PIXBUF_ENABLE_BACKEND
+        -DG_LOG_DOMAIN="libpixbufloader-svg"
+    )
+    if (BUILD_SHARED_LIBS)
+        target_link_libraries(pixbufloader-svg
+            PRIVATE
+                ${LIBRSVG_TARGET}
+                PkgConfig::GDK_PIXBUF
+        )
+    else()
+        target_link_libraries(pixbufloader-svg
+            PRIVATE
+                ${LIBRSVG_TARGET}
+        )
+    endif()
 
+    if (BUILD_SHARED_LIBS)
+        install(TARGETS pixbufloader-svg
+            RUNTIME DESTINATION "${GDK_PIXBUF_MODULEDIR}"
+            LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}"
+        )
+    else()
+        install(TARGETS pixbufloader-svg
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib
+        )
+    endif()
+endif()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/librsvg.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" @ONLY)
 file(READ "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" librsvg_pc)
 list(JOIN librsvg_pc_requires_private " " requires_private)
 string(REPLACE "Requires.private:" "Requires.private: ${requires_private}" librsvg_pc "${librsvg_pc}")
+if (ENABLE_GDK_PIXBUF_LOADER AND NOT BUILD_SHARED_LIBS)
+    string(REPLACE "-lm" "-lpixbufloader-svg -lm" librsvg_pc "${librsvg_pc}")
+endif()
+if (NOT BUILD_SHARED_LIBS)
+    string(REPLACE "gdk-pixbuf-2.0" "" librsvg_pc "${librsvg_pc}")
+endif()
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" "${librsvg_pc}")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" RENAME "librsvg-${RSVG_API_VERSION}.pc")

--- a/ports/librsvg/fix_libpixbufloader-svg_static_build.patch
+++ b/ports/librsvg/fix_libpixbufloader-svg_static_build.patch
@@ -1,0 +1,155 @@
+diff --git a/gdk-pixbuf-loader/io-svg.c b/gdk-pixbuf-loader/io-svg.c
+index bcdfd0bb..326973ee 100644
+--- a/gdk-pixbuf-loader/io-svg.c
++++ b/gdk-pixbuf-loader/io-svg.c
+@@ -26,7 +26,6 @@
+ #include <stdlib.h>
+ 
+ #include <rsvg.h>
+-#include <gdk-pixbuf/gdk-pixbuf.h>
+ 
+ #define N_(string) (string)
+ #define _(string) (string)
+@@ -43,8 +42,8 @@ typedef struct {
+         gpointer                    user_data;
+ } SvgContext;
+ 
+-G_MODULE_EXPORT void fill_vtable (GdkPixbufModule *module);
+-G_MODULE_EXPORT void fill_info (GdkPixbufFormat *info);
++// G_MODULE_EXPORT void fill_vtable (GdkPixbufModule *module);
++// G_MODULE_EXPORT void fill_info (GdkPixbufFormat *info);
+ 
+ enum {
+         ERROR_WRITING = 1,
+@@ -173,16 +172,20 @@ gdk_pixbuf__svg_image_stop_load (gpointer data, GError **error)
+         return result;
+ }
+ 
+-void
+-fill_vtable (GdkPixbufModule *module)
++#ifdef BUILD_SHARED_LIBS
++#define MODULE_ENTRY(function) G_MODULE_EXPORT void function
++#else
++#define MODULE_ENTRY(function) void _gdk_pixbuf__svg_ ## function
++#endif
++
++MODULE_ENTRY (fill_vtable) (GdkPixbufModule *module)
+ {
+         module->begin_load     = gdk_pixbuf__svg_image_begin_load;
+         module->stop_load      = gdk_pixbuf__svg_image_stop_load;
+         module->load_increment = gdk_pixbuf__svg_image_load_increment;
+ }
+ 
+-void
+-fill_info (GdkPixbufFormat *info)
++MODULE_ENTRY (fill_info) (GdkPixbufFormat *info)
+ {
+         static const GdkPixbufModulePattern signature[] = {
+                 {  " <svg",  "*    ", 100 },
+diff --git a/rsvg-cairo-draw.c b/rsvg-cairo-draw.c
+index caa91049..7452cb4f 100644
+--- a/rsvg-cairo-draw.c
++++ b/rsvg-cairo-draw.c
+@@ -1230,7 +1230,6 @@ rsvg_cairo_surface_to_pixbuf (cairo_surface_t *surface)
+                           !!(content & CAIRO_CONTENT_ALPHA),
+                           8,
+                           width, height);
+-
+     if (gdk_pixbuf_get_has_alpha (dest))
+       convert_alpha (gdk_pixbuf_get_pixels (dest),
+                     gdk_pixbuf_get_rowstride (dest),
+diff --git a/rsvg.h b/rsvg.h
+index e4350da7..a968c3eb 100644
+--- a/rsvg.h
++++ b/rsvg.h
+@@ -31,7 +31,90 @@
+ #include <glib-object.h>
+ #include <gio/gio.h>
+ 
++#ifdef BUILD_SHARED_LIBS
+ #include <gdk-pixbuf/gdk-pixbuf.h>
++#else
++#include <stdio.h>
++typedef enum {
++	GDK_COLORSPACE_RGB
++} GdkColorspace;
++typedef enum
++{
++  GDK_PIXBUF_FORMAT_WRITABLE = 1 << 0,
++  GDK_PIXBUF_FORMAT_SCALABLE = 1 << 1,
++  GDK_PIXBUF_FORMAT_THREADSAFE = 1 << 2
++} GdkPixbufFormatFlags;
++typedef void GdkPixbuf;
++typedef void GdkPixbufLoader;
++typedef struct {
++	char *prefix;
++	char *mask;
++	int relevance;
++} GdkPixbufModulePattern;
++typedef struct {
++  gchar *name;
++  GdkPixbufModulePattern *signature;
++  gchar *domain;
++  gchar *description;
++  gchar **mime_types;
++  gchar **extensions;
++  guint32 flags;
++  gboolean disabled;
++  gchar *license;
++} GdkPixbufFormat;
++struct _GdkPixbufAnimation;
++typedef struct _GdkPixbufAnimation GdkPixbufAnimation;
++typedef GdkPixbuf *(* GdkPixbufModuleLoadFunc) (FILE*, GError**);
++typedef GdkPixbuf *(* GdkPixbufModuleLoadXpmDataFunc) (const char**);
++typedef void (* GdkPixbufModuleSizeFunc) (gint*, gint*, gpointer);
++typedef void (* GdkPixbufModulePreparedFunc) (GdkPixbuf*, GdkPixbufAnimation*, gpointer);
++typedef void (* GdkPixbufModuleUpdatedFunc) (GdkPixbuf*, int, int, int, int, gpointer);
++typedef gpointer (* GdkPixbufModuleBeginLoadFunc) (GdkPixbufModuleSizeFunc, GdkPixbufModulePreparedFunc, GdkPixbufModuleUpdatedFunc, gpointer, GError**);
++typedef gboolean (* GdkPixbufModuleStopLoadFunc) (gpointer, GError**);
++typedef gboolean (* GdkPixbufModuleIncrementLoadFunc) (gpointer, const guchar*, guint, GError**);
++typedef GdkPixbufAnimation *(* GdkPixbufModuleLoadAnimationFunc) (FILE*, GError**);
++typedef gboolean (* GdkPixbufModuleSaveFunc) (FILE*, GdkPixbuf*, gchar**, gchar**, GError**);
++typedef gboolean (*GdkPixbufSaveFunc) (const gchar*, gsize, GError**, gpointer);
++typedef gboolean (* GdkPixbufModuleSaveCallbackFunc) (GdkPixbufSaveFunc, gpointer, GdkPixbuf*, gchar**, gchar**, GError**);
++typedef gboolean (* GdkPixbufModuleSaveOptionSupportedFunc) (const gchar *option_key);
++typedef struct {
++	char *module_name;
++	char *module_path;
++	GModule *module;
++	GdkPixbufFormat *info;
++    GdkPixbufModuleLoadFunc load;
++    GdkPixbufModuleLoadXpmDataFunc load_xpm_data;
++    GdkPixbufModuleBeginLoadFunc begin_load;
++    GdkPixbufModuleStopLoadFunc stop_load;
++    GdkPixbufModuleIncrementLoadFunc load_increment;
++    GdkPixbufModuleLoadAnimationFunc load_animation;
++    GdkPixbufModuleSaveFunc save;
++    GdkPixbufModuleSaveCallbackFunc save_to_callback;
++    GdkPixbufModuleSaveOptionSupportedFunc is_save_option_supported;
++    void (*_reserved1) (void);
++    void (*_reserved2) (void);
++    void (*_reserved3) (void);
++    void (*_reserved4) (void);
++} GdkPixbufModule;
++extern GdkPixbufLoader *gdk_pixbuf_loader_new_with_mime_type(const char*, GError**);
++extern GdkPixbufLoader *gdk_pixbuf_loader_new(void);
++extern gboolean gdk_pixbuf_loader_write(GdkPixbufLoader*, const guchar*, gsize, GError**);
++extern gboolean gdk_pixbuf_loader_close(GdkPixbufLoader*, GError**);
++extern GdkPixbuf *gdk_pixbuf_loader_get_pixbuf(GdkPixbufLoader*);
++extern GdkPixbufFormat *gdk_pixbuf_loader_get_format(GdkPixbufLoader*);
++extern gchar **gdk_pixbuf_format_get_mime_types(GdkPixbufFormat*);
++extern int gdk_pixbuf_get_width(const GdkPixbuf*);
++extern int gdk_pixbuf_get_height(const GdkPixbuf*);
++extern guchar *gdk_pixbuf_get_pixels(const GdkPixbuf*);
++extern int gdk_pixbuf_get_rowstride(const GdkPixbuf*);
++extern int gdk_pixbuf_get_n_channels(const GdkPixbuf*);
++extern gboolean gdk_pixbuf_get_has_alpha(const GdkPixbuf*);
++extern GdkPixbuf *gdk_pixbuf_new (GdkColorspace, gboolean, int, int, int);
++extern GQuark gdk_pixbuf_error_quark(void);
++#define GDK_PIXBUF_ERROR gdk_pixbuf_error_quark ()
++#define GDK_PIXBUF_ERROR_FAILED 5
++#define GDK_COLORSPACE_RGB 0
++#endif
+ 
+ G_BEGIN_DECLS
+ 

--- a/ports/librsvg/portfile.cmake
+++ b/ports/librsvg/portfile.cmake
@@ -11,7 +11,13 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        fix_libpixbufloader-svg_static_build.patch
 )
+
+if("pixbufloader" IN_LIST FEATURES)
+    vcpkg_list(APPEND options "-DENABLE_GDK_PIXBUF_LOADER=ON")
+endif()
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" "${CMAKE_CURRENT_LIST_DIR}/config.h.linux" DESTINATION "${SOURCE_PATH}")
 
@@ -20,6 +26,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+        ${options}
 )
 
 vcpkg_cmake_install()

--- a/ports/librsvg/vcpkg.json
+++ b/ports/librsvg/vcpkg.json
@@ -1,14 +1,17 @@
 {
   "name": "librsvg",
   "version": "2.40.20",
-  "port-version": 10,
+  "port-version": 11,
   "description": "A small library to render Scalable Vector Graphics (SVG)",
   "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
   "license": "LGPL-2.0-or-later",
   "dependencies": [
     "cairo",
     "fontconfig",
-    "gdk-pixbuf",
+    {
+      "name": "gdk-pixbuf",
+      "platform": "!static"
+    },
     "glib",
     "libcroco",
     {
@@ -20,5 +23,13 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "pixbufloader"
+  ],
+  "features": {
+    "pixbufloader": {
+      "description": "Build gdk-pixbuf svg loader"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2962,7 +2962,7 @@
     },
     "gdk-pixbuf": {
       "baseline": "2.42.10",
-      "port-version": 5
+      "port-version": 6
     },
     "gemmlowp": {
       "baseline": "2021-09-28",
@@ -4882,7 +4882,7 @@
     },
     "librsvg": {
       "baseline": "2.40.20",
-      "port-version": 10
+      "port-version": 11
     },
     "librsync": {
       "baseline": "2.3.4",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66a84811f5ef70381593f57ac61bf4dc266a5681",
+      "version": "2.42.10",
+      "port-version": 6
+    },
+    {
       "git-tree": "42ac551a9c1a0035116dd3fa21f6d5e0c34085f3",
       "version": "2.42.10",
       "port-version": 5

--- a/versions/l-/librsvg.json
+++ b/versions/l-/librsvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1938b505561171b413aba309462ae2cc192ec75",
+      "version": "2.40.20",
+      "port-version": 11
+    },
+    {
       "git-tree": "ba6e6aad1557505c8ede7b320d554bd2cab6bb7d",
       "version": "2.40.20",
       "port-version": 10


### PR DESCRIPTION
This changes the behavior of librsvg to be able to be built without gdk-pixbuf support (to avoid circular dependency) when built statically, and gdk-pixbuf to be built with librsvg support. librsvg is optional when building gdk-pixbuf dynamically, and enabled by default when building statically.

This fixes #38012.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
