### PR TITLE
[vtk] Fix build of vtkHDF5Helper (#38529)

### DIFF
--- a/ports/vtk/hdf5helper.patch
+++ b/ports/vtk/hdf5helper.patch
@@ -1,0 +1,11 @@
+--- src/IO/ERF/vtkHDF5Helper.h.old	2024-02-27 17:35:26.000000000 +0100
++++ src/IO/ERF/vtkHDF5Helper.h	2024-05-02 15:49:35.716258500 +0200
+@@ -42,7 +42,7 @@ public:
+   /**
+    *  Check existence of group defined by groupName relative to fileId.
+    */
+-  static bool GroupExists(int64_t fileId, const char* groupName);
++  static bool GroupExists(hid_t fileId, const char* groupName);
+ 
+   /**
+    *  Get length of array defined by arrayId.

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -38,6 +38,7 @@ vcpkg_from_github(
         remove-prefix-changes.patch
         10945.diff
         10972.diff
+        hdf5helper.patch
 )
 
 # =============================================================================

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.3.0-pv5.12.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9190,7 +9190,7 @@
     },
     "vtk": {
       "baseline": "9.3.0-pv5.12.0",
-      "port-version": 2
+      "port-version": 3
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0bb2f77c2eeff358d3be93b1d5f0d006573137b7",
+      "version-semver": "9.3.0-pv5.12.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "a5f26b78563bc7130aa6a5367d6492a8d97ee2d7",
       "version-semver": "9.3.0-pv5.12.0",
       "port-version": 2


### PR DESCRIPTION
Fixes #38529

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
