### PR TITLE
Test krb5 other platform

### DIFF
--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO krb5/krb5
+    REF krb5-${VERSION}-final
+    SHA512 184ef8645d7e17f30a8e3d4005364424d2095b3d0c96f26ecef0c2dd2f3a096a0dd40558ed113121483717e44f6af41e71be0e5e079c76a205535d0c11a2ea34
+    HEAD_REF master
+    PATCHES
+        remove_tests_apps_utils.patch
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}/src"
+    AUTOCONFIG
+    OPTIONS
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat1")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat5")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat7")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat8")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/krb5/")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/krb5/")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/var")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/var")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/krb5/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/krb5/debug/")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/copyright.rst")

--- a/ports/krb5/remove_tests_apps_utils.patch
+++ b/ports/krb5/remove_tests_apps_utils.patch
@@ -1,0 +1,30 @@
+diff --git a/src/configure.ac b/src/configure.ac
+--- a/src/configure.ac
++++ b/src/configure.ac
+@@ -1524,7 +1524,7 @@ V5_AC_OUTPUT_MAKEFILE(.
+ 	lib/gssapi lib/gssapi/generic lib/gssapi/krb5 lib/gssapi/spnego
+ 	lib/gssapi/mechglue
+ 
+-	lib/rpc lib/rpc/unit-test
++	lib/rpc
+ 
+ 	lib/kadm5 lib/kadm5/clnt lib/kadm5/srv
+ 	lib/krad
+@@ -1557,17 +1557,4 @@ V5_AC_OUTPUT_MAKEFILE(.
+ 	plugins/authdata/greet_client
+ 	plugins/authdata/greet_server
+ 	plugins/tls/k5tls
+-
+-	clients clients/klist clients/kinit clients/kvno
+-	clients/kdestroy clients/kpasswd clients/ksu clients/kswitch
+-
+-	kadmin kadmin/cli kadmin/dbutil kadmin/ktutil kadmin/server
+-
+-	appl
+-	appl/sample appl/sample/sclient appl/sample/sserver
+-	appl/simple appl/simple/client appl/simple/server
+-	appl/gss-sample appl/user_user
+-
+-	tests tests/asn.1 tests/create tests/hammer tests/verify tests/gssapi
+-	tests/threads tests/shlib tests/gss-threads tests/misc
+ )

--- a/ports/krb5/vcpkg.json
+++ b/ports/krb5/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "krb5",
+  "version": "1.21.2",
+  "description": "Network authentication protocol",
+  "homepage": "https://web.mit.edu/kerberos/",
+  "license": "MIT",
+  "supports": "!windows"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4040,6 +4040,10 @@
       "baseline": "4.3.2",
       "port-version": 0
     },
+    "krb5": {
+      "baseline": "1.21.2",
+      "port-version": 0
+    },
     "ktx": {
       "baseline": "4.3.1",
       "port-version": 1

--- a/versions/k-/krb5.json
+++ b/versions/k-/krb5.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5f1e3f4548ae4dca49b36b8b97cbddc04819aaf4",
+      "version": "1.21.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

