### PR TITLE
[usd] update to v24.05

### DIFF
--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PixarAnimationStudios/OpenUSD
     REF "v${USD_VERSION}"
-    SHA512 6669191c3497e244c958949b62a749958ab01e8e1edc7b3476d59c31395e147acf6f4ba7aae069c5ceab7fe2eb321e81e4e5f66beb72814be36e0fec98d3d034
+    SHA512 e510f6421caba5e74c6efe5b56b17e9c9741ece0cfd5020148ca89b3ac32bd8781ab00dfc7a134163c85af3f4f01f2529a9baa5a9df9b0c80cbca003e6d199e2
     HEAD_REF master
     PATCHES
         fix_build-location.patch

--- a/ports/usd/vcpkg.json
+++ b/ports/usd/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "usd",
-  "version": "23.5",
-  "port-version": 3,
+  "version": "24.5",
   "description": "Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.",
   "homepage": "https://github.com/PixarAnimationStudios/USD",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8949,8 +8949,8 @@
       "port-version": 1
     },
     "usd": {
-      "baseline": "23.5",
-      "port-version": 3
+      "baseline": "24.5",
+      "port-version": 0
     },
     "usearch": {
       "baseline": "2.3.2",

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c153b9f60e4a0f694dac0575011b99556c31084",
+      "version": "24.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "a589441a5a488b6ad5d797ae17dab850b8b03620",
       "version": "23.5",
       "port-version": 3


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- ~~[ ] The "supports" clause reflects platforms that may be fixed by this new version.~~
- ~~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- ~~[ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
