### PR TITLE
[projectm-eval] Add new port

### DIFF
--- a/ports/projectm-eval/portfile.cmake
+++ b/ports/projectm-eval/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO projectM-visualizer/projectm-eval
+    REF "v${VERSION}"
+    SHA512 "ff5abf4c5deb5a665ed116a1a7a56cfaa0acedc6c211b16ef0c118bc1316f256667681c999c31880dd3aa6aec5ab92ce0747c42ba1ab98ac5046b6ef015de935"
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      -DBUILD_NS_EEL_SHIM=ON
+      -DCMAKE_DISABLE_FIND_PACKAGE_BISON=ON
+      -DCMAKE_DISABLE_FIND_PACKAGE_FLEX=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME "projectm-eval"
+  CONFIG_PATH "lib/cmake/projectM-Eval"
+)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/projectm-eval/usage
+++ b/ports/projectm-eval/usage
@@ -1,0 +1,4 @@
+projectm-eval provides CMake targets:
+
+  find_package(projectM-Eval REQUIRED)
+  target_link_libraries(main PRIVATE projectM::Eval)

--- a/ports/projectm-eval/vcpkg.json
+++ b/ports/projectm-eval/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "projectm-eval",
+  "version": "1.0.0",
+  "description": "The projectM Expression Evaluation Library. A portable drop-in replacement of Milkdrop's \"ns-eel2\" expression parser for use in Milkdrop, projectM and other applications.",
+  "homepage": "https://github.com/projectM-visualizer/projectm-eval",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6964,6 +6964,10 @@
       "baseline": "9.4.0",
       "port-version": 0
     },
+    "projectm-eval": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "prometheus-cpp": {
       "baseline": "1.2.4",
       "port-version": 0

--- a/versions/p-/projectm-eval.json
+++ b/versions/p-/projectm-eval.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3c32881926b002ddd0fa05b351774ebe69f81fa1",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This new overlay-port introduces the ProjectM Expression Evaluation Library, which is a prerequisite for building the ProjectM Library. This addition is to complement the PR #38535, which aims to address the external dependency concern.

ProjectM: https://github.com/projectM-visualizer/projectm
ProjectM Eval: https://github.com/projectM-visualizer/projectm-eval

---
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.