### PR TITLE
[crashpad] Update to latest version 2024-05-10

### DIFF
--- a/ports/crashpad/fix-atomic_thread_fence.patch
+++ b/ports/crashpad/fix-atomic_thread_fence.patch
@@ -1,0 +1,13 @@
+diff --git a/base/atomicops_internals_portable.h b/base/atomicops_internals_portable.h
+index 2486fb7..ffbab08 100644
+--- a/base/atomicops_internals_portable.h
++++ b/base/atomicops_internals_portable.h
+@@ -54,7 +54,7 @@ inline void MemoryBarrier() {
+ #if defined(__GLIBCXX__)
+   // Work around libstdc++ bug 51038 where atomic_thread_fence was declared but
+   // not defined, leading to the linker complaining about undefined references.
+-  __atomic_thread_fence(std::memory_order_seq_cst);
++  __atomic_thread_fence(static_cast<int>(std::memory_order_seq_cst));
+ #else
+   std::atomic_thread_fence(std::memory_order_seq_cst);
+ #endif

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -18,17 +18,20 @@ function(checkout_in_path PATH URL REF)
         OUT_SOURCE_PATH DEP_SOURCE_PATH
         URL "${URL}"
         REF "${REF}"
+        PATCHES "${PATCH_FILE}"
     )
     file(RENAME "${DEP_SOURCE_PATH}" "${PATH}")
     file(REMOVE_RECURSE "${DEP_SOURCE_PATH}")
 endfunction()
 
 # mini_chromium contains the toolchains and build configuration
+set(PATCH_FILE "fix-atomic_thread_fence.patch")
 checkout_in_path(
     "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium"
     "https://chromium.googlesource.com/chromium/mini_chromium"
     "a6607b1fd76b740f31c2249fef2c0bec27ffbe52"
 )
+set(PATCH_FILE "")
 
 if(VCPKG_TARGET_IS_LINUX)
     # fetch lss

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://chromium.googlesource.com/crashpad/crashpad
-    REF 7e0af1d4d45b526f01677e74a56f4a951b70517d
+    REF 1174aa4fc3196f478b5b4b77fc970d1cb85cb7cf
 )
 
 vcpkg_find_acquire_program(PYTHON3)
@@ -27,7 +27,7 @@ endfunction()
 checkout_in_path(
     "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium"
     "https://chromium.googlesource.com/chromium/mini_chromium"
-    "dce72d97d1c2e9beb5e206c6a05a702269794ca3"
+    "a6607b1fd76b740f31c2249fef2c0bec27ffbe52"
 )
 
 if(VCPKG_TARGET_IS_LINUX)

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "crashpad",
-  "version-date": "2024-04-11",
+  "version-date": "2024-05-10",
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1997,7 +1997,7 @@
       "port-version": 2
     },
     "crashpad": {
-      "baseline": "2024-04-11",
+      "baseline": "2024-05-10",
       "port-version": 0
     },
     "crashrpt": {

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b5cf64b2017b9e79f210ff3aa8b1d84e794508bc",
+      "version-date": "2024-05-10",
+      "port-version": 0
+    },
+    {
       "git-tree": "faece66eb2a9a6f95f5a11c7f4ebd3cefd70d54f",
       "version-date": "2024-04-11",
       "port-version": 0


### PR DESCRIPTION
Fixes #38702

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.