### PR TITLE
[daw-json-link] update to 3.24.0

### DIFF
--- a/ports/daw-json-link/portfile.cmake
+++ b/ports/daw-json-link/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/daw_json_link
     REF "v${VERSION}"
-    SHA512 cdc57c54f4db9081e0375306155db3b958e26133237d6198b2c60b6a3ef2e36715917592377b4a74905ed0bafbf02bcc8568c7b9c8c3352640d4b3d270271721
-    HEAD_REF master
+    SHA512 710dcc677414d9e4e748276cd43344e403fc664ad67b7a47d032b68a7b21c7a89b0e3ef5cea650ab9a5f3b7148f482aa2fc1152b9fe31d67efaac152bd7a9cd8
+    HEAD_REF release
 )
 
 vcpkg_cmake_configure(

--- a/ports/daw-json-link/vcpkg.json
+++ b/ports/daw-json-link/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daw-json-link",
-  "version": "3.23.2",
+  "version": "3.24.0",
   "description": "Perhaps the fastest JSON deserializer/serializer posssible or at least close to it.",
   "homepage": "https://github.com/beached/daw_json_link",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2165,7 +2165,7 @@
       "port-version": 0
     },
     "daw-json-link": {
-      "baseline": "3.23.2",
+      "baseline": "3.24.0",
       "port-version": 0
     },
     "daw-utf-range": {

--- a/versions/d-/daw-json-link.json
+++ b/versions/d-/daw-json-link.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba24e4cb2d3b922cf9f7879cb6936f355cba5204",
+      "version": "3.24.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d959f64437877ff47611c6fac0a1e982d66a69e1",
       "version": "3.23.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/38572
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
