### PR TITLE
[liba52] add new port

### DIFF
--- a/ports/liba52/CMakeLists.txt
+++ b/ports/liba52/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.7.2)
+project (liba52 VERSION 0.7.4)
+
+file(GLOB LIBA52_SOURCES "${CMAKE_CURRENT_LIST_DIR}/liba52/*.c")
+file(GLOB LIBA52_HEADERS "${CMAKE_CURRENT_LIST_DIR}/liba52/*.h")
+
+include_directories(
+    "${CMAKE_CURRENT_LIST_DIR}/include"
+    "${CMAKE_CURRENT_LIST_DIR}/liba52"
+    "${CMAKE_CURRENT_LIST_DIR}/vc++"
+)
+add_library(liba52 ${LIBA52_SOURCES} ${LIBA52_HEADERS})
+set_target_properties(liba52 PROPERTIES PREFIX "")
+
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(liba52 PRIVATE A52_EXPORT)
+endif ()
+
+install(
+    TARGETS liba52
+        ARCHIVE DESTINATION "lib"
+        LIBRARY DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+    )

--- a/ports/liba52/fix-dll-export.patch
+++ b/ports/liba52/fix-dll-export.patch
@@ -1,0 +1,46 @@
+diff --git a/include/a52.h b/include/a52.h
+index 9db52cc..02459f6 100644
+--- a/include/a52.h
++++ b/include/a52.h
+@@ -24,6 +24,18 @@
+ #ifndef A52_H
+ #define A52_H
+ 
++#ifdef A52_EXPORT
++  #if defined(_WIN32)
++    #define A52_API __declspec(dllexport)
++  #elif defined(__GNUC__) && __GNUC__ >= 4
++    #define A52_API __attribute__((visibility("default")))
++  #else
++    #define A52_API
++  #endif
++#else
++  #define A52_API
++#endif
++
+ #ifndef LIBA52_DOUBLE
+ typedef float sample_t;
+ #else
+@@ -48,15 +60,15 @@ typedef struct a52_state_s a52_state_t;
+ #define A52_LFE 16
+ #define A52_ADJUST_LEVEL 32
+ 
+-a52_state_t * a52_init (uint32_t mm_accel);
+-sample_t * a52_samples (a52_state_t * state);
+-int a52_syncinfo (uint8_t * buf, int * flags,
++A52_API a52_state_t * a52_init (uint32_t mm_accel);
++A52_API sample_t * a52_samples (a52_state_t * state);
++A52_API int a52_syncinfo (uint8_t * buf, int * flags,
+ 		  int * sample_rate, int * bit_rate);
+-int a52_frame (a52_state_t * state, uint8_t * buf, int * flags,
++A52_API int a52_frame (a52_state_t * state, uint8_t * buf, int * flags,
+ 	       sample_t * level, sample_t bias);
+-void a52_dynrng (a52_state_t * state,
++A52_API void a52_dynrng (a52_state_t * state,
+ 		 sample_t (* call) (sample_t, void *), void * data);
+-int a52_block (a52_state_t * state);
+-void a52_free (a52_state_t * state);
++A52_API int a52_block (a52_state_t * state);
++A52_API void a52_free (a52_state_t * state);
+ 
+ #endif /* A52_H */

--- a/ports/liba52/portfile.cmake
+++ b/ports/liba52/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://code.videolan.org
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO videolan/liba52
+    REF "${VERSION}"
+    SHA512 85a406053410b9ccd861b94e249ad4241e150801c91536496446bdf977bac1b42025dbcb63f519a5b169330ba40e56dba85f5ce101d890dc09d33617e2b51c76
+    PATCHES
+        fix-dll-export.patch
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/include"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+    RENAME liba52
+    PATTERN "*.in" EXCLUDE
+    PATTERN "*.am" EXCLUDE
+)
+file(INSTALL "${SOURCE_PATH}/vc++/config.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/liba52")
+file(INSTALL "${SOURCE_PATH}/vc++/inttypes.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/liba52")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/liba52/vcpkg.json
+++ b/ports/liba52/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "liba52",
+  "version": "0.7.4",
+  "description": "a free ATSC A/52 stream decoder",
+  "homepage": "https://liba52.sourceforge.io/",
+  "supports": "!(android | osx | uwp)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4140,6 +4140,10 @@
       "baseline": "2.3.0",
       "port-version": 0
     },
+    "liba52": {
+      "baseline": "0.7.4",
+      "port-version": 0
+    },
     "libaaplus": {
       "baseline": "2.36",
       "port-version": 1

--- a/versions/l-/liba52.json
+++ b/versions/l-/liba52.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6645ec35160fd24cf6062d26d868845c9128a9e6",
+      "version": "0.7.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds #24973

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.