### PR TITLE
[cpprestsdk] fix bad define in header for clang

### DIFF
--- a/ports/cpprestsdk/fix-clang-dllimport.patch
+++ b/ports/cpprestsdk/fix-clang-dllimport.patch
@@ -1,0 +1,52 @@
+diff --git a/Release/include/cpprest/details/cpprest_compat.h b/Release/include/cpprest/details/cpprest_compat.h
+index bf107479..00581371 100644
+--- a/Release/include/cpprest/details/cpprest_compat.h
++++ b/Release/include/cpprest/details/cpprest_compat.h
+@@ -29,7 +29,6 @@
+ #else // ^^^ _WIN32 ^^^ // vvv !_WIN32 vvv
+ 
+ #define __declspec(x) __attribute__((x))
+-#define dllimport
+ #define novtable /* no novtable equivalent */
+ #define __assume(x)                                                                                                    \
+     do                                                                                                                 \
+@@ -74,9 +73,17 @@
+ #define _ASYNCRTIMP_TYPEINFO
+ #else // ^^^ _NO_ASYNCRTIMP ^^^ // vvv !_NO_ASYNCRTIMP vvv
+ #ifdef _ASYNCRT_EXPORT
++#ifdef _WIN32
+ #define _ASYNCRTIMP __declspec(dllexport)
++#else
++#define _ASYNCRTIMP __attribute__((visibility("default")))
++#endif
+ #else // ^^^ _ASYNCRT_EXPORT ^^^ // vvv !_ASYNCRT_EXPORT vvv
++#ifdef _WIN32
+ #define _ASYNCRTIMP __declspec(dllimport)
++#else
++#define _ASYNCRTIMP
++#endif
+ #endif // _ASYNCRT_EXPORT
+ 
+ #if defined(_WIN32)
+diff --git a/Release/include/pplx/pplx.h b/Release/include/pplx/pplx.h
+index d9ba9c61..8d36252c 100644
+--- a/Release/include/pplx/pplx.h
++++ b/Release/include/pplx/pplx.h
+@@ -30,9 +30,17 @@
+ #define _PPLXIMP
+ #else
+ #ifdef _PPLX_EXPORT
++#ifdef _WIN32
+ #define _PPLXIMP __declspec(dllexport)
+ #else
++#define _PPLXIMP __attribute__((visibility("default")))
++#endif
++#else
++#ifdef _WIN32
+ #define _PPLXIMP __declspec(dllimport)
++#else
++#define _PPLXIMP
++#endif
+ #endif
+ #endif
+ 

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix-find-openssl.patch
         fix_narrowing.patch
         fix-uwp.patch
+        fix-clang-dllimport.patch # workaround for https://github.com/microsoft/cpprestsdk/issues/1710
 )
 
 set(OPTIONS)

--- a/ports/cpprestsdk/vcpkg.json
+++ b/ports/cpprestsdk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cpprestsdk",
   "version": "2.10.19",
+  "port-version": 1,
   "description": [
     "C++11 JSON, REST, and OAuth library",
     "The C++ REST SDK is a Microsoft project for cloud-based client-server communication in native code using a modern asynchronous C++ API design. This project aims to help C++ developers connect to and interact with services."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1934,7 +1934,7 @@
     },
     "cpprestsdk": {
       "baseline": "2.10.19",
-      "port-version": 0
+      "port-version": 1
     },
     "cppslippi": {
       "baseline": "1.4.3.16",

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a10a640d968ca2ac8f1d0df0836e3d23a7fb2199",
+      "version": "2.10.19",
+      "port-version": 1
+    },
+    {
       "git-tree": "110c2c2a08e520877aa3fa9231ab69e0a76f388d",
       "version": "2.10.19",
       "port-version": 0


### PR DESCRIPTION
- **[cpprestsdk] fix clang build on new zlib**
- **./vcpkg x-add-version --all**


Defining `dllimport` is *bad* and breaks clang, and since this is in maintaince mode they aren't going to fix it.  

This had the ability to blow up projects before, but newer zlib versions use `__has_declspec_attribute`, so that makes it impossible to even _build_ cpprestsdk on systems like these (I'm on Fedora 40).

Refs:

https://github.com/microsoft/cpprestsdk/issues/1710
https://github.com/llvm/llvm-project/issues/53269

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
