### PR TITLE
[Stormlib] UNICODE needs to be PUBLIC

### DIFF
--- a/ports/stormlib/CMakeLists.txt
+++ b/ports/stormlib/CMakeLists.txt
@@ -265,7 +265,7 @@ target_link_libraries(stormlib PRIVATE ${LINK_LIBS})
 target_compile_definitions(stormlib PRIVATE _7ZIP_ST BZ_STRICT_ANSI)
 
 if(WIN32)
-	target_compile_definitions(stormlib PRIVATE  UNICODE _UNICODE)
+	target_compile_definitions(stormlib PUBLIC UNICODE _UNICODE)
 endif()
 
 if(NOT MSVC)

--- a/ports/stormlib/vcpkg.json
+++ b/ports/stormlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "stormlib",
   "version-date": "2019-05-10",
-  "port-version": 5,
+  "port-version": 6,
   "description": "StormLib is a library for opening and manipulating Blizzard MPQ files",
   "dependencies": [
     "bzip2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8442,7 +8442,7 @@
     },
     "stormlib": {
       "baseline": "2019-05-10",
-      "port-version": 5
+      "port-version": 6
     },
     "strict-variant": {
       "baseline": "0.5",

--- a/versions/s-/stormlib.json
+++ b/versions/s-/stormlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "716e1e685cabe4c6ff87e14056be76454558ed15",
+      "version-date": "2019-05-10",
+      "port-version": 6
+    },
+    {
       "git-tree": "be1785249ddff2cfdcee25685c3775946edf9d6e",
       "version-date": "2019-05-10",
       "port-version": 5


### PR DESCRIPTION
Usually UNICODE can be set or not without issues. However in the case of stormlib, TCHAR is part of the API, which can lead to issues.

By default CMake uses MBCS instead of unicode:
- https://gitlab.kitware.com/cmake/cmake/-/blob/v3.27.7/Source/cmLocalVisualStudio7Generator.cxx#L805
- https://gitlab.kitware.com/cmake/cmake/-/blob/v3.27.7/Source/cmVisualStudio10TargetGenerator.cxx#L1516
- https://gitlab.kitware.com/cmake/cmake/-/blob/v3.27.7/Source/cmVisualStudioGeneratorOptions.cxx#L137

This means that a project using CMake defaults would see sizeof(TCHAR)==1 while stormlib would see sizeof(TCHAR)==2.

Make the define PUBLIC so that targets linking stormlib::stormlib will automatically define it too.

Ideally, we would remove the use of this define entirely (this is something that must be controlled by the user, for example using a toolchain file), but this would break current users. We also can not use a feature to togggle this behaviour due to https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md#features

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
