### PR TITLE
[discord-rpc] Remove unneeded dependency

### DIFF
--- a/ports/discord-rpc/portfile.cmake
+++ b/ports/discord-rpc/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO discordapp/discord-rpc
-    REF v3.4.0
+    REF "v${VERSION}"
     SHA512 ca981b833aff5f21fd629a704deadd8e3fb5423d959ddb75e381313f6462d984c567671b10c8f031905c08d85792ddbe2dddc402ba2613c42de9e80fc68d0d51
     HEAD_REF master
     PATCHES disable-downloading.patch
@@ -15,11 +15,10 @@ vcpkg_cmake_configure(
     OPTIONS
         -DUSE_STATIC_CRT=${STATIC_CRT}
         -DBUILD_EXAMPLES=OFF
-        -DRAPIDJSONTEST=TRUE
         "-DRAPIDJSON=${CURRENT_INSTALLED_DIR}"
 )
 
-if(EXISTS ${SOURCE_PATH}/thirdparty)
+if(EXISTS "${SOURCE_PATH}/thirdparty")
     message(FATAL_ERROR "The source directory should not be modified during the build.")
 endif()
 
@@ -27,7 +26,6 @@ vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Copy copright information
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/discord-rpc" RENAME "copyright")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_copy_pdbs()

--- a/ports/discord-rpc/vcpkg.json
+++ b/ports/discord-rpc/vcpkg.json
@@ -1,17 +1,14 @@
 {
   "name": "discord-rpc",
   "version": "3.4.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Rich Presence allows you to leverage the totally overhauled \"Now Playing\" section in a Discord user's profile to help people play your game together.",
   "homepage": "https://github.com/discordapp/discord-rpc",
+  "license": "MIT",
   "dependencies": [
     "rapidjson",
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2270,7 +2270,7 @@
     },
     "discord-rpc": {
       "baseline": "3.4.0",
-      "port-version": 3
+      "port-version": 4
     },
     "discordcoreapi": {
       "baseline": "2.0.5",

--- a/versions/d-/discord-rpc.json
+++ b/versions/d-/discord-rpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ff8f211964141f0bc8ba459c88c1d8af8415c24",
+      "version": "3.4.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "929ff2e2379863aabc478dfb7773549404c3f74f",
       "version": "3.4.0",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
