### PR TITLE
[faac] add new port

### DIFF
--- a/ports/faac/CMakeLists.txt
+++ b/ports/faac/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.7.2)
+project (faac VERSION 1.30)
+
+option(FAAC_BUILD_BINARIES "Build faac binaries" ON)
+
+file(GLOB FAAC_SOURCES "${CMAKE_CURRENT_LIST_DIR}/libfaac/*.c")
+file(GLOB FAAC_HEADERS "${CMAKE_CURRENT_LIST_DIR}/libfaac/*.h")
+
+add_definitions(-DPACKAGE_VERSION=\"${PROJECT_VERSION}\" -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES)
+
+add_library(faac ${FAAC_SOURCES} ${FAAC_HEADERS})
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        "${CMAKE_CURRENT_LIST_DIR}/include"
+)
+
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(faac PRIVATE FAACEXPORT)
+endif ()
+
+install(
+    TARGETS faac
+        ARCHIVE DESTINATION "lib"
+        LIBRARY DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+    )
+
+if (FAAC_BUILD_BINARIES)
+    add_executable(faac_cli
+        "${CMAKE_SOURCE_DIR}/frontend/input.c"
+        "${CMAKE_SOURCE_DIR}/frontend/main.c"
+        "${CMAKE_SOURCE_DIR}/frontend/mp4write.c"
+    )
+    target_include_directories(faac_cli
+        PRIVATE
+            "${CMAKE_CURRENT_LIST_DIR}/frontend"
+            ${FAAC_HEADERS}
+    )
+    if (MSVC)
+        target_include_directories(faac_cli
+            PRIVATE
+                "${CMAKE_CURRENT_LIST_DIR}/project/msvc"
+        )
+    endif ()
+    target_link_libraries(faac_cli PRIVATE faac)
+
+    install(
+        TARGETS faac_cli
+            RUNTIME DESTINATION "bin"
+        )
+endif ()

