### PR TITLE
[eventpp] Optimize build

### DIFF
--- a/ports/eventpp/portfile.cmake
+++ b/ports/eventpp/portfile.cmake
@@ -1,3 +1,5 @@
+set(VCPKG_BUILD_TYPE release) # header-only
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wqking/eventpp
@@ -8,15 +10,12 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DBUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/eventpp")
-vcpkg_fixup_pkgconfig()
-vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/share/eventpp/license" "${CURRENT_PACKAGES_DIR}/share/eventpp/readme.md")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license")

--- a/ports/eventpp/vcpkg.json
+++ b/ports/eventpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "eventpp",
   "version-semver": "0.1.3",
+  "port-version": 1,
   "description": "C++ library for event dispatcher and callback list",
   "homepage": "https://github.com/wqking/eventpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2538,7 +2538,7 @@
     },
     "eventpp": {
       "baseline": "0.1.3",
-      "port-version": 0
+      "port-version": 1
     },
     "evpp": {
       "baseline": "0.7.0",

--- a/versions/e-/eventpp.json
+++ b/versions/e-/eventpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c5fdcbe4047f79d958a4b62342ad444a04d2090",
+      "version-semver": "0.1.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "13f41aca93677fedad3baaf9ed698546434ae379",
       "version-semver": "0.1.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
