### PR TITLE
[krb5] Update portfile

### DIFF
--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -1,37 +1,95 @@
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://kerberos.org/dist/krb5/1.21/krb5-${VERSION}.tar.gz"
-    FILENAME "krb5-${VERSION}.tar.gz"
-    SHA512 4e09296b412383d53872661718dbfaa90201e0d85f69db48e57a8d4bd73c95a90c7ec7b6f0f325f6bc967f8d203b256b071c0191facf080aca0e2caec5d0ac49
+vcpkg_from_github(
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO krb5/krb5
+	REF "krb5-1.21.2-final"
+	SHA512 184ef8645d7e17f30a8e3d4005364424d2095b3d0c96f26ecef0c2dd2f3a096a0dd40558ed113121483717e44f6af41e71be0e5e079c76a205535d0c11a2ea34
+	PATCHES relative_paths.patch
 )
 
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-)
+if ("${VCPKG_TARGET_IS_OSX}")
+	# Required for recent macOS and static build: https://mailman.mit.edu/pipermail/krbdev/2024-January/013653.html
+	if ("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "static")
+		set(LD_FLAGS "-framework Kerberos")
+	endif ()
+	set(EXTRA_OPTIONS
+		"--disable-nls"
+		"--disable-silent-rules"
+		"--without-system-verto"
+		"--without-keyutils"
+	)
+endif ()
 
 vcpkg_configure_make(
-    SOURCE_PATH "${SOURCE_PATH}/src"
-    AUTOCONFIG
-    OPTIONS
-        "CFLAGS=-fcommon \$CFLAGS"
+	SOURCE_PATH "${SOURCE_PATH}"
+	PROJECT_SUBPATH src
+	AUTOCONFIG
+	NO_ADDITIONAL_PATHS
+	DETERMINE_BUILD_TRIPLET
+	OPTIONS
+		--disable-rpath
+		"CFLAGS=-fcommon \$CFLAGS"
+		"LDFLAGS=${LD_FLAGS}"
+    ${EXTRA_OPTIONS}
 )
 
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat1")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat5")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat7")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat8")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/krb5/")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/krb5/")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/var")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/var")
+vcpkg_copy_tools(
+	SEARCH_DIR "${CURRENT_PACKAGES_DIR}/bin"
+	DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin"
+	TOOL_NAMES
+		gss-client
+		kadmin
+		kdestroy
+		kinit
+		klist
+		kpasswd
+		kswitch
+		ktutil
+		kvno
+		sclient
+		sim_client
+		uuclient
+		compile_et
+		k5srvutil
+		krb5-config
+	AUTO_CLEAN
+)
 
-# remove due to absolute path error
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/krb5/bin/compile_et")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/krb5/bin/krb5-config")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/krb5/debug/")
+vcpkg_copy_tools(
+	SEARCH_DIR "${CURRENT_PACKAGES_DIR}/sbin"
+	DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/sbin"
+	TOOL_NAMES
+		gss-server
+		kadmind
+		kdb5_util
+		kprop
+		kpropd
+		kproplog
+		krb5kdc
+		sim_server
+		sserver
+		uuserver
+		kadmin.local
+		krb5-send-pr
+)
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/copyright.rst")
+# Required because AUTO_CLEAN doesn't work with sbin
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/sbin")
+
+# Empty directories
+file(REMOVE_RECURSE
+	"${CURRENT_PACKAGES_DIR}/var"
+	"${CURRENT_PACKAGES_DIR}/share/man/cat1"
+	"${CURRENT_PACKAGES_DIR}/share/man/cat5"
+	"${CURRENT_PACKAGES_DIR}/share/man/cat7"
+	"${CURRENT_PACKAGES_DIR}/share/man/cat8"
+)
+# Also empty when static
+if("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "static")
+	file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/krb5")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/NOTICE")

--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
 	OUT_SOURCE_PATH SOURCE_PATH
 	REPO krb5/krb5
