### PR TITLE
[yara] Update to 4.5.0

### DIFF
--- a/ports/yara/portfile.cmake
+++ b/ports/yara/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO VirusTotal/yara
   REF "v${VERSION}"
-  SHA512 dc77ec46a30ca2fff33b639166fc554c9c6d9e955642774e23da3ea7dbb25fe154cfd4ef83c9808920193028b9099258a63b3f1b9a66864a1f3905f0a8e8053f
+  SHA512 c9fe8a89879d1a742236101f1754e6b25e70356cdf5c020b2583e3ac509600c3b462756c412b01f2ebcb17df351c83afcf04d1cfaa87e6753eb25bab0f797aa3
   HEAD_REF master
   PATCHES
     # Module elf request new library tlshc(https://github.com/avast/tlshc), the related upstream PR: https://github.com/VirusTotal/yara/pull/1624.

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "yara",
-  "version": "4.3.2",
-  "port-version": 1,
+  "version": "4.5.0",
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9569,8 +9569,8 @@
       "port-version": 1
     },
     "yara": {
-      "baseline": "4.3.2",
-      "port-version": 1
+      "baseline": "4.5.0",
+      "port-version": 0
     },
     "yas": {
       "baseline": "7.1.0",

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "36109d80198f355066776d9166f4ab7f564a91f3",
+      "version": "4.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f5f938703b1025e041b7ad9eb9ab28f954e39e57",
       "version": "4.3.2",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/38622

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x86-windows
x64-windows
x64-windows-static
```