### PR TITLE
[soem] Remove MSVC /WX too, in addition to -Werror.

### DIFF
--- a/ports/soem/disable-werror-and-wx.patch
+++ b/ports/soem/disable-werror-and-wx.patch
@@ -1,8 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7fa930c..e14b1bd 100644
+index 7fa930c..5d96ae4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -31,12 +31,10 @@ if(WIN32)
+@@ -27,16 +27,13 @@ if(WIN32)
+   find_library(packet_LIBRARY NAMES packet)
+   include_directories(${winpcap_INCLUDE_DIRS})
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /D _CRT_SECURE_NO_WARNINGS")
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  /WX")
    set(OS_LIBS ${winpcap_LIBRARY} ${packet_LIBRARY} Ws2_32.lib Winmm.lib)
  elseif(UNIX AND NOT APPLE)
    set(OS "linux")
@@ -15,7 +19,7 @@ index 7fa930c..e14b1bd 100644
    set(OS_LIBS pthread pcap)
  elseif(${CMAKE_SYSTEM_NAME} MATCHES "rt-kernel")
    set(OS "rtk")
-@@ -45,10 +43,6 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "rt-kernel")
+@@ -45,10 +42,6 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "rt-kernel")
    include_directories(oshw/${OS}/${ARCH})
    file(GLOB OSHW_EXTRA_SOURCES oshw/${OS}/${ARCH}/*.c)
    set(OSHW_SOURCES "${OS_HW_SOURCES} ${OSHW_ARCHSOURCES}")

--- a/ports/soem/portfile.cmake
+++ b/ports/soem/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         winpcap.patch
-        disable-werror.patch
+        disable-werror-and-wx.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/soem/vcpkg.json
+++ b/ports/soem/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "soem",
   "version-date": "2023-06-09",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Simple Open Source EtherCAT Master",
   "homepage": "https://github.com/OpenEtherCATsociety/SOEM",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8226,7 +8226,7 @@
     },
     "soem": {
       "baseline": "2023-06-09",
-      "port-version": 1
+      "port-version": 2
     },
     "soil": {
       "baseline": "2021-04-22",

--- a/versions/s-/soem.json
+++ b/versions/s-/soem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4bc716a66ac48f993a2242f2b584a897313901a3",
+      "version-date": "2023-06-09",
+      "port-version": 2
+    },
+    {
       "git-tree": "fdbb2e9fafc4dfc1aca0c45a872b3b202e2a9254",
       "version-date": "2023-06-09",
       "port-version": 1

--- a/versions/s-/soem.json
+++ b/versions/s-/soem.json
@@ -3,11 +3,6 @@
     {
       "git-tree": "4bc716a66ac48f993a2242f2b584a897313901a3",
       "version-date": "2023-06-09",
-      "port-version": 2
-    },
-    {
-      "git-tree": "fdbb2e9fafc4dfc1aca0c45a872b3b202e2a9254",
-      "version-date": "2023-06-09",
       "port-version": 1
     },
     {

--- a/versions/s-/soem.json
+++ b/versions/s-/soem.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "4bc716a66ac48f993a2242f2b584a897313901a3",
+      "git-tree": "cedfc66b0bc8a2673c113bc88bcc973d4fc2ef08",
+      "version-date": "2023-06-09",
+      "port-version": 2
+    },
+    {
+      "git-tree": "fdbb2e9fafc4dfc1aca0c45a872b3b202e2a9254",
       "version-date": "2023-06-09",
       "port-version": 1
     },


### PR DESCRIPTION
This PR adds to https://github.com/microsoft/vcpkg/pull/31889 by also removing the MSVC `/WX` flag, to disable "Treat all compiler warnings as errors" for MSVC too.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