--- a/ports/faac/fix-dll-export.patch
+++ b/ports/faac/fix-dll-export.patch
@@ -1,0 +1,136 @@
+diff --git a/include/faac.h b/include/faac.h
+index f30299f..620d532 100644
+--- a/include/faac.h
++++ b/include/faac.h
+@@ -27,15 +27,16 @@ extern "C" {
+ #endif /* __cplusplus */
+ 
+ 
+-#if !defined(FAACAPI) && defined(__GNUC__) && (__GNUC__ >= 4)
++#if defined(FAACEXPORT)
+ # if defined(_WIN32)
+-#  define FAACAPI __stdcall __declspec(dllexport)
+-# else
++#  define FAACAPI __declspec(dllexport)
++# elif defined(__GNUC__) && (__GNUC__ >= 4)
+ #  define FAACAPI __attribute__((visibility("default")))
+-# endif
+-#endif
+-#ifndef FAACAPI
++# else
+ #  define FAACAPI
++# endif
++#else
++# define FAACAPI
+ #endif
+ 
+ #pragma pack(push, 1)
+@@ -58,34 +59,34 @@ typedef void *faacEncHandle;
+ 
+ 	Returns FAAC_CFG_VERSION.
+ */
+-int FAACAPI faacEncGetVersion(char **faac_id_string,
++FAACAPI int faacEncGetVersion(char **faac_id_string,
+ 			      char **faac_copyright_string);
+ 
+ 
+-faacEncConfigurationPtr FAACAPI
++FAACAPI faacEncConfigurationPtr
+   faacEncGetCurrentConfiguration(faacEncHandle hEncoder);
+ 
+ 
+-int FAACAPI faacEncSetConfiguration(faacEncHandle hEncoder,
++FAACAPI int faacEncSetConfiguration(faacEncHandle hEncoder,
+ 				    faacEncConfigurationPtr config);
+ 
+ 
+-faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
++FAACAPI faacEncHandle faacEncOpen(unsigned long sampleRate,
+ 				  unsigned int numChannels,
+ 				  unsigned long *inputSamples,
+                                   unsigned long *maxOutputBytes
+                                  );
+ 
+-int FAACAPI faacEncGetDecoderSpecificInfo(faacEncHandle hEncoder, unsigned char **ppBuffer,
++FAACAPI int faacEncGetDecoderSpecificInfo(faacEncHandle hEncoder, unsigned char **ppBuffer,
+ 					  unsigned long *pSizeOfDecoderSpecificInfo);
+ 
+ 
+-int FAACAPI faacEncEncode(faacEncHandle hEncoder, int32_t * inputBuffer, unsigned int samplesInput,
++FAACAPI int faacEncEncode(faacEncHandle hEncoder, int32_t * inputBuffer, unsigned int samplesInput,
+ 			 unsigned char *outputBuffer,
+ 			 unsigned int bufferSize);
+ 
+ 
+-int FAACAPI faacEncClose(faacEncHandle hEncoder);
++FAACAPI int faacEncClose(faacEncHandle hEncoder);
+ 
+ 
+ 
+diff --git a/libfaac/frame.c b/libfaac/frame.c
+index a65468a..baed73f 100644
+--- a/libfaac/frame.c
++++ b/libfaac/frame.c
+@@ -56,7 +56,7 @@ static const struct {
+     double freq;
+ } g_bw = {0.42, 18000};
+ 
+-int FAACAPI faacEncGetVersion( char **faac_id_string,
++int faacEncGetVersion( char **faac_id_string,
+ 			      				char **faac_copyright_string)
+ {
+   if (faac_id_string)
+@@ -69,7 +69,7 @@ int FAACAPI faacEncGetVersion( char **faac_id_string,
+ }
+ 
+ 
+-int FAACAPI faacEncGetDecoderSpecificInfo(faacEncHandle hpEncoder,unsigned char** ppBuffer,unsigned long* pSizeOfDecoderSpecificInfo)
++int faacEncGetDecoderSpecificInfo(faacEncHandle hpEncoder,unsigned char** ppBuffer,unsigned long* pSizeOfDecoderSpecificInfo)
+ {
+     faacEncStruct* hEncoder = (faacEncStruct*)hpEncoder;
+     BitStream* pBitStream = NULL;
+@@ -101,7 +101,7 @@ int FAACAPI faacEncGetDecoderSpecificInfo(faacEncHandle hpEncoder,unsigned char*
+ }
+ 
+ 
+-faacEncConfigurationPtr FAACAPI faacEncGetCurrentConfiguration(faacEncHandle hpEncoder)
++faacEncConfigurationPtr faacEncGetCurrentConfiguration(faacEncHandle hpEncoder)
+ {
+     faacEncStruct* hEncoder = (faacEncStruct*)hpEncoder;
+     faacEncConfigurationPtr config = &(hEncoder->config);
+@@ -109,7 +109,7 @@ faacEncConfigurationPtr FAACAPI faacEncGetCurrentConfiguration(faacEncHandle hpE
+     return config;
+ }
+ 
+-int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
++int faacEncSetConfiguration(faacEncHandle hpEncoder,
+                                     faacEncConfigurationPtr config)
+ {
+     faacEncStruct* hEncoder = (faacEncStruct*)hpEncoder;
+@@ -233,7 +233,7 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
+     return 1;
+ }
+ 
+-faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
++faacEncHandle faacEncOpen(unsigned long sampleRate,
+                                   unsigned int numChannels,
+                                   unsigned long *inputSamples,
+                                   unsigned long *maxOutputBytes)
+@@ -324,7 +324,7 @@ faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
+     return hEncoder;
+ }
+ 
+-int FAACAPI faacEncClose(faacEncHandle hpEncoder)
++int faacEncClose(faacEncHandle hpEncoder)
+ {
+     faacEncStruct* hEncoder = (faacEncStruct*)hpEncoder;
+     unsigned int channel;
+@@ -358,7 +358,7 @@ int FAACAPI faacEncClose(faacEncHandle hpEncoder)
+     return 0;
+ }
+ 
+-int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
++int faacEncEncode(faacEncHandle hpEncoder,
+                           int32_t *inputBuffer,
+                           unsigned int samplesInput,
+                           unsigned char *outputBuffer,

--- a/ports/faac/fix-gcc-build.patch
+++ b/ports/faac/fix-gcc-build.patch
@@ -1,0 +1,12 @@
+diff --git a/libfaac/quantize.c b/libfaac/quantize.c
+index 870737a..1a99570 100644
+--- a/libfaac/quantize.c
++++ b/libfaac/quantize.c
+@@ -30,6 +30,7 @@
+ #ifdef __SSE2__
+ # ifdef __GNUC__
+ #  include <cpuid.h>
++#  include <immintrin.h>
+ # endif
+ #endif
+ 

--- a/ports/faac/portfile.cmake
+++ b/ports/faac/portfile.cmake
@@ -1,0 +1,36 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO knik0/faac
+    REF 78d8e0141600ac006a94ac6fd5601f # 1_30
+    SHA512 bf206165dea9ac1f005a8880570e5e93499a2a1f880867ed861303f3954a392e61f640dddfd45585d1a9e054fab463ca195fb38989a273d5f56d984c282ff02a
+    HEAD_REF master
+    PATCHES
+        fix-dll-export.patch
+        fix-gcc-build.patch
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    cli   FAAC_BUILD_BINARIES
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+if("cli" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES faac_cli AUTO_CLEAN)
+endif()
+
+file(INSTALL "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
+
+file(REMOVE "${CURRENT_PACKAGES_DIR}/include/Makefile.am")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/faac/vcpkg.json
+++ b/ports/faac/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "faac",
+  "version": "1.30",
+  "description": "Freeware Advanced Audio (AAC) Encoder",
+  "homepage": "https://sourceforge.net/projects/faac/",
+  "supports": "!(android | osx | uwp | (arm & windows))",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "features": {
+    "cli": {
+      "description": "Build the embedded encoder executable"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2576,6 +2576,10 @@
       "baseline": "21.10",
       "port-version": 0
     },
+    "faac": {
+      "baseline": "1.30",
+      "port-version": 0
+    },
     "faad2": {
       "baseline": "2.11.1",
       "port-version": 0

--- a/versions/f-/faac.json
+++ b/versions/f-/faac.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6ba53d3a7f2b9450e09a7421597f258d36a4590a",
+      "version": "1.30",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds #24972

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.