### PR TITLE
[qcoro] Depend on only required Qt features

### DIFF
--- a/ports/qcoro/vcpkg.json
+++ b/ports/qcoro/vcpkg.json
@@ -1,12 +1,19 @@
 {
   "name": "qcoro",
   "version": "0.10.0",
+  "port-version": 1,
   "description": "Coroutine support for Qt",
   "homepage": "https://www.github.com/danvratil/qcoro",
   "documentation": "https://qcoro.dvratil.cz",
   "license": "MIT",
   "dependencies": [
-    "qtbase",
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "thread"
+      ]
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -26,30 +33,66 @@
   ],
   "features": {
     "dbus": {
-      "description": "Coroutine support for QtDBus module"
+      "description": "Coroutine support for QtDBus module",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "dbus"
+          ]
+        }
+      ]
     },
     "network": {
-      "description": "Coroutine support for QtNetwork module"
+      "description": "Coroutine support for QtNetwork module",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "network"
+          ]
+        }
+      ]
     },
     "qml": {
       "description": "Coroutine support for QtQml module",
       "dependencies": [
-        "qtdeclarative"
+        {
+          "name": "qtdeclarative",
+          "default-features": false
+        }
       ]
     },
     "quick": {
       "description": "Coroutine support for QtQuick module",
       "dependencies": [
-        "qtdeclarative"
+        {
+          "name": "qtdeclarative",
+          "default-features": false
+        }
       ]
     },
     "test": {
-      "description": "Support code for easier testing of coroutines with QtTest."
+      "description": "Support code for easier testing of coroutines with QtTest.",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "testlib"
+          ]
+        }
+      ]
     },
     "websockets": {
       "description": "Coroutine support for QtWebSockets module",
       "dependencies": [
-        "qtwebsockets"
+        {
+          "name": "qtwebsockets",
+          "default-features": false
+        }
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7090,7 +7090,7 @@
     },
     "qcoro": {
       "baseline": "0.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qcustomplot": {
       "baseline": "2.1.1",

--- a/versions/q-/qcoro.json
+++ b/versions/q-/qcoro.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f8b9f743a339335725fe9fe3475f584cc9654b69",
+      "version": "0.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "98bf3c0f6c546401e5976e2d474765d838050fd3",
       "version": "0.10.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
