### PR TITLE
[bde] Update to 4.8.0.0

### DIFF
--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -1,6 +1,5 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-
 # Acquire Python and add it to PATH
 vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
@@ -10,7 +9,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH TOOLS_PATH
     REPO "bloomberg/bde-tools"
     REF "${VERSION}"
-    SHA512 3aa64215c473ccecbd213234826b0c8cffd9491e7bf358e5947c80103e0723ef56da8ec7cc9cf51c6b7a887e5b0b52e80f3201d933accf7f6d5cc95fc1cb35dc
+    SHA512 e5c5a0639e06a554f0f3ba7d18db8947f84a3645494b6dd5642be4bb9457d65e5d1ad1f047bb2f5fd61553fa10ae93a6a9573e5c799e9baab1b943be1000b7e2
     HEAD_REF main
 )
 
@@ -23,7 +22,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "bloomberg/bde"
     REF "${VERSION}"
-    SHA512 27e204e22883065e3ae9ab92d2c87d8e26a2871a36ede01367ee0e4d4a0e0de4f7b9452a0c219066dbb37a6f06ec3acabd6be029b8fdaab6c6ea4094300371d0
+    SHA512 f35fdfbae64d8405264420f0e7c983e628adbba1219b3f75ae99c6a58d91bf8bc7f8690b56a891798d3e32620cb9e98ac6234e55d6227caf52d622b0ce05456c
     HEAD_REF main
 )
 
@@ -56,8 +55,5 @@ endforeach()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake" "${CURRENT_PACKAGES_DIR}/debug/${CMAKE_INSTALL_LIBDIR}/cmake")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE
-     DESTINATION ${CURRENT_PACKAGES_DIR}/share/bde
-     RENAME copyright
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 vcpkg_fixup_pkgconfig()

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "bde",
-  "version": "3.124.0.0",
+  "version": "4.8.0.0",
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
+  "license": "Apache-2.0",
   "supports": "!windows & !arm & !android & !osx",
   "dependencies": [
     {

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa76296b5abefaf07a8f663ced20cea1a0c901b6",
+      "version": "4.8.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f8c8bc5beb99b215e68af4269bc1bac20957d485",
       "version": "3.124.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -557,7 +557,7 @@
       "port-version": 0
     },
     "bde": {
-      "baseline": "3.124.0.0",
+      "baseline": "4.8.0.0",
       "port-version": 0
     },
     "bdwgc": {


### PR DESCRIPTION
Fixes #38636
Usage test passed on `x64-linux`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
