### PR TITLE
[cinatra, tanakh-cmdline] Add new ports

### DIFF
--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -1,0 +1,59 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO qicosmos/cinatra
+    REF ${VERSION}
+    SHA512 55bba51bb6190b76bc6415d3c36e82daeb5f174f1cb10490951cf05863f55653a6d68ffd3b66c5b3b2ebb6e68a7a84c090e973a6718f3f2a5849b04330e4b180
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_UNIT_TESTS=OFF
+        -DBUILD_EXAMPLES=ON
+        -DBUILD_PRESS_TOOL=ON
+)
+
+vcpkg_install_cmake()
+
+# Copy include directory while preserving the folder structure but exclude asio and async_simple
+file(GLOB_RECURSE CINATRA_HEADERS "${SOURCE_PATH}/include/*")
+foreach(HEADER ${CINATRA_HEADERS})
+    get_filename_component(HEADER_NAME "${HEADER}" NAME)
+    get_filename_component(HEADER_PATH "${HEADER}" PATH)
+    file(RELATIVE_PATH HEADER_RELATIVE_PATH "${SOURCE_PATH}/include" "${HEADER_PATH}")
+    # Check in the path for 'asio' or 'async_simple' to exclude them
+    if(NOT HEADER_PATH MATCHES "asio" AND NOT HEADER_PATH MATCHES "async_simple")
+        file(INSTALL "${HEADER}"
+             DESTINATION "${CURRENT_PACKAGES_DIR}/include/${HEADER_RELATIVE_PATH}")
+    endif()
+endforeach()
+
+
+
+# Copy example web content
+file(COPY ${SOURCE_PATH}/example/www DESTINATION ${CURRENT_PACKAGES_DIR}/tools/cinatra/examples)
+
+# Copy executables to the tools directory
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/cinatra_example.exe")
+    file(COPY "${CURRENT_PACKAGES_DIR}/bin/cinatra_example.exe"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
+    file(COPY "${CURRENT_PACKAGES_DIR}/bin/cinatra_press_tool.exe"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_copy_pdbs()
+
+# Cleanup unwanted directories
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${SOURCE_PATH}/.git")
+# Prevent file conflicts
+file(REMOVE
+    "${CURRENT_PACKAGES_DIR}/include/asio.hpp"
+    "${CURRENT_PACKAGES_DIR}/include/cmdline.h"
+)

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -22,9 +22,6 @@ vcpkg_cmake_install()
 # Copy the entire include directory
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
 
-# Copy example web content
-file(COPY ${SOURCE_PATH}/example/www DESTINATION ${CURRENT_PACKAGES_DIR}/tools/cinatra/examples)
-
 # Copy executables to the tools directory
 if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/cinatra_example.exe")
     file(COPY "${CURRENT_PACKAGES_DIR}/bin/cinatra_example.exe"

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -12,11 +12,6 @@ set(VCPKG_BUILD_TYPE "release") # header-only port
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra)
 file(COPY ${SOURCE_PATH}/include/cinatra.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra.hpp)
 
-vcpkg_copy_tools(
-    TOOL_NAMES cinatra_press_tool
-    SEARCH_DIRS "${CURRENT_PACKAGES_DIR}/include/cinatra"
-)
-
 # Copy executables to the tools directory
 if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
     file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe"

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -21,16 +21,14 @@ vcpkg_cmake_install()
 # Copy the entire include directory to ${CURRENT_PACKAGES_DIR}/include/cinatra
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra)
 
-# Copy executables to the tools directory using vcpkg_copy_tools
-vcpkg_copy_tools(
-    TOOL_NAMES cinatra_press_tool
-    SEARCH_DIRS "${CURRENT_PACKAGES_DIR}/include/cinatra"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra"
-    AUTO_CLEAN
-)
+# Copy executables to the tools directory
+if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
+    file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
+endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-
 
 
 

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -8,8 +8,6 @@ vcpkg_from_github(
 
 set(VCPKG_BUILD_TYPE "release") # header-only port
 
-vcpkg_cmake_install()
-
 # Copy the entire include directory to ${CURRENT_PACKAGES_DIR}/include/cinatra
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra)
 file(COPY ${SOURCE_PATH}/include/cinatra.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra.hpp)

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -18,7 +18,6 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-
 # Copy the entire include directory
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
 

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -8,30 +8,25 @@ vcpkg_from_github(
 
 set(VCPKG_BUILD_TYPE "release") # header-only port
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DBUILD_UNIT_TESTS=OFF
-        -DBUILD_EXAMPLES=OFF
-        -DBUILD_PRESS_TOOL=ON
-)
-
 vcpkg_cmake_install()
 
 # Copy the entire include directory to ${CURRENT_PACKAGES_DIR}/include/cinatra
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra)
+file(COPY ${SOURCE_PATH}/include/cinatra.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra.hpp)
 
 vcpkg_copy_tools(
     TOOL_NAMES cinatra_press_tool
     SEARCH_DIRS "${CURRENT_PACKAGES_DIR}/include/cinatra"
 )
 
