### PR TITLE
[mongo-c-driver/libbson] update to 1.27.0

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 78da2fc51515b3b81214246665685680e9821b641cb6d3b821b23bdb3a8290df9d8b27b9aebce1d809454ae0b5619d758e8cb9699ac1096a7cc828994bad8f88
+    SHA512 547caacbff9ff43788c658743825ee16ae13e75f9322b0fcd8e107985f9d043a3cb133893ea870c2e5e2c92bc13a9cb69d9a102603f8fa3deb3f2fe26a6f8432
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.26.2",
+  "version": "1.27.0",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.27.0",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
-  "license": null,
+  "license": "Apache-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/mongo-c-driver/disable-dynamic-when-static.patch
+++ b/ports/mongo-c-driver/disable-dynamic-when-static.patch
@@ -1,9 +1,9 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 3070c43..0052a4e 100644
+index 74c541f..737e566 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -820,7 +820,7 @@ set_property(
-    "MONGOC_CYRUS_PLUGIN_PATH_PREFIX=$<IF:$<STREQUAL:${CYRUS_PLUGIN_PATH_PREFIX},>,NULL,\"${CYRUS_PLUGIN_PATH_PREFIX}\">"
+@@ -826,7 +826,7 @@ set (
+    "${SOURCE_DIR}/src/uthash"
  )
  
 -if (ENABLE_SHARED)
@@ -11,7 +11,16 @@ index 3070c43..0052a4e 100644
     add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
     if(WIN32)
        # Add resource-definition script for Windows shared library (.dll).
-@@ -1262,7 +1262,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
+@@ -902,7 +902,7 @@ if (ENABLE_SHARED)
+                RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    endif () # ENABLE_SHM_COUNTERS
+ 
+-endif () # ENABLE_SHARED
++endif () # NOT MONGOC_ENABLE_STATIC_BUILD
+ 
+ if (MONGOC_ENABLE_STATIC_BUILD)
+    add_library (mongoc_static STATIC ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
+@@ -1272,7 +1272,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
     list (APPEND TARGETS_TO_INSTALL mongoc_static)
  endif ()
  
@@ -20,15 +29,15 @@ index 3070c43..0052a4e 100644
     list (APPEND TARGETS_TO_INSTALL mongoc_shared)
  endif ()
  
-@@ -1317,6 +1317,7 @@ endif()
+@@ -1327,6 +1327,7 @@ endif()
  set_property(TARGET ${TARGETS_TO_INSTALL} APPEND PROPERTY pkg_config_INCLUDE_DIRECTORIES "${MONGOC_HEADER_INSTALL_DIR}")
  
  # Deprecated alias for libmongoc-1.0.pc, see CDRIVER-2086.
-+if(NOT MONGOC_ENABLE_STATIC_INSTALL)
++if (NOT MONGOC_ENABLE_STATIC_BUILD)
  if (MONGOC_ENABLE_SSL)
     configure_file (
        ${CMAKE_CURRENT_SOURCE_DIR}/src/libmongoc-ssl-1.0.pc.in
-@@ -1327,6 +1328,7 @@ if (MONGOC_ENABLE_SSL)
+@@ -1337,6 +1338,7 @@ if (MONGOC_ENABLE_SSL)
        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     )
  endif ()

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 78da2fc51515b3b81214246665685680e9821b641cb6d3b821b23bdb3a8290df9d8b27b9aebce1d809454ae0b5619d758e8cb9699ac1096a7cc828994bad8f88
+    SHA512 547caacbff9ff43788c658743825ee16ae13e75f9322b0fcd8e107985f9d043a3cb133893ea870c2e5e2c92bc13a9cb69d9a102603f8fa3deb3f2fe26a6f8432
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.26.2",
+  "version": "1.27.0",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.27.0",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
-  "license": null,
+  "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     "libbson",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4209,7 +4209,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.26.2",
+      "baseline": "1.27.0",
       "port-version": 0
     },
     "libcaer": {
@@ -5813,7 +5813,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.26.2",
+      "baseline": "1.27.0",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35c61d8654f8bffe97afaa8720872c3780c0b843",
+      "version": "1.27.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "eb512263f9f4c415f70c080d8d42d809939af4a4",
       "version": "1.26.2",
       "port-version": 0

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "35c61d8654f8bffe97afaa8720872c3780c0b843",
+      "git-tree": "b6eca9fe6dd2ea79b7465c253d081f75ed779e95",
       "version": "1.27.0",
       "port-version": 0
     },

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b078fd55e3fd2bdab100d1e02b7869c93352865",
+      "version": "1.27.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "863c473a941f5db2ce3878b7290854c96bd561a9",
       "version": "1.26.2",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7b078fd55e3fd2bdab100d1e02b7869c93352865",
+      "git-tree": "2bd06209a79a00729f7c3635e87b77a4bf36faa6",
       "version": "1.27.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/38512

All features passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
