### PR TITLE
[projectm4] Add new port

### DIFF
--- a/ports/projectm4/portfile.cmake
+++ b/ports/projectm4/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO projectM-visualizer/projectm
+    REF "f60cd86"
+    SHA512 "15b41c198ae4fb3e274babad9cb136d2eeea3460b9dd2197a84d698b47fc247dd318be6160dea3f7fccf46828cd1a455959d8f7cfe07c5cec796ea268ae896e6"
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      -DBUILD_TESTING=OFF
+      -DENABLE_SDL_UI=OFF
+      -DENABLE_SYSTEM_PROJECTM_EVAL=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME "projectm4"
+  CONFIG_PATH "lib/cmake/projectM4"
+  DO_NOT_DELETE_PARENT_CONFIG_PATH
+)
+
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME "projectm4playlist"
+  CONFIG_PATH "lib/cmake/projectM4Playlist"
+)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/projectm4/usage
+++ b/ports/projectm4/usage
@@ -1,0 +1,4 @@
+projectm provides CMake targets:
+
+  find_package(projectM4 REQUIRED COMPONENTS Playlist)
+  target_link_libraries(main PRIVATE libprojectM::projectM libprojectM::playlist)

--- a/ports/projectm4/vcpkg.json
+++ b/ports/projectm4/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "projectm4",
+  "version-date": "2024-05-03",
+  "description": "Cross-platform Music Visualization Library. Open-source and Milkdrop-compatible.",
+  "homepage": "https://github.com/projectM-visualizer/projectm",
+  "license": "LGPL-2.1",
+  "supports": "!osx",
+  "dependencies": [
+    "glew",
+    "projectm-eval",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6980,6 +6980,10 @@
       "baseline": "1.0.0",
       "port-version": 0
     },
+    "projectm4": {
+      "baseline": "2024-05-03",
+      "port-version": 0
+    },
     "prometheus-cpp": {
       "baseline": "1.2.4",
       "port-version": 0

--- a/versions/p-/projectm4.json
+++ b/versions/p-/projectm4.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4b88f8c47d772a9f7ed544c02866f59b7e4e852a",
+      "version-date": "2024-05-03",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This is a new overlay-port to add the ProjectM library: https://github.com/projectM-visualizer/projectm

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