-	REF "krb5-1.21.2-final"
+	REF "krb5-${VERSION}-final"
 	SHA512 184ef8645d7e17f30a8e3d4005364424d2095b3d0c96f26ecef0c2dd2f3a096a0dd40558ed113121483717e44f6af41e71be0e5e079c76a205535d0c11a2ea34
 	PATCHES relative_paths.patch
 )

--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -81,12 +81,11 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/sbin")
 
 # Empty directories
 file(REMOVE_RECURSE
+	"${CURRENT_PACKAGES_DIR}/debug"
+	"${CURRENT_PACKAGES_DIR}/share/man"
 	"${CURRENT_PACKAGES_DIR}/var"
-	"${CURRENT_PACKAGES_DIR}/share/man/cat1"
-	"${CURRENT_PACKAGES_DIR}/share/man/cat5"
-	"${CURRENT_PACKAGES_DIR}/share/man/cat7"
-	"${CURRENT_PACKAGES_DIR}/share/man/cat8"
 )
+
 # Also empty when static
 if("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "static")
 	file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/krb5")

--- a/ports/krb5/relative_paths.patch
+++ b/ports/krb5/relative_paths.patch
@@ -1,0 +1,35 @@
+diff --git a/src/build-tools/krb5-config.in b/src/build-tools/krb5-config.in
+index 8e6eb8660..89a401dab 100755
+--- a/src/build-tools/krb5-config.in
++++ b/src/build-tools/krb5-config.in
+@@ -27,7 +27,7 @@
+ # Configurable parameters set by autoconf
+ version_string="Kerberos 5 release @KRB5_VERSION@"
+ 
+-prefix=@prefix@
++prefix='$(pwd)/../../../'
+ exec_prefix=@exec_prefix@
+ includedir=@includedir@
+ libdir=@libdir@
+@@ -39,7 +39,7 @@ PTHREAD_CFLAGS='@PTHREAD_CFLAGS@'
+ DL_LIB='@DL_LIB@'
+ DEFCCNAME='@DEFCCNAME@'
+ DEFKTNAME='@DEFKTNAME@'
+-DEFCKTNAME='@DEFCKTNAME@'
++DEFCKTNAME='$(pwd)/../../../var/krb5/user/%{euid}/client.keytab'
+ 
+ LIBS='@LIBS@'
+ GEN_LIB=@GEN_LIB@
+diff --git a/src/util/et/compile_et.sh b/src/util/et/compile_et.sh
+index f17ddba71..6a98a8bab 100755
+--- a/src/util/et/compile_et.sh
++++ b/src/util/et/compile_et.sh
+@@ -2,7 +2,7 @@
+ #
+ #
+ AWK=@AWK@
+-DIR=@DIR@
++DIR='$(pwd)/../../../share/et'
+ 
+ usage="usage: $0 [ -d scriptDir ] [ --textdomain domain [ --localedir dir ] ]"
+ usage="$usage inputfile.et"

--- a/ports/krb5/vcpkg.json
+++ b/ports/krb5/vcpkg.json
@@ -1,8 +1,15 @@
 {
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "krb5",
   "version": "1.21.2",
-  "description": "Network authentication protocol",
+  "port-version": 1,
+  "description": [
+    "Kerberos is a network authentication protocol.",
+    "It is designed to provide strong authentication for client/server applications by using secret-key cryptography.",
+    "A free implementation of this protocol is available from the Massachusetts Institute of Technology.",
+    "Kerberos is available in many commercial products as well."
+  ],
   "homepage": "https://web.mit.edu/kerberos/",
   "license": "MIT",
-  "supports": "linux"
+  "supports": "osx | (x64 & linux)"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4050,7 +4050,7 @@
     },
     "krb5": {
       "baseline": "1.21.2",
-      "port-version": 0
+      "port-version": 1
     },
     "ktx": {
       "baseline": "4.3.1",

--- a/versions/k-/krb5.json
+++ b/versions/k-/krb5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19f68551b5a14434b8e38068b96aa801a4dac1d8",
+      "version": "1.21.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "287bac02bb53283b043688050edd9d02e0b039c7",
       "version": "1.21.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.