### PR TITLE
[mongo-c-driver/libbson] update to 1.27.1

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 547caacbff9ff43788c658743825ee16ae13e75f9322b0fcd8e107985f9d043a3cb133893ea870c2e5e2c92bc13a9cb69d9a102603f8fa3deb3f2fe26a6f8432
+    SHA512 642264ec4358eb2de76b5dc0d7534c8751df980fc7fe21a010a44e4a7799a351ec6a8ed46fba54a6029b5d5e8c82df055a1a0eb01f23c1247a91bab8d6a5b306
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "libbson",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
-  "license": "Apache-2.0",
+  "license": null,
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 547caacbff9ff43788c658743825ee16ae13e75f9322b0fcd8e107985f9d043a3cb133893ea870c2e5e2c92bc13a9cb69d9a102603f8fa3deb3f2fe26a6f8432
+    SHA512 642264ec4358eb2de76b5dc0d7534c8751df980fc7fe21a010a44e4a7799a351ec6a8ed46fba54a6029b5d5e8c82df055a1a0eb01f23c1247a91bab8d6a5b306
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
-  "license": "Apache-2.0",
+  "license": null,
   "supports": "!uwp",
   "dependencies": [
     "libbson",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4209,7 +4209,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.27.0",
+      "baseline": "1.27.1",
       "port-version": 0
     },
     "libcaer": {
@@ -5813,7 +5813,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.27.0",
+      "baseline": "1.27.1",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9183756e6de3ce01d1a0003e3be83d2a4e87ef5a",
+      "version": "1.27.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b6eca9fe6dd2ea79b7465c253d081f75ed779e95",
       "version": "1.27.0",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b7f4dd21cdf50ca64c63af7067db1a8c3ef708b3",
+      "version": "1.27.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2bd06209a79a00729f7c3635e87b77a4bf36faa6",
       "version": "1.27.0",
       "port-version": 0


### PR DESCRIPTION
Solves https://github.com/microsoft/vcpkg/issues/38512#issuecomment-2098286326

All features passed with following triplets:
x86-windows
x64-windows
x64-windows-static
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