-# Manually remove the tool from include directory
+# Copy executables to the tools directory
 if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
+    file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
     file(REMOVE "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
 endif()
 
-vcpkg_installcopyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 
 

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -18,15 +18,17 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-# Copy the entire include directory
-file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
+# Copy the entire include directory to ${CURRENT_PACKAGES_DIR}/include/cinatra
+file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra)
 
 # Copy executables to the tools directory
-if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra_press_tool.exe")
-    file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra_press_tool.exe"
+if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
+    file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe"
          DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
-    file(REMOVE "${CURRENT_PACKAGES_DIR}/include/cinatra_press_tool.exe")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+
 

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -25,10 +25,12 @@ file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cin
 vcpkg_copy_tools(
     TOOL_NAMES cinatra_press_tool
     SEARCH_DIRS "${CURRENT_PACKAGES_DIR}/include/cinatra"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra"
     AUTO_CLEAN
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
 
 
 

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+set(VCPKG_BUILD_TYPE "release") # header-only port
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -25,6 +25,7 @@ file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
 if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra_press_tool.exe")
     file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra_press_tool.exe"
          DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/include/cinatra_press_tool.exe")
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -6,16 +6,16 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_UNIT_TESTS=OFF
-        -DBUILD_EXAMPLES=ON
+        -DBUILD_EXAMPLES=OFF
         -DBUILD_PRESS_TOOL=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
+
 
 # Copy the entire include directory
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -21,12 +21,12 @@ vcpkg_cmake_install()
 # Copy the entire include directory to ${CURRENT_PACKAGES_DIR}/include/cinatra
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra)
 
-# Copy executables to the tools directory
-if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
-    file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe"
-         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
-    file(REMOVE "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
-endif()
+# Copy executables to the tools directory using vcpkg_copy_tools
+vcpkg_copy_tools(
+    TOOL_NAMES cinatra_press_tool
+    AUTO_CLEAN
+    SEARCH_DIRS "${CURRENT_PACKAGES_DIR}/include/cinatra"
+)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -21,14 +21,19 @@ vcpkg_cmake_install()
 # Copy the entire include directory to ${CURRENT_PACKAGES_DIR}/include/cinatra
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra)
 
-# Copy executables to the tools directory
+vcpkg_copy_tools(
+    TOOL_NAMES cinatra_press_tool
+    SEARCH_DIRS "${CURRENT_PACKAGES_DIR}/include/cinatra"
+)
+
+# Manually remove the tool from include directory
 if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
