### PR TITLE
[qwt] update to 6.3.0

### DIFF
--- a/ports/qwt/config.patch
+++ b/ports/qwt/config.patch
@@ -41,15 +41,15 @@ index 7da1485a0..b69b5ca71 100644
  QWT_INSTALL_PREFIX = $$[QT_INSTALL_PREFIX]
  
  unix {
--    QWT_INSTALL_PREFIX    = /usr/local/qwt-$$QWT_VERSION-dev
-+    # QWT_INSTALL_PREFIX    = /usr/local/qwt-$$QWT_VERSION-dev
-     # QWT_INSTALL_PREFIX = /usr/local/qwt-$$QWT_VERSION-dev-qt-$$QT_VERSION
+-    QWT_INSTALL_PREFIX    = /usr/local/qwt-$$QWT_VERSION
++    # QWT_INSTALL_PREFIX    = /usr/local/qwt-$$QWT_VERSION
+     # QWT_INSTALL_PREFIX = /usr/local/qwt-$$QWT_VERSION-qt-$$QT_VERSION
  }
  
  win32 {
--    QWT_INSTALL_PREFIX    = C:/Qwt-$$QWT_VERSION-dev
-+    # QWT_INSTALL_PREFIX    = C:/Qwt-$$QWT_VERSION-dev
-     # QWT_INSTALL_PREFIX = C:/Qwt-$$QWT_VERSION-dev-qt-$$QT_VERSION
+-    QWT_INSTALL_PREFIX    = C:/Qwt-$$QWT_VERSION
++    # QWT_INSTALL_PREFIX    = C:/Qwt-$$QWT_VERSION
+     # QWT_INSTALL_PREFIX = C:/Qwt-$$QWT_VERSION-qt-$$QT_VERSION
  }
  
 -QWT_INSTALL_DOCS      = $${QWT_INSTALL_PREFIX}/doc
@@ -124,16 +124,6 @@ index 7da1485a0..b69b5ca71 100644
  
  ######################################################################
  # When Qt has been built as framework qmake wants
-@@ -171,8 +172,4 @@ macx:!static:CONFIG(qt_framework, qt_framework|qt_no_framework) {
- # Create and install pc files for pkg-config
- # See http://www.freedesktop.org/wiki/Software/pkg-config/
- ######################################################################
--
--unix {
--
--    QWT_CONFIG     += QwtPkgConfig
--}
-+# QWT_CONFIG     += QwtPkgConfig # Qt6 has no pkgconfig files
 diff --git a/src/src.pro b/src/src.pro
 index 762e4c49b..d70a1b62b 100644
 --- a/src/src.pro

--- a/ports/qwt/portfile.cmake
+++ b/ports/qwt/portfile.cmake
@@ -1,8 +1,9 @@
-vcpkg_from_git(
+vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL "https://git.code.sf.net/p/qwt/git"
-    REF "907846e0e981b216349156ee83b13208faae2934"
-    FETCH_REF qwt-6.2
+    REPO qwt/qwt
+    REF ${VERSION}
+    FILENAME "qwt-${VERSION}.zip"
+    SHA512 4008c3e4dace0f18e572b473a51a293bb896abbd62b9c5f0a92734b2121923d2e2cbf67c997b84570a13bf4fdd7669b56497c82fbae35049ed856b2f0a65e475
     PATCHES
         config.patch
         fix_dll_install.patch
@@ -23,6 +24,10 @@ vcpkg_qmake_configure(
 )
 vcpkg_qmake_install()
 vcpkg_copy_pdbs()
+
+# Qt6 pkg-config files not installed https://github.com/microsoft/vcpkg/issues/25988
+# vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/qwt/vcpkg.json
+++ b/ports/qwt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qwt",
-  "version-date": "2023-05-12",
+  "version": "6.3.0",
   "description": "Widgets library for technical applications",
   "homepage": "https://sourceforge.net/projects/qwt",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7517,7 +7517,7 @@
       "port-version": 0
     },
     "qwt": {
-      "baseline": "2023-05-12",
+      "baseline": "6.3.0",
       "port-version": 0
     },
     "qwtw": {

--- a/versions/q-/qwt.json
+++ b/versions/q-/qwt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0790b160a3437533b20a9f7eca6b41868f236b5e",
+      "version": "6.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a1e2a09246f114b613350042641546934ea0ff27",
       "version-date": "2023-05-12",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.