### PR TITLE
[bext-sml] Update to 1.1.11

### DIFF
--- a/ports/bext-sml/portfile.cmake
+++ b/ports/bext-sml/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO boost-ext/sml
-    REF v${VERSION}
-    SHA512 7612f301ed3e4edd4171214d85c6b746af19079622aef80c0965536782e4f50635332e7435966b072e1cb415c3a680260211740313d52d1927ab5af78ecdd30e
+    REF "v${VERSION}"
+    SHA512 ac40d4c273ea91d52419e88c27c079efbcb5d29d59690b82840b69091fdd16dc72d90aa661c1bd340c448904dc59837ca1d284d0f144f254fcaf11f4a6998649
     HEAD_REF master
 )
 
@@ -12,4 +12,4 @@ file(INSTALL "${SOURCE_PATH}/include/boost/sml.hpp"
 )
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/bext-sml/vcpkg.json
+++ b/ports/bext-sml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bext-sml",
-  "version": "1.1.9",
+  "version": "1.1.11",
   "description": "Your scalable C++14 one header only State Machine Library with no dependencies",
   "homepage": "https://github.com/boost-ext/sml",
   "license": "BSL-1.0"

--- a/versions/b-/bext-sml.json
+++ b/versions/b-/bext-sml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9214514200facf25365f0183697bfceda8e44575",
+      "version": "1.1.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a92a1e011efcac69647356c0806c794d4d8ceac",
       "version": "1.1.9",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -597,7 +597,7 @@
       "port-version": 0
     },
     "bext-sml": {
-      "baseline": "1.1.9",
+      "baseline": "1.1.11",
       "port-version": 0
     },
     "bext-sml2": {


### PR DESCRIPTION
Fixes #38606
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
