### PR TITLE
[robotraconteur] Update to version v1.2.0

### DIFF
--- a/ports/robotraconteur/portfile.cmake
+++ b/ports/robotraconteur/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
 	OPTIONS
 	    -DBUILD_GEN=ON
 	    -DBUILD_TESTING=OFF
-		-DCMAKE_CXX_STANDARD=11
+	    -DCMAKE_CXX_STANDARD=11
 )
 
 vcpkg_cmake_install()

--- a/ports/robotraconteur/portfile.cmake
+++ b/ports/robotraconteur/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
 	REPO robotraconteur/robotraconteur
 	REF "v${VERSION}"
-	SHA512 b9ebfb0803bf0efe46bbb8dd2c8d63837141f6f416256d2edcf4e78e4658e2d6c028a2fbd200b13571cfe08d6045273147144da4bcdafc6375b670713ba4f5f6
+	SHA512 39926abd6f4b66c528abade88c06e62a5d9e1c2d12fc1f235d6491b7b6e36eec18923a222a60420e98d3a57b86611483d62319227d91915a747aa7dc731dc5be
 	HEAD_REF master
 )
 
@@ -15,6 +15,7 @@ vcpkg_cmake_configure(
 	OPTIONS
 	    -DBUILD_GEN=ON
 	    -DBUILD_TESTING=OFF
+		-DCMAKE_CXX_STANDARD=11
 )
 
 vcpkg_cmake_install()

--- a/ports/robotraconteur/vcpkg.json
+++ b/ports/robotraconteur/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "robotraconteur",
-  "version-semver": "1.1.1",
+  "version-semver": "1.2.0",
   "description": "The Robot Raconteur communication framework core library",
   "homepage": "http://robotraconteur.com",
   "license": "Apache-2.0",
-  "supports": "(windows & (x86 | x64)) | (linux & (x86 | x64 | arm64)) | (osx & (x64 | arm64))",
+  "supports": "(windows & (x86 | x64)) | (linux & (x86 | x64 | arm64 | arm)) | (osx & (x64 | arm64))",
   "dependencies": [
     "boost-algorithm",
     "boost-array",

--- a/ports/robotraconteur/vcpkg.json
+++ b/ports/robotraconteur/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "The Robot Raconteur communication framework core library",
   "homepage": "http://robotraconteur.com",
   "license": "Apache-2.0",
-  "supports": "(windows & (x86 | x64)) | (linux & (x86 | x64 | arm64 | arm)) | (osx & (x64 | arm64))",
+  "supports": "(windows & (x86 | x64)) | (linux & (x86 | x64 | arm64 | arm32)) | (osx & (x64 | arm64))",
   "dependencies": [
     "boost-algorithm",
     "boost-array",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7733,7 +7733,7 @@
       "port-version": 0
     },
     "robotraconteur": {
-      "baseline": "1.1.1",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "robotraconteur-companion": {

--- a/versions/r-/robotraconteur.json
+++ b/versions/r-/robotraconteur.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59fd72d178df2c7f291fa0397ea22e53c1a5eed1",
+      "version-semver": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "da6a4cf1a0949a70ff94feb0df9241b73c88a249",
       "version-semver": "1.1.1",
       "port-version": 0

--- a/versions/r-/robotraconteur.json
+++ b/versions/r-/robotraconteur.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "59fd72d178df2c7f291fa0397ea22e53c1a5eed1",
+      "git-tree": "5607a942906a086cd399770048006177c2371081",
       "version-semver": "1.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This PR updates the version and makes two changes to the `robotraconteur` port:

- Sets `CMAKE_CXX_STANDARD=11` to force C++11 support on all platforms. By default Robot Raconteur builds for C++98 on Linux.
- Adds `arm` architecture for `linux` platform to `supports` in `vcpkg.json`.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
