### PR TITLE
[google-cloud-cpp] update to the latest release (2.24.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 52cab0e1ee1ebd51097d28b2cd9a390110ce3f45e92d262fb301cfebdea369ea8b9290c44c26d6b6ba568b0dab1e4871ea819f8a440efeefb38c99f2776aac27
+    SHA512 f0196fadab18164a1b1313717329063167c003279d0898ecedd18ca562c4344a4a5be302bd951fa5c95582078fe5e88a1a8debbc66db8c8dfafedfdf7a019522
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.23.0",
-  "port-version": 1,
+  "version": "2.24.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -56,6 +55,18 @@
     },
     "advisorynotifications": {
       "description": "Advisory Notifications API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "aiplatform": {
+      "description": "Vertex AI API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -458,6 +469,18 @@
         }
       ]
     },
+    "contentwarehouse": {
+      "description": "Document AI Warehouse API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "datacatalog": {
       "description": "Google Cloud Data Catalog API C++ Client Library",
       "dependencies": [
@@ -614,6 +637,18 @@
         }
       ]
     },
+    "domains": {
+      "description": "Cloud Domains API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "edgecontainer": {
       "description": "Distributed Cloud Edge Container API C++ Client Library",
       "dependencies": [
@@ -628,6 +663,18 @@
     },
     "edgenetwork": {
       "description": "Distributed Cloud Edge Network API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "essentialcontacts": {
+      "description": "Essential Contacts API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -677,6 +724,18 @@
     },
     "functions": {
       "description": "Cloud Functions API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "gkebackup": {
+      "description": "Backup for GKE API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -918,6 +977,18 @@
         }
       ]
     },
+    "networkservices": {
+      "description": "Network Services API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "notebooks": {
       "description": "Notebooks API C++ Client Library",
       "dependencies": [
@@ -1066,6 +1137,18 @@
     },
     "rapidmigrationassessment": {
       "description": "Rapid Migration Assessment C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "recaptchaenterprise": {
+      "description": "reCAPTCHA Enterprise API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",
@@ -1440,6 +1523,18 @@
     },
     "texttospeech": {
       "description": "Cloud Text-to-Speech API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "timeseriesinsights": {
+      "description": "Timeseries Insights API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3129,8 +3129,8 @@
       "port-version": 8
     },
     "google-cloud-cpp": {
-      "baseline": "2.23.0",
-      "port-version": 1
+      "baseline": "2.24.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4816de9ec5d3d8dfd30354bd9a27bf34e1d16998",
+      "version": "2.24.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "497d6d4bc7aecae76ea08934fab2ea655fc634ca",
       "version": "2.23.0",
       "port-version": 1

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4816de9ec5d3d8dfd30354bd9a27bf34e1d16998",
+      "git-tree": "339cf73b54f41dadee8c436b55791521612fcce9",
       "version": "2.24.0",
       "port-version": 0
     },


### PR DESCRIPTION
Tested locally (on x64-linux) with:
```
for feature in <new_features>; do ./vcpkg remove google-cloud-cpp; ./vcpkg install "google-cloud-cpp[core,${feature}]" || break; done
```
and
```
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'
```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

