### PR TITLE
[dawn] add new port

### DIFF
--- a/ports/dawn/dawn-find_package.patch
+++ b/ports/dawn/dawn-find_package.patch
@@ -1,0 +1,52 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6abb9f0c84..5c387071d1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,6 +40,26 @@ project(
+     LANGUAGES C CXX
+     HOMEPAGE_URL "https://dawn.googlesource.com/dawn"
+ )
++
++find_package(absl CONFIG REQUIRED)
++add_library(libabsl INTERFACE)
++add_library(absl_strings ALIAS absl::strings)
++add_library(absl_flat_hash_map ALIAS absl::flat_hash_map)
++add_library(absl_flat_hash_set ALIAS absl::flat_hash_set)
++add_library(absl_str_format_internal ALIAS absl::str_format_internal)
++add_library(absl_inlined_vector ALIAS absl::inlined_vector)
++find_package(glfw3 CONFIG REQUIRED)
++find_package(glslang CONFIG REQUIRED)
++add_library(glslang ALIAS glslang::glslang)
++add_library(glslang-default-resource-limits INTERFACE)
++find_package(VulkanUtilityLibraries CONFIG REQUIRED)
++find_package(VulkanHeaders CONFIG REQUIRED)
++add_library(Vulkan-Headers ALIAS Vulkan::Headers)
++find_path(SPIRV_HEADERS_INCLUDE_DIRS "spirv/1.0/GLSL.std.450.h")
++add_library(SPIRV-Headers INTERFACE)
++target_include_directories(SPIRV-Headers INTERFACE "${SPIRV_HEADERS_INCLUDE_DIRS}")
++cmake_path(GET SPIRV_HEADERS_INCLUDE_DIRS PARENT_PATH SPIRV-Headers_SOURCE_DIR)
++
+ enable_testing()
+ 
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+@@ -567,6 +587,8 @@ add_subdirectory(third_party)
+ set(BUILD_SHARED_LIBS_SAVED ${BUILD_SHARED_LIBS})
+ set(BUILD_SHARED_LIBS 0)
+ add_subdirectory(src/tint)
++target_include_directories(tint_lang_spirv_reader_ast_parser PRIVATE "${SPIRV-Tools_SOURCE_PATH}")
++target_include_directories(tint_lang_spirv_reader_parser PRIVATE "${SPIRV-Tools_SOURCE_PATH}")
+ set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_SAVED})
+ add_subdirectory(generator)
+ add_subdirectory(src/dawn)
+diff --git a/src/dawn/wire/CMakeLists.txt b/src/dawn/wire/CMakeLists.txt
+index 123a8e98dc..c14f4fd6be 100644
+--- a/src/dawn/wire/CMakeLists.txt
++++ b/src/dawn/wire/CMakeLists.txt
+@@ -111,6 +111,7 @@ target_link_libraries(dawn_wire
+     PUBLIC
+       dawn_headers
+     PRIVATE
++      libtint
+       absl_flat_hash_map
+       absl_flat_hash_set
+       dawn_common

--- a/ports/dawn/portfile.cmake
+++ b/ports/dawn/portfile.cmake
@@ -1,0 +1,40 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/dawn
+    REF fda42b9b030a9da4a3f3b3dc994bdba9eeb36b38
+    SHA512 579e49753b22300390d929ded3fed7d8efd5babb97be8bd71c5789da7e797423e3718d23c9a47799c19bae6b4911b43925ba3c8bfd649c9bc45c10bb3515a2e1
+    HEAD_REF master
+    PATCHES
+        dawn-find_package.patch
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SPIRV-Tools_SOURCE_PATH
+    REPO KhronosGroup/SPIRV-Tools
+    REF "vulkan-sdk-1.3.280.0"
+    SHA512 3ccab3118e0a1d6f20d031cd1f90f2546b618370b90aacc468fc598d523463452f65ed2c89c1de4e2bb8933b9757eb8123363483bcd853e92d41c95ea419e79f
+)
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DDAWN_BUILD_SAMPLES=OFF
+        -DDAWN_ENABLE_INSTALL=ON
+        -DDAWN_JINJA2_DIR=OFF
+        -DDAWN_USE_GLFW=OFF # TODO: I somehow get linker errors when enabling this
+        -DTINT_BUILD_CMD_TOOLS=OFF
+        -DTINT_BUILD_TESTS=OFF
+        -DTINT_ENABLE_INSTALL=ON
+        "-DDAWN_SPIRV_TOOLS_DIR=${SPIRV-Tools_SOURCE_PATH}"
+        -DSPIRV_TOOLS_BUILD_STATIC=ON
+)
+
+vcpkg_cmake_install()
+#vcpkg_cmake_config_fixup(PACKAGE_NAME absl CONFIG_PATH lib/cmake/absl)
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/dawn/vcpkg.json
+++ b/ports/dawn/vcpkg.json
@@ -1,0 +1,28 @@
+{
+    "name": "dawn",
+    "version": "6475",
+    "description": [
+      ""
+    ],
+    "homepage": "https://dawn.googlesource.com/dawn/",
+    "license": "Apache-2.0",
+    "dependencies": [
+      {
+        "name": "vcpkg-cmake",
+        "host": true
+      },
+      {
+        "name": "vcpkg-cmake-config",
+        "host": true
+      },
+      "abseil",
+      "glfw3",
+      "glslang",
+      "spirv-headers",
+      "vulkan-headers",
+      "vulkan-utility-libraries"
+    ],
+    "features": {
+    }
+  }
+  

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2180,6 +2180,10 @@
       "baseline": "2.2.4",
       "port-version": 0
     },
+    "dawn": {
+      "baseline": "6475",
+      "port-version": 0
+    },
     "daxa": {
       "baseline": "2.0.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #35606

This is not finished and missing a lot of things!
Due to dawn depending on SPIRV-Tools internals, I wanted to ask what would be the best way forward?
Compiling SPIRV-Tools as part of the dawn port seems less than ideal, any suggestions?
I also currently get the following linker error when building (tried to force SPIRV-Tools to be built as static, but this doesn't help):
`SPIRV-Tools-shared.lib(SPIRV-Tools-shared.dll) : error LNK2005: spvContextDestroy already defined in SPIRV-Tools.lib(table.cpp.obj)`
Also about missing tint symbols, which I fixed by adding the library as a dependency. Seems like dawn is rarely built as a shared lib?

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.
