### PR TITLE
[qttools] remove assistant as a host default feature

### DIFF
--- a/ports/qttools/vcpkg.json
+++ b/ports/qttools/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "qttools",
   "version": "6.7.0",
+  "port-version": 1,
   "description": "A collection of tools and utilities that come with the Qt framework to assist developers in the creation, management, and deployment of Qt applications.",
   "homepage": "https://www.qt.io/",
   "license": null,
   "dependencies": [
-    "litehtml",
     {
       "name": "qtbase",
       "default-features": false
@@ -15,7 +15,6 @@
       "host": true,
       "default-features": false,
       "features": [
-        "assistant",
         "linguist"
       ]
     }
@@ -25,6 +24,10 @@
       "description": "Build Qt Assistant",
       "dependencies": [
         {
+          "name": "litehtml",
+          "default-features": false
+        },
+        {
           "name": "qtbase",
           "default-features": false,
           "features": [
@@ -32,6 +35,14 @@
             "png",
             "sql-sqlite",
             "widgets"
+          ]
+        },
+        {
+          "name": "qttools",
+          "host": true,
+          "default-features": false,
+          "features": [
+            "assistant"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7462,7 +7462,7 @@
     },
     "qttools": {
       "baseline": "6.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qttranslations": {
       "baseline": "6.7.0",

--- a/versions/q-/qttools.json
+++ b/versions/q-/qttools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cadaced31348f820f58f783d06111ab2ce7a4ba6",
+      "version": "6.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "db60b03c6a66d957671dbf1ca32f996ccf80633d",
       "version": "6.7.0",
       "port-version": 0


### PR DESCRIPTION
Not everyone will need assistant as host feature as not everyone uses local Qt documentation. The Qt documentation format is also not that commonly used outside of Qt itself. Assistant pulls in additional uncommonly used dependencies litehtml and gumbo.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
