### PR TITLE
[faad2] fix exports in static builds and mingw builds

### DIFF
--- a/ports/faad2/fix-dll-export.patch
+++ b/ports/faad2/fix-dll-export.patch
@@ -1,0 +1,41 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5c0aeff..7da416c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -158,6 +158,11 @@ foreach(LIB faad faad_drm faad_fixed faad_drm_fixed)
+   target_compile_options(${LIB} PRIVATE
+     ${FAAD_FLAGS}
+   )
++  if(BUILD_SHARED_LIBS)
++    target_compile_definitions(${LIB} PRIVATE
++      NEAACDECEXPORT
++    )
++  endif()
+ endforeach()
+ 
+ foreach(LIB faad_drm faad_drm_fixed)
+diff --git a/include/neaacdec.h b/include/neaacdec.h
+index f7d5f67..0be1b98 100644
+--- a/include/neaacdec.h
++++ b/include/neaacdec.h
+@@ -58,11 +58,15 @@ extern "C" {
+ #endif
+ 
+ 
+-#ifdef _WIN32
+-  #pragma pack(push, 8)
+-  #define NEAACDECAPI __declspec(dllexport)
+-#elif defined(__GNUC__) && __GNUC__ >= 4
+-  #define NEAACDECAPI __attribute__((visibility("default")))
++#ifdef NEAACDECEXPORT
++  #if defined(_WIN32)
++    #pragma pack(push, 8)
++    #define NEAACDECAPI __declspec(dllexport)
++  #elif defined(__GNUC__) && __GNUC__ >= 4
++    #define NEAACDECAPI __attribute__((visibility("default")))
++  #else
++    #define NEAACDECAPI
++  #endif
+ #else
+   #define NEAACDECAPI
+ #endif

--- a/ports/faad2/portfile.cmake
+++ b/ports/faad2/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 b8f17680610b2f47344ea52b54412a02810a85eaf9d4c91b97ca09b2c6415c62d4af1b0771bfcacb9dfee400ed34504c0bd3c28369921c0392b3809e7de46ec5
     HEAD_REF master
     PATCHES
+        fix-dll-export.patch
         fix-install.patch
 )
 
@@ -17,7 +18,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-if(VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     vcpkg_copy_tools(TOOL_NAMES faad_cli AUTO_CLEAN)
 else()
     vcpkg_copy_tools(TOOL_NAMES faad AUTO_CLEAN)

--- a/ports/faad2/vcpkg.json
+++ b/ports/faad2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "faad2",
   "version": "2.11.1",
+  "port-version": 1,
   "description": "Freeware Advanced Audio (AAC) Decoder",
   "homepage": "https://sourceforge.net/projects/faac/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2578,7 +2578,7 @@
     },
     "faad2": {
       "baseline": "2.11.1",
-      "port-version": 0
+      "port-version": 1
     },
     "fadbad": {
       "baseline": "2.1.0",

--- a/versions/f-/faad2.json
+++ b/versions/f-/faad2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b6b81b30bf95411f4cde482b6d1ad1155e2211d9",
+      "version": "2.11.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "60bebbccf8a5258a6cf7ff00ef78ca0e3450b9fb",
       "version": "2.11.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #24977
Fixes x64-mingw-dynamic and x64-mingw-static

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.