### PR TITLE
[OpenVR] Updated to version 2.5.1

### DIFF
--- a/ports/openvr/portfile.cmake
+++ b/ports/openvr/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ValveSoftware/openvr
-    REF v1.23.7
-    SHA512 c5942483ffca5cb9f80b52e49833756a5730efb75498ae0374e7f1c1344d52ea7b6b2d26584d415f777dda219fd418b0a20abb2132a0a0fe0ea30b60608f8cb7
+    REF v2.5.1
+    SHA512 e224737e75f21ec074ca8450a1f1d81764aafeec924cc92a3f5571efc466d74280cb59b0ddfcd251431165ffbfae8aa0c8afe94144fe1c9106a3aa4c2761f3dc
     HEAD_REF master
 )
 

--- a/ports/openvr/portfile.cmake
+++ b/ports/openvr/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ValveSoftware/openvr
-    REF "v${VERSION}"
+    REF v2.5.1
     SHA512 e224737e75f21ec074ca8450a1f1d81764aafeec924cc92a3f5571efc466d74280cb59b0ddfcd251431165ffbfae8aa0c8afe94144fe1c9106a3aa4c2761f3dc
     HEAD_REF master
 )

--- a/ports/openvr/portfile.cmake
+++ b/ports/openvr/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ValveSoftware/openvr
-    REF v2.5.1
+    REF "v${VERSION}"
     SHA512 e224737e75f21ec074ca8450a1f1d81764aafeec924cc92a3f5571efc466d74280cb59b0ddfcd251431165ffbfae8aa0c8afe94144fe1c9106a3aa4c2761f3dc
     HEAD_REF master
 )

--- a/ports/openvr/vcpkg.json
+++ b/ports/openvr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openvr",
-  "version": "1.23.7",
+  "version": "2.5.1",
   "description": "An API and runtime that allows access to VR hardware from multiple vendors without requiring that applications have specific knowledge of the hardware they are targeting.",
   "homepage": "https://github.com/ValveSoftware/openvr",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6557,7 +6557,7 @@
       "port-version": 2
     },
     "openvr": {
-      "baseline": "1.23.7",
+      "baseline": "2.5.1",
       "port-version": 0
     },
     "openxr-loader": {

--- a/versions/o-/openvr.json
+++ b/versions/o-/openvr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7aa7b3754d9fec9dcdb5b91142d1b84af31a43ce",
+      "version": "2.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "97dd61e39d83bb4dfb8456227f147c9137aafc65",
       "version": "1.23.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