-    file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe"
-         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
     file(REMOVE "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
 endif()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_installcopyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+
 
 
 

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -17,20 +17,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-# Copy include directory while preserving the folder structure but exclude asio and async_simple
-file(GLOB_RECURSE CINATRA_HEADERS "${SOURCE_PATH}/include/*")
-foreach(HEADER ${CINATRA_HEADERS})
-    get_filename_component(HEADER_NAME "${HEADER}" NAME)
-    get_filename_component(HEADER_PATH "${HEADER}" PATH)
-    file(RELATIVE_PATH HEADER_RELATIVE_PATH "${SOURCE_PATH}/include" "${HEADER_PATH}")
-    # Check in the path for 'asio' or 'async_simple' to exclude them
-    if(NOT HEADER_PATH MATCHES "asio" AND NOT HEADER_PATH MATCHES "async_simple")
-        file(INSTALL "${HEADER}"
-             DESTINATION "${CURRENT_PACKAGES_DIR}/include/${HEADER_RELATIVE_PATH}")
-    endif()
-endforeach()
-
-
+# Copy the entire include directory
+file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
 
 # Copy example web content
 file(COPY ${SOURCE_PATH}/example/www DESTINATION ${CURRENT_PACKAGES_DIR}/tools/cinatra/examples)
@@ -52,8 +40,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${SOURCE_PATH}/.git")
-# Prevent file conflicts
-file(REMOVE
-    "${CURRENT_PACKAGES_DIR}/include/asio.hpp"
-    "${CURRENT_PACKAGES_DIR}/include/cmdline.h"
-)
+

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -23,20 +23,10 @@ vcpkg_cmake_install()
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
 
 # Copy executables to the tools directory
-if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/cinatra_example.exe")
-    file(COPY "${CURRENT_PACKAGES_DIR}/bin/cinatra_example.exe"
-         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/cinatra_press_tool.exe")
     file(COPY "${CURRENT_PACKAGES_DIR}/bin/cinatra_press_tool.exe"
          DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-vcpkg_copy_pdbs()
-
-# Cleanup unwanted directories
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-file(REMOVE_RECURSE "${SOURCE_PATH}/.git")
 

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -24,8 +24,8 @@ file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cin
 # Copy executables to the tools directory using vcpkg_copy_tools
 vcpkg_copy_tools(
     TOOL_NAMES cinatra_press_tool
-    AUTO_CLEAN
     SEARCH_DIRS "${CURRENT_PACKAGES_DIR}/include/cinatra"
+    AUTO_CLEAN
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -23,8 +23,8 @@ vcpkg_cmake_install()
 file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
 
 # Copy executables to the tools directory
-if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/cinatra_press_tool.exe")
-    file(COPY "${CURRENT_PACKAGES_DIR}/bin/cinatra_press_tool.exe"
+if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra_press_tool.exe")
+    file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra_press_tool.exe"
          DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
 endif()
 

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -1,3 +1,4 @@
+set(VCPKG_BUILD_TYPE "release") # header-only port
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO qicosmos/cinatra

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -9,7 +9,4 @@ vcpkg_from_github(
 
 file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/cinatra")
 
-# Install the license file(s)
-vcpkg_install_copyright(
-    FILE_LIST "${SOURCE_PATH}/LICENSE"
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -7,9 +7,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-# Copy all header files directly into the include directory of the package
-file(COPY "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-file(RENAME "${CURRENT_PACKAGES_DIR}/include/include" "${CURRENT_PACKAGES_DIR}/include/cinatra")
+file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/cinatra")
 
 # Install the license file(s)
 vcpkg_install_copyright(

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -7,6 +7,14 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/cinatra")
+# Install only Cinatra’s own headers—not vendored dependencies
+file(INSTALL
+    "${SOURCE_PATH}/include/cinatra"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/cinatra"
+)
+file(INSTALL
+    "${SOURCE_PATH}/include/cinatra.hpp"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -10,9 +10,6 @@ vcpkg_from_github(
 # Install only Cinatra’s own headers—not vendored dependencies
 file(INSTALL
     "${SOURCE_PATH}/include/cinatra"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include/cinatra"
-)
-file(INSTALL
     "${SOURCE_PATH}/include/cinatra.hpp"
     DESTINATION "${CURRENT_PACKAGES_DIR}/include"
 )

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -6,8 +6,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-set(VCPKG_BUILD_TYPE "release") # Header-only library
-
 # Copy all header files directly into the include directory of the package
 file(COPY "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 file(RENAME "${CURRENT_PACKAGES_DIR}/include/include" "${CURRENT_PACKAGES_DIR}/include/cinatra")

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -15,11 +15,3 @@ file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 vcpkg_install_copyright(
     FILE_LIST "${SOURCE_PATH}/LICENSE"
 )
-
-
-
-
-
-
-
-

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -9,7 +9,8 @@ vcpkg_from_github(
 set(VCPKG_BUILD_TYPE "release") # Header-only library
 
 # Copy all header files directly into the include directory of the package
-file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(RENAME "${CURRENT_PACKAGES_DIR}/include/include" "${CURRENT_PACKAGES_DIR}/include/cinatra")
 
 # Install the license file(s)
 vcpkg_install_copyright(

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -2,24 +2,22 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO qicosmos/cinatra
     REF ${VERSION}
-    SHA512 55bba51bb6190b76bc6415d3c36e82daeb5f174f1cb10490951cf05863f55653a6d68ffd3b66c5b3b2ebb6e68a7a84c090e973a6718f3f2a5849b04330e4b180
+    SHA512 1432a5d799736469c34faffec540c5908484e5581edaceb1f809fce619fb357b182f8a6a1e7f814d2ba81ae94d31bfda30923af61ee557449363ef7cc084a902
     HEAD_REF master
 )
 
-set(VCPKG_BUILD_TYPE "release") # header-only port
+set(VCPKG_BUILD_TYPE "release") # Header-only library
 
-# Copy the entire include directory to ${CURRENT_PACKAGES_DIR}/include/cinatra
-file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra)
-file(COPY ${SOURCE_PATH}/include/cinatra.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/cinatra.hpp)
+# Copy all header files directly into the include directory of the package
+file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 
-# Copy executables to the tools directory
-if(EXISTS "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
-    file(COPY "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe"
-         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cinatra")
-    file(REMOVE "${CURRENT_PACKAGES_DIR}/include/cinatra/cinatra_press_tool.exe")
-endif()
+# Install the license file(s)
+vcpkg_install_copyright(
+    FILE_LIST "${SOURCE_PATH}/LICENSE"
+)
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+
 
 
 

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
   "license": "MIT",
+  "supports": "!uwp & !android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "cinatra",
-  "version": "0.9.1",
+  "version-date": "2024-05-15",
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
   "license": "MIT"
 }
-

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -3,5 +3,11 @@
   "version-date": "2024-05-15",
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -3,10 +3,6 @@
   "version": "0.9.1",
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
-  "license": "MIT",
-  "dependencies": [
-    "asio",
-    "async-simple",
-    "tanakh-cmdline"
-  ]
+  "license": "MIT"
 }
+

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cinatra",
-  "version-date": "2024-05-15",
+  "version": "0.9.1",
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
   "license": "MIT",

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "cinatra",
+  "version": "0.9.1",
+  "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
+  "homepage": "https://github.com/qicosmos/cinatra",
+  "license": "MIT",
+  "dependencies": [
+    "asio",
+    "async-simple",
+    "tanakh-cmdline"
+  ]
+}

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -4,9 +4,9 @@
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
   "license": "MIT",
+  "supports": "!uwp & !android",
   "dependencies": [
     "asio",
     "tanakh-cmdline"
-  ],
-  "supports": "!uwp & !android"
+  ]
 }

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -4,5 +4,9 @@
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
   "license": "MIT",
+  "dependencies": [
+    "asio",
+    "tanakh-cmdline"
+  ],
   "supports": "!uwp & !android"
 }

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cinatra",
-  "version": "0.9.1",
+  "version": "0.9.5",
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
   "license": "MIT",

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -4,11 +4,5 @@
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
   "license": "MIT",
-  "supports": "!uwp & !android",
-  "dependencies": [
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    }
-  ]
+  "supports": "!uwp & !android"
 }

--- a/ports/tanakh-cmdline/portfile.cmake
+++ b/ports/tanakh-cmdline/portfile.cmake
@@ -1,0 +1,12 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tanakh/cmdline
+    REF e4cd007fb8f0314002d9a5b4d82939106e4144e4
+    SHA512 0d69105d79672daaf0194f15479794ab1b62c4ae270eb56e6664bc65e4cf4ebbc0d5bf76bc92ecea23fb401121165f9e8a79e39136b34ef680444208294ecf60
+    HEAD_REF master
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL ${SOURCE_PATH}/cmdline.h
+     DESTINATION ${CURRENT_PACKAGES_DIR}/include)

--- a/ports/tanakh-cmdline/portfile.cmake
+++ b/ports/tanakh-cmdline/portfile.cmake
@@ -1,3 +1,4 @@
+set(VCPKG_BUILD_TYPE "release") # header-only port
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tanakh/cmdline

--- a/ports/tanakh-cmdline/portfile.cmake
+++ b/ports/tanakh-cmdline/portfile.cmake
@@ -9,4 +9,6 @@ vcpkg_from_github(
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(INSTALL "${SOURCE_PATH}/cmdline.h"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/include/tanakh-cmdline"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/tanakh-cmdline"
+)
+

--- a/ports/tanakh-cmdline/portfile.cmake
+++ b/ports/tanakh-cmdline/portfile.cmake
@@ -8,5 +8,5 @@ vcpkg_from_github(
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
-file(INSTALL ${SOURCE_PATH}/cmdline.h
-     DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL "${SOURCE_PATH}/cmdline.h"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/include/tanakh-cmdline"

--- a/ports/tanakh-cmdline/vcpkg.json
+++ b/ports/tanakh-cmdline/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "tanakh-cmdline",
+  "version-date": "2014-02-04",
+  "description": "A simple, header-only command line parser for C++.",
+  "homepage": "https://github.com/tanakh/cmdline",
+  "license": "BSD-3-Clause"
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -190,12 +190,6 @@ chromium-base:x64-linux=skip
 #  because the first attempt to build it fails, but subsequent attempts succeed
 chromium-base:x64-osx=skip
 
-cinatra:x64-android=fail
-cinatra:arm-neon-android=fail
-cinatra:arm64-android=fail
-cinatra:x64-uwp=fail
-cinatra:arm64-uwp=fail
-
 clamav:arm64-windows=fail
 
 # clapack is replaced by lapack-reference on the platforms lapack-reference supports

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -190,6 +190,12 @@ chromium-base:x64-linux=skip
 #  because the first attempt to build it fails, but subsequent attempts succeed
 chromium-base:x64-osx=skip
 
+cinatra:x64-android=fail
+cinatra:arm-neon-android=fail
+cinatra:arm64-android=fail
+cinatra:x64-uwp=fail
+cinatra:arm64-uwp=fail
+
 clamav:arm64-windows=fail
 
 # clapack is replaced by lapack-reference on the platforms lapack-reference supports

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1625,7 +1625,7 @@
       "port-version": 0
     },
     "cinatra": {
-      "baseline": "0.9.1",
+      "baseline": "2024-05-15",
       "port-version": 0
     },
     "cista": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1625,7 +1625,7 @@
       "port-version": 0
     },
     "cinatra": {
-      "baseline": "2024-05-15",
+      "baseline": "0.9.1",
       "port-version": 0
     },
     "cista": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1624,6 +1624,10 @@
       "baseline": "3.3.2",
       "port-version": 0
     },
+    "cinatra": {
+      "baseline": "0.9.1",
+      "port-version": 0
+    },
     "cista": {
       "baseline": "0.14",
       "port-version": 0
@@ -8539,6 +8543,10 @@
     "talib": {
       "baseline": "0.4.0",
       "port-version": 1
+    },
+    "tanakh-cmdline": {
+      "baseline": "2014-02-04",
+      "port-version": 0
     },
     "taocpp-json": {
       "baseline": "2020-09-14",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1625,7 +1625,7 @@
       "port-version": 0
     },
     "cinatra": {
-      "baseline": "0.9.1",
+      "baseline": "0.9.5",
       "port-version": 0
     },
     "cista": {

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7cf8abd8f0a5e8ba4f7d33b323b2a1747edd9197",
+      "git-tree": "a635d0ebc9b0ddd71333e27c2ae75b5a4b002fe5",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b0f386d456900d6e7188de730e3fbd79ef7e4f23",
+      "git-tree": "175139ce718dd33ab8be4a41fe1e1f33f62e48d0",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce7e7fba41dc0718831bc3ce20644051f46a6878",
+      "git-tree": "38c5fdc2dc007125c20bb4d1fdc08bd420a65bd9",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "175139ce718dd33ab8be4a41fe1e1f33f62e48d0",
+      "git-tree": "db70eceb4c3fe4e96d61c1fe6dbf5b2755f272a0",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "efd96330a34dc84875cf350c65f27231bc406159",
+      "git-tree": "7cf8abd8f0a5e8ba4f7d33b323b2a1747edd9197",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "175139ce718dd33ab8be4a41fe1e1f33f62e48d0",
+      "git-tree": "cc0388ac79b071ff47afed98257702c78fab9172",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aa7c57f4eec2afcb67a8775bb9372fc0df141750",
+      "git-tree": "175139ce718dd33ab8be4a41fe1e1f33f62e48d0",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce7e7fba41dc0718831bc3ce20644051f46a6878",
+      "git-tree": "91af211a6a62396620de86d320f075490e0ea302",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "db70eceb4c3fe4e96d61c1fe6dbf5b2755f272a0",
+      "git-tree": "f6a2103ba7b442d859e751c0b7184e2f698a3e2f",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f14ed90b0ac73f6a970d7688329dfbabe7b08a58",
+      "version-date": "2024-05-15",
+      "port-version": 0
+    },
+    {
       "git-tree": "ce7e7fba41dc0718831bc3ce20644051f46a6878",
       "version": "0.9.1",
       "port-version": 0

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ce7e7fba41dc0718831bc3ce20644051f46a6878",
+      "version": "0.9.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "f14ed90b0ac73f6a970d7688329dfbabe7b08a58",
-      "version-date": "2024-05-15",
-      "port-version": 0
-    },
-    {
       "git-tree": "ce7e7fba41dc0718831bc3ce20644051f46a6878",
       "version": "0.9.1",
       "port-version": 0

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f6a2103ba7b442d859e751c0b7184e2f698a3e2f",
+      "git-tree": "b0f386d456900d6e7188de730e3fbd79ef7e4f23",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cc0388ac79b071ff47afed98257702c78fab9172",
+      "git-tree": "efd96330a34dc84875cf350c65f27231bc406159",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "38c5fdc2dc007125c20bb4d1fdc08bd420a65bd9",
+      "git-tree": "aa7c57f4eec2afcb67a8775bb9372fc0df141750",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "487af220101a0c5d3fc7140877df4c8784cf71f0",
+      "git-tree": "8b6ddabb6cc09d7b7ead22fba9cf0f7c1d08f527",
       "version": "0.9.5",
       "port-version": 0
     },

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -4,11 +4,6 @@
       "git-tree": "8b6ddabb6cc09d7b7ead22fba9cf0f7c1d08f527",
       "version": "0.9.5",
       "port-version": 0
-    },
-    {
-      "git-tree": "a635d0ebc9b0ddd71333e27c2ae75b5a4b002fe5",
-      "version": "0.9.1",
-      "port-version": 0
     }
   ]
 }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8b6ddabb6cc09d7b7ead22fba9cf0f7c1d08f527",
+      "git-tree": "8cff798d206572b136ba66d8031919e304edb5e0",
       "version": "0.9.5",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dcc6f807b27741d808e0351f68f4da8b08c21bca",
+      "git-tree": "55c81c978f5eb001d763feb2ec48245498d59791",
       "version": "0.9.5",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8cff798d206572b136ba66d8031919e304edb5e0",
+      "git-tree": "dcc6f807b27741d808e0351f68f4da8b08c21bca",
       "version": "0.9.5",
       "port-version": 0
     }

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "487af220101a0c5d3fc7140877df4c8784cf71f0",
+      "version": "0.9.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "a635d0ebc9b0ddd71333e27c2ae75b5a4b002fe5",
       "version": "0.9.1",
       "port-version": 0

--- a/versions/t-/tanakh-cmdline.json
+++ b/versions/t-/tanakh-cmdline.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "deb95fac2b311b1ca310826ca96ad483a5d6929b",
+      "version-date": "2014-02-04",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/t-/tanakh-cmdline.json
+++ b/versions/t-/tanakh-cmdline.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c63b9d91537d2d6dc9f8fc614d49661c68eaeeb3",
+      "git-tree": "e74481b77f5ef4227aa1bed9b7188fcada93a28e",
       "version-date": "2014-02-04",
       "port-version": 0
     }

--- a/versions/t-/tanakh-cmdline.json
+++ b/versions/t-/tanakh-cmdline.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "deb95fac2b311b1ca310826ca96ad483a5d6929b",
+      "git-tree": "c63b9d91537d2d6dc9f8fc614d49661c68eaeeb3",
       "version-date": "2014-02-04",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
